### PR TITLE
innerText: fix whitespace handling at inline-block boundaries

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -38,7 +38,7 @@ PASS Whitespace collapses across element boundaries ("<div><span>abc </span><spa
 PASS Whitespace collapses across element boundaries ("<div><span>abc </span><span style='white-space:pre'></span> def")
 PASS Whitespace around <input> should not be collapsed ("<div>abc <input> def")
 PASS Whitespace around inline-block should not be collapsed ("<div>abc <span style='display:inline-block'></span> def")
-FAIL Trailing space at end of inline-block should be collapsed ("<div>abc <span style='display:inline-block'> def </span> ghi") assert_equals: innerText expected "abc def ghi" but got "abc def  ghi"
+PASS Trailing space at end of inline-block should be collapsed ("<div>abc <span style='display:inline-block'> def </span> ghi")
 FAIL Whitespace between <input> and block should be collapsed ("<div><input> <div>abc</div>") assert_equals: innerText expected "abc" but got "\nabc"
 PASS Whitespace between inline-block and block should be collapsed ("<div><span style='inline-block'></span> <div>abc</div>")
 PASS Whitespace around <img> should not be collapsed ("<div>abc <img> def")
@@ -169,7 +169,7 @@ FAIL Invisible <p> doesn't induce extra line breaks ("<div style='visibility:hid
 PASS <pre> trailing newlines don't suppress <p> blank line ("<div><pre>abc\n\n</pre><p>def")
 PASS No blank lines around <div> with margin ("<div>abc<div style='margin:2em'>def")
 PASS No newlines at display:inline-block boundary ("<div>123<span style='display:inline-block'>abc</span>def")
-FAIL Leading/trailing space removal at display:inline-block boundary ("<div>123<span style='display:inline-block'> abc </span>def") assert_equals: innerText expected "123abcdef" but got "123 abc def"
+PASS Leading/trailing space removal at display:inline-block boundary ("<div>123<span style='display:inline-block'> abc </span>def")
 PASS Blank lines around <p> even without margin ("<div>123<p style='margin:0px'>abc</p>def")
 PASS No blank lines around <h1> ("<div>123<h1>abc</h1>def")
 PASS No blank lines around <h2> ("<div>123<h2>abc</h2>def")

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1095,13 +1095,13 @@ void TextIterator::representNodeOffsetZero()
     // on m_currentNode to see if it necessitates emitting a character first and will early return
     // before encountering shouldRepresentNodeOffsetZero()s worse case behavior.
     RefPtr currentNode = m_currentNode;
+    bool emitsNewlinesPerInnerTextSpec = m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec);
     if (shouldEmitTabBeforeNode(*currentNode)) {
         if (shouldRepresentNodeOffsetZero()) {
             RefPtr parentNode = currentNode->parentNode();
             emitCharacter('\t', WTF::move(parentNode), WTF::move(currentNode), 0, 0);
         }
     } else if (shouldEmitNewlineBeforeNode(*currentNode)) {
-        bool emitsNewlinesPerInnerTextSpec = m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec);
         if (shouldRepresentNodeOffsetZero()) {
             RefPtr parentNode = currentNode->parentNode();
             emitCharacter('\n', WTF::move(parentNode), WTF::move(currentNode), 0, 0);
@@ -1129,6 +1129,18 @@ void TextIterator::representNodeOffsetZero()
         if (shouldRepresentNodeOffsetZero()) {
             RefPtr parentNode = currentNode->parentNode();
             emitCharacter(objectReplacementCharacter, WTF::move(parentNode), WTF::move(currentNode), 0, 0);
+        }
+    }
+
+    // When entering an inline-level block formatting context (e.g. inline-block),
+    // suppress leading collapsed whitespace. For normal blocks, the '\n' emitted
+    // above achieves this because '\n' is collapsible whitespace, preventing
+    // shouldEmitWhitespace from firing. Inline-blocks don't emit '\n', so mimic
+    // the same effect without emitting a visible character.
+    if (emitsNewlinesPerInnerTextSpec) {
+        if (CheckedPtr renderer = dynamicDowncast<RenderBlock>(m_currentNode->renderer()); renderer && renderer->isInline() && !renderer->isRenderTable()) {
+            m_lastTextNodeEndedWithCollapsedSpace = false;
+            m_lastCharacter = '\n';
         }
     }
 }
@@ -1191,6 +1203,13 @@ void TextIterator::exitNode(Node* exitedNode)
         RefPtr parentNode = baseNode->parentNode();
         emitCharacter(' ', WTF::move(parentNode), WTF::move(baseNode), 1, 1);
     }
+
+    // Trailing collapsed whitespace inside a block formatting context (e.g. inline-block)
+    // should not leak into the outer flow. For block-level elements, emitCharacter('\n')
+    // above already resets this flag, but for inline-level elements that establish a BFC
+    // (like inline-block), no newline is emitted, so we must reset it explicitly.
+    if (m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec) && is<RenderBlock>(exitedNode->renderer()))
+        m_lastTextNodeEndedWithCollapsedSpace = false;
 }
 
 void TextIterator::emitCharacter(char16_t character, RefPtr<Node>&& characterNode, RefPtr<Node>&& offsetBaseNode, int textStartOffset, int textEndOffset)


### PR DESCRIPTION
#### 0db1abc4325425550f7948871cb1c3d78b9dcd83
<pre>
innerText: fix whitespace handling at inline-block boundaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=312143">https://bugs.webkit.org/show_bug.cgi?id=312143</a>

Reviewed by Darin Adler.

The TextIterator tracks collapsed whitespace via
m_lastTextNodeEndedWithCollapsedSpace to emit spaces between text runs.
However, this flag was leaking across inline-block boundaries in both
directions:

  1. Trailing collapsed whitespace inside an inline-block (at its block
     end boundary) leaked into the outer flow, causing a spurious extra
     space after the inline-block&apos;s content.

  2. Leading collapsed whitespace inside an inline-block (at its block
     start boundary) was emitted as a visible space, because the
     TextIterator didn&apos;t know it had entered a new block formatting context.

For normal block-level elements, these issues don&apos;t arise: entering a
block emits &apos;\n&apos; (which suppresses leading whitespace since &apos;\n&apos; is
collapsible), and exiting emits &apos;\n&apos; (which resets the collapsed space
flag). Inline-blocks are inline-level, so no &apos;\n&apos; is emitted in either
direction.

Fix this by:
  - In exitNode(), resetting m_lastTextNodeEndedWithCollapsedSpace when
    exiting any RenderBlock, so trailing collapsed whitespace from an inner
    BFC doesn&apos;t leak outward.
  - In representNodeOffsetZero(), setting m_lastCharacter to &apos;\n&apos; when
    entering an inline-level RenderBlock (excluding inline-tables which
    have their own handling), to suppress leading collapsed whitespace
    inside the BFC — mimicking the effect of the &apos;\n&apos; emitted for normal
    blocks without producing visible output.

No new tests, rebaselined existing test.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::representNodeOffsetZero):
(WebCore::TextIterator::exitNode):

Canonical link: <a href="https://commits.webkit.org/311163@main">https://commits.webkit.org/311163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d3526bd20f6bb5f33788631bf9af6d472d00b44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109973 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120805 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85081 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101494 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22100 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20242 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12629 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167278 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11452 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128925 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129058 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34997 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139755 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86644 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16553 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28603 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92560 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28130 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28358 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28254 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->