### PR TITLE
Bring TestWebKitAPI up to code with regard to adoptRef, adoptCF, and adoptOSObject

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/CGImagePixelReader.cpp
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/CGImagePixelReader.cpp
@@ -37,7 +37,7 @@ CGImagePixelReader::CGImagePixelReader(CGImageRef image)
     : m_width(CGImageGetWidth(image))
     , m_height(CGImageGetHeight(image))
 {
-    auto colorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr colorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
     auto bytesPerPixel = 4;
     auto bytesPerRow = bytesPerPixel * CGImageGetWidth(image);
     auto bitsPerComponent = 8;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/DaemonTestUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/DaemonTestUtilities.mm
@@ -84,7 +84,7 @@ RetainPtr<NSURL> currentExecutableDirectory()
 static OSObjectPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpc = adoptOSObject(xpc_array_create(nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr xpc = adoptOSObject(xpc_array_create(nullptr, 0));
     for (id value in array) {
         if ([value isKindOfClass:NSString.class])
             xpc_array_set_string(xpc.get(), XPC_ARRAY_APPEND, [value UTF8String]);
@@ -97,7 +97,7 @@ static OSObjectPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
 static OSObjectPtr<xpc_object_t> convertDictionaryToXPC(NSDictionary<NSString *, id> *dictionary)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpc = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr xpc = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     for (NSString *key in dictionary) {
         ASSERT([key isKindOfClass:NSString.class]);
         const char* keyUTF8 = key.UTF8String;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.mm
@@ -78,7 +78,7 @@ static RetainPtr<nw_protocol_definition_t> proxyDefinition(HTTPServer::Protocol 
                         "Proxy-Authenticate: Basic realm=\"testrealm\"\r\n"
                         "Content-Length: 0\r\n"
                         "\r\n";
-                    auto response = adoptOSObject(dispatch_data_create(challengeResponse, strlen(challengeResponse), nullptr, nullptr));
+                    OSObjectPtr response = adoptOSObject(dispatch_data_create(challengeResponse, strlen(challengeResponse), nullptr, nullptr));
                     nw_framer_write_output_data(retainedFramer.get(), response.get());
                     state = State::DidRequestCredentials;
                     break;
@@ -90,7 +90,7 @@ static RetainPtr<nw_protocol_definition_t> proxyDefinition(HTTPServer::Protocol 
                     const char* negotiationResponse = ""
                         "HTTP/1.1 200 Connection Established\r\n"
                         "Connection: close\r\n\r\n";
-                    auto response = adoptOSObject(dispatch_data_create(negotiationResponse, strlen(negotiationResponse), nullptr, nullptr));
+                    OSObjectPtr response = adoptOSObject(dispatch_data_create(negotiationResponse, strlen(negotiationResponse), nullptr, nullptr));
                     nw_framer_write_output_data(retainedFramer.get(), response.get());
                     nw_framer_mark_ready(retainedFramer.get());
                     state = State::PassThrough;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestProtocol.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestProtocol.mm
@@ -99,8 +99,8 @@ static NSURL *createRedirectURL(NSString *query)
 
 static NSString *contentTypeForFileExtension(NSString *fileExtension)
 {
-    auto identifier = adoptCF(UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExtension, nullptr));
-    auto mimeType = adoptCF(UTTypeCopyPreferredTagWithClass(identifier.get(), kUTTagClassMIMEType));
+    RetainPtr identifier = adoptCF(UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExtension, nullptr));
+    RetainPtr mimeType = adoptCF(UTTypeCopyPreferredTagWithClass(identifier.get(), kUTTagClassMIMEType));
     return (__bridge NSString *)mimeType.autorelease();
 }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -822,7 +822,7 @@ String certDataBase64(""
 static RetainPtr<SecCertificateRef> createCertificate()
 {
     RetainPtr certData = adoptNS([[NSData alloc] initWithBase64EncodedString:certDataBase64.createNSString().get() options:0]);
-    auto cert = adoptCF(SecCertificateCreateWithData(kCFAllocatorDefault, (CFDataRef)certData.get()));
+    RetainPtr cert = adoptCF(SecCertificateCreateWithData(kCFAllocatorDefault, (CFDataRef)certData.get()));
     EXPECT_NOT_NULL(cert);
     return cert;
 }
@@ -837,7 +837,7 @@ static RetainPtr<SecKeyRef> createPrivateKey()
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate
     };
 
-    auto privateKey = adoptCF(SecKeyCreateWithData((CFDataRef)keyData.get(), (CFDictionaryRef)keyAttrs, NULL));
+    RetainPtr privateKey = adoptCF(SecKeyCreateWithData((CFDataRef)keyData.get(), (CFDictionaryRef)keyAttrs, NULL));
     EXPECT_NOT_NULL(privateKey);
     return privateKey;
 }
@@ -994,7 +994,7 @@ TEST(IPCSerialization, Basic)
 
     // NSData/CFData
     runTestNS({ [NSData dataWithBytes:"Data test" length:strlen("Data test")] });
-    auto cfData = adoptCF(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)"Data test", strlen("Data test")));
+    RetainPtr cfData = adoptCF(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)"Data test", strlen("Data test")));
     runTestCF({ cfData.get() });
 
     // NSDate
@@ -1012,14 +1012,14 @@ TEST(IPCSerialization, Basic)
     runTestCF({ kCFBooleanFalse });
 
     // CGColor
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
     constexpr CGFloat testComponents[4] = { 1, .75, .5, .25 };
-    auto cgColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), testComponents));
+    RetainPtr cgColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), testComponents));
     runTestCF({ cgColor.get() });
 
     // CGColorSpace
     runTestCF({ sRGBColorSpace.get() });
-    auto grayColorSpace = adoptCF(CGColorSpaceCreateDeviceGray());
+    RetainPtr grayColorSpace = adoptCF(CGColorSpaceCreateDeviceGray());
     runTestCF({ grayColorSpace.get() });
 
     auto runNumberTest = [&](NSNumber *number) {
@@ -1058,7 +1058,7 @@ TEST(IPCSerialization, Basic)
     runTestNS({ @{ @"Dictionary": @[ @"array value", @12 ] } });
 
     // CFDictionary with a non-toll-free bridged CFType, also run as NSDictionary
-    auto cfDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 1, NULL, NULL));
+    RetainPtr cfDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 1, NULL, NULL));
     CFDictionaryAddValue(cfDictionary.get(), CFSTR("MyKey"), cgColor.get());
     runTestCF({ cfDictionary.get() });
     runTestNS({ bridge_cast(cfDictionary.get()) });
@@ -1184,9 +1184,9 @@ TEST(IPCSerialization, Basic)
     // CFURL
     // The following URL described is quite nonsensical.
     const UInt8 baseBytes[10] = { 'h', 't', 't', 'p', ':', '/', '/', 0xE2, 0x80, 0x80 };
-    auto baseURL = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, baseBytes, 10, kCFStringEncodingUTF8, nullptr, true));
+    RetainPtr baseURL = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, baseBytes, 10, kCFStringEncodingUTF8, nullptr, true));
     const UInt8 compoundBytes[10] = { 'p', 'a', 't', 'h' };
-    auto compoundURL = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, compoundBytes, 4, kCFStringEncodingUTF8, baseURL.get(), true));
+    RetainPtr compoundURL = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, compoundBytes, 4, kCFStringEncodingUTF8, baseURL.get(), true));
     runTestCF({ baseURL.get() });
     runTestCF({ compoundURL.get() });
 
@@ -1206,10 +1206,10 @@ TEST(IPCSerialization, Basic)
 
     // SecTrust -- evaluate the trust of the cert created above
     SecTrustRef trustRef = NULL;
-    auto policy = adoptCF(SecPolicyCreateBasicX509());
+    RetainPtr policy = adoptCF(SecPolicyCreateBasicX509());
     EXPECT_TRUE(SecTrustCreateWithCertificates(cert.get(), policy.get(), &trustRef) == errSecSuccess);
     EXPECT_NOT_NULL(trustRef);
-    auto trust = adoptCF(trustRef);
+    RetainPtr trust = adoptCF(trustRef);
     runTestCF({ trust.get() });
 
     EXPECT_TRUE(SecTrustEvaluateWithError(trust.get(), NULL) == errSecSuccess);
@@ -1221,7 +1221,7 @@ TEST(IPCSerialization, Basic)
         (id)kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly : @(YES),
         (id)kSecAttrAccessibleWhenUnlocked: @(YES) };
     SecAccessControlCreateFlags flags = (kSecAccessControlDevicePasscode | kSecAccessControlBiometryAny | kSecAccessControlOr);
-    auto accessControlRef = adoptCF(SecAccessControlCreateWithFlags(kCFAllocatorDefault, (CFTypeRef)protection, flags, NULL));
+    RetainPtr accessControlRef = adoptCF(SecAccessControlCreateWithFlags(kCFAllocatorDefault, (CFTypeRef)protection, flags, NULL));
     EXPECT_NOT_NULL(accessControlRef);
     runTestCF({ accessControlRef.get() });
 
@@ -1235,7 +1235,7 @@ TEST(IPCSerialization, Basic)
     CFArrayRef itemsPtr = NULL;
     EXPECT_TRUE(SecKeychainItemImport(certData, CFSTR(".pem"), NULL, NULL, 0, NULL, tempKeychain, &itemsPtr) == errSecSuccess);
     EXPECT_NOT_NULL(itemsPtr);
-    auto items = adoptCF(itemsPtr);
+    RetainPtr items = adoptCF(itemsPtr);
     EXPECT_GT(CFArrayGetCount(items.get()), 0);
 
     RetainPtr keychainItemRef = (SecKeychainItemRef)CFArrayGetValueAtIndex(items.get(), 0);
@@ -1888,13 +1888,13 @@ TEST(IPCSerialization, PKPayment)
 
 static RetainPtr<DDScannerResult> fakeDataDetectorResultForTesting()
 {
-    auto scanner = adoptCF(PAL::softLink_DataDetectorsCore_DDScannerCreate(DDScannerTypeStandard, 0, nullptr));
+    RetainPtr scanner = adoptCF(PAL::softLink_DataDetectorsCore_DDScannerCreate(DDScannerTypeStandard, 0, nullptr));
     auto stringToScan = CFSTR("webkit.org");
-    auto query = adoptCF(PAL::softLink_DataDetectorsCore_DDScanQueryCreateFromString(kCFAllocatorDefault, stringToScan, CFRangeMake(0, CFStringGetLength(stringToScan))));
+    RetainPtr query = adoptCF(PAL::softLink_DataDetectorsCore_DDScanQueryCreateFromString(kCFAllocatorDefault, stringToScan, CFRangeMake(0, CFStringGetLength(stringToScan))));
     if (!PAL::softLink_DataDetectorsCore_DDScannerScanQuery(scanner.get(), query.get()))
         return nil;
 
-    auto results = adoptCF(PAL::softLink_DataDetectorsCore_DDScannerCopyResultsWithOptions(scanner.get(), DDScannerCopyResultsOptionsNoOverlap));
+    RetainPtr results = adoptCF(PAL::softLink_DataDetectorsCore_DDScannerCopyResultsWithOptions(scanner.get(), DDScannerCopyResultsOptionsNoOverlap));
     if (!CFArrayGetCount(results.get()))
         return nil;
 
@@ -2205,69 +2205,69 @@ TEST(CoreIPCCFDictionary, InsertDifferentValueTypes)
     // Test that a CoreIPCCFDictionary can be created, encoded, and decoded with valid key-value pairs.
     // Keys will be string type (CFStringRef).
     // Values will be all possible variants from IPC::CFType.
-    auto cfDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    RetainPtr cfDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 
     // CFBooleanRef
-    auto booleanKey = adoptCF(CFSTR("booleanKey"));
-    auto booleanValue = adoptCF(kCFBooleanFalse);
+    RetainPtr booleanKey = adoptCF(CFSTR("booleanKey"));
+    RetainPtr booleanValue = adoptCF(kCFBooleanFalse);
     CFDictionaryAddValue(cfDictionary.get(), booleanKey.get(), booleanValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 1);
 
     // CFCharacterSetRef
-    auto charSetKey = adoptCF(CFSTR("charSetKey"));
-    auto charSetValue = adoptCF(CFCharacterSetCreateWithCharactersInString(kCFAllocatorDefault, CFSTR("ABC")));
+    RetainPtr charSetKey = adoptCF(CFSTR("charSetKey"));
+    RetainPtr charSetValue = adoptCF(CFCharacterSetCreateWithCharactersInString(kCFAllocatorDefault, CFSTR("ABC")));
     CFDictionaryAddValue(cfDictionary.get(), charSetKey.get(), charSetValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 2);
 
     // CFDataRef
-    auto dataKey = adoptCF(CFSTR("dataKey"));
-    auto dataValue = adoptCF(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)"Data test", strlen("Data test")));
+    RetainPtr dataKey = adoptCF(CFSTR("dataKey"));
+    RetainPtr dataValue = adoptCF(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)"Data test", strlen("Data test")));
     CFDictionaryAddValue(cfDictionary.get(), dataKey.get(), dataValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 3);
 
     // CFDateRef
-    auto dateKey = adoptCF(CFSTR("dateKey"));
-    auto dateValue = adoptCF(CFDateCreate(kCFAllocatorDefault, 1.23));
+    RetainPtr dateKey = adoptCF(CFSTR("dateKey"));
+    RetainPtr dateValue = adoptCF(CFDateCreate(kCFAllocatorDefault, 1.23));
     CFDictionaryAddValue(cfDictionary.get(), dateKey.get(), dateValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 4);
 
     // CFDictionaryRef
-    auto dictKey = adoptCF(CFSTR("dictKey"));
-    auto dictValue = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-    auto key1 = adoptCF(CFSTR("key1"));
-    auto value1 = adoptCF(CFSTR("value1"));
+    RetainPtr dictKey = adoptCF(CFSTR("dictKey"));
+    RetainPtr dictValue = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    RetainPtr key1 = adoptCF(CFSTR("key1"));
+    RetainPtr value1 = adoptCF(CFSTR("value1"));
     CFDictionaryAddValue(dictValue.get(), key1.get(), value1.get());
     CFDictionaryAddValue(cfDictionary.get(), dictKey.get(), dictValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 5);
 
     // CFNullRef
-    auto nullKey = adoptCF(CFSTR("nullKey"));
-    auto nullValue = adoptCF(kCFNull);
+    RetainPtr nullKey = adoptCF(CFSTR("nullKey"));
+    RetainPtr nullValue = adoptCF(kCFNull);
     CFDictionaryAddValue(cfDictionary.get(), nullKey.get(), nullValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 6);
 
     // CFNumberRef
-    auto numberKey = adoptCF(CFSTR("numberKey"));
+    RetainPtr numberKey = adoptCF(CFSTR("numberKey"));
     int32_t num = 123;
-    auto numberValue = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, (const void*)&num));
+    RetainPtr numberValue = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, (const void*)&num));
     CFDictionaryAddValue(cfDictionary.get(), numberKey.get(), numberValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 7);
 
     // CFStringRef
-    auto stringKey = adoptCF(CFSTR("stringKey"));
-    auto stringValue = adoptCF(CFSTR("stringValue"));
+    RetainPtr stringKey = adoptCF(CFSTR("stringKey"));
+    RetainPtr stringValue = adoptCF(CFSTR("stringValue"));
     CFDictionaryAddValue(cfDictionary.get(), stringKey.get(), stringValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 8);
 
     // CFURLRef
-    auto urlKey = adoptCF(CFSTR("urlKey"));
-    auto url = adoptCF(CFSTR("localhost.com"));
-    auto urlValue = adoptCF(CFURLCreateWithString(kCFAllocatorDefault, url.get(), NULL));
+    RetainPtr urlKey = adoptCF(CFSTR("urlKey"));
+    RetainPtr url = adoptCF(CFSTR("localhost.com"));
+    RetainPtr urlValue = adoptCF(CFURLCreateWithString(kCFAllocatorDefault, url.get(), NULL));
     CFDictionaryAddValue(cfDictionary.get(), urlKey.get(), urlValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 9);
 
     // SecCertificateRef
-    auto secCertificateKey = adoptCF(CFSTR("secCertificateKey"));
+    RetainPtr secCertificateKey = adoptCF(CFSTR("secCertificateKey"));
     auto secCertificateValue = createCertificate();
     CFDictionaryAddValue(cfDictionary.get(), secCertificateKey.get(), secCertificateValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 10);
@@ -2275,42 +2275,42 @@ TEST(CoreIPCCFDictionary, InsertDifferentValueTypes)
     // SecTrustRef
     auto certificate = createCertificate();
     NSArray* certArray = @[(__bridge id) certificate.get()];
-    auto policy = adoptCF(SecPolicyCreateBasicX509());
+    RetainPtr policy = adoptCF(SecPolicyCreateBasicX509());
     SecTrustRef trust;
     SecTrustCreateWithCertificates((__bridge CFTypeRef) certArray, policy.get(), &trust);
 
-    auto secTrustKey = adoptCF(CFSTR("secTrustKey"));
-    auto secTrustValue = adoptCF(trust);
+    RetainPtr secTrustKey = adoptCF(CFSTR("secTrustKey"));
+    RetainPtr secTrustValue = adoptCF(trust);
     CFDictionaryAddValue(cfDictionary.get(), secTrustKey.get(), secTrustValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 11);
 
     // CGColorSpaceRef
-    auto colorSpaceKey = adoptCF(CFSTR("colorSpaceKey"));
-    auto colorSpaceValue = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr colorSpaceKey = adoptCF(CFSTR("colorSpaceKey"));
+    RetainPtr colorSpaceValue = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
     CFDictionaryAddValue(cfDictionary.get(), colorSpaceKey.get(), colorSpaceValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 12);
 
     // CGColorRef
-    auto colorKey = adoptCF(CFSTR("colorKey"));
-    auto colorValue = adoptCF(CGColorCreateSRGB(1.0, 0.0, 0.0, 1.0));
+    RetainPtr colorKey = adoptCF(CFSTR("colorKey"));
+    RetainPtr colorValue = adoptCF(CGColorCreateSRGB(1.0, 0.0, 0.0, 1.0));
     CFDictionaryAddValue(cfDictionary.get(), colorKey.get(), colorValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 13);
 
     // SecAccessControlRef
-    auto secAccessControlKey = adoptCF(CFSTR("secAccessControlKey"));
+    RetainPtr secAccessControlKey = adoptCF(CFSTR("secAccessControlKey"));
     SecAccessControlCreateFlags flags = (kSecAccessControlDevicePasscode | kSecAccessControlBiometryAny | kSecAccessControlOr);
     NSDictionary *protection = @{
         (id)kSecUseDataProtectionKeychain : @(YES),
         (id)kSecAttrSynchronizable : @(NO),
         (id)kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly : @(YES),
         (id)kSecAttrAccessibleWhenUnlocked: @(YES) };
-    auto secAccessControlValue = adoptCF(SecAccessControlCreateWithFlags(kCFAllocatorDefault, (CFTypeRef)protection, flags, NULL));
+    RetainPtr secAccessControlValue = adoptCF(SecAccessControlCreateWithFlags(kCFAllocatorDefault, (CFTypeRef)protection, flags, NULL));
     CFDictionaryAddValue(cfDictionary.get(), secAccessControlKey.get(), secAccessControlValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 14);
 
     // CFSocketRef (should not be accepted by CoreIPCCFDictionary)
-    auto socketKey = adoptCF(CFSTR("socketKey"));
-    auto socketValue = adoptCF(CFSocketCreate(kCFAllocatorDefault, 0, 0, 0, 0, NULL, NULL));
+    RetainPtr socketKey = adoptCF(CFSTR("socketKey"));
+    RetainPtr socketValue = adoptCF(CFSocketCreate(kCFAllocatorDefault, 0, 0, 0, 0, NULL, NULL));
     CFDictionaryAddValue(cfDictionary.get(), socketKey.get(), socketValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 15);
 
@@ -2358,94 +2358,94 @@ TEST(CoreIPCCFDictionary, InsertDifferentKeyTypes)
     // Test that a CoreIPCCFDictionary can be created, encoded, and decoded with valid key-value pairs.
     // Keys will be all possible variants from CoreIPCCFDictionary::KeyType
     // Values will be string type (CFStringRef).
-    auto cfDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    RetainPtr cfDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 
     // CFBooleanRef
-    auto booleanKey = adoptCF(kCFBooleanFalse);
-    auto booleanValue = adoptCF(CFSTR("booleanValue"));
+    RetainPtr booleanKey = adoptCF(kCFBooleanFalse);
+    RetainPtr booleanValue = adoptCF(CFSTR("booleanValue"));
     CFDictionaryAddValue(cfDictionary.get(), booleanKey.get(), booleanValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 1);
 
     // CFCharacterSetRef
-    auto charSetKey = adoptCF(CFCharacterSetCreateWithCharactersInString(kCFAllocatorDefault, CFSTR("ABC")));
-    auto charSetValue = adoptCF(CFSTR("charSetValue"));
+    RetainPtr charSetKey = adoptCF(CFCharacterSetCreateWithCharactersInString(kCFAllocatorDefault, CFSTR("ABC")));
+    RetainPtr charSetValue = adoptCF(CFSTR("charSetValue"));
     CFDictionaryAddValue(cfDictionary.get(), charSetKey.get(), charSetValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 2);
 
     // CFDataRef
-    auto dataKey = adoptCF(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)"Data test", strlen("Data test")));
-    auto dataValue = adoptCF(CFSTR("dataValue"));
+    RetainPtr dataKey = adoptCF(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)"Data test", strlen("Data test")));
+    RetainPtr dataValue = adoptCF(CFSTR("dataValue"));
     CFDictionaryAddValue(cfDictionary.get(), dataKey.get(), dataValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 3);
 
     // CFDateRef
-    auto dateKey = adoptCF(CFDateCreate(kCFAllocatorDefault, 1.23));
-    auto dateValue = adoptCF(CFSTR("dateValue"));
+    RetainPtr dateKey = adoptCF(CFDateCreate(kCFAllocatorDefault, 1.23));
+    RetainPtr dateValue = adoptCF(CFSTR("dateValue"));
     CFDictionaryAddValue(cfDictionary.get(), dateKey.get(), dateValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 4);
 
     // CFDictionaryRef
-    auto dictKey = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-    auto dictValue = adoptCF(CFSTR("dictValue"));
-    auto key1 = adoptCF(CFSTR("key1"));
-    auto value1 = adoptCF(CFSTR("value1"));
+    RetainPtr dictKey = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    RetainPtr dictValue = adoptCF(CFSTR("dictValue"));
+    RetainPtr key1 = adoptCF(CFSTR("key1"));
+    RetainPtr value1 = adoptCF(CFSTR("value1"));
     CFDictionaryAddValue(dictKey.get(), key1.get(), value1.get());
     CFDictionaryAddValue(cfDictionary.get(), dictKey.get(), dictValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 5);
 
     // CFNullRef
-    auto nullKey = adoptCF(kCFNull);
-    auto nullValue = adoptCF(CFSTR("nullValue"));
+    RetainPtr nullKey = adoptCF(kCFNull);
+    RetainPtr nullValue = adoptCF(CFSTR("nullValue"));
     CFDictionaryAddValue(cfDictionary.get(), nullKey.get(), nullValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 6);
 
     // CFNumberRef
     int32_t num = 123;
-    auto numberKey = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, (const void*)&num));
-    auto numberValue = adoptCF(CFSTR("numberValue"));
+    RetainPtr numberKey = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, (const void*)&num));
+    RetainPtr numberValue = adoptCF(CFSTR("numberValue"));
     CFDictionaryAddValue(cfDictionary.get(), numberKey.get(), numberValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 7);
 
     // CFStringRef
-    auto stringKey = adoptCF(CFSTR("stringKey"));
-    auto stringValue = adoptCF(CFSTR("stringValue"));
+    RetainPtr stringKey = adoptCF(CFSTR("stringKey"));
+    RetainPtr stringValue = adoptCF(CFSTR("stringValue"));
     CFDictionaryAddValue(cfDictionary.get(), stringKey.get(), stringValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 8);
 
     // CFURLRef
-    auto url = adoptCF(CFSTR("localhost.com"));
-    auto urlKey = adoptCF(CFURLCreateWithString(kCFAllocatorDefault, url.get(), NULL));
-    auto urlValue = adoptCF(CFSTR("urlValue"));
+    RetainPtr url = adoptCF(CFSTR("localhost.com"));
+    RetainPtr urlKey = adoptCF(CFURLCreateWithString(kCFAllocatorDefault, url.get(), NULL));
+    RetainPtr urlValue = adoptCF(CFSTR("urlValue"));
     CFDictionaryAddValue(cfDictionary.get(), urlKey.get(), urlValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 9);
 
     // SecCertificateRef
     auto secCertificateKey = createCertificate();
-    auto secCertificateValue = adoptCF(CFSTR("secCertificateValue"));
+    RetainPtr secCertificateValue = adoptCF(CFSTR("secCertificateValue"));
     CFDictionaryAddValue(cfDictionary.get(), secCertificateKey.get(), secCertificateValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 10);
 
     // SecTrustRef
     auto certificate = createCertificate();
     NSArray* certArray = @[(__bridge id) certificate.get()];
-    auto policy = adoptCF(SecPolicyCreateBasicX509());
+    RetainPtr policy = adoptCF(SecPolicyCreateBasicX509());
     SecTrustRef trust;
     SecTrustCreateWithCertificates((__bridge CFTypeRef) certArray, policy.get(), &trust);
 
-    auto secTrustKey = adoptCF(trust);
-    auto secTrustValue = adoptCF(CFSTR("secTrustValue"));
+    RetainPtr secTrustKey = adoptCF(trust);
+    RetainPtr secTrustValue = adoptCF(CFSTR("secTrustValue"));
     CFDictionaryAddValue(cfDictionary.get(), secTrustKey.get(), secTrustValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 11);
 
     // CGColorSpaceRef
-    auto colorSpaceKey = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto colorSpaceValue = adoptCF(CFSTR("colorSpaceValue"));
+    RetainPtr colorSpaceKey = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr colorSpaceValue = adoptCF(CFSTR("colorSpaceValue"));
     CFDictionaryAddValue(cfDictionary.get(), colorSpaceKey.get(), colorSpaceValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 12);
 
     // CGColorRef
-    auto colorKey = adoptCF(CGColorCreateSRGB(1.0, 0.0, 0.0, 1.0));
-    auto colorValue = adoptCF(CFSTR("colorValue"));
+    RetainPtr colorKey = adoptCF(CGColorCreateSRGB(1.0, 0.0, 0.0, 1.0));
+    RetainPtr colorValue = adoptCF(CFSTR("colorValue"));
     CFDictionaryAddValue(cfDictionary.get(), colorKey.get(), colorValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 13);
 
@@ -2456,14 +2456,14 @@ TEST(CoreIPCCFDictionary, InsertDifferentKeyTypes)
         (id)kSecAttrSynchronizable : @(NO),
         (id)kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly : @(YES),
         (id)kSecAttrAccessibleWhenUnlocked: @(YES) };
-    auto secAccessControlKey = adoptCF(SecAccessControlCreateWithFlags(kCFAllocatorDefault, (CFTypeRef)protection, flags, NULL));
-    auto secAccessControlValue = adoptCF(CFSTR("secAccessControlValue"));
+    RetainPtr secAccessControlKey = adoptCF(SecAccessControlCreateWithFlags(kCFAllocatorDefault, (CFTypeRef)protection, flags, NULL));
+    RetainPtr secAccessControlValue = adoptCF(CFSTR("secAccessControlValue"));
     CFDictionaryAddValue(cfDictionary.get(), secAccessControlKey.get(), secAccessControlValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 14);
 
     // CFSocketRef (should not be accepted by CoreIPCCFDictionary)
-    auto socketKey = adoptCF(CFSocketCreate(kCFAllocatorDefault, 0, 0, 0, 0, NULL, NULL));
-    auto socketValue = adoptCF(CFSTR("socketValue"));
+    RetainPtr socketKey = adoptCF(CFSocketCreate(kCFAllocatorDefault, 0, 0, 0, 0, NULL, NULL));
+    RetainPtr socketValue = adoptCF(CFSTR("socketValue"));
     CFDictionaryAddValue(cfDictionary.get(), socketKey.get(), socketValue.get());
     EXPECT_EQ(CFDictionaryGetCount(cfDictionary.get()), 15);
 

--- a/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
@@ -541,7 +541,7 @@ class ListHashSetReferencedItem : public RefCounted<ListHashSetReferencedItem> {
 public:
     static Ref<ListHashSetReferencedItem> create()
     {
-        auto result = adoptRef(*new ListHashSetReferencedItem());
+        Ref result = adoptRef(*new ListHashSetReferencedItem());
         return result;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -497,14 +497,14 @@ TEST(NativePromise, AsyncResolve)
     AutoWorkQueue awq;
     auto queue = awq.queue();
     queue->dispatch([queue] {
-        auto producer = adoptRef(new RefCountedProducer());
+        RefPtr producer = adoptRef(new RefCountedProducer());
         auto promise = producer->promise();
 
         // Kick off three racing tasks, and make sure we get the one that finishes
         // earliest.
-        auto delayedSettleTask1 = adoptRef(new DelayedSettle(queue, producer, TestPromise::Result(32), 10));
-        auto delayedSettleTask2 = adoptRef(new DelayedSettle(queue, producer, TestPromise::Result(42), 5));
-        auto delayedSettleTask3 = adoptRef(new DelayedSettle(queue, producer, TestPromise::Error(32.0), 7));
+        Ref delayedSettleTask1 = adoptRef(*new DelayedSettle(queue, producer, TestPromise::Result(32), 10));
+        Ref delayedSettleTask2 = adoptRef(*new DelayedSettle(queue, producer, TestPromise::Result(42), 5));
+        Ref delayedSettleTask3 = adoptRef(*new DelayedSettle(queue, producer, TestPromise::Error(32.0), 7));
 
         delayedSettleTask1->dispatch();
         delayedSettleTask2->dispatch();
@@ -539,10 +539,10 @@ TEST(NativePromise, CompletionPromises)
                 },
                 doFailAndReject())->then(queue,
                     [queue](int val) {
-                        auto producer = adoptRef(new RefCountedProducer());
+                        RefPtr producer = adoptRef(new RefCountedProducer());
                         auto p = producer->promise();
 
-                        auto resolver = adoptRef(new DelayedSettle(queue, producer, TestPromise::Result(val - 8), 10));
+                        Ref resolver = adoptRef(*new DelayedSettle(queue, producer, TestPromise::Result(val - 8), 10));
                         resolver->dispatch();
                         return p;
                     },

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -2833,7 +2833,7 @@ TEST(WTF_ThreadSafeWeakPtr, ThreadSafety)
 
 TEST(WTF_ThreadSafeWeakPtr, UseAfterMoveResistance)
 {
-    auto counter = adoptRef(*new ThreadSafeInstanceCounter());
+    Ref counter = adoptRef(*new ThreadSafeInstanceCounter());
     auto weakPtr = ThreadSafeWeakPtr { counter.get() };
     auto movedTo = WTF::move(weakPtr);
     SUPPRESS_USE_AFTER_MOVE EXPECT_NULL(weakPtr.get());
@@ -3022,7 +3022,7 @@ TEST(WTF_ThreadSafeWeakPtr, ThreadSafeWeakHashAmortizedCleanupWhenOnlyAdding)
 
     ThreadSafeWeakHashSet<Struct> set;
     for (int i = 0; i < 10000; ++i) {
-        auto obj = adoptRef(*new Struct);
+        Ref obj = adoptRef(*new Struct);
         set.add(obj.get());
     }
     EXPECT_LT(set.sizeIncludingEmptyEntriesForTesting(), 1000u);
@@ -3038,7 +3038,7 @@ TEST(WTF_ThreadSafeWeakPtr, AmortizedCleanupNotQuadratic)
     ThreadSafeWeakHashSet<Struct> set;
     HashSet<Ref<Struct>> strongSet;
     for (int i = 0; i < 1000000; ++i) {
-        auto obj = adoptRef(*new Struct);
+        Ref obj = adoptRef(*new Struct);
         set.add(obj.get());
         strongSet.add(WTF::move(obj));
     }
@@ -3086,7 +3086,7 @@ TEST(WTF_ThreadSafeWeakPtr, MultipleInheritance)
     ThreadSafeWeakHashSet<Dog> dogs;
     ThreadSafeWeakHashSet<Cat> cats;
     {
-        auto catDog = adoptRef(*new CatDog);
+        Ref catDog = adoptRef(*new CatDog);
         Cat* catPointer { nullptr };
         Dog* dogPointer { nullptr };
 
@@ -3107,12 +3107,12 @@ TEST(WTF_ThreadSafeWeakPtr, MultipleInheritance)
     EXPECT_TRUE(dogs.isEmptyIgnoringNullReferences());
     EXPECT_TRUE(cats.isEmptyIgnoringNullReferences());
 
-    auto keepCat = adoptRef(new CatDog);
+    RefPtr keepCat = adoptRef(new CatDog);
     RefPtr<Cat> cat(keepCat.get());
     keepCat = nullptr;
     cat = nullptr;
 
-    auto keepDog = adoptRef(new CatDog);
+    RefPtr keepDog = adoptRef(new CatDog);
     RefPtr<Dog> dog(keepDog.get());
     keepDog = nullptr;
     dog = nullptr;

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/StringCF.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/StringCF.cpp
@@ -59,7 +59,7 @@ TEST(StringCF, ConstructFromLatin1WithHighBytes)
 {
     // Create a CFString with Latin-1 characters above ASCII range (e.g. U+00E9 = é).
     const uint8_t latin1Bytes[] = { 'r', 0xE9, 's', 'u', 'm', 0xE9 }; // "résumé" in Latin-1
-    auto cfString = adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, latin1Bytes, sizeof(latin1Bytes), kCFStringEncodingISOLatin1, false));
+    RetainPtr cfString = adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, latin1Bytes, sizeof(latin1Bytes), kCFStringEncodingISOLatin1, false));
 
     String string(cfString.get());
     EXPECT_EQ(string.length(), 6u);
@@ -73,7 +73,7 @@ TEST(StringCF, ConstructFromUTF16WithLatin1Characters)
     // Use a long string so CF is likely to expose its internal UTF-16 buffer via
     // CFStringGetCharactersSpan, exercising the create8BitIfPossible narrowing path.
     Vector<char16_t> characters(FillWith { }, 4096, 'A');
-    auto cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters.span().data()), characters.size()));
+    RetainPtr cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters.span().data()), characters.size()));
 
     String string(cfString.get());
     EXPECT_EQ(string.length(), 4096u);
@@ -85,7 +85,7 @@ TEST(StringCF, ConstructFromUTF16WithHighLatin1Characters)
 {
     // Create a CFString from UTF-16 characters that include high Latin-1 chars (U+00E9).
     const char16_t characters[] = { 'r', 0x00E9, 's', 'u', 'm', 0x00E9 }; // "résumé"
-    auto cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters), std::size(characters)));
+    RetainPtr cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters), std::size(characters)));
 
     String string(cfString.get());
     EXPECT_EQ(string.length(), 6u);
@@ -97,7 +97,7 @@ TEST(StringCF, ConstructFromUTF16WithNonLatin1Characters)
 {
     // Create a CFString with characters outside Latin-1 range (e.g. U+4E16 = 世, U+754C = 界).
     const char16_t characters[] = { 0x4E16, 0x754C }; // "世界"
-    auto cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters), std::size(characters)));
+    RetainPtr cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters), std::size(characters)));
 
     String string(cfString.get());
     EXPECT_EQ(string.length(), 2u);
@@ -110,7 +110,7 @@ TEST(StringCF, ConstructFromUTF16MixedLatin1AndNonLatin1)
 {
     // Mix of Latin-1 and non-Latin-1 characters — should stay 16-bit.
     const char16_t characters[] = { 'H', 'i', 0x4E16 }; // "Hi世"
-    auto cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters), std::size(characters)));
+    RetainPtr cfString = adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters), std::size(characters)));
 
     String string(cfString.get());
     EXPECT_EQ(string.length(), 3u);

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/VectorCF.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/VectorCF.cpp
@@ -86,7 +86,7 @@ TEST(VectorCF, CreateCFArrayWithFunctor_CFNumber)
 TEST(VectorCF, MakeVector_CFString)
 {
     const size_t elementCount = 3;
-    auto cfStrings = adoptCF(CFArrayCreateMutable(nullptr, elementCount, &kCFTypeArrayCallBacks));
+    RetainPtr cfStrings = adoptCF(CFArrayCreateMutable(nullptr, elementCount, &kCFTypeArrayCallBacks));
     CFArrayAppendValue(cfStrings.get(), CFSTR("one"));
     CFArrayAppendValue(cfStrings.get(), CFSTR("two"));
     CFArrayAppendValue(cfStrings.get(), CFSTR("three"));
@@ -104,7 +104,7 @@ TEST(VectorCF, MakeVector_CFString)
 TEST(VectorCF, MakeVector_CFNumber)
 {
     const size_t elementCount = 3;
-    auto cfNumbers = adoptCF(CFArrayCreateMutable(nullptr, elementCount, &kCFTypeArrayCallBacks));
+    RetainPtr cfNumbers = adoptCF(CFArrayCreateMutable(nullptr, elementCount, &kCFTypeArrayCallBacks));
     float number = 1;
     CFArrayAppendValue(cfNumbers.get(), CFNumberCreate(nullptr, kCFNumberFloatType, &number));
     number = 2;
@@ -125,7 +125,7 @@ TEST(VectorCF, MakeVector_CFNumber)
 TEST(VectorCF, MakeVectorWithFunctor)
 {
     const size_t elementCount = 3;
-    auto cfNumbers = adoptCF(CFArrayCreateMutable(nullptr, elementCount, &kCFTypeArrayCallBacks));
+    RetainPtr cfNumbers = adoptCF(CFArrayCreateMutable(nullptr, elementCount, &kCFTypeArrayCallBacks));
     double number = 1;
     CFArrayAppendValue(cfNumbers.get(), CFNumberCreate(nullptr, kCFNumberDoubleType, &number));
     number = 2;
@@ -153,7 +153,7 @@ TEST(VectorCF, VectorFromCFData)
     uint8_t bytes[] = { 0x01, 0x02, 0x03, 0x04 };
     auto byteLength = sizeof(bytes);
     EXPECT_EQ(elementCount, byteLength);
-    auto cfData = adoptCF(CFDataCreate(nullptr, static_cast<const UInt8*>(&bytes[0]), Checked<CFIndex>(byteLength)));
+    RetainPtr cfData = adoptCF(CFDataCreate(nullptr, static_cast<const UInt8*>(&bytes[0]), Checked<CFIndex>(byteLength)));
 
     auto vectorData = makeVector(cfData.get());
 

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
@@ -255,8 +255,8 @@ TEST(WTF_ContextualizedNSString, tokenizer)
     RetainPtr contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
     auto contextualizedCFString = bridge_cast(static_cast<NSString *>(contextualizedString.get()));
 
-    auto locale = adoptCF(CFLocaleCreate(kCFAllocatorDefault, CFSTR("en_US")));
-    auto tokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, contextualizedCFString, CFRangeMake(0, CFStringGetLength(contextualizedCFString)), kCFStringTokenizerUnitWord, locale.get()));
+    RetainPtr locale = adoptCF(CFLocaleCreate(kCFAllocatorDefault, CFSTR("en_US")));
+    RetainPtr tokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, contextualizedCFString, CFRangeMake(0, CFStringGetLength(contextualizedCFString)), kCFStringTokenizerUnitWord, locale.get()));
 
     CFIndex indices[] = { 4, 7, 12, 17 };
     unsigned index = 0;

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainPtr.mm
@@ -399,7 +399,7 @@ TEST(RETAIN_PTR_TEST_NAME, HashMapCFTypeDeletedValue)
 {
     HashMap<RetainPtr<CFStringRef>, int> map;
 
-    auto key = adoptCF(CFStringCreateWithCString(nullptr, "hello world", kCFStringEncodingASCII));
+    RetainPtr key = adoptCF(CFStringCreateWithCString(nullptr, "hello world", kCFStringEncodingASCII));
     map.add(key, 1);
     EXPECT_EQ(true, map.contains(key));
     map.remove(key);

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
@@ -120,7 +120,7 @@ TEST(TypeCastsCocoa, bridge_id_cast)
     }
 
     @autoreleasepool {
-        auto objectCF = adoptCF(CFStringCreateWithBytes(NULL, (const UInt8*)helloWorldCString, helloWorldCStringLength(), kCFStringEncodingUTF8, false));
+        RetainPtr objectCF = adoptCF(CFStringCreateWithBytes(NULL, (const UInt8*)helloWorldCString, helloWorldCStringLength(), kCFStringEncodingUTF8, false));
         auto objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
 

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
@@ -54,7 +54,7 @@ TEST(TypeCastsOSObjectCF, osObjectCast)
     EXPECT_EQ(1L, CFGetRetainCount(groupPtr));
 
     // Down cast.
-    auto object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+    OSObjectPtr object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
     uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
     EXPECT_EQ(object.get(), osObjectCast<dispatch_group_t>(object.get()));
     EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
@@ -67,7 +67,7 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast)
 
     // Same cast / up cast bad cast from CFTypeRef.
     {
-        auto objectCF = adoptCF<CFTypeRef>(dispatch_group_create());
+        RetainPtr objectCF = adoptCF<CFTypeRef>(dispatch_group_create());
         uintptr_t objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
         EXPECT_EQ(objectCF.get(), dynamicOSObjectCast<dispatch_group_t>(objectCF.get()));
         EXPECT_EQ(objectCF.get(), dynamicOSObjectCast<dispatch_object_t>(objectCF.get()));
@@ -77,7 +77,7 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast)
 
     // Down cast / bad cast.
     {
-        auto object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+        OSObjectPtr object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
         uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
         EXPECT_EQ(object.get(), dynamicOSObjectCast<dispatch_group_t>(object.get()));
         EXPECT_EQ(NULL, dynamicOSObjectCast<dispatch_source_t>(object.get()));
@@ -86,7 +86,7 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast)
 
     // Up cast / bad cast.
     {
-        auto object = adoptOSObject(dispatch_group_create());
+        OSObjectPtr object = adoptOSObject(dispatch_group_create());
         uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
         EXPECT_EQ(object.get(), dynamicOSObjectCast<dispatch_object_t>(object.get()));
         EXPECT_EQ(NULL, dynamicOSObjectCast<dispatch_source_t>(object.get()));
@@ -103,7 +103,7 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast)
 
     // Bad down cast.
     {
-        auto object = adoptOSObject(dispatch_queue_create("testQueue", NULL));
+        OSObjectPtr object = adoptOSObject(dispatch_queue_create("testQueue", NULL));
         uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
         EXPECT_EQ(NULL, dynamicOSObjectCast<dispatch_queue_global_t>(object.get()));
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
@@ -122,7 +122,7 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_OSObjectPtr)
 
     // Down cast / bad cast.
     {
-        auto object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+        OSObjectPtr object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
         uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
 
@@ -145,7 +145,7 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_OSObjectPtr)
 
     // Up cast.
     {
-        auto object = adoptOSObject(dispatch_group_create());
+        OSObjectPtr object = adoptOSObject(dispatch_group_create());
         uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
 
@@ -158,7 +158,7 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_OSObjectPtr)
 
     // Bad up cast (excluding dispatch_object_t).
     {
-        auto object = adoptOSObject(dispatch_queue_create("testQueue", NULL));
+        OSObjectPtr object = adoptOSObject(dispatch_queue_create("testQueue", NULL));
         uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
 
@@ -180,7 +180,7 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_const_OSObjectPtr)
 
     // Down cast / bad cast.
     {
-        auto object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+        OSObjectPtr object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
         uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
 
@@ -190,7 +190,7 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_const_OSObjectPtr)
         EXPECT_EQ(objectPtr, objectCastPtr);
         EXPECT_EQ(2L, CFGetRetainCount((CFTypeRef)objectCastPtr)); // Both object and objectCast retain it.
 
-        auto object2 = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+        OSObjectPtr object2 = adoptOSObject<dispatch_object_t>(dispatch_group_create());
         uintptr_t objectPtr2 = reinterpret_cast<uintptr_t>(object2.get());
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr2));
 
@@ -202,7 +202,7 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_const_OSObjectPtr)
 
     // Up cast.
     {
-        auto object = adoptOSObject(dispatch_group_create());
+        OSObjectPtr object = adoptOSObject(dispatch_group_create());
         uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
 
@@ -215,7 +215,7 @@ TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_const_OSObjectPtr)
 
     // Bad up cast (excluding dispatch_object_t).
     {
-        auto object = adoptOSObject(dispatch_queue_create("testQueue", nullptr));
+        OSObjectPtr object = adoptOSObject(dispatch_queue_create("testQueue", nullptr));
         uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
@@ -52,7 +52,7 @@ TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)
     if (results) {
         for (unsigned i = 0, count = CFArrayGetCount(results.get()); i < count; ++i) {
             RetainPtr fontDescriptor = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(results.get(), i));
-            auto ctFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), 16.0, nullptr));
+            RetainPtr ctFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), 16.0, nullptr));
             FontPlatformData platformData(ctFont.get(), 16.0);
             FontCascade fontCascade(platformData);
             if (fontCascade.canTakeFixedPitchFastContentMeasuring()) {

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp
@@ -50,7 +50,7 @@ constexpr CGFloat contextHeight = 1;
 TEST(BifurcatedGraphicsContextTests, Basic)
 {
     auto colorSpace = DestinationColorSpace::SRGB();
-    auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    RetainPtr primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
     GraphicsContextCG primaryContext(primaryCGContext.get());
     RecorderImpl secondaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight), { });
@@ -117,8 +117,8 @@ TEST(BifurcatedGraphicsContextTests, Text)
 TEST(BifurcatedGraphicsContextTests, DrawTiledGradientImage)
 {
     auto colorSpace = DestinationColorSpace::SRGB();
-    auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
-    auto secondaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    RetainPtr primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    RetainPtr secondaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
     GraphicsContextCG primaryContext(primaryCGContext.get());
     GraphicsContextCG secondaryContext(secondaryCGContext.get());
@@ -149,8 +149,8 @@ TEST(BifurcatedGraphicsContextTests, DrawTiledGradientImage)
 TEST(BifurcatedGraphicsContextTests, DrawGradientImage)
 {
     auto colorSpace = DestinationColorSpace::SRGB();
-    auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
-    auto secondaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    RetainPtr primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    RetainPtr secondaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
     GraphicsContextCG primaryContext(primaryCGContext.get());
     GraphicsContextCG secondaryContext(secondaryCGContext.get());
@@ -181,7 +181,7 @@ TEST(BifurcatedGraphicsContextTests, DrawGradientImage)
 TEST(BifurcatedGraphicsContextTests, Borders)
 {
     auto colorSpace = DestinationColorSpace::SRGB();
-    auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    RetainPtr primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
     GraphicsContextCG primaryContext(primaryCGContext.get());
     RecorderImpl secondaryContext({ }, FloatRect(0, 0, contextWidth, contextHeight), { });
@@ -205,7 +205,7 @@ TEST(BifurcatedGraphicsContextTests, Borders)
 TEST(BifurcatedGraphicsContextTests, TransformedClip)
 {
     auto colorSpace = DestinationColorSpace::SRGB();
-    auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, 100, 100, 8, 4 * 100, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    RetainPtr primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, 100, 100, 8, 4 * 100, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
     GraphicsContextCG primaryContextCG(primaryCGContext.get());
     GraphicsContext& primaryContext = primaryContextCG;
@@ -263,7 +263,7 @@ TEST(BifurcatedGraphicsContextTests, TransformedClip)
 TEST(BifurcatedGraphicsContextTests, ApplyDeviceScaleFactor)
 {
     auto colorSpace = DestinationColorSpace::SRGB();
-    auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, 100, 100, 8, 4 * 100, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    RetainPtr primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, 100, 100, 8, 4 * 100, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
     GraphicsContextCG primaryContextCG(primaryCGContext.get());
     GraphicsContext& primaryContext = primaryContextCG;

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm
@@ -52,7 +52,7 @@ TEST(PAL, MediaTime)
 
 static RetainPtr<CMFormatDescriptionRef> makeFormatDescriptionWithTencData(std::span<const uint8_t> tencData)
 {
-    auto data = adoptCF(CFDataCreate(kCFAllocatorDefault, tencData.data(), tencData.size()));
+    RetainPtr data = adoptCF(CFDataCreate(kCFAllocatorDefault, tencData.data(), tencData.size()));
     RetainPtr extensions = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:(__bridge NSData *)data.get(), @"CommonEncryptionTrackEncryptionBox", nil]);
     CMFormatDescriptionRef desc = nullptr;
     PAL::CMVideoFormatDescriptionCreate(kCFAllocatorDefault, kCMVideoCodecType_H264, 1920, 1080, (__bridge CFDictionaryRef)extensions.get(), &desc);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm
@@ -61,7 +61,7 @@ constexpr CGFloat contextHeight = 1;
 RetainPtr<CGImageRef> greenImage()
 {
     auto colorSpace = DestinationColorSpace::SRGB();
-    auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    RetainPtr cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
     GraphicsContextCG ctx(cgContext.get());
     ctx.fillRect(FloatRect(0, 0, contextWidth, contextHeight), Color::green);
     return adoptCF(CGBitmapContextCreateImage(cgContext.get()));
@@ -70,7 +70,7 @@ RetainPtr<CGImageRef> greenImage()
 TEST(GraphicsContextTests, DrawNativeImageDoesNotLeakCompositeOperator)
 {
     auto colorSpace = DestinationColorSpace::SRGB();
-    auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    RetainPtr cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
     GraphicsContextCG ctx(cgContext.get());
 
     EXPECT_EQ(ctx.compositeOperation(), CompositeOperator::SourceOver);
@@ -99,7 +99,7 @@ TEST(GraphicsContextTests, DrawNativeImageDoesNotLeakCompositeOperator)
 TEST(GraphicsContextTests, CGBitmapRenderingModeIsUnaccelerated)
 {
     auto srgb = DestinationColorSpace::SRGB();
-    auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, 3, 3, 8, 4 * 3, srgb.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    RetainPtr cgContext = adoptCF(CGBitmapContextCreate(nullptr, 3, 3, 8, 4 * 3, srgb.platformColorSpace(), kCGImageAlphaPremultipliedLast));
     ASSERT_NE(cgContext.get(), nullptr);
     GraphicsContextCG context(cgContext.get());
     EXPECT_EQ(context.renderingMode(), RenderingMode::Unaccelerated);
@@ -114,7 +114,7 @@ TEST(GraphicsContextTests, IOSurfaceRenderingModeIsAccelerated)
     auto bitsPerPixel = 32;
     auto bitsPerComponent = 8;
     auto bitmapInfo = static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedFirst) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
-    auto cgContext = adoptCF(CGIOSurfaceContextCreate(surface->surface(), size.width(), size.height(), bitsPerComponent, bitsPerPixel, srgb.platformColorSpace(), bitmapInfo));
+    RetainPtr cgContext = adoptCF(CGIOSurfaceContextCreate(surface->surface(), size.width(), size.height(), bitsPerComponent, bitsPerPixel, srgb.platformColorSpace(), bitmapInfo));
     GraphicsContextCG context(cgContext.get());
     EXPECT_EQ(context.renderingMode(), RenderingMode::Accelerated);
 }
@@ -198,7 +198,7 @@ TEST(GraphicsContextTests, DrawsReportHasDrawn)
     auto bitsPerPixel = 32;
     auto bitsPerComponent = 8;
     auto bitmapInfo = static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedFirst) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
-    auto cgContext = adoptCF(CGIOSurfaceContextCreate(surface->surface(), size.width(), size.height(), bitsPerComponent, bitsPerPixel, srgb.platformColorSpace(), bitmapInfo));
+    RetainPtr cgContext = adoptCF(CGIOSurfaceContextCreate(surface->surface(), size.width(), size.height(), bitsPerComponent, bitsPerPixel, srgb.platformColorSpace(), bitmapInfo));
     GraphicsContextCG context(cgContext.get());
 
     // Context starts saying has drawn, conservative estimate.
@@ -214,7 +214,7 @@ TEST(GraphicsContextTests, OutOfGamutSRGBNotDrawn)
 {
     auto colorSpace = DestinationColorSpace::ExtendedSRGB();
     auto bitmapInfo = static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedLast) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder16Host) | static_cast<CGBitmapInfo>(kCGBitmapFloatComponents);
-    auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 16, 8 * contextWidth, colorSpace.platformColorSpace(), bitmapInfo));
+    RetainPtr cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 16, 8 * contextWidth, colorSpace.platformColorSpace(), bitmapInfo));
     GraphicsContextCG ctx(cgContext.get());
 
     // Draw an out of gamut white

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -62,7 +62,7 @@ class TestedGraphicsContextGLCocoa : public GraphicsContextGLCocoa {
 public:
     static RefPtr<TestedGraphicsContextGLCocoa> create(GraphicsContextGLAttributes&& attributes)
     {
-        auto context = adoptRef(*new TestedGraphicsContextGLCocoa(WTF::move(attributes)));
+        Ref context = adoptRef(*new TestedGraphicsContextGLCocoa(WTF::move(attributes)));
         if (!context->initialize())
             return nullptr;
         return context;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/XPCEndpoint.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/XPCEndpoint.mm
@@ -63,7 +63,7 @@ private:
             endpointReceivedMessageFromClient = true;
 
             // FIXME: This is a false positive. <rdar://164843889>
-            SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+            SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
             xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, testMessageFromEndpoint);
             xpc_connection_send_message(connection, message.get());
         }
@@ -81,7 +81,7 @@ private:
     void didConnect() final
     {
         // FIXME: This is a false positive. <rdar://164843889>
-        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, testMessageFromClient);
         xpc_connection_send_message(connection().get(), message.get());
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ApplicationManifest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ApplicationManifest.mm
@@ -54,8 +54,8 @@ TEST(ApplicationManifest, Coding)
     EXPECT_STREQ("https://test.com/app/index.html", manifest.get().startURL.absoluteString.UTF8String);
     EXPECT_EQ(_WKApplicationManifestDisplayModeMinimalUI,  manifest.get().displayMode);
 
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
     EXPECT_TRUE(CGColorEqualToColor(manifest.get().themeColor.CGColor, redColor.get()));
 }
 
@@ -110,8 +110,8 @@ TEST(ApplicationManifest, Basic)
         EXPECT_TRUE([manifest.startURL isEqual:[NSURL URLWithString:@"http://example.com/app/start"]]);
         EXPECT_TRUE([manifest.scope isEqual:[NSURL URLWithString:@"http://example.com/app"]]);
 
-        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
         EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, redColor.get()));
 
         done = true;
@@ -160,16 +160,16 @@ TEST(ApplicationManifest, AlwaysFetchData)
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", json]];
 
     {
-        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
         while (!CGColorEqualToColor([webView themeColor].CGColor, redColor.get()))
             Util::runFor(1_s);
     }
 
     __block bool done = false;
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
-        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
         EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, redColor.get()));
 
         done = true;
@@ -188,16 +188,16 @@ TEST(ApplicationManifest, OnlyFirstManifest)
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", json1, json2]];
 
     {
-        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
         while (!CGColorEqualToColor([webView themeColor].CGColor, redColor.get()))
             Util::runFor(1_s);
     }
 
     __block bool done = false;
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
-        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
         EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, redColor.get()));
 
         done = true;
@@ -233,16 +233,16 @@ TEST(ApplicationManifest, MediaAttriute)
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\" media=\"invalid\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\" media=\"screen\">", json1, json2]];
 
     {
-        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
         while (!CGColorEqualToColor([webView themeColor].CGColor, redColor.get()))
             Util::runFor(1_s);
     }
 
     __block bool done = false;
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
-        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
         EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, redColor.get()));
 
         done = true;
@@ -327,8 +327,8 @@ TEST(ApplicationManifest, Icons)
         EXPECT_TRUE([manifest.startURL isEqual:[NSURL URLWithString:@"http://example.com/app/start"]]);
         EXPECT_TRUE([manifest.scope isEqual:[NSURL URLWithString:@"http://example.com/app"]]);
 
-        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-        auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+        RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
         EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, redColor.get()));
 
         size_t iconIndex = 0;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Challenge.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Challenge.mm
@@ -65,7 +65,7 @@ static RetainPtr<SecIdentityRef> createTestIdentity(const Vector<uint8_t>& priva
     };
     const NSUInteger pemEncodedPrivateKeyHeaderLength = 26;
     CFErrorRef error = nullptr;
-    auto privateKey = adoptCF(SecKeyCreateWithData((__bridge CFDataRef)[derEncodedPrivateKey subdataWithRange:NSMakeRange(pemEncodedPrivateKeyHeaderLength, [derEncodedPrivateKey length] - pemEncodedPrivateKeyHeaderLength)], (__bridge CFDictionaryRef)options, &error));
+    RetainPtr privateKey = adoptCF(SecKeyCreateWithData((__bridge CFDataRef)[derEncodedPrivateKey subdataWithRange:NSMakeRange(pemEncodedPrivateKeyHeaderLength, [derEncodedPrivateKey length] - pemEncodedPrivateKeyHeaderLength)], (__bridge CFDictionaryRef)options, &error));
     EXPECT_NULL(error);
     EXPECT_NOT_NULL(privateKey.get());
 
@@ -415,7 +415,7 @@ void verifyCertificateAndPublicKey(SecTrustRef trust)
             EXPECT_EQ(expected[i], bytes[i]);
     };
 
-    auto publicKey = adoptCF(SecKeyCopyExternalRepresentation(adoptCF(SecTrustCopyPublicKey(trust)).get(), nullptr));
+    RetainPtr publicKey = adoptCF(SecKeyCopyExternalRepresentation(adoptCF(SecTrustCopyPublicKey(trust)).get(), nullptr));
     compareData(publicKey, {
         0x30, 0x82, 0x02, 0x0a, 0x02, 0x82, 0x02, 0x01, 0x00, 0xde, 0xb8, 0x4d, 0xe1, 0x23, 0xe0, 0xf1,
         0x56, 0x3f, 0x3e, 0xd1, 0x83, 0x34, 0xa6, 0x37, 0x4f, 0xd2, 0x48, 0x4a, 0x06, 0xf2, 0xf1, 0x81,
@@ -454,7 +454,7 @@ void verifyCertificateAndPublicKey(SecTrustRef trust)
     
     EXPECT_EQ(1, SecTrustGetCertificateCount(trust));
 
-    auto certificate = adoptCF(SecCertificateCopyData((SecCertificateRef)CFArrayGetValueAtIndex(adoptCF(SecTrustCopyCertificateChain(trust)).get(), 0)));
+    RetainPtr certificate = adoptCF(SecCertificateCopyData((SecCertificateRef)CFArrayGetValueAtIndex(adoptCF(SecTrustCopyCertificateChain(trust)).get(), 0)));
     compareData(certificate, {
         0x30, 0x82, 0x05, 0x80, 0x30, 0x82, 0x03, 0x68, 0x02, 0x09, 0x00, 0x8a, 0x1e, 0x23, 0xd1, 0x53,
         0x93, 0x10, 0xb8, 0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditorStateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditorStateTests.mm
@@ -361,9 +361,9 @@ TEST(EditorStateTests, CaretColorInContentEditable)
     UIView<UITextInputTraits_Private> *textInput = (UIView<UITextInputTraits_Private> *) [webView textInputContentView];
     UIColor *insertionPointColor = textInput.insertionPointColor;
     UIColor *redColor = [UIColor redColor];
-    auto colorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB));
-    auto cgInsertionPointColor = adoptCF(CGColorCreateCopyByMatchingToColorSpace(colorSpace.get(), kCGRenderingIntentDefault, insertionPointColor.CGColor, NULL));
-    auto cgRedColor = adoptCF(CGColorCreateCopyByMatchingToColorSpace(colorSpace.get(), kCGRenderingIntentDefault, redColor.CGColor, NULL));
+    RetainPtr colorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB));
+    RetainPtr cgInsertionPointColor = adoptCF(CGColorCreateCopyByMatchingToColorSpace(colorSpace.get(), kCGRenderingIntentDefault, insertionPointColor.CGColor, NULL));
+    RetainPtr cgRedColor = adoptCF(CGColorCreateCopyByMatchingToColorSpace(colorSpace.get(), kCGRenderingIntentDefault, redColor.CGColor, NULL));
     EXPECT_TRUE(CGColorEqualToColor(cgInsertionPointColor.get(), cgRedColor.get()));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EventAttribution.mm
@@ -299,7 +299,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
     RetainPtr publicKey = adoptNS([[NSMutableData alloc] initWithLength:exportSize]);
     ccder_encode_rsa_pub(rsaPublicKey, static_cast<uint8_t*>([publicKey mutableBytes]), static_cast<uint8_t*>([publicKey mutableBytes]) + [publicKey length]);
 
-    auto secKey = adoptCF(SecKeyCreateWithData((__bridge CFDataRef)publicKey.get(), (__bridge CFDictionaryRef)@{
+    RetainPtr secKey = adoptCF(SecKeyCreateWithData((__bridge CFDataRef)publicKey.get(), (__bridge CFDictionaryRef)@{
         (__bridge id)kSecAttrKeyType: (__bridge id)kSecAttrKeyTypeRSA,
         (__bridge id)kSecAttrKeyClass: (__bridge id)kSecAttrKeyClassPublic
     }, nil));
@@ -555,14 +555,14 @@ static void attemptConnectionInProcessWithoutEntitlement()
 #if USE(APPLE_INTERNAL_SDK)
     __block bool done = false;
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptOSObject(xpc_connection_create_mach_service("org.webkit.pcmtestdaemon.service", mainDispatchQueueSingleton(), 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr connection = adoptOSObject(xpc_connection_create_mach_service("org.webkit.pcmtestdaemon.service", mainDispatchQueueSingleton(), 0));
     xpc_connection_set_event_handler(connection.get(), ^(xpc_object_t event) {
         EXPECT_EQ(event, XPC_ERROR_CONNECTION_INTERRUPTED);
         done = true;
     });
     xpc_connection_activate(connection.get());
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_connection_send_message(connection.get(), dictionary.get());
     TestWebKitAPI::Util::run(&done);
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FirstVisuallyNonEmptyMilestone.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FirstVisuallyNonEmptyMilestone.mm
@@ -92,8 +92,8 @@ TEST(WebKit, FirstVisuallyNonEmptyMilestoneWithDeferredScript)
 
 static NSString *contentTypeForFileExtension(NSString *fileExtension)
 {
-    auto identifier = adoptCF(UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExtension, nullptr));
-    auto mimeType = adoptCF(UTTypeCopyPreferredTagWithClass(identifier.get(), kUTTagClassMIMEType));
+    RetainPtr identifier = adoptCF(UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExtension, nullptr));
+    RetainPtr mimeType = adoptCF(UTTypeCopyPreferredTagWithClass(identifier.get(), kUTTagClassMIMEType));
     return (__bridge NSString *)mimeType.autorelease();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GPUProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GPUProcess.mm
@@ -544,7 +544,7 @@ TEST(GPUProcess, CanvasBasicCrashHandling)
         NSInteger viewHeightInPixels = viewHeight * backingScaleFactor;
 
         uint8_t *rgba = (unsigned char *)calloc(viewWidthInPixels * viewHeightInPixels * 4, sizeof(unsigned char));
-        auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        RetainPtr context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
         CGContextDrawImage(context.get(), CGRectMake(0, 0, viewWidthInPixels, viewHeightInPixels), cgImage.get());
 
         NSInteger pixelIndex = getPixelIndex(50, 50, viewWidthInPixels);
@@ -599,7 +599,7 @@ TEST(GPUProcess, CanvasBasicCrashHandling)
         NSInteger viewHeightInPixels = viewHeight * backingScaleFactor;
 
         uint8_t *rgba = (unsigned char *)calloc(viewWidthInPixels * viewHeightInPixels * 4, sizeof(unsigned char));
-        auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        RetainPtr context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
         CGContextDrawImage(context.get(), CGRectMake(0, 0, viewWidthInPixels, viewHeightInPixels), cgImage.get());
 
         NSInteger pixelIndex = getPixelIndex(50, 50, viewWidthInPixels);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
@@ -890,7 +890,7 @@ TEST(IPCTestingAPI, CGColorInNSSecureCoding)
     archiver.get().delegate = delegate.get();
 
     NSString *key = @"SomeString";
-    auto value = adoptCF(CGColorCreateSRGB(0.2, 0.3, 0.4, 0.5));
+    RetainPtr value = adoptCF(CGColorCreateSRGB(0.2, 0.3, 0.4, 0.5));
     auto payload = @{ key : static_cast<id>(value.get()) };
     [archiver encodeObject:payload forKey:NSKeyedArchiveRootObjectKey];
     [archiver finishEncoding];
@@ -915,7 +915,7 @@ TEST(IPCTestingAPI, CGColorInNSSecureCoding)
     CGColorRef resultValue = static_cast<CGColorRef>(result.allValues[0]);
     ASSERT_EQ(CFGetTypeID(resultValue), CGColorGetTypeID());
     RetainPtr resultValueColorSpace = CGColorGetColorSpace(resultValue);
-    auto resultValueColorSpaceName = adoptCF(CGColorSpaceCopyName(resultValueColorSpace.get()));
+    RetainPtr resultValueColorSpaceName = adoptCF(CGColorSpaceCopyName(resultValueColorSpace.get()));
     EXPECT_NE(CFStringFind(resultValueColorSpaceName.get(), CFSTR("SRGB"), 0).location, kCFNotFound);
     ASSERT_EQ(CGColorGetNumberOfComponents(resultValue), CGColorGetNumberOfComponents(value.get()));
     for (size_t i = 0; i < CGColorGetNumberOfComponents(resultValue); ++i)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PDFLinkReferrer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PDFLinkReferrer.mm
@@ -52,13 +52,13 @@ static RetainPtr<NSData> createPDFWithLinkToURL(NSURL *url)
     CGDataConsumerCallbacks callbacks;
     callbacks.putBytes = (CGDataConsumerPutBytesCallback)putPDFBytesCallback;
     callbacks.releaseConsumer = (CGDataConsumerReleaseInfoCallback)emptyReleaseInfoCallback;
-    auto consumer = adoptCF(CGDataConsumerCreate(pdfData.get(), &callbacks));
-    auto contextDictionary = adoptCF(CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    RetainPtr consumer = adoptCF(CGDataConsumerCreate(pdfData.get(), &callbacks));
+    RetainPtr contextDictionary = adoptCF(CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CGRect rectangle = CGRectMake(0, 0, 1000, 1000);
-    auto pdfContext = adoptCF(CGPDFContextCreate(consumer.get(), &rectangle, contextDictionary.get()));
+    RetainPtr pdfContext = adoptCF(CGPDFContextCreate(consumer.get(), &rectangle, contextDictionary.get()));
 
-    auto pageDictionary = adoptCF(CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-    auto boxData = adoptCF(CFDataCreate(NULL, (const UInt8 *)&rectangle, sizeof(CGRect)));
+    RetainPtr pageDictionary = adoptCF(CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    RetainPtr boxData = adoptCF(CFDataCreate(NULL, (const UInt8 *)&rectangle, sizeof(CGRect)));
     CFDictionarySetValue(pageDictionary.get(), kCGPDFContextMediaBox, boxData.get());
     CGPDFContextBeginPage(pdfContext.get(), pageDictionary.get());
     

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -2812,7 +2812,7 @@ static bool isTestServerTrust(SecTrustRef trust)
     if (SecTrustGetCertificateCount(trust) != 1)
         return false;
 
-    auto chain = adoptCF(SecTrustCopyCertificateChain(trust));
+    RetainPtr chain = adoptCF(SecTrustCopyCertificateChain(trust));
     auto certificate = checked_cf_cast<SecCertificateRef>(CFArrayGetValueAtIndex(chain.get(), 0));
     if (![bridge_cast(adoptCF(SecCertificateCopySubjectSummary(certificate)).get()) isEqualToString:@"Me"])
         return false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -4344,14 +4344,14 @@ TEST(SiteIsolation, ThemeColor)
     __block bool observedUnderPageBackgroundColor { false };
     RetainPtr observer = adoptNS([TestObserver new]);
     observer.get().observeValueForKeyPath = ^(NSString *path, id view) {
-        auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
         if ([path isEqualToString:@"themeColor"]) {
-            auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+            RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
             EXPECT_TRUE(CGColorEqualToColor([[view themeColor] CGColor], redColor.get()));
             observedThemeColor = true;
         } else {
             EXPECT_WK_STREQ(path, "underPageBackgroundColor");
-            auto blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
+            RetainPtr blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
             EXPECT_TRUE(CGColorEqualToColor([[view underPageBackgroundColor] CGColor], blueColor.get()));
             observedUnderPageBackgroundColor = true;
         }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextWidth.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextWidth.mm
@@ -48,13 +48,13 @@ TEST(WebKit, TextWidth)
     }];
     TestWebKitAPI::Util::run(&didEvaluateJavaScript);
 
-    auto font = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 24, CFSTR("en-US")));
+    RetainPtr font = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 24, CFSTR("en-US")));
     // Use CFAttributedString so we don't have to deal with NSFont / UIFont and have this code be platform-dependent.
     CFTypeRef keys[] = { kCTFontAttributeName };
     CFTypeRef values[] = { font.get() };
-    auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-    auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, CFSTR("This is a test string"), attributes.get()));
-    auto line = adoptCF(CTLineCreateWithAttributedString(static_cast<CFAttributedStringRef>(attributedString)));
+    RetainPtr attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    RetainPtr attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, CFSTR("This is a test string"), attributes.get()));
+    RetainPtr line = adoptCF(CTLineCreateWithAttributedString(static_cast<CFAttributedStringRef>(attributedString)));
     double coreTextWidth = CTLineGetTypographicBounds(line.get(), nullptr, nullptr, nullptr);
 
     EXPECT_NEAR(webKitWidth, coreTextWidth, 3);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSnapshot.mm
@@ -300,7 +300,7 @@ TEST(WKWebView, SnapshotImageBaseCase)
         NSInteger viewHeightInPixels = viewHeight * backingScaleFactor;
 
         uint8_t *rgba = (unsigned char *)calloc(viewWidthInPixels * viewHeightInPixels * 4, sizeof(unsigned char));
-        auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        RetainPtr context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
         CGContextDrawImage(context.get(), CGRectMake(0, 0, viewWidthInPixels, viewHeightInPixels), cgImage.get());
 
         NSInteger pixelIndex = getPixelIndex(0, 0, viewWidthInPixels);
@@ -444,10 +444,10 @@ TEST(WKWebView, SnapshotImageLargeAsyncDecoding)
         EXPECT_EQ(viewWidth, snapshotImage.size.width);
 
         auto cgImage = Util::convertToCGImage(snapshotImage);
-        auto colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
+        RetainPtr colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
 
         uint8_t *rgba = (unsigned char *)calloc(viewWidth * viewHeight * 4, sizeof(unsigned char));
-        auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidth, viewHeight, 8, 4 * viewWidth, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        RetainPtr context = adoptCF(CGBitmapContextCreate(rgba, viewWidth, viewHeight, 8, 4 * viewWidth, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
         CGContextDrawImage(context.get(), CGRectMake(0, 0, viewWidth, viewHeight), cgImage.get());
 
         // Top-left corner of the div (0, 0, 100, 100)
@@ -522,7 +522,7 @@ TEST(WKWebView, SnapshotAfterScreenUpdates)
         NSInteger viewHeightInPixels = viewHeight * backingScaleFactor;
         
         uint8_t *rgba = (unsigned char *)calloc(viewWidthInPixels * viewHeightInPixels * 4, sizeof(unsigned char));
-        auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        RetainPtr context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
         CGContextDrawImage(context.get(), CGRectMake(0, 0, viewWidthInPixels, viewHeightInPixels), cgImage.get());
         
         NSInteger pixelIndex = getPixelIndex(0, 0, viewWidthInPixels);
@@ -585,7 +585,7 @@ TEST(WKWebView, SnapshotWithoutAfterScreenUpdates)
         NSInteger viewHeightInPixels = viewHeight * backingScaleFactor;
         
         uint8_t *rgba = (unsigned char *)calloc(viewWidthInPixels * viewHeightInPixels * 4, sizeof(unsigned char));
-        auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        RetainPtr context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
         CGContextDrawImage(context.get(), CGRectMake(0, 0, viewWidthInPixels, viewHeightInPixels), cgImage.get());
 
         NSInteger pixelIndex = getPixelIndex(0, 0, viewWidthInPixels);
@@ -643,7 +643,7 @@ TEST(WKWebView, SnapshotWebGL)
         NSInteger viewHeightInPixels = viewHeight * backingScaleFactor;
 
         uint8_t *rgba = (unsigned char *)calloc(viewWidthInPixels * viewHeightInPixels * 4, sizeof(unsigned char));
-        auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        RetainPtr context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
         CGContextDrawImage(context.get(), CGRectMake(0, 0, viewWidthInPixels, viewHeightInPixels), cgImage.get());
 
         NSInteger pixelIndex = getPixelIndex(0, 0, viewWidthInPixels);
@@ -692,7 +692,7 @@ TEST(WKWebView, SnapshotWithoutSelectionHighlighting)
         NSInteger viewHeightInPixels = viewHeight * backingScaleFactor;
 
         uint8_t *rgba = (unsigned char *)calloc(viewWidthInPixels * viewHeightInPixels * 4, sizeof(unsigned char));
-        auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        RetainPtr context = adoptCF(CGBitmapContextCreate(rgba, viewWidthInPixels, viewHeightInPixels, 8, 4 * viewWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
         CGContextDrawImage(context.get(), CGRectMake(0, 0, viewWidthInPixels, viewHeightInPixels), cgImage.get());
 
         // Get a pixel from inside where the selection highlight would normally be and verify that the highlight isn't in the snapshot.
@@ -735,9 +735,9 @@ TEST(WKWebView, SnapshotWithContentsRect)
         EXPECT_GT(snapshotHeightInPixels, viewHeight);
 
         auto cgImage = Util::convertToCGImage(snapshotImage);
-        auto colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
+        RetainPtr colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
         uint8_t *rgba = (unsigned char *)calloc(snapshotWidthInPixels * snapshotHeightInPixels * 4, sizeof(unsigned char));
-        auto context = adoptCF(CGBitmapContextCreate(rgba, snapshotWidthInPixels, snapshotHeightInPixels, 8, 4 * snapshotWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        RetainPtr context = adoptCF(CGBitmapContextCreate(rgba, snapshotWidthInPixels, snapshotHeightInPixels, 8, 4 * snapshotWidthInPixels, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
         CGContextDrawImage(context.get(), CGRectMake(0, 0, snapshotWidthInPixels, snapshotHeightInPixels), cgImage.get());
 
         // Inside the blue div.
@@ -844,10 +844,10 @@ TEST(WKWebView, RemoteSnapshotWithTransform)
         EXPECT_EQ(viewWidth, snapshotImage.size.width);
 
         auto cgImage = Util::convertToCGImage(snapshotImage);
-        auto colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
+        RetainPtr colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
 
         uint8_t *rgba = (unsigned char *)calloc(viewWidth * viewHeight * 4, sizeof(unsigned char));
-        auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidth, viewHeight, 8, 4 * viewWidth, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        RetainPtr context = adoptCF(CGBitmapContextCreate(rgba, viewWidth, viewHeight, 8, 4 * viewWidth, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
         CGContextDrawImage(context.get(), CGRectMake(0, 0, viewWidth, viewHeight), cgImage.get());
 
         void (^verifyPixel)(NSPoint) = ^(NSPoint point) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewThemeColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewThemeColor.mm
@@ -44,8 +44,8 @@ TEST(WKWebViewThemeColor, MetaElementValidNameAndColor)
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<meta name='theme-color' content='red'>"];
 
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
     EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, redColor.get()));
 }
 
@@ -56,8 +56,8 @@ TEST(WKWebViewThemeColor, MetaElementValidNameAndColorAndMedia)
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<meta name='theme-color' content='red' media='screen'>"];
 
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
     EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, redColor.get()));
 }
 
@@ -68,8 +68,8 @@ TEST(WKWebViewThemeColor, MetaElementInvalidName)
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<meta name='not-theme-color' content='blue'><meta name='theme-color' content='red'>"];
 
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
     EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, redColor.get()));
 }
 
@@ -80,8 +80,8 @@ TEST(WKWebViewThemeColor, MetaElementInvalidColor)
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<meta name='theme-color' content='invalid'><meta name='theme-color' content='red'>"];
 
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
     EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, redColor.get()));
 }
 
@@ -92,8 +92,8 @@ TEST(WKWebViewThemeColor, MetaElementInvalidMedia)
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<meta name='theme-color' content='blue' media='invalid'><meta name='theme-color' content='red' media='screen'>"];
 
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
     EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, redColor.get()));
 }
 
@@ -104,8 +104,8 @@ TEST(WKWebViewThemeColor, MetaElementMultipleValid)
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<div><meta name='theme-color' content='red'></div><meta name='theme-color' content='blue'>"];
 
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
     EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, redColor.get()));
 }
 
@@ -116,8 +116,8 @@ TEST(WKWebViewThemeColor, MetaElementValidSubframe)
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<iframe srcdoc=\"<meta name='theme-color' content='blue'>\"></iframe><meta name='theme-color' content='red'>"];
 
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
     EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, redColor.get()));
 }
 
@@ -215,9 +215,9 @@ TEST(WKWebViewThemeColor, MetaElementValidSubframe)
 
 TEST(WKWebViewThemeColor, KVO)
 {
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
-    auto blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     RetainPtr themeColorObserver = adoptNS([[WKWebViewThemeColorObserver alloc] initWithWebView:webView.get()]);
@@ -288,8 +288,8 @@ TEST(WKWebViewThemeColor, KVO)
 
 TEST(WKWebViewThemeColor, ApplicationManifest)
 {
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(![webView themeColor]);
@@ -317,8 +317,8 @@ TEST(WKWebViewThemeColor, MetaElementOverridesApplicationManifest)
     NSDictionary *manifestObject = @{ @"name": @"Test", @"theme_color": @"blue" };
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:[NSString stringWithFormat:@"<link rel='manifest' href='data:application/manifest+json;charset=utf-8;base64,%@'><meta name='theme-color' content='red'>", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]]];
 
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
     EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, redColor.get()));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewUnderPageBackgroundColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewUnderPageBackgroundColor.mm
@@ -51,8 +51,8 @@ static RetainPtr<CGColor> defaultBackgroundColor()
 
     // Some of the above can sometimes be a monochrome color, so convert it to sRGB so the comparisons below work.
     // `WebCore::ColorSpace` doesn't have an equivalent monochrome enum value, but treats `CGColor` with only two components as monochrome and converts them to `SRGB`.
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto sRGBColor = adoptCF(CGColorCreateCopyByMatchingToColorSpace(sRGBColorSpace.get(), kCGRenderingIntentDefault, [color CGColor], NULL));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr sRGBColor = adoptCF(CGColorCreateCopyByMatchingToColorSpace(sRGBColorSpace.get(), kCGRenderingIntentDefault, [color CGColor], NULL));
     return sRGBColor.get();
 }
 
@@ -64,8 +64,8 @@ TEST(WKWebViewUnderPageBackgroundColor, OnLoad)
 
 TEST(WKWebViewUnderPageBackgroundColor, SingleSolidColor)
 {
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));
@@ -89,8 +89,8 @@ TEST(WKWebViewUnderPageBackgroundColor, SingleBlendedColor)
 
 TEST(WKWebViewUnderPageBackgroundColor, MultipleSolidColors)
 {
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));
@@ -181,9 +181,9 @@ TEST(WKWebViewUnderPageBackgroundColor, MultipleBlendedColors)
 
 TEST(WKWebViewUnderPageBackgroundColor, KVO)
 {
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
-    auto blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     RetainPtr underPageBackgroundColorObserver = adoptNS([[WKWebViewUnderPageBackgroundColorObserver alloc] initWithWebView:webView.get()]);
@@ -285,10 +285,10 @@ constexpr CGFloat whiteColorComponents[4] = { 1, 1, 1, 1 };
 
 TEST(WKWebViewUnderPageBackgroundColor, MatchesScrollView)
 {
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
-    auto blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
-    auto whiteColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), whiteColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
+    RetainPtr whiteColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), whiteColorComponents));
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebPushDaemon.mm
@@ -439,7 +439,7 @@ private:
 OSObjectPtr<xpc_object_t> WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder(TestEncoder&& encoder) const
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
 
     uint64_t protocolVersion = WebKit::WebPushD::protocolVersionValue;
     if (m_shouldIncrementProtocolVersionForTesting)
@@ -448,11 +448,11 @@ OSObjectPtr<xpc_object_t> WebPushXPCConnectionMessageSender::messageDictionaryFr
 
     __block auto blockBytes = encoder.takeBytes();
     auto buffer = blockBytes.span();
-    auto dispatchData = adoptOSObject(dispatch_data_create(buffer.data(), buffer.size(), mainDispatchQueueSingleton(), ^{
+    OSObjectPtr dispatchData = adoptOSObject(dispatch_data_create(buffer.data(), buffer.size(), mainDispatchQueueSingleton(), ^{
         blockBytes.clear();
     }));
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto encoderData = adoptOSObject(xpc_data_create_with_dispatch_data(dispatchData.get()));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr encoderData = adoptOSObject(xpc_data_create_with_dispatch_data(dispatchData.get()));
 
     xpc_dictionary_set_value(dictionary.get(), WebKit::WebPushD::protocolEncodedMessageKey, encoderData.get());
 
@@ -517,7 +517,7 @@ static WebKit::WebPushD::WebPushDaemonConnectionConfiguration defaultWebPushDaem
 OSObjectPtr<xpc_connection_t> createAndConfigureConnectionToService(const char* serviceName, std::optional<WebKit::WebPushD::WebPushDaemonConnectionConfiguration> configuration = std::nullopt)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptOSObject(xpc_connection_create_mach_service(serviceName, mainDispatchQueueSingleton(), 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr connection = adoptOSObject(xpc_connection_create_mach_service(serviceName, mainDispatchQueueSingleton(), 0));
     xpc_connection_set_event_handler(connection.get(), ^(xpc_object_t) { });
     xpc_connection_activate(connection.get());
     auto sender = WebPushXPCConnectionMessageSender { connection.get() };
@@ -534,7 +534,7 @@ TEST(WebPushD, BasicCommunication)
     NSURL *tempDir = setUpTestWebPushD();
 
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptOSObject(xpc_connection_create_mach_service("org.webkit.webpushtestdaemon.service", mainDispatchQueueSingleton(), 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT OSObjectPtr connection = adoptOSObject(xpc_connection_create_mach_service("org.webkit.webpushtestdaemon.service", mainDispatchQueueSingleton(), 0));
 
     __block bool done = false;
     __block bool interrupted = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
@@ -364,7 +364,7 @@ bool addKeyToKeychain(const String& privateKeyBase64, const String& rpId, const 
         (id)kSecAttrKeySizeInBits: @256,
     };
     CFErrorRef errorRef = nullptr;
-    auto key = adoptCF(SecKeyCreateWithData(
+    RetainPtr key = adoptCF(SecKeyCreateWithData(
         (__bridge CFDataRef)adoptNS([[NSData alloc] initWithBase64EncodedString:privateKeyBase64.createNSString().get() options:NSDataBase64DecodingIgnoreUnknownCharacters]).get(),
         (__bridge CFDictionaryRef)options,
         &errorRef

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm
@@ -2119,7 +2119,7 @@ TEST(DragAndDropTests, DataTransferSanitizeHTML)
 
 static BOOL isCompletelyWhite(UIImage *image)
 {
-    auto data = adoptCF(CGDataProviderCopyData(CGImageGetDataProvider(image.CGImage)));
+    RetainPtr data = adoptCF(CGDataProviderCopyData(CGImageGetDataProvider(image.CGImage)));
     auto* dataPtr = CFDataGetBytePtr(data.get());
     int imageWidth = image.size.width;
     for (int row = 0; row < image.size.height; ++row) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextStyleFontSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextStyleFontSize.mm
@@ -54,8 +54,8 @@ static auto contentSizeCategory = kCTFontContentSizeCategoryXXXL;
 
 TEST(TextStyleFontSize, Startup)
 {
-    auto descriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(kCTUIFontTextStyleBody, contentSizeCategory, nullptr));
-    auto sizeNumber = adoptCF(CTFontDescriptorCopyAttribute(descriptor.get(), kCTFontSizeAttribute));
+    RetainPtr descriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(kCTUIFontTextStyleBody, contentSizeCategory, nullptr));
+    RetainPtr sizeNumber = adoptCF(CTFontDescriptorCopyAttribute(descriptor.get(), kCTFontSizeAttribute));
     auto expected = static_cast<NSNumber *>(sizeNumber.get()).integerValue;
 
     static NSString *testMarkup = @"<html><head></head><body><div id='target' style='-webkit-text-size-adjust: none; font: -apple-system-body;'>Hello</div></body></html>";
@@ -75,8 +75,8 @@ TEST(TextStyleFontSize, AfterCrash)
 
     WebCore::setContentSizeCategory(contentSizeCategory);
 
-    auto descriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(kCTUIFontTextStyleBody, contentSizeCategory, nullptr));
-    auto sizeNumber = adoptCF(CTFontDescriptorCopyAttribute(descriptor.get(), kCTFontSizeAttribute));
+    RetainPtr descriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(kCTUIFontTextStyleBody, contentSizeCategory, nullptr));
+    RetainPtr sizeNumber = adoptCF(CTFontDescriptorCopyAttribute(descriptor.get(), kCTFontSizeAttribute));
     auto expected = static_cast<NSNumber *>(sizeNumber.get()).integerValue;
 
     static NSString *testMarkup = @"<html><head></head><body><div id='target' style='-webkit-text-size-adjust: none; font: -apple-system-body;'>Hello</div></body></html>";

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
@@ -728,9 +728,9 @@ TEST(WKScrollViewTests, IndicatorStyleSetByClient)
 
 TEST(WKScrollViewTests, BackgroundColorSetByClient)
 {
-    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto blackColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blackColorComponents));
-    auto whiteColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), whiteColorComponents));
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr blackColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blackColorComponents));
+    RetainPtr whiteColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), whiteColorComponents));
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500)]);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/BackgroundColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/BackgroundColor.mm
@@ -126,8 +126,8 @@ TEST(WebKit, BackgroundColorToggleAppearance)
 
     const auto& checkWhitePixel = [&] {
         uint8_t* pixelBuffer = static_cast<uint8_t*>(calloc(width * height, 4));
-        auto colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
-        auto context = adoptCF(CGBitmapContextCreate(pixelBuffer, width, height, 8, 4 * width, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+        RetainPtr colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
+        RetainPtr context = adoptCF(CGBitmapContextCreate(pixelBuffer, width, height, 8, 4 * width, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
 
         [[webView layer] renderInContext:context.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MediaPlaybackSleepAssertion.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MediaPlaybackSleepAssertion.mm
@@ -119,14 +119,14 @@ static void simulateKeyDown(NSWindow *window)
 static bool hasAssertionType(CFStringRef type)
 {
     int32_t pid = getpid();
-    auto cfPid = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &pid));
+    RetainPtr cfPid = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &pid));
     CFDictionaryRef bareAssertionsByPID = nullptr;
 
     IOPMCopyAssertionsByProcess(&bareAssertionsByPID);
     if (!bareAssertionsByPID)
         return false;
 
-    auto assertionsByPID = adoptCF(bareAssertionsByPID);
+    RetainPtr assertionsByPID = adoptCF(bareAssertionsByPID);
 
     CFArrayRef assertions = (CFArrayRef)CFDictionaryGetValue(assertionsByPID.get(), cfPid.get());
     if (!assertions)

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/SnapshotViaRenderInContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/SnapshotViaRenderInContext.mm
@@ -101,7 +101,7 @@ TEST(WebKitLegacy, RenderInContextSnapshot)
     unsigned char* pixelBuffer = static_cast<unsigned char*>(calloc(width * height, 4));
     
     RetainPtr<CGColorSpaceRef> colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
-    auto context = adoptCF(CGBitmapContextCreate(pixelBuffer, width, height, 8, 4 * width, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+    RetainPtr context = adoptCF(CGBitmapContextCreate(pixelBuffer, width, height, 8, 4 * width, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
     
     // Flip the context
     CGContextScaleCTM(context.get(), 1, -1);

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebThreadLock.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebThreadLock.mm
@@ -41,7 +41,7 @@ TEST(WebKitLegacy, NestedRunLoopUnderRunLoopObserverDoubleUnlock)
     WebThreadLock();
     
     __block BOOL spunInnerRunLoop = NO;
-    auto observer = adoptCF(CFRunLoopObserverCreateWithHandler(NULL, kCFRunLoopBeforeWaiting, NO, 2, ^(CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
+    RetainPtr observer = adoptCF(CFRunLoopObserverCreateWithHandler(NULL, kCFRunLoopBeforeWaiting, NO, 2, ^(CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
         Util::spinRunLoop(1);
         spunInnerRunLoop = YES;
     }));


### PR DESCRIPTION
#### d399725cdc64ea33a7e8d6bc96d658866edbc0ae
<pre>
Bring TestWebKitAPI up to code with regard to adoptRef, adoptCF, and adoptOSObject
<a href="https://rdar.apple.com/174609096">rdar://174609096</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312100">https://bugs.webkit.org/show_bug.cgi?id=312100</a>

Reviewed by Richard Robinson.

In <a href="https://commits.webkit.org/311010@main">https://commits.webkit.org/311010@main</a> I replaced all uses of `auto` with `adoptNS` in TestWebKitAPI
to bring them up to the new coding style guidelines.

It&apos;s bugging me that I didn&apos;t go adoptCF, adoptRef, and adoptOSObject as well.

So here we are.

* Tools/TestWebKitAPI/Helpers/cocoa/CGImagePixelReader.cpp:
(TestWebKitAPI::CGImagePixelReader::CGImagePixelReader):
* Tools/TestWebKitAPI/Helpers/cocoa/DaemonTestUtilities.mm:
(TestWebKitAPI::convertArrayToXPC):
(TestWebKitAPI::convertDictionaryToXPC):
* Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.mm:
(TestWebKitAPI::proxyDefinition):
* Tools/TestWebKitAPI/Helpers/cocoa/TestProtocol.mm:
(contentTypeForFileExtension):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(createCertificate):
(createPrivateKey):
(TEST(IPCSerialization, Basic)):
(fakeDataDetectorResultForTesting):
(TEST(CoreIPCCFDictionary, InsertDifferentValueTypes)):
(TEST(CoreIPCCFDictionary, InsertDifferentKeyTypes)):
* Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp:
(TestWebKitAPI::ListHashSetReferencedItem::create):
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::TEST(NativePromise, AsyncResolve)):
(TestWebKitAPI::TEST(NativePromise, CompletionPromises)):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST(WTF_ThreadSafeWeakPtr, UseAfterMoveResistance)):
(TestWebKitAPI::TEST(WTF_ThreadSafeWeakPtr, ThreadSafeWeakHashAmortizedCleanupWhenOnlyAdding)):
(TestWebKitAPI::TEST(WTF_ThreadSafeWeakPtr, AmortizedCleanupNotQuadratic)):
(TestWebKitAPI::TEST(WTF_ThreadSafeWeakPtr, MultipleInheritance)):
* Tools/TestWebKitAPI/Tests/WTF/cf/StringCF.cpp:
(TestWebKitAPI::TEST(StringCF, ConstructFromLatin1WithHighBytes)):
(TestWebKitAPI::TEST(StringCF, ConstructFromUTF16WithLatin1Characters)):
(TestWebKitAPI::TEST(StringCF, ConstructFromUTF16WithHighLatin1Characters)):
(TestWebKitAPI::TEST(StringCF, ConstructFromUTF16WithNonLatin1Characters)):
(TestWebKitAPI::TEST(StringCF, ConstructFromUTF16MixedLatin1AndNonLatin1)):
* Tools/TestWebKitAPI/Tests/WTF/cf/VectorCF.cpp:
(TestWebKitAPI::TEST(VectorCF, MakeVector_CFString)):
(TestWebKitAPI::TEST(VectorCF, MakeVector_CFNumber)):
(TestWebKitAPI::TEST(VectorCF, MakeVectorWithFunctor)):
(TestWebKitAPI::TEST(VectorCF, VectorFromCFData)):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm:
(TEST(WTF_ContextualizedNSString, tokenizer)):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainPtr.mm:
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, HashMapCFTypeDeletedValue)):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm:
(TestWebKitAPI::TEST(TypeCastsCocoa, bridge_id_cast)):
* Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp:
(TestWebKitAPI::TEST(TypeCastsOSObjectCF, osObjectCast)):
(TestWebKitAPI::TEST(TypeCastsOSObjectCF, dynamicOSObjectCast)):
(TestWebKitAPI::TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_OSObjectPtr)):
(TestWebKitAPI::TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_const_OSObjectPtr)):
* Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp:
(TestWebKitAPI::TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp:
(TestWebKitAPI::TEST(BifurcatedGraphicsContextTests, Basic)):
(TestWebKitAPI::TEST(BifurcatedGraphicsContextTests, DrawTiledGradientImage)):
(TestWebKitAPI::TEST(BifurcatedGraphicsContextTests, DrawGradientImage)):
(TestWebKitAPI::TEST(BifurcatedGraphicsContextTests, Borders)):
(TestWebKitAPI::TEST(BifurcatedGraphicsContextTests, TransformedClip)):
(TestWebKitAPI::TEST(BifurcatedGraphicsContextTests, ApplyDeviceScaleFactor)):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm:
(TestWebKitAPI::makeFormatDescriptionWithTencData):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm:
(TestWebKitAPI::greenImage):
(TestWebKitAPI::TEST(GraphicsContextTests, DrawNativeImageDoesNotLeakCompositeOperator)):
(TestWebKitAPI::TEST(GraphicsContextTests, CGBitmapRenderingModeIsUnaccelerated)):
(TestWebKitAPI::TEST(GraphicsContextTests, IOSurfaceRenderingModeIsAccelerated)):
(TestWebKitAPI::TEST(GraphicsContextTests, DrawsReportHasDrawn)):
(TestWebKitAPI::TEST(GraphicsContextTests, OutOfGamutSRGBNotDrawn)):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:
(TestWebKitAPI::WebCore::TestedGraphicsContextGLCocoa::create):
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/XPCEndpoint.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ApplicationManifest.mm:
(TestWebKitAPI::TEST(ApplicationManifest, Coding)):
(TestWebKitAPI::TEST(ApplicationManifest, Basic)):
(TestWebKitAPI::TEST(ApplicationManifest, AlwaysFetchData)):
(TestWebKitAPI::TEST(ApplicationManifest, OnlyFirstManifest)):
(TestWebKitAPI::TEST(ApplicationManifest, MediaAttriute)):
(TestWebKitAPI::TEST(ApplicationManifest, Icons)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Challenge.mm:
(createTestIdentity):
(verifyCertificateAndPublicKey):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditorStateTests.mm:
(TestWebKitAPI::TEST(EditorStateTests, CaretColorInContentEditable)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EventAttribution.mm:
(TestWebKitAPI::signUnlinkableTokenAndSendSecretToken):
(TestWebKitAPI::attemptConnectionInProcessWithoutEntitlement):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FirstVisuallyNonEmptyMilestone.mm:
(contentTypeForFileExtension):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GPUProcess.mm:
(TestWebKitAPI::TEST(GPUProcess, CanvasBasicCrashHandling)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm:
(CGColorInNSSecureCoding)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PDFLinkReferrer.mm:
(createPDFWithLinkToURL):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, ThemeColor)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextWidth.mm:
(TEST(WebKit, TextWidth)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSnapshot.mm:
(TestWebKitAPI::TEST(WKWebView, SnapshotImageBaseCase)):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageLargeAsyncDecoding)):
(TestWebKitAPI::TEST(WKWebView, SnapshotAfterScreenUpdates)):
(TestWebKitAPI::TEST(WKWebView, SnapshotWithoutAfterScreenUpdates)):
(TestWebKitAPI::TEST(WKWebView, SnapshotWebGL)):
(TestWebKitAPI::TEST(WKWebView, SnapshotWithoutSelectionHighlighting)):
(TestWebKitAPI::TEST(WKWebView, SnapshotWithContentsRect)):
(TestWebKitAPI::TEST(WKWebView, RemoteSnapshotWithTransform)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewThemeColor.mm:
(TEST(WKWebViewThemeColor, MetaElementValidNameAndColor)):
(TEST(WKWebViewThemeColor, MetaElementValidNameAndColorAndMedia)):
(TEST(WKWebViewThemeColor, MetaElementInvalidName)):
(TEST(WKWebViewThemeColor, MetaElementInvalidColor)):
(TEST(WKWebViewThemeColor, MetaElementInvalidMedia)):
(TEST(WKWebViewThemeColor, MetaElementMultipleValid)):
(TEST(WKWebViewThemeColor, MetaElementValidSubframe)):
(TEST(WKWebViewThemeColor, KVO)):
(TEST(WKWebViewThemeColor, ApplicationManifest)):
(TEST(WKWebViewThemeColor, MetaElementOverridesApplicationManifest)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewUnderPageBackgroundColor.mm:
(defaultBackgroundColor):
(TEST(WKWebViewUnderPageBackgroundColor, SingleSolidColor)):
(TEST(WKWebViewUnderPageBackgroundColor, MultipleSolidColors)):
(TEST(WKWebViewUnderPageBackgroundColor, KVO)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder const):
(TestWebKitAPI::createAndConfigureConnectionToService):
(TestWebKitAPI::TEST(WebPushD, BasicCommunication)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::WebCore::addKeyToKeychain):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm:
(TestWebKitAPI::isCompletelyWhite):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextStyleFontSize.mm:
(TEST(TextStyleFontSize, Startup)):
(TEST(TextStyleFontSize, AfterCrash)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm:
(TestWebKitAPI::(WKScrollViewTests, BackgroundColorSetByClient)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/BackgroundColor.mm:
(TestWebKitAPI::TEST(WebKit, BackgroundColorToggleAppearance)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MediaPlaybackSleepAssertion.mm:
(TestWebKitAPI::hasAssertionType):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/SnapshotViaRenderInContext.mm:
(TestWebKitAPI::TEST(WebKitLegacy, RenderInContextSnapshot)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebThreadLock.mm:
(TestWebKitAPI::TEST(WebKitLegacy, NestedRunLoopUnderRunLoopObserverDoubleUnlock)):

Canonical link: <a href="https://commits.webkit.org/311046@main">https://commits.webkit.org/311046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b42cceb13376fbf0e622596368fdf5f73917b3d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155919 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109733 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120702 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101391 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21976 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20118 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12511 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167161 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128823 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128955 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34924 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139644 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86520 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23773 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16442 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28486 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28013 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28241 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28137 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->