### PR TITLE
Improve <img>'s naturalWidth & naturalHeight with SVG images

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height-expected.txt
@@ -10,46 +10,46 @@ PASS non existent image with width/height attributes, no natural dimensions
 PASS non existent image with width/height attributes, no natural dimensions (when not rendered)
 PASS SVG image, no natural dimensions
 PASS SVG image, no natural dimensions (when not rendered)
-FAIL SVG image with width/height attrs, no natural dimensions assert_equals: naturalWidth expected 300 but got 40
+PASS SVG image with width/height attrs, no natural dimensions
 PASS SVG image with width/height attrs, no natural dimensions (when not rendered)
-FAIL SVG image with width attr, no natural dimensions assert_equals: naturalWidth expected 300 but got 40
+PASS SVG image with width attr, no natural dimensions
 PASS SVG image with width attr, no natural dimensions (when not rendered)
-FAIL SVG image with height attr, no natural dimensions assert_equals: naturalHeight expected 150 but got 10
+PASS SVG image with height attr, no natural dimensions
 PASS SVG image with height attr, no natural dimensions (when not rendered)
 PASS SVG image, percengage natural dimensions
 PASS SVG image, percengage natural dimensions (when not rendered)
 PASS SVG image, negative percengage natural dimensions
 PASS SVG image, negative percengage natural dimensions (when not rendered)
 PASS SVG image, with natural width
-FAIL SVG image, with natural width (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 300
+PASS SVG image, with natural width (when not rendered)
 PASS SVG image, with natural height
-FAIL SVG image, with natural height (when not rendered) assert_equals: naturalHeight when not rendered expected 60 but got 150
-FAIL SVG image, with natural width of 0 assert_equals: naturalWidth expected 0 but got 300
-FAIL SVG image, with natural width of 0 (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 300
-FAIL SVG image, with natural height of 0 assert_equals: naturalHeight expected 0 but got 150
-FAIL SVG image, with natural height of 0 (when not rendered) assert_equals: naturalHeight when not rendered expected 0 but got 150
+PASS SVG image, with natural height (when not rendered)
+PASS SVG image, with natural width of 0
+PASS SVG image, with natural width of 0 (when not rendered)
+PASS SVG image, with natural height of 0
+PASS SVG image, with natural height of 0 (when not rendered)
 PASS SVG image, with natural width being negative
 PASS SVG image, with natural width being negative (when not rendered)
 PASS SVG image, with natural height being negative
 PASS SVG image, with natural height being negative (when not rendered)
-FAIL SVG image, no natural dimensions, and aspect ratio from viewBox assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, no natural dimensions, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
-FAIL SVG image, percengage natural dimensions, and aspect ratio from viewBox assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, percengage natural dimensions, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
-FAIL SVG image, negative percengage natural dimensions, and aspect ratio from viewBox assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
+PASS SVG image, no natural dimensions, and aspect ratio from viewBox
+PASS SVG image, no natural dimensions, and aspect ratio from viewBox (when not rendered)
+PASS SVG image, percengage natural dimensions, and aspect ratio from viewBox
+PASS SVG image, percengage natural dimensions, and aspect ratio from viewBox (when not rendered)
+PASS SVG image, negative percengage natural dimensions, and aspect ratio from viewBox
+PASS SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (when not rendered)
 PASS SVG image, with natural width, and aspect ratio from viewBox
-FAIL SVG image, with natural width, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 600
+PASS SVG image, with natural width, and aspect ratio from viewBox (when not rendered)
 PASS SVG image, with natural height, and aspect ratio from viewBox
-FAIL SVG image, with natural height, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 180 but got 600
-FAIL SVG image, with natural width of 0, and aspect ratio from viewBox assert_equals: naturalWidth expected 0 but got 600
-FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
-FAIL SVG image, with natural height of 0, and aspect ratio from viewBox assert_equals: naturalWidth expected 0 but got 720
-FAIL SVG image, with natural height of 0, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
-FAIL SVG image, with natural width being negative, and aspect ratio from viewBox assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, with natural width being negative, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
-FAIL SVG image, with natural height being negative, and aspect ratio from viewBox assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, with natural height being negative, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
+PASS SVG image, with natural height, and aspect ratio from viewBox (when not rendered)
+PASS SVG image, with natural width of 0, and aspect ratio from viewBox
+PASS SVG image, with natural width of 0, and aspect ratio from viewBox (when not rendered)
+PASS SVG image, with natural height of 0, and aspect ratio from viewBox
+PASS SVG image, with natural height of 0, and aspect ratio from viewBox (when not rendered)
+PASS SVG image, with natural width being negative, and aspect ratio from viewBox
+PASS SVG image, with natural width being negative, and aspect ratio from viewBox (when not rendered)
+PASS SVG image, with natural height being negative, and aspect ratio from viewBox
+PASS SVG image, with natural height being negative, and aspect ratio from viewBox (when not rendered)
 PASS SVG image, no natural dimensions, viewBox with 0 width/height
 PASS SVG image, no natural dimensions, viewBox with 0 width/height (when not rendered)
 PASS SVG image, no natural dimensions, viewBox with 0 width
@@ -57,25 +57,25 @@ PASS SVG image, no natural dimensions, viewBox with 0 width (when not rendered)
 PASS SVG image, no natural dimensions, viewBox with 0 height
 PASS SVG image, no natural dimensions, viewBox with 0 height (when not rendered)
 PASS SVG image, with natural width, viewBox with 0 width/height
-FAIL SVG image, with natural width, viewBox with 0 width/height (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 300
+PASS SVG image, with natural width, viewBox with 0 width/height (when not rendered)
 PASS SVG image, with natural width, viewBox with 0 width
-FAIL SVG image, with natural width, viewBox with 0 width (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 300
+PASS SVG image, with natural width, viewBox with 0 width (when not rendered)
 PASS SVG image, with natural width, viewBox with 0 height
-FAIL SVG image, with natural width, viewBox with 0 height (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 300
+PASS SVG image, with natural width, viewBox with 0 height (when not rendered)
 PASS SVG image, with natural height, viewBox with 0 width/height
-FAIL SVG image, with natural height, viewBox with 0 width/height (when not rendered) assert_equals: naturalHeight when not rendered expected 60 but got 150
+PASS SVG image, with natural height, viewBox with 0 width/height (when not rendered)
 PASS SVG image, with natural height, viewBox with 0 width
-FAIL SVG image, with natural height, viewBox with 0 width (when not rendered) assert_equals: naturalHeight when not rendered expected 60 but got 150
+PASS SVG image, with natural height, viewBox with 0 width (when not rendered)
 PASS SVG image, with natural height, viewBox with 0 height
-FAIL SVG image, with natural height, viewBox with 0 height (when not rendered) assert_equals: naturalHeight when not rendered expected 60 but got 150
+PASS SVG image, with natural height, viewBox with 0 height (when not rendered)
 PASS SVG image, with natural width and height
 PASS SVG image, with natural width and height (when not rendered)
 PASS SVG image, with natural width and height, and aspect ratio from viewBox
 PASS SVG image, with natural width and height, and aspect ratio from viewBox (when not rendered)
-FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox assert_equals: naturalWidth expected 0 but got 300
-FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 300
-FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
+PASS SVG image, with natural width and height of 0, and aspect ratio from viewBox
+PASS SVG image, with natural width and height of 0, and aspect ratio from viewBox (when not rendered)
+PASS SVG image, with natural width and height being negative, and aspect ratio from viewBox
+PASS SVG image, with natural width and height being negative, and aspect ratio from viewBox (when not rendered)
 PASS SVG image, with natural width matching default concrete object size
 PASS SVG image, with natural width matching default concrete object size (when not rendered)
 PASS SVG image, with natural height matching default concrete object size
@@ -96,46 +96,46 @@ PASS non existent image with width/height attributes, no natural dimensions (wit
 PASS non existent image with width/height attributes, no natural dimensions (with srcset/1x) (when not rendered)
 PASS SVG image, no natural dimensions (with srcset/1x)
 PASS SVG image, no natural dimensions (with srcset/1x) (when not rendered)
-FAIL SVG image with width/height attrs, no natural dimensions (with srcset/1x) assert_equals: naturalWidth expected 300 but got 40
+PASS SVG image with width/height attrs, no natural dimensions (with srcset/1x)
 PASS SVG image with width/height attrs, no natural dimensions (with srcset/1x) (when not rendered)
-FAIL SVG image with width attr, no natural dimensions (with srcset/1x) assert_equals: naturalWidth expected 300 but got 40
+PASS SVG image with width attr, no natural dimensions (with srcset/1x)
 PASS SVG image with width attr, no natural dimensions (with srcset/1x) (when not rendered)
-FAIL SVG image with height attr, no natural dimensions (with srcset/1x) assert_equals: naturalHeight expected 150 but got 10
+PASS SVG image with height attr, no natural dimensions (with srcset/1x)
 PASS SVG image with height attr, no natural dimensions (with srcset/1x) (when not rendered)
 PASS SVG image, percengage natural dimensions (with srcset/1x)
 PASS SVG image, percengage natural dimensions (with srcset/1x) (when not rendered)
 PASS SVG image, negative percengage natural dimensions (with srcset/1x)
 PASS SVG image, negative percengage natural dimensions (with srcset/1x) (when not rendered)
 PASS SVG image, with natural width (with srcset/1x)
-FAIL SVG image, with natural width (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 300
+PASS SVG image, with natural width (with srcset/1x) (when not rendered)
 PASS SVG image, with natural height (with srcset/1x)
-FAIL SVG image, with natural height (with srcset/1x) (when not rendered) assert_equals: naturalHeight when not rendered expected 60 but got 150
-FAIL SVG image, with natural width of 0 (with srcset/1x) assert_equals: naturalWidth expected 0 but got 300
-FAIL SVG image, with natural width of 0 (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 300
-FAIL SVG image, with natural height of 0 (with srcset/1x) assert_equals: naturalHeight expected 0 but got 150
-FAIL SVG image, with natural height of 0 (with srcset/1x) (when not rendered) assert_equals: naturalHeight when not rendered expected 0 but got 150
+PASS SVG image, with natural height (with srcset/1x) (when not rendered)
+PASS SVG image, with natural width of 0 (with srcset/1x)
+PASS SVG image, with natural width of 0 (with srcset/1x) (when not rendered)
+PASS SVG image, with natural height of 0 (with srcset/1x)
+PASS SVG image, with natural height of 0 (with srcset/1x) (when not rendered)
 PASS SVG image, with natural width being negative (with srcset/1x)
 PASS SVG image, with natural width being negative (with srcset/1x) (when not rendered)
 PASS SVG image, with natural height being negative (with srcset/1x)
 PASS SVG image, with natural height being negative (with srcset/1x) (when not rendered)
-FAIL SVG image, no natural dimensions, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, no natural dimensions, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
-FAIL SVG image, percengage natural dimensions, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, percengage natural dimensions, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
-FAIL SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
+PASS SVG image, no natural dimensions, and aspect ratio from viewBox (with srcset/1x)
+PASS SVG image, no natural dimensions, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
+PASS SVG image, percengage natural dimensions, and aspect ratio from viewBox (with srcset/1x)
+PASS SVG image, percengage natural dimensions, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
+PASS SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (with srcset/1x)
+PASS SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
 PASS SVG image, with natural width, and aspect ratio from viewBox (with srcset/1x)
-FAIL SVG image, with natural width, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 600
+PASS SVG image, with natural width, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
 PASS SVG image, with natural height, and aspect ratio from viewBox (with srcset/1x)
-FAIL SVG image, with natural height, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 180 but got 600
-FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 0 but got 600
-FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
-FAIL SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 0 but got 720
-FAIL SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
-FAIL SVG image, with natural width being negative, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, with natural width being negative, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
-FAIL SVG image, with natural height being negative, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, with natural height being negative, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
+PASS SVG image, with natural height, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
+PASS SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/1x)
+PASS SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
+PASS SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/1x)
+PASS SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
+PASS SVG image, with natural width being negative, and aspect ratio from viewBox (with srcset/1x)
+PASS SVG image, with natural width being negative, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
+PASS SVG image, with natural height being negative, and aspect ratio from viewBox (with srcset/1x)
+PASS SVG image, with natural height being negative, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
 PASS SVG image, no natural dimensions, viewBox with 0 width/height (with srcset/1x)
 PASS SVG image, no natural dimensions, viewBox with 0 width/height (with srcset/1x) (when not rendered)
 PASS SVG image, no natural dimensions, viewBox with 0 width (with srcset/1x)
@@ -143,25 +143,25 @@ PASS SVG image, no natural dimensions, viewBox with 0 width (with srcset/1x) (wh
 PASS SVG image, no natural dimensions, viewBox with 0 height (with srcset/1x)
 PASS SVG image, no natural dimensions, viewBox with 0 height (with srcset/1x) (when not rendered)
 PASS SVG image, with natural width, viewBox with 0 width/height (with srcset/1x)
-FAIL SVG image, with natural width, viewBox with 0 width/height (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 300
+PASS SVG image, with natural width, viewBox with 0 width/height (with srcset/1x) (when not rendered)
 PASS SVG image, with natural width, viewBox with 0 width (with srcset/1x)
-FAIL SVG image, with natural width, viewBox with 0 width (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 300
+PASS SVG image, with natural width, viewBox with 0 width (with srcset/1x) (when not rendered)
 PASS SVG image, with natural width, viewBox with 0 height (with srcset/1x)
-FAIL SVG image, with natural width, viewBox with 0 height (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 300
+PASS SVG image, with natural width, viewBox with 0 height (with srcset/1x) (when not rendered)
 PASS SVG image, with natural height, viewBox with 0 width/height (with srcset/1x)
-FAIL SVG image, with natural height, viewBox with 0 width/height (with srcset/1x) (when not rendered) assert_equals: naturalHeight when not rendered expected 60 but got 150
+PASS SVG image, with natural height, viewBox with 0 width/height (with srcset/1x) (when not rendered)
 PASS SVG image, with natural height, viewBox with 0 width (with srcset/1x)
-FAIL SVG image, with natural height, viewBox with 0 width (with srcset/1x) (when not rendered) assert_equals: naturalHeight when not rendered expected 60 but got 150
+PASS SVG image, with natural height, viewBox with 0 width (with srcset/1x) (when not rendered)
 PASS SVG image, with natural height, viewBox with 0 height (with srcset/1x)
-FAIL SVG image, with natural height, viewBox with 0 height (with srcset/1x) (when not rendered) assert_equals: naturalHeight when not rendered expected 60 but got 150
+PASS SVG image, with natural height, viewBox with 0 height (with srcset/1x) (when not rendered)
 PASS SVG image, with natural width and height (with srcset/1x)
 PASS SVG image, with natural width and height (with srcset/1x) (when not rendered)
 PASS SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/1x)
 PASS SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
-FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 0 but got 300
-FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 300
-FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
+PASS SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/1x)
+PASS SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
+PASS SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/1x)
+PASS SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
 PASS SVG image, with natural width matching default concrete object size (with srcset/1x)
 PASS SVG image, with natural width matching default concrete object size (with srcset/1x) (when not rendered)
 PASS SVG image, with natural height matching default concrete object size (with srcset/1x)
@@ -180,82 +180,82 @@ PASS non existent image, no natural dimensions (with srcset/2x)
 PASS non existent image, no natural dimensions (with srcset/2x) (when not rendered)
 PASS non existent image with width/height attributes, no natural dimensions (with srcset/2x)
 PASS non existent image with width/height attributes, no natural dimensions (with srcset/2x) (when not rendered)
-FAIL SVG image, no natural dimensions (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
+PASS SVG image, no natural dimensions (with srcset/2x)
 PASS SVG image, no natural dimensions (with srcset/2x) (when not rendered)
-FAIL SVG image with width/height attrs, no natural dimensions (with srcset/2x) assert_equals: naturalWidth expected 300 but got 40
+PASS SVG image with width/height attrs, no natural dimensions (with srcset/2x)
 PASS SVG image with width/height attrs, no natural dimensions (with srcset/2x) (when not rendered)
-FAIL SVG image with width attr, no natural dimensions (with srcset/2x) assert_equals: naturalWidth expected 300 but got 40
+PASS SVG image with width attr, no natural dimensions (with srcset/2x)
 PASS SVG image with width attr, no natural dimensions (with srcset/2x) (when not rendered)
-FAIL SVG image with height attr, no natural dimensions (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
+PASS SVG image with height attr, no natural dimensions (with srcset/2x)
 PASS SVG image with height attr, no natural dimensions (with srcset/2x) (when not rendered)
-FAIL SVG image, percengage natural dimensions (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
+PASS SVG image, percengage natural dimensions (with srcset/2x)
 PASS SVG image, percengage natural dimensions (with srcset/2x) (when not rendered)
-FAIL SVG image, negative percengage natural dimensions (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
+PASS SVG image, negative percengage natural dimensions (with srcset/2x)
 PASS SVG image, negative percengage natural dimensions (with srcset/2x) (when not rendered)
-FAIL SVG image, with natural width (with srcset/2x) assert_equals: naturalHeight expected 150 but got 75
-FAIL SVG image, with natural width (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 30 but got 300
-FAIL SVG image, with natural height (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
-FAIL SVG image, with natural height (with srcset/2x) (when not rendered) assert_equals: naturalHeight when not rendered expected 30 but got 150
-FAIL SVG image, with natural width of 0 (with srcset/2x) assert_equals: naturalWidth expected 0 but got 300
-FAIL SVG image, with natural width of 0 (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 300
-FAIL SVG image, with natural height of 0 (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
-FAIL SVG image, with natural height of 0 (with srcset/2x) (when not rendered) assert_equals: naturalHeight when not rendered expected 0 but got 150
-FAIL SVG image, with natural width being negative (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
+PASS SVG image, with natural width (with srcset/2x)
+PASS SVG image, with natural width (with srcset/2x) (when not rendered)
+PASS SVG image, with natural height (with srcset/2x)
+PASS SVG image, with natural height (with srcset/2x) (when not rendered)
+PASS SVG image, with natural width of 0 (with srcset/2x)
+PASS SVG image, with natural width of 0 (with srcset/2x) (when not rendered)
+PASS SVG image, with natural height of 0 (with srcset/2x)
+PASS SVG image, with natural height of 0 (with srcset/2x) (when not rendered)
+PASS SVG image, with natural width being negative (with srcset/2x)
 PASS SVG image, with natural width being negative (with srcset/2x) (when not rendered)
-FAIL SVG image, with natural height being negative (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
+PASS SVG image, with natural height being negative (with srcset/2x)
 PASS SVG image, with natural height being negative (with srcset/2x) (when not rendered)
-FAIL SVG image, no natural dimensions, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, no natural dimensions, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
-FAIL SVG image, percengage natural dimensions, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, percengage natural dimensions, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
-FAIL SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
+PASS SVG image, no natural dimensions, and aspect ratio from viewBox (with srcset/2x)
+PASS SVG image, no natural dimensions, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
+PASS SVG image, percengage natural dimensions, and aspect ratio from viewBox (with srcset/2x)
+PASS SVG image, percengage natural dimensions, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
+PASS SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (with srcset/2x)
+PASS SVG image, negative percengage natural dimensions, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
 PASS SVG image, with natural width, and aspect ratio from viewBox (with srcset/2x)
-FAIL SVG image, with natural width, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 30 but got 600
+PASS SVG image, with natural width, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
 PASS SVG image, with natural height, and aspect ratio from viewBox (with srcset/2x)
-FAIL SVG image, with natural height, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 90 but got 600
-FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 0 but got 600
-FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
-FAIL SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 0 but got 720
-FAIL SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
-FAIL SVG image, with natural width being negative, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, with natural width being negative, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
-FAIL SVG image, with natural height being negative, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, with natural height being negative, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
-FAIL SVG image, no natural dimensions, viewBox with 0 width/height (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
+PASS SVG image, with natural height, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
+PASS SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/2x)
+PASS SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
+PASS SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/2x)
+PASS SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
+PASS SVG image, with natural width being negative, and aspect ratio from viewBox (with srcset/2x)
+PASS SVG image, with natural width being negative, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
+PASS SVG image, with natural height being negative, and aspect ratio from viewBox (with srcset/2x)
+PASS SVG image, with natural height being negative, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
+PASS SVG image, no natural dimensions, viewBox with 0 width/height (with srcset/2x)
 PASS SVG image, no natural dimensions, viewBox with 0 width/height (with srcset/2x) (when not rendered)
-FAIL SVG image, no natural dimensions, viewBox with 0 width (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
+PASS SVG image, no natural dimensions, viewBox with 0 width (with srcset/2x)
 PASS SVG image, no natural dimensions, viewBox with 0 width (with srcset/2x) (when not rendered)
-FAIL SVG image, no natural dimensions, viewBox with 0 height (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
+PASS SVG image, no natural dimensions, viewBox with 0 height (with srcset/2x)
 PASS SVG image, no natural dimensions, viewBox with 0 height (with srcset/2x) (when not rendered)
-FAIL SVG image, with natural width, viewBox with 0 width/height (with srcset/2x) assert_equals: naturalHeight expected 150 but got 75
-FAIL SVG image, with natural width, viewBox with 0 width/height (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 30 but got 300
-FAIL SVG image, with natural width, viewBox with 0 width (with srcset/2x) assert_equals: naturalHeight expected 150 but got 75
-FAIL SVG image, with natural width, viewBox with 0 width (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 30 but got 300
-FAIL SVG image, with natural width, viewBox with 0 height (with srcset/2x) assert_equals: naturalHeight expected 150 but got 75
-FAIL SVG image, with natural width, viewBox with 0 height (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 30 but got 300
-FAIL SVG image, with natural height, viewBox with 0 width/height (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
-FAIL SVG image, with natural height, viewBox with 0 width/height (with srcset/2x) (when not rendered) assert_equals: naturalHeight when not rendered expected 30 but got 150
-FAIL SVG image, with natural height, viewBox with 0 width (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
-FAIL SVG image, with natural height, viewBox with 0 width (with srcset/2x) (when not rendered) assert_equals: naturalHeight when not rendered expected 30 but got 150
-FAIL SVG image, with natural height, viewBox with 0 height (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
-FAIL SVG image, with natural height, viewBox with 0 height (with srcset/2x) (when not rendered) assert_equals: naturalHeight when not rendered expected 30 but got 150
+PASS SVG image, with natural width, viewBox with 0 width/height (with srcset/2x)
+PASS SVG image, with natural width, viewBox with 0 width/height (with srcset/2x) (when not rendered)
+PASS SVG image, with natural width, viewBox with 0 width (with srcset/2x)
+PASS SVG image, with natural width, viewBox with 0 width (with srcset/2x) (when not rendered)
+PASS SVG image, with natural width, viewBox with 0 height (with srcset/2x)
+PASS SVG image, with natural width, viewBox with 0 height (with srcset/2x) (when not rendered)
+PASS SVG image, with natural height, viewBox with 0 width/height (with srcset/2x)
+PASS SVG image, with natural height, viewBox with 0 width/height (with srcset/2x) (when not rendered)
+PASS SVG image, with natural height, viewBox with 0 width (with srcset/2x)
+PASS SVG image, with natural height, viewBox with 0 width (with srcset/2x) (when not rendered)
+PASS SVG image, with natural height, viewBox with 0 height (with srcset/2x)
+PASS SVG image, with natural height, viewBox with 0 height (with srcset/2x) (when not rendered)
 PASS SVG image, with natural width and height (with srcset/2x)
-FAIL SVG image, with natural width and height (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 30 but got 60
+PASS SVG image, with natural width and height (with srcset/2x) (when not rendered)
 PASS SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/2x)
-FAIL SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 30 but got 60
-FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 0 but got 300
-FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 300
-FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 300 but got 720
-FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 300 but got 600
-FAIL SVG image, with natural width matching default concrete object size (with srcset/2x) assert_equals: naturalHeight expected 150 but got 75
-FAIL SVG image, with natural width matching default concrete object size (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 150 but got 300
-FAIL SVG image, with natural height matching default concrete object size (with srcset/2x) assert_equals: naturalWidth expected 300 but got 150
-FAIL SVG image, with natural height matching default concrete object size (with srcset/2x) (when not rendered) assert_equals: naturalHeight when not rendered expected 75 but got 150
+PASS SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
+PASS SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/2x)
+PASS SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
+PASS SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/2x)
+PASS SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
+PASS SVG image, with natural width matching default concrete object size (with srcset/2x)
+PASS SVG image, with natural width matching default concrete object size (with srcset/2x) (when not rendered)
+PASS SVG image, with natural height matching default concrete object size (with srcset/2x)
+PASS SVG image, with natural height matching default concrete object size (with srcset/2x) (when not rendered)
 PASS SVG image, with natural width matching default concrete object size, and aspect ratio from viewBox (with srcset/2x)
-FAIL SVG image, with natural width matching default concrete object size, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 150 but got 300
+PASS SVG image, with natural width matching default concrete object size, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
 PASS SVG image, with natural height matching default concrete object size, and aspect ratio from viewBox (with srcset/2x)
-FAIL SVG image, with natural height matching default concrete object size, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 150 but got 300
+PASS SVG image, with natural height matching default concrete object size, and aspect ratio from viewBox (with srcset/2x) (when not rendered)
 PASS SVG image, with natural width and height matching default concrete object size (with srcset/2x)
-FAIL SVG image, with natural width and height matching default concrete object size (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 150 but got 300
+PASS SVG image, with natural width and height matching default concrete object size (with srcset/2x) (when not rendered)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-density-vs-zoom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-density-vs-zoom-expected.txt
@@ -4,12 +4,12 @@
 
 
 PASS SVG, no intrinsic dims: baseline
-FAIL SVG, no intrinsic dims + 2x density: defaults not scaled assert_equals: naturalWidth expected 300 but got 150
-FAIL SVG, no intrinsic dims + 2x zoom: rendered size scaled, naturalWidth/Height not assert_equals: naturalWidth expected 300 but got 600
+PASS SVG, no intrinsic dims + 2x density: defaults not scaled
+PASS SVG, no intrinsic dims + 2x zoom: rendered size scaled, naturalWidth/Height not
 PASS SVG, intrinsic width only: baseline
-FAIL SVG, intrinsic width only + 2x density: width scaled, default height not assert_equals: naturalHeight expected 150 but got 75
-FAIL SVG, intrinsic width only + 2x zoom: everything scaled assert_equals: naturalWidth expected 60 but got 120
+PASS SVG, intrinsic width only + 2x density: width scaled, default height not
+PASS SVG, intrinsic width only + 2x zoom: everything scaled
 PASS SVG, both intrinsic dims: baseline
 PASS SVG, both intrinsic dims + 2x density: both scaled
-FAIL SVG, both intrinsic dims + 2x zoom: rendered size scaled, naturalWidth/Height not assert_equals: naturalWidth expected 60 but got 120
+PASS SVG, both intrinsic dims + 2x zoom: rendered size scaled, naturalWidth/Height not
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -656,7 +656,7 @@ unsigned HTMLImageElement::width()
 
         // if the image is available, use its width
         if (RefPtr image = m_imageLoader->image())
-            return image->imageSizeForRenderer(nullptr, 1.0f).width().toUnsigned();
+            return image->imageSizeForRenderer(nullptr, 1.0f, CachedImage::IntrinsicSize).width().toUnsigned();
     }
 
     CheckedPtr box = renderBox();
@@ -679,7 +679,7 @@ unsigned HTMLImageElement::height()
 
         // if the image is available, use its height
         if (RefPtr image = m_imageLoader->image())
-            return image->imageSizeForRenderer(nullptr, 1.0f).height().toUnsigned();
+            return image->imageSizeForRenderer(nullptr, 1.0f, CachedImage::IntrinsicSize).height().toUnsigned();
     }
 
     CheckedPtr box = renderBox();
@@ -689,29 +689,20 @@ unsigned HTMLImageElement::height()
     return Style::adjustLayoutUnitForAbsoluteZoom(contentRect.height(), *box).round();
 }
 
-float HTMLImageElement::effectiveImageDevicePixelRatio() const
-{
-    RefPtr cachedImage = m_imageLoader->image();
-    if (!cachedImage)
-        return 1.0f;
-
-    RefPtr image = cachedImage->image();
-    if (image && image->drawsSVGImage())
-        return 1.0f;
-
-    return m_imageDevicePixelRatio;
-}
-
 unsigned HTMLImageElement::naturalWidth() const
 {
     RefPtr image = m_imageLoader->image();
-    return image ? image->unclampedImageSizeForRenderer(protect(renderer()).get(), effectiveImageDevicePixelRatio()).width().toUnsigned() : 0;
+    if (!image)
+        return 0;
+    return image->unclampedImageSizeForRenderer(protect(renderer()).get(), 1.0f, CachedImage::IntrinsicSize, m_imageDevicePixelRatio).width().toUnsigned();
 }
 
 unsigned HTMLImageElement::naturalHeight() const
 {
     RefPtr image = m_imageLoader->image();
-    return image ? image->unclampedImageSizeForRenderer(protect(renderer()).get(), effectiveImageDevicePixelRatio()).height().toUnsigned() : 0;
+    if (!image)
+        return 0;
+    return image->unclampedImageSizeForRenderer(protect(renderer()).get(), 1.0f, CachedImage::IntrinsicSize, m_imageDevicePixelRatio).height().toUnsigned();
 }
 
 bool HTMLImageElement::isURLAttribute(const Attribute& attribute) const

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -243,8 +243,6 @@ private:
 
     void copyNonAttributePropertiesFromElement(const Element&) final;
 
-    float effectiveImageDevicePixelRatio() const;
-    
 #if ENABLE(SERVICE_CONTROLS)
     bool childShouldCreateRenderer(const Node&) const override;
 #endif

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -308,39 +308,54 @@ void CachedImage::setContainerContextForClient(const CachedImageClient& client, 
     m_svgImageCache->setContainerContextForClient(client, containerSize, containerZoom, imageURL);
 }
 
-FloatSize CachedImage::imageSizeForRenderer(const RenderElement* renderer, SizeType sizeType) const
+FloatSize CachedImage::internalImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType sizeType, float density) const
 {
     RefPtr image = m_image;
     if (!image)
         return { };
 
+    if (RefPtr svgImage = dynamicDowncast<SVGImage>(*image)) {
+        FloatSize size;
+        if (sizeType == UsedSize) {
+            // The SVG cache size is already in CSS pixels (set by the layout
+            // system via setContainerContextForClient), so density does not apply.
+            size = m_svgImageCache->imageSizeForRenderer(renderer);
+        } else
+            size = svgImage->resolvedIntrinsicSize(density);
+        if (multiplier != 1.0f)
+            size.scale(multiplier);
+        return size;
+    }
+
+    FloatSize imageSize;
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
     if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer); renderImage && renderImage->isMultiRepresentationHEIC())
-        return renderImage->style().fontCascade().primaryFont().metricsForMultiRepresentationHEIC().size();
+        imageSize = renderImage->style().fontCascade().primaryFont().metricsForMultiRepresentationHEIC().size();
+    else
 #endif
+        imageSize = image->size(renderer ? renderer->imageOrientation() : ImageOrientation(ImageOrientation::Orientation::FromImage));
 
-    if (image->drawsSVGImage() && sizeType == UsedSize)
-        return m_svgImageCache->imageSizeForRenderer(renderer);
-
-    return image->size(renderer ? renderer->imageOrientation() : ImageOrientation(ImageOrientation::Orientation::FromImage));
+    float scaleFactor = multiplier * density;
+    float widthScale = image->hasRelativeWidth() ? 1.0f : scaleFactor;
+    float heightScale = image->hasRelativeHeight() ? 1.0f : scaleFactor;
+    if (widthScale != 1.0f || heightScale != 1.0f)
+        imageSize.scale(widthScale, heightScale);
+    return imageSize;
 }
 
-
-LayoutSize CachedImage::unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType sizeType) const
+FloatSize CachedImage::imageSizeForRenderer(const RenderElement* renderer) const
 {
-    LayoutSize imageSize = LayoutSize(imageSizeForRenderer(renderer, sizeType));
-    if (imageSize.isEmpty() || multiplier == 1.0f)
-        return imageSize;
-
-    float widthScale = m_image->hasRelativeWidth() ? 1.0f : multiplier;
-    float heightScale = m_image->hasRelativeHeight() ? 1.0f : multiplier;
-    imageSize.scale(widthScale, heightScale);
-    return imageSize;    
+    return internalImageSizeForRenderer(renderer, 1.0f, UsedSize, 1.0f);
 }
 
-LayoutSize CachedImage::imageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType sizeType) const
+LayoutSize CachedImage::unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType sizeType, float density) const
 {
-    auto imageSize = unclampedImageSizeForRenderer(renderer, multiplier, sizeType);
+    return LayoutSize(internalImageSizeForRenderer(renderer, multiplier, sizeType, density));
+}
+
+LayoutSize CachedImage::imageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType sizeType, float density) const
+{
+    auto imageSize = unclampedImageSizeForRenderer(renderer, multiplier, sizeType, density);
     if (imageSize.isEmpty() || multiplier == 1.0f)
         return imageSize;
 

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -79,10 +79,10 @@ public:
         UsedSize,
         IntrinsicSize
     };
-    WEBCORE_EXPORT FloatSize imageSizeForRenderer(const RenderElement* renderer, SizeType = UsedSize) const;
+    WEBCORE_EXPORT FloatSize imageSizeForRenderer(const RenderElement*) const;
     // This method takes a zoom multiplier that can be used to increase the natural size of the image by the zoom.
-    LayoutSize imageSizeForRenderer(const RenderElement*, float multiplier, SizeType = UsedSize) const; // returns the size of the complete image.
-    LayoutSize unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType = UsedSize) const;
+    LayoutSize imageSizeForRenderer(const RenderElement*, float multiplier, SizeType = UsedSize, float density = 1.0f) const;
+    LayoutSize unclampedImageSizeForRenderer(const RenderElement*, float multiplier, SizeType = UsedSize, float density = 1.0f) const;
     void computeIntrinsicDimensions(float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio);
 
     bool hasHDRContent() const;
@@ -106,6 +106,8 @@ public:
     bool allowsAnimation(const Image&) const;
 
 private:
+    FloatSize internalImageSizeForRenderer(const RenderElement*, float multiplier, SizeType, float density) const;
+
     void clear();
 
     void setBodyDataFrom(const CachedResource&) final;

--- a/Source/WebCore/platform/graphics/GeneratedImage.h
+++ b/Source/WebCore/platform/graphics/GeneratedImage.h
@@ -34,6 +34,8 @@ class GeneratedImage : public Image {
 public:
     void setContainerSize(const FloatSize& size) override { m_size = size; }
     bool usesContainerSize() const override { return true; }
+    bool hasIntrinsicWidth() const override { return false; }
+    bool hasIntrinsicHeight() const override { return false; }
     bool hasRelativeWidth() const override { return true; }
     bool hasRelativeHeight() const override { return true; }
     void computeIntrinsicDimensions(float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio) override;

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -97,6 +97,9 @@ public:
 
     virtual void setContainerSize(const FloatSize&) { }
     virtual bool usesContainerSize() const { return false; }
+    virtual bool hasIntrinsicWidth() const { return true; }
+    virtual bool hasIntrinsicHeight() const { return true; }
+    // FIXME: hasRelativeWidth/Height should be deduplicated with hasIntrinsicWidth/Height.
     virtual bool hasRelativeWidth() const { return false; }
     virtual bool hasRelativeHeight() const { return false; }
     virtual void computeIntrinsicDimensions(float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio);

--- a/Source/WebCore/rendering/RenderImageResource.cpp
+++ b/Source/WebCore/rendering/RenderImageResource.cpp
@@ -29,10 +29,8 @@
 #include "RenderImageResource.h"
 
 #include "CachedImage.h"
-#include "Image.h"
 #include "NullGraphicsContext.h"
 #include "RenderElement.h"
-#include "RenderImage.h"
 #include "RenderStyle+GettersInlines.h"
 #include "StyleCachedImage.h"
 #include "StyleInvalidImage.h"
@@ -144,10 +142,7 @@ LayoutSize RenderImageResource::imageSize(float multiplier, CachedImage::SizeTyp
 {
     if (!m_styleImage)
         return { };
-    auto size = LayoutSize(m_styleImage->imageSize(m_renderer.get(), multiplier, type));
-    if (auto* renderImage = dynamicDowncast<RenderImage>(m_renderer.get()))
-        size.scale(renderImage->imageDevicePixelRatio());
-    return size;
+    return LayoutSize(m_styleImage->imageSize(m_renderer.get(), multiplier, type));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -67,9 +67,9 @@ RenderSVGRoot::RenderSVGRoot(SVGSVGElement& element, RenderStyle&& style)
 {
     ASSERT(isRenderSVGRoot());
     LayoutSize intrinsicSize(computeIntrinsicSize());
-    if (!intrinsicSize.width())
+    if (!svgSVGElement().hasIntrinsicWidth())
         intrinsicSize.setWidth(defaultWidth);
-    if (!intrinsicSize.height())
+    if (!svgSVGElement().hasIntrinsicHeight())
         intrinsicSize.setHeight(defaultHeight);
     setIntrinsicSize(intrinsicSize);
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -65,9 +65,9 @@ LegacyRenderSVGRoot::LegacyRenderSVGRoot(SVGSVGElement& element, RenderStyle&& s
 {
     ASSERT(isLegacyRenderSVGRoot());
     LayoutSize intrinsicSize(computeIntrinsicSize());
-    if (!intrinsicSize.width())
+    if (!svgSVGElement().hasIntrinsicWidth())
         intrinsicSize.setWidth(defaultWidth);
-    if (!intrinsicSize.height())
+    if (!svgSVGElement().hasIntrinsicHeight())
         intrinsicSize.setHeight(defaultHeight);
     setIntrinsicSize(intrinsicSize);
 }

--- a/Source/WebCore/style/values/images/kinds/StyleCachedImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCachedImage.cpp
@@ -30,6 +30,7 @@
 #include "ContainerNodeInlines.h"
 #include "ReferencedSVGResources.h"
 #include "RenderElement.h"
+#include "RenderImage.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGResourceMasker.h"
 #include "RenderView.h"
@@ -236,7 +237,10 @@ FloatSize CachedImage::imageSize(const RenderElement* renderer, float multiplier
         return m_containerSize;
     if (!m_cachedImage)
         return { };
-    return m_cachedImage->imageSizeForRenderer(renderer, multiplier, sizeType) / m_scaleFactor;
+    float density = 1.0f;
+    if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer))
+        density = renderImage->imageDevicePixelRatio();
+    return m_cachedImage->imageSizeForRenderer(renderer, multiplier, sizeType, density) / m_scaleFactor;
 }
 
 bool CachedImage::imageHasRelativeWidth() const

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -100,6 +100,45 @@ RefPtr<SVGSVGElement> SVGImage::rootElement() const
     return DocumentSVG::rootElement(*localMainFrame->document());
 }
 
+FloatSize SVGImage::resolvedIntrinsicSize(float density) const
+{
+    constexpr float defaultWidth = 300;
+    constexpr float defaultHeight = 150;
+
+    RefPtr rootElement = this->rootElement();
+    if (!rootElement)
+        return { defaultWidth, defaultHeight };
+
+    std::optional<float> aspectRatio;
+    auto viewBox = rootElement->viewBox();
+    if (!viewBox.isEmpty())
+        aspectRatio = viewBox.width() / viewBox.height();
+
+    constexpr float defaultRatio = defaultWidth / defaultHeight;
+    float width = defaultWidth;
+    float height = defaultHeight;
+
+    // Four cases for { hasIntrinsicWidth, hasIntrinsicHeight }.
+    if (rootElement->hasIntrinsicWidth()) {
+        width = rootElement->intrinsicWidth() * density;
+        if (rootElement->hasIntrinsicHeight())
+            height = rootElement->intrinsicHeight() * density;  // Case 1: { true, true }
+        else if (aspectRatio)                                   // Case 2: { true, false }
+            height = width / *aspectRatio;
+    } else if (rootElement->hasIntrinsicHeight()) {
+        height = rootElement->intrinsicHeight() * density;
+        if (aspectRatio)                                        // Case 3: { false, true }
+            width = height * *aspectRatio;
+    } else if (aspectRatio) {
+        if (*aspectRatio >= defaultRatio)                       // Case 4: { false, false }
+            height = width / *aspectRatio;
+        else
+            width = height * *aspectRatio;
+    }
+
+    return { width, height };
+}
+
 bool SVGImage::renderingTaintsOrigin() const
 {
     RefPtr rootElement = this->rootElement();
@@ -373,15 +412,27 @@ LocalFrameView* SVGImage::frameView() const
     return localMainFrame->view();
 }
 
+bool SVGImage::hasIntrinsicWidth() const
+{
+    RefPtr rootElement = this->rootElement();
+    return rootElement && rootElement->hasIntrinsicWidth();
+}
+
+bool SVGImage::hasIntrinsicHeight() const
+{
+    RefPtr rootElement = this->rootElement();
+    return rootElement && rootElement->hasIntrinsicHeight();
+}
+
 bool SVGImage::hasRelativeWidth() const
 {
-    // FIXME: This seems wrong.
+    // FIXME: Delete this function and replace all the calls to it with !hasIntrinsicWidth().
     return false;
 }
 
 bool SVGImage::hasRelativeHeight() const
 {
-    // FIXME: This seems wrong.
+    // FIXME: Delete this function and replace all the calls to it with !hasIntrinsicHeight().
     return false;
 }
 

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -59,6 +59,8 @@ public:
 
     bool renderingTaintsOrigin() const final;
 
+    bool hasIntrinsicWidth() const final;
+    bool hasIntrinsicHeight() const final;
     bool hasRelativeWidth() const final;
     bool hasRelativeHeight() const final;
 
@@ -74,6 +76,8 @@ public:
 
     Page* internalPage() { return m_page.get(); }
     WEBCORE_EXPORT RefPtr<SVGSVGElement> rootElement() const;
+
+    FloatSize resolvedIntrinsicSize(float density = 1.0f) const;
 
     RefPtr<NativeImage> nativeImage(const FloatSize&, const DestinationColorSpace& = DestinationColorSpace::SRGB());
 


### PR DESCRIPTION
#### 7a59ef69ef562614ed25ae6bd54081a674e44d23
<pre>
Improve &lt;img&gt;&apos;s naturalWidth &amp; naturalHeight with SVG images
<a href="https://bugs.webkit.org/show_bug.cgi?id=284341">https://bugs.webkit.org/show_bug.cgi?id=284341</a>
<a href="https://rdar.apple.com/141196049">rdar://141196049</a>

Reviewed by Said Abou-Hallawa (OOPS\!).

For SVG images that lack some intrinsic dimensions, we need to use the
300 x 150 CSS defaults for naturalWidth &amp; naturalHeight. However,
srcset&apos;s density should only scale intrinsic dimensions, not these
defaults. This is standardized in HTML and more background is
available here:

    <a href="https://github.com/whatwg/html/issues/11287">https://github.com/whatwg/html/issues/11287</a>

To fix this we add SVGImage::resolvedIntrinsicSize(density) which
resolves missing dimensions using the defaults and the aspect ratio, if
any, applying density only to intrinsic dimensions. We add
SVGImage::hasIntrinsicWidth/Height() (and the corresponding Image
virtuals) so callers can query which dimensions exist.

We thread a density parameter through CachedImage&apos;s sizing methods
(separate from the existing multiplier) so that
StyleCachedImage::imageSize() can pass it from the renderer&apos;s
imageDevicePixelRatio to internalImageSizeForRenderer().

Canonical link: <a href="https://commits.webkit.org/312552@main">https://commits.webkit.org/312552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/437841de86d4cb3b93473484e2824beb71353276

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160309 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115375 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2b4a120-eff8-4817-827c-507f72ef2034) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124289 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4b8e30e-1522-4d1d-9e7d-1a3d7c4d3e3f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104888 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afb60bcf-2f87-4fd0-b19d-176906c29592) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25579 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24080 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16931 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171689 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18047 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132539 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132563 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35839 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143552 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95222 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27177 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20366 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32949 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99710 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32450 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32694 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->