### PR TITLE
`Option` element renders incorrectly when the label value is empty.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -838,7 +838,6 @@ imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/mes
 [ Debug ] imported/w3c/web-platform-tests/css/css-position/position-absolute-crash-chrome-013.html [ Skip ]
 [ Debug ] imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-revert.html [ Skip ]
 [ Debug ] imported/w3c/web-platform-tests/css/css-scoping/slotted-matches.html [ Skip ]
-imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace.html [ ImageOnlyFailure ]
 
 # Cookie tests that are flaky since their import because they fail and and out some kind of unique id.
 imported/w3c/web-platform-tests/cookies/prefix/document-cookie.non-secure.html [ Pass Failure ]

--- a/LayoutTests/fast/forms/HTMLOptionElement_label02-expected.html
+++ b/LayoutTests/fast/forms/HTMLOptionElement_label02-expected.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
     <select>
-        <option></option>
+        <option>should display this</option>
     </select>
 </body>

--- a/LayoutTests/fast/forms/HTMLOptionElement_label02.html
+++ b/LayoutTests/fast/forms/HTMLOptionElement_label02.html
@@ -2,6 +2,6 @@
 <!-- Even though it's empty, the label exists, so it is used. -->
 <body>
     <select>
-        <option label="">empty label should display empty string</option>
+        <option label="">should display this</option>
     </select>
 </body>

--- a/LayoutTests/fast/forms/HTMLOptionElement_label04-expected.html
+++ b/LayoutTests/fast/forms/HTMLOptionElement_label04-expected.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <body>
     <select>
-        <option></option>
+        <option>this text should appear</option>
     </select>
 </body>

--- a/LayoutTests/fast/forms/HTMLOptionElement_label04.html
+++ b/LayoutTests/fast/forms/HTMLOptionElement_label04.html
@@ -2,6 +2,6 @@
 <!-- Even though the label is missing the 'equals value' piece, it exists, so it is used. -->
 <body>
     <select>
-        <option label>this text should not appear</option>
+        <option label>this text should appear</option>
     </select>
 </body>

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -514,29 +514,30 @@ String HTMLOptionElement::label() const
     return collectOptionInnerTextCollapsingWhitespace();
 }
 
-// Same as label() but ignores the label content attribute in quirks mode for compatibility with other browsers.
 String HTMLOptionElement::displayLabel() const
 {
-    if (document().inQuirksMode())
+    String label = attributeWithoutSynchronization(labelAttr);
+    if (label.isEmpty())
         return collectOptionInnerTextCollapsingWhitespace();
-    return label();
+    return label;
 }
 
 String HTMLOptionElement::textIndentedToRespectGroupLabel() const
 {
     if (!document().settings().htmlEnhancedSelectParsingEnabled()) {
         if (is<HTMLOptGroupElement>(parentNode()))
-            return makeString("    "_s, label());
-        return label();
+            return makeString("    "_s, displayLabel());
+        return displayLabel();
     }
 
     for (Ref ancestor : ancestorsOfType<HTMLElement>(*this)) {
         if (is<HTMLOptGroupElement>(ancestor))
-            return makeString("    "_s, label());
+            return makeString("    "_s, displayLabel());
+
         if (isAnyOf<HTMLDataListElement, HTMLSelectElement, HTMLOptionElement, HTMLHRElement>(ancestor))
-            return label();
+            return displayLabel();
     }
-    return label();
+    return displayLabel();
 }
 
 bool HTMLOptionElement::isDisabledFormControl() const


### PR DESCRIPTION
#### 09798e6f16d630da3ed15f4ba0b7a3a9ac1615fb
<pre>
`Option` element renders incorrectly when the label value is empty.
<a href="https://bugs.webkit.org/show_bug.cgi?id=312119">https://bugs.webkit.org/show_bug.cgi?id=312119</a>

Reviewed by Anne van Kesteren.

When an &lt;option&gt; element has an empty label attribute, it renders the empty string,
resulting in a blank item in the selection list. This behavior differs from Firefox and Chromium.

According to the HTML specification &quot;4.10.10 The option element&quot;:

&quot;The label attribute provides a label for the element.
The label of an option element is the value of the label content attribute,
if there is one and its value is not the empty string, or,
otherwise, the value of the element&apos;s text IDL attribute.&quot;

Option spec: <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element</a>

This means that when the label attribute is empty, the element’s text content should be used instead.

During rendering, the `HTMLOptionElement::label()` function is called to retrieve the label text.
If a label attribute is present, it returns that value, otherwise, it falls back to the option’s text content.

This patch adds a check to ensure that the label attribute is not empty before returning its value,
allowing proper fallback to the text content when necessary.

Canonical link: <a href="https://commits.webkit.org/311421@main">https://commits.webkit.org/311421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21095c17ce6d31deb2ae88a753f3621b73c2280e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110939 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121493 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85313 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102161 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22766 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20989 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13452 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168164 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12324 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129606 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129714 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140482 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87522 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24542 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17286 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29428 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93443 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28951 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->