### PR TITLE
[JSC] Add "exclusive" type to JSC stress tests and add "memoryHog!" annotation

### DIFF
--- a/JSTests/microbenchmarks/array-from-derived-object-func.js
+++ b/JSTests/microbenchmarks/array-from-derived-object-func.js
@@ -1,5 +1,5 @@
 //@ $skipModes << :lockdown if ($buildType == "debug")
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/microbenchmarks/array-from-object-func.js
+++ b/JSTests/microbenchmarks/array-from-object-func.js
@@ -1,5 +1,5 @@
 //@ $skipModes << :lockdown if $buildType == "debug"
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/microbenchmarks/bigint64-array-index-of-large.js
+++ b/JSTests/microbenchmarks/bigint64-array-index-of-large.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 20 << 20;
 let array = new BigInt64Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/bigint64-array-index-of-medium.js
+++ b/JSTests/microbenchmarks/bigint64-array-index-of-medium.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 4096;
 let array = new BigInt64Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/bigint64-array-index-of-small.js
+++ b/JSTests/microbenchmarks/bigint64-array-index-of-small.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 16;
 let array = new BigInt64Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/biguint64-array-index-of-large.js
+++ b/JSTests/microbenchmarks/biguint64-array-index-of-large.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 20 << 20;
 let array = new BigUint64Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/biguint64-array-index-of-medium.js
+++ b/JSTests/microbenchmarks/biguint64-array-index-of-medium.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 4096;
 let array = new BigUint64Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/biguint64-array-index-of-small.js
+++ b/JSTests/microbenchmarks/biguint64-array-index-of-small.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 16;
 let array = new BigUint64Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/float32-array-index-of-large.js
+++ b/JSTests/microbenchmarks/float32-array-index-of-large.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 20 << 20;
 let array = new Float32Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/float32-array-index-of-medium.js
+++ b/JSTests/microbenchmarks/float32-array-index-of-medium.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 4096;
 let array = new Float32Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/float32-array-index-of-small.js
+++ b/JSTests/microbenchmarks/float32-array-index-of-small.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 16;
 let array = new Float32Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/float64-array-index-of-large.js
+++ b/JSTests/microbenchmarks/float64-array-index-of-large.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 20 << 20;
 let array = new Float64Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/float64-array-index-of-medium.js
+++ b/JSTests/microbenchmarks/float64-array-index-of-medium.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 4096;
 let array = new Float64Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/float64-array-index-of-small.js
+++ b/JSTests/microbenchmarks/float64-array-index-of-small.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 16;
 let array = new Float64Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/get-private-name.js
+++ b/JSTests/microbenchmarks/get-private-name.js
@@ -1,5 +1,5 @@
 //@ $skipModes << :lockdown if $buildType == "debug"
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function assert(b, m = "Assertion failed") {
     if (!b)

--- a/JSTests/microbenchmarks/int32-array-index-of-large.js
+++ b/JSTests/microbenchmarks/int32-array-index-of-large.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 20 << 20;
 let array = new Int32Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/int32-array-index-of-medium.js
+++ b/JSTests/microbenchmarks/int32-array-index-of-medium.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 4096;
 let array = new Int32Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/int32-array-index-of-small.js
+++ b/JSTests/microbenchmarks/int32-array-index-of-small.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 let size = 16;
 let array = new Int32Array(size);
 for (let i = 0; i < size; ++i)

--- a/JSTests/microbenchmarks/large-empty-array-join.js
+++ b/JSTests/microbenchmarks/large-empty-array-join.js
@@ -1,4 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ exclusive!
 //@ $skipModes << :lockdown if $memoryLimited or $buildType == "debug"
 const array = [];
 for (let i = 0; i < 100; ++i)

--- a/JSTests/microbenchmarks/loop-unrolling-array-clone-big.js
+++ b/JSTests/microbenchmarks/loop-unrolling-array-clone-big.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 let arr = Array(20).fill(0)
 
 for (let i = 0; i < arr.length; ++i) {

--- a/JSTests/microbenchmarks/loop-unrolling-array-clone-small.js
+++ b/JSTests/microbenchmarks/loop-unrolling-array-clone-small.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 let arr = Array(20).fill(0)
 
 for (let i = 0; i < arr.length; ++i) {

--- a/JSTests/microbenchmarks/loop-unrolling-constant-small.js
+++ b/JSTests/microbenchmarks/loop-unrolling-constant-small.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 let arr = Array(1000).fill(0)
 
 for (let i = 0; i < arr.length; ++i) {

--- a/JSTests/microbenchmarks/loop-unrolling-variable-large.js
+++ b/JSTests/microbenchmarks/loop-unrolling-variable-large.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 let arr = Array(10000).fill(0)
 
 for (let i = 0; i < arr.length; ++i) {

--- a/JSTests/microbenchmarks/loop-unrolling-variable-medium-dep.js
+++ b/JSTests/microbenchmarks/loop-unrolling-variable-medium-dep.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 let arr = Array(1000).fill(0)
 
 for (let i = 0; i < arr.length; ++i) {

--- a/JSTests/microbenchmarks/loop-unrolling-variable-medium.js
+++ b/JSTests/microbenchmarks/loop-unrolling-variable-medium.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 let arr = Array(1000).fill(0)
 
 for (let i = 0; i < arr.length; ++i) {

--- a/JSTests/microbenchmarks/loop-unrolling-variable-small.js
+++ b/JSTests/microbenchmarks/loop-unrolling-variable-small.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 let arr = Array(1000).fill(0)
 
 for (let i = 0; i < arr.length; ++i) {

--- a/JSTests/microbenchmarks/lots-of-fields.js
+++ b/JSTests/microbenchmarks/lots-of-fields.js
@@ -1,6 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
 // This test uses all available memory on some small memory devices.
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function foo() {
     var result = 0;

--- a/JSTests/microbenchmarks/mul-immediate-sub.js
+++ b/JSTests/microbenchmarks/mul-immediate-sub.js
@@ -1,4 +1,5 @@
 //@ skip if not $jitTests
+//@ exclusive!
 //@ $skipModes << :lockdown if $memoryLimited
 
 function doTest(max) {

--- a/JSTests/microbenchmarks/put-by-val-direct-large-index.js
+++ b/JSTests/microbenchmarks/put-by-val-direct-large-index.js
@@ -1,5 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
-//@ skip if $memoryLimited
+//@ memoryHog!
 var acc = [];
 for (var i = 0; i < 1e6; i++) {
     acc.push({[5e4 + (i % 1e4)]: true});

--- a/JSTests/microbenchmarks/set-delete-add.js
+++ b/JSTests/microbenchmarks/set-delete-add.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 var map = new Set();
 
 for (var i = 0; i < 1000; i++) {

--- a/JSTests/microbenchmarks/string-index-of-10000001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-404.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10000001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-beg.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10000001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-end.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10000001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-mid.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1000001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-404.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1000001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-beg.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1000001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-end.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1000001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-mid.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-100001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-404.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-100001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-beg.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-100001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-end.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-100001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-mid.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-404.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-beg.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-end.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-mid.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-404.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-beg.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-end.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-mid.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-101-404.js
+++ b/JSTests/microbenchmarks/string-index-of-101-404.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-101-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-101-beg.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-101-end.js
+++ b/JSTests/microbenchmarks/string-index-of-101-end.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-101-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-101-mid.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-11-404.js
+++ b/JSTests/microbenchmarks/string-index-of-11-404.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-11-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-11-beg.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-11-end.js
+++ b/JSTests/microbenchmarks/string-index-of-11-end.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-11-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-11-mid.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/typed-array-from-array.js
+++ b/JSTests/microbenchmarks/typed-array-from-array.js
@@ -1,3 +1,4 @@
+//@ exclusive!
 //@ $skipModes << :lockdown if $memoryLimited or $buildType == "debug"
 // Here we're using $memoryLimited as a proxy for "slower device" and this test is very slow in lockdown.
 

--- a/JSTests/microbenchmarks/u16-string-index-of-10000001-404.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-10000001-404.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-10000001-beg.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-10000001-beg.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-10000001-end.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-10000001-end.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-10000001-mid.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-10000001-mid.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/mozilla/mozilla-tests.yaml
+++ b/JSTests/mozilla/mozilla-tests.yaml
@@ -2037,6 +2037,7 @@
   cmd: defaultRunMozillaTest :normal, "../shell.js"
 - path: js1_5/Array/regress-157652.js
   cmd: |
+      exclusive!
       if ($memoryLimited || $buildType == "debug")
           skip
       else
@@ -2134,6 +2135,7 @@
   cmd: defaultRunMozillaTest :normal, "../shell.js"
 - path: js1_5/Regress/regress-159334.js
   cmd: |
+      exclusive!
       if ($architecture !~ /x86/i and $hostOS == "darwin") or ($architecture == "arm64" and $hostOS == "linux") or $memoryLimited
           skip
       else

--- a/JSTests/slowMicrobenchmarks/dense-set.js
+++ b/JSTests/slowMicrobenchmarks/dense-set.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 (function() {
     
     function bench(name, f, arg) {

--- a/JSTests/slowMicrobenchmarks/function-constructor-with-huge-strings.js
+++ b/JSTests/slowMicrobenchmarks/function-constructor-with-huge-strings.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 var hugeString = "x";
 for (i = 0; i < 25; ++i) {
     hugeString += hugeString;

--- a/JSTests/slowMicrobenchmarks/map-constant-key.js
+++ b/JSTests/slowMicrobenchmarks/map-constant-key.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function assert(b) {
     if (!b)

--- a/JSTests/stress/PrintStream-truncation-for-extremely-long-strings.js
+++ b/JSTests/stress/PrintStream-truncation-for-extremely-long-strings.js
@@ -1,4 +1,5 @@
-//@ skip if $architecture == "arm" or $memoryLimited
+//@ memoryHog!
+//@ skip if $architecture == "arm"
 //@ runDefault
 
 let a = '?'.repeat(5000001);

--- a/JSTests/stress/StringObject-define-length-getter-rope-string-oom.js
+++ b/JSTests/stress/StringObject-define-length-getter-rope-string-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 try {
     let char16 = decodeURI('%E7%9A%84');
     let rope = char16.padEnd(2147483644, 1);

--- a/JSTests/stress/array-buffer-view-watchpoint-can-be-fired-in-really-add-in-dfg.js
+++ b/JSTests/stress/array-buffer-view-watchpoint-can-be-fired-in-really-add-in-dfg.js
@@ -1,3 +1,4 @@
+//@ exclusive!
 //@ requireOptions("-e", "let iterations=40000") if $memoryLimited
 //@ runDefault("--jitPolicyScale=0")
 

--- a/JSTests/stress/array-prototype-concat-of-long-spliced-arrays.js
+++ b/JSTests/stress/array-prototype-concat-of-long-spliced-arrays.js
@@ -1,3 +1,4 @@
+//@ exclusive!
 //@ $skipModes << :lockdown if $memoryLimited  or $buildType == "debug"
 
 function shouldEqual(actual, expected) {

--- a/JSTests/stress/array-prototype-concat-of-long-spliced-arrays2.js
+++ b/JSTests/stress/array-prototype-concat-of-long-spliced-arrays2.js
@@ -1,3 +1,4 @@
+//@ exclusive!
 //@ $skipModes << :lockdown if $memoryLimited or $buildType == "debug"
 
 function shouldEqual(actual, expected) {

--- a/JSTests/stress/array-reverse-doesnt-clobber.js
+++ b/JSTests/stress/array-reverse-doesnt-clobber.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 // This tests that array.Prototype.reverse() doesn't inadvertently clobber indexed properties.
 // This test shouldn't throw or crash.

--- a/JSTests/stress/array-sink-materialize-cycle-break-in-exit-invalid.js
+++ b/JSTests/stress/array-sink-materialize-cycle-break-in-exit-invalid.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function g10(f) {
     function t() {
         try {

--- a/JSTests/stress/atob-btoa-oom-check.js
+++ b/JSTests/stress/atob-btoa-oom-check.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--validateExceptionChecks=1")
 try {
     btoa('\u0100'.padStart(2 ** 31-1));

--- a/JSTests/stress/big-int-constructor-oom.js
+++ b/JSTests/stress/big-int-constructor-oom.js
@@ -1,4 +1,5 @@
-//@ skip if $buildType == "debug" or $memoryLimited
+//@ memoryHog!
+//@ skip if $buildType == "debug"
 
 function assert(a) {
     if (!a)

--- a/JSTests/stress/big-wasm-memory-grow-no-max.js
+++ b/JSTests/stress/big-wasm-memory-grow-no-max.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $addressBits <= 32
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 //@ runDefault()
 
 function test() {

--- a/JSTests/stress/big-wasm-memory-grow.js
+++ b/JSTests/stress/big-wasm-memory-grow.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $addressBits <= 32
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 //@ runDefault()
 
 function test() {

--- a/JSTests/stress/big-wasm-memory.js
+++ b/JSTests/stress/big-wasm-memory.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $addressBits <= 32
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 //@ runDefault()
 
 function test() {

--- a/JSTests/stress/bigdecimal-identifiers-fail-on-oom.js
+++ b/JSTests/stress/bigdecimal-identifiers-fail-on-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function foo() {
     let m = new WebAssembly.Memory({initial: 1000});

--- a/JSTests/stress/bigint-can-throw-oom.js
+++ b/JSTests/stress/bigint-can-throw-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--useConcurrentJIT=0")
 
 function canThrow(func, errorMessage) {

--- a/JSTests/stress/bounds-checking-in-cold-loop.js
+++ b/JSTests/stress/bounds-checking-in-cold-loop.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runFTLEager("--watchdog=1000", "--watchdog-exception-ok")
 let a = [];
 a[0] = undefined;

--- a/JSTests/stress/btoa-string-overflow.js
+++ b/JSTests/stress/btoa-string-overflow.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 function shouldThrow(func, errorMessage) {
     var errorThrown = false;

--- a/JSTests/stress/call-varargs-inlining-should-not-clobber-previous-to-free-register.js
+++ b/JSTests/stress/call-varargs-inlining-should-not-clobber-previous-to-free-register.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--useConcurrentJIT=0", "--watchdog=4000", "--watchdog-exception-ok")
 (function __v0() {
     try {

--- a/JSTests/stress/check-is-constant-non-cell-should-not-array-profile-during-osr-exit.js
+++ b/JSTests/stress/check-is-constant-non-cell-should-not-array-profile-during-osr-exit.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ requireOptions("--watchdog=1000", "--watchdog-exception-ok")
 
 function foo() {

--- a/JSTests/stress/check-stack-overflow-before-value-profiling-arguments.js
+++ b/JSTests/stress/check-stack-overflow-before-value-profiling-arguments.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ requireOptions("-e", "let arraysize=0x100000") if ["arm"].include?($architecture)
 //@ runDefault("--useConcurrentJIT=0", "--thresholdForJITAfterWarmUp=10", "--slowPathAllocsBetweenGCs=10", "--useConcurrentGC=0")
 

--- a/JSTests/stress/codeblock-destructor-access-unlinkedcodeblock.js
+++ b/JSTests/stress/codeblock-destructor-access-unlinkedcodeblock.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited || $buildType == "debug" || $cloop
+//@ memoryHog!
+//@ skip if $buildType == "debug" || $cloop
 //@ runDefault("--returnEarlyFromInfiniteLoopsForFuzzing=1")
 //@ slow!
 

--- a/JSTests/stress/constructFunctionSkippingEvalEnabledCheck-should-throw-out-of-memory-error.js
+++ b/JSTests/stress/constructFunctionSkippingEvalEnabledCheck-should-throw-out-of-memory-error.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 var exception;
 try {

--- a/JSTests/stress/create-error-out-of-memory-rope-string.js
+++ b/JSTests/stress/create-error-out-of-memory-rope-string.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function assert(a, message) {
     if (!a)
         throw new Error(message);

--- a/JSTests/stress/data-view-byte-length-oob-exit.js
+++ b/JSTests/stress/data-view-byte-length-oob-exit.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 const crash_point= 0x41414141;
 const loop_start = crash_point&0xffffff00;
 const loop_end   = crash_point+1;

--- a/JSTests/stress/dataview-byte-length-large-array-oob-baseline.js
+++ b/JSTests/stress/dataview-byte-length-large-array-oob-baseline.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 function test(v) {
     return v.byteLength;
 }

--- a/JSTests/stress/dataview-byte-length-large-array-oob.js
+++ b/JSTests/stress/dataview-byte-length-large-array-oob.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 function test(v) {
     return v.byteLength;
 }

--- a/JSTests/stress/dataview-byte-length-large-array.js
+++ b/JSTests/stress/dataview-byte-length-large-array.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 function test(v) {
     return v.byteLength;
 }

--- a/JSTests/stress/describe-huge-strings.js
+++ b/JSTests/stress/describe-huge-strings.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 // This test should not crash
 

--- a/JSTests/stress/dont-reserve-huge-capacity-lexer.js
+++ b/JSTests/stress/dont-reserve-huge-capacity-lexer.js
@@ -1,4 +1,4 @@
-//@ if $memoryLimited then skip else runDefault end
+//@ memoryHog!
 
 var fe="f";                                                                         
 try

--- a/JSTests/stress/eval-huge-big-int-memory-overflow.js
+++ b/JSTests/stress/eval-huge-big-int-memory-overflow.js
@@ -1,4 +1,4 @@
-//@ if $memoryLimited then skip else runDefault end
+//@ memoryHog!
 
 try {
     eval('1'.repeat(2**20)+'n');

--- a/JSTests/stress/exception-checks-before-and-after-viewwithunderlyingstring.js
+++ b/JSTests/stress/exception-checks-before-and-after-viewwithunderlyingstring.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function shouldThrow(func, errorMessage) {
     var errorThrown = false;

--- a/JSTests/stress/exhaust-gigacage-and-allocate-vm.js
+++ b/JSTests/stress/exhaust-gigacage-and-allocate-vm.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ skip if $useCompressedHeap
 //@ runDefault
 

--- a/JSTests/stress/fast-stringifier-check-string-length.js
+++ b/JSTests/stress/fast-stringifier-check-string-length.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 var string = "\x00".repeat(715827883);
 try {
     JSON.stringify(string);

--- a/JSTests/stress/force-string-array-or-string.js
+++ b/JSTests/stress/force-string-array-or-string.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--jitPolicyScale=0")
 function foo(a0, a1) {
     try {

--- a/JSTests/stress/function-name-too-long-to-reify.js
+++ b/JSTests/stress/function-name-too-long-to-reify.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 var prop = "".padEnd(2 ** 31 - 1, "a");
 

--- a/JSTests/stress/get-array-length-reuse.js
+++ b/JSTests/stress/get-array-length-reuse.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function foo(a) {
   arguments;

--- a/JSTests/stress/get-own-property-descriptors-oom.js
+++ b/JSTests/stress/get-own-property-descriptors-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--watchdog=1000", "--watchdog-exception-ok")
 
 try {

--- a/JSTests/stress/has-own-property-name-cache-string-keys.js
+++ b/JSTests/stress/has-own-property-name-cache-string-keys.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function assert(b) {
     if (!b)

--- a/JSTests/stress/has-own-property-name-cache-symbol-keys.js
+++ b/JSTests/stress/has-own-property-name-cache-symbol-keys.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function assert(b) {
     if (!b)

--- a/JSTests/stress/incremental-marking-should-not-dead-lock-in-new-property-transition.js
+++ b/JSTests/stress/incremental-marking-should-not-dead-lock-in-new-property-transition.js
@@ -1,3 +1,4 @@
+//@ exclusive!
 //@ skip if $hostOS == "playstation" || ($memoryLimited and not ["arm"].include?($architecture))
 //@ runDefault("--gcIncrementScale=100", "--gcIncrementBytes=10", "--numberOfGCMarkers=1")
 

--- a/JSTests/stress/intl-canonicalize-locale-list-error-oom.js
+++ b/JSTests/stress/intl-canonicalize-locale-list-error-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function shouldThrow(func, errorMessage) {
     var errorThrown = false;

--- a/JSTests/stress/intl-data-time-format-string-overflow.js
+++ b/JSTests/stress/intl-data-time-format-string-overflow.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 (async function () {
     arguments = 'a'.repeat(2147483647 - null);
     new Intl.DateTimeFormat(['de-de'], {

--- a/JSTests/stress/joined-strings-should-not-exceed-max-string-length.js
+++ b/JSTests/stress/joined-strings-should-not-exceed-max-string-length.js
@@ -1,5 +1,5 @@
-//@ skip if $memoryLimited
-//@ runFTLNoCJIT if !$memoryLimited
+//@ memoryHog!
+//@ runFTLNoCJIT
 // This test should not crash or fail any assertions.
 
 function shouldEqual(stepId, actual, expected) {

--- a/JSTests/stress/js-fixed-array-out-of-memory.js
+++ b/JSTests/stress/js-fixed-array-out-of-memory.js
@@ -1,4 +1,5 @@
-//@ if $buildType == "debug" && !$memoryLimited then runDefault("--maxSingleAllocationSize=1048576") else skip end
+//@ memoryHog!
+//@ if $buildType == "debug" then runDefault("--maxSingleAllocationSize=1048576") else skip end
 
 var exception;
 

--- a/JSTests/stress/json-stringified-overflow-2.js
+++ b/JSTests/stress/json-stringified-overflow-2.js
@@ -1,4 +1,4 @@
-//@ if $memoryLimited then skip else runDefault end
+//@ memoryHog!
 
 try {
     const s = "a".padStart(0x80000000 - 1);

--- a/JSTests/stress/json-stringified-overflow.js
+++ b/JSTests/stress/json-stringified-overflow.js
@@ -1,4 +1,4 @@
-//@ if $memoryLimited then skip else runDefault end
+//@ memoryHog!
 
 try {
     const s = "123".padStart(1073741823);

--- a/JSTests/stress/json-stringify-out-of-memory.js
+++ b/JSTests/stress/json-stringify-out-of-memory.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $buildType == "debug"
+//@ memoryHog!
+//@ skip if $buildType == "debug"
 //@ runDefault
 
 var a = [];

--- a/JSTests/stress/json-stringify-stack-overflow.js
+++ b/JSTests/stress/json-stringify-stack-overflow.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ if $buildType == "release" then runDefault else skip end
 
 function shouldThrowStackOverflow(fn) {

--- a/JSTests/stress/json-stringify-string-builder-overflow.js
+++ b/JSTests/stress/json-stringify-string-builder-overflow.js
@@ -1,6 +1,6 @@
 //@ slow!
-//@ skip if $memoryLimited
-//@ runDefault if !$memoryLimited
+//@ memoryHog!
+//@ runDefault
 
 var longString = "x".repeat(2 ** 30);
 var arr = Array(4).fill(longString);

--- a/JSTests/stress/large-string-should-not-crash-error-creation.js
+++ b/JSTests/stress/large-string-should-not-crash-error-creation.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 try {
     bar_693 = '2.3023e-320';

--- a/JSTests/stress/large-unshift-splice.js
+++ b/JSTests/stress/large-unshift-splice.js
@@ -1,4 +1,4 @@
-//@ if $memoryLimited then skip else runDefault end
+//@ memoryHog!
 
 function make_contig_arr(sz)
 {

--- a/JSTests/stress/literal-parser-error-message-oom.js
+++ b/JSTests/stress/literal-parser-error-message-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 
 try {

--- a/JSTests/stress/make-large-string-jit-strcat.js
+++ b/JSTests/stress/make-large-string-jit-strcat.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 // Like make-large-string-jit.js, but tests MakeRope with three arguments and op_strcat
 // in the DFG and FTL JITs.
 

--- a/JSTests/stress/make-large-string-jit.js
+++ b/JSTests/stress/make-large-string-jit.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 // Like make-large-string.js, but tests MakeRope with two arguments in the DFG and FTL JITs.
 
 var s = "s";

--- a/JSTests/stress/make-large-string-strcat.js
+++ b/JSTests/stress/make-large-string-strcat.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 var s = "s";
 

--- a/JSTests/stress/make-large-string.js
+++ b/JSTests/stress/make-large-string.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 var s = "s";
 

--- a/JSTests/stress/make-rope-overflow-nested-catch.js
+++ b/JSTests/stress/make-rope-overflow-nested-catch.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 (function () {
     function shouldBe(actual, expected) {
         if (actual !== expected)

--- a/JSTests/stress/make-rope-overflow-nested.js
+++ b/JSTests/stress/make-rope-overflow-nested.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 (function () {
     function shouldBe(actual, expected) {
         if (actual !== expected)

--- a/JSTests/stress/many-substrings-of-rope-shouldnt-use-excessive-memory.js
+++ b/JSTests/stress/many-substrings-of-rope-shouldnt-use-excessive-memory.js
@@ -1,4 +1,5 @@
-//@ skip if $architecture == "arm" or $memoryLimited
+//@ memoryHog!
+//@ skip if $architecture == "arm"
 //@ runDefault
 
 function getLongRopeString() {

--- a/JSTests/stress/map-forEach.js
+++ b/JSTests/stress/map-forEach.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 function startScan() {
     for (let i = 0; i < 5; i++) {
         new WebAssembly.Memory({

--- a/JSTests/stress/map-rehash-oom.js
+++ b/JSTests/stress/map-rehash-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function testMap() {
     const oomString = '\u1234'.padEnd(0x7fffffff, 'a');

--- a/JSTests/stress/max-typed-array-length-toString.js
+++ b/JSTests/stress/max-typed-array-length-toString.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 var exception;
 try {

--- a/JSTests/stress/missing-exception-check-in-JSValue-toWTFStringSlowCase.js
+++ b/JSTests/stress/missing-exception-check-in-JSValue-toWTFStringSlowCase.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 
 try {

--- a/JSTests/stress/missing-exception-check-in-json-stringifier-gap.js
+++ b/JSTests/stress/missing-exception-check-in-json-stringifier-gap.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 
 const s0 = (10).toLocaleString();

--- a/JSTests/stress/numberingSystemsForLocale-cached-strings-should-be-immortal-and-safe-for-concurrent-access.js
+++ b/JSTests/stress/numberingSystemsForLocale-cached-strings-should-be-immortal-and-safe-for-concurrent-access.js
@@ -1,4 +1,5 @@
 //@ skip if $useCompressedHeap
+//@ exclusive!
 //@ requireOptions("-e", "let hardness=100") if ! $memoryLimited
 //@ requireOptions("-e", "let hardness=20") if $memoryLimited
 //@ runDefault

--- a/JSTests/stress/operationSwitchCharWithUnknownKeyType-should-avoid-resolving-rope-strings.js
+++ b/JSTests/stress/operationSwitchCharWithUnknownKeyType-should-avoid-resolving-rope-strings.js
@@ -1,4 +1,5 @@
-//@ if $memoryLimited then skip else runDefault("--useConcurrentJIT=false") end
+//@ memoryHog!
+//@ runDefault("--useConcurrentJIT=false")
 //@ slow!
 
 var o = (-1).toLocaleString().padEnd(2 ** 31 - 1, "a");

--- a/JSTests/stress/operationSwitchCharWithUnknownKeyType-should-avoid-resolving-rope-strings2.js
+++ b/JSTests/stress/operationSwitchCharWithUnknownKeyType-should-avoid-resolving-rope-strings2.js
@@ -1,4 +1,5 @@
-//@ if $memoryLimited then skip else runDefault("--useConcurrentJIT=false") end
+//@ memoryHog!
+//@ runDefault("--useConcurrentJIT=false")
 //@ slow!
 
 function f(o) {

--- a/JSTests/stress/out-of-memory-handle-in-join.js
+++ b/JSTests/stress/out-of-memory-handle-in-join.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function shouldThrow(func, errorMessage) {
     var errorThrown = false;

--- a/JSTests/stress/out-of-memory-in-globalFuncUnescape.js
+++ b/JSTests/stress/out-of-memory-in-globalFuncUnescape.js
@@ -1,4 +1,5 @@
-//@ if $buildType == "release" && !$memoryLimited then runDefault else skip end
+//@ memoryHog!
+//@ if $buildType == "release" then runDefault else skip end
 
 var exception;
 try {

--- a/JSTests/stress/out-of-memory-in-intl-segmenter.js
+++ b/JSTests/stress/out-of-memory-in-intl-segmenter.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 var exception;
 try {

--- a/JSTests/stress/out-of-memory-making-error-string-in-literal-parser.js
+++ b/JSTests/stress/out-of-memory-making-error-string-in-literal-parser.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ slow!
 //@ runDefault
 

--- a/JSTests/stress/out-of-memory-while-constructing-BytecodeGenerator.js
+++ b/JSTests/stress/out-of-memory-while-constructing-BytecodeGenerator.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 
 function bar() {

--- a/JSTests/stress/out-of-memory-while-describing-symbol-for-error.js
+++ b/JSTests/stress/out-of-memory-while-describing-symbol-for-error.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 let a = "?".repeat(2147483647);
 var exception;

--- a/JSTests/stress/own-property-names-oom.js
+++ b/JSTests/stress/own-property-names-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ slow!
 //@ runDefault
 try {

--- a/JSTests/stress/pretty-print-oom.js
+++ b/JSTests/stress/pretty-print-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runNoisyTestDefault
 
 prettyPrint('a'.repeat(2 ** 31 - 1));

--- a/JSTests/stress/race-to-add-opaque-roots-in-ConcurrentPtrHashSet.js
+++ b/JSTests/stress/race-to-add-opaque-roots-in-ConcurrentPtrHashSet.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--verifyGC=true", "--slowPathAllocsBetweenGCs=2")
 //@ slow!
 

--- a/JSTests/stress/re-enter-resolve-rope-string.js
+++ b/JSTests/stress/re-enter-resolve-rope-string.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 //@ runNoFTL("--watchdog=3000", "--watchdog-exception-ok")
 async function foo() {
   foo();

--- a/JSTests/stress/regexp-accumulatedResult-overflow.js
+++ b/JSTests/stress/regexp-accumulatedResult-overflow.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $addressBits <= 32
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 //@ runDefault()
 
 // Testcase: regExpProtoFuncReplace accumulatedResult StringBuilder

--- a/JSTests/stress/regexp-bol-optimize-out-of-stack.js
+++ b/JSTests/stress/regexp-bol-optimize-out-of-stack.js
@@ -1,4 +1,5 @@
 // This test that the beginning of line (bol) optimization throws when we run out of stack space.
+//@ exclusive!
 //@ requireOptions("-e", "let arrayLength=25000") if $memoryLimited
 
 arrayLength = typeof(arrayLength) === 'undefined' ? 50000 : arrayLength;

--- a/JSTests/stress/regexp-escape-oom.js
+++ b/JSTests/stress/regexp-escape-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 
 var exception;

--- a/JSTests/stress/regexp-huge-oom.js
+++ b/JSTests/stress/regexp-huge-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 // Test that throw an OOM exception when compiling / executing a pathologically large RegExp's
 
 function shouldBe(actual, expected)

--- a/JSTests/stress/regexp-quantify-atom-copy-term-out-of-stack.js
+++ b/JSTests/stress/regexp-quantify-atom-copy-term-out-of-stack.js
@@ -1,3 +1,4 @@
+//@ exclusive!
 //@ requireOptions("-e", "let depth=25000") if $memoryLimited
 
 depth = typeof(depth) === 'undefined' ? 50000 : depth;

--- a/JSTests/stress/regress-109102631.js
+++ b/JSTests/stress/regress-109102631.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function main() {
     const buffer = new ArrayBuffer(4294967296);
 

--- a/JSTests/stress/regress-178385.js
+++ b/JSTests/stress/regress-178385.js
@@ -1,4 +1,5 @@
-//@ skip if $hostOS == "windows" or $memoryLimited
+//@ memoryHog!
+//@ skip if $hostOS == "windows"
 // FIXME: unskip this test when https://bugs.webkit.org/show_bug.cgi?id=179298 is fixed.
 
 var exception;

--- a/JSTests/stress/regress-185888.js
+++ b/JSTests/stress/regress-185888.js
@@ -1,4 +1,4 @@
-//@ if $memoryLimited then skip else runDefault end
+//@ memoryHog!
 
 var exception;
 try {

--- a/JSTests/stress/regress-189132.js
+++ b/JSTests/stress/regress-189132.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 try {
     var a0 = '\ud801';

--- a/JSTests/stress/regress-190187.js
+++ b/JSTests/stress/regress-190187.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $buildType == "debug"
+//@ memoryHog!
+//@ skip if $buildType == "debug"
 //@ runDefault
 //@ slow!
 

--- a/JSTests/stress/regress-191563.js
+++ b/JSTests/stress/regress-191563.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function foo(str, count) {
     while (str.length < count) {

--- a/JSTests/stress/regress-192717.js
+++ b/JSTests/stress/regress-192717.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $buildType == "debug" or not $jitTests
+//@ memoryHog!
+//@ skip if $buildType == "debug" or not $jitTests
 //@ runDefault("--useLLInt=false", "--forceCodeBlockToJettisonDueToOldAge=true", "--maxPerThreadStackUsage=200000", "--exceptionStackTraceLimit=1", "--defaultErrorStackTraceLimit=1")
 
 let foo = 'let a';

--- a/JSTests/stress/regress-84402043.js
+++ b/JSTests/stress/regress-84402043.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 //@requireOptions("--watchdog=1000", "--watchdog-exception-ok")
 
 new Uint8Array({length: 2**32});

--- a/JSTests/stress/sampling-profiler-richards.js
+++ b/JSTests/stress/sampling-profiler-richards.js
@@ -1,6 +1,6 @@
 //@ skip if not $jitTests
 //@ skip if $architecture == "x86"
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--collectContinuously=1", "--useSamplingProfiler=1", "--collectExtraSamplingProfilerData=1")
 
 "use strict";

--- a/JSTests/stress/scoped-arguments-table-should-be-tolerant-for-oom.js
+++ b/JSTests/stress/scoped-arguments-table-should-be-tolerant-for-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ slow!
 
 function canThrow(func, errorMessage) {

--- a/JSTests/stress/set-rehash-oom.js
+++ b/JSTests/stress/set-rehash-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 function testSet() {
     const oomString = '\u1234'.padEnd(0x7fffffff, 'a');

--- a/JSTests/stress/splay-flash-access-1ms.js
+++ b/JSTests/stress/splay-flash-access-1ms.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ skip if $architecture == "x86"
 //@ runNoisyTestDefault
 //@ runNoisyTestNoCJIT

--- a/JSTests/stress/splay-flash-access.js
+++ b/JSTests/stress/splay-flash-access.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited || $architecture == "x86"
+//@ memoryHog!
+//@ skip if $architecture == "x86"
 //@ runNoisyTestDefault
 //@ runNoisyTestNoCJIT
 

--- a/JSTests/stress/stack-frame-code-block-offset.js
+++ b/JSTests/stress/stack-frame-code-block-offset.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 class __c_0 {
   constructor() { return __v_20 }
 }

--- a/JSTests/stress/stack-overflow-in-scope-with-catch.js
+++ b/JSTests/stress/stack-overflow-in-scope-with-catch.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 // This tests can easily use more than the 600M that $memoryLimited devices
 // are capped at due JSCTEST_memoryLimit. Skip it to avoid the crash as a

--- a/JSTests/stress/stack-overflow-regexp.js
+++ b/JSTests/stress/stack-overflow-regexp.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 // Test that we do not overflow the stack while handling regular expressions.
 

--- a/JSTests/stress/stress-agent.js
+++ b/JSTests/stress/stress-agent.js
@@ -1,5 +1,5 @@
 //@ skip if $useCompressedHeap
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ skip if $buildType == "debug"
 //@ runDefault("--collectContinuously=1")
 for (let i=0; i<1000; i++) {

--- a/JSTests/stress/string-16bit-repeat-overflow.js
+++ b/JSTests/stress/string-16bit-repeat-overflow.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 var exception;
 try {
     print('\ud000'.repeat(2**31));

--- a/JSTests/stress/string-joining-long-strings-should-not-crash.js
+++ b/JSTests/stress/string-joining-long-strings-should-not-crash.js
@@ -1,5 +1,5 @@
-//@ skip if $memoryLimited
-//@ runDefault if !$memoryLimited
+//@ memoryHog!
+//@ runDefault
 // This test should not crash.
 
 var error;

--- a/JSTests/stress/string-overflow-createError-builder.js
+++ b/JSTests/stress/string-overflow-createError-builder.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 var exception;
 try {

--- a/JSTests/stress/string-overflow-createError-fit.js
+++ b/JSTests/stress/string-overflow-createError-fit.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 var exception;
 try {

--- a/JSTests/stress/string-overflow-createError.js
+++ b/JSTests/stress/string-overflow-createError.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 var exception;
 try {

--- a/JSTests/stress/string-overflow-in-dfg-graph-dump.js
+++ b/JSTests/stress/string-overflow-in-dfg-graph-dump.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--validateAbstractInterpreterState=1", "--jitPolicyScale=0", "--useConcurrentJIT=0")
 
 const s = 'A'.repeat(2**25 * 5);

--- a/JSTests/stress/string-prototype-replace-should-throw-out-of-memory-error-when-using-too-much-memory.js
+++ b/JSTests/stress/string-prototype-replace-should-throw-out-of-memory-error-when-using-too-much-memory.js
@@ -1,5 +1,6 @@
-//@ skip if $memoryLimited or $buildType == "debug"
-//@ runFTLNoCJIT("--timeoutMultiplier=1.5") if !$memoryLimited
+//@ memoryHog!
+//@ skip if $buildType == "debug"
+//@ runFTLNoCJIT("--timeoutMultiplier=1.5")
 //@ slow!
 // This test should not crash or fail any assertions.
 

--- a/JSTests/stress/string-regexp-replace-oom.js
+++ b/JSTests/stress/string-regexp-replace-oom.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $addressBits <= 32
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 //@ runDefault()
 
 Object.__proto__.__proto__[Symbol.replace] = () => {};

--- a/JSTests/stress/test-exception-assert-in-ExceptionHelpers-createError.js
+++ b/JSTests/stress/test-exception-assert-in-ExceptionHelpers-createError.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 
 try {

--- a/JSTests/stress/test-out-of-memory.js
+++ b/JSTests/stress/test-out-of-memory.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 
 const a = [0];

--- a/JSTests/stress/too-large-base64-string.js
+++ b/JSTests/stress/too-large-base64-string.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 function shouldThrow(func, errorMessage) {
     var errorThrown = false;
     var error = null;

--- a/JSTests/stress/try-get-value-without-gc.js
+++ b/JSTests/stress/try-get-value-without-gc.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--watchdog=1000", "--watchdog-exception-ok")
 function main() {
     error = (new Function(`return (function () { arguments.callee.displayName = 'a'.repeat(0x100000) + 'b'; `.repeat(100) + `return new Error();` + ` })();`.repeat(100)))();

--- a/JSTests/stress/typed-array-always-large.js
+++ b/JSTests/stress/typed-array-always-large.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $addressBits <= 32
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 //@ runDefault()
 
 function getArrayLength(array)

--- a/JSTests/stress/typed-array-eventually-large.js
+++ b/JSTests/stress/typed-array-eventually-large.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $addressBits <= 32
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 //@ runDefault()
 
 function getArrayLength(array)

--- a/JSTests/stress/typed-array-filter-oom.js
+++ b/JSTests/stress/typed-array-filter-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 this.g ??= createGlobalObject();
 function f1(a2) {
   function f3() {

--- a/JSTests/stress/typed-array-large-eventually-oob.js
+++ b/JSTests/stress/typed-array-large-eventually-oob.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $addressBits <= 32
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 //@ runDefault()
 function getArrayLength(array)
 {

--- a/JSTests/stress/typed-array-large-slice.js
+++ b/JSTests/stress/typed-array-large-slice.js
@@ -1,4 +1,5 @@
-//@ skip if $memoryLimited or $addressBits <= 32
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 
 let giga = 1024 * 1024 * 1024;
 

--- a/JSTests/stress/typed-array-oom-in-buffer-accessor.js
+++ b/JSTests/stress/typed-array-oom-in-buffer-accessor.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ requireOptions("--useGC=0")
 let z = new Float64Array(1000);
 

--- a/JSTests/stress/typed-array-set.js
+++ b/JSTests/stress/typed-array-set.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault
 let f64 = new Float64Array(2 ** 29);
 f64.__proto__ = new Uint8Array();

--- a/JSTests/stress/typed-array-subarray-can-throw-oom-error.js
+++ b/JSTests/stress/typed-array-subarray-can-throw-oom-error.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ slow!
 
 function foo() {

--- a/JSTests/stress/typedarray-sort-out-of-memory.js
+++ b/JSTests/stress/typedarray-sort-out-of-memory.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 let ar = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 1073741824));
 

--- a/JSTests/stress/unlinked-code-block-destructor.js
+++ b/JSTests/stress/unlinked-code-block-destructor.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ skip if $buildType == "debug"
 //@ runDefault("--destroy-vm", "--forceDebuggerBytecodeGeneration=1", "--returnEarlyFromInfiniteLoopsForFuzzing=1")
 

--- a/JSTests/stress/unshiftCountSlowCase-correct-postCapacity.js
+++ b/JSTests/stress/unshiftCountSlowCase-correct-postCapacity.js
@@ -1,4 +1,5 @@
-//@ if $buildType == "release" && !$memoryLimited then runDefault else skip end
+//@ memoryHog!
+//@ if $buildType == "release" then runDefault else skip end
 
 function temp(i) {
     let a1 = [{}];

--- a/JSTests/stress/v8-deltablue-strict.js
+++ b/JSTests/stress/v8-deltablue-strict.js
@@ -1,5 +1,5 @@
 //@ $skipModes << :lockdown if $buildType == "debug"
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 "use strict";
 

--- a/JSTests/stress/var-injection-cache-invalidation.js
+++ b/JSTests/stress/var-injection-cache-invalidation.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 a = 0;
 

--- a/JSTests/stress/verify-can-gc-node-index.js
+++ b/JSTests/stress/verify-can-gc-node-index.js
@@ -1,5 +1,5 @@
 // Often hits JSCTEST_memoryLimit on ARM with --memory-limited.
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--destroy-vm", "--maximumFunctionForCallInlineCandidateBytecodeCostForDFG=500", "--maximumFunctionForCallInlineCandidateBytecodeCostForFTL=500", "--maximumInliningRecursion=5")
 
 function* gen() {

--- a/JSTests/stress/watchdog-fire-while-in-forEachInIterable.js
+++ b/JSTests/stress/watchdog-fire-while-in-forEachInIterable.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--watchdog=100", "--watchdog-exception-ok")
 
 const a = [];

--- a/JSTests/stress/weakblock-trigger-gc.js
+++ b/JSTests/stress/weakblock-trigger-gc.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--useJIT=0", "--useConcurrentGC=0")
 $vm.gc()
 let start = $vm.totalGCTime()

--- a/JSTests/wasm/function-tests/grow-memory-cause-gc.js
+++ b/JSTests/wasm/function-tests/grow-memory-cause-gc.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 
 import Builder from '../Builder.js';
 import * as assert from '../assert.js';

--- a/JSTests/wasm/gc/array_new_data.js
+++ b/JSTests/wasm/gc/array_new_data.js
@@ -1,3 +1,4 @@
+//@ exclusive!
 //@ $skipModes << :wasm_aggressive_inline if $memoryLimited
 
 // This tests in the :wasm_aggressive_inline test configuration will use more than the

--- a/JSTests/wasm/js-api/test_memory_constructor.js
+++ b/JSTests/wasm/js-api/test_memory_constructor.js
@@ -1,5 +1,5 @@
 // FIXME: use the assert library: https://bugs.webkit.org/show_bug.cgi?id=165684
-//@ skip if $memoryLimited
+//@ memoryHog!
 import Builder from '../Builder.js';
 
 function assert(b) {

--- a/JSTests/wasm/references/multitable.js
+++ b/JSTests/wasm/references/multitable.js
@@ -1,4 +1,5 @@
-//@ if $memoryLimited then skip else requireOptions("--verifyGC=0") end
+//@ memoryHog!
+//@ requireOptions("--verifyGC=0")
 //@ $skipModes << "wasm-no-jit".to_sym if $buildType == "debug"
 
 import * as assert from '../assert.js';

--- a/JSTests/wasm/stress/array-element-creation.js
+++ b/JSTests/wasm/stress/array-element-creation.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefaultWasm("--useConcurrentJIT=0")
 
 function main() {

--- a/JSTests/wasm/stress/block_end_aliasing.js
+++ b/JSTests/wasm/stress/block_end_aliasing.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 //@ runDefaultWasm("--useBBQJIT=0", "--useConcurrentJIT=0", "--thresholdForOMGOptimizeSoon=0", "--thresholdForOMGOptimizeAfterWarmUp=0")
 function instantiate(filename, importObject) {
   let bytes = read(filename, 'binary');

--- a/JSTests/wasm/stress/block_end_aliasing_2.js
+++ b/JSTests/wasm/stress/block_end_aliasing_2.js
@@ -1,4 +1,4 @@
-//@skip if $memoryLimited
+//@ memoryHog!
 //@ runDefaultWasm("--useBBQJIT=0", "--useConcurrentJIT=0", "--thresholdForOMGOptimizeSoon=0", "--thresholdForOMGOptimizeAfterWarmUp=0")
 function instantiate(filename, importObject) {
   let bytes = read(filename, 'binary');

--- a/JSTests/wasm/stress/catch-pinned-registers.js
+++ b/JSTests/wasm/stress/catch-pinned-registers.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefault("--jitPolicyScale=0.1")
 function instantiate(moduleBase64, importObject) {
     let bytes = Uint8Array.fromBase64(moduleBase64);

--- a/JSTests/wasm/stress/enumerator-oom.js
+++ b/JSTests/wasm/stress/enumerator-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefaultWasm("--watchdog=1000", "--watchdog-exception-ok")
 
 function func_1_() {

--- a/JSTests/wasm/stress/externref-result-tuple.js
+++ b/JSTests/wasm/stress/externref-result-tuple.js
@@ -1,4 +1,5 @@
-//@ skip if $addressBits <= 32 or $memoryLimited
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/wasm/stress/initialize-100k-functions.js
+++ b/JSTests/wasm/stress/initialize-100k-functions.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ requireOptions("--useDollarVM=1")
 
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/inline-simd-function.js
+++ b/JSTests/wasm/stress/inline-simd-function.js
@@ -1,5 +1,6 @@
 //@ slow!
-//@ skip if $buildType == "debug" or $memoryLimited
+//@ memoryHog!
+//@ skip if $buildType == "debug"
 //@ $skipModes << "wasm-no-jit".to_sym
 //@ $skipModes << "wasm-no-wasm-jit".to_sym
 //@ $skipModes << "wasm-collect-continuously".to_sym

--- a/JSTests/wasm/stress/only-referenced.js
+++ b/JSTests/wasm/stress/only-referenced.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 (async function () {
   let bytes0 = readFile('./resources/only-referenced.wasm', 'binary');
   let global1 = new WebAssembly.Global({value: 'externref', mutable: true}, {});

--- a/JSTests/wasm/stress/simd-regalloc-stress-2.js
+++ b/JSTests/wasm/stress/simd-regalloc-stress-2.js
@@ -1,5 +1,6 @@
 //@ requireOptions("--useWasmSIMD=1", "--useBBQJIT=1", "--thresholdForBBQOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeSoon=0")
-//@ skip if !$isSIMDPlatform or $memoryLimited
+//@ memoryHog!
+//@ skip if !$isSIMDPlatform
 import * as assert from "../assert.js"
 
 function instantiate(filename, importObject) {

--- a/JSTests/wasm/stress/simple-inline-stacktrace-2.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-2.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefaultWasm("--wasmInliningMaximumDepth=10", "--wasmInliningMaximumWasmCalleeSize=10000000", "--wasmInliningBudget=100000", "--useBBQJIT=0")
 var wasm_code = read('simple-inline-stacktrace.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);

--- a/JSTests/wasm/stress/strcat-bigint-oom.js
+++ b/JSTests/wasm/stress/strcat-bigint-oom.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runDefaultWasm("--watchdog=1000", "--watchdog-exception-ok")
 let b = 2n ** 1000n;
 

--- a/JSTests/wasm/stress/too-many-locals.js
+++ b/JSTests/wasm/stress/too-many-locals.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 import Builder from '../Builder.js'
 import * as assert from '../assert.js'
 

--- a/JSTests/wasm/stress/wasm-js-multi-value-exception-in-iterator.js
+++ b/JSTests/wasm/stress/wasm-js-multi-value-exception-in-iterator.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 import * as assert from '../assert.js';
 import { compile } from "../wabt-wrapper.js";
 

--- a/JSTests/wasm/v8/grow-huge-memory.js
+++ b/JSTests/wasm/v8/grow-huge-memory.js
@@ -1,5 +1,6 @@
 //@ requireOptions("--useBBQJIT=1")
-//@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
+//@ memoryHog!
+//@ skip if ($architecture != "arm64" && $architecture != "x86_64")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/grow-memory.js
+++ b/JSTests/wasm/v8/grow-memory.js
@@ -1,6 +1,6 @@
 //@ requireOptions("--useBBQJIT=1")
 //@ skip if ($architecture != "arm64" && $architecture != "x86_64")
-//@ skip if $memoryLimited
+//@ memoryHog!
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/huge-memory.js
+++ b/JSTests/wasm/v8/huge-memory.js
@@ -1,5 +1,6 @@
 //@ requireOptions("--useBBQJIT=1")
-//@ skip if $memoryLimited or $addressBits <= 32
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/huge-typedarray.js
+++ b/JSTests/wasm/v8/huge-typedarray.js
@@ -1,5 +1,6 @@
 //@ requireOptions("--useBBQJIT=1")
-//@ skip if $memoryLimited or $addressBits <= 32
+//@ memoryHog!
+//@ skip if $addressBits <= 32
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-873600.js
+++ b/JSTests/wasm/v8/regress/regress-873600.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table.js
+++ b/JSTests/wasm/v8/table.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ runV8WebAssemblySuiteQuick(:no_module, "mjsunit.js")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/wast-tests/harness.js
+++ b/JSTests/wasm/wast-tests/harness.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited
+//@ memoryHog!
 //@ skip unless $isSIMDPlatform
 asyncTestStart(1);
 let context = {

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -753,9 +753,9 @@ class TestRunner
         @testRunnerType = testRunnerType
         @runnerDir = runnerDir
     end
-    def prepare(runlist, serialPlans, completedPlans, remoteHosts)
+    def prepare(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts)
         prepareScripts(runlist)
-        prepareRunner(runlist, serialPlans, completedPlans, remoteHosts)
+        prepareRunner(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts)
     end
     def prepareScripts(runlist)
         Dir.mkdir(@runnerDir) unless @runnerDir.directory?
@@ -806,6 +806,7 @@ end
 COLLECT_CONTINUOUSLY_OPTIONS = shouldCollectContinuously? ? ["--collectContinuously=true", "--useGenerationalGC=false", "--verifyGC=true"] : []
 
 $serialPlans = Set.new
+$exclusivePlans = Set.new
 $runlist = []
 
 def frameworkFromJSCPath(jscPath)
@@ -899,6 +900,8 @@ def addRunCommandConfig(config, *additionalEnv)
         # it in the $runlist for code that dosn't care about
         # scheduling.
         $serialPlans.add(plan)
+    elsif $runCommandOptions[:exclusive]
+        $exclusivePlans.add(plan)
     end
 
     if $numChildProcesses > 1 and $runCommandOptions[:isSlow]
@@ -965,6 +968,17 @@ end
 
 def serial!
     $runCommandOptions[:serial] = true
+end
+
+def exclusive!
+    $runCommandOptions[:exclusive] = true
+end
+
+def memoryHog!
+    exclusive!
+    if $memoryLimited
+        skip
+    end
 end
 
 
@@ -3188,7 +3202,7 @@ def runBundle
     raise unless $bundle
 
     testRunner = TestRunner.create($testRunnerType, $runnerDir)
-    evaluator = BundleTestsExecutor.new($runlist, $serialPlans, ITERATION_LIMITS, $treatFailingAsFlaky, testRunner)
+    evaluator = BundleTestsExecutor.new($runlist, $serialPlans, $exclusivePlans, ITERATION_LIMITS, $treatFailingAsFlaky, testRunner)
     evaluator.loop
 end
 
@@ -3197,7 +3211,7 @@ def runTarball
 
     prepareBundle
     testRunner = TestRunner.create($testRunnerType, $runnerDir)
-    testRunner.prepare($runlist, $serialPlans, Set.new, nil)
+    testRunner.prepare($runlist, $serialPlans, $exclusivePlans, Set.new, nil)
     compressBundle
 end
 
@@ -3291,9 +3305,9 @@ class TestRunnerGnuParallel < TestRunner
             }
         }
     end
-    def prepareRunner(runlist, serialPlans, completedPlans, remoteHosts)
-        prepareGnuParallelRunnerJobs("parallel-tests", runlist, completedPlans | serialPlans)
-        prepareGnuParallelRunnerJobs("serial-tests", serialPlans, completedPlans)
+    def prepareRunner(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts)
+        prepareGnuParallelRunnerJobs("parallel-tests", runlist, completedPlans | serialPlans | exclusivePlans)
+        prepareGnuParallelRunnerJobs("serial-tests", serialPlans | exclusivePlans, completedPlans)
     end
 end
 
@@ -3447,8 +3461,8 @@ ExecutorSelfTests.run
 TestResultEvaluatorSelfTests.run
 
 class NonRemoteTestsExecutor < BasicTestsExecutor
-    def initialize(runlist, serialPlans, maxIterationsBounds, treatFailingAsFlaky, testRunner)
-        super(runlist, serialPlans,
+    def initialize(runlist, serialPlans, exclusivePlans, maxIterationsBounds, treatFailingAsFlaky, testRunner)
+        super(runlist, serialPlans, exclusivePlans,
               nil,
               maxIterationsBounds,
               treatFailingAsFlaky
@@ -3458,11 +3472,11 @@ class NonRemoteTestsExecutor < BasicTestsExecutor
     def prepareExecution(remoteHosts)
         remoteHosts
     end
-    def refreshExecution(runlist, serialPlans, completedTests, remoteHosts)
+    def refreshExecution(runlist, serialPlans, exclusivePlans, completedTests, remoteHosts)
         if not @remoteHosts.nil?
             raise "remoteHosts #{@remoteHosts}, expected nil"
         end
-        @testRunner.prepare(runlist, serialPlans, completedTests, remoteHosts)
+        @testRunner.prepare(runlist, serialPlans, exclusivePlans, completedTests, remoteHosts)
     end
 end
 
@@ -3470,7 +3484,7 @@ class NormalTestsExecutor < NonRemoteTestsExecutor
     def prepareArtifacts(remoteHosts)
         raise "remoteHosts not nil" unless remoteHosts.nil?
         prepareBundle
-        @testRunner.prepare(@runlist, @serialPlans, Set.new, nil)
+        @testRunner.prepare(@runlist, @serialPlans, @exclusivePlans, Set.new, nil)
     end
     def executeTests(remoteHosts)
         runTestRunner(@testRunner, nil, nil)
@@ -3497,21 +3511,21 @@ class BundleTestsExecutor < NonRemoteTestsExecutor
 end
 
 class BaseRemoteTestsExecutor < BasicTestsExecutor
-    def initialize(runlist, serialPlans, remoteHosts, iterationLimits,
+    def initialize(runlist, serialPlans, exclusivePlans, remoteHosts, iterationLimits,
                    treatFailingAsFlaky, testRunner)
-        super(runlist, serialPlans, remoteHosts, iterationLimits, treatFailingAsFlaky)
+        super(runlist, serialPlans, exclusivePlans, remoteHosts, iterationLimits, treatFailingAsFlaky)
         @testRunner = testRunner
     end
     def updateStatusMap(iteration, statusMap)
         return getStatusMap(statusMap)
     end
-    def refreshExecution(runlist, serialPlans, completedTests, remoteHosts)
+    def refreshExecution(runlist, serialPlans, exclusivePlans, completedTests, remoteHosts)
         # Note, when running tests remotely, we always prepare tests
         # for all the hosts when refreshing execution, as even hosts
         # that went away during testing may have come back online in
         # the meantime -- so we don't expect a list of live remote
         # hosts to be passed in.
-        @testRunner.prepare(runlist, serialPlans, completedTests, remoteHosts)
+        @testRunner.prepare(runlist, serialPlans, exclusivePlans, completedTests, remoteHosts)
     end
 end
 
@@ -3525,17 +3539,17 @@ class RemoteTestsExecutor < BaseRemoteTestsExecutor
         # always end up scheduling tests on dead remotes and hamper
         # our progress.
         remoteHosts = getLiveRemoteHosts(remoteHosts)
-        @testRunner.prepare(@runlist, @serialPlans, Set.new, remoteHosts)
+        @testRunner.prepare(@runlist, @serialPlans, @exclusivePlans, Set.new, remoteHosts)
         compressBundle
         remoteHosts
     end
     def prepareExecution(remoteHosts)
         return prepareRemotes(remoteHosts)
     end
-    def refreshExecution(runlist, serialPlans, completedTests, remoteHosts)
+    def refreshExecution(runlist, serialPlans, exclusivePlans, completedTests, remoteHosts)
         # Don't assign tests to remotes that are down.
         remoteHosts = getLiveRemoteHosts(remoteHosts)
-        super(runlist, serialPlans, completedTests, remoteHosts)
+        super(runlist, serialPlans, exclusivePlans, completedTests, remoteHosts)
     end
     def executeTests(remoteHosts)
         forEachRemote(remoteHosts, :dropOnFailure => true) {
@@ -3562,7 +3576,7 @@ end
 class GnuParallelTestsExecutor < BaseRemoteTestsExecutor
     def prepareArtifacts(remoteHosts)
         prepareBundle
-        @testRunner.prepare(@runlist, @serialPlans, Set.new, remoteHosts)
+        @testRunner.prepare(@runlist, @serialPlans, @exclusivePlans, Set.new, remoteHosts)
         compressBundle
     end
     def prepareExecution(remoteHosts)
@@ -3579,7 +3593,7 @@ def runNormal
     raise if $bundle or $tarball
 
     testRunner = TestRunner.create($testRunnerType, $runnerDir)
-    evaluator = NormalTestsExecutor.new($runlist, $serialPlans, ITERATION_LIMITS,
+    evaluator = NormalTestsExecutor.new($runlist, $serialPlans, $exclusivePlans, ITERATION_LIMITS,
                                         $treatFailingAsFlaky, testRunner)
     statusMap = evaluator.loop
     detectFailures(statusMap)
@@ -3590,7 +3604,7 @@ def runRemote
     raise unless $remote
 
     testRunner = TestRunner.create($testRunnerType, $runnerDir)
-    executor = RemoteTestsExecutor.new($runlist, $serialPlans, $remoteHosts, ITERATION_LIMITS, $treatFailingAsFlaky, testRunner)
+    executor = RemoteTestsExecutor.new($runlist, $serialPlans, $exclusivePlans, $remoteHosts, ITERATION_LIMITS, $treatFailingAsFlaky, testRunner)
     statusMap = executor.loop
     detectFailures(statusMap)
 end
@@ -3599,7 +3613,7 @@ def runGnuParallel
     raise "Can only use --gnu-parallel-runner with --remote*" unless $remote
     raise "Can only use --gnu-parallel-runner with the default writer" unless $testWriter == "default"
     testRunner = TestRunner.create($testRunnerType, $runnerDir)
-    executor = GnuParallelTestsExecutor.new($runlist, $serialPlans,
+    executor = GnuParallelTestsExecutor.new($runlist, $serialPlans, $exclusivePlans,
                                             $remoteHosts, ITERATION_LIMITS,
                                             $treatFailingAsFlaky, testRunner)
     statusMap = executor.loop

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
@@ -325,7 +325,7 @@ class TestRunnerShell < TestRunner
         super(testRunnerType, runnerDir)
         @testListPath = runnerDir + 'testlist'
     end
-    def prepareRunner(runlist, serialPlans, completedPlans, remoteHosts)
+    def prepareRunner(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts)
         FileUtils.cp SCRIPTS_PATH + "jsc-stress-test-helpers" + "shell-runner.sh", @runnerDir + "runscript"
         File.open(@testListPath, "w") { |f|
             runlist.each { |plan|
@@ -349,7 +349,7 @@ class TestRunnerMake < TestRunner
         outp.puts "\tsh test_script_#{index}"
         target
     end
-    def prepareRunnerForRemote(runlist, serialPlans, completedPlans, remoteHosts, remoteIndex)
+    def prepareRunnerForRemote(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts, remoteIndex)
         # The goals of our parallel test runner are scalability and simplicity. The
         # simplicity part is particularly important. We don't want to have to have
         # a full-time contributor just philosophising about parallel testing.
@@ -357,11 +357,14 @@ class TestRunnerMake < TestRunner
         # As such, we just pass off all of the hard work to 'make'. This
         # creates a dummy directory ("$outputDir/.runner") in which we
         # create a dummy Makefile. The Makefile has a 'parallel' rule that
-        # depends all tests, other than the ones marked 'serial'. The
-        # serial tests are arranged in a chain; the last target in the
-        # serial chain depends on 'parallel' and 'all' depends on the head
-        # of the chain. Running 'make -j <whatever>' on this Makefile
-        # results in 'make' doing all of the hard work:
+        # depends all tests, other than the ones marked 'serial' or
+        # 'exclusive'. The serial tests are arranged in a chain; the last
+        # target in the serial chain depends on 'parallel' and 'all'
+        # depends on the head of the chain. The exclusive tests are
+        # arranged in their own chain, independent of 'parallel', so they
+        # can run concurrently with parallel tests but only one exclusive
+        # test runs at a time. Running 'make -j <whatever>' on this
+        # Makefile results in 'make' doing all of the hard work:
         #
         # - Load balancing just works. Most systems have a great load balancer in
         #   'make'. If your system doesn't then just install a real 'make'.
@@ -388,6 +391,7 @@ class TestRunnerMake < TestRunner
         # files we won't miss any failures.
         runPlans = []
         serialRunPlans = []
+        exclusiveRunPlans = []
         runlist.each {
             | plan |
             if completedPlans.include?(plan)
@@ -396,6 +400,8 @@ class TestRunnerMake < TestRunner
             if remoteHosts.nil? or plan.index % remoteHosts.length == remoteIndex
                 if serialPlans.include?(plan)
                     serialRunPlans << plan
+                elsif exclusivePlans.include?(plan)
+                    exclusiveRunPlans << plan
                 else
                     runPlans << plan
                 end
@@ -404,17 +410,36 @@ class TestRunnerMake < TestRunner
 
         File.open(@runnerDir + "Makefile.#{remoteIndex}", "w") {
             | outp |
+            all_deps = []
+
             if serialRunPlans.empty?
-                outp.puts("all: parallel")
+                all_deps << "parallel"
             else
-                serialPrereq = "test_done_#{serialRunPlans[-1].index}"
-                outp.puts("all: #{serialPrereq}")
+                all_deps << "test_done_#{serialRunPlans[-1].index}"
+            end
+
+            if !exclusiveRunPlans.empty?
+                all_deps << "test_done_#{exclusiveRunPlans[-1].index}"
+            end
+
+            outp.puts("all: " + all_deps.join(" "))
+
+            if !serialRunPlans.empty?
                 prev_target = "parallel"
                 serialRunPlans.each {
                     | plan |
                     prev_target = output_target(outp, plan, [prev_target])
                 }
             end
+
+            if !exclusiveRunPlans.empty?
+                prev_target = nil
+                exclusiveRunPlans.each {
+                    | plan |
+                    prev_target = output_target(outp, plan, prev_target ? [prev_target] : [])
+                }
+            end
+
             parallelTargets = runPlans.collect {
                 | plan |
                 output_target(outp, plan, [])
@@ -422,13 +447,13 @@ class TestRunnerMake < TestRunner
             outp.puts("parallel: " + parallelTargets.join(" "))
         }
     end
-    def prepareRunner(runlist, serialPlans, completedPlans, remoteHosts)
+    def prepareRunner(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts)
         if remoteHosts.nil?
-            prepareRunnerForRemote(runlist, serialPlans, completedPlans, remoteHosts, 0)
+            prepareRunnerForRemote(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts, 0)
         else
             remoteHosts.each_index {
                 |remoteIndex|
-                prepareRunnerForRemote(runlist, serialPlans, completedPlans, remoteHosts, remoteIndex)
+                prepareRunnerForRemote(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts, remoteIndex)
             }
         end
     end
@@ -438,7 +463,7 @@ class TestRunnerMake < TestRunner
 end
 
 class TestRunnerRuby < TestRunner
-    def prepareRunner(runlist, serialPlans, completedPlans, remoteHosts)
+    def prepareRunner(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts)
         File.open(@runnerDir + "runscript", "w") {
             | outp |
             runlist.each {

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-playstation.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-playstation.rb
@@ -387,7 +387,7 @@ def preparePlayStationTestRunner(runlist, serialPlans, completedPlans)
 end
 
 class PlaystationTestRunner < TestRunner
-    def prepareRunner(runlist, serialPlans, completedPlans, remoteHosts)
+    def prepareRunner(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts)
         File.open(@runnerDir + "runscript", "w") {
             | outp |
             runlist.each {

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb
@@ -381,7 +381,7 @@ class Plan < BasePlan
 end
 
 class TestRunnerShell < TestRunner
-    def prepareRunner(runlist, serialPlans, completedPlans, remoteHosts)
+    def prepareRunner(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts)
         File.open("#{@runnerDir + "runscript"}", "w") { |f|
             runlist.each { |plan|
                 if completedPlans.include?(plan)
@@ -405,9 +405,10 @@ class TestRunnerMake < TestRunner
         outp.puts "\truby test_script_#{index}"
         target
     end
-    def prepareRunnerForRemote(runlist, serialPlans, completedPlans, remoteIndex)
+    def prepareRunnerForRemote(runlist, serialPlans, exclusivePlans, completedPlans, remoteIndex)
         runPlans = []
         serialRunPlans = []
+        exclusiveRunPlans = []
         runlist.each {
             | plan |
             if completedPlans.include?(plan)
@@ -416,6 +417,8 @@ class TestRunnerMake < TestRunner
             if @remoteHosts.nil? or plan.index % @remoteHosts.length == remoteIndex
                 if serialPlans.include?(plan)
                     serialRunPlans << plan
+                elsif exclusivePlans.include?(plan)
+                    exclusiveRunPlans << plan
                 else
                     runPlans << plan
                 end
@@ -424,17 +427,36 @@ class TestRunnerMake < TestRunner
 
         File.open(@runnerDir + "Makefile.#{remoteIndex}", "w") {
             | outp |
+            all_deps = []
+
             if serialRunPlans.empty?
-                outp.puts("all: parallel")
+                all_deps << "parallel"
             else
-                serialPrereq = "test_done_#{serialRunPlans[-1].index}"
-                outp.puts("all: #{serialPrereq}")
+                all_deps << "test_done_#{serialRunPlans[-1].index}"
+            end
+
+            if !exclusiveRunPlans.empty?
+                all_deps << "test_done_#{exclusiveRunPlans[-1].index}"
+            end
+
+            outp.puts("all: " + all_deps.join(" "))
+
+            if !serialRunPlans.empty?
                 prev_target = "parallel"
                 serialRunPlans.each {
                     | plan |
                     prev_target = output_target(outp, plan, [prev_target])
                 }
             end
+
+            if !exclusiveRunPlans.empty?
+                prev_target = nil
+                exclusiveRunPlans.each {
+                    | plan |
+                    prev_target = output_target(outp, plan, prev_target ? [prev_target] : [])
+                }
+            end
+
             parallelTargets = runPlans.collect {
                 | plan |
                 output_target(outp, plan, [])
@@ -442,13 +464,13 @@ class TestRunnerMake < TestRunner
             outp.puts("parallel: " + parallelTargets.join(" "))
         }
     end
-    def prepareRunner(runlist, serialPlans, completedPlans, remoteHosts)
+    def prepareRunner(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts)
         if remoteHosts.nil?
-            prepareRunnerForRemote(runlist, serialPlans, completedPlans, 0)
+            prepareRunnerForRemote(runlist, serialPlans, exclusivePlans, completedPlans, 0)
         else
             remoteHosts.each_index {
                 |remoteIndex|
-                prepareRunnerForRemote(runlist, serialPlans, completedPlans, remoteIndex)
+                prepareRunnerForRemote(runlist, serialPlans, exclusivePlans, completedPlans, remoteIndex)
             }
         end
     end
@@ -458,7 +480,7 @@ class TestRunnerMake < TestRunner
 end
 
 class TestRunnerRuby < TestRunner
-    def prepareRunner(runlist, serialPlans, completedPlans, remoteHosts)
+    def prepareRunner(runlist, serialPlans, exclusivePlans, completedPlans, remoteHosts)
         File.open(@runnerDir + "runscript", "w") {
             | outp |
             runlist.each {

--- a/Tools/Scripts/webkitruby/jsc-stress-test/executor.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test/executor.rb
@@ -27,10 +27,11 @@
 # --treat-failing-as-flaky is in effect. It's a class so that we can
 # easily instantiate a subclass for testing.
 class BaseTestsExecutor
-    def initialize(runlist, serialPlans, remoteHosts, iterationLimits,
+    def initialize(runlist, serialPlans, exclusivePlans, remoteHosts, iterationLimits,
                    treatFailingAsFlaky, logStream=$stderr)
         @runlist = runlist
         @serialPlans = serialPlans
+        @exclusivePlans = exclusivePlans
         @remoteHosts = remoteHosts
         @treatFailingAsFlaky = treatFailingAsFlaky
         @infraIterationsFloor = iterationLimits.infraIterationsFloor
@@ -162,7 +163,7 @@ class BaseTestsExecutor
             end
 
             # Regenerate the lists of tests to run
-            refreshExecution(@runlist, @serialPlans, completedTests, @remoteHosts)
+            refreshExecution(@runlist, @serialPlans, @exclusivePlans, completedTests, @remoteHosts)
 
             numFlaky = @runlist.size - completedTests.size - evaluator.missing.size
             testsInfo = "completed #{completedTests.size}/#{@runlist.size} (#{numFlaky} flaky, #{evaluator.missing.size} missing)"
@@ -210,7 +211,7 @@ module ExecutorSelfTests
     class MockTestsExecutor < BaseTestsExecutor
         attr_reader :executedIterations
         def initialize(runlist, iterationResults, maxIterationsBounds, treatFailingAsFlaky, logStream)
-            super(runlist, [], nil, maxIterationsBounds, treatFailingAsFlaky, logStream)
+            super(runlist, [], Set.new, nil, maxIterationsBounds, treatFailingAsFlaky, logStream)
             @iterationResults = iterationResults
             @executedIterations = 0
             @remainingRetrySeconds = nil
@@ -249,7 +250,7 @@ module ExecutorSelfTests
             putd("statusMap: #{statusMap}")
             statusMap
         end
-        def refreshExecution(runlist, serialPlans, completedTests, remoteHosts)
+        def refreshExecution(runlist, serialPlans, exclusivePlans, completedTests, remoteHosts)
         end
     end
 


### PR DESCRIPTION
#### 6cf1b3714e4f3f8b468b229fec09634f3f825a6e
<pre>
[JSC] Add &quot;exclusive&quot; type to JSC stress tests and add &quot;memoryHog!&quot; annotation
<a href="https://bugs.webkit.org/show_bug.cgi?id=312090">https://bugs.webkit.org/show_bug.cgi?id=312090</a>
<a href="https://rdar.apple.com/174593586">rdar://174593586</a>

Reviewed by NOBODY (OOPS!).

This patch introduces &quot;exclusive&quot; mechanism into JSC stress tests.
The condition is, (1) any tests in &quot;exclusive&quot; condition cannot run
concurrently, but (2) they can run with the other condition&apos;s tests.
We introduce this since we want to run memory-hog tests exclusively to
make its reliability better.
Also, we add memoryHog!: skip a test when $memoryLimited is set.
Otherwise, setting it as exclusive!.

* JSTests/microbenchmarks/array-from-derived-object-func.js:
* JSTests/microbenchmarks/array-from-object-func.js:
* JSTests/microbenchmarks/bigint64-array-index-of-large.js:
* JSTests/microbenchmarks/bigint64-array-index-of-medium.js:
* JSTests/microbenchmarks/bigint64-array-index-of-small.js:
* JSTests/microbenchmarks/biguint64-array-index-of-large.js:
* JSTests/microbenchmarks/biguint64-array-index-of-medium.js:
* JSTests/microbenchmarks/biguint64-array-index-of-small.js:
* JSTests/microbenchmarks/float32-array-index-of-large.js:
* JSTests/microbenchmarks/float32-array-index-of-medium.js:
* JSTests/microbenchmarks/float32-array-index-of-small.js:
* JSTests/microbenchmarks/float64-array-index-of-large.js:
* JSTests/microbenchmarks/float64-array-index-of-medium.js:
* JSTests/microbenchmarks/float64-array-index-of-small.js:
* JSTests/microbenchmarks/get-private-name.js:
* JSTests/microbenchmarks/int32-array-index-of-large.js:
* JSTests/microbenchmarks/int32-array-index-of-medium.js:
* JSTests/microbenchmarks/int32-array-index-of-small.js:
* JSTests/microbenchmarks/jquery-todomvc-regexp.js:
* JSTests/microbenchmarks/large-empty-array-join.js:
* JSTests/microbenchmarks/loop-unrolling-array-clone-big.js:
* JSTests/microbenchmarks/loop-unrolling-array-clone-small.js:
* JSTests/microbenchmarks/loop-unrolling-constant-small.js:
* JSTests/microbenchmarks/loop-unrolling-variable-large.js:
* JSTests/microbenchmarks/loop-unrolling-variable-medium-dep.js:
* JSTests/microbenchmarks/loop-unrolling-variable-medium.js:
* JSTests/microbenchmarks/loop-unrolling-variable-small.js:
* JSTests/microbenchmarks/lots-of-fields.js:
* JSTests/microbenchmarks/mul-immediate-sub.js:
* JSTests/microbenchmarks/put-by-val-direct-large-index.js:
* JSTests/microbenchmarks/set-delete-add.js:
* JSTests/microbenchmarks/string-index-of-10000001-404.js:
* JSTests/microbenchmarks/string-index-of-10000001-beg.js:
* JSTests/microbenchmarks/string-index-of-10000001-end.js:
* JSTests/microbenchmarks/string-index-of-10000001-mid.js:
* JSTests/microbenchmarks/string-index-of-1000001-404.js:
* JSTests/microbenchmarks/string-index-of-1000001-beg.js:
* JSTests/microbenchmarks/string-index-of-1000001-end.js:
* JSTests/microbenchmarks/string-index-of-1000001-mid.js:
* JSTests/microbenchmarks/string-index-of-100001-404.js:
* JSTests/microbenchmarks/string-index-of-100001-beg.js:
* JSTests/microbenchmarks/string-index-of-100001-end.js:
* JSTests/microbenchmarks/string-index-of-100001-mid.js:
* JSTests/microbenchmarks/string-index-of-10001-404.js:
* JSTests/microbenchmarks/string-index-of-10001-beg.js:
* JSTests/microbenchmarks/string-index-of-10001-end.js:
* JSTests/microbenchmarks/string-index-of-10001-mid.js:
* JSTests/microbenchmarks/string-index-of-1001-404.js:
* JSTests/microbenchmarks/string-index-of-1001-beg.js:
* JSTests/microbenchmarks/string-index-of-1001-end.js:
* JSTests/microbenchmarks/string-index-of-1001-mid.js:
* JSTests/microbenchmarks/string-index-of-101-404.js:
* JSTests/microbenchmarks/string-index-of-101-beg.js:
* JSTests/microbenchmarks/string-index-of-101-end.js:
* JSTests/microbenchmarks/string-index-of-101-mid.js:
* JSTests/microbenchmarks/string-index-of-11-404.js:
* JSTests/microbenchmarks/string-index-of-11-beg.js:
* JSTests/microbenchmarks/string-index-of-11-end.js:
* JSTests/microbenchmarks/string-index-of-11-mid.js:
* JSTests/microbenchmarks/typed-array-from-array.js:
* JSTests/microbenchmarks/u16-string-index-of-10000001-404.js:
* JSTests/microbenchmarks/u16-string-index-of-10000001-beg.js:
* JSTests/microbenchmarks/u16-string-index-of-10000001-end.js:
* JSTests/microbenchmarks/u16-string-index-of-10000001-mid.js:
* JSTests/mozilla/mozilla-tests.yaml:
* JSTests/slowMicrobenchmarks/dense-set.js:
* JSTests/slowMicrobenchmarks/function-constructor-with-huge-strings.js:
* JSTests/slowMicrobenchmarks/map-constant-key.js:
* JSTests/stress/PrintStream-truncation-for-extremely-long-strings.js:
* JSTests/stress/StringObject-define-length-getter-rope-string-oom.js:
* JSTests/stress/array-buffer-view-watchpoint-can-be-fired-in-really-add-in-dfg.js:
* JSTests/stress/array-prototype-concat-of-long-spliced-arrays.js:
* JSTests/stress/array-prototype-concat-of-long-spliced-arrays2.js:
* JSTests/stress/array-reverse-doesnt-clobber.js:
* JSTests/stress/array-sink-materialize-cycle-break-in-exit-invalid.js:
* JSTests/stress/atob-btoa-oom-check.js:
* JSTests/stress/big-int-constructor-oom.js:
* JSTests/stress/big-wasm-memory-grow-no-max.js:
* JSTests/stress/big-wasm-memory-grow.js:
* JSTests/stress/big-wasm-memory.js:
* JSTests/stress/bigdecimal-identifiers-fail-on-oom.js:
* JSTests/stress/bigint-can-throw-oom.js:
* JSTests/stress/bounds-checking-in-cold-loop.js:
* JSTests/stress/btoa-string-overflow.js:
* JSTests/stress/call-varargs-inlining-should-not-clobber-previous-to-free-register.js:
* JSTests/stress/check-is-constant-non-cell-should-not-array-profile-during-osr-exit.js:
* JSTests/stress/check-stack-overflow-before-value-profiling-arguments.js:
* JSTests/stress/codeblock-destructor-access-unlinkedcodeblock.js:
* JSTests/stress/constructFunctionSkippingEvalEnabledCheck-should-throw-out-of-memory-error.js:
* JSTests/stress/create-error-out-of-memory-rope-string.js:
* JSTests/stress/data-view-byte-length-oob-exit.js:
* JSTests/stress/dataview-byte-length-large-array-oob-baseline.js:
* JSTests/stress/dataview-byte-length-large-array-oob.js:
* JSTests/stress/dataview-byte-length-large-array.js:
* JSTests/stress/describe-huge-strings.js:
* JSTests/stress/dont-reserve-huge-capacity-lexer.js:
* JSTests/stress/eval-huge-big-int-memory-overflow.js:
* JSTests/stress/exception-checks-before-and-after-viewwithunderlyingstring.js:
* JSTests/stress/exhaust-gigacage-and-allocate-vm.js:
* JSTests/stress/fast-stringifier-check-string-length.js:
* JSTests/stress/force-string-array-or-string.js:
* JSTests/stress/function-name-too-long-to-reify.js:
* JSTests/stress/get-array-length-reuse.js:
* JSTests/stress/get-own-property-descriptors-oom.js:
* JSTests/stress/has-own-property-name-cache-string-keys.js:
* JSTests/stress/has-own-property-name-cache-symbol-keys.js:
* JSTests/stress/incremental-marking-should-not-dead-lock-in-new-property-transition.js:
* JSTests/stress/intl-canonicalize-locale-list-error-oom.js:
* JSTests/stress/intl-data-time-format-string-overflow.js:
* JSTests/stress/joined-strings-should-not-exceed-max-string-length.js:
* JSTests/stress/js-fixed-array-out-of-memory.js:
* JSTests/stress/json-stringified-overflow-2.js:
* JSTests/stress/json-stringified-overflow.js:
* JSTests/stress/json-stringify-out-of-memory.js:
* JSTests/stress/json-stringify-stack-overflow.js:
* JSTests/stress/json-stringify-string-builder-overflow.js:
* JSTests/stress/large-string-should-not-crash-error-creation.js:
* JSTests/stress/large-unshift-splice.js:
* JSTests/stress/literal-parser-error-message-oom.js:
* JSTests/stress/make-large-string-jit-strcat.js:
* JSTests/stress/make-large-string-jit.js:
* JSTests/stress/make-large-string-strcat.js:
* JSTests/stress/make-large-string.js:
* JSTests/stress/make-rope-overflow-nested-catch.js:
* JSTests/stress/make-rope-overflow-nested.js:
* JSTests/stress/many-substrings-of-rope-shouldnt-use-excessive-memory.js:
* JSTests/stress/map-forEach.js:
* JSTests/stress/map-rehash-oom.js:
* JSTests/stress/max-typed-array-length-toString.js:
* JSTests/stress/missing-exception-check-in-JSValue-toWTFStringSlowCase.js:
* JSTests/stress/missing-exception-check-in-json-stringifier-gap.js:
* JSTests/stress/numberingSystemsForLocale-cached-strings-should-be-immortal-and-safe-for-concurrent-access.js:
* JSTests/stress/operationSwitchCharWithUnknownKeyType-should-avoid-resolving-rope-strings.js:
* JSTests/stress/operationSwitchCharWithUnknownKeyType-should-avoid-resolving-rope-strings2.js:
* JSTests/stress/out-of-memory-handle-in-join.js:
* JSTests/stress/out-of-memory-in-globalFuncUnescape.js:
* JSTests/stress/out-of-memory-in-intl-segmenter.js:
* JSTests/stress/out-of-memory-making-error-string-in-literal-parser.js:
* JSTests/stress/out-of-memory-while-constructing-BytecodeGenerator.js:
* JSTests/stress/out-of-memory-while-describing-symbol-for-error.js:
* JSTests/stress/own-property-names-oom.js:
* JSTests/stress/pretty-print-oom.js:
* JSTests/stress/race-to-add-opaque-roots-in-ConcurrentPtrHashSet.js:
* JSTests/stress/re-enter-resolve-rope-string.js:
* JSTests/stress/regexp-accumulatedResult-overflow.js:
* JSTests/stress/regexp-bol-optimize-out-of-stack.js:
* JSTests/stress/regexp-escape-oom.js:
* JSTests/stress/regexp-huge-oom.js:
* JSTests/stress/regexp-quantify-atom-copy-term-out-of-stack.js:
* JSTests/stress/regress-109102631.js:
* JSTests/stress/regress-178385.js:
* JSTests/stress/regress-185888.js:
* JSTests/stress/regress-189132.js:
* JSTests/stress/regress-190187.js:
* JSTests/stress/regress-191563.js:
* JSTests/stress/regress-192717.js:
* JSTests/stress/regress-84402043.js:
* JSTests/stress/sampling-profiler-richards.js:
* JSTests/stress/scoped-arguments-table-should-be-tolerant-for-oom.js:
* JSTests/stress/set-rehash-oom.js:
* JSTests/stress/splay-flash-access-1ms.js:
* JSTests/stress/splay-flash-access.js:
* JSTests/stress/stack-frame-code-block-offset.js:
* JSTests/stress/stack-overflow-in-scope-with-catch.js:
* JSTests/stress/stack-overflow-regexp.js:
* JSTests/stress/stress-agent.js:
* JSTests/stress/string-16bit-repeat-overflow.js:
* JSTests/stress/string-joining-long-strings-should-not-crash.js:
* JSTests/stress/string-overflow-createError-builder.js:
* JSTests/stress/string-overflow-createError-fit.js:
* JSTests/stress/string-overflow-createError.js:
* JSTests/stress/string-overflow-in-dfg-graph-dump.js:
* JSTests/stress/string-prototype-replace-should-throw-out-of-memory-error-when-using-too-much-memory.js:
* JSTests/stress/string-regexp-replace-oom.js:
* JSTests/stress/test-exception-assert-in-ExceptionHelpers-createError.js:
* JSTests/stress/test-out-of-memory.js:
* JSTests/stress/too-large-base64-string.js:
* JSTests/stress/try-get-value-without-gc.js:
* JSTests/stress/typed-array-always-large.js:
* JSTests/stress/typed-array-eventually-large.js:
* JSTests/stress/typed-array-filter-oom.js:
* JSTests/stress/typed-array-large-eventually-oob.js:
* JSTests/stress/typed-array-large-slice.js:
* JSTests/stress/typed-array-oom-in-buffer-accessor.js:
* JSTests/stress/typed-array-set.js:
* JSTests/stress/typed-array-subarray-can-throw-oom-error.js:
* JSTests/stress/typedarray-sort-out-of-memory.js:
* JSTests/stress/unlinked-code-block-destructor.js:
* JSTests/stress/unshiftCountSlowCase-correct-postCapacity.js:
* JSTests/stress/v8-deltablue-strict.js:
* JSTests/stress/var-injection-cache-invalidation.js:
* JSTests/stress/verify-can-gc-node-index.js:
* JSTests/stress/watchdog-fire-while-in-forEachInIterable.js:
* JSTests/stress/weakblock-trigger-gc.js:
* JSTests/wasm/function-tests/grow-memory-cause-gc.js:
* JSTests/wasm/gc/array_new_data.js:
* JSTests/wasm/js-api/test_memory_constructor.js:
* JSTests/wasm/references/multitable.js:
* JSTests/wasm/stress/array-element-creation.js:
* JSTests/wasm/stress/block_end_aliasing.js:
* JSTests/wasm/stress/block_end_aliasing_2.js:
* JSTests/wasm/stress/catch-pinned-registers.js:
* JSTests/wasm/stress/enumerator-oom.js:
* JSTests/wasm/stress/externref-result-tuple.js:
* JSTests/wasm/stress/initialize-100k-functions.js:
* JSTests/wasm/stress/inline-simd-function.js:
* JSTests/wasm/stress/only-referenced.js:
* JSTests/wasm/stress/simd-regalloc-stress-2.js:
* JSTests/wasm/stress/simple-inline-stacktrace-2.js:
* JSTests/wasm/stress/strcat-bigint-oom.js:
* JSTests/wasm/stress/too-many-locals.js:
* JSTests/wasm/stress/wasm-js-multi-value-exception-in-iterator.js:
* JSTests/wasm/v8/grow-huge-memory.js:
* JSTests/wasm/v8/grow-memory.js:
* JSTests/wasm/v8/huge-memory.js:
* JSTests/wasm/v8/huge-typedarray.js:
* JSTests/wasm/v8/regress/regress-873600.js:
* JSTests/wasm/v8/table.js:
* JSTests/wasm/wast-tests/harness.js:
* Tools/Scripts/run-jsc-stress-tests:
* Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb:
* Tools/Scripts/webkitruby/jsc-stress-test-writer-playstation.rb:
* Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb:
* Tools/Scripts/webkitruby/jsc-stress-test/executor.rb:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cf1b3714e4f3f8b468b229fec09634f3f825a6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156116 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/29451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157987 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/29584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/29452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/164937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159074 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/29584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/22633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/29584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/29452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/12709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/148166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/29584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/22633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16950 "Built successfully and passed tests") | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/167416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/29452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/28974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/22633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23766 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/28974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/187999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/28683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/187999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->