### PR TITLE
[CMake] Fix WebGPU build for Mac

### DIFF
--- a/Source/WebGPU/CMakeLists.txt
+++ b/Source/WebGPU/CMakeLists.txt
@@ -1,1 +1,5 @@
 add_subdirectory(WGSL)
+
+if (APPLE)
+    add_subdirectory(WebGPU)
+endif ()

--- a/Source/WebGPU/WGSL/CMakeLists.txt
+++ b/Source/WebGPU/WGSL/CMakeLists.txt
@@ -28,20 +28,21 @@
 # Build wgslc.
 # For simplicity, build it as a monolithic executable.
 
-# Target 'wgsl-types' generates TypeDeclarations.h in the build tree.
+# Target 'wgsl-types' generates TypeDeclarations.h and TypeOverloads.h in the build tree.
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/TypeDeclarations.h
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/TypeDeclarations.h ${CMAKE_CURRENT_BINARY_DIR}/TypeOverloads.h
     COMMAND ${Ruby_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/generator/main.rb
         ${CMAKE_CURRENT_SOURCE_DIR}/TypeDeclarations.rb
         ${CMAKE_CURRENT_BINARY_DIR}/TypeDeclarations.h
+        ${CMAKE_CURRENT_BINARY_DIR}/TypeOverloads.h
     DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/generator/main.rb
         ${CMAKE_CURRENT_SOURCE_DIR}/TypeDeclarations.rb
     )
 add_custom_target(wgsl-types
     ALL
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/TypeDeclarations.h)
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/TypeDeclarations.h ${CMAKE_CURRENT_BINARY_DIR}/TypeOverloads.h)
 
 set(wgslc_SOURCES
     AliasAnalysis.cpp
@@ -55,6 +56,7 @@ set(wgslc_SOURCES
     EntryPointRewriter.cpp
     GlobalSorting.cpp
     GlobalVariableRewriter.cpp
+    IOValidator.cpp
     Lexer.cpp
     MangleNames.cpp
     Overload.cpp

--- a/Source/WebGPU/WebGPU/CMakeLists.txt
+++ b/Source/WebGPU/WebGPU/CMakeLists.txt
@@ -1,0 +1,136 @@
+set(WebGPU_SOURCES
+    Adapter.mm
+    BindGroup.mm
+    BindGroupLayout.mm
+    Buffer.mm
+    CommandBuffer.mm
+    CommandEncoder.mm
+    CommandsMixin.mm
+    ComputePassEncoder.mm
+    ComputePipeline.mm
+    Device.mm
+    ExternalTexture.mm
+    HardwareCapabilities.mm
+    Instance.mm
+    Pipeline.mm
+    PipelineLayout.mm
+    PresentationContext.mm
+    PresentationContextIOSurface.mm
+    QuerySet.mm
+    Queue.mm
+    RenderBundle.mm
+    RenderBundleEncoder.mm
+    RenderPassEncoder.mm
+    RenderPipeline.mm
+    Sampler.mm
+    ShaderModule.mm
+    Texture.mm
+    TextureView.mm
+    XRBinding.mm
+    XRProjectionLayer.mm
+    XRSubImage.mm
+    XRView.mm
+)
+
+# WGSL compiler sources are compiled into the WebGPU framework
+set(WGSL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../WGSL)
+set(WebGPU_WGSL_SOURCES
+    ${WGSL_DIR}/AliasAnalysis.cpp
+    ${WGSL_DIR}/AttributeValidator.cpp
+    ${WGSL_DIR}/BoundsCheck.cpp
+    ${WGSL_DIR}/CallGraph.cpp
+    ${WGSL_DIR}/CompilationMessage.cpp
+    ${WGSL_DIR}/CompilationScope.cpp
+    ${WGSL_DIR}/ConstantValue.cpp
+    ${WGSL_DIR}/Constraints.cpp
+    ${WGSL_DIR}/EntryPointRewriter.cpp
+    ${WGSL_DIR}/GlobalSorting.cpp
+    ${WGSL_DIR}/GlobalVariableRewriter.cpp
+    ${WGSL_DIR}/Lexer.cpp
+    ${WGSL_DIR}/MangleNames.cpp
+    ${WGSL_DIR}/Overload.cpp
+    ${WGSL_DIR}/Parser.cpp
+    ${WGSL_DIR}/PointerRewriter.cpp
+    ${WGSL_DIR}/Token.cpp
+    ${WGSL_DIR}/TypeCheck.cpp
+    ${WGSL_DIR}/Types.cpp
+    ${WGSL_DIR}/TypeStore.cpp
+    ${WGSL_DIR}/UniformityAnalysis.cpp
+    ${WGSL_DIR}/VisibilityValidator.cpp
+    ${WGSL_DIR}/WGSL.cpp
+    ${WGSL_DIR}/WGSLEnums.cpp
+    ${WGSL_DIR}/WGSLShaderModule.cpp
+    ${WGSL_DIR}/AST/ASTBinaryExpression.cpp
+    ${WGSL_DIR}/AST/ASTBuilder.cpp
+    ${WGSL_DIR}/AST/ASTDecrementIncrementStatement.cpp
+    ${WGSL_DIR}/AST/ASTStringDumper.cpp
+    ${WGSL_DIR}/AST/ASTUnaryExpression.cpp
+    ${WGSL_DIR}/AST/ASTVisitor.cpp
+    ${WGSL_DIR}/Metal/MetalCodeGenerator.cpp
+    ${WGSL_DIR}/IOValidator.cpp
+    ${WGSL_DIR}/Metal/MetalFunctionWriter.cpp
+)
+
+add_library(WebGPU SHARED ${WebGPU_SOURCES} ${WebGPU_WGSL_SOURCES})
+
+set_target_properties(WebGPU PROPERTIES
+    FRAMEWORK TRUE
+    OUTPUT_NAME WebGPU
+)
+
+find_library(METAL_FRAMEWORK Metal)
+find_library(IOSURFACE_FRAMEWORK IOSurface)
+find_library(COREFOUNDATION_FRAMEWORK CoreFoundation)
+find_library(COREVIDEO_FRAMEWORK CoreVideo)
+find_library(FOUNDATION_FRAMEWORK Foundation)
+find_library(QUARTZCORE_FRAMEWORK QuartzCore)
+
+target_link_libraries(WebGPU PRIVATE
+    ${METAL_FRAMEWORK}
+    ${IOSURFACE_FRAMEWORK}
+    ${COREFOUNDATION_FRAMEWORK}
+    ${COREVIDEO_FRAMEWORK}
+    ${FOUNDATION_FRAMEWORK}
+    ${QUARTZCORE_FRAMEWORK}
+    WTF
+)
+
+target_include_directories(WebGPU PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${WGSL_DIR}
+    ${WGSL_DIR}/AST
+    ${WGSL_DIR}/Metal
+    ${CMAKE_CURRENT_BINARY_DIR}/../WGSL
+    ${WTF_FRAMEWORK_HEADERS_DIR}
+    ${bmalloc_FRAMEWORK_HEADERS_DIR}
+)
+
+target_compile_definitions(WebGPU PRIVATE
+    WGPU_SHARED_LIBRARY
+    WGPU_IMPLEMENTATION
+    __WEBGPU__
+)
+
+# Generate an empty cmakeconfig.h for the WebGPU target
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmakeconfig.h "")
+target_include_directories(WebGPU PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_compile_options(WebGPU PRIVATE "-ObjC++" -std=c++2b -fobjc-arc)
+
+set(WebGPU_FRAMEWORK_HEADERS_DIR "${CMAKE_BINARY_DIR}/WebGPU/Headers")
+file(MAKE_DIRECTORY ${WebGPU_FRAMEWORK_HEADERS_DIR}/WebGPU)
+file(COPY
+    ${CMAKE_CURRENT_SOURCE_DIR}/WebGPU.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/WebGPUExt.h
+    DESTINATION ${WebGPU_FRAMEWORK_HEADERS_DIR}/WebGPU)
+
+target_include_directories(WebGPU PUBLIC ${WebGPU_FRAMEWORK_HEADERS_DIR})
+
+if (TARGET WTF_CopyHeaders)
+    add_dependencies(WebGPU WTF_CopyHeaders)
+endif ()
+if (TARGET bmalloc_CopyHeaders)
+    add_dependencies(WebGPU bmalloc_CopyHeaders)
+endif ()
+add_dependencies(WebGPU wgsl-types)


### PR DESCRIPTION
#### f557e873a21c6dce2a29d32dd1e029639d1f2e76
<pre>
[CMake] Fix WebGPU build for Mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=312031">https://bugs.webkit.org/show_bug.cgi?id=312031</a>
<a href="https://rdar.apple.com/174587148">rdar://174587148</a>

Reviewed by BJ Burg and Mike Wyrzykowski.

Source/WebGPU/WebGPU/CMakeLists.txt is a new file that compiles 33 WebGPU
Objective-C++ sources and the WGSL compiler sources into a shared framework,
linking Metal, IOSurface, CoreFoundation, CoreVideo, Foundation, and
QuartzCore. ARC is enabled and public headers (WebGPU.h, WebGPUExt.h) are
copied to the build directory for downstream consumers.

The WGSL generator is updated to produce both TypeDeclarations.h and
TypeOverloads.h, and IOValidator.cpp is added to the wgslc source list.
The top-level WebGPU CMakeLists.txt conditionally includes the WebGPU
subdirectory on Apple platforms.

* Source/WebGPU/CMakeLists.txt:
* Source/WebGPU/WGSL/CMakeLists.txt:
* Source/WebGPU/WebGPU/CMakeLists.txt: Added.

Canonical link: <a href="https://commits.webkit.org/311119@main">https://commits.webkit.org/311119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/310b79ce86d8ec95c64c0cee007e95f83576be76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156093 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/29561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/29429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/164914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159051 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/29561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/22610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/29561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/29429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/12686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/29561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/22610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/167393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/29429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/28951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/22610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23759 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/28951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/28660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/92617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->