### PR TITLE
Import WPT tests for compression dictionary transport

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/README.md
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/README.md
@@ -1,0 +1,3 @@
+These are the tests for the [Compression Dictionary Transport](https://datatracker.ietf.org/doc/draft-ietf-httpbis-compression-dictionary/) standard (currently in IETF draft state, approved for publication). The tests are marked as tentative, pending the publication of the RFC.
+
+The MDN reference is [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Compression_dictionary_transport).

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: compression-dictionary-transport
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cache.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cache.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Clear-Site-Data with "cache" directive must unregister dictionary assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cache.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cache.tentative.https.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+</head>
+<body>
+<script>
+
+compression_dictionary_promise_test(async (t) => {
+  const dict = await (await fetch(kRegisterDictionaryPath)).text();
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+  // Clear site data.
+  assert_equals(await clearSiteData(/*directive=*/'cache'), 'OK');
+  // Check if `available-dictionary` header is not available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {max_retry: 0}),
+      '"available-dictionary" header is not available');
+}, 'Clear-Site-Data with "cache" directive must unregister dictionary');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cookies.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cookies.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Clear-Site-Data with "cookies" directive must unregister dictionary assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cookies.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cookies.tentative.https.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+</head>
+<body>
+<script>
+
+compression_dictionary_promise_test(async (t) => {
+  const dict = await (await fetch(kRegisterDictionaryPath)).text();
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+  // Clear site data.
+  assert_equals(await clearSiteData(/*directive=*/'cookies'), 'OK');
+  // Check if `available-dictionary` header is not available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {max_retry: 0}),
+      '"available-dictionary" header is not available');
+}, 'Clear-Site-Data with "cookies" directive must unregister dictionary');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-storage.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-storage.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Clear-Site-Data with "storage" directive must not unregister dictionary assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-storage.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-storage.tentative.https.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+</head>
+<body>
+<script>
+
+compression_dictionary_promise_test(async (t) => {
+  const dict = await (await fetch(kRegisterDictionaryPath)).text();
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+  // Clear site data.
+  assert_equals(await clearSiteData(/*directive=*/'storage'), 'OK');
+  // Check if `available-dictionary` header is not available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {max_retry: 0}),
+      kDefaultDictionaryHashBase64);
+}, 'Clear-Site-Data with "storage" directive must not unregister dictionary');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-compressed.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-compressed.tentative.https-expected.txt
@@ -1,0 +1,7 @@
+
+FAIL Decompresion using gzip-encoded dictionary works as expected assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+FAIL Decompresion using Brotli-encoded dictionary works as expected assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+FAIL Decompresion using Zstandard-encoded dictionary works as expected assert_equals: expected "This is a test dictionary.\n" but got "(\ufffd/\ufffd$\x1b\ufffd\0\0This is a test dictionary.\n?\rv\ufffd"
+FAIL A dcb dictionary-compressed dictionary can be used as a dictionary for future requests. assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+FAIL A dcz dictionary-compressed dictionary can be used as a dictionary for future requests. assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-compressed.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-compressed.tentative.https.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+</head>
+<body>
+<script>
+
+// This is a set of tests for the dictionary itself being compressed, both by
+// non-dictionary content encodings and dictionary encodings. The encoding used
+// for the dictionary itself is independent of the encoding used for the data
+// so the test uses different encodings just to make sure that the dictionaries
+// don't carry any encoding-specific dependencies.
+
+compression_dictionary_promise_test(async (t) => {
+  const dictionaryUrl =
+    `${SAME_ORIGIN_RESOURCES_URL}/register-dictionary.py?content_encoding=gzip`;
+  const dict = await (await fetch(dictionaryUrl)).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  const dictionary_hash = await waitUntilAvailableDictionaryHeader(t, {});
+  assert_equals(dictionary_hash, kDefaultDictionaryHashBase64);
+
+  // Check if the data compressed using the dictionary can be decompressed.
+  const data_url = `${kCompressedDataPath}?content_encoding=dcb`;
+  const data = await (await fetch(data_url)).text();
+  assert_equals(data, kExpectedCompressedData);
+}, 'Decompresion using gzip-encoded dictionary works as expected');
+
+compression_dictionary_promise_test(async (t) => {
+  const dictionaryUrl =
+    `${SAME_ORIGIN_RESOURCES_URL}/register-dictionary.py?content_encoding=br`;
+  const dict = await (await fetch(dictionaryUrl)).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  const dictionary_hash = await waitUntilAvailableDictionaryHeader(t, {});
+  assert_equals(dictionary_hash, kDefaultDictionaryHashBase64);
+
+  // Check if the data compressed using the dictionary can be decompressed.
+  const data_url = `${kCompressedDataPath}?content_encoding=dcz`;
+  const data = await (await fetch(data_url)).text();
+  assert_equals(data, kExpectedCompressedData);
+}, 'Decompresion using Brotli-encoded dictionary works as expected');
+
+compression_dictionary_promise_test(async (t) => {
+  const dictionaryUrl =
+    `${SAME_ORIGIN_RESOURCES_URL}/register-dictionary.py?content_encoding=zstd`;
+  const dict = await (await fetch(dictionaryUrl)).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  const dictionary_hash = await waitUntilAvailableDictionaryHeader(t, {});
+  assert_equals(dictionary_hash, kDefaultDictionaryHashBase64);
+
+  // Check if the data compressed using Brotli with the dictionary can be
+  // decompressed (Zstandard decompression of the data is tested separately).
+  const data_url = `${kCompressedDataPath}?content_encoding=dcb`;
+  const data = await (await fetch(data_url)).text();
+  assert_equals(data, kExpectedCompressedData);
+}, 'Decompresion using Zstandard-encoded dictionary works as expected');
+
+compression_dictionary_promise_test(async (t) => {
+  const dictionaryUrl = `${SAME_ORIGIN_RESOURCES_URL}/register-dictionary.py?id=id1`;
+  const dict = await (await fetch(dictionaryUrl)).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+
+  // Register another dictionary, compressed with dcb using the first dictionary.
+  const compressedDictionaryUrl =
+    `${SAME_ORIGIN_RESOURCES_URL}/register-dictionary.py?content_encoding=dcb&id=id2`;
+  const dict2 = await (await fetch(compressedDictionaryUrl)).text();
+  assert_equals(dict2, kDefaultDictionaryContent);
+  await waitUntilHeader(t, "dictionary-id", {expected_header: '"id2"'});
+
+  // Check if the data compressed using dcz with the updated dictionary works.
+  const data_url = `${SAME_ORIGIN_RESOURCES_URL}/compressed-data.py?content_encoding=dcz`;
+  const data = await (await fetch(data_url)).text();
+  assert_equals(data, kExpectedCompressedData);
+}, 'A dcb dictionary-compressed dictionary can be used as a dictionary for future requests.');
+
+compression_dictionary_promise_test(async (t) => {
+  const dictionaryUrl = `${SAME_ORIGIN_RESOURCES_URL}/register-dictionary.py?id=id1`;
+  const dict = await (await fetch(dictionaryUrl)).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+
+  // Register another dictionary, compressed with dcz using the first dictionary.
+  const compressedDictionaryUrl =
+    `${SAME_ORIGIN_RESOURCES_URL}/register-dictionary.py?content_encoding=dcz&id=id2`;
+  const dict2 = await (await fetch(compressedDictionaryUrl)).text();
+  assert_equals(dict2, kDefaultDictionaryContent);
+  await waitUntilHeader(t, "dictionary-id", {expected_header: '"id2"'});
+
+  // Check if the data compressed using dcb with the updated dictionary works.
+  const data_url = `${SAME_ORIGIN_RESOURCES_URL}/compressed-data.py?content_encoding=dcb`;
+  const data = await (await fetch(data_url)).text();
+  assert_equals(data, kExpectedCompressedData);
+}, 'A dcz dictionary-compressed dictionary can be used as a dictionary for future requests.');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-decompression.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-decompression.tentative.https-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL Decompresion using Brotli with the dictionary works as expected assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+FAIL Decompresion using Zstandard with the dictionary works as expected assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+FAIL Decompresion of a cross origin resource works as expected assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-decompression.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-decompression.tentative.https.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+</head>
+<body>
+<script>
+
+compression_dictionary_promise_test(async (t) => {
+  const dict = await (await fetch(kRegisterDictionaryPath)).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+
+  // Check if the data compressed using Brotli with the dictionary can be
+  // decompressed.
+  const data_url = `${kCompressedDataPath}?content_encoding=dcb`;
+  assert_equals(await (await fetch(data_url)).text(), kExpectedCompressedData);
+}, 'Decompresion using Brotli with the dictionary works as expected');
+
+compression_dictionary_promise_test(async (t) => {
+  const dict = await (await fetch(kRegisterDictionaryPath)).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+
+  // Check if the data compressed using Zstandard with the dictionary can be
+  // decompressed.
+  const data_url = `${kCompressedDataPath}?content_encoding=dcz`;
+  assert_equals(await (await fetch(data_url)).text(), kExpectedCompressedData);
+}, 'Decompresion using Zstandard with the dictionary works as expected');
+
+compression_dictionary_promise_test(async (t) => {
+  const dict =
+      await (await fetch(getRemoteHostUrl(kRegisterDictionaryPath))).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {check_remote: true}),
+      kDefaultDictionaryHashBase64);
+
+  // Check if the data compressed using Brotli with the dictionary can be
+  // decompressed.
+  const data_url =
+      getRemoteHostUrl(`${kCompressedDataPath}?content_encoding=dcb`);
+  assert_equals(await (await fetch(data_url)).text(), kExpectedCompressedData);
+}, 'Decompresion of a cross origin resource works as expected');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Fetch cross-origin no-cors request does not include Available-Dictionary header assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/utils.js"></script>
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+</head>
+<body>
+<script>
+
+function getHeadersCrossorigin() {
+  function headersCallback(r) {
+    return (x) => {
+      r(x);
+    }
+  }
+  let script = document.createElement("script");
+  return new Promise((resolve, reject) => {
+    getHeadersCrossorigin['callback'] = headersCallback(resolve);
+    script.src =
+      `${CROSS_ORIGIN_RESOURCES_URL}/echo-headers.py?callback=getHeadersCrossorigin.callback`;
+    document.head.appendChild(script);
+  });
+}
+
+compression_dictionary_promise_test(async (t) => {
+  // Register the dictionary
+  const dict = await (await fetch(kRegisterDictionaryPath)).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+  // Test a no-cors crossorigin fetch
+  const headers = await getHeadersCrossorigin();
+  assert_false("available-dictionary" in headers);
+}, 'Fetch cross-origin no-cors request does not include Available-Dictionary header');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element.tentative.https-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL Browser supports link element with compression-dictionary rel. assert_true: expected true got false
+FAIL Fetch same origin dictionary using link element assert_true: Headers should be available expected true got false
+FAIL Fetch cross origin dictionary using link element assert_true: Headers should be available expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element.tentative.https.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/utils.js"></script>
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+</head>
+<body>
+<script>
+
+function addLinkRelCompressionDictionaryElement(url, crossOrigin) {
+  const link = document.createElement('link');
+  link.rel = 'compression-dictionary';
+  link.href = url;
+  if (crossOrigin) {
+    link.crossOrigin = crossOrigin;
+  }
+  document.head.appendChild(link);
+}
+
+test(t => {
+    const link_element = document.createElement('link');
+    assert_true(link_element.relList.supports('compression-dictionary'));
+  }, "Browser supports link element with compression-dictionary rel.");
+
+compression_dictionary_promise_test(async (t) => {
+  const dict_token = token();
+  const url = `${kRegisterDictionaryPath}?save_header=${dict_token}`;
+  addLinkRelCompressionDictionaryElement(url);
+  // Wait for a while to ensure that the dictionary is fetched.
+  await new Promise(resolve => window.requestIdleCallback(resolve));
+  const headers = await waitUntilPreviousRequestHeaders(t, dict_token);
+  assert_true(headers !== undefined, 'Headers should be available');
+  assert_equals(headers['sec-fetch-mode'], 'cors');
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+  // Check if the data compressed using Brotli with the dictionary can be
+  // decompressed.
+  const data_url = `${kCompressedDataPath}?content_encoding=dcb`;
+  assert_equals(await (await fetch(data_url)).text(), kExpectedCompressedData);
+}, 'Fetch same origin dictionary using link element');
+
+compression_dictionary_promise_test(async (t) => {
+  const dict_token = token();
+  const url =
+      getRemoteHostUrl(`${kRegisterDictionaryPath}?save_header=${dict_token}`);
+  addLinkRelCompressionDictionaryElement(url, 'anonymous');
+  // Wait for a while to ensure that the dictionary is fetched.
+  await new Promise(resolve => window.requestIdleCallback(resolve));
+  const headers = await waitUntilPreviousRequestHeaders(
+      t, dict_token, /*check_remote=*/ true);
+  assert_true(headers !== undefined, 'Headers should be available');
+  assert_equals(headers['sec-fetch-mode'], 'cors');
+
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {check_remote: true}),
+      kDefaultDictionaryHashBase64);
+  // Check if the data compressed using Brotli with the dictionary can be
+  // decompressed.
+  const data_url =
+      getRemoteHostUrl(`${kCompressedDataPath}?content_encoding=dcb`);
+  assert_equals(await (await fetch(data_url)).text(), kExpectedCompressedData);
+}, 'Fetch cross origin dictionary using link element');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-header.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-header.tentative.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Fetch same origin dictionary using link header assert_true: Headers should be available expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-header.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-header.tentative.https.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/utils.js"></script>
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+</head>
+<body>
+<script>
+
+async function addIframeWithLinkRelCompressionDictionaryHeader(dict_url) {
+  return new Promise((resolve) => {
+    const base_page_url = './resources/empty.html';
+    const page_url =
+        base_page_url +
+        `?pipe=header(link,<${dict_url}>; rel="compression-dictionary")`;
+    const iframe = document.createElement('iframe');
+    iframe.src = page_url;
+    iframe.addEventListener('load', () => {
+      resolve(iframe);
+    });
+    document.body.appendChild(iframe);
+  })
+}
+
+compression_dictionary_promise_test(async (t) => {
+  const dict_token = token();
+  const url = new URL(
+      `${kRegisterDictionaryPath}?save_header=${dict_token}`, location.href);
+  const iframe =
+      await addIframeWithLinkRelCompressionDictionaryHeader(url.href);
+  t.add_cleanup(() => {
+    iframe.remove();
+  });
+  // Wait for a while to ensure that the dictionary is fetched.
+  await new Promise(resolve => window.requestIdleCallback(resolve));
+  const headers = await waitUntilPreviousRequestHeaders(t, dict_token);
+  assert_true(headers !== undefined, 'Headers should be available');
+  assert_equals(headers['sec-fetch-mode'], 'cors');
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+  // Check if the data compressed using Brotli with the dictionary can be
+  // decompressed.
+  const data_url = `${kCompressedDataPath}?content_encoding=dcb`;
+  assert_equals(await (await fetch(data_url)).text(), kExpectedCompressedData);
+}, 'Fetch same origin dictionary using link header');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-registration.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-registration.tentative.https-expected.txt
@@ -1,0 +1,7 @@
+
+FAIL Simple dictionary registration and unregistration assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+FAIL Dictionary registration with dictionary ID assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+FAIL New dictionary registration overrides the existing one assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+FAIL Dictionary registration does not invalidate cache entry assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+FAIL Expired dictionary is not used assert_equals: expected ":U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:" but got "\"available-dictionary\" header is not available"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-registration.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-registration.tentative.https.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="timeout" content="long"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/utils.js"></script>
+<script src="./resources/compression-dictionary-util.sub.js"></script>
+</head>
+<body>
+<script>
+
+compression_dictionary_promise_test(async (t) => {
+  const dict = await (await fetch(kRegisterDictionaryPath)).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+}, 'Simple dictionary registration and unregistration');
+
+compression_dictionary_promise_test(async (t) => {
+  const dict = await (await fetch(`${kRegisterDictionaryPath}?id=test`)).text();
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+  assert_equals(await checkHeader('dictionary-id', {}), '"test"');
+}, 'Dictionary registration with dictionary ID');
+
+compression_dictionary_promise_test(async (t) => {
+  // Registers a first dictionary.
+  const dictionary_path1 = `${kRegisterDictionaryPath}?id=id1`;
+  const dict1 = await (await fetch(dictionary_path1)).text();
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+  // Check the `dictionary-id` header.
+  assert_equals(await checkHeader('dictionary-id', {}), '"id1"');
+
+  // Registers a second dictionary.
+  const kAlternativeDictionaryContent =
+      'This is an alternative test dictionary.';
+  const dictionary_path2 =
+      `${kRegisterDictionaryPath}?content=${kAlternativeDictionaryContent}&id=id2`;
+  const expected_dictionary_header =
+      await calculateDictionaryHash(kAlternativeDictionaryContent);
+  const dict2 = await (await fetch(dictionary_path2)).text();
+  assert_equals(dict2, kAlternativeDictionaryContent);
+  // Wait until `available-dictionary` header is available.
+  // Note: Passing `expected_header` to ignore the old dictionary.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(
+          t, {expected_header: expected_dictionary_header}),
+      expected_dictionary_header);
+  // Check the `dictionary-id` header.
+  assert_equals(await checkHeader('dictionary-id', {}), '"id2"');
+}, 'New dictionary registration overrides the existing one');
+
+compression_dictionary_promise_test(async (t) => {
+  // Dictionary responses often include
+  // Vary: available-dictionary, accept-encoding
+  // We need to make sure that the browser cache does not actually vary
+  // based on those headers, otherwise a resource that uses itself as a
+  // dictionary would trigger a second fetch of the same resource.
+  const dictionaryUrl = `${SAME_ORIGIN_RESOURCES_URL}/register-dictionary.py?id=cache`;
+  const dict = await (await fetch(dictionaryUrl)).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  // Wait until `available-dictionary` header is available.
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {}),
+      kDefaultDictionaryHashBase64);
+
+  // re-fetch the dictionary (should come from cache)
+  const dict2 = await (await fetch(dictionaryUrl)).text();
+  assert_equals(dict2, kDefaultDictionaryContent);
+
+  const entries = performance.getEntriesByName(dictionaryUrl);
+  assert_equals(entries.length, 2);
+  assert_not_equals(entries[0].transferSize, 0);
+  assert_equals(entries[1].transferSize, 0);
+}, 'Dictionary registration does not invalidate cache entry');
+
+compression_dictionary_promise_test(async (t) => {
+  // Register a dictionary that has already expired (age > max-age).
+  // Make sure it is on a path separate from another dictionary so they can
+  // be checked independently.
+  const pattern = "%2Ffetch%2Fcompression-dictionary%2Fresources%2Fecho-headers.py";
+  await fetch(`${kRegisterDictionaryPath}?id=id1&age=7200&max-age=3600&match=${pattern}`);
+  // register another dictionary that we can use to tell when the first
+  // dictionary should also be registered (since the first dictionary
+  // should not send any headers that can be detected directly).
+  const pattern2 = "%2Ffetch%2Fcompression-dictionary%2Fresources%2Fecho-headers2.py";
+  await fetch(`${kRegisterDictionaryPath}?id=id2&match=${pattern2}`);
+  assert_equals(
+      await waitUntilAvailableDictionaryHeader(t, {use_alt_path: true}),
+      kDefaultDictionaryHashBase64);
+  assert_equals((await checkHeaders({use_alt_path: true}))['dictionary-id'], '"id2"');
+  // Make sure the expired dictionary isn't announced as being available.
+  const headers = await (await fetch('./resources/echo-headers.py')).json();
+  assert_false("available-dictionary" in headers);
+}, 'Expired dictionary is not used');
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/clear-site-data.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/clear-site-data.py
@@ -1,0 +1,4 @@
+def main(request, response):
+    directive = request.GET.first(b"directive")
+    response.headers.set(b"Clear-Site-Data", b"\"" + directive + b"\"")
+    return b"OK"

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/compressed-data.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/compressed-data.py
@@ -1,0 +1,62 @@
+def main(request, response):
+    response.headers.set(b"Access-Control-Allow-Origin", b"*")
+    response.headers.set(b"Content-Type", b"text/plain")
+
+    if b'cacheable' in request.GET:
+        response.headers.set(b"Cache-Control", b"max-age=3600")
+
+    # `dcb_data` and `dcz_data` are generated using the following commands:
+    #
+    # $ echo "This is a test dictionary." > /tmp/dict
+    # $ echo -n "This is compressed test data using a test dictionary" \
+    #    > /tmp/data
+    #
+    # $ echo -en '\xffDCB' > /tmp/out.dcb
+    # $ openssl dgst -sha256 -binary /tmp/dict >> /tmp/out.dcb
+    # $ brotli --stdout -D /tmp/dict /tmp/data >> /tmp/out.dcb
+    # $ xxd -p /tmp/out.dcb | tr -d '\n' | sed 's/\(..\)/\\x\1/g'
+    dcb_data = b"\xff\x44\x43\x42\x53\x96\x9b\xcf\x5e\x96\x0e\x0e\xdb\xf0\xa4\xbd\xde\x6b\x0b\x3e\x93\x81\xe1\x56\xde\x7f\x5b\x91\xce\x83\x91\x62\x42\x70\xf4\x16\xa1\x98\x01\x80\x62\xa4\x4c\x1d\xdf\x12\x84\x8c\xae\xc2\xca\x60\x22\x07\x6e\x81\x05\x14\xc9\xb7\xc3\x44\x8e\xbc\x16\xe0\x15\x0e\xec\xc1\xee\x34\x33\x3e\x0d"
+    # $ echo -en '\x5e\x2a\x4d\x18\x20\x00\x00\x00' > /tmp/out.dcz
+    # $ openssl dgst -sha256 -binary /tmp/dict >> /tmp/out.dcz
+    # $ zstd -D /tmp/dict -f -o /tmp/tmp.zstd /tmp/data
+    # $ cat /tmp/tmp.zstd >> /tmp/out.dcz
+    # $ xxd -p /tmp/out.dcz | tr -d '\n' | sed 's/\(..\)/\\x\1/g'
+    dcz_data = b"\x5e\x2a\x4d\x18\x20\x00\x00\x00\x53\x96\x9b\xcf\x5e\x96\x0e\x0e\xdb\xf0\xa4\xbd\xde\x6b\x0b\x3e\x93\x81\xe1\x56\xde\x7f\x5b\x91\xce\x83\x91\x62\x42\x70\xf4\x16\x28\xb5\x2f\xfd\x24\x34\xf5\x00\x00\x98\x63\x6f\x6d\x70\x72\x65\x73\x73\x65\x64\x61\x74\x61\x20\x75\x73\x69\x6e\x67\x03\x00\x59\xf9\x73\x54\x46\x27\x26\x10\x9e\x99\xf2\xbc"
+
+    # `large_dcb_data` and `large_dcz_data` are generated the same way as
+    # above but with a larger input (348 bytes) that compresses well with the
+    # dictionary, so the encoded size is smaller than the decoded size:
+    #
+    # $ echo "This is a test dictionary." > /tmp/dict
+    # $ python3 -c "import sys; sys.stdout.write(
+    #     'This is a test dictionary. ' * 10 +
+    #     'This is additional test data that also references the test '
+    #     'dictionary content.')" > /tmp/large_data
+    # $ echo -en '\xffDCB' > /tmp/out.dcb
+    # $ openssl dgst -sha256 -binary /tmp/dict >> /tmp/out.dcb
+    # $ brotli --stdout -D /tmp/dict /tmp/large_data >> /tmp/out.dcb
+    # $ xxd -p /tmp/out.dcb | tr -d '\n' | sed 's/\(..\)/\\x\1/g'
+    large_dcb_data = b"\xff\x44\x43\x42\x53\x96\x9b\xcf\x5e\x96\x0e\x0e\xdb\xf0\xa4\xbd\xde\x6b\x0b\x3e\x93\x81\xe1\x56\xde\x7f\x5b\x91\xce\x83\x91\x62\x42\x70\xf4\x16\xa1\xd8\x0a\x00\x2f\xea\xb6\x54\x17\xd2\x63\x1f\x3a\x79\x10\x85\x6f\xb0\x01\x07\x6e\x41\x4a\xc3\x42\xb4\xe9\xb0\x01\x17\x71\x94\x7c\xe9\xaf\x81\xdc\xde\xc0\xc8\xc1\x66\x88\x34\x03\x5e\x7f\x8c\x8e\x46\x6f\xc9\x48\xab\xc8\x71\x2c"
+    # $ echo -en '\x5e\x2a\x4d\x18\x20\x00\x00\x00' > /tmp/out.dcz
+    # $ openssl dgst -sha256 -binary /tmp/dict >> /tmp/out.dcz
+    # $ zstd -D /tmp/dict -f -o /tmp/tmp.zstd /tmp/large_data
+    # $ cat /tmp/tmp.zstd >> /tmp/out.dcz
+    # $ xxd -p /tmp/out.dcz | tr -d '\n' | sed 's/\(..\)/\\x\1/g'
+    large_dcz_data = b"\x5e\x2a\x4d\x18\x20\x00\x00\x00\x53\x96\x9b\xcf\x5e\x96\x0e\x0e\xdb\xf0\xa4\xbd\xde\x6b\x0b\x3e\x93\x81\xe1\x56\xde\x7f\x5b\x91\xce\x83\x91\x62\x42\x70\xf4\x16\x28\xb5\x2f\xfd\x64\x5c\x00\xfd\x01\x00\xf4\x02\x20\x64\x64\x69\x74\x69\x6f\x6e\x61\x6c\x61\x74\x61\x20\x74\x68\x61\x74\x20\x61\x6c\x73\x6f\x20\x72\x65\x66\x65\x72\x65\x6e\x63\x65\x73\x20\x74\x68\x65\x20\x63\x6f\x6e\x74\x65\x6e\x74\x2e\x04\x00\x60\x2d\x72\x35\x2b\xbb\x3c\xa0\xce\xed\x19\x04\x0c\x4b\x9e\x2f"
+
+    use_large = b'large' in request.GET
+
+    if b'content_encoding' in request.GET:
+        content_encoding = request.GET.first(b"content_encoding")
+        response.headers.set(b"Content-Encoding", content_encoding)
+        if content_encoding == b"dcb":
+            # Send the pre compressed file
+            response.content = large_dcb_data if use_large else dcb_data
+        if content_encoding == b"dcz":
+            # Send the pre compressed file
+            response.content = large_dcz_data if use_large else dcz_data
+
+
+
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/compression-dictionary-util.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/compression-dictionary-util.sub.js
@@ -1,0 +1,145 @@
+const SAME_ORIGIN = "https://{{host}}:{{ports[https][0]}}";
+const CROSS_ORIGIN = "https://{{hosts[alt][www]}}:{{ports[https][0]}}";
+
+const RESOURCES_PATH = "/fetch/compression-dictionary/resources";
+const SAME_ORIGIN_RESOURCES_URL = SAME_ORIGIN + RESOURCES_PATH;
+const CROSS_ORIGIN_RESOURCES_URL = CROSS_ORIGIN + RESOURCES_PATH;
+
+const kDefaultDictionaryContent = 'This is a test dictionary.\n';
+const kDefaultDictionaryHashBase64 =
+    ':U5abz16WDg7b8KS93msLPpOB4Vbef1uRzoORYkJw9BY=:';
+const kRegisterDictionaryPath = './resources/register-dictionary.py';
+const kCompressedDataPath = './resources/compressed-data.py';
+const kExpectedCompressedData =
+    `This is compressed test data using a test dictionary`;
+const kCheckHeaderMaxRetry = 10;
+const kCheckHeaderRetryTimeout = 200;
+const kCheckPreviousRequestHeadersMaxRetry = 5;
+const kCheckPreviousRequestHeadersRetryTimeout = 250;
+
+// Gets the remote URL corresponding to `relative_path`.
+function getRemoteHostUrl(relative_path) {
+  const remote_origin = new URL(get_host_info().HTTPS_REMOTE_ORIGIN);
+  let result = new URL(relative_path, location.href);
+  result.protocol = remote_origin.protocol;
+  result.hostname = remote_origin.hostname;
+  result.port = remote_origin.port;
+  return result.href;
+}
+
+// Calculates the Structured Field Byte Sequence containing the SHA-256 hash of
+// the contents of the dictionary text.
+async function calculateDictionaryHash(dictionary_text) {
+  const encoded = (new TextEncoder()).encode(dictionary_text);
+  const digest = await crypto.subtle.digest('SHA-256', encoded)
+  return ':' + btoa(String.fromCharCode(...new Uint8Array(digest))) + ':';
+}
+
+// Checks the HTTP request headers which is sent to the server.
+async function checkHeaders({check_remote = false, use_alt_path = false}) {
+  let url = use_alt_path ? './resources/echo-headers2.py' :
+                           './resources/echo-headers.py';
+  if (check_remote) {
+    url = getRemoteHostUrl(url);
+  }
+  return await (await fetch(url)).json();
+}
+
+// Checks the specified header in the HTTP request headers.
+async function checkHeader(header, {
+    check_remote = false,
+    use_alt_path = false}) {
+  return (await checkHeaders({check_remote: check_remote, use_alt_path: use_alt_path}))[header];
+}
+
+// Waits until the specified header is available in the HTTP
+// request headers, and returns the header. If the header is not available after
+// the specified number of retries, returns an error message. If the
+// `expected_header` is specified, this method waits until the header is
+// available and matches the `expected_header`.
+async function waitUntilHeader(test, header, {
+  max_retry = kCheckHeaderMaxRetry,
+  expected_header = undefined,
+  check_remote = false,
+  use_alt_path = false
+}) {
+  for (let retry_count = 0; retry_count <= max_retry; retry_count++) {
+    const response_header = await checkHeader(header, {check_remote: check_remote,
+                                                       use_alt_path: use_alt_path});
+    if (response_header) {
+      if (expected_header === undefined || response_header == expected_header) {
+        return response_header;
+      }
+    }
+    await new Promise(
+        (resolve) => test.step_timeout(
+            resolve, kCheckHeaderRetryTimeout));
+  }
+  return `"${header}" header is not available`;
+}
+
+async function waitUntilAvailableDictionaryHeader(test, {
+  max_retry = kCheckHeaderMaxRetry,
+  expected_header = undefined,
+  check_remote = false,
+  use_alt_path = false
+}) {
+  return waitUntilHeader(test, 'available-dictionary', {
+    max_retry: max_retry,
+    expected_header: expected_header,
+    check_remote: check_remote,
+    use_alt_path: use_alt_path
+  });
+}
+
+// Checks the HTTP request headers which was sent to the server with `token`
+// to register a dictionary.
+async function checkPreviousRequestHeaders(token, check_remote = false) {
+  let url = `./resources/register-dictionary.py?get_previous_header=${token}`;
+  if (check_remote) {
+    url = getRemoteHostUrl(url);
+  }
+  return await (await fetch(url)).json();
+}
+
+// Waits until the HTTP request headers which was sent to the server with
+// `token` to register a dictionary is available, and returns the header. If the
+// header is not available after the specified number of retries, returns
+// `undefined`.
+async function waitUntilPreviousRequestHeaders(
+    test, token, check_remote = false) {
+  for (let retry_count = 0; retry_count <= kCheckPreviousRequestHeadersMaxRetry;
+       retry_count++) {
+    const header =
+        (await checkPreviousRequestHeaders(token, check_remote))['headers'];
+    if (header) {
+      return header;
+    }
+    await new Promise(
+        (resolve) => test.step_timeout(
+            resolve, kCheckPreviousRequestHeadersRetryTimeout));
+  }
+  return undefined;
+}
+
+// Clears the site data for the specified directive by sending a request to
+// `./resources/clear-site-data.py` which returns `Clear-Site-Data` response
+// header.
+// Note: When `directive` is 'cache' or 'cookies' is specified, registered
+// compression dictionaries should be also cleared.
+async function clearSiteData(directive = 'cache') {
+  return await (await fetch(
+                    `./resources/clear-site-data.py?directive=${directive}`))
+      .text();
+}
+
+// A utility test method that adds the `clearSiteData()` method to the
+// testharness cleanup function. This is intended to ensure that registered
+// dictionaries are cleared in tests and that registered dictionaries do not
+// interfere with subsequent tests.
+function compression_dictionary_promise_test(func, name, properties) {
+  promise_test(async (test) => {
+    test.add_cleanup(clearSiteData);
+    await func(test);
+  }, name, properties);
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/echo-headers.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/echo-headers.py
@@ -1,0 +1,7 @@
+import importlib
+
+handler_utils = importlib.import_module(
+    "fetch.compression-dictionary.resources.handler_utils")
+
+def main(request, response):
+    return handler_utils.create_echo_response(request, response)

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/echo-headers2.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/echo-headers2.py
@@ -1,0 +1,7 @@
+import importlib
+
+handler_utils = importlib.import_module(
+    "fetch.compression-dictionary.resources.handler_utils")
+
+def main(request, response):
+    return handler_utils.create_echo_response(request, response)

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/empty.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/empty.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/handler_utils.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/handler_utils.py
@@ -1,0 +1,16 @@
+import json
+
+def create_echo_response(request, response):
+    response.headers.set(b"Access-Control-Allow-Origin", b"*")
+    headers = {}
+    for header in request.headers:
+        key = header.decode('utf-8')
+        value = request.headers.get(header).decode('utf-8')
+        headers[key] = value
+    result = json.dumps(headers)
+    # If there is a callback, treat it as JSONP and wrap the result in the provided callback
+    if b'callback' in request.GET:
+        callback = request.GET.first(b"callback").decode('utf-8')
+        result = callback + '(' + result + ');'
+
+    return result

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/register-dictionary.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/register-dictionary.py
@@ -1,0 +1,84 @@
+import json
+
+def main(request, response):
+    response.headers.set(b"Access-Control-Allow-Origin", b"*")
+    match = b"/fetch/compression-dictionary/resources/*"
+    content = b"This is a test dictionary.\n"
+    max_age = b"3600"
+    if b"match" in request.GET:
+        match = request.GET.first(b"match")
+    if b"content" in request.GET:
+        content = request.GET.first(b"content")
+    if b"max-age" in request.GET:
+        max_age = request.GET.first(b"max-age")
+
+    token = request.GET.first(b"save_header", None)
+    if token is not None:
+        headers = {}
+        for header in request.headers:
+            key = header.decode('utf-8')
+            value = request.headers.get(header).decode('utf-8')
+            headers[key] = value
+        with request.server.stash.lock:
+            request.server.stash.put(token, json.dumps(headers))
+
+    previous_token = request.GET.first(b"get_previous_header", None)
+    if previous_token is not None:
+        result = {}
+        with request.server.stash.lock:
+            store = request.server.stash.take(previous_token)
+            if store is not None:
+                headers = json.loads(store)
+                result["headers"] = headers
+            return json.dumps(result)
+
+    options = b"match=\"" + match + b"\""
+    if b"id" in request.GET:
+        options += b", id=\"" + request.GET.first(b"id") + b"\""
+    response.headers.set(b"Use-As-Dictionary", options)
+    response.headers.set(b"Cache-Control", b"max-age=" + max_age)
+    if b"age" in request.GET:
+        response.headers.set(b"Age", request.GET.first(b"age"))
+    response.headers.set(b"Vary", b"available-dictionary,accept-encoding")
+
+    # Compressed responses are generated using the following commands:
+    #
+    # $ echo "This is a test dictionary." > /tmp/dict
+    # $ echo "This is a test dictionary." > /tmp/data
+    #
+    # $ gzip < /tmp/data > /tmp/out.gz
+    # $ xxd -p /tmp/out.gz | tr -d '\n' | sed 's/\(..\)/\\x\1/g'
+    gzip_data = b"\x1f\x8b\x08\x00\x10\x31\x47\x68\x00\x03\x0b\xc9\xc8\x2c\x56\x00\xa2\x44\x85\x92\xd4\xe2\x12\x85\x94\xcc\xe4\x92\xcc\xfc\xbc\xc4\xa2\x4a\x3d\x2e\x00\x79\xf2\x36\x63\x1b\x00\x00\x00"
+    # $ brotli -o /tmp/out.br /tmp/data
+    # $ xxd -p /tmp/out.br | tr -d '\n' | sed 's/\(..\)/\\x\1/g'
+    br_data = b"\xa1\xd0\x00\xc0\x6f\xa4\x74\xf3\x56\xb5\x02\x48\x18\x9d\x2a\x9b\xcb\x42\x14\x81\xa7\x14\xda\x89\x29\x93\x7b\xc8\x09"
+    # $ zstd -f -o /tmp/out.zstd /tmp/data
+    # $ xxd -p /tmp/out.zstd | tr -d '\n' | sed 's/\(..\)/\\x\1/g'
+    zstd_data = b"\x28\xb5\x2f\xfd\x24\x1b\xd9\x00\x00\x54\x68\x69\x73\x20\x69\x73\x20\x61\x20\x74\x65\x73\x74\x20\x64\x69\x63\x74\x69\x6f\x6e\x61\x72\x79\x2e\x0a\x3f\x0d\x76\xa0"
+    # $ echo -en '\xffDCB' > /tmp/out.dcb
+    # $ openssl dgst -sha256 -binary /tmp/dict >> /tmp/out.dcb
+    # $ brotli --stdout -D /tmp/dict /tmp/data >> /tmp/out.dcb
+    # $ xxd -p /tmp/out.dcb | tr -d '\n' | sed 's/\(..\)/\\x\1/g'
+    dcb_data = b"\xff\x44\x43\x42\x53\x96\x9b\xcf\x5e\x96\x0e\x0e\xdb\xf0\xa4\xbd\xde\x6b\x0b\x3e\x93\x81\xe1\x56\xde\x7f\x5b\x91\xce\x83\x91\x62\x42\x70\xf4\x16\xa1\xd0\x00\xc0\x2f\x01\x10\xc4\x84\x0a\x05"
+    # $ echo -en '\x5e\x2a\x4d\x18\x20\x00\x00\x00' > /tmp/out.dcz
+    # $ openssl dgst -sha256 -binary /tmp/dict >> /tmp/out.dcz
+    # $ zstd -D /tmp/dict -f -o /tmp/tmp.zstd /tmp/data
+    # $ cat /tmp/tmp.zstd >> /tmp/out.dcz
+    # $ xxd -p /tmp/out.dcz | tr -d '\n' | sed 's/\(..\)/\\x\1/g'
+    dcz_data = b"\x5e\x2a\x4d\x18\x20\x00\x00\x00\x53\x96\x9b\xcf\x5e\x96\x0e\x0e\xdb\xf0\xa4\xbd\xde\x6b\x0b\x3e\x93\x81\xe1\x56\xde\x7f\x5b\x91\xce\x83\x91\x62\x42\x70\xf4\x16\x28\xb5\x2f\xfd\x24\x1b\x35\x00\x00\x00\x01\x00\x1e\x4e\x20\x3f\x0d\x76\xa0"
+
+    if b'content_encoding' in request.GET:
+        content_encoding = request.GET.first(b"content_encoding")
+        response.headers.set(b"Content-Encoding", content_encoding)
+        if content_encoding == b"gzip":
+            content = gzip_data
+        elif content_encoding == b"br":
+            content = br_data
+        elif content_encoding == b"zstd":
+            content = zstd_data
+        elif content_encoding == b"dcb":
+            content = dcb_data
+        elif content_encoding == b"dcz":
+            content = dcz_data
+
+    return content

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/w3c-import.log
@@ -1,0 +1,24 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/clear-site-data.py
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/compressed-data.py
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/compression-dictionary-util.sub.js
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/echo-headers.py
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/echo-headers2.py
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/empty.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/handler_utils.py
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/register-dictionary.py

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/w3c-import.log
@@ -1,0 +1,27 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/README.md
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cache.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cookies.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-storage.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-compressed.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-decompression.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-header.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-registration.tentative.https.html

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -2975,6 +2975,33 @@
     "imported/w3c/web-platform-tests/fetch/api/request/request-keepalive-quota.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cache.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cookies.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-storage.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-compressed.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-decompression.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-header.tentative.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-registration.tentative.https.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/fetch/connection-pool/network-partition-key.html": [
         "slow"
     ],


### PR DESCRIPTION
#### 6a0f7aa86405932d52dc50709024be3fc590b646
<pre>
Import WPT tests for compression dictionary transport
<a href="https://bugs.webkit.org/show_bug.cgi?id=312148">https://bugs.webkit.org/show_bug.cgi?id=312148</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d6a0d1b375b633935aea264b3accad1a728461b9">https://github.com/web-platform-tests/wpt/commit/d6a0d1b375b633935aea264b3accad1a728461b9</a>

* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/README.md: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cache.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cache.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cookies.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-cookies.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-storage.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-clear-site-data-storage.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-compressed.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-compressed.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-decompression.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-decompression.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-element.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-header.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-with-link-header.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-registration.tentative.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-registration.tentative.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/clear-site-data.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/compressed-data.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/compression-dictionary-util.sub.js: Added.
(getRemoteHostUrl):
(async calculateDictionaryHash):
(async checkHeaders):
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/echo-headers.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/echo-headers2.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/empty.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/handler_utils.py: Added.
(create_echo_response):
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/register-dictionary.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/resources/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/w3c-import.log: Added.
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/311215@main">https://commits.webkit.org/311215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ce662ba351463651c6b375a54643f7911f61eee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164864 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110121 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120813 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110121 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101500 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22109 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20250 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12637 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167342 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128931 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129064 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35027 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139764 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86655 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23891 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16562 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28611 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28138 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->