### PR TITLE
[CSS Font Loading] FontFace.loaded promise never rejects for failed local() font sources

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6195,7 +6195,6 @@ imported/w3c/web-platform-tests/clear-site-data/navigation-insecure.html [ Skip 
 imported/w3c/web-platform-tests/clear-site-data/resource.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub.html [ Skip ]
 imported/w3c/web-platform-tests/cookies/domain/domain-attribute-idn-host.sub.https.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-font-loading/font-face-reject.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-fonts/test_datafont_same_origin.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-values/dynamic-viewport-units-rule-cache.html [ Skip ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6388,7 +6388,6 @@ imported/w3c/web-platform-tests/clear-site-data/navigation-insecure.html [ Skip 
 imported/w3c/web-platform-tests/clear-site-data/resource.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub.html [ Skip ]
 imported/w3c/web-platform-tests/cookies/domain/domain-attribute-idn-host.sub.https.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-font-loading/font-face-reject.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-fonts/test_datafont_same_origin.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-values/dynamic-viewport-units-rule-cache.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/font-face-reject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/font-face-reject-expected.txt
@@ -1,6 +1,4 @@
 a
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT font-face-reject Test timed out
+PASS font-face-reject
 

--- a/LayoutTests/platform/glib/fast/css/font-face-multiple-faces-expected.txt
+++ b/LayoutTests/platform/glib/fast/css/font-face-multiple-faces-expected.txt
@@ -60,9 +60,9 @@ layer at (0,0) size 800x600
             text run at (641,1) width 57: "Papyrus"
         RenderText {#text} at (698,2) size 10x19
           text run at (698,2) width 10: " "
-        RenderInline {SPAN} at (708,1) size 57x18
-          RenderText {#text} at (708,1) size 57x18
-            text run at (708,1) width 57: "Papyrus"
+        RenderInline {SPAN} at (708,1) size 64x18
+          RenderText {#text} at (708,1) size 64x18
+            text run at (708,1) width 64: "Papyrus"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (4,85) size 776x40 [border: (1px solid #ADD8E6)]
         RenderInline {SPAN} at (1,2) size 70x19

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -659,7 +659,7 @@ size_t CSSFontFace::pump(ExternalResourceDownloadPolicy policy)
             // but it seems that this behavior is a requirement of the design of FontRanges. FIXME: Perhaps rethink
             // this design.
             if (policy == ExternalResourceDownloadPolicy::Allow || !source->requiresExternalResource()) {
-                if (policy == ExternalResourceDownloadPolicy::Allow && m_status == Status::Pending)
+                if (m_status == Status::Pending)
                     setStatus(Status::Loading);
                 source->load(m_trustedType, protect(document()).get());
             }
@@ -682,7 +682,7 @@ size_t CSSFontFace::pump(ExternalResourceDownloadPolicy policy)
                 setStatus(Status::Success);
             return i;
         case CSSFontFaceSource::Status::Failure:
-            if (policy == ExternalResourceDownloadPolicy::Allow && m_status == Status::Pending)
+            if ((policy == ExternalResourceDownloadPolicy::Allow || !source->requiresExternalResource()) && m_status == Status::Pending)
                 setStatus(Status::Loading);
             break;
         }

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -661,7 +661,7 @@ size_t CSSFontFace::pump(ExternalResourceDownloadPolicy policy)
             // but it seems that this behavior is a requirement of the design of FontRanges. FIXME: Perhaps rethink
             // this design.
             if (policy == ExternalResourceDownloadPolicy::Allow || !source->requiresExternalResource()) {
-                if (policy == ExternalResourceDownloadPolicy::Allow && m_status == Status::Pending)
+                if (m_status == Status::Pending)
                     setStatus(Status::Loading);
                 source->load(m_trustedType, protect(document()).get());
             }
@@ -684,7 +684,7 @@ size_t CSSFontFace::pump(ExternalResourceDownloadPolicy policy)
                 setStatus(Status::Success);
             return i;
         case CSSFontFaceSource::Status::Failure:
-            if (policy == ExternalResourceDownloadPolicy::Allow && m_status == Status::Pending)
+            if ((policy == ExternalResourceDownloadPolicy::Allow || !source->requiresExternalResource()) && m_status == Status::Pending)
                 setStatus(Status::Loading);
             break;
         }


### PR DESCRIPTION
#### d8412a5c254e327317b095389fba0eaaaa6664c5
<pre>
[CSS Font Loading] FontFace.loaded promise never rejects for failed local() font sources
<a href="https://bugs.webkit.org/show_bug.cgi?id=312121">https://bugs.webkit.org/show_bug.cgi?id=312121</a>
<a href="https://rdar.apple.com/174631384">rdar://174631384</a>

Reviewed by Vitor Roriz and Brent Fulgham.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

In CSSFontFace::pump(), local() sources in the src descriptor of a
@font-face rule (as opposed to url() sources, including url() pointing
at a local file path) are correctly loaded even with Forbid download
policy, since they resolve against installed system fonts and don&apos;t
require external resources. However, the CSSFontFace status transition
from Pending to Loading was guarded by policy == Allow, so with Forbid
policy the status stayed Pending even after all local() sources failed
synchronously.

This meant fontStateChanged was never called with Failure, so the
FontFace.loaded promise never rejected. The font face was then skipped
entirely in CSSSegmentedFontFace::fontRanges() and never retried with
Allow policy, causing the promise to hang forever.

Note that ExternalResourceDownloadPolicy is a rendering-pipeline concern
(don&apos;t start network downloads mid-layout), not a security policy.
local() sources in the src descriptor are intentionally exempt because
they resolve against fonts already installed on the user&apos;s device. The
actual security gate for font loading is downloadableBinaryFontTrustedTypes,
checked at source-population time in appendSources(), which is unaffected
by this change. Hence, it does not impact anything related to Lockdown Mode.

The fix removes the redundant policy check in the inner conditional,
since the outer conditional already guards with the same condition.
This allows the Pending to Loading status transition for local() sources
regardless of download policy. (Thanks to Brent for highlighting)

* LayoutTests/TestExpectations: Unskip Test
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/font-face-reject-expected.txt: Progression
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::pump):

&gt; Rebaseline (Platform Specific Expectation):
* LayoutTests/platform/glib/fast/css/font-face-multiple-faces-expected.txt:
Matches Chrome and Firefox now (also matching Safari on macOS now)

Canonical link: <a href="https://commits.webkit.org/312933@main">https://commits.webkit.org/312933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c4378db6e951fc75745fa33ae0aee5815783ebb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170427 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c66b2b8-f434-48c5-912a-0f09bbd39310) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34999 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac715f2a-b3fb-4c57-b87c-9733a929b8d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27604 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105908 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/834d3643-b994-4e15-aaa3-b1cfb87ad232) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18148 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172914 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19956 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24488 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34672 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133607 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36099 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96561 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28135 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34166 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/101611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33666 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33909 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33815 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->