### PR TITLE
Implement shadowrootslotassignment attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-repeats-slot-assignment.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-repeats-slot-assignment.tentative-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL attachShadow() on declarative shadow root with manual slotAssignment assert_equals: slotAssignment should be "manual" from declarative attribute expected "manual" but got "named"
-FAIL attachShadow() on declarative shadow root does not change slotAssignment assert_equals: expected "manual" but got "named"
+PASS attachShadow() on declarative shadow root with manual slotAssignment
+PASS attachShadow() on declarative shadow root does not change slotAssignment
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-slot-assignment-serialization.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-slot-assignment-serialization.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL shadowrootslotassignment=manual is serialized and appears before shadowrootclonable and shadowrootserializable assert_equals: expected "manual" but got "named"
+PASS shadowrootslotassignment=manual is serialized and appears before shadowrootclonable and shadowrootserializable
 PASS shadowrootslotassignment=named is not serialized as it's the default
-FAIL shadowrootslotassignment=manual serializes between shadowrootdelegatesfocus and shadowrootclonable assert_equals: expected "manual" but got "named"
+PASS shadowrootslotassignment=manual serializes between shadowrootdelegatesfocus and shadowrootclonable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-slot-assignment-serialization.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-slot-assignment-serialization.tentative.html
@@ -11,8 +11,7 @@
 <div id="wrapper"></div>
 
 <script>
-  // Attribute serialization order follows the ShadowRoot IDL attribute order:
-  // mode, delegatesFocus, slotAssignment, clonable, serializable
+  // Serialization order: mode, delegatesFocus, serializable, slotAssignment, clonable
 
   test((t) => {
     t.add_cleanup(() => wrapper.replaceChildren());
@@ -23,7 +22,7 @@
     assert_equals(host.shadowRoot.slotAssignment, "manual");
     assert_equals(
       host.getHTML({ serializableShadowRoots: true }),
-      `<template shadowrootmode="open" shadowrootslotassignment="manual" shadowrootserializable=""></template>`,
+      `<template shadowrootmode="open" shadowrootserializable="" shadowrootslotassignment="manual"></template>`,
     );
   }, "shadowrootslotassignment=manual is serialized and appears before shadowrootclonable and shadowrootserializable");
 
@@ -49,7 +48,7 @@
     assert_equals(host.shadowRoot.slotAssignment, "manual");
     assert_equals(
       host.getHTML({ serializableShadowRoots: true }),
-      `<template shadowrootmode="open" shadowrootdelegatesfocus="" shadowrootslotassignment="manual" shadowrootclonable="" shadowrootserializable=""></template>`,
+      `<template shadowrootmode="open" shadowrootdelegatesfocus="" shadowrootserializable="" shadowrootslotassignment="manual" shadowrootclonable=""></template>`,
     );
   }, "shadowrootslotassignment=manual serializes between shadowrootdelegatesfocus and shadowrootclonable");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-slot-assignment.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-slot-assignment.tentative-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL shadowrootslotassignment reflection assert_equals: Missing attribute should map to named expected (string) "named" but got (undefined) undefined
-FAIL shadowrootslotassignment reflection, setter assert_equals: expected (string) "manual" but got (object) null
-FAIL Declarative Shadow DOM: shadowrootslotassignment=manual assert_equals: slotAssignment should be "manual" expected "manual" but got "named"
+PASS shadowrootslotassignment reflection
+PASS shadowrootslotassignment reflection, setter
+PASS Declarative Shadow DOM: shadowrootslotassignment=manual
 PASS Declarative Shadow DOM: shadowrootslotassignment=named
-FAIL Declarative Shadow DOM: shadowrootslotassignment is case insensitive assert_equals: slotAssignment should be "manual" (case insensitive) expected "manual" but got "named"
+PASS Declarative Shadow DOM: shadowrootslotassignment is case insensitive
 PASS Declarative Shadow DOM: shadowrootslotassignment invalid value defaults to named
-FAIL Declarative Shadow DOM: shadowrootslotassignment on closed shadows can be set to manual assert_equals: slotAssignment should be "manual" (closed root) expected "manual" but got "named"
+PASS Declarative Shadow DOM: shadowrootslotassignment on closed shadows can be set to manual
 PASS Declarative Shadow DOM: missing shadowrootslotassignment defaults to named
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3450,7 +3450,7 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init, std::
     return shadow.get();
 }
 
-ExceptionOr<ShadowRoot&> Element::attachDeclarativeShadow(ShadowRootMode mode, ShadowRootDelegatesFocus delegatesFocus, ShadowRootClonable clonable, ShadowRootSerializable serializable, String referenceTarget, CustomElementRegistryKind registryKind)
+ExceptionOr<ShadowRoot&> Element::attachDeclarativeShadow(ShadowRootMode mode, ShadowRootDelegatesFocus delegatesFocus, ShadowRootClonable clonable, ShadowRootSerializable serializable, SlotAssignmentMode slotAssignment, String referenceTarget, CustomElementRegistryKind registryKind)
 {
     if (this->shadowRoot())
         return Exception { ExceptionCode::NotSupportedError };
@@ -3459,7 +3459,7 @@ ExceptionOr<ShadowRoot&> Element::attachDeclarativeShadow(ShadowRootMode mode, S
         delegatesFocus == ShadowRootDelegatesFocus::Yes,
         clonable == ShadowRootClonable::Yes,
         serializable == ShadowRootSerializable::Yes,
-        SlotAssignmentMode::Named,
+        slotAssignment,
         std::nullopt,
         referenceTarget,
     }, registryKind);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -113,6 +113,7 @@ enum class ShadowRootDelegatesFocus : bool { No, Yes };
 enum class ShadowRootMode : uint8_t;
 enum class ShadowRootClonable : bool { No, Yes };
 enum class ShadowRootSerializable : bool { No, Yes };
+enum class SlotAssignmentMode : bool;
 enum class AllowScrollingOverflowHidden : bool { No, Yes };
 enum class VisibilityAdjustment : uint8_t;
 
@@ -462,7 +463,7 @@ public:
     enum class CustomElementRegistryKind : bool { Window, Null };
 
     WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&, std::optional<CustomElementRegistryKind> = std::nullopt);
-    ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, ShadowRootDelegatesFocus, ShadowRootClonable, ShadowRootSerializable, String referenceTarget, CustomElementRegistryKind);
+    ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, ShadowRootDelegatesFocus, ShadowRootClonable, ShadowRootSerializable, SlotAssignmentMode, String referenceTarget, CustomElementRegistryKind);
 
     WEBCORE_EXPORT ShadowRoot* NODELETE userAgentShadowRoot() const;
     WEBCORE_EXPORT ShadowRoot& ensureUserAgentShadowRoot();

--- a/Source/WebCore/dom/ShadowRootMode.h
+++ b/Source/WebCore/dom/ShadowRootMode.h
@@ -25,6 +25,11 @@
 
 #pragma once
 
+#include <optional>
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/AtomString.h>
+#include <wtf/text/StringView.h>
+
 namespace WebCore {
 
 enum class ShadowRootMode : uint8_t {
@@ -32,5 +37,32 @@ enum class ShadowRootMode : uint8_t {
     Closed,
     Open
 };
+
+static constexpr auto shadowRootModeOpenLiteral = "open"_s;
+static constexpr auto shadowRootModeClosedLiteral = "closed"_s;
+
+inline std::optional<ShadowRootMode> parseShadowRootMode(StringView value)
+{
+    if (equalLettersIgnoringASCIICase(value, shadowRootModeOpenLiteral))
+        return ShadowRootMode::Open;
+    if (equalLettersIgnoringASCIICase(value, shadowRootModeClosedLiteral))
+        return ShadowRootMode::Closed;
+    return { };
+}
+
+inline const AtomString& serializeShadowRootMode(ShadowRootMode mode)
+{
+    static MainThreadNeverDestroyed<const AtomString> open(shadowRootModeOpenLiteral);
+    static MainThreadNeverDestroyed<const AtomString> closed(shadowRootModeClosedLiteral);
+    switch (mode) {
+    case ShadowRootMode::Open:
+        return open;
+    case ShadowRootMode::Closed:
+        return closed;
+    case ShadowRootMode::UserAgent:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
 
 }

--- a/Source/WebCore/dom/SlotAssignmentMode.h
+++ b/Source/WebCore/dom/SlotAssignmentMode.h
@@ -25,12 +25,39 @@
 
 #pragma once
 
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/AtomString.h>
+#include <wtf/text/StringView.h>
+
 namespace WebCore {
 
 enum class SlotAssignmentMode : bool {
     Manual,
     Named,
 };
+
+static constexpr auto slotAssignmentModeNamedLiteral = "named"_s;
+static constexpr auto slotAssignmentModeManualLiteral = "manual"_s;
+
+inline SlotAssignmentMode parseSlotAssignmentMode(StringView value)
+{
+    if (equalLettersIgnoringASCIICase(value, slotAssignmentModeManualLiteral))
+        return SlotAssignmentMode::Manual;
+    return SlotAssignmentMode::Named;
+}
+
+inline const AtomString& serializeSlotAssignmentMode(SlotAssignmentMode mode)
+{
+    static MainThreadNeverDestroyed<const AtomString> named(slotAssignmentModeNamedLiteral);
+    static MainThreadNeverDestroyed<const AtomString> manual(slotAssignmentModeManualLiteral);
+    switch (mode) {
+    case SlotAssignmentMode::Manual:
+        return manual;
+    case SlotAssignmentMode::Named:
+        return named;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
 
 }
 

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -405,23 +405,13 @@ void MarkupAccumulator::startAppendingNode(const Node& node, Namespaces* namespa
             m_markup.append("<meta charset=\"UTF-8\"><!-- Encoding specified by WebKit -->"_s);
 
     } else if (RefPtr shadowRoot = suitableShadowRoot(node)) {
-        m_markup.append("<template shadowrootmode=\""_s);
-        switch (shadowRoot->mode()) {
-        case ShadowRootMode::Open:
-            m_markup.append("open"_s);
-            break;
-        case ShadowRootMode::Closed:
-            m_markup.append("closed"_s);
-            break;
-        case ShadowRootMode::UserAgent:
-            ASSERT_NOT_REACHED();
-            break;
-        }
-        m_markup.append('"');
+        m_markup.append("<template shadowrootmode=\""_s, serializeShadowRootMode(shadowRoot->mode()), '"');
         if (shadowRoot->delegatesFocus())
             m_markup.append(" shadowrootdelegatesfocus=\"\""_s);
         if (shadowRoot->serializable())
             m_markup.append(" shadowrootserializable=\"\""_s);
+        if (shadowRoot->slotAssignmentMode() == SlotAssignmentMode::Manual)
+            m_markup.append(" shadowrootslotassignment=\"manual\""_s);
         if (shadowRoot->isClonable())
             m_markup.append(" shadowrootclonable=\"\""_s);
         bool shouldAppendRegistryAttribute = [&] {

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -408,6 +408,7 @@ shadowrootdelegatesfocus
 shadowrootmode
 shadowrootreferencetarget
 shadowrootserializable
+shadowrootslotassignment
 shape
 size
 sizes

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012, 2013 Google Inc. All rights reserved.
- * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -43,6 +43,7 @@
 #include "SerializedNode.h"
 #include "ShadowRoot.h"
 #include "ShadowRootInit.h"
+#include "ShadowRootMode.h"
 #include "SlotAssignmentMode.h"
 #include "TemplateContentDocumentFragment.h"
 #include "markup.h"
@@ -97,15 +98,17 @@ void HTMLTemplateElement::adoptDeserializedContent(Ref<TemplateContentDocumentFr
 
 const AtomString& HTMLTemplateElement::shadowRootMode() const
 {
-    static MainThreadNeverDestroyed<const AtomString> open("open"_s);
-    static MainThreadNeverDestroyed<const AtomString> closed("closed"_s);
-
     auto modeString = attributeWithoutSynchronization(HTMLNames::shadowrootmodeAttr);
-    if (equalLettersIgnoringASCIICase(modeString, "closed"_s))
-        return closed;
-    if (equalLettersIgnoringASCIICase(modeString, "open"_s))
-        return open;
-    return emptyAtom();
+    auto mode = parseShadowRootMode(modeString);
+    if (!mode)
+        return emptyAtom();
+    return serializeShadowRootMode(*mode);
+}
+
+const AtomString& HTMLTemplateElement::shadowRootSlotAssignment() const
+{
+    auto value = attributeWithoutSynchronization(HTMLNames::shadowrootslotassignmentAttr);
+    return serializeSlotAssignmentMode(parseSlotAssignmentMode(value));
 }
 
 void HTMLTemplateElement::setDeclarativeShadowRoot(ShadowRoot& shadowRoot)

--- a/Source/WebCore/html/HTMLTemplateElement.h
+++ b/Source/WebCore/html/HTMLTemplateElement.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2013 Google Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -49,6 +50,7 @@ public:
     DocumentFragment* NODELETE contentIfAvailable() const;
 
     const AtomString& shadowRootMode() const;
+    const AtomString& shadowRootSlotAssignment() const;
 
     void setDeclarativeShadowRoot(ShadowRoot&);
 
@@ -58,7 +60,7 @@ private:
     HTMLTemplateElement(const QualifiedName&, Document&);
 
     Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) const final;
-    SerializedNode serializeNode(CloningOperation) const override;
+    SerializedNode serializeNode(CloningOperation) const final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
     const RefPtr<TemplateContentDocumentFragment> m_content;

--- a/Source/WebCore/html/HTMLTemplateElement.idl
+++ b/Source/WebCore/html/HTMLTemplateElement.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012 Google Inc. All rights reserved.
- * Copyright (c) 2017-2025 Apple Inc. All rights reserved.
+ * Copyright (c) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -36,6 +36,7 @@
     readonly attribute DocumentFragment content;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString shadowRootMode;
     [CEReactions=NotNeeded, Reflect] attribute boolean shadowRootDelegatesFocus;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString shadowRootSlotAssignment;
     [CEReactions=NotNeeded, Reflect] attribute boolean shadowRootClonable;
     [CEReactions=NotNeeded, Reflect] attribute boolean shadowRootSerializable;
     [EnabledBySetting=ScopedCustomElementRegistryEnabled, CEReactions=NotNeeded, Reflect] attribute DOMString shadowRootCustomElementRegistry;

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -57,6 +57,8 @@
 #include "SVGElementInlines.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
+#include "ShadowRootMode.h"
+#include "SlotAssignmentMode.h"
 #include "Text.h"
 #include "UserScriptTypes.h"
 #include <unicode/ubrk.h>
@@ -553,27 +555,27 @@ void HTMLConstructionSite::insertHTMLTemplateElement(AtomHTMLToken&& token)
         auto delegatesFocus = ShadowRootDelegatesFocus::No;
         auto clonable = ShadowRootClonable::No;
         auto serializable = ShadowRootSerializable::No;
+        auto slotAssignment = SlotAssignmentMode::Named;
         String referenceTarget;
         auto registryKind = Element::CustomElementRegistryKind::Window;
         for (auto& attribute : token.attributes()) {
-            if (attribute.name() == HTMLNames::shadowrootmodeAttr) {
-                if (equalLettersIgnoringASCIICase(attribute.value(), "closed"_s))
-                    mode = ShadowRootMode::Closed;
-                else if (equalLettersIgnoringASCIICase(attribute.value(), "open"_s))
-                    mode = ShadowRootMode::Open;
-            } else if (attribute.name() == HTMLNames::shadowrootdelegatesfocusAttr)
+            if (attribute.name() == HTMLNames::shadowrootmodeAttr)
+                mode = parseShadowRootMode(attribute.value());
+            else if (attribute.name() == HTMLNames::shadowrootdelegatesfocusAttr)
                 delegatesFocus = ShadowRootDelegatesFocus::Yes;
             else if (attribute.name() == HTMLNames::shadowrootclonableAttr)
                 clonable = ShadowRootClonable::Yes;
             else if (attribute.name() == HTMLNames::shadowrootserializableAttr)
                 serializable = ShadowRootSerializable::Yes;
+            else if (attribute.name() == HTMLNames::shadowrootslotassignmentAttr)
+                slotAssignment = parseSlotAssignmentMode(attribute.value());
             else if (document().settings().shadowRootReferenceTargetEnabled() && attribute.name() == HTMLNames::shadowrootreferencetargetAttr)
                 referenceTarget = AtomString(attribute.value());
             else if (attribute.name() == HTMLNames::shadowrootcustomelementregistryAttr)
                 registryKind = Element::CustomElementRegistryKind::Null;
         }
         if (mode && is<Element>(currentNode())) {
-            auto exceptionOrShadowRoot = currentElement().attachDeclarativeShadow(*mode, delegatesFocus, clonable, serializable, referenceTarget, registryKind);
+            auto exceptionOrShadowRoot = currentElement().attachDeclarativeShadow(*mode, delegatesFocus, clonable, serializable, slotAssignment, referenceTarget, registryKind);
             if (!exceptionOrShadowRoot.hasException()) {
                 Ref shadowRoot = exceptionOrShadowRoot.releaseReturnValue();
                 auto element = createHTMLElement(token);

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -45,6 +45,7 @@
 #include "ScriptElement.h"
 #include "SecurityPolicy.h"
 #include "Settings.h"
+#include "ShadowRootMode.h"
 #include "SizesAttributeParser.h"
 #include <wtf/MainThread.h>
 #include <wtf/SortedArrayMap.h>
@@ -494,10 +495,8 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
             bool isDeclarativeShadowRoot = false;
             static constexpr auto shadowRootAsUTF16 = std::to_array<char16_t>({ 's', 'h', 'a', 'd', 'o', 'w', 'r', 'o', 'o', 't', 'm', 'o', 'd', 'e' });
             const auto* shadowRootModeAttribute = findAttribute(token.attributes(), shadowRootAsUTF16);
-            if (shadowRootModeAttribute) {
-                String shadowRootValue(shadowRootModeAttribute->value);
-                isDeclarativeShadowRoot = equalIgnoringASCIICase(shadowRootValue, "open"_s) || equalIgnoringASCIICase(shadowRootValue, "closed"_s);
-            }
+            if (shadowRootModeAttribute)
+                isDeclarativeShadowRoot = !!parseShadowRootMode(StringView(shadowRootModeAttribute->value.span()));
             // If this is a declarative shadow root <template shadowrootmode> element
             // *and* we're not already inside a non-Declartive Shadow DOM (DSD)
             // <template> element, then we leave the template count at zero.


### PR DESCRIPTION
#### 4cd6d5756a6477c6a9a3aba8c3afe47b8a882c05
<pre>
Implement shadowrootslotassignment attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=310090">https://bugs.webkit.org/show_bug.cgi?id=310090</a>
<a href="https://rdar.apple.com/173227340">rdar://173227340</a>

Reviewed by Darin Adler and Ryosuke Niwa.

This gives web developers the ability to set the slot assignment to
&quot;manual&quot; declaratively. (Slotting will still have to happen through
script in those cases.)

We also clean up the shadowrootmode attribute as it has very similar
requirements.

Test changes upstreamed here:

    <a href="https://github.com/web-platform-tests/wpt/pull/59210">https://github.com/web-platform-tests/wpt/pull/59210</a>

Canonical link: <a href="https://commits.webkit.org/311295@main">https://commits.webkit.org/311295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5810e0d53ca8e0572c0caea0ef9fac233b7adb99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165379 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121262 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101929 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20726 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13150 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132220 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167861 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11982 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129377 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129487 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87218 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23837 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24310 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17014 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29124 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93089 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28650 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28879 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28775 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->