### PR TITLE
[MediaCapabilities] Check MIME Type Validity should reject MIME types with extra parameters

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.any-expected.txt
@@ -8,7 +8,7 @@ PASS Test that decodingInfo rejects if the video configuration has a framerate s
 PASS Test that decodingInfo rejects if the video configuration has a framerate set to Infinity
 PASS Test that decodingInfo rejects if the video configuration contentType doesn't parse
 PASS Test that decodingInfo rejects if the video configuration contentType isn't of type video
-FAIL Test that decodingInfo rejects if the video configuration contentType has more than one parameter assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that decodingInfo rejects if the video configuration contentType has more than one parameter
 PASS Test that decodingInfo rejects if the video configuration contentType has one parameter that isn't codecs
 PASS Test that decodingInfo() rejects framerate in the form of x/y
 PASS Test that decodingInfo() rejects framerate in the form of x/0
@@ -19,7 +19,7 @@ PASS Test that decodingInfo() rejects framerate in the form of x/
 PASS Test that decodingInfo() rejects framerate with trailing unallowed characters
 PASS Test that decodingInfo rejects if the audio configuration contenType doesn't parse
 PASS Test that decodingInfo rejects if the audio configuration contentType isn't of type audio
-FAIL Test that decodingInfo rejects if the audio configuration contentType has more than one parameters assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that decodingInfo rejects if the audio configuration contentType has more than one parameters
 PASS Test that decodingInfo rejects if the audio configuration contentType has one parameter that isn't codecs
 FAIL Test that decodingInfo returns a valid MediaCapabilitiesInfo objects assert_equals: expected "object" but got "undefined"
 PASS Test that decodingInfo rejects if the MediaConfiguration does not have a valid type

--- a/LayoutTests/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.any.worker-expected.txt
@@ -8,7 +8,7 @@ PASS Test that decodingInfo rejects if the video configuration has a framerate s
 PASS Test that decodingInfo rejects if the video configuration has a framerate set to Infinity
 PASS Test that decodingInfo rejects if the video configuration contentType doesn't parse
 PASS Test that decodingInfo rejects if the video configuration contentType isn't of type video
-FAIL Test that decodingInfo rejects if the video configuration contentType has more than one parameter assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that decodingInfo rejects if the video configuration contentType has more than one parameter
 PASS Test that decodingInfo rejects if the video configuration contentType has one parameter that isn't codecs
 PASS Test that decodingInfo() rejects framerate in the form of x/y
 PASS Test that decodingInfo() rejects framerate in the form of x/0
@@ -19,7 +19,7 @@ PASS Test that decodingInfo() rejects framerate in the form of x/
 PASS Test that decodingInfo() rejects framerate with trailing unallowed characters
 PASS Test that decodingInfo rejects if the audio configuration contenType doesn't parse
 PASS Test that decodingInfo rejects if the audio configuration contentType isn't of type audio
-FAIL Test that decodingInfo rejects if the audio configuration contentType has more than one parameters assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that decodingInfo rejects if the audio configuration contentType has more than one parameters
 PASS Test that decodingInfo rejects if the audio configuration contentType has one parameter that isn't codecs
 FAIL Test that decodingInfo returns a valid MediaCapabilitiesInfo objects assert_equals: expected "object" but got "undefined"
 PASS Test that decodingInfo rejects if the MediaConfiguration does not have a valid type

--- a/LayoutTests/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.any-expected.txt
@@ -8,7 +8,7 @@ PASS Test that encodingInfo rejects if the video configuration has a framerate s
 PASS Test that encodingInfo rejects if the video configuration has a framerate set to Infinity
 PASS Test that encodingInfo rejects if the video configuration contentType doesn't parse
 PASS Test that encodingInfo rejects if the video configuration contentType isn't of type video
-FAIL Test that encodingInfo rejects if the video configuration contentType has more than one parameter assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that encodingInfo rejects if the video configuration contentType has more than one parameter
 PASS Test that encodingInfo rejects if the video configuration contentType has one parameter that isn't codecs
 PASS Test that encodingInfo() rejects framerate in the form of x/y
 PASS Test that encodingInfo() rejects framerate in the form of x/0
@@ -19,7 +19,7 @@ PASS Test that encodingInfo() rejects framerate in the form of x/
 PASS Test that encodingInfo() rejects framerate with trailing unallowed characters
 PASS Test that encodingInfo rejects if the audio configuration contenType doesn't parse
 PASS Test that encodingInfo rejects if the audio configuration contentType isn't of type audio
-FAIL Test that encodingInfo rejects if the audio configuration contentType has more than one parameters assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that encodingInfo rejects if the audio configuration contentType has more than one parameters
 PASS Test that encodingInfo rejects if the audio configuration contentType has one parameter that isn't codecs
 PASS Test that encodingInfo returns a valid MediaCapabilitiesInfo objects for record type
 PASS Test that encodingInfo rejects if the MediaConfiguration does not have a valid type

--- a/LayoutTests/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.any.worker-expected.txt
@@ -8,7 +8,7 @@ PASS Test that encodingInfo rejects if the video configuration has a framerate s
 PASS Test that encodingInfo rejects if the video configuration has a framerate set to Infinity
 PASS Test that encodingInfo rejects if the video configuration contentType doesn't parse
 PASS Test that encodingInfo rejects if the video configuration contentType isn't of type video
-FAIL Test that encodingInfo rejects if the video configuration contentType has more than one parameter assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that encodingInfo rejects if the video configuration contentType has more than one parameter
 PASS Test that encodingInfo rejects if the video configuration contentType has one parameter that isn't codecs
 PASS Test that encodingInfo() rejects framerate in the form of x/y
 PASS Test that encodingInfo() rejects framerate in the form of x/0
@@ -19,7 +19,7 @@ PASS Test that encodingInfo() rejects framerate in the form of x/
 PASS Test that encodingInfo() rejects framerate with trailing unallowed characters
 PASS Test that encodingInfo rejects if the audio configuration contenType doesn't parse
 PASS Test that encodingInfo rejects if the audio configuration contentType isn't of type audio
-FAIL Test that encodingInfo rejects if the audio configuration contentType has more than one parameters assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that encodingInfo rejects if the audio configuration contentType has more than one parameters
 PASS Test that encodingInfo rejects if the audio configuration contentType has one parameter that isn't codecs
 PASS Test that encodingInfo returns a valid MediaCapabilitiesInfo objects for record type
 PASS Test that encodingInfo rejects if the MediaConfiguration does not have a valid type

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -80,9 +80,19 @@ static bool isValidMediaMIMEType(const ContentType& contentType)
 
     auto codecs = contentType.codecs();
 
-    // FIXME: The spec requires that the "codecs" parameter is the only parameter present.
+    // Count total parameters by counting semicolons in the raw type string.
+    // The spec requires that for bucket MIME types, "codecs" is the only parameter.
+    size_t parameterCount = 0;
+    for (auto codePoint : StringView(contentType.raw()).codePoints()) {
+        if (codePoint == ';')
+            ++parameterCount;
+    }
+
     if (bucketMIMETypes.contains(contentType.containerType()))
-        return codecs.size() == 1;
+        return parameterCount == 1 && codecs.size() == 1;
+    // FIXME: The spec says non-bucket types must have no parameters, but WebRTC
+    // content types use non-codecs parameters (e.g. profile-level-id). See
+    // https://github.com/w3c/media-capabilities/issues/238
     return !codecs.size();
 }
 


### PR DESCRIPTION
#### 29aced2d659b76f874f60f4195fc12b7615f1e00
<pre>
[MediaCapabilities] Check MIME Type Validity should reject MIME types with extra parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=312091">https://bugs.webkit.org/show_bug.cgi?id=312091</a>
<a href="https://rdar.apple.com/174593729">rdar://174593729</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per the Check MIME Type Validity algorithm [1], if the combined type and
subtype of a MIME type allow multiple media codecs, the parameters must
contain a single key named &quot;codecs&quot; and nothing else. We were only
checking that the codecs parameter existed with a single value, without
verifying that no extra parameters were present. This caused content
types like &apos;video/webm; codecs=&quot;vp09.00.10.08&quot;; foo=&quot;bar&quot;&apos; to
incorrectly pass validation.

Count semicolons in the raw content type string to determine the total
number of parameters and reject when extras are present for bucket MIME
types. For non-bucket types (single-codec), preserve the existing
behavior since WebRTC content types legitimately use non-codecs
parameters such as profile-level-id [2].

[1] <a href="https://w3c.github.io/media-capabilities/#check-mime-type-validity">https://w3c.github.io/media-capabilities/#check-mime-type-validity</a>
[2] <a href="https://github.com/w3c/media-capabilities/issues/238">https://github.com/w3c/media-capabilities/issues/238</a>

* LayoutTests/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.any-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.any.worker-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.any-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.any.worker-expected.txt: Ditto
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp:
(WebCore::isValidMediaMIMEType):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29aced2d659b76f874f60f4195fc12b7615f1e00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109678 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120651 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84993 "2 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101340 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21929 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20065 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12456 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167106 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11280 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128774 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128907 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139594 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86450 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23727 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16393 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92387 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27861 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28091 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27934 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->