### PR TITLE
[JSC] Fix `Object.defineProperties` Proxy trap ordering

### DIFF
--- a/JSTests/microbenchmarks/define-properties-slow-path.js
+++ b/JSTests/microbenchmarks/define-properties-slow-path.js
@@ -1,0 +1,26 @@
+// Force definePropertiesSlow by using indexed keys on the properties object.
+const properties = {
+  0: { value: 0, writable: true, enumerable: true, configurable: true },
+  1: { value: 1, writable: true, enumerable: true, configurable: true },
+  2: { value: 2, writable: true, enumerable: true, configurable: true },
+  3: { value: 3, writable: true, enumerable: true, configurable: true },
+  4: { value: 4, writable: true, enumerable: true, configurable: true },
+  5: { value: 5, writable: true, enumerable: true, configurable: true },
+  6: { value: 6, writable: true, enumerable: true, configurable: true },
+  7: { value: 7, writable: true, enumerable: true, configurable: true },
+  8: { value: 8, writable: true, enumerable: true, configurable: true },
+  9: { value: 9, writable: true, enumerable: true, configurable: true },
+  a: { value: 'a', writable: true, enumerable: true, configurable: true },
+  b: { value: 'b', writable: true, enumerable: true, configurable: true },
+  c: { value: 'c', writable: true, enumerable: true, configurable: true },
+};
+
+var count = 50_000;
+
+function test() {
+  for (let i = 0; i < count; i++) {
+    Object.defineProperties({}, properties);
+  }
+}
+
+test();

--- a/JSTests/stress/object-define-properties-proxy-trap-order.js
+++ b/JSTests/stress/object-define-properties-proxy-trap-order.js
@@ -1,0 +1,54 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("expected " + expected + " but got " + actual);
+}
+
+{
+    let log = [];
+    let logger = new Proxy({}, { get(t, k) { log.push(k); } });
+    Object.defineProperties({}, new Proxy({ a: { value: 0 }, b: { value: 1 } }, logger));
+    shouldBe(log.join(), "ownKeys,getOwnPropertyDescriptor,get,getOwnPropertyDescriptor,get");
+}
+
+{
+    let log = [];
+    let logger = new Proxy({}, { get(t, k) { log.push(k); } });
+    Object.create(null, new Proxy({ a: { value: 0 }, b: { value: 1 } }, logger));
+    shouldBe(log.join(), "ownKeys,getOwnPropertyDescriptor,get,getOwnPropertyDescriptor,get");
+}
+
+{
+    let log = [];
+    let target = {};
+    Object.defineProperty(target, "a", { value: { value: 0 }, enumerable: true });
+    Object.defineProperty(target, "b", { value: { value: 1 }, enumerable: false });
+    Object.defineProperty(target, "c", { value: { value: 2 }, enumerable: true });
+    let props = new Proxy(target, new Proxy({}, { get(t, k) { log.push(k); } }));
+    let result = Object.defineProperties({}, props);
+    shouldBe(log.join(), "ownKeys,getOwnPropertyDescriptor,get,getOwnPropertyDescriptor,getOwnPropertyDescriptor,get");
+    shouldBe(result.a, 0);
+    shouldBe(result.hasOwnProperty("b"), false);
+    shouldBe(result.c, 2);
+}
+
+{
+    let log = [];
+    let s = Symbol("s");
+    let logger = new Proxy({}, { get(t, k) { log.push(k); } });
+    let result = Object.defineProperties({}, new Proxy({ a: { value: 0 }, [s]: { value: 1 } }, logger));
+    shouldBe(log.join(), "ownKeys,getOwnPropertyDescriptor,get,getOwnPropertyDescriptor,get");
+    shouldBe(result.a, 0);
+    shouldBe(result[s], 1);
+}
+
+{
+    let result = {};
+    let threw = false;
+    try {
+        Object.defineProperties(result, new Proxy({ a: { value: 0 }, b: 1 }, {}));
+    } catch {
+        threw = true;
+    }
+    shouldBe(threw, true);
+    shouldBe(result.hasOwnProperty("a"), false);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -940,6 +940,3 @@ test/staging/sm/misc/future-reserved-words.js:
   default: 'Test262Error: implements: function argument retroactively strict Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/staging/sm/module/await-restricted-nested.js:
   module: 'Test262: This statement should not be evaluated.'
-test/staging/sm/object/defineProperties-order.js:
-  default: 'Test262Error: Expected SameValue(«"ownKeys,getOwnPropertyDescriptor,getOwnPropertyDescriptor,get,get"», «"ownKeys,getOwnPropertyDescriptor,get,getOwnPropertyDescriptor,get"») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«"ownKeys,getOwnPropertyDescriptor,getOwnPropertyDescriptor,get,get"», «"ownKeys,getOwnPropertyDescriptor,get,getOwnPropertyDescriptor,get"») to be true'

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -818,9 +818,10 @@ static JSValue definePropertiesSlow(JSGlobalObject* globalObject, JSObject* obje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     PropertyNameArrayBuilder propertyNames(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
-    asObject(properties)->methodTable()->getOwnPropertyNames(asObject(properties), globalObject, propertyNames, DontEnumPropertiesMode::Exclude);
+    asObject(properties)->methodTable()->getOwnPropertyNames(asObject(properties), globalObject, propertyNames, DontEnumPropertiesMode::Include);
     RETURN_IF_EXCEPTION(scope, { });
     size_t numProperties = propertyNames.size();
+    Vector<Identifier> enumerableNames;
     Vector<PropertyDescriptor> descriptors;
     MarkedArgumentBuffer markBuffer;
 #define RETURN_IF_EXCEPTION_CLEARING_OVERFLOW(value) do { \
@@ -830,11 +831,27 @@ static JSValue definePropertiesSlow(JSGlobalObject* globalObject, JSObject* obje
     } \
 } while (false)
     for (size_t i = 0; i < numProperties; i++) {
-        JSValue prop = properties->get(globalObject, propertyNames[i]);
+        auto& propertyName = propertyNames[i];
+        ASSERT(!propertyName.isPrivateName());
+
+        PropertySlot slot(properties, PropertySlot::InternalMethodType::GetOwnProperty);
+        bool hasProperty = properties->methodTable()->getOwnPropertySlot(properties, globalObject, propertyName, slot);
+        RETURN_IF_EXCEPTION_CLEARING_OVERFLOW({ });
+        if (!hasProperty)
+            continue;
+        if (slot.attributes() & PropertyAttribute::DontEnum)
+            continue;
+
+        JSValue prop;
+        if (!slot.isTaintedByOpaqueObject()) [[likely]]
+            prop = slot.getValue(globalObject, propertyName);
+        else
+            prop = properties->get(globalObject, propertyName);
         RETURN_IF_EXCEPTION_CLEARING_OVERFLOW({ });
         PropertyDescriptor descriptor;
         toPropertyDescriptor(globalObject, prop, descriptor);
         RETURN_IF_EXCEPTION_CLEARING_OVERFLOW({ });
+        enumerableNames.append(propertyName);
         descriptors.append(descriptor);
         // Ensure we mark all the values that we're accumulating
         if (descriptor.isDataDescriptor() && descriptor.value())
@@ -848,11 +865,8 @@ static JSValue definePropertiesSlow(JSGlobalObject* globalObject, JSObject* obje
     }
     RELEASE_ASSERT(!markBuffer.hasOverflowed());
 #undef RETURN_IF_EXCEPTION_CLEARING_OVERFLOW
-    for (size_t i = 0; i < numProperties; i++) {
-        auto& propertyName = propertyNames[i];
-        ASSERT(!propertyName.isPrivateName());
-
-        object->methodTable()->defineOwnProperty(object, globalObject, propertyName, descriptors[i], true);
+    for (size_t i = 0; i < descriptors.size(); i++) {
+        object->methodTable()->defineOwnProperty(object, globalObject, enumerableNames[i], descriptors[i], true);
         RETURN_IF_EXCEPTION(scope, { });
     }
     return object;


### PR DESCRIPTION
#### 8eca46ec5bfb58e4d9035036d3bbcdbb6b2a45bf
<pre>
[JSC] Fix `Object.defineProperties` Proxy trap ordering
<a href="https://bugs.webkit.org/show_bug.cgi?id=312115">https://bugs.webkit.org/show_bug.cgi?id=312115</a>

Reviewed by Yusuke Suzuki.

ObjectDefineProperties [1] step 4 iterates each key returned by
[[OwnPropertyKeys]] and performs [[GetOwnProperty]] followed by Get
sequentially per key. definePropertiesSlow was passing
DontEnumPropertiesMode::Exclude to getOwnPropertyNames, which for a Proxy
invokes every getOwnPropertyDescriptor trap upfront to filter enumerable
keys before the loop runs any get trap, producing an observable ordering
difference from V8 and SpiderMonkey.

Switch to DontEnumPropertiesMode::Include and check enumerability per key
inside the loop, matching the existing pattern used by Object.assign,
entries, and values in this file. Object.create with a properties argument
shares this path and is fixed as well.

                                       TipOfTree                  Patched

define-properties-all-of-keys        8.3952+-0.4725            8.1928+-0.3873          might be 1.0247x faster
define-properties-simple             6.5400+-0.3455            6.4480+-0.3268          might be 1.0143x faster
define-properties-slow-path         32.9335+-1.8871           31.2145+-1.3597          might be 1.0551x faster

[1]: <a href="https://tc39.es/ecma262/#sec-objectdefineproperties">https://tc39.es/ecma262/#sec-objectdefineproperties</a>

Test: JSTests/stress/object-define-properties-proxy-trap-order.js

* JSTests/microbenchmarks/define-properties-slow-path.js: Added.
(test):
* JSTests/stress/object-define-properties-proxy-trap-order.js: Added.
(shouldBe):
(throw.new.Error.get Object):
(throw.new.Error):
(shouldBe.get Object):
(shouldBe.get let):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::definePropertiesSlow):

Canonical link: <a href="https://commits.webkit.org/311520@main">https://commits.webkit.org/311520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44e8c29352da4c42c19ff7c3ba51ed0be1f79091

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111068 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121574 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85365 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102242 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22868 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21100 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13581 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149036 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168294 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17821 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12453 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129701 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129809 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35215 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87651 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24631 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17401 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188948 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93572 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48511 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29080 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29206 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->