### PR TITLE
Fix website coding style guideline formatting

### DIFF
--- a/Websites/webkit.org/code-style.md
+++ b/Websites/webkit.org/code-style.md
@@ -1625,7 +1625,7 @@ public:
 
 ### Smart Pointer Variable Types
 
-[](#auto-with-adopt) When declaring a local variable that is initialized with an `adopt` method, the variable's type should be explicitly declared as the smart pointer type and not declared using `auto`.
+[](#auto-with-adopt) When declaring a local variable that is initialized with an `adopt` method, the variable's type should be declared explicitly as the smart pointer type and not declared using `auto`.
 
 ###### Right:
 
@@ -1645,6 +1645,7 @@ OSObjectPtr synchronousFileLoadingGroup = adoptOSObject(dispatch_group_create())
 
 ###### Wrong:
 
+```cpp
 auto nsDictionary = adoptNS([NSMutableDictionary new]);
 
 auto cfDictionary = adoptCF(CFDictionaryCreateMutable(
@@ -1655,6 +1656,7 @@ auto origin1 = adoptRef(*new SecurityOrigin);
 auto origin2 = adoptRef(new SecurityOrigin);
 
 auto synchronousFileLoadingGroup = adoptOSObject(dispatch_group_create());
+```
 
 ### Python
 


### PR DESCRIPTION
#### 24bd6b583a44a1c5e3758f4694b5554f58166509
<pre>
Fix website coding style guideline formatting
<a href="https://rdar.apple.com/174627459">rdar://174627459</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312118">https://bugs.webkit.org/show_bug.cgi?id=312118</a>

Reviewed by Richard Robinson.

In <a href="https://commits.webkit.org/311018@main">https://commits.webkit.org/311018@main</a> I:

- Forgot to decorate one of the code blocks
- Left some grammatical room for improvement.

Let&apos;s fix both of those.

* Websites/webkit.org/code-style.md:

Canonical link: <a href="https://commits.webkit.org/311094@main">https://commits.webkit.org/311094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fcc1628c8710f5780a5a14ed0d6fa6b46040f00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109784 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120733 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85041 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101422 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22014 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20157 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12546 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131679 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167196 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128854 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34950 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139678 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86555 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16476 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28521 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28048 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28276 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->