### PR TITLE
[JSC][WASM][Debugger] Fix WasmDebugger RWI lifecycle: init ordering, cache handling, and process exit

### DIFF
--- a/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
+++ b/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
@@ -15,7 +15,7 @@ WebKit's WebAssembly debugging uses a **singleton `WasmDebugServer`** that manag
 ### Key Design Principles
 
 1. **Process-Wide Singleton**: One `WasmDebugServer::singleton()` per WebContent process
-2. **WorkQueue-Based IPC**: Debugging commands processed on background thread (supports debugging infinite loops)
+2. **WorkQueue-Based IPC**: Debugging commands processed on background thread (supports debugging while main thread is blocked)
 3. **RWI Integration**: One `WasmDebuggerDebuggable` target per WebContent process
 4. **GDB Remote Serial Protocol**: LLDB communicates using standard GDB packets
 
@@ -57,7 +57,7 @@ WebKit's WebAssembly debugging uses a **singleton `WasmDebugServer`** that manag
 ### UI Process (Safari)
 
 **WebProcessProxy** - Manages one WebContent process
-- Creates `WasmDebuggerDebuggable` on construction (if `enableWasmDebugger` enabled)
+- Creates `WasmDebuggerDebuggable` only after receiving `WasmDebugServerReady` from WebContent
 - Forwards debugging commands via IPC
 - Routes responses back to LLDB
 
@@ -73,12 +73,12 @@ WebKit's WebAssembly debugging uses a **singleton `WasmDebugServer`** that manag
 
 **WasmDebuggerDispatcher** - WorkQueue-based IPC receiver
 - Receives debugging commands on **WorkQueue thread** (not main thread)
-- Enables debugging when main thread blocked in infinite loop
+- Enables debugging when main thread is blocked
 - Matches `WebInspectorInterruptDispatcher` pattern (JavaScript debugging)
 
 **WebProcess** - Process singleton
 - Owns `WasmDebuggerDispatcher` instance
-- Initializes `WasmDebugServer` on startup
+- Calls `DebugServer::singleton().startRWI()` in `initializeWebProcess()` and sends `WasmDebugServerReady` IPC on success
 - Sets up response handler for IPC communication
 
 ### JavaScriptCore (JSC)
@@ -113,18 +113,106 @@ WasmDebugServer (JSC)
 
 **Key Points:**
 - External client relays raw GDB packets between LLDB and WebKit
-- Target registration: WebProcessProxy creates `WasmDebuggerDebuggable` with auto-assigned numeric Target ID and name showing OS PID
+- Target registration: WebProcessProxy creates `WasmDebuggerDebuggable` in `wasmDebugServerReady()` (after `WasmDebugServerReady` IPC) with auto-assigned numeric Target ID and name showing OS PID
 - IPC routing: Messages dispatched to WorkQueue in WebContent Process, NOT main thread
-- WorkQueue enables debugging when main thread blocked in infinite loop
+- WorkQueue enables debugging when main thread is blocked
 - Pattern matches `WebInspectorInterruptDispatcher` (JavaScript debugging)
 
 **Critical Architecture Decision: WorkQueue Threading**
 
-Main thread can be blocked in infinite Wasm loop, but debugging must still work:
+Main thread can be blocked, but debugging must still work:
 - Kernel queues IPC messages independently
 - WorkQueue thread (in WebContent Process) processes debug commands concurrently
 - Mutator thread waits on condition variable when paused
 - WorkQueue thread signals condition variable to resume execution
+
+---
+
+## Component Lifecycle
+
+### Startup (Fresh Process Launch)
+
+```
+UIProcess                         WebContent Process (main thread)
+─────────────────────────────────────────────────────────────────
+                                  platformInitializeWebProcess()
+                                  - shouldEnableWebAssemblyDebugger param
+                                  - JSC::Options::enableWasmDebugger = true
+
+                                  initializeWebProcess()
+                                  - DebugServer::singleton().startRWI()
+wasmDebugServerReady()   ◄──────  - send WasmDebugServerReady IPC
+- createWasmDebuggerTarget()
+- register with RemoteInspector
+```
+
+**Key invariant**: The `WasmDebuggerDebuggable` is created only after `startRWI()` succeeds in the WebContent process. This guarantees that when LLDB attaches and sends packets, the `WasmDebugServer` is fully initialized and ready to handle them.
+
+### Process Cache Entry
+
+When a tab navigates away and the WebContent process enters the process cache:
+
+```
+UIProcess (main thread)           WebContent WorkQueue thread
+──────────────────────────────────────────────────────────────
+setIsInProcessCache(true)
+if m_wasmDebuggerDebuggable:
+    destroyWasmDebuggerTarget()
+    - detach from RemoteInspector
+    send ResetServer IPC   ──────►  resetServer()
+                                    - DebugServer::reset()
+                                    - if VM stopped: resumeImpl()
+                                    - clearAllBreakpoints()
+                                    - reset protocol state
+```
+
+**Why WorkQueue, not main thread**: The WorkQueue thread runs independently of the JS/Wasm mutator. If the main VM is stopped at a breakpoint when the tab closes, the main thread is unresponsive and cannot process IPCs. The WorkQueue handles `ResetServer` regardless, and `reset()` resumes the stopped VM before clearing state.
+
+**STW invariant**: Stop-the-world stops ALL mutators simultaneously. If any VM is stopped (blocked in `stopCode()`), the main thread is also stopped — making it impossible to process `SetIsInProcessCache`. Therefore, when `setIsInProcessCache` runs on the main thread, no VM can be blocked in `stopCode()`, and the WorkQueue is always idle and ready to receive `ResetServer`.
+
+### Process Cache Exit
+
+When a cached process is reused for a new navigation:
+
+```
+WebContent Process (main thread)  UIProcess
+──────────────────────────────────────────────────────────────
+setIsInProcessCache(false)
+- send WasmDebugServerReady ────► wasmDebugServerReady()
+                                  - createWasmDebuggerTarget()
+                                  - re-register with RemoteInspector
+```
+
+The `WasmDebugServer` itself never stops — it is a process-lifetime singleton. Only the `WasmDebuggerDebuggable` (the RWI target visible to LLDB) is destroyed on cache entry and recreated on cache exit.
+
+### Process Exit (No Cache)
+
+When the WebContent process exits normally (tab closed, no process cache):
+
+```
+UIProcess (main thread)
+────────────────────────
+shutDown()
+if m_wasmDebuggerDebuggable:
+    destroyWasmDebuggerTarget()
+    - detach from RemoteInspector
+shutDownProcess()
+```
+
+The debuggable is destroyed before the process is killed so LLDB detaches cleanly
+via RemoteInspector before the connection drops. No ResetServer IPC is needed —
+all WebContent process state is discarded on exit.
+
+### Full Lifecycle Summary
+
+```
+1. Fresh launch:   enable option → startRWI → WasmDebugServerReady → createDebuggable
+2. Cache entry:    destroyDebuggable → send ResetServer → reset()
+3. Cache exit:     WasmDebugServerReady → createDebuggable
+4. Cache entry:    destroyDebuggable → send ResetServer → reset()
+   (steps 3-4 repeat indefinitely)
+5. Process exit:   destroyDebuggable → shutDownProcess()
+```
 
 ---
 
@@ -238,8 +326,8 @@ When the Wasm debugger pauses at a breakpoint (stop-the-world), the main thread 
 3. **From the user's perspective** - Web Inspector appears frozen or disconnected
 
 The interaction is asymmetric:
-- **Pausing in Wasm debugger** → Blocks main thread → **Freezes both JS execution and Web Inspector**
-- **Pausing in JS debugger** → Runs nested event loop → **Wasm debugger continues working** (uses WorkQueue IPC)
+- **Pausing in Wasm debugger** - Blocks main thread - **Freezes both JS execution and Web Inspector**
+- **Pausing in JS debugger** - Runs nested event loop - **Wasm debugger continues working** (uses WorkQueue IPC)
 
 **Why Stop-the-World Is Correct**:
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -104,11 +104,11 @@ bool DebugServer::start()
 }
 
 #if ENABLE(REMOTE_INSPECTOR)
-bool DebugServer::startRWI(Function<bool(const String&)>&& rwiResponseHandler)
+void DebugServer::startRWI(Function<bool(const String&)>&& rwiResponseHandler)
 {
     if (isState(State::Running) || isState(State::Starting)) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Server already running or is starting");
-        return true;
+        return;
     }
 
     setState(State::Starting);
@@ -123,7 +123,6 @@ bool DebugServer::startRWI(Function<bool(const String&)>&& rwiResponseHandler)
 
     setState(State::Running);
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Wasm Debug Server started in RWI mode (WorkQueue-based)");
-    return true;
 }
 #endif
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -107,7 +107,7 @@ public:
     // 1. Direct TCP socket mode (JSC shell debugging)
     // 2. Remote Web Inspector integration mode (WebKit debugging)
     bool isRWIMode() const { return !!m_rwiResponseHandler; }
-    JS_EXPORT_PRIVATE bool startRWI(Function<bool(const String&)>&& rwiResponseHandler);
+    JS_EXPORT_PRIVATE void startRWI(Function<bool(const String&)>&& rwiResponseHandler);
 #endif
 
     void trackInstance(JSWebAssemblyInstance*);
@@ -144,8 +144,9 @@ public:
 
     JS_EXPORT_PRIVATE ModuleManager& moduleManager() const;
 
+    JS_EXPORT_PRIVATE void reset();
+
 private:
-    void reset();
 
     void setState(State);
     JS_EXPORT_PRIVATE bool NODELETE isState(State) const;

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
@@ -265,13 +265,11 @@ void setupTestEnvironment(DebugServer*& debugServer, ExecutionHandler*& executio
     Options::setOptions("--enableWasmDebugger=true");
 
     debugServer = &DebugServer::singleton();
-    bool started = debugServer->startRWI([](const String& packet) {
+    debugServer->startRWI([](const String& packet) {
         replyCount++;
         dataLogLnIf(verboseLogging, RWI_REPLY_PREFIX, packet);
         return true;
     });
-
-    RELEASE_ASSERT(started, "Failed to start DebugServer in RWI mode");
     RELEASE_ASSERT(debugServer->hasDebugger(), "DebugServer has no debug client after RWI start");
 
     executionHandler = &debugServer->execution();

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -402,10 +402,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     parameters.shouldEnableMemoryPressureReliefLogging = [defaults boolForKey:@"LogMemoryJetsamDetails"];
     parameters.shouldSuppressMemoryPressureHandler = [defaults boolForKey:WebKitSuppressMemoryPressureHandlerDefaultsKey];
 
-#if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
-    parameters.shouldEnableWebAssemblyDebugger = process.createWasmDebuggerDebuggable();
-#endif
-
     // FIXME: This should really be configurable; we shouldn't just blindly allow read access to the UI process bundle.
     parameters.uiProcessBundleResourcePath = m_resolvedPaths.uiProcessBundleResourcePath;
     if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(parameters.uiProcessBundleResourcePath, SandboxExtension::Type::ReadOnly))

--- a/Source/WebKit/UIProcess/Inspector/WasmDebuggerDebuggable.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WasmDebuggerDebuggable.cpp
@@ -68,9 +68,9 @@ std::optional<ProcessID> WasmDebuggerDebuggable::webContentProcessPID() const
     if (!process)
         return std::nullopt;
 
-    // When WasmDebuggerDebuggable is created, the WebContent process is guaranteed to have
-    // finished launching (see didFinishLaunching -> createWasmDebuggerTarget).
-    // Therefore, processID() must return a valid non-zero PID.
+    // WasmDebuggerDebuggable is created in wasmDebugServerReady(), which is an IPC handler
+    // called by the WebContent process after startRWI() succeeds. Since the message came from
+    // the process itself, it is guaranteed to be running and processID() must be non-zero.
     auto pid = process->processID();
     RELEASE_ASSERT(pid);
     return pid;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -820,8 +820,8 @@ void WebProcessPool::resolvePathsForSandboxExtensions()
 
 Ref<WebProcessProxy> WebProcessPool::createNewWebProcess(WebsiteDataStore* websiteDataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, WebProcessProxy::EnableWebAssemblyDebugger enableWebAssemblyDebugger, WebProcessProxy::IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode)
 {
-    auto processProxy = WebProcessProxy::create(*this, websiteDataStore, lockdownMode, enhancedSecurity, isPrewarmed, crossOriginMode, WebProcessProxy::ShouldLaunchProcess::Yes, enableWebAssemblyDebugger);
-    initializeNewWebProcess(processProxy, websiteDataStore, isPrewarmed);
+    auto processProxy = WebProcessProxy::create(*this, websiteDataStore, lockdownMode, enhancedSecurity, isPrewarmed, crossOriginMode, WebProcessProxy::ShouldLaunchProcess::Yes);
+    initializeNewWebProcess(processProxy, websiteDataStore, isPrewarmed, enableWebAssemblyDebugger);
     m_processes.append(processProxy.copyRef());
 
     return processProxy;
@@ -957,7 +957,7 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
     };
 }
 
-void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDataStore* websiteDataStore, WebProcessProxy::IsPrewarmed isPrewarmed)
+void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDataStore* websiteDataStore, WebProcessProxy::IsPrewarmed isPrewarmed, WebProcessProxy::EnableWebAssemblyDebugger enableWebAssemblyDebugger)
 {
     WebProcessCreationParameters parameters;
     parameters.auxiliaryProcessParameters = AuxiliaryProcessProxy::auxiliaryProcessParameters();
@@ -1042,6 +1042,12 @@ void WebProcessPool::initializeNewWebProcess(WebProcessProxy& process, WebsiteDa
     parameters.memoryFootprintPollIntervalForTesting = m_configuration->memoryFootprintPollIntervalForTesting();
 
     parameters.memoryFootprintNotificationThresholds = m_configuration->memoryFootprintNotificationThresholds();
+
+#if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
+    parameters.shouldEnableWebAssemblyDebugger = (enableWebAssemblyDebugger == WebProcessProxy::EnableWebAssemblyDebugger::Yes);
+#else
+    UNUSED_PARAM(enableWebAssemblyDebugger);
+#endif
 
     // Add any platform specific parameters
     platformInitializeWebProcess(process, parameters);
@@ -1342,8 +1348,7 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
         // In the common case, we delay process launch until something is actually loaded in the page.
         process = dummyProcessProxy(pageConfiguration->websiteDataStore().sessionID());
         if (!process) {
-            auto enableWebAssemblyDebugger = protect(pageConfiguration->preferences())->webAssemblyDebuggerEnabled() ? WebProcessProxy::EnableWebAssemblyDebugger::Yes : WebProcessProxy::EnableWebAssemblyDebugger::No;
-            process = WebProcessProxy::create(*this, protect(pageConfiguration->websiteDataStore()).ptr(), lockdownMode, enhancedSecurity, WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Shared, WebProcessProxy::ShouldLaunchProcess::No, enableWebAssemblyDebugger);
+            process = WebProcessProxy::create(*this, protect(pageConfiguration->websiteDataStore()).ptr(), lockdownMode, enhancedSecurity, WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Shared, WebProcessProxy::ShouldLaunchProcess::No);
             m_dummyProcessProxies.add(pageConfiguration->websiteDataStore().sessionID(), *process);
             m_processes.append(*process);
         }

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -655,7 +655,7 @@ private:
 
     RefPtr<WebProcessProxy> tryTakePrewarmedProcess(WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
 
-    void initializeNewWebProcess(WebProcessProxy&, WebsiteDataStore*, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No);
+    void initializeNewWebProcess(WebProcessProxy&, WebsiteDataStore*, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No, WebProcessProxy::EnableWebAssemblyDebugger = WebProcessProxy::EnableWebAssemblyDebugger::No);
 
     void handleMessage(IPC::Connection&, const String& messageName, const UserData& messageBody);
     void handleSynchronousMessage(IPC::Connection&, const String& messageName, const UserData& messageBody, CompletionHandler<void(UserData&&)>&&);

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -285,9 +285,9 @@ Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> WebPro
     return result;
 }
 
-Ref<WebProcessProxy> WebProcessProxy::create(WebProcessPool& processPool, WebsiteDataStore* websiteDataStore, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode, ShouldLaunchProcess shouldLaunchProcess, EnableWebAssemblyDebugger enableWebAssemblyDebugger)
+Ref<WebProcessProxy> WebProcessProxy::create(WebProcessPool& processPool, WebsiteDataStore* websiteDataStore, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode, ShouldLaunchProcess shouldLaunchProcess)
 {
-    Ref proxy = adoptRef(*new WebProcessProxy(processPool, websiteDataStore, isPrewarmed, crossOriginMode, lockdownMode, enhancedSecurity, enableWebAssemblyDebugger));
+    Ref proxy = adoptRef(*new WebProcessProxy(processPool, websiteDataStore, isPrewarmed, crossOriginMode, lockdownMode, enhancedSecurity));
     if (shouldLaunchProcess == ShouldLaunchProcess::Yes) {
         if (liveProcessesLRU().computeSize() >= s_maxProcessCount) {
             for (auto& processPool : WebProcessPool::allProcessPools())
@@ -311,7 +311,7 @@ Ref<WebProcessProxy> WebProcessProxy::createForRemoteWorkers(RemoteWorkerType wo
     return proxy;
 }
 
-WebProcessProxy::WebProcessProxy(WebProcessPool& processPool, WebsiteDataStore* websiteDataStore, IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, EnableWebAssemblyDebugger enableWebAssemblyDebugger)
+WebProcessProxy::WebProcessProxy(WebProcessPool& processPool, WebsiteDataStore* websiteDataStore, IsPrewarmed isPrewarmed, CrossOriginMode crossOriginMode, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity)
     : AuxiliaryProcessProxy(processPool.shouldTakeUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No
     , processPool.alwaysRunsAtBackgroundPriority() ? AlwaysRunsAtBackgroundPriority::Yes : AlwaysRunsAtBackgroundPriority::No)
     , m_backgroundResponsivenessTimer(makeUniqueRef<BackgroundProcessResponsivenessTimer>(*this))
@@ -329,9 +329,6 @@ WebProcessProxy::WebProcessProxy(WebProcessPool& processPool, WebsiteDataStore* 
     , m_shutdownPreventingScopeCounter([this](RefCounterEvent event) { if (event == RefCounterEvent::Decrement) maybeShutDown(); })
     , m_webLockRegistry(websiteDataStore ? makeUniqueWithoutRefCountedCheck<WebLockRegistryProxy>(*this) : nullptr)
     , m_webPermissionController(makeUniqueRefWithoutRefCountedCheck<WebPermissionControllerProxy>(*this))
-#if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
-    , m_createWasmDebuggerDebuggable(enableWebAssemblyDebugger == EnableWebAssemblyDebugger::Yes)
-#endif
 {
     RELEASE_ASSERT(isMainThreadOrCheckDisabled());
     WEBPROCESSPROXY_RELEASE_LOG(Process, "constructor:");
@@ -447,6 +444,15 @@ void WebProcessProxy::setIsInProcessCache(bool value, WillShutDown willShutDown)
         // WebProcessProxy objects normally keep the process pool alive but we do not want this to be the case
         // for cached processes or it would leak the pool.
         m_processPool.setIsWeak(IsWeak::Yes);
+#if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
+        // Destroy the debuggable so LLDB detaches cleanly. It will be recreated when the
+        // process exits cache via wasmDebugServerReady(). Also send ResetServer to the
+        // WorkQueue dispatcher — safe even if the main VM is blocked.
+        if (m_wasmDebuggerDebuggable) [[unlikely]] {
+            destroyWasmDebuggerTarget();
+            send(Messages::WasmDebuggerDispatcher::ResetServer(), 0);
+        }
+#endif
     } else {
         RELEASE_ASSERT(m_processPool);
         m_processPool.setIsWeak(IsWeak::No);
@@ -735,12 +741,12 @@ void WebProcessProxy::shutDown()
         ASSERT(!m_isInProcessCache);
     }
 
-    shutDownProcess();
-
 #if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
-    if (m_wasmDebuggerDebuggable)
+    if (m_wasmDebuggerDebuggable) [[unlikely]]
         destroyWasmDebuggerTarget();
 #endif
+
+    shutDownProcess();
 
     m_backgroundResponsivenessTimer->invalidate();
     m_audibleMediaActivity = std::nullopt;
@@ -1481,11 +1487,6 @@ void WebProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connect
 
     protect(processPool())->processDidFinishLaunching(*this);
     m_backgroundResponsivenessTimer->updateState();
-
-#if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
-    if (m_createWasmDebuggerDebuggable || JSC::Options::enableWasmDebugger()) [[unlikely]]
-        createWasmDebuggerTarget();
-#endif
 
 #if ENABLE(IPC_TESTING_API)
     if (m_ignoreInvalidMessageForTesting)
@@ -3207,7 +3208,7 @@ void WebProcessProxy::createWasmDebuggerTarget()
 
 void WebProcessProxy::destroyWasmDebuggerTarget()
 {
-    if (RefPtr debuggable = m_wasmDebuggerDebuggable) {
+    if (RefPtr debuggable = m_wasmDebuggerDebuggable) [[unlikely]] {
         debuggable->detachFromProcess();
         m_wasmDebuggerDebuggable = nullptr;
     }
@@ -3259,6 +3260,19 @@ void WebProcessProxy::setWasmDebuggerTargetIndicating(bool indicating)
     UNUSED_PARAM(indicating);
 }
 
+void WebProcessProxy::wasmDebugServerReady()
+{
+    // WebContent sends WasmDebugServerReady in two cases:
+    //   1. Fresh launch: after startRWI() succeeds in initializeWebProcess()
+    //   2. Cache reuse: when SetIsInProcessCache(false) is processed and enableWasmDebugger is true
+    // Guard against a stale WasmDebugServerReady IPC delivered after the process entered the cache:
+    // setIsInProcessCache(true) already called destroyWasmDebuggerTarget(), so we must not recreate it.
+    if (m_isInProcessCache)
+        return;
+    if (!m_wasmDebuggerDebuggable) [[likely]]
+        createWasmDebuggerTarget();
+}
+
 void WebProcessProxy::sendWasmDebuggerResponse(const String& response)
 {
     RefPtr debuggable = m_wasmDebuggerDebuggable;
@@ -3272,7 +3286,7 @@ void WebProcessProxy::sendWasmDebuggerResponse(const String& response)
 
 void WebProcessProxy::updateWasmDebuggerTarget()
 {
-    if (RefPtr debuggable = m_wasmDebuggerDebuggable)
+    if (RefPtr debuggable = m_wasmDebuggerDebuggable) [[unlikely]]
         debuggable->update();
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -200,7 +200,7 @@ public:
         Shared
     };
 
-    static Ref<WebProcessProxy> create(WebProcessPool&, WebsiteDataStore*, LockdownMode, EnhancedSecurity, IsPrewarmed, WebCore::CrossOriginMode = WebCore::CrossOriginMode::Shared, ShouldLaunchProcess = ShouldLaunchProcess::Yes, EnableWebAssemblyDebugger = EnableWebAssemblyDebugger::No);
+    static Ref<WebProcessProxy> create(WebProcessPool&, WebsiteDataStore*, LockdownMode, EnhancedSecurity, IsPrewarmed, WebCore::CrossOriginMode = WebCore::CrossOriginMode::Shared, ShouldLaunchProcess = ShouldLaunchProcess::Yes);
 
     static Ref<WebProcessProxy> createForRemoteWorkers(RemoteWorkerType, WebProcessPool&, WebCore::Site&&, WebsiteDataStore&, LockdownMode, EnhancedSecurity);
 
@@ -597,7 +597,6 @@ public:
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
     void createWasmDebuggerTarget();
-    bool createWasmDebuggerDebuggable() const { return m_createWasmDebuggerDebuggable; }
     void destroyWasmDebuggerTarget();
     void NODELETE connectWasmDebuggerTarget(bool isAutomaticConnection, bool immediatelyPause);
     void NODELETE disconnectWasmDebuggerTarget();
@@ -606,6 +605,7 @@ public:
 
     void sendWasmDebuggerResponse(const String& response);
     void updateWasmDebuggerTarget();
+    void wasmDebugServerReady();
 #endif
 
 #if ENABLE(IPC_TESTING_API)
@@ -622,7 +622,7 @@ public:
 private:
     Type type() const final { return Type::WebContent; }
 
-    WebProcessProxy(WebProcessPool&, WebsiteDataStore*, IsPrewarmed, WebCore::CrossOriginMode, LockdownMode, EnhancedSecurity, [[maybe_unused]] EnableWebAssemblyDebugger = EnableWebAssemblyDebugger::No);
+    WebProcessProxy(WebProcessPool&, WebsiteDataStore*, IsPrewarmed, WebCore::CrossOriginMode, LockdownMode, EnhancedSecurity);
 
     // AuxiliaryProcessProxy
     ASCIILiteral processName() const final { return "WebContent"_s; }
@@ -940,7 +940,6 @@ private:
 #endif
 #if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
     RefPtr<WasmDebuggerDebuggable> m_wasmDebuggerDebuggable;
-    bool m_createWasmDebuggerDebuggable { false };
 #endif
 
     bool m_isEligibleForWebProcessCache { true };

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -113,6 +113,7 @@ messages -> WebProcessProxy WantsDispatchMessage {
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
     SendWasmDebuggerResponse(String response)
+    WasmDebugServerReady()
 #endif
 
     DidPostMessage(WebKit::WebPageProxyIdentifier pageID, WebKit::UserContentControllerIdentifier identifier, struct WebKit::FrameInfoData frameInfoData, WebKit::ScriptMessageHandlerIdentifier messageHandlerID, WebKit::JavaScriptEvaluationResult message) -> (Expected<WebKit::JavaScriptEvaluationResult, String> reply)

--- a/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.cpp
@@ -60,14 +60,22 @@ void WasmDebuggerDispatcher::deref() const
 void WasmDebuggerDispatcher::initializeConnection(IPC::Connection& connection)
 {
     // Register message receiver on WorkQueue (NOT main thread).
-    // This allows IPC messages to be processed even when main thread is blocked in infinite loop
+    // This allows IPC messages to be processed even when main thread is blocked
     connection.addMessageReceiver(m_queue.get(), *this, Messages::WasmDebuggerDispatcher::messageReceiverName());
+}
+
+void WasmDebuggerDispatcher::resetServer()
+{
+    JSC::Wasm::DebugServer& debugServer = JSC::Wasm::DebugServer::singleton();
+    if (!debugServer.hasDebugger())
+        return;
+    debugServer.reset();
 }
 
 void WasmDebuggerDispatcher::dispatchMessage(const String& message)
 {
     // This method runs on WorkQueue thread (NOT main thread).
-    // Safe to call even when main thread is blocked in infinite loop.
+    // Safe to call even when main thread is blocked.
     JSC::Wasm::DebugServer& debugServer = JSC::Wasm::DebugServer::singleton();
 
     if (!debugServer.hasDebugger()) {

--- a/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.h
+++ b/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.h
@@ -55,6 +55,7 @@ private:
 
     // Message handlers - called on WorkQueue thread, safe to call while mutator is blocked.
     void dispatchMessage(const String& message);
+    void resetServer();
 
     const CheckedRef<WebProcess> m_process;
     const Ref<WTF::WorkQueue> m_queue;

--- a/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.messages.in
@@ -28,6 +28,7 @@
 ]
 messages -> WasmDebuggerDispatcher {
     DispatchMessage(String message)
+    ResetServer()
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -755,11 +755,10 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR) && CPU(ARM64)
     if (JSC::Options::enableWasmDebugger()) [[unlikely]] {
-        bool success = JSC::Wasm::DebugServer::singleton().startRWI([](const String& response) {
+        JSC::Wasm::DebugServer::singleton().startRWI([](const String& response) {
             return WebKit::WebProcess::singleton().send(Messages::WebProcessProxy::SendWasmDebuggerResponse(response), 0);
         });
-        if (!success)
-            WEBPROCESS_RELEASE_LOG_ERROR(Inspector, "Failed to start WasmDebugServer in RWI mode");
+        send(Messages::WebProcessProxy::WasmDebugServerReady(), 0);
     }
 #endif
 
@@ -859,6 +858,14 @@ void WebProcess::setIsInProcessCache(bool isInProcessCache, CompletionHandler<vo
 #else
     UNUSED_PARAM(isInProcessCache);
 #endif
+
+#if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR) && CPU(ARM64)
+    // When exiting process cache, notify UIProcess that DebugServer is still running
+    // so it can recreate the debuggable. DebugServer never stops (process-lifetime).
+    if (!isInProcessCache && JSC::Options::enableWasmDebugger())
+        send(Messages::WebProcessProxy::WasmDebugServerReady(), 0);
+#endif
+
     completionHandler();
 }
 


### PR DESCRIPTION
#### 953faee9f74d5acf8f87ec419a4217503715eefe
<pre>
[JSC][WASM][Debugger] Fix WasmDebugger RWI lifecycle: init ordering, cache handling, and process exit
<a href="https://bugs.webkit.org/show_bug.cgi?id=312094">https://bugs.webkit.org/show_bug.cgi?id=312094</a>
<a href="https://rdar.apple.com/174599638">rdar://174599638</a>

Reviewed by Devin Rousso and BJ Burg.

Init ordering fix: WasmDebuggerDebuggable was created in didFinishLaunching()
before startRWI() was called, so early LLDB packets could arrive before the
debug server was ready. Fix by introducing a WasmDebugServerReady IPC sent
from WebContent after startRWI() succeeds. The UIProcess creates the debuggable
only in wasmDebugServerReady(), guaranteeing the debug server is initialized
before LLDB can attach.

Process cache improvement: Previously nothing happened on cache entry or exit,
leaving the debuggable alive when the process was cached (LLDB stayed attached
to an idle process) and never recreating it on cache reuse. Now on cache entry
the debuggable is destroyed and a ResetServer IPC is dispatched to the
WasmDebuggerDispatcher WorkQueue — which runs independently of the mutator —
to cleanly reset server state. On cache exit, WebContent resends WasmDebugServerReady
so the UIProcess recreates the debuggable for the new navigation.

Process exit fix: destroyWasmDebuggerTarget() is now called before shutDownProcess()
in shutDown() so LLDB is notified via RemoteInspector and detaches cleanly before
the WebContent process is killed.

Make DebugServer::reset() public so WasmDebuggerDispatcher can call it directly.
Change DebugServer::startRWI() to return void since it always succeeds.
Remove m_createWasmDebuggerDebuggable and move the enableWebAssemblyDebugger
parameter from WebProcessProxy::create() into initializeNewWebProcess(), since
debuggable creation is now driven by WasmDebugServerReady rather than launch.

Add a complete Component Lifecycle section to RWI_ARCHITECTURE.md.

Canonical link: <a href="https://commits.webkit.org/311292@main">https://commits.webkit.org/311292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d6faf9bb69b8ee455677a53ca1489d1a2b27840

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165169 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110428 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121079 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85134 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101750 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22362 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20535 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12941 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148398 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167651 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17183 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11764 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129201 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24601 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129313 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35075 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140031 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87002 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24138 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16830 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188231 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28915 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92872 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48392 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28670 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28566 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->