### PR TITLE
Marquee element renders with incorrect height when vertical mode is used and height is `auto`

### DIFF
--- a/LayoutTests/fast/css/MarqueeLayoutTest-expected.txt
+++ b/LayoutTests/fast/css/MarqueeLayoutTest-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS getComputedStyle(horiz).height is "10px"
-PASS getComputedStyle(vertAuto).height is "200px"
+PASS getComputedStyle(vertAuto).height is "300px"
 PASS getComputedStyle(vertFixed).height is "100px"
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/css/MarqueeLayoutTest.html
+++ b/LayoutTests/fast/css/MarqueeLayoutTest.html
@@ -57,6 +57,7 @@ marquee {
 }
 #vertAuto marquee {
     height: auto;
+    max-height: 300px;
 }
 
 #vertFixed .pre {
@@ -77,7 +78,7 @@ var horiz = document.querySelector('#horiz marquee');
 var vertAuto = document.querySelector('#vertAuto marquee');
 var vertFixed = document.querySelector('#vertFixed marquee');
 shouldBe('getComputedStyle(horiz).height', '"10px"');
-shouldBe('getComputedStyle(vertAuto).height', '"200px"');
+shouldBe('getComputedStyle(vertAuto).height', '"300px"');
 shouldBe('getComputedStyle(vertFixed).height', '"100px"');
 if (window.testRunner) {
     testRunner.dumpAsText();

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -615,9 +615,6 @@ void Adjuster::adjust(RenderStyle& style) const
                 style.setTextWrapMode(TextWrapMode::NoWrap);
                 style.setTextAlign(TextAlign::Start);
             }
-            // Apparently this is the expected legacy behavior.
-            if (isVertical && style.height().isAuto())
-                style.setHeight(200_css_px);
         }
 
         if (m_element->visibilityAdjustment().contains(VisibilityAdjustment::Subtree)) [[unlikely]]


### PR DESCRIPTION
#### ab866aa40e0c17955cbd80d4efced95e40c8b404
<pre>
Marquee element renders with incorrect height when vertical mode is used and height is `auto`
<a href="https://bugs.webkit.org/show_bug.cgi?id=285337">https://bugs.webkit.org/show_bug.cgi?id=285337</a>

Reviewed by NOBODY (OOPS!).

When a marquee has vertical mode enabled and its height is set to auto, it defaults to a height of 200px,
resulting in incorrect rendering.

This occurs because, in StyleAdjuster, there is a check that sets the height to `200px`
when vertical mode is enabled and the height is auto.
This behavior was introduced in a very old commit - bbb4a55, apparently because, at the time,
marquees with these conditions rendered incorrectly in WebKit.

This patch removes that code,
making the rendering of marquees under these conditions consistent with Firefox and Chromium.
Also, modified a test that was checking for 200px height case.

* LayoutTests/fast/css/MarqueeLayoutTest.html:
* LayoutTests/fast/css/MarqueeLayoutTest-expected.txt:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab866aa40e0c17955cbd80d4efced95e40c8b404

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109856 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120750 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85052 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101439 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22035 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20175 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12565 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131698 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167215 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11389 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128871 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129004 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139696 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86576 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23826 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16494 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28540 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92496 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->