### PR TITLE
[css-mixins-1] Fix cycle detection and nested function calls

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt
@@ -4,7 +4,7 @@ PASS Cycle reference without fallback makes result invalid
 FAIL Local with self-cycle in unused fallback assert_equals: expected "PASS" but got "FAIL"
 FAIL Local shadowing cyclic property --x assert_equals: expected "PASS" but got ""
 FAIL Local shadowing cyclic outer local --x assert_equals: expected "PASS" but got ""
-FAIL Argument shadowing cyclic outer local --x assert_equals: expected "10px" but got ""
+PASS Argument shadowing cyclic outer local --x
 PASS Arguments shadowing cyclic properties
 PASS Observing property cycle locally
 PASS Using cyclic values with no fallback
@@ -22,6 +22,6 @@ PASS Cycle through local, other function, fallback in function
 PASS Cycle through various variables and other functions
 FAIL Function in a cycle with its own default assert_equals: expected "PASS" but got "10px"
 FAIL Cyclic defaults assert_equals: expected "42px PASS-y PASS-z" but got "42px var(--z) var(--y)"
-FAIL Cyclic outer --b shadows custom property assert_equals: expected "PASS" but got ""
-FAIL Locals are function specific assert_equals: expected "10px" but got ""
+FAIL Cyclic outer --b shadows custom property assert_equals: expected "PASS" but got "var(--b)"
+PASS Locals are function specific
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt
@@ -6,7 +6,7 @@ PASS Literal result, typed return, mismatch
 PASS Missing result descriptor
 PASS Literal result, empty
 PASS result cascading behavior
-FAIL Another dashed-function in result assert_equals: expected "12px" but got ""
+PASS Another dashed-function in result
 PASS Unused argument
 PASS Single parameter
 PASS Multiple parameters
@@ -16,7 +16,7 @@ PASS Untyped parameter with calc()
 PASS Various typed parameters
 PASS Parameter with complex type (auto)
 PASS Parameter with complex type (px)
-FAIL Passing argument to inner function assert_equals: expected "12px" but got ""
+PASS Passing argument to inner function
 PASS var() in argument resolved before call
 PASS var() in argument resolved before call, typed
 FAIL Argument captures IACVT due to invalid var() assert_equals: expected "PASS" but got ""
@@ -40,19 +40,19 @@ PASS Local referring to another local
 PASS Locals appearing after result
 PASS Locals cascading behavior
 PASS Custom properties are visible inside function
-FAIL Substitute local from outer scope assert_equals: expected "PASS" but got ""
-FAIL Substitute argument from outer scope assert_equals: expected "PASS" but got ""
-FAIL Inner argument shadowing outer argument assert_equals: expected "PASS" but got ""
-FAIL Inner argument shadowing outer local assert_equals: expected "PASS" but got ""
-FAIL Inner local shadowing outer argument assert_equals: expected "PASS" but got ""
-FAIL Inner local shadowing outer local assert_equals: expected "PASS" but got ""
-FAIL Referencing outer local containing var() assert_equals: expected "1" but got ""
-FAIL Referencing outer typed argument assert_equals: expected "10px" but got ""
-FAIL Same function with different scopes assert_equals: expected "1 2 3 0" but got ""
-FAIL Referencing local two frames up assert_equals: expected "1" but got ""
-FAIL IACVT outer local shadows property assert_equals: expected "PASS" but got ""
-FAIL Inner function call should see resolved outer locals assert_equals: expected "10px" but got ""
-FAIL Inner function call should see resolved outer locals (reverse) assert_equals: expected "10px" but got ""
+PASS Substitute local from outer scope
+PASS Substitute argument from outer scope
+PASS Inner argument shadowing outer argument
+PASS Inner argument shadowing outer local
+PASS Inner local shadowing outer argument
+PASS Inner local shadowing outer local
+FAIL Referencing outer local containing var() assert_equals: expected "1" but got "0"
+PASS Referencing outer typed argument
+PASS Same function with different scopes
+PASS Referencing local two frames up
+PASS IACVT outer local shadows property
+PASS Inner function call should see resolved outer locals
+PASS Inner function call should see resolved outer locals (reverse)
 PASS Parameter shadows custom property
 PASS Local shadows parameter
 FAIL IACVT argument shadows outer scope assert_equals: expected "PASS" but got ""
@@ -72,8 +72,8 @@ FAIL Local variable with initial keyword, no value via IACVT-capture assert_equa
 FAIL Default with initial keyword assert_equals: expected "PASS" but got ""
 FAIL initial appearing via fallback assert_equals: expected "PASS" but got ""
 PASS Local variable with inherit keyword
-FAIL Local variable with inherit keyword (nested) assert_equals: expected "PASS" but got ""
-FAIL Inheriting an invalid value assert_equals: expected "PASS" but got ""
+FAIL Local variable with inherit keyword (nested) assert_equals: expected "PASS" but got "FAIL3"
+FAIL Inheriting an invalid value assert_equals: expected "PASS" but got "FAIL1"
 FAIL Default with inherit keyword assert_equals: expected "PASS1 PASS2" but got ""
 FAIL Default with inherit keyword (nested) assert_equals: expected "PASS1 PASS2" but got ""
 PASS Local with the unset keyword

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt
@@ -3,19 +3,19 @@ PASS Return untyped url() from function
 PASS Return untyped url() from function, quoted
 PASS Return typed url() from function
 PASS Return typed url() from function, quoted
-FAIL Return attr(type(<length>)) from untyped function assert_equals: expected "42px" but got "784px"
-FAIL Return attr(type(<length>)) from typed function assert_equals: expected "42px" but got "784px"
-FAIL Return attr(type(*)) from typed function assert_equals: expected "42px" but got "784px"
-FAIL Return attr(type(*)) from untyped function assert_equals: expected "42px" but got "784px"
+PASS Return attr(type(<length>)) from untyped function
+PASS Return attr(type(<length>)) from typed function
+PASS Return attr(type(*)) from typed function
+PASS Return attr(type(*)) from untyped function
 FAIL attr() in default parameter value assert_equals: expected "42px" but got "784px"
-FAIL attr() in local variable assert_equals: expected "42px" but got "784px"
-PASS Returned url() is attr-tainted
-PASS Returned url() is attr-tainted, typed attr()
+PASS attr() in local variable
+FAIL Returned url() is attr-tainted assert_equals: expected "url(\"http://web-platform.test:8800/css/css-mixins/parent\")" but got "url(\"http://web-platform.test:8800/css/css-mixins/cat.png\")"
+FAIL Returned url() is attr-tainted, typed attr() assert_equals: expected "url(\"http://web-platform.test:8800/css/css-mixins/parent\")" but got "url(\"http://web-platform.test:8800/css/css-mixins/cat.png\")"
 PASS Returned url() is attr-tainted, typed return
 PASS Returned url() is attr-tainted, local
 PASS Returned url() is attr-tainted, argument
 PASS Returned url() is attr-tainted, default
-PASS Returned url() is attr-tainted, parent stack frame
+FAIL Returned url() is attr-tainted, parent stack frame assert_equals: expected "url(\"http://web-platform.test:8800/css/css-mixins/parent\")" but got "url(\"http://web-platform.test:8800/css/css-mixins/cat.png\")"
 PASS Returned url() is attr-tainted, initial
 PASS Returned url() is attr-tainted, inherit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-shadow-expected.txt
@@ -7,7 +7,7 @@ PASS Combining functions from various scopes
 PASS ::part() can not see inner functions
 PASS ::slotted() can see inner functions
 PASS :host can see inner functions
-FAIL Outer functions can't see inner functions assert_equals: expected "20px C" but got ""
-FAIL Outer functions can't see inner functions (local vars) assert_equals: expected "22px C" but got ""
+FAIL Outer functions can't see inner functions assert_equals: expected "20px C" but got "C C"
+FAIL Outer functions can't see inner functions (local vars) assert_equals: expected "22px C" but got "C C"
 FAIL Function with same name in different scopes assert_equals: expected "24px" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-attr-substitution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-attr-substitution-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL var() in attribute value substitutes locally assert_equals: expected "PASS" but got ""
-FAIL var() in attribute value substitutes locally, argument assert_equals: expected "PASS" but got ""
-FAIL var() in attribute value substitutes locally, typed assert_equals: expected "12px" but got ""
-FAIL attr() fallback substitutes locally assert_equals: expected "PASS" but got ""
+PASS var() in attribute value substitutes locally
+PASS var() in attribute value substitutes locally, argument
+PASS var() in attribute value substitutes locally, typed
+PASS attr() fallback substitutes locally
 PASS attr() cycle through local
 FAIL attr() cycle through unused fallback in local assert_equals: expected "PASS" but got "FAIL"
 PASS attr() cycle through function

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution-expected.txt
@@ -5,16 +5,16 @@ FAIL var() in if() declaration value substitutes locally assert_equals: expected
 FAIL var() in if() condition's custom property value substitutes locally, argument assert_equals: expected "PASS" but got "if(style(--x: 3px): PASS; else: FAIL;)"
 FAIL var() in if() condition's specified value substitutes locally, argument assert_equals: expected "PASS" but got "if(style(--y: 3px): PASS; else: FAIL;)"
 FAIL var() in if() declaration value substitutes locally, argument assert_equals: expected "PASS" but got "if(style(--true): PASS; else: FAIL;)"
-FAIL dashed function in if() declaration value assert_equals: expected "PASS" but got ""
-FAIL dashed function with argument in if() declaration value assert_equals: expected "PASS" but got ""
+FAIL dashed function in if() declaration value assert_equals: expected "PASS" but got "if(style(--true): PASS; else: FAIL;)"
+FAIL dashed function with argument in if() declaration value assert_equals: expected "PASS" but got "if(style(--true): PASS; else: FAIL;)"
 PASS if() cycle through local
 FAIL if() cycle in condition custom property through local assert_equals: expected "PASS" but got "if(style(--x): FAIL1; else: FAIL2;)"
 PASS if() cycle in condition specified value through local
 PASS if() cycle through function
 FAIL if() no cycle in overridden local assert_equals: expected "PASS" but got "if(style(--x): PASS; else: FAIL)"
 FAIL if() no cycle in overridden argument assert_equals: expected "PASS" but got "if(style(--x): PASS; else: FAIL)"
-FAIL CSS-wide keywords are interpreted locally (initial) assert_equals: expected "PASS" but got ""
-FAIL CSS-wide keywords are interpreted locally (inherit) assert_equals: expected "PASS" but got ""
+FAIL CSS-wide keywords are interpreted locally (initial) assert_equals: expected "PASS" but got "if(style(--c: initial): PASS; else: FAIL)"
+FAIL CSS-wide keywords are interpreted locally (inherit) assert_equals: expected "PASS" but got "if(style(--c: inherit): PASS; else: FAIL)"
 FAIL CSS-wide keywords are interpreted locally (guaranteed-invalid, initial) assert_equals: expected "PASS" but got "if(style(--c: initial): PASS; else: FAIL)"
 FAIL CSS-wide keywords are interpreted locally (guaranteed-invalid, unset) assert_equals: expected "PASS" but got "if(style(--c: unset): PASS; else: FAIL)"
 FAIL CSS-wide keywords are interpreted locally (revert) assert_equals: expected "PASS" but got "if(style(--c: revert): FAIL; else: PASS)"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/parameter-types.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/parameter-types.tentative-expected.txt
@@ -1,9 +1,9 @@
 
 FAIL A parameter retains its type assert_equals: expected "PASS" but got "if(\n        style(--c:red): PASS;\n        else: FAIL)"
 FAIL A parameter type acts as a local registration assert_equals: expected "PASS" but got "if(\n        style(--c:blue): PASS;\n        else: FAIL)"
-FAIL A parameter retains its type (parent stack frame) assert_equals: expected "PASS" but got ""
-FAIL A parameter type acts as a local registration (parent stack frame) assert_equals: expected "PASS" but got ""
-FAIL Universally typed parameter can shadow other parameters assert_equals: expected "PASS" but got ""
+FAIL A parameter retains its type (parent stack frame) assert_equals: expected "PASS" but got "if(\n        style(--c:red): PASS;\n        else: FAIL)"
+FAIL A parameter type acts as a local registration (parent stack frame) assert_equals: expected "PASS" but got "if(\n        style(--c:blue): PASS;\n        else: FAIL)"
+FAIL Universally typed parameter can shadow other parameters assert_equals: expected "PASS" but got "if(\n        style(--c:red): FAIL1;\n        style(--c:#f00): FAIL2;\n        style(--c:lime): FAIL3;\n        style(--c:#0f0): PASS;\n        else: FAIL4)"
 FAIL Invalid value for typed local becomes IACVT assert_equals: expected "PASS" but got "3"
 FAIL if() within @function can query registered custom property assert_equals: expected "PASS" but got "if(style(--c:#f00): PASS; else: FAIL)"
 

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -234,6 +234,12 @@ bool PropertyCascade::mayOverrideExistingProperty(CSSPropertyID propertyID, cons
     return !!m_lastIndexForLogicalGroup;
 }
 
+const PropertyCascade::Property& PropertyCascade::functionResultProperty() const
+{
+    ASSERT(hasNormalProperty(CSSPropertyResult));
+    return normalProperty(CSSPropertyResult);
+}
+
 const PropertyCascade::Property* PropertyCascade::lastPropertyResolvingLogicalPropertyPair(CSSPropertyID propertyID, WritingMode writingMode) const
 {
     ASSERT(CSSProperty::isInLogicalPropertyGroup(propertyID));

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -105,6 +105,7 @@ public:
 
     bool hasCustomProperty(const AtomString&) const;
     const Property& customProperty(const AtomString&) const LIFETIME_BOUND;
+    const Property& functionResultProperty() const LIFETIME_BOUND;
 
     std::span<const CSSPropertyID> logicalGroupPropertyIDs() const LIFETIME_BOUND;
     const HashMap<AtomString, Property>& customProperties() const LIFETIME_BOUND { return m_customProperties; }

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -640,6 +640,8 @@ RefPtr<const CustomProperty> Builder::resolveCustomPropertyForContainerQueries(c
 
 RefPtr<const CustomProperty> Builder::resolveFunctionResult(const CSSCustomPropertyValue& value)
 {
+    SetForScope resultScope(m_state->m_currentProperty, &m_cascade.functionResultProperty());
+
     auto resolvedValue = resolveCustomPropertyValue(const_cast<CSSCustomPropertyValue&>(value));
     if (!resolvedValue)
         return nullptr;

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -158,6 +158,7 @@ public:
     const CSSToLengthConversionData& cssToLengthConversionData() const LIFETIME_BOUND { return m_cssToLengthConversionData; }
 
     GuardedSubstitutionContexts::Guard guardSubstitutionContext(SubstitutionContext&& context) { return m_guardedSubstitutionContexts.guard(WTF::move(context)); }
+    void addGuardedFunctionContexts(const BuilderState& other) { m_guardedSubstitutionContexts.addFunctionContextsFrom(other.m_guardedSubstitutionContexts); }
 
     void setIsBuildingKeyframeStyle() { m_isBuildingKeyframeStyle = true; }
     bool hasRevertRuleOrLayerInKeyframeStyle() const { return m_hasRevertRuleOrLayerInKeyframeStyle; }

--- a/Source/WebCore/style/StyleSubstitutionContext.h
+++ b/Source/WebCore/style/StyleSubstitutionContext.h
@@ -93,6 +93,15 @@ public:
 
     Guard guard(SubstitutionContext&& context) { return { *this, WTF::move(context) }; }
 
+    void addFunctionContextsFrom(const GuardedSubstitutionContexts& other)
+    {
+        for (auto& context : other.m_guarded) {
+            if (context.key().type == SubstitutionContext::Type::Function)
+                m_guarded.add(context);
+        }
+        m_top = other.m_top;
+    }
+
 private:
     HashSet<GenericHashKey<SubstitutionContext>> m_guarded;
     Guard* m_top { nullptr };

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -211,11 +211,13 @@ RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFun
     auto builderContext = BuilderContext {
         .document = m_styleBuilder.state().document(),
         .parentStyle = &m_styleBuilder.state().renderStyle(),
+        .element = m_styleBuilder.state().element(),
         .localPropertyRegistry = &argumentRegistrations
     };
 
     auto argumentStyles = RenderStyle::createPtr();
     Builder argumentBuilder(*argumentStyles, WTF::move(builderContext), argumentMatchResult.get());
+    argumentBuilder.state().addGuardedFunctionContexts(m_styleBuilder.state());
     for (auto& parameter : parameters)
         argumentBuilder.applyCustomProperty(parameter.name);
 
@@ -320,11 +322,13 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     auto builderContext = BuilderContext {
         .document = m_styleBuilder.state().document(),
         .parentStyle = &m_styleBuilder.state().renderStyle(),
+        .element = m_styleBuilder.state().element(),
         .localPropertyRegistry = &registrations
     };
 
     auto bodyStyles = RenderStyle::createPtr();
     Builder bodyBuilder(*bodyStyles, WTF::move(builderContext), bodyMatchResult.get());
+    bodyBuilder.state().addGuardedFunctionContexts(m_styleBuilder.state());
 
     // "Return the value of the result property in body styles."
     auto resolvedResult = bodyBuilder.resolveFunctionResult(*resultValue);


### PR DESCRIPTION
#### 9df4aed36a6c810e46410e4442d9db7c4a0db3e9
<pre>
[css-mixins-1] Fix cycle detection and nested function calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=312101">https://bugs.webkit.org/show_bug.cgi?id=312101</a>
<a href="https://rdar.apple.com/174609179">rdar://174609179</a>

Reviewed by Alan Baradlay (OOPS\!).

Various fixes.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-attr-substitution-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/local-if-substitution-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/parameter-types.tentative-expected.txt:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::functionResultProperty const):
* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveFunctionResult):

Initialize m_currentProperty when resolving the result descriptor.

* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::addGuardedFunctionContexts):

Helper to add parent context guards.

* Source/WebCore/style/StyleSubstitutionContext.h:
(WebCore::Style::GuardedSubstitutionContexts::addFunctionContextsFrom):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::resolveAndRegisterDashedFunctionArguments):
(WebCore::Style::SubstitutionResolver::substituteDashedFunction):

Initialize element for nested style builder.
Pass guarded substitution contexts from parent to the nested builder.

Canonical link: <a href="https://commits.webkit.org/311178@main">https://commits.webkit.org/311178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8e3348b68762157444fb511f0377ec42a257288

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164652 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109704 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120676 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85009 "2 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101365 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21950 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20092 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12482 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167132 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11306 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128797 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128930 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35010 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139617 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86488 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23754 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16416 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28310 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92413 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27910 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28117 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27961 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->