### PR TITLE
Resync `dom/traversal` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-currentNode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-currentNode-expected.txt
@@ -1,5 +1,6 @@
 
 PASS Test that TreeWalker.parent() doesn't set the currentNode to a node not under the root.
+PASS Test that setting currentNode to non-Node values throws.
 PASS Test that we handle setting the currentNode to arbitrary nodes not under the root element.
 PASS Test how we handle the case when the traversed to node is within the root, but the currentElement is not.
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-currentNode.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-currentNode.html
@@ -33,6 +33,14 @@ test(function()
 
 test(function()
 {
+    var w = document.createTreeWalker(subTree, NodeFilter.SHOW_ELEMENT, all);
+    assert_throws_js(TypeError, function() { w.currentNode = null; });
+    assert_throws_js(TypeError, function() { w.currentNode = {}; });
+    assert_throws_js(TypeError, function() { w.currentNode = window; });
+}, "Test that setting currentNode to non-Node values throws.");
+
+test(function()
+{
     var w = document.createTreeWalker(subTree,
                                       NodeFilter.SHOW_ELEMENT
                                       | NodeFilter.SHOW_COMMENT,

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-realm-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-realm-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Node returned by TreeWalker from different realm assert_true: expected true got false
+FAIL Node returned by TreeWalker from different realm with acceptNode assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-realm.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-realm.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<title>TreeWalker tests</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+test(t => {
+  const i = document.createElement("iframe");
+  i.srcdoc = "<!DOCTYPE html>";
+  document.body.appendChild(i);
+  t.add_cleanup(() => i.remove());
+
+  const walker = document.createTreeWalker(i.contentDocument,
+                                           NodeFilter.SHOW_ELEMENT);
+  walker.nextNode();
+  assert_true(walker.currentNode instanceof i.contentWindow.Node);
+}, "Node returned by TreeWalker from different realm");
+
+test(t => {
+  const i = document.createElement("iframe");
+  i.srcdoc = "<!DOCTYPE html>";
+  document.body.appendChild(i);
+  t.add_cleanup(() => i.remove());
+
+  let acceptNode_node;
+  const walker = document.createTreeWalker(
+      i.contentDocument, NodeFilter.SHOW_ELEMENT,
+      {
+          acceptNode(node) {
+              acceptNode_node = node;
+              return NodeFilter.FILTER_ACCEPT;
+          }
+      });
+
+  walker.nextNode();
+  assert_true(acceptNode_node instanceof i.contentWindow.Node);
+  assert_true(walker.currentNode instanceof i.contentWindow.Node);
+}, "Node returned by TreeWalker from different realm with acceptNode");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/unfinished/001.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/unfinished/001.xml
@@ -49,5 +49,5 @@
  </body>
  <!-- some more nodes to test this: -->
  <?test node?>
- 
+ <![CDATA[]]>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/unfinished/002.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/unfinished/002.xml
@@ -50,5 +50,5 @@
  </body>
  <!-- some more nodes to test this: -->
  <?test node?>
- 
+ <![CDATA[]]>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/unfinished/010.xml
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/unfinished/010.xml
@@ -60,5 +60,5 @@
  </body>
  <!-- some more nodes to test this: -->
  <?body test?>
- 
+ <![CDATA[]]>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/w3c-import.log
@@ -24,6 +24,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-currentNode.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-previousNodeLastChildReject.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-previousSiblingLastChildSkip.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-realm.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-traversal-reject.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-traversal-skip-most.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-traversal-skip.html


### PR DESCRIPTION
#### 7f06806685b001a7a23e8550a23e55bdea0eec64
<pre>
Resync `dom/traversal` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=312144">https://bugs.webkit.org/show_bug.cgi?id=312144</a>
<a href="https://rdar.apple.com/174648256">rdar://174648256</a>

Reviewed by Brandon Stewart, Vitor Roriz, and Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d9f5c182f95f8dc39b5ea5f22f3ee3bd16900997">https://github.com/web-platform-tests/wpt/commit/d9f5c182f95f8dc39b5ea5f22f3ee3bd16900997</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-currentNode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-currentNode.html:
* LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-realm-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/traversal/TreeWalker-realm.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/traversal/unfinished/001.xml:
* LayoutTests/imported/w3c/web-platform-tests/dom/traversal/unfinished/002.xml:
* LayoutTests/imported/w3c/web-platform-tests/dom/traversal/unfinished/010.xml:
* LayoutTests/imported/w3c/web-platform-tests/dom/traversal/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/311124@main">https://commits.webkit.org/311124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/803897f0388d0e27f0680897ab5f2c878c2b2079

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164789 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120796 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101485 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22099 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20232 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12620 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167269 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19561 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128916 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129049 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34970 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139743 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86633 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16541 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28594 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28121 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28349 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28245 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->