### PR TITLE
[threaded-animations] allow acceleration for effects composing using implicit keyframes

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Two replacing animations with explicit keyframes for the same accelerated property yield only a single accelerated animation.
 PASS An animation with an implicit keyframe for an accelerated property can run accelerated.
-PASS Two animations with implicit keyframes for the same accelerated property prevents acceleration throughout the stack.
-PASS Dynamically adding an animation with an implicit keyframe for an accelerated property with an accelerated animation targeting that same property lower down the stack prevents the stack from being accelerated.
+PASS Two animations with implicit keyframes for the same accelerated property can run accelerated.
+PASS Dynamically adding an animation with an implicit keyframe for an accelerated property with an accelerated animation targeting that same property lower down the stack can run accelerated.
 

--- a/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes.html
+++ b/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes.html
@@ -59,8 +59,8 @@ promise_test(async test => {
     animations.push(target.animate({ transform: "translateX(100px)" }, duration));
     animations.push(target.animate({ transform: "translateY(100px)" }, duration));
     await allAnimationsAreReadyToAnimateAccelerated(animations);
-    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
-}, "Two animations with implicit keyframes for the same accelerated property prevents acceleration throughout the stack.");
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 2);
+}, "Two animations with implicit keyframes for the same accelerated property can run accelerated.");
 
 promise_test(async test => {
     const target = createDiv(test);
@@ -75,13 +75,13 @@ promise_test(async test => {
     // throughout the effect stack.
     animations.push(target.animate({ transform: "translateY(100px)" }, duration));
     await allAnimationsAreReadyToAnimateAccelerated(animations);
-    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 2);
 
     // Reset to the original state.
     animations[1].cancel();
     await allAnimationsAreReadyToAnimateAccelerated(animations);
     assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
-}, "Dynamically adding an animation with an implicit keyframe for an accelerated property with an accelerated animation targeting that same property lower down the stack prevents the stack from being accelerated.");
+}, "Dynamically adding an animation with an implicit keyframe for an accelerated property with an accelerated animation targeting that same property lower down the stack can run accelerated.");
 
 </script>
 </body>

--- a/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-from-keyframe-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-from-keyframe-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Fill mode is not adjusted for effects that participate in composition due to an implicit "from" keyframe.
+

--- a/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-from-keyframe.html
+++ b/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-from-keyframe.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<style>
+
+#target {
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+
+<div id="target"></div>
+
+<script>
+
+promise_test(async t => {
+    const target = document.getElementById("target");
+
+    const duration = 1000 * 1000;
+    const animations = [
+        target.animate({ translate: "100px" }, duration),
+        target.animate({ translate: "200px" }, duration)
+    ];
+
+    await Promise.all(animations.map(animation => animationAcceleration(animation)));
+
+    const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(target);
+    const remoteAnimations = remoteAnimationStack.animations;
+    assert_equals(remoteAnimations.length, 2, "We have the expected number of animations in the remote layer tree");
+    assert_equals(remoteAnimations[0].timing.fill, 'auto', 'Omitted fill mode is preserved for effect that is composed with another effect further up the stack');
+    assert_equals(remoteAnimations[1].timing.fill, 'forwards', 'Omitted fille mode is set to "forwards" for the last effect animating a given property');
+}, 'Fill mode is not adjusted for effects that participate in composition due to an implicit "from" keyframe.');
+
+</script>
+</body>

--- a/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-to-keyframe-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-to-keyframe-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Fill mode is not adjusted for effects that participate in composition due to an implicit "to" keyframe.
+

--- a/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-to-keyframe.html
+++ b/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-to-keyframe.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<style>
+
+#target {
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+
+<div id="target"></div>
+
+<script>
+
+promise_test(async t => {
+    const target = document.getElementById("target");
+
+    const duration = 1000 * 1000;
+    const animations = [
+        target.animate({ translate: "100px", offset: 0 }, duration),
+        target.animate({ translate: "200px", offset: 0 }, duration)
+    ];
+
+    await Promise.all(animations.map(animation => animationAcceleration(animation)));
+
+    const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(target);
+    const remoteAnimations = remoteAnimationStack.animations;
+    assert_equals(remoteAnimations.length, 2, "We have the expected number of animations in the remote layer tree");
+    assert_equals(remoteAnimations[0].timing.fill, 'auto', 'Omitted fill mode is preserved for effect that is composed with another effect further up the stack');
+    assert_equals(remoteAnimations[1].timing.fill, 'forwards', 'Omitted fille mode is set to "forwards" for the last effect animating a given property');
+}, 'Fill mode is not adjusted for effects that participate in composition due to an implicit "to" keyframe.');
+
+</script>
+</body>

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -253,7 +253,16 @@ bool KeyframeEffectStack::allowsAcceleration() const
         if (effect->preventsAcceleration())
             return false;
         auto& acceleratedProperties = effect->acceleratedProperties();
-        if (!allAcceleratedProperties.isEmpty()) {
+
+        auto effectSupportsImplicitKeyframesComposition = [&] {
+#if ENABLE(THREADED_ANIMATIONS)
+            return effect->canHaveAcceleratedRepresentation();
+#else
+            return false;
+#endif
+        };
+
+        if (!allAcceleratedProperties.isEmpty() && !effectSupportsImplicitKeyframesComposition()) {
             auto previouslySeenAcceleratedPropertiesAffectingCurrentEffect = allAcceleratedProperties.intersectionWith(acceleratedProperties);
             if (!previouslySeenAcceleratedPropertiesAffectingCurrentEffect.isEmpty()
                 && !effect->acceleratedPropertiesWithImplicitKeyframe().intersectionWith(previouslySeenAcceleratedPropertiesAffectingCurrentEffect).isEmpty()) {


### PR DESCRIPTION
#### 748235460fb6c55b84993596d7eff50ed045de8e
<pre>
[threaded-animations] allow acceleration for effects composing using implicit keyframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=312140">https://bugs.webkit.org/show_bug.cgi?id=312140</a>
<a href="https://rdar.apple.com/174646583">rdar://174646583</a>

Reviewed by Simon Fraser and Anne van Kesteren.

If an effect stack featured several effects animating the same underlying accelerated property
with implicit keyframes, we would disable acceleration support throughout the stack as a legacy
behavior from the non-threaded animation support.

However, with threaded animations, there is no reason not to support acceleration in this case
and attempting to write a test case when fixing bug 310806 in 310985@main made this obvious.
We address this and ensure we update tests for threaded animations covering that behavior
and add new tests that we were originally aiming to write for bug 310806.

Note that `webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes.html`
still tests the legacy behavior described above.

Tests: webanimations/threaded-animations/fill-mode-adjustment-implicit-from-keyframe.html
       webanimations/threaded-animations/fill-mode-adjustment-implicit-to-keyframe.html
* LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes-expected.txt:
* LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes.html:
* LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-from-keyframe-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-from-keyframe.html: Added.
* LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-to-keyframe-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-implicit-to-keyframe.html: Added.
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::allowsAcceleration const):

Canonical link: <a href="https://commits.webkit.org/311112@main">https://commits.webkit.org/311112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c039da2e7b8f584887e5a4a1dda9384234bbdf92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156082 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/29417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157953 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/29550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29418 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/164903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159040 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/29550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/29550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/12675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/29550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11498 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/19617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/167382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/28940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/139799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23757 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/28940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/28649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92606 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->