### PR TITLE
[threaded-animations] animating `offset-path` with a percentage-based `offset-distance` value fails

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/accelerating-offset-path-and-offset-distance-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/accelerating-offset-path-and-offset-distance-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Animating 'offset-path' with a fixed 'offset-distance' on the underlying style allows acceleration.
+PASS Animating 'offset-path' with a percentage 'offset-distance' on the underlying style does not allow acceleration.
+PASS Animating 'offset-path' with a calculated 'offset-distance' on the underlying style does not allow acceleration.
+PASS Animating 'offset-path' with an 'offset-distance' animated to a fixed value allows acceleration.
+PASS Animating 'offset-path' with an 'offset-distance' animated to a percentage value does not allow acceleration.
+PASS Animating 'offset-path' with an 'offset-distance' animated to a calculated value does not allow acceleration.
+

--- a/LayoutTests/webanimations/threaded-animations/accelerating-offset-path-and-offset-distance.html
+++ b/LayoutTests/webanimations/threaded-animations/accelerating-offset-path-and-offset-distance.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="threaded-animations-utils.js"></script>
+<style>
+
+div {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+<script>
+
+const createDiv = test => {
+    const div = document.createElement("div");
+    test.add_cleanup(() => div.remove());
+    return document.body.appendChild(div);
+}
+
+const duration = 1000 * 1000; // 1000s.
+
+promise_test(async test => {
+    const target = createDiv(test);
+    target.style.offsetDistance = "100px";
+    const animation = target.animate({ offsetPath: "rect(0px 100px 100px 0px)" }, duration);
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
+}, "Animating 'offset-path' with a fixed 'offset-distance' on the underlying style allows acceleration.");
+
+promise_test(async test => {
+    const target = createDiv(test);
+    target.style.offsetDistance = "50%";
+    const animation = target.animate({ offsetPath: "rect(0px 100px 100px 0px)" }, duration);
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+}, "Animating 'offset-path' with a percentage 'offset-distance' on the underlying style does not allow acceleration.");
+
+promise_test(async test => {
+    const target = createDiv(test);
+    target.style.offsetDistance = "calc(100px + 50%)";
+    const animation = target.animate({ offsetPath: "rect(0px 100px 100px 0px)" }, duration);
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+}, "Animating 'offset-path' with a calculated 'offset-distance' on the underlying style does not allow acceleration.");
+
+promise_test(async test => {
+    const target = createDiv(test);
+    const animation = target.animate({
+        offsetPath: "rect(0px 100px 100px 0px)",
+        offsetDistance: "100px"
+    }, duration);
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 2);
+}, "Animating 'offset-path' with an 'offset-distance' animated to a fixed value allows acceleration.");
+
+promise_test(async test => {
+    const target = createDiv(test);
+    const animation = target.animate({
+        offsetPath: "rect(0px 100px 100px 0px)",
+        offsetDistance: "50%"
+    }, duration);
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+}, "Animating 'offset-path' with an 'offset-distance' animated to a percentage value does not allow acceleration.");
+
+promise_test(async test => {
+    const target = createDiv(test);
+    const animation = target.animate({
+        offsetPath: "rect(0px 100px 100px 0px)",
+        offsetDistance: "calc(100px + 50%)"
+    }, duration);
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+}, "Animating 'offset-path' with an 'offset-distance' animated to a calculated value does not allow acceleration.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -403,12 +403,18 @@ void BlendingKeyframes::analyzeKeyframe(const BlendingKeyframe& keyframe)
             m_hasPropertiesWithRevertRuleOrLayer = true;
     };
 
+    auto analyzeOffsetDistance = [&] {
+        if (!m_animatesOffsetDistanceToPercentOrCalculated && keyframe.animatesProperty(CSSPropertyOffsetDistance))
+            m_animatesOffsetDistanceToPercentOrCalculated = style->offsetDistance().isPercentOrCalculated();
+    };
+
     analyzeSizeDependentTransform();
     analyzeDiscreteTransformInterval();
     analyzeExplicitlyInheritedKeyframeProperty();
     analyzeKeyframeForExplicitProperties();
     analyzeKeyframeRangeOffset();
     analyzeCSSWideKeywords();
+    analyzeOffsetDistance();
 }
 
 void BlendingKeyframes::updatedComputedOffsets(NOESCAPE const Function<double(const BlendingKeyframe::Offset&)>& callback)

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -165,6 +165,7 @@ public:
     bool hasExplicitlyInheritedKeyframeProperty() const { return m_hasExplicitlyInheritedKeyframeProperty; }
     bool usesAnchorFunctions() const { return m_usesAnchorFunctions; }
     bool hasKeyframeNotUsingRangeOffset() const { return m_hasKeyframeNotUsingRangeOffset; }
+    bool animatesOffsetDistanceToPercentOrCalculated() const { return m_animatesOffsetDistanceToPercentOrCalculated; }
 
     void updatedComputedOffsets(NOESCAPE const Function<double(const BlendingKeyframe::Offset&)>&);
     bool hasKeyframeWithUnresolvedComputedOffset() const;
@@ -191,6 +192,7 @@ private:
     bool m_hasExplicitlyInheritedKeyframeProperty { false };
     bool m_hasKeyframeNotUsingRangeOffset { false };
     bool m_hasPropertiesWithRevertRuleOrLayer { false };
+    bool m_animatesOffsetDistanceToPercentOrCalculated { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4562,8 +4562,9 @@ void RenderLayerBacking::updateAcceleratedEffectsAndBaseValues(HashSet<Ref<Accel
     bool hasEffectAffectingBackdropFilter = false;
     auto borderBoxRect = snappedIntRect(m_owningLayer.rendererBorderBoxRect());
 
+    auto* style = target->lastStyleChangeEventStyle();
     auto baseValues = [&]() -> AcceleratedEffectValues {
-        if (auto* style = target->lastStyleChangeEventStyle())
+        if (style)
             return { *style, borderBoxRect, &renderer };
         return { };
     }();
@@ -4588,13 +4589,27 @@ void RenderLayerBacking::updateAcceleratedEffectsAndBaseValues(HashSet<Ref<Accel
         if (effectStack->allowsAcceleration()) {
             auto animatesWidth = effectStack->containsProperty(CSSPropertyWidth);
             auto animatesHeight = effectStack->containsProperty(CSSPropertyHeight);
+            auto animatesOffsetPath = effectStack->containsProperty(CSSPropertyOffsetPath);
+
+            // If offset-distance is a percentage or is calculated, we won't have the necessary
+            // information in the remote layer tree to recompute it based on an animated offset-path.
+            if (animatesOffsetPath && style->offsetDistance().isPercentOrCalculated())
+                disallowedAcceleratedProperties.add(transformRelatedAcceleratedProperties);
+
             for (const auto& effect : effectStack->sortedEffects() | std::views::reverse) {
                 if (!effect || !effect->canHaveAcceleratedRepresentation() || !effect->canBeAccelerated())
                     continue;
-                if (animatesWidth || animatesHeight) {
-                    auto& blendingKeyframes = effect->blendingKeyframes();
-                    if ((animatesWidth && blendingKeyframes.hasWidthDependentTransform()) || (animatesHeight && blendingKeyframes.hasHeightDependentTransform()))
-                        disallowedAcceleratedProperties.add(transformRelatedAcceleratedProperties);
+                if (!disallowedAcceleratedProperties.containsAll(transformRelatedAcceleratedProperties)) {
+                    if (animatesWidth || animatesHeight) {
+                        auto& blendingKeyframes = effect->blendingKeyframes();
+                        if ((animatesWidth && blendingKeyframes.hasWidthDependentTransform()) || (animatesHeight && blendingKeyframes.hasHeightDependentTransform()))
+                            disallowedAcceleratedProperties.add(transformRelatedAcceleratedProperties);
+                    }
+                    if (animatesOffsetPath) {
+                        auto& blendingKeyframes = effect->blendingKeyframes();
+                        if (blendingKeyframes.animatesOffsetDistanceToPercentOrCalculated())
+                            disallowedAcceleratedProperties.add(transformRelatedAcceleratedProperties);
+                    }
                 }
                 Ref acceleratedEffect = effect->acceleratedRepresentation(borderBoxRect, baseValues, disallowedAcceleratedProperties);
                 // FIXME: it feels like we should be able to assert here, or perhaps we could just fold this into the logic


### PR DESCRIPTION
#### 89607e24306f029358480b0aa46d773e8019a00d
<pre>
[threaded-animations] animating `offset-path` with a percentage-based `offset-distance` value fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=310804">https://bugs.webkit.org/show_bug.cgi?id=310804</a>
<a href="https://rdar.apple.com/173926809">rdar://173926809</a>

Reviewed by Sam Weinig.

If the `offset-path` property is animated, any `offset-distance` value that depends on it will
require a styling context to resolve. In those cases, we disable threaded animations for
transform-related properties.

Test: webanimations/threaded-animations/accelerating-offset-path-and-offset-distance.html

* LayoutTests/webanimations/threaded-animations/accelerating-offset-path-and-offset-distance-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/accelerating-offset-path-and-offset-distance.html: Added.
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::analyzeKeyframe):
* Source/WebCore/animation/BlendingKeyframes.h:
(WebCore::BlendingKeyframes::animatesOffsetDistanceToPercentOrCalculated const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):

Canonical link: <a href="https://commits.webkit.org/311224@main">https://commits.webkit.org/311224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25387c22c04f089b42e43a4ace5c8282271be130

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110142 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120836 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85086 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101521 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22141 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20270 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12657 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167364 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11480 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128955 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129085 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28922 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139782 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86689 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23809 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16580 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92588 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28158 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28386 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->