### PR TITLE
NavigationDisabler should not block navigations in unrelated frames

### DIFF
--- a/LayoutTests/fast/events/before-unload-forbidden-navigation-expected.txt
+++ b/LayoutTests/fast/events/before-unload-forbidden-navigation-expected.txt
@@ -1,4 +1,4 @@
-This test ensures navigation is forbidden while beforeunload event is being fired. You should see PASS 1/2 and PASS 2/2 below:
+This test ensures self-navigation is forbidden while beforeunload event is being fired. You should see PASS 1/2 and PASS 2/2 below:
 
 PASS 1/2
 

--- a/LayoutTests/fast/events/before-unload-forbidden-navigation.html
+++ b/LayoutTests/fast/events/before-unload-forbidden-navigation.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body>
-<p>This test ensures navigation is forbidden while beforeunload event is being fired. You should see PASS 1/2 and PASS 2/2 below:</p>
+<p>This test ensures self-navigation is forbidden while beforeunload event is being fired. You should see PASS 1/2 and PASS 2/2 below:</p>
 <pre id="log">FAIL</pre>
 <script>
 
@@ -37,10 +37,8 @@ function fired(contentWindow) {
         return;
     didFireBeforeUnloadEvent = true;
 
-    location.href = 'resources/before-unload-in-subframe-fail.html';
     contentWindow.location.href = 'resources/before-unload-in-subframe-fail.html';
     navigateByClickingHyperlink(contentWindow, 'resources/before-unload-in-subframe-fail.html');
-    navigateByClickingHyperlink(window, 'resources/before-unload-in-subframe-fail.html');
 
     log.innerHTML = 'PASS 1/2';
     contentWindow.frameElement.halfPassed = true;

--- a/LayoutTests/fast/events/before-unload-sibling-frame-expected.txt
+++ b/LayoutTests/fast/events/before-unload-sibling-frame-expected.txt
@@ -1,4 +1,4 @@
-This tests navigating a sibling iframe during beforeunload. The navigation should be prevented.
+This tests navigating a sibling iframe during beforeunload. The navigation should be allowed.
 
 PASS
 

--- a/LayoutTests/fast/events/before-unload-sibling-frame.html
+++ b/LayoutTests/fast/events/before-unload-sibling-frame.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body>
-<p>This tests navigating a sibling iframe during beforeunload. The navigation should be prevented.</p>
+<p>This tests navigating a sibling iframe during beforeunload. The navigation should be allowed.</p>
 <div id="log"></div>
 <script>
 
@@ -21,17 +21,21 @@ const frame2 = document.createElement('iframe');
 document.body.appendChild(frame2);
 
 window.onmessage = (event) => {
-    if (event.data == 'load')
-        log.textContent = 'FAIL - the navigation succeeded';
+    if (event.data == 'load') {
+        log.textContent = 'PASS';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
 }
 
 function startTest() {
     frame2.src = 'resources/message-top.html';
     setTimeout(() => {
-        if (log.textContent == '')
-            log.textContent = 'PASS';
-        if (window.testRunner)
-            testRunner.notifyDone();
+        if (log.textContent == '') {
+            log.textContent = 'FAIL - the sibling navigation was blocked';
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
     }, 1000);
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/navigation-during-beforeunload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/navigation-during-beforeunload-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Navigating a sibling iframe during another iframe's beforeunload should not be blocked
+PASS Navigating the same frame during its own beforeunload should be blocked
+PASS Navigating the parent frame during a child's beforeunload should not be blocked
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/navigation-during-beforeunload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/navigation-during-beforeunload.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test that beforeunload in one frame does not block navigation in sibling or parent frames</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+// Test 1: Navigation of a sibling iframe should not be blocked by another iframe's beforeunload.
+promise_test(async test => {
+    const frame1 = document.createElement("iframe");
+    const frame2 = document.createElement("iframe");
+    document.body.appendChild(frame1);
+    document.body.appendChild(frame2);
+
+    // Wait for both frames to load about:blank.
+    await new Promise(resolve => test.step_timeout(resolve, 0));
+
+    // Set up a beforeunload listener on frame1 that tries to navigate frame2.
+    let frame2NavigationStarted = false;
+    frame1.contentWindow.addEventListener("beforeunload", () => {
+        // During frame1's beforeunload, try to navigate frame2.
+        frame2.contentWindow.location.href = "support/navigation-target.html";
+        frame2NavigationStarted = true;
+    });
+
+    // Navigate frame1, which will trigger its beforeunload.
+    const frame2LoadPromise = new Promise(resolve => {
+        frame2.addEventListener("load", resolve);
+    });
+    frame1.contentWindow.location.href = "support/navigation-target.html";
+
+    // frame2 should successfully navigate.
+    await frame2LoadPromise;
+    assert_true(frame2NavigationStarted, "beforeunload handler ran");
+    assert_true(frame2.contentWindow.location.href.includes("navigation-target.html"),
+        "Sibling iframe should have navigated to navigation-target.html");
+
+    frame1.remove();
+    frame2.remove();
+}, "Navigating a sibling iframe during another iframe's beforeunload should not be blocked");
+
+// Test 2: Navigation of the frame being unloaded should be blocked during its own beforeunload.
+promise_test(async test => {
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+
+    await new Promise(resolve => test.step_timeout(resolve, 0));
+
+    frame.contentWindow.addEventListener("beforeunload", () => {
+        // Try to navigate the same frame during its own beforeunload - should be blocked.
+        frame.contentWindow.location.href = "support/navigation-target2.html";
+    });
+
+    const loadPromise = new Promise(resolve => {
+        frame.addEventListener("load", resolve);
+    });
+
+    // Navigate frame - its beforeunload tries to redirect to a different page instead.
+    frame.contentWindow.location.href = "support/navigation-target.html";
+
+    await loadPromise;
+    // The original navigation should have proceeded, not the one from beforeunload.
+    assert_true(frame.contentWindow.location.href.endsWith("navigation-target.html"),
+        "Frame should have navigated to navigation-target.html, not navigation-target2.html");
+
+    frame.remove();
+}, "Navigating the same frame during its own beforeunload should be blocked");
+
+// Test 3: Navigation of the parent frame should not be blocked during a child's beforeunload.
+promise_test(async test => {
+    // Run this test inside a container iframe so that navigating the parent
+    // doesn't navigate the test harness away.
+    const container = document.createElement("iframe");
+    container.src = "support/navigation-during-beforeunload-container.html";
+
+    const result = await new Promise(resolve => {
+        window.addEventListener("message", function handler(event) {
+            if (event.data && event.data.type === "navigation-during-beforeunload-result") {
+                window.removeEventListener("message", handler);
+                resolve(event.data);
+            }
+        });
+        document.body.appendChild(container);
+    });
+
+    assert_equals(result.status, "complete", "Inner test ran to completion");
+    assert_true(result.triedToNavigateParent, "beforeunload handler ran and tried to navigate parent");
+    assert_false(result.parentNavigationBlocked,
+        "Parent frame navigation should not have been blocked during child's beforeunload");
+
+    container.remove();
+}, "Navigating the parent frame during a child's beforeunload should not be blocked");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/navigation-during-beforeunload-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/navigation-during-beforeunload-container.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<body>
+<script>
+// This page runs inside a container iframe. It creates a child iframe, sets up
+// a beforeunload handler that tries to navigate this page (the parent), then
+// navigates the child. It reports results back via postMessage.
+//
+// If the browser blocks the parent navigation, the child loads successfully
+// and we report parentNavigationBlocked: true.
+// If the browser allows the parent navigation, this page navigates away,
+// but a beforeunload handler reports parentNavigationBlocked: false first.
+
+let triedToNavigateParent = false;
+
+function sendResult(parentNavigationBlocked) {
+    window.parent.postMessage({
+        type: "navigation-during-beforeunload-result",
+        status: "complete",
+        triedToNavigateParent: triedToNavigateParent,
+        parentNavigationBlocked: parentNavigationBlocked
+    }, "*");
+}
+
+// If *this* page gets navigated away, report failure to the test harness.
+window.addEventListener("beforeunload", () => {
+    if (triedToNavigateParent)
+        sendResult(false);
+});
+
+const frame = document.createElement("iframe");
+document.body.appendChild(frame);
+
+// Wait for the child iframe to load about:blank, then set up the test.
+setTimeout(() => {
+    frame.contentWindow.addEventListener("beforeunload", () => {
+        triedToNavigateParent = true;
+        window.location.href = "navigation-target.html";
+    });
+
+    frame.addEventListener("load", () => {
+        // Child loaded successfully - parent navigation was blocked.
+        sendResult(true);
+    }, { once: true });
+
+    frame.contentWindow.location.href = "navigation-target.html";
+}, 0);
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/navigation-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/navigation-target.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>navigation target</title>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/navigation-target2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/navigation-target2.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>navigation target 2</title>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS Ensure that refresh is observed
+PASS Ensure that non-fractional part in refresh time does not get discarded
+PASS Ensure that multiple periods in refresh time just get ignored
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test fractional values in meta http-equiv=refresh</title>
+<link rel="author" title="Psychpsyo"  href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/#pragma-directives">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+  async function measureRefreshTime(src) {
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+
+    const loadPromise = new Promise(resolve => {
+      frame.addEventListener("load", () => {
+        resolve(performance.now());
+      });
+    });
+    frame.src = src;
+    const startTime = await loadPromise;
+
+    const unloadPromise = new Promise(resolve => {
+      frame.contentWindow.addEventListener("beforeunload", () => {
+        resolve(performance.now());
+      });
+    });
+    const endTime = await unloadPromise;
+    return endTime - startTime;
+  }
+
+  promise_test(async test => {
+    const refreshTime = await measureRefreshTime("resources/refresh1.html");
+    assert_greater_than(refreshTime, 900);
+  }, "Ensure that refresh is observed");
+
+  promise_test(async test => {
+    const refreshTime = await measureRefreshTime("resources/refresh1.99.html");
+    assert_greater_than(refreshTime, 900);
+  }, "Ensure that non-fractional part in refresh time does not get discarded");
+
+  promise_test(async test => {
+    const refreshTime = await measureRefreshTime("resources/refresh1dotdot9dot.html");
+    assert_greater_than(refreshTime, 900);
+  }, "Ensure that multiple periods in refresh time just get ignored");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/gotRefreshed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/gotRefreshed.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>got refreshed</title>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.99.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.99.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>refresh 1.99</title>
+
+<meta http-equiv="refresh" content="1.99;url=gotRefreshed.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>refresh 1</title>
+
+<meta http-equiv="refresh" content="1;url=gotRefreshed.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1dotdot9dot.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1dotdot9dot.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>refresh 1..9.</title>
+
+<meta http-equiv="refresh" content="1..9.;url=gotRefreshed.html">

--- a/Source/WebCore/loader/NavigationDisabler.h
+++ b/Source/WebCore/loader/NavigationDisabler.h
@@ -35,20 +35,17 @@ public:
     NavigationDisabler(LocalFrame* frame)
         : m_frame(frame)
     {
-        if (frame) {
-            if (auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame()))
-                ++localFrame->m_navigationDisableCount;
-        } else // Disable all navigations when destructing a frame-less document.
+        if (frame)
+            ++frame->m_navigationDisableCount;
+        else // Disable all navigations when destructing a frame-less document.
             ++s_globalNavigationDisableCount;
     }
 
     ~NavigationDisabler()
     {
         if (auto* frame = m_frame.get()) {
-            if (auto* mainFrame = dynamicDowncast<LocalFrame>(frame->mainFrame())) {
-                ASSERT(mainFrame->m_navigationDisableCount);
-                --mainFrame->m_navigationDisableCount;
-            }
+            ASSERT(frame->m_navigationDisableCount);
+            --frame->m_navigationDisableCount;
         } else {
             ASSERT(s_globalNavigationDisableCount);
             --s_globalNavigationDisableCount;
@@ -57,9 +54,10 @@ public:
 
     static bool isNavigationAllowed(Frame& frame)
     {
-        if (auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame()))
-            return !localFrame->m_navigationDisableCount && !s_globalNavigationDisableCount;
-        return true;
+        if (s_globalNavigationDisableCount)
+            return false;
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        return !localFrame || !localFrame->m_navigationDisableCount;
     }
 
 private:


### PR DESCRIPTION
#### e5d4f4568fdeda62d3855fff8da75d118e810250
<pre>
NavigationDisabler should not block navigations in unrelated frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=312044">https://bugs.webkit.org/show_bug.cgi?id=312044</a>
<a href="https://rdar.apple.com/174592318">rdar://174592318</a>

Reviewed by Anne van Kesteren.

NavigationDisabler was storing its disable count on the main frame,
making it page-global. This meant that when shouldClose() dispatched
beforeunload for one iframe, its NavigationDisabler would block
navigations in all other iframes on the page, including siblings. If
JavaScript happened to schedule a navigation on a sibling iframe during
this window (e.g. via the beforeunload handler), the navigation would be
silently dropped.

Fix by storing the disable count on the specific frame rather than the
main frame. isNavigationAllowed() now checks only the target frame&apos;s own
disable count. Sibling frames, ancestor frames, and descendant frames
are all unaffected.

This matches Chromium&apos;s FrameNavigationDisabler, which sets
navigation_disable_count_ on the specific frame being navigated and
checks only that frame&apos;s count in IsNavigationAllowed().

Tests: imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/navigation-during-beforeunload.html
       imported/w3c/web-platform-tests/html/meta/refresh-time.html

* LayoutTests/fast/events/before-unload-sibling-frame-expected.txt:
* LayoutTests/fast/events/before-unload-sibling-frame.html:
Updated test: navigating a sibling iframe during beforeunload should now
succeed, not be blocked.

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/navigation-during-beforeunload-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/navigation-during-beforeunload.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/navigation-during-beforeunload-container.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/navigation-target.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/navigation-target2.html: Added.
WPT test with three subtests: sibling navigation (not blocked), self
navigation (blocked), and parent navigation (not blocked). The parent
navigation test uses a container iframe so the test harness isn&apos;t
navigated away. This test is passing in Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/gotRefreshed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.99.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1dotdot9dot.html: Added.
Imported WPT test from upstream that was failing due to this bug in
shipping Safari.

* Source/WebCore/loader/NavigationDisabler.h:
(WebCore::NavigationDisabler::NavigationDisabler):
(WebCore::NavigationDisabler::~NavigationDisabler):
(WebCore::NavigationDisabler::isNavigationAllowed):

Canonical link: <a href="https://commits.webkit.org/311054@main">https://commits.webkit.org/311054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad5a797152c140f81de3603a2d171cd2b2de5f37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164755 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120766 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22975 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101455 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12586 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167235 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128888 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28929 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129021 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34930 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139706 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23847 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16504 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28560 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92517 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28087 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28315 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28211 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->