### PR TITLE
[WTF] drop `ALWAYS_LOG_WITH_STREAM` in favor of the less verbose `WTF_ALWAYS_LOG`

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -844,12 +844,6 @@ inline void wtfCompileTimeCheckPrintfSpecifier(const char* format, ...)
 
 /* ALWAYS_LOG */
 
-#define ALWAYS_LOG_WITH_STREAM(commands) do { \
-        WTF::TextStream stream(WTF::TextStream::LineMode::SingleLine); \
-        commands; \
-        WTFLogAlways("%s", stream.release().utf8().data()); \
-    } while (0)
-
 #define WTF_ALWAYS_LOG(commands) do { \
         WTF::TextStream stream(WTF::TextStream::LineMode::SingleLine); \
         stream << commands; \

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -263,7 +263,7 @@ double Value::doubleValue(NoConversionDataRequiredToken, const CSSCalcSymbolTabl
 double Value::doubleValueDeprecated() const
 {
     if (m_tree.requiresConversionData)
-        ALWAYS_LOG_WITH_STREAM(stream << "ERROR: The value returned from Value::doubleValueDeprecated is likely incorrect as the calculation tree has unresolved units that require CSSToLengthConversionData to interpret. Update caller to use non-deprecated variant of this function.");
+        WTF_ALWAYS_LOG("ERROR: The value returned from Value::doubleValueDeprecated is likely incorrect as the calculation tree has unresolved units that require CSSToLengthConversionData to interpret. Update caller to use non-deprecated variant of this function.");
 
     return doubleValue(NoConversionDataRequiredToken { });
 }

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -397,7 +397,7 @@ RefPtr<CSSValue> CSSUnitValue::toCSSValueWithProperty(CSSPropertyID propertyID) 
         auto category = calculationCategoryForProperty(propertyID, m_unit);
 
         if (!type.matches(category)) {
-            ALWAYS_LOG_WITH_STREAM(stream << "calc() type '" << type << "' is not valid for category '" << category << "'");
+            WTF_ALWAYS_LOG("calc() type '" << type << "' is not valid for category '" << category << "'");
             return nullptr;
         }
 

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -633,7 +633,7 @@ void BifurcatedGraphicsContext::verifyStateSynchronization()
     // will cause further painting to the secondary context to be mistransformed.
     auto secondaryContextCTM = m_secondaryContext.getCTM();
     if (!m_hasLoggedAboutDesynchronizedState && !primaryContextCTM.isEssentiallyEqualToAsFloats(secondaryContextCTM)) {
-        ALWAYS_LOG_WITH_STREAM(stream << "BifurcatedGraphicsContext(" << this << ") CTM is out of sync: " << primaryContextCTM << " != " << secondaryContextCTM);
+        WTF_ALWAYS_LOG("BifurcatedGraphicsContext(" << this << ") CTM is out of sync: " << primaryContextCTM << " != " << secondaryContextCTM);
         m_hasLoggedAboutDesynchronizedState = true;
     }
 }

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -40,7 +40,7 @@ static const Seconds surfaceAgeBeforeMarkingPurgeable { 2_s };
 
 #define ENABLE_IOSURFACE_POOL_STATISTICS 0
 #if ENABLE_IOSURFACE_POOL_STATISTICS
-#define DUMP_POOL_STATISTICS(commands) do { ALWAYS_LOG_WITH_STREAM(commands); } while (0);
+#define DUMP_POOL_STATISTICS(commands) do { WTF_ALWAYS_LOG(commands); } while (0);
 #else
 #define DUMP_POOL_STATISTICS(commands) ((void)0)
 #endif
@@ -52,12 +52,12 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(IOSurfacePool);
 IOSurfacePool::IOSurfacePool()
     : m_collectionTimer(RunLoop::mainSingleton(), "IOSurfacePool::CollectionTimer"_s, this, &IOSurfacePool::collectionTimerFired)
 {
-    DUMP_POOL_STATISTICS(stream << "IOSurfacePool [" << m_poolIdentifier << "] constructor.");
+    DUMP_POOL_STATISTICS("IOSurfacePool [" << m_poolIdentifier << "] constructor.");
 }
 
 IOSurfacePool::~IOSurfacePool()
 {
-    DUMP_POOL_STATISTICS(stream << "IOSurfacePool [" << m_poolIdentifier << "] destructor.");
+    DUMP_POOL_STATISTICS("IOSurfacePool [" << m_poolIdentifier << "] destructor.");
     callOnMainRunLoopAndWait([&] {
         discardAllSurfaces();
     });
@@ -127,7 +127,7 @@ std::unique_ptr<IOSurface> IOSurfacePool::takeSurface(IntSize size, const Destin
     CachedSurfaceMap::iterator mapIter = m_cachedSurfaces.find(size);
 
     if (mapIter == m_cachedSurfaces.end()) {
-        DUMP_POOL_STATISTICS(stream << "IOSurfacePool::takeSurface [" << m_poolIdentifier << "] - failed to find surface matching size " << size << " color space " << colorSpace << " format " << format << "\n" << poolStatistics());
+        DUMP_POOL_STATISTICS("IOSurfacePool::takeSurface [" << m_poolIdentifier << "] - failed to find surface matching size " << size << " color space " << colorSpace << " format " << format << "\n" << poolStatistics());
         return nullptr;
     }
 
@@ -149,7 +149,7 @@ std::unique_ptr<IOSurface> IOSurfacePool::takeSurface(IntSize size, const Destin
 
         surface->setVolatile(false);
 
-        DUMP_POOL_STATISTICS(stream << "IOSurfacePool::takeSurface [" << m_poolIdentifier << "] - taking surface " << surface.get() << " with size " << size << " color space " << colorSpace << " format " << format << "\n" << poolStatistics());
+        DUMP_POOL_STATISTICS("IOSurfacePool::takeSurface [" << m_poolIdentifier << "] - taking surface " << surface.get() << " with size " << size << " color space " << colorSpace << " format " << format << "\n" << poolStatistics());
         return surface;
     }
 
@@ -166,11 +166,11 @@ std::unique_ptr<IOSurface> IOSurfacePool::takeSurface(IntSize size, const Destin
 
         surface->setVolatile(false);
 
-        DUMP_POOL_STATISTICS(stream << "IOSurfacePool::takeSurface [" << m_poolIdentifier << "] - taking surface " << surface.get() << " with size " << size << " color space " << colorSpace << " format " << format << "\n" << poolStatistics());
+        DUMP_POOL_STATISTICS("IOSurfacePool::takeSurface [" << m_poolIdentifier << "] - taking surface " << surface.get() << " with size " << size << " color space " << colorSpace << " format " << format << "\n" << poolStatistics());
         return surface;
     }
 
-    DUMP_POOL_STATISTICS(stream << "IOSurfacePool::takeSurface [" << m_poolIdentifier << "] - failing\n" << poolStatistics());
+    DUMP_POOL_STATISTICS("IOSurfacePool::takeSurface [" << m_poolIdentifier << "] - failing\n" << poolStatistics());
     return nullptr;
 }
 
@@ -200,12 +200,12 @@ void IOSurfacePool::addSurface(std::unique_ptr<IOSurface>&& surface)
     if (surfaceIsInUse) {
         m_inUseSurfaces.prepend(WTF::move(surface));
         scheduleCollectionTimer();
-        DUMP_POOL_STATISTICS(stream << "IOSurfacePool::addSurface [" << m_poolIdentifier << "] - in-use\n" << poolStatistics());
+        DUMP_POOL_STATISTICS("IOSurfacePool::addSurface [" << m_poolIdentifier << "] - in-use\n" << poolStatistics());
         return;
     }
 
     insertSurfaceIntoPool(WTF::move(surface));
-    DUMP_POOL_STATISTICS(stream << "IOSurfacePool::addSurface [" << m_poolIdentifier << "]\n" << poolStatistics());
+    DUMP_POOL_STATISTICS("IOSurfacePool::addSurface [" << m_poolIdentifier << "]\n" << poolStatistics());
 }
 
 void IOSurfacePool::insertSurfaceIntoPool(std::unique_ptr<IOSurface> surface)
@@ -257,11 +257,11 @@ void IOSurfacePool::tryEvictOldestCachedSurface()
 
 void IOSurfacePool::evict(size_t additionalSize)
 {
-    DUMP_POOL_STATISTICS(stream << "IOSurfacePool::evict [" << m_poolIdentifier << "] - before evict\n" << poolStatistics());
+    DUMP_POOL_STATISTICS("IOSurfacePool::evict [" << m_poolIdentifier << "] - before evict\n" << poolStatistics());
 
     if (additionalSize >= m_maximumBytesCached) {
         discardAllSurfacesInternal();
-        DUMP_POOL_STATISTICS(stream << "IOSurfacePool::evict [" << m_poolIdentifier << "] - after evict all\n" << poolStatistics());
+        DUMP_POOL_STATISTICS("IOSurfacePool::evict [" << m_poolIdentifier << "] - after evict all\n" << poolStatistics());
         return;
     }
 
@@ -282,7 +282,7 @@ void IOSurfacePool::evict(size_t additionalSize)
     while (m_inUseBytesCached > maximumInUseBytes || m_bytesCached > targetSize)
         tryEvictInUseSurface();
 
-    DUMP_POOL_STATISTICS(stream << "IOSurfacePool::evict [" << m_poolIdentifier << "] - after evict\n" << poolStatistics());
+    DUMP_POOL_STATISTICS("IOSurfacePool::evict [" << m_poolIdentifier << "] - after evict\n" << poolStatistics());
 }
 
 void IOSurfacePool::collectInUseSurfaces()
@@ -340,7 +340,7 @@ void IOSurfacePool::collectionTimerFired()
         m_collectionTimer.stop();
 
     platformGarbageCollectNow();
-    DUMP_POOL_STATISTICS(stream << "IOSurfacePool::collectionTimerFired [" << m_poolIdentifier << "]\n" << poolStatistics());
+    DUMP_POOL_STATISTICS("IOSurfacePool::collectionTimerFired [" << m_poolIdentifier << "]\n" << poolStatistics());
 }
 
 void IOSurfacePool::scheduleCollectionTimer()

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3137,7 +3137,7 @@ def check_log(clean_lines, line_number, file_state, error):
 
     line = clean_lines.elided[line_number]  # Get rid of comments and strings.
 
-    using_always_log = search(r'\b(WTF_ALWAYS_LOG|ALWAYS_LOG_WITH_STREAM|WTFLogAlways)\s*\(', line)
+    using_always_log = search(r'\b(WTF_ALWAYS_LOG|WTFLogAlways)\s*\(', line)
     if not using_always_log:
         return
 


### PR DESCRIPTION
#### 142912be8cd48bcfbb509cec5cbfbaf97dba89e9
<pre>
[WTF] drop `ALWAYS_LOG_WITH_STREAM` in favor of the less verbose `WTF_ALWAYS_LOG`
<a href="https://bugs.webkit.org/show_bug.cgi?id=312159">https://bugs.webkit.org/show_bug.cgi?id=312159</a>

Reviewed by Wenson Hsieh.

No reason to have both when they do the exact same thing (except for the former requiring an extra `stream &lt;&lt;` at the beginning).

* Source/WTF/wtf/Assertions.h:
(ALWAYS_LOG_WITH_STREAM): Deleted.
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_log):

* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::CSSCalc::Value::doubleValueDeprecated const):
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::CSSUnitValue::toCSSValueWithProperty const):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::verifyStateSynchronization):
* Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp:
(WebCore::IOSurfacePool::IOSurfacePool):
(WebCore::IOSurfacePool::~IOSurfacePool):
(WebCore::IOSurfacePool::takeSurface):
(WebCore::IOSurfacePool::addSurface):
(WebCore::IOSurfacePool::evict):
(WebCore::IOSurfacePool::collectionTimerFired):
Replace existing uses of `ALWAYS_LOG_WITH_STREAM` with `WTF_LOG_ALWAYS` (and remove the `stream &lt;&lt;` at the beginning).

Canonical link: <a href="https://commits.webkit.org/311101@main">https://commits.webkit.org/311101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8af306d0363de745848061c784b193bb9cedb081

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156063 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22580 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157934 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/29531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29399 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/164884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159021 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/29531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/155382 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/29531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/12656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148113 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/29531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16897 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11479 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/19602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/167363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/28999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34954 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/28921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139784 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/28921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/187946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28630 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92587 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/187946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28157 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->