### PR TITLE
[threaded-animations] remove `KeyframeEffectStack::m_acceleratedEffects`

### DIFF
--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -34,7 +34,6 @@
 #include "RenderStyle+GettersInlines.h"
 #include "RotateTransformOperation.h"
 #include "ScaleTransformOperation.h"
-#include "Settings.h"
 #include "StyleInterpolation.h"
 #include "StyleRotate.h"
 #include "StyleScale.h"
@@ -334,14 +333,8 @@ void KeyframeEffectStack::applyPendingAcceleratedActions() const
     }
 }
 
-bool KeyframeEffectStack::hasAcceleratedEffects(const Settings& settings) const
+bool KeyframeEffectStack::hasAcceleratedEffects() const
 {
-#if ENABLE(THREADED_ANIMATIONS)
-    if (settings.threadedScrollDrivenAnimationsEnabled() || settings.threadedTimeBasedAnimationsEnabled())
-        return !m_acceleratedEffects.isEmptyIgnoringNullReferences();
-#else
-    UNUSED_PARAM(settings);
-#endif
     return hasMatchingEffect([](const auto& effect) {
         return effect.isRunningAccelerated();
     });

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -84,19 +84,13 @@ public:
 
     void applyPendingAcceleratedActions() const;
 
-    bool hasAcceleratedEffects(const Settings&) const;
-#if ENABLE(THREADED_ANIMATIONS)
-    void setAcceleratedEffects(WeakListHashSet<AcceleratedEffect>&& acceleratedEffects) { m_acceleratedEffects = WTF::move(acceleratedEffects); }
-#endif
+    bool hasAcceleratedEffects() const;
 
 private:
     void startAcceleratedAnimationsIfPossible();
     void stopAcceleratedAnimations();
 
     Vector<WeakPtr<KeyframeEffect>> m_effects;
-#if ENABLE(THREADED_ANIMATIONS)
-    WeakListHashSet<AcceleratedEffect> m_acceleratedEffects;
-#endif
     HashSet<String> m_invalidCSSAnimationNames;
     HashSet<AnimatableCSSProperty> m_acceleratedPropertiesOverriddenByCascade;
     std::optional<Style::Animations> m_cssAnimationList;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4580,7 +4580,6 @@ void RenderLayerBacking::updateAcceleratedEffectsAndBaseValues(HashSet<Ref<Accel
     AcceleratedEffects acceleratedEffects;
     HashSet<Ref<AcceleratedTimeline>> effectTimelines;
     if (auto* effectStack = target->keyframeEffectStack()) {
-        WeakListHashSet<AcceleratedEffect> weakAcceleratedEffects;
         if (effectStack->allowsAcceleration()) {
             auto animatesWidth = effectStack->containsProperty(CSSPropertyWidth);
             auto animatesHeight = effectStack->containsProperty(CSSPropertyHeight);
@@ -4612,11 +4611,9 @@ void RenderLayerBacking::updateAcceleratedEffectsAndBaseValues(HashSet<Ref<Accel
                 if (!hasEffectAffectingBackdropFilter && acceleratedProperties.contains(AcceleratedEffectProperty::BackdropFilter))
                     hasEffectAffectingBackdropFilter = true;
                 effectTimelines.add(Ref { *acceleratedEffect->timeline() });
-                weakAcceleratedEffects.add(acceleratedEffect.ptr());
                 acceleratedEffects.append(WTF::move(acceleratedEffect));
             }
         }
-        effectStack->setAcceleratedEffects(WTF::move(weakAcceleratedEffects));
     }
 
     // Effects were added in reverse, so we need to reverse the accelerated effects.

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -256,7 +256,7 @@ bool Styleable::isRunningAcceleratedTransformRelatedAnimation() const
 bool Styleable::hasRunningAcceleratedAnimations() const
 {
     if (auto* effectStack = keyframeEffectStack()) {
-        if (effectStack->hasAcceleratedEffects(element.document().settings()))
+        if (effectStack->hasAcceleratedEffects())
             return true;
     }
 


### PR DESCRIPTION
#### 15d5907f99af2f747033e5981ad5d61e918a3587
<pre>
[threaded-animations] remove `KeyframeEffectStack::m_acceleratedEffects`
<a href="https://bugs.webkit.org/show_bug.cgi?id=312142">https://bugs.webkit.org/show_bug.cgi?id=312142</a>
<a href="https://rdar.apple.com/174647940">rdar://174647940</a>

Reviewed by Anne van Kesteren.

We keep a list of all accelerated effects on `KeyframeEffectStack` for the sole purpose
of implementing `KeyframeEffectStack::hasAcceleratedEffects()` which can already query
all effects using `KeyframeEffect::isRunningAccelerated()`. It probably was useful during
bring up of threaded animations when that was the most reliable way to implenent that
function but seems unnecessary at this juncture so we remove it.

* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::hasAcceleratedEffects const):
* Source/WebCore/animation/KeyframeEffectStack.h:
(WebCore::KeyframeEffectStack::setAcceleratedEffects): Deleted.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::hasRunningAcceleratedAnimations const):

Canonical link: <a href="https://commits.webkit.org/311111@main">https://commits.webkit.org/311111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70e00f5f80a7741bf31bf69e734c18ee2c08e467

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164786 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120795 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101484 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22096 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20229 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12617 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131757 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167266 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11440 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128915 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129048 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139745 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86630 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23756 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23875 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16543 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28591 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92548 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28118 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28346 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28242 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->