### PR TITLE
Reset CJK encoding state appropriately

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/encoding/textdecoder-mistakes.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/encoding/textdecoder-mistakes.any-expected.txt
@@ -45,24 +45,24 @@ PASS selected single-byte: windows-1258
 PASS selected single-byte: iso-8859-8-i
 PASS selected single-byte: iso-8859-16
 PASS selected single-byte: x-mac-cyrillic
-FAIL Concatenating two ISO-2022-JP outputs is not always valid assert_equals: expected "¥\ufffd¥" but got "\ufffd¥\ufffd¥"
+PASS Concatenating two ISO-2022-JP outputs is not always valid
 PASS gb18030 version and ranges
 PASS gbk version and ranges
 PASS gbk decoder is gb18030 decoder
 PASS Replacement, push back ASCII characters: big5
-FAIL Replacement, push back ASCII characters: iso-2022-jp assert_equals: expected "\ufffd\ufffd" but got "\ufffd$"
+PASS Replacement, push back ASCII characters: iso-2022-jp
 PASS Replacement, push back ASCII characters: gb18030
 PASS Replacement, push back ASCII characters: euc-jp
 PASS Replacement, push back ASCII characters: euc-kr
 PASS Replacement, push back ASCII characters: shift_jis
 PASS Replacement, push back ASCII characters: gbk
-FAIL Sticky multibyte state: iso-2022-jp assert_equals: expected "@" but got "\ufffd@"
-FAIL Sticky multibyte state: gb18030 assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: big5 assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: shift_jis assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: euc-kr assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: gbk assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: euc-jp assert_equals: expected "　" but got "\ufffd"
+PASS Sticky multibyte state: iso-2022-jp
+PASS Sticky multibyte state: gb18030
+PASS Sticky multibyte state: big5
+PASS Sticky multibyte state: shift_jis
+PASS Sticky multibyte state: euc-kr
+PASS Sticky multibyte state: gbk
+PASS Sticky multibyte state: euc-jp
 PASS Sticky fatal BOM: utf-8
 PASS Sticky fatal BOM: utf-16le
 PASS Sticky fatal BOM: utf-16be

--- a/LayoutTests/imported/w3c/web-platform-tests/encoding/textdecoder-mistakes.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/encoding/textdecoder-mistakes.any.worker-expected.txt
@@ -45,24 +45,24 @@ PASS selected single-byte: windows-1258
 PASS selected single-byte: iso-8859-8-i
 PASS selected single-byte: iso-8859-16
 PASS selected single-byte: x-mac-cyrillic
-FAIL Concatenating two ISO-2022-JP outputs is not always valid assert_equals: expected "¥\ufffd¥" but got "\ufffd¥\ufffd¥"
+PASS Concatenating two ISO-2022-JP outputs is not always valid
 PASS gb18030 version and ranges
 PASS gbk version and ranges
 PASS gbk decoder is gb18030 decoder
 PASS Replacement, push back ASCII characters: big5
-FAIL Replacement, push back ASCII characters: iso-2022-jp assert_equals: expected "\ufffd\ufffd" but got "\ufffd$"
+PASS Replacement, push back ASCII characters: iso-2022-jp
 PASS Replacement, push back ASCII characters: gb18030
 PASS Replacement, push back ASCII characters: euc-jp
 PASS Replacement, push back ASCII characters: euc-kr
 PASS Replacement, push back ASCII characters: shift_jis
 PASS Replacement, push back ASCII characters: gbk
-FAIL Sticky multibyte state: iso-2022-jp assert_equals: expected "@" but got "\ufffd@"
-FAIL Sticky multibyte state: gb18030 assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: big5 assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: shift_jis assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: euc-kr assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: gbk assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: euc-jp assert_equals: expected "　" but got "\ufffd"
+PASS Sticky multibyte state: iso-2022-jp
+PASS Sticky multibyte state: gb18030
+PASS Sticky multibyte state: big5
+PASS Sticky multibyte state: shift_jis
+PASS Sticky multibyte state: euc-kr
+PASS Sticky multibyte state: gbk
+PASS Sticky multibyte state: euc-jp
 PASS Sticky fatal BOM: utf-8
 PASS Sticky fatal BOM: utf-16le
 PASS Sticky fatal BOM: utf-16be

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encoding/textdecoder-mistakes.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encoding/textdecoder-mistakes.any-expected.txt
@@ -45,24 +45,24 @@ PASS selected single-byte: windows-1258
 PASS selected single-byte: iso-8859-8-i
 FAIL selected single-byte: iso-8859-16 assert_equals: 128 -> 128 expected "" but got ""
 PASS selected single-byte: x-mac-cyrillic
-FAIL Concatenating two ISO-2022-JP outputs is not always valid assert_equals: expected "¥\ufffd¥" but got "\ufffd¥\ufffd¥"
+PASS Concatenating two ISO-2022-JP outputs is not always valid
 PASS gb18030 version and ranges
 PASS gbk version and ranges
 PASS gbk decoder is gb18030 decoder
 PASS Replacement, push back ASCII characters: big5
-FAIL Replacement, push back ASCII characters: iso-2022-jp assert_equals: expected "\ufffd\ufffd" but got "\ufffd$"
+PASS Replacement, push back ASCII characters: iso-2022-jp
 PASS Replacement, push back ASCII characters: gb18030
 PASS Replacement, push back ASCII characters: euc-jp
 PASS Replacement, push back ASCII characters: euc-kr
 PASS Replacement, push back ASCII characters: shift_jis
 PASS Replacement, push back ASCII characters: gbk
-FAIL Sticky multibyte state: iso-2022-jp assert_equals: expected "@" but got "\ufffd@"
-FAIL Sticky multibyte state: gb18030 assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: big5 assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: shift_jis assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: euc-kr assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: gbk assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: euc-jp assert_equals: expected "　" but got "\ufffd"
+PASS Sticky multibyte state: iso-2022-jp
+PASS Sticky multibyte state: gb18030
+PASS Sticky multibyte state: big5
+PASS Sticky multibyte state: shift_jis
+PASS Sticky multibyte state: euc-kr
+PASS Sticky multibyte state: gbk
+PASS Sticky multibyte state: euc-jp
 PASS Sticky fatal BOM: utf-8
 PASS Sticky fatal BOM: utf-16le
 PASS Sticky fatal BOM: utf-16be

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encoding/textdecoder-mistakes.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encoding/textdecoder-mistakes.any.worker-expected.txt
@@ -45,24 +45,24 @@ PASS selected single-byte: windows-1258
 PASS selected single-byte: iso-8859-8-i
 FAIL selected single-byte: iso-8859-16 assert_equals: 128 -> 128 expected "" but got ""
 PASS selected single-byte: x-mac-cyrillic
-FAIL Concatenating two ISO-2022-JP outputs is not always valid assert_equals: expected "¥\ufffd¥" but got "\ufffd¥\ufffd¥"
+PASS Concatenating two ISO-2022-JP outputs is not always valid
 PASS gb18030 version and ranges
 PASS gbk version and ranges
 PASS gbk decoder is gb18030 decoder
 PASS Replacement, push back ASCII characters: big5
-FAIL Replacement, push back ASCII characters: iso-2022-jp assert_equals: expected "\ufffd\ufffd" but got "\ufffd$"
+PASS Replacement, push back ASCII characters: iso-2022-jp
 PASS Replacement, push back ASCII characters: gb18030
 PASS Replacement, push back ASCII characters: euc-jp
 PASS Replacement, push back ASCII characters: euc-kr
 PASS Replacement, push back ASCII characters: shift_jis
 PASS Replacement, push back ASCII characters: gbk
-FAIL Sticky multibyte state: iso-2022-jp assert_equals: expected "@" but got "\ufffd@"
-FAIL Sticky multibyte state: gb18030 assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: big5 assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: shift_jis assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: euc-kr assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: gbk assert_equals: expected "@" but got ":@"
-FAIL Sticky multibyte state: euc-jp assert_equals: expected "　" but got "\ufffd"
+PASS Sticky multibyte state: iso-2022-jp
+PASS Sticky multibyte state: gb18030
+PASS Sticky multibyte state: big5
+PASS Sticky multibyte state: shift_jis
+PASS Sticky multibyte state: euc-kr
+PASS Sticky multibyte state: gbk
+PASS Sticky multibyte state: euc-jp
 PASS Sticky fatal BOM: utf-8
 PASS Sticky fatal BOM: utf-16le
 PASS Sticky fatal BOM: utf-16be

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -202,6 +202,7 @@ String TextCodecCJK::decodeCommon(std::span<const uint8_t> bytes, bool flush, bo
             result.append(replacementCharacter);
             if (stopOnError) {
                 m_lead = 0x00;
+                m_prependedByte = std::nullopt;
                 return result.toString();
             }
         }
@@ -237,7 +238,7 @@ static std::optional<char16_t> codePointJIS0212(uint16_t pointer)
 // https://encoding.spec.whatwg.org/#euc-jp-decoder
 String TextCodecCJK::eucJPDecode(std::span<const uint8_t> bytes, bool flush, bool stopOnError, bool& sawError)
 {
-    return decodeCommon(bytes, flush, stopOnError, sawError, [this] (uint8_t byte, StringBuilder& result) {
+    auto result = decodeCommon(bytes, flush, stopOnError, sawError, [this](uint8_t byte, StringBuilder& result) {
         if (uint8_t lead = std::exchange(m_lead, 0x00)) {
             if (lead == 0x8E && byte >= 0xA1 && byte <= 0xDF) {
                 result.append(static_cast<char32_t>(0xFF61 - 0xA1 + byte));
@@ -248,9 +249,10 @@ String TextCodecCJK::eucJPDecode(std::span<const uint8_t> bytes, bool flush, boo
                 m_lead = byte;
                 return SawError::No;
             }
+            bool jis0212 = std::exchange(m_jis0212, false);
             if (lead >= 0xA1 && lead <= 0xFE && byte >= 0xA1 && byte <= 0xFE) {
                 uint16_t pointer = (lead - 0xA1) * 94 + byte - 0xA1;
-                if (auto codePoint = std::exchange(m_jis0212, false) ? codePointJIS0212(pointer) : codePointJIS0208(pointer)) {
+                if (auto codePoint = jis0212 ? codePointJIS0212(pointer) : codePointJIS0208(pointer)) {
                     result.append(*codePoint);
                     return SawError::No;
                 }
@@ -269,6 +271,9 @@ String TextCodecCJK::eucJPDecode(std::span<const uint8_t> bytes, bool flush, boo
         }
         return SawError::Yes;
     });
+    if (flush)
+        m_jis0212 = false;
+    return result;
 }
 
 // https://encoding.spec.whatwg.org/#euc-jp-encoder
@@ -440,7 +445,7 @@ String TextCodecCJK::iso2022JPDecode(std::span<const uint8_t> bytes, bool flush,
             return result.toString();
         }
     }
-    if (m_iso2022JPSecondPrependedByte && byteParser(*std::exchange(m_iso2022JPSecondPrependedByte, std::nullopt), result) == SawError::Yes && stopOnError) {
+    if (m_iso2022JPSecondPrependedByte && byteParser(*std::exchange(m_iso2022JPSecondPrependedByte, std::nullopt), result) == SawError::Yes) {
         sawError = true;
         result.append(replacementCharacter);
         if (stopOnError) {
@@ -465,7 +470,7 @@ String TextCodecCJK::iso2022JPDecode(std::span<const uint8_t> bytes, bool flush,
                 return result.toString();
             }
         }
-        if (m_iso2022JPSecondPrependedByte && byteParser(*std::exchange(m_iso2022JPSecondPrependedByte, std::nullopt), result) == SawError::Yes && stopOnError) {
+        if (m_iso2022JPSecondPrependedByte && byteParser(*std::exchange(m_iso2022JPSecondPrependedByte, std::nullopt), result) == SawError::Yes) {
             sawError = true;
             result.append(replacementCharacter);
             if (stopOnError) {
@@ -483,21 +488,32 @@ String TextCodecCJK::iso2022JPDecode(std::span<const uint8_t> bytes, bool flush,
         case ISO2022JPDecoderState::LeadByte:
             break;
         case ISO2022JPDecoderState::TrailByte:
-            m_iso2022JPDecoderState = ISO2022JPDecoderState::LeadByte;
-            [[fallthrough]];
         case ISO2022JPDecoderState::EscapeStart:
             sawError = true;
             result.append(replacementCharacter);
             break;
-        case ISO2022JPDecoderState::Escape:
+        case ISO2022JPDecoderState::Escape: {
+            uint8_t lead = std::exchange(m_lead, 0x00);
+            // Set output state before calling byteParser, which reads these.
+            m_iso2022JPOutput = false;
+            m_iso2022JPDecoderState = m_iso2022JPDecoderOutputState;
             sawError = true;
             result.append(replacementCharacter);
-            if (m_lead) {
-                ASSERT(isASCII(m_lead));
-                result.append(std::exchange(m_lead, 0x00));
+            // Reprocess lead byte (always 0x24 or 0x28) in output state.
+            if (!stopOnError && lead) {
+                byteParser(lead, result);
+                if (m_iso2022JPDecoderState == ISO2022JPDecoderState::TrailByte)
+                    result.append(replacementCharacter);
             }
             break;
         }
+        }
+        m_iso2022JPDecoderState = ISO2022JPDecoderState::ASCII;
+        m_iso2022JPDecoderOutputState = ISO2022JPDecoderState::ASCII;
+        m_iso2022JPOutput = false;
+        m_lead = 0x00;
+        m_prependedByte = std::nullopt;
+        m_iso2022JPSecondPrependedByte = std::nullopt;
     }
 
     return result.toString();


### PR DESCRIPTION
#### c8676c91582c3851d63c20a646b2dbb9cd76ee26
<pre>
Reset CJK encoding state appropriately
<a href="https://bugs.webkit.org/show_bug.cgi?id=312106">https://bugs.webkit.org/show_bug.cgi?id=312106</a>

Reviewed by Chris Dumez.

We did not reset state correctly for CJK encodings:

1. decodeCommon: Clear m_prependedByte on fatal early return. When
   byteParser() sets m_prependedByte (pushing back an ASCII byte) and
   returns error, the stopOnError early return cleared m_lead but not
   m_prependedByte, leaking it into the next decode() call.

2. eucJPDecode: Reset m_jis0212 unconditionally when lead is non-zero.
   The spec resets jis0212 at the start of lead-byte processing
   regardless of whether the trail byte is valid, but the code only
   reset it inside the successful range check. Also reset m_jis0212 on
   flush.

3. iso2022JPDecode: Fix flush handler for EscapeStart/Escape/TrailByte
   states. TrailByte no longer falls through to EscapeStart (they&apos;re
   separate states with different EOF behavior). Escape now reprocesses
   the lead byte through byteParser in the output state instead of
   appending it as a literal character. All ISO-2022-JP state is reset
   after flush.

4. iso2022JPDecode: Fix m_iso2022JPSecondPrependedByte error handling.
   The outer condition had &amp;&amp; stopOnError, silently swallowing errors
   in non-fatal mode. Removed to match the m_prependedByte pattern.

Canonical link: <a href="https://commits.webkit.org/311075@main">https://commits.webkit.org/311075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3553b62458c91f9199ae16bf629b0a2c922263b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164781 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120789 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101478 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12612 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167261 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11435 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128909 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28955 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129042 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86625 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23747 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23869 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16534 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28586 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92543 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28113 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28341 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28237 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->