### PR TITLE
Resync `css/css-font-loading` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -4410,6 +4410,7 @@
         "web-platform-tests/css/css-flexbox/webkit-box-vertical-writing-mode-ref.html",
         "web-platform-tests/css/css-flexbox/whitespace-in-flexitem-001-ref.html",
         "web-platform-tests/css/css-font-loading/fontface-descriptor-updates-ref.html",
+        "web-platform-tests/css/css-font-loading/fontface-from-arraybuffer-ref.html",
         "web-platform-tests/css/css-font-loading/fontface-override-descriptors-ref.html",
         "web-platform-tests/css/css-font-loading/fontface-size-adjust-descriptor-ref.html",
         "web-platform-tests/css/css-font-loading/fontfaceset-clear-css-connected-2-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/WEB_FEATURES.yml
@@ -1,4 +1,8 @@
 features:
+- name: font-loading
+  files:
+  - "*"
+  - "!fontface-override-descriptor-getter-setter.sub.html"
 - name: font-metric-overrides
   files:
   - fontface-override-descriptor-getter-setter.sub.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-descriptor-updates-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-descriptor-updates-2-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL FontFace descriptor mutations are reflected in FontFaceSet assert_in_array: ranges: expected U+20-7F to be present value "U+20-7F" not in array ["U+0-10ffff", "U+0-10ffff", "U+20-7f", "U+0-10ffff", "U+0-10ffff", "U+0-10ffff", "U+0-10ffff"]
+FAIL Descriptor mutations before adding to FontFaceSet are correctly reflected assert_false: weights: expected 700 to be absent expected false got true
+PASS Font matching uses updated style and family name
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-descriptor-updates-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-descriptor-updates-2.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<title>CSS Font Loading test: modification of descriptors reflects in FontFaceSet</title>
+<link rel="author" title="Sejal Anand" href="mailto:sejalanand@microsoft.com">
+<link rel="help" href="https://drafts.csswg.org/css-font-loading/#fontface-interface">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<span id="probe" style="position:absolute;visibility:hidden;font-size:20px">Test</span>
+
+<script>
+function snapshotFontFaces() {
+  const faces = Array.from(document.fonts);
+  return {
+    families:  faces.map(f => f.family),
+    weights:   faces.map(f => f.weight),
+    ranges:    faces.map(f => f.unicodeRange),
+    styles:    faces.map(f => f.style),
+    stretches: faces.map(f => f.stretch),
+    featureSettings: faces.map(f => f.featureSettings),
+    variationSettings: faces.map(f => f.variationSettings),
+  };
+}
+
+function applyUpdates(updates) {
+  for (const [fontFace, props] of updates) {
+    for (const [key, value] of Object.entries(props)) {
+      fontFace[key] = value;
+    }
+  }
+}
+
+function assertSnapshot(snapshot, expectations) {
+  for (const [field, { present = [], absent = [] }] of Object.entries(expectations)) {
+    present.forEach(v =>
+      assert_in_array(v, snapshot[field], `${field}: expected ${v} to be present`)
+    );
+    absent.forEach(v =>
+      assert_false(snapshot[field].includes(v), `${field}: expected ${v} to be absent`)
+    );
+  }
+}
+
+promise_test(async () => {
+  const f1 = new FontFace("originalFamily", "url(resources/GenR102.woff2)");
+  const f2 = new FontFace("weightTest", "url(resources/GenR102.woff2)", { weight: "700" });
+  const f3 = new FontFace("unicodeTest", "url(resources/GenR102.woff2)", { unicodeRange: "U+0020-007F" });
+  const f4 = new FontFace("styleTest", "url(resources/GenR102.woff2)", { style: "oblique" });
+  const f5 = new FontFace("stretchTest", "url(resources/GenR102.woff2)", { stretch: "expanded" });
+  const f6 = new FontFace("featureTest", "url(resources/GenR102.woff2)", { featureSettings: "'liga' 1" });
+  const f7 = new FontFace("variationTest", "url(resources/GenR102.woff2)", { variationSettings: "'wght' 700" });
+
+  [f1, f2, f3, f4, f5, f6, f7].forEach(f => document.fonts.add(f));
+
+  const before = snapshotFontFaces();
+
+  assertSnapshot(before, {
+    families:  { present: ["originalFamily"] },
+    weights:   { present: ["700"] },
+    ranges:    { present: ["U+20-7F"] },
+    styles:    { present: ["oblique"] },
+    stretches: { present: ["expanded"] },
+    featureSettings:   { present: ['"liga"'] },
+    variationSettings: { present: ['"wght" 700'] },
+  });
+
+  applyUpdates([
+    [f1, { family: "updatedFamily" }],
+    [f2, { weight: "400" }],
+    [f3, { unicodeRange: "U+0000-00FF" }],
+    [f4, { style: "italic" }],
+    [f5, { stretch: "normal" }],
+    [f6, { featureSettings: "'smcp' 1" }],
+    [f7, { variationSettings: "'wght' 400" }],
+  ]);
+
+  const after = snapshotFontFaces();
+
+  assertSnapshot(after, {
+    families:  { present: ["updatedFamily"], absent: ["originalFamily"] },
+    weights:   { present: ["400"], absent: ["700"] },
+    ranges:    { present: ["U+0-FF"], absent: ["U+20-7F"] },
+    styles:    { present: ["italic"], absent: ["oblique"] },
+    stretches: { present: ["normal"], absent: ["expanded"] },
+    featureSettings:   { present: ['"smcp"'], absent: ['"liga"'] },
+    variationSettings: { present: ['"wght" 400'], absent: ['"wght" 700'] },
+  });
+}, "FontFace descriptor mutations are reflected in FontFaceSet");
+
+promise_test(async () => {
+  // css_font_face_ is created during FontFace construction, but
+  // segmented_font_faces_ remains empty until the FontFace is added to
+  // document.fonts (which inserts it into the FontFaceCache). Mutating
+  // descriptors in this state should not crash, and the updated values
+  // should be picked up when the font is eventually added.
+  const f = new FontFace("preAddFamily", "url(resources/GenR102.woff2)", {
+    weight: "700",
+    style: "oblique",
+    stretch: "expanded",
+    unicodeRange: "U+0020-007F",
+  });
+
+  // Mutate all descriptors BEFORE adding to document.fonts.
+  f.family = "renamedPreAdd";
+  f.weight = "300";
+  f.style = "italic";
+  f.stretch = "condensed";
+  f.unicodeRange = "U+0000-00FF";
+
+  document.fonts.add(f);
+
+  const snapshot = snapshotFontFaces();
+  assertSnapshot(snapshot, {
+    families:  { present: ["renamedPreAdd"], absent: ["preAddFamily"] },
+    weights:   { present: ["300"], absent: ["700"] },
+    styles:    { present: ["italic"], absent: ["oblique"] },
+    stretches: { present: ["condensed"], absent: ["expanded"] },
+    ranges:    { present: ["U+0-FF"], absent: ["U+20-7F"] },
+  });
+
+  document.fonts.delete(f);
+}, "Descriptor mutations before adding to FontFaceSet are correctly reflected");
+
+promise_test(async () => {
+  // Two faces under the same family, distinguished by style.
+  // GenR102 and GenI102 have different glyph widths.
+  const fNormal = new FontFace("testFamily",
+    "url(resources/GenR102.woff2)", { style: "normal" });
+  const fItalic = new FontFace("testFamily",
+    "url(resources/GenI102.woff2)", { style: "italic" });
+  document.fonts.add(fNormal);
+  document.fonts.add(fItalic);
+  await Promise.all([fNormal.load(), fItalic.load()]);
+
+  const el = document.getElementById('probe');
+  el.style.fontFamily = 'testFamily';
+
+  // Measure which font renders for each style.
+  el.style.fontStyle = 'normal';
+  const widthA = el.offsetWidth;
+  el.style.fontStyle = 'italic';
+  const widthB = el.offsetWidth;
+  assert_not_equals(widthA, widthB, 'the two fonts have different widths');
+
+  // Swap styles: normal face becomes italic, italic face becomes normal.
+  fNormal.style = "italic";
+  fItalic.style = "normal";
+
+  // After swap, font-style:normal should render GenI102 (old italic width).
+  el.style.fontStyle = 'normal';
+  assert_equals(el.offsetWidth, widthB,
+    'after style swap, normal renders the previously-italic font');
+
+  // Rename one face's family.
+  fNormal.family = "renamedFamily";
+  el.style.fontFamily = 'renamedFamily';
+  el.style.fontStyle = 'italic';
+  assert_equals(el.offsetWidth, widthA,
+    'after family rename, new name matches the renamed face');
+
+  document.fonts.delete(fNormal);
+  document.fonts.delete(fItalic);
+}, "Font matching uses updated style and family name");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-font-variation-settings-persisted-js-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-font-variation-settings-persisted-js-api-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Test FontFace variationSettings property assert_equals: expected (string) "\"wght\" 850" but got (undefined) undefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-font-variation-settings-persisted-js-api.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-font-variation-settings-persisted-js-api.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Testing that variationSettings is persisted in the FontFace object</title>
+  <link rel="help" href="https://www.w3.org/TR/css-fonts-4/#propdef-font-variation-settings" />
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+  <script>
+    const face = new FontFace(
+      "wght",
+      'local("Ahem"), url("/fonts/Ahem.ttf")',
+      { variationSettings: "'wght' 850" }
+    );
+
+    test(() => {
+      assert_equals(face.variationSettings, "\"wght\" 850");
+    }, "Test FontFace variationSettings property");
+  </script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-fonts-loading.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-fonts-loading.html
@@ -26,7 +26,7 @@ promise_test(async t => {
   dynamicFace.load();
   const readyPromise2 = fontSet.ready;
   assert_not_equals(readyPromise1, readyPromise2, "A new FontFace added should create a new document.fonts.ready promise");
-  
+
   await readyPromise2;
   assert_equals(fontSet.status, "loaded", "document.fonts.status should be 'loaded'");
 }, "document.fonts.ready is replaced as new fonts are loaded");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <head>
+        <script src="/common/reftest-wait.js"></script>
+    </head>
+    <body>
+        <canvas id="canvas" width="500px" height="500px"></canvas>
+        <script>
+        const ahem_font = new FontFace(
+          "FontFamily AhemTest",
+          "url(/fonts/Ahem.ttf)",
+        );
+        document.fonts.add(ahem_font);
+        ahem_font.load().then(
+          () => {
+            const ctx = canvas.getContext("2d");
+            ctx.font = '36px "FontFamily AhemTest"';
+            ctx.fillText("Ahem font loaded", 20, 50);
+            takeScreenshot();
+          },
+        );
+        </script>
+    </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <head>
+        <script src="/common/reftest-wait.js"></script>
+    </head>
+    <body>
+        <canvas id="canvas" width="500px" height="500px"></canvas>
+        <script>
+        const ahem_font = new FontFace(
+          "FontFamily AhemTest",
+          "url(/fonts/Ahem.ttf)",
+        );
+        document.fonts.add(ahem_font);
+        ahem_font.load().then(
+          () => {
+            const ctx = canvas.getContext("2d");
+            ctx.font = '36px "FontFamily AhemTest"';
+            ctx.fillText("Ahem font loaded", 20, 50);
+            takeScreenshot();
+          },
+        );
+        </script>
+    </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <head>
+        <title>Constructing a FontFace from an ArrayBuffer should be equivalent to loading the same data from an URL</title>
+        <link rel="help" href="https://drafts.csswg.org/css-font-loading/#font-face-constructor">
+        <link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
+        <link rel=match href=fontface-from-arraybuffer-ref.html>
+        <link rel="help" href="https://github.com/servo/servo/issues/39657">
+        <script src="/common/reftest-wait.js"></script>
+    </head>
+    <body>
+        <canvas id="canvas" width="500px" height="500px"></canvas>
+        <script>
+          fetch("/fonts/Ahem.ttf")
+          .then(res => res.arrayBuffer())
+          .then(arrayBuffer => {
+            const ahem_font = new FontFace(
+              "FontFamily AhemTest",
+              arrayBuffer,
+            );
+            document.fonts.add(ahem_font);
+            ahem_font.load().then(
+              () => {
+                const ctx = canvas.getContext("2d");
+                ctx.font = '36px "FontFamily AhemTest"';
+                ctx.fillText("Ahem font loaded", 20, 50);
+                takeScreenshot();
+              }
+            );
+          });
+        </script>
+    </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-arraybuffer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-arraybuffer-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Constructing a FontFace from an ArrayBuffer should reject with a SyntaxError promise_rejects_dom: function "function() { throw e; }" threw object "NetworkError:  A network error occurred." that is not a DOMException SyntaxError: property "code" is equal to 19, expected 12
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-arraybuffer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-arraybuffer.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+    <title>Constructing a FontFace from an ArrayBuffer should reject with a SyntaxError</title>
+    <link rel="help" href="https://drafts.csswg.org/css-font-loading/#font-face-constructor">
+    <link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+
+    <script>
+        promise_test(function(t) {
+        const bogus_font = new FontFace(
+            "FontFamily AhemTest",
+            new ArrayBuffer(8),
+        );
+        document.fonts.add(bogus_font);
+        return promise_rejects_dom(t, 'SyntaxError', bogus_font.loaded);
+        })
+    </script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-family.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-family.tentative-expected.txt
@@ -1,0 +1,8 @@
+
+FAIL family: content:Segoe UI assert_equals: FontFace.family should be the quoted string after construction with invalid family name content:Segoe UI expected "\"content:Segoe UI\"" but got "content:Segoe UI"
+FAIL family: sans-serif assert_equals: FontFace.family should be the quoted string after construction with invalid family name sans-serif expected "\"sans-serif\"" but got "sans-serif"
+FAIL family: A, B assert_equals: FontFace.family should be the quoted string after construction with invalid family name A, B expected "\"A, B\"" but got "A, B"
+FAIL family: inherit assert_equals: FontFace.family should be the quoted string after construction with invalid family name inherit expected "\"inherit\"" but got "inherit"
+FAIL family: a 1 assert_equals: FontFace.family should be the quoted string after construction with invalid family name a 1 expected "\"a 1\"" but got "a 1"
+FAIL family:  assert_not_equals: FontFace should be quoted after construction with invalid family name  got disallowed value "error"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-family.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-family.tentative.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Mozilla" href="https://mozilla.com">
+<link rel="help" href="https://drafts.csswg.org/css-font-loading-3/">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1986533">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6236">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+// These are values that are invalid as a family-name, or CSS generics.
+const kInvalidValues = [
+  "content:Segoe UI",
+  "sans-serif",
+  "A, B",
+  "inherit",
+  "a 1",
+  "",
+];
+
+for (let familyName of kInvalidValues) {
+  promise_test(async function() {
+    let face = new FontFace(familyName, "url('resources/Rochester.otf')");
+    assert_not_equals(face.status, "error", `FontFace should be quoted after construction with invalid family name ${familyName}`);
+    assert_equals(face.family, `"${familyName}"`, `FontFace.family should be the quoted string after construction with invalid family name ${familyName}`);
+    await face.load();
+    assert_true(true, `FontFace should load after invalid family name ${familyName} specified`);
+  }, `family: ${familyName}`);
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent.html
@@ -11,7 +11,7 @@ promise_test(async t => {
   fontSet.addEventListener("loading", () => {
     loadingFired = true;
   });
-  
+
   const TestFont = new FontFace("GoodFont", "url(/fonts/Ahem.ttf)");
   fontSet.add(TestFont);
   await TestFont.load();

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/historical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/historical-expected.txt
@@ -1,0 +1,3 @@
+
+PASS FontFaceSet constructor should not be supported
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/historical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/historical.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<link rel=help href="https://drafts.csswg.org/css-font-loading/">
+
+<div id=log></div>
+<script>
+"use strict";
+
+// https://github.com/w3c/csswg-drafts/commit/b03a8c9721b56774723ed7804ca6f3f04a922d69
+test(function() {
+  // Get the FontFaceSet interface object, even in Chrome where it isn't exposed.
+  const FontFaceSet = "FontFaceSet" in self ? self.FontFaceSet : document.fonts.constructor;
+  assert_throws_js(TypeError, function() {
+    new FontFaceSet([]);
+  });
+}, "FontFaceSet constructor should not be supported");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/w3c-import.log
@@ -18,10 +18,19 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/empty-family-load.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/font-face-reject.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-descriptor-updates-2.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-descriptor-updates-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-descriptor-updates-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-descriptor-updates.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-font-variation-settings-persisted-js-api.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-fonts-loading.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-arraybuffer.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-family.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-load-in-modal-dialog.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-override-descriptor-getter-setter.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-override-descriptors-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-override-descriptors-ref.html
@@ -29,7 +38,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-size-adjust-descriptor-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-size-adjust-descriptor-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-size-adjust-descriptor.html
-/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfaceset-add-css-connected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfaceset-clear-css-connected-2-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfaceset-clear-css-connected-2-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfaceset-clear-css-connected-2.html
@@ -47,5 +55,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfaceset-update-after-stylesheet-change.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfaceset-worker-fontface-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontfacesetloadevent-constructor.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/historical.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/nonexistent-file-url.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css-font-loading/fontface-loadingevent-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css-font-loading/fontface-loadingevent-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL FontFaceSet fires correct loading event assert_true: The 'loading' event should have fired expected true got false
+


### PR DESCRIPTION
#### 0d4650affa9024319559afe108fbff42b1a3de0f
<pre>
Resync `css/css-font-loading` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=312122">https://bugs.webkit.org/show_bug.cgi?id=312122</a>
<a href="https://rdar.apple.com/174631708">rdar://174631708</a>

Reviewed by Brandon Stewart and Vitor Roriz.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/1a2d26f274ee5189cc0e82fb530c3e638d0cdf4d">https://github.com/web-platform-tests/wpt/commit/1a2d26f274ee5189cc0e82fb530c3e638d0cdf4d</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-descriptor-updates-2-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-descriptor-updates-2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-font-variation-settings-persisted-js-api-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-font-variation-settings-persisted-js-api.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-fonts-loading.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-from-arraybuffer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-arraybuffer-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-arraybuffer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-family.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-family.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-loadingevent.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/historical-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/historical.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css-font-loading/fontface-loadingevent-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/311099@main">https://commits.webkit.org/311099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc85999deab52693f83f822928cb3e501a76946c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164776 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120784 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101473 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22079 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20219 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12607 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167256 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128904 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129037 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34953 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86620 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23872 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16536 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28581 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28108 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28336 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28232 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->