### PR TITLE
Multipart form data parser should not expect CRLF at the end

### DIFF
--- a/LayoutTests/http/wpt/fetch/resources/wrong-form-data.py
+++ b/LayoutTests/http/wpt/fetch/resources/wrong-form-data.py
@@ -3,9 +3,8 @@ from wptserve.utils import isomorphic_decode
 
 def main(request, response):
     value = request.GET.first(b"value", b"")
-    body = b"--boundary" + value + b"--boundary--\r\n"
     headers = [(b"Content-Type", b"multipart/form-data; boundary=boundary"),
                (b"Cache-Control", b"no-cache"),
                (b"Pragma", b"no-cache")]
 
-    return 200, headers, body
+    return 200, headers, value

--- a/LayoutTests/http/wpt/fetch/wrong-form-data-expected.txt
+++ b/LayoutTests/http/wpt/fetch/wrong-form-data-expected.txt
@@ -1,6 +1,13 @@
 
+PASS Validate form data - onePartWithEpilogue
+PASS Validate form data - onePartWithTransportPadding
+PASS Validate form data - onePartWithoutEpilogue
+PASS Validate form data - twoPartsWithEpilogue
+PASS Validate form data - twoPartsWithoutEpilogue
+PASS Validate form data - twoPartsWithTransportPadding
 PASS Validate buggy form data - empty
-PASS Validate buggy form data - cr
+PASS Validate buggy form data - cr1
+PASS Validate buggy form data - cr2
 PASS Validate buggy form data - cr_
 PASS Validate buggy form data - dashes
 

--- a/LayoutTests/http/wpt/fetch/wrong-form-data.html
+++ b/LayoutTests/http/wpt/fetch/wrong-form-data.html
@@ -8,16 +8,40 @@
   </head>
   <body>
     <script>
-const urlsToCheck = [
-    ["empty", ""],
-    ["cr", "?value=%0A"],
-    ["cr_", "?value=%0A_"],
-    ["dashes", "?value=-%20-"]
+const validUrlsToCheck = [
+    ["onePartWithEpilogue", "--boundary%0D%0AContent-Disposition%3A%20form-data%3B%20name%3D%22username%22%0D%0A%0D%0Afoo%0D%0A--boundary--%0D%0A"],
+    ["onePartWithTransportPadding", "--boundary%20%09%0D%0AContent-Disposition%3A%20form-data%3B%20name%3D%22username%22%0D%0A%0D%0Afoo%0D%0A--boundary--%0D%0A"],
+    ["onePartWithoutEpilogue", "--boundary%0D%0AContent-Disposition%3A%20form-data%3B%20name%3D%22username%22%0D%0A%0D%0Afoo%0D%0A--boundary--"],
+    ["twoPartsWithEpilogue", "--boundary%0D%0AContent-Disposition%3A%20form-data%3B%20name%3D%22username%22%0D%0A%0D%0Afoo%0D%0A--boundary%0D%0AContent-Disposition%3A%20form-data%3B%20name%3D%22account%22%0D%0A%0D%0Agoo%0D%0A--boundary--%0D%0A"],
+    ["twoPartsWithoutEpilogue", "--boundary%0D%0AContent-Disposition%3A%20form-data%3B%20name%3D%22username%22%0D%0A%0D%0Afoo%0D%0A--boundary%0D%0AContent-Disposition%3A%20form-data%3B%20name%3D%22account%22%0D%0A%0D%0Agoo%0D%0A--boundary--"],
+    ["twoPartsWithTransportPadding", "--boundary%0D%0AContent-Disposition%3A%20form-data%3B%20name%3D%22username%22%0D%0A%0D%0Afoo%0D%0A--boundary%09%20%0D%0AContent-Disposition%3A%20form-data%3B%20name%3D%22account%22%0D%0A%0D%0Agoo%0D%0A--boundary--"]
+];
+const invalidUrlsToCheck = [
+    ["empty", "--boundary--boundary--%0D%0A"],
+    ["cr1", "--boundary%0A--boundary--%0D%0A"],
+    ["cr2", "--boundary%0D--boundary--%0D%0A"],
+    ["cr_", "--boundary%0A_--boundary--%0D%0A"],
+    ["dashes", "--boundary-%20---boundary--%0D%0A"],
 ];
 
-urlsToCheck.forEach(url => {
+validUrlsToCheck.forEach(url => {
     promise_test(async t => {
-    const response = await fetch("resources/wrong-form-data.py" + url[1]);
+        const response = await fetch("resources/wrong-form-data.py?value=" + url[1]);
+        const formData = await response.formData();
+        let iterator = formData.entries();
+        assert_array_equals(iterator.next().value, ["username", "foo"]);
+
+        const result = iterator.next();
+        if (result.done)
+            return;
+        assert_array_equals(result.value, ["account", "goo"]);
+        assert_true(iterator.next().done);
+    }, "Validate form data - " + url[0]);
+});
+
+invalidUrlsToCheck.forEach(url => {
+    promise_test(async t => {
+    const response = await fetch("resources/wrong-form-data.py?value=" + url[1]);
     await promise_rejects_js(t, TypeError, response.formData());
     }, "Validate buggy form data - " + url[0]);
 });

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -212,8 +212,11 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
             return nullptr;
 
         skip(data, currentBoundaryIndex + boundaryLength);
-        if (spanHasPrefix(data, "--\r\n"_span))
+        if (spanHasPrefix(data, "--\r\n"_span)) {
+            // FIXME: This is not valid as per RFC, but is consistent with how empty form data are serialized.
             return form;
+        }
+        skipWhile<isTabOrSpace>(data);
         if (!spanHasPrefix(data, "\r\n"_span))
             return nullptr;
 
@@ -222,8 +225,9 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
             parseMultipartPart(data.first(nextBoundaryIndex - oneNewLine.length()), form.get());
             currentBoundaryIndex = nextBoundaryIndex;
             skip(data, nextBoundaryIndex + boundaryLength);
-            if (spanHasPrefix(data, "--\r\n"_span))
+            if (spanHasPrefix(data, "--"_span))
                 return form;
+            skipWhile<isTabOrSpace>(data);
             if (!spanHasPrefix(data, "\r\n"_span))
                 return nullptr;
         }


### PR DESCRIPTION
#### d9c3d2e9d1dd6a3758e99ea3443171b70cdbd88c
<pre>
Multipart form data parser should not expect CRLF at the end
<a href="https://rdar.apple.com/174348783">rdar://174348783</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312136">https://bugs.webkit.org/show_bug.cgi?id=312136</a>

Reviewed by Chris Dumez.

Our checks added in <a href="https://rdar.apple.com/172038722">rdar://172038722</a> were too strict.
While form generators include CRLF after the close delimiter, RFC 2046 does not mandate this.
We update the implementation accordingly, which aligns with other UAs.
We also check for transport-padding as requested by RFC 2046, which aligns with Chrome, not Firefox.
Finally, we keep allowing a start delimiter finishing with &apos;--&apos;, which is counted as a close delimiter.
The reason is that, even though not allowed by RFC and Chrome, it is allowed by Firefox and is the way an empty FormData is serialized by User Agents.
We add tests for close delimiter without CRLF and for transport-padding.

* LayoutTests/http/wpt/fetch/resources/wrong-form-data.py:
(main):
* LayoutTests/http/wpt/fetch/wrong-form-data-expected.txt:
* LayoutTests/http/wpt/fetch/wrong-form-data.html:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::packageFormData):

Canonical link: <a href="https://commits.webkit.org/311089@main">https://commits.webkit.org/311089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f116cade02db67789cd6dcffde823495fd718dea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164862 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120810 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101497 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12633 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167345 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11456 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19576 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128934 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24306 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129067 "Found 1 new API test failure: WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/ephemeral (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34946 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139758 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86648 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23888 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16556 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28607 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92564 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28134 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28362 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28258 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->