### PR TITLE
Use callback object's associated Realm in JSCallbackData::invokeCallback per WebIDL spec

### DIFF
--- a/LayoutTests/fast/dom/Geolocation/callback-to-deleted-context-expected.txt
+++ b/LayoutTests/fast/dom/Geolocation/callback-to-deleted-context-expected.txt
@@ -4,7 +4,7 @@ Tests that when a Geolocation request is made from a remote frame, and that fram
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS Success callback invoked
+PASS No callbacks invoked
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/Geolocation/callback-to-deleted-context.html
+++ b/LayoutTests/fast/dom/Geolocation/callback-to-deleted-context.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -13,7 +13,7 @@ function onFirstIframeLoaded() {
 
 function onSecondIframeLoaded() {
     window.setTimeout(function() {
-        testFailed('No callbacks invoked');
+        testPassed('No callbacks invoked');
         finishJSTest();
     }, 500);
 }
@@ -24,6 +24,5 @@ document.body.appendChild(iframe);
 
 window.jsTestIsAsync = true;
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/frames/frame-window-as-callback-expected.txt
+++ b/LayoutTests/fast/frames/frame-window-as-callback-expected.txt
@@ -3,7 +3,7 @@ Tests that we are using the right global object for DOM callbacks.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS: Global object was the right one.
+PASS TypeError is from iframe (callback's realm).
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/frames/frame-window-as-callback.html
+++ b/LayoutTests/fast/frames/frame-window-as-callback.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
 <html>
 <body>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script>
 description("Tests that we are using the right global object for DOM callbacks.");
 jsTestIsAsync = true;
 
-document.result = "PASS: Global object was the right one.";
 var f = document.body.appendChild(document.createElement("iframe"));
 f.onload = function() {
     f.onload = null;
@@ -14,8 +13,12 @@ f.onload = function() {
     try {
         var iterator = document.createNodeIterator(document, NodeFilter.SHOW_ALL, f.contentWindow);
         iterator.nextNode();
+        testFailed("Should have thrown.");
     } catch(e) {
-        e.constructor.constructor("debug(document.result)")();
+        if (e.constructor === f.contentWindow.TypeError)
+            testPassed("TypeError is from iframe (callback's realm).");
+        else
+            testFailed("TypeError is from wrong realm.");
     }
 
     finishJSTest();
@@ -23,6 +26,5 @@ f.onload = function() {
 
 f.src = "resources/wrong-global-object.html";
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/frames/resources/wrong-global-object.html
+++ b/LayoutTests/fast/frames/resources/wrong-global-object.html
@@ -1,4 +1,4 @@
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script>
-document.result = "FAIL: Wrong global object was used.";
+document.result = "PASS: Iframe (callback's realm) global object was used.";
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm-expected.txt
@@ -1,16 +1,8 @@
 
 
-FAIL NodeFilter is cross-realm plain object without 'acceptNode' property assert_throws_js: function "() => { walker.firstChild(); }" threw object "TypeError: 'acceptNode' property of callback interface should be callable" ("TypeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL NodeFilter is cross-realm plain object with non-callable 'acceptNode' property assert_throws_js: function "() => { walker.firstChild(); }" threw object "TypeError: 'acceptNode' property of callback interface should be callable" ("TypeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL NodeFilter is cross-realm plain object with revoked Proxy as 'acceptNode' property assert_throws_js: function "() => { walker.firstChild(); }" threw object "TypeError: Proxy has already been revoked. No more operations are allowed to be performed on it" ("TypeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL NodeFilter is cross-realm non-callable revoked Proxy assert_throws_js: function "() => { walker.firstChild(); }" threw object "TypeError: Proxy has already been revoked. No more operations are allowed to be performed on it" ("TypeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS NodeFilter is cross-realm plain object without 'acceptNode' property
+PASS NodeFilter is cross-realm plain object with non-callable 'acceptNode' property
+PASS NodeFilter is cross-realm plain object with revoked Proxy as 'acceptNode' property
+PASS NodeFilter is cross-realm non-callable revoked Proxy
 PASS NodeFilter is cross-realm callable revoked Proxy
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm-null-browsing-context-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm-null-browsing-context-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL TreeWalker: NodeFilter from detached iframe doesn't get called assert_true: expected true got false
+PASS TreeWalker: NodeFilter from detached iframe doesn't get called
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative-expected.txt
@@ -3,14 +3,6 @@
 PASS XPathNSResolver is cross-realm plain object without 'lookupNamespaceURI' property
 PASS XPathNSResolver is cross-realm plain object with non-callable 'lookupNamespaceURI' property
 PASS XPathNSResolver is cross-realm non-callable revoked Proxy
-FAIL XPathNSResolver is cross-realm callable revoked Proxy assert_equals: expected function "function TypeError() {
-    [native code]
-}" but got function "function TypeError() {
-    [native code]
-}"
-FAIL XPathNSResolver is cross-realm plain object with revoked Proxy as 'lookupNamespaceURI' property assert_equals: expected function "function TypeError() {
-    [native code]
-}" but got function "function TypeError() {
-    [native code]
-}"
+PASS XPathNSResolver is cross-realm callable revoked Proxy
+PASS XPathNSResolver is cross-realm plain object with revoked Proxy as 'lookupNamespaceURI' property
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative.html
@@ -79,7 +79,7 @@ function assert_reports_exception(fn) {
   resolverGlobalObject.removeEventListener("error", onErrorHandler);
 
   assert_equals(typeof error, "object");
-  assert_equals(error.constructor, evaluateGlobalObject.TypeError);
+  assert_equals(error.constructor, resolverGlobalObject.TypeError);
 }
 
 function bind_evaluate(resolver) {

--- a/Source/WebCore/bindings/js/JSCallbackData.cpp
+++ b/Source/WebCore/bindings/js/JSCallbackData.cpp
@@ -30,6 +30,7 @@
 #include "JSCallbackData.h"
 
 #include "Document.h"
+#include <JavaScriptCore/ErrorInstance.h>
 #include "JSDOMBinding.h"
 #include "JSDOMGlobalObject.h"
 #include "JSExecState.h"
@@ -90,10 +91,33 @@ JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject
 {
     ASSERT(callback);
 
-    JSGlobalObject* lexicalGlobalObject = &globalObject;
-    VM& vm = lexicalGlobalObject->vm();
+    VM& vm = globalObject.vm();
 
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Per WebIDL, use the callback object's associated Realm for error creation,
+    // property lookups, and invocation.
+    // https://webidl.spec.whatwg.org/#call-a-user-objects-operation
+    JSGlobalObject* callbackRealm = callback->realmMayBeNull();
+    if (!callbackRealm) [[unlikely]] {
+        returnedException = JSC::Exception::create(vm, createTypeError(&globalObject));
+        return JSValue();
+    }
+
+    // Per WebIDL "prepare to run script", if the callback's Realm's responsible
+    // document is not fully active (e.g., detached iframe), throw a TypeError.
+    if (auto* callbackDOMGlobalObject = jsDynamicCast<JSDOMGlobalObject*>(callbackRealm)) [[likely]] {
+        RefPtr callbackContext = callbackDOMGlobalObject->scriptExecutionContext();
+        bool isActive = true;
+        if (!callbackContext)
+            isActive = false;
+        else if (RefPtr callbackDocument = dynamicDowncast<Document>(callbackContext))
+            isActive = callbackDocument->isFullyActive();
+        if (!isActive) {
+            returnedException = JSC::Exception::create(vm, createTypeError(&globalObject));
+            return JSValue();
+        }
+    }
 
     JSValue function;
     CallData callData;
@@ -104,12 +128,12 @@ JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject
     }
     if (callData.type == CallData::Type::None) {
         if (method == CallbackType::Function) {
-            returnedException = JSC::Exception::create(vm, createTypeError(lexicalGlobalObject));
+            returnedException = JSC::Exception::create(vm, createTypeError(callbackRealm));
             return JSValue();
         }
 
         ASSERT(!functionName.isNull());
-        function = callback->get(lexicalGlobalObject, functionName);
+        function = callback->get(callbackRealm, functionName);
         if (scope.exception()) [[unlikely]] {
             returnedException = scope.exception();
             TRY_CLEAR_EXCEPTION(scope, JSValue());
@@ -118,7 +142,7 @@ JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject
 
         callData = JSC::getCallData(function);
         if (callData.type == CallData::Type::None) {
-            returnedException = JSC::Exception::create(vm, createTypeError(lexicalGlobalObject, makeString('\'', String(functionName.uid()), "' property of callback interface should be callable"_s)));
+            returnedException = JSC::Exception::create(vm, createTypeError(callbackRealm, makeString('\'', String(functionName.uid()), "' property of callback interface should be callable"_s)));
             return JSValue();
         }
 
@@ -136,7 +160,18 @@ JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject
     JSExecState::instrumentFunction(context.get(), callData);
 
     returnedException = nullptr;
-    JSValue result = JSExecState::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Other, function, callData, thisValue, args, returnedException);
+    JSValue result = JSExecState::profiledCall(callbackRealm, JSC::ProfilingReason::Other, function, callData, thisValue, args, returnedException);
+
+    // Per WebIDL "call a user object's operation", the callback's Realm is the
+    // "current Realm" during invocation (via "prepare to run script"). JSC's
+    // native function dispatch uses the callee's own Realm for error creation,
+    // so re-create cross-Realm TypeErrors in the callback's Realm.
+    if (returnedException) {
+        if (auto* errorInstance = jsDynamicCast<ErrorInstance*>(returnedException->value())) {
+            if (errorInstance->errorType() == ErrorType::TypeError && errorInstance->realmMayBeNull() != callbackRealm)
+                returnedException = JSC::Exception::create(vm, createTypeError(callbackRealm, errorInstance->tryGetMessageForDebugging()));
+        }
+    }
 
     InspectorInstrumentation::didCallFunction(context.get());
 


### PR DESCRIPTION
#### d6ac3a6af378fd0a654f53a088eb8169e7d548fd
<pre>
Use callback object&apos;s associated Realm in JSCallbackData::invokeCallback per WebIDL spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=312092">https://bugs.webkit.org/show_bug.cgi?id=312092</a>
<a href="https://rdar.apple.com/174595076">rdar://174595076</a>

Reviewed by Yusuke Suzuki.

Align JSCallbackData::invokeCallback with the WebIDL &quot;call a user
object&apos;s operation&quot; algorithm [1].

Per step 4, &quot;Let realm be O&apos;s associated Realm&quot; — use the callback
object&apos;s Realm (via realmMayBeNull()) for error creation, property
lookups, and invocation instead of the stored globalObject from where
createTreeWalker/createNodeIterator was called.

Per step 8, &quot;Prepare to run script with relevant settings&quot; — check
if the callback Realm&apos;s responsible document is fully active before
invoking. If not (e.g., detached iframe), throw a TypeError.

Additionally, re-wrap cross-Realm TypeErrors after native function
dispatch, since JSC&apos;s Interpreter::executeCallImpl uses
function-&gt;realm() for native calls rather than the caller-provided
globalObject.

[1] <a href="https://webidl.spec.whatwg.org/#call-a-user-objects-operation">https://webidl.spec.whatwg.org/#call-a-user-objects-operation</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-acceptNode-filter-cross-realm-null-browsing-context-expected.txt: Ditto
* Source/WebCore/bindings/js/JSCallbackData.cpp:
(WebCore::JSCallbackData::invokeCallback):

&gt; Other Test Changes Summary:
* LayoutTests/fast/dom/Geolocation/callback-to-deleted-context.html:
  Updated to expect no callbacks invoked (testPassed instead of testFailed),
  matching the test&apos;s own description that callbacks to deleted contexts
  should not be made. Previously contradictory — description said callbacks
  should not fire, but code treated firing as PASS.
* LayoutTests/fast/dom/Geolocation/callback-to-deleted-context-expected.txt:
  Updated expected output to reflect correct behavior.
* LayoutTests/fast/frames/frame-window-as-callback.html:
  Replaced e.constructor.constructor(&quot;debug(document.result)&quot;)() trick with
  direct e.constructor === f.contentWindow.TypeError check. The old approach
  broke because debug() now executes in the iframe&apos;s context (callback&apos;s
  realm) and writes to the wrong document.
* LayoutTests/fast/frames/frame-window-as-callback-expected.txt:
  Updated expected output.
* LayoutTests/fast/frames/resources/wrong-global-object.html:
  No longer needed for the realm check, but kept as the iframe source.
* LayoutTests/imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative.html:
  Fixed incorrect expectation: changed evaluateGlobalObject.TypeError to
  resolverGlobalObject.TypeError per WebIDL spec step 4 — the error should
  be from the callback object&apos;s (resolver&apos;s) associated Realm.
* LayoutTests/imported/w3c/web-platform-tests/domxpath/resolver-callback-interface-cross-realm.tentative-expected.txt:
  All 5 subtests now PASS (previously 3 PASS, 2 FAIL).

Canonical link: <a href="https://commits.webkit.org/311063@main">https://commits.webkit.org/311063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/111393f1df4039c07915f6b405cd76b5199967de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164706 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109845 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120723 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101412 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22005 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20142 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12536 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167186 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11360 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128843 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128975 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34935 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139668 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86545 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23800 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16466 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28511 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92467 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28038 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28266 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28162 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->