### PR TITLE
[JSC][JSPI] Hide JSPI wrapper functions from stack traces

### DIFF
--- a/JSTests/wasm/stress/jspi-stack-traces.js
+++ b/JSTests/wasm/stress/jspi-stack-traces.js
@@ -1,0 +1,270 @@
+//@ requireOptions("--useJSPI=1")
+
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test that JSPI internal wrapper functions are invisible in stack traces.
+// Specifically, no stack frame should mention "promising", "Suspending", or
+// "pinball" (the internal fulfill handler used for resuspension). The stack
+// should go directly from the JS caller to the wasm functions to the JS
+// callee.
+//
+// Two wasm modules are used:
+//
+//   wasmModule:  JS -> promising(wasmEntry) -> callImport -> Suspending(js_func) -> JS
+//   deepModule:  JS -> promising(threeTimes) -> wrappedWasm -> Suspending(js_func) -> JS
+//                (threeTimes calls wrappedWasm three times and sums the results)
+//
+// Six test cases cover the combinations of:
+//   - Sync vs. async (suspended) stack capture
+//   - Normal return vs. exception
+//   - Single-call vs. multi-call (deep) wasm chains
+
+let wasmModule = `
+(module
+  (import "env" "js_func" (func $js_func (result i32)))
+  (func $callImport (export "callImport") (result i32)
+    call $js_func
+  )
+  (func $wasmEntry (export "wasmEntry") (result i32)
+    call $callImport
+  )
+)`;
+
+// Test 1: Stack trace captured synchronously (before any suspension)
+// The JS callback returns a plain value, no suspension occurs.
+
+async function testSyncStackTrace() {
+    let capturedStack = null;
+
+    function captureStack() {
+        capturedStack = new Error().stack;
+        return 42;
+    }
+
+    const instance = await instantiate(wasmModule, {
+        env: {
+            js_func: new WebAssembly.Suspending(captureStack)
+        }
+    });
+    const entry = WebAssembly.promising(instance.exports.wasmEntry);
+
+    const result = await entry();
+    assert.eq(result, 42);
+    assert.truthy(capturedStack !== null, "Stack should have been captured");
+
+    const frames = capturedStack.split("\n").map(f => f.trim()).filter(f => f.length > 0);
+
+    // Check that no frame mentions JSPI internal functions
+    for (const frame of frames) {
+        assert.falsy(frame.includes("promising"), "No frame should contain 'promising', got: " + frame);
+        assert.falsy(frame.includes("Suspending"), "No frame should contain 'Suspending', got: " + frame);
+        assert.falsy(frame.includes("pinball"), "No frame should contain 'pinball', got: " + frame);
+    }
+
+    // Verify the expected frame structure: captureStack -> callImport (wasm) -> wasmEntry (wasm)
+    let captureIdx = frames.findIndex(f => f.startsWith("captureStack@"));
+    assert.truthy(captureIdx >= 0, "Should find captureStack frame in: " + capturedStack);
+    assert.truthy(frames[captureIdx + 1].includes("wasm-function"),
+        "Frame after captureStack should be wasm callImport, got: " + frames[captureIdx + 1]);
+    assert.truthy(frames[captureIdx + 2].includes("wasm-function"),
+        "Frame after callImport should be wasm wasmEntry, got: " + frames[captureIdx + 2]);
+}
+
+// Test 2: Stack trace captured after suspension (the JS callback is async and awaits)
+// This triggers an actual JSPI suspension and resumption.
+
+async function testAsyncStackTrace() {
+    let capturedStack = null;
+
+    async function captureStackAsync() {
+        await Promise.resolve(); // Force suspension
+        capturedStack = new Error().stack;
+        return 99;
+    }
+
+    const instance = await instantiate(wasmModule, {
+        env: {
+            js_func: new WebAssembly.Suspending(captureStackAsync)
+        }
+    });
+    const entry = WebAssembly.promising(instance.exports.wasmEntry);
+
+    const result = await entry();
+    assert.eq(result, 99);
+    assert.truthy(capturedStack !== null, "Stack should have been captured after resume");
+
+    const frames = capturedStack.split("\n").map(f => f.trim()).filter(f => f.length > 0);
+
+    // After suspension and resumption, the stack may be shorter (only the async
+    // continuation), but it should still not contain promising/Suspending frames.
+    for (const frame of frames) {
+        assert.falsy(frame.includes("promising"), "No frame should contain 'promising' after resume, got: " + frame);
+        assert.falsy(frame.includes("Suspending"), "No frame should contain 'Suspending' after resume, got: " + frame);
+        assert.falsy(frame.includes("pinball"), "No frame should contain 'pinball' after resume, got: " + frame);
+    }
+}
+
+// Test 3: Stack trace from an exception thrown before suspension.
+// Verify the stack in the caught rejection doesn't contain JSPI wrapper frames.
+
+async function testExceptionStackTrace() {
+    function throwFromJS() {
+        throw new Error("intentional");
+    }
+
+    const instance = await instantiate(wasmModule, {
+        env: {
+            js_func: new WebAssembly.Suspending(throwFromJS)
+        }
+    });
+    const entry = WebAssembly.promising(instance.exports.wasmEntry);
+
+    try {
+        await entry();
+        assert.truthy(false, "Should have thrown");
+    } catch (e) {
+        assert.truthy(e instanceof Error);
+        assert.eq(e.message, "intentional");
+        const frames = e.stack.split("\n").map(f => f.trim()).filter(f => f.length > 0);
+
+        // The throw site should be visible
+        let throwIdx = frames.findIndex(f => f.startsWith("throwFromJS@"));
+        assert.truthy(throwIdx >= 0, "Should find throwFromJS in stack: " + e.stack);
+
+        // No JSPI wrapper frames
+        for (const frame of frames) {
+            assert.falsy(frame.includes("promising"), "Exception stack should not contain 'promising', got: " + frame);
+            assert.falsy(frame.includes("Suspending"), "Exception stack should not contain 'Suspending', got: " + frame);
+            assert.falsy(frame.includes("pinball"), "Exception stack should not contain 'pinball', got: " + frame);
+        }
+    }
+}
+
+// Test 4: Stack trace from an exception thrown after suspension (async throw).
+
+async function testAsyncExceptionStackTrace() {
+    async function throwAfterSuspend() {
+        await Promise.resolve();
+        throw new Error("async intentional");
+    }
+
+    const instance = await instantiate(wasmModule, {
+        env: {
+            js_func: new WebAssembly.Suspending(throwAfterSuspend)
+        }
+    });
+    const entry = WebAssembly.promising(instance.exports.wasmEntry);
+
+    try {
+        await entry();
+        assert.truthy(false, "Should have thrown");
+    } catch (e) {
+        assert.truthy(e instanceof Error);
+        assert.eq(e.message, "async intentional");
+        const frames = e.stack.split("\n").map(f => f.trim()).filter(f => f.length > 0);
+
+        for (const frame of frames) {
+            assert.falsy(frame.includes("promising"), "Async exception stack should not contain 'promising', got: " + frame);
+            assert.falsy(frame.includes("Suspending"), "Async exception stack should not contain 'Suspending', got: " + frame);
+            assert.falsy(frame.includes("pinball"), "Async exception stack should not contain 'pinball', got: " + frame);
+        }
+    }
+}
+
+// Test 5: Deeper wasm call chain with multiple calls through the Suspending import.
+// Wasm function "threeTimes" calls the import three times and sums the results.
+// This matches the V8 test structure more closely.
+
+let deepModule = `
+(module
+  (import "env" "js_func" (func $js_func (result i32)))
+  (func $wrappedWasm (export "wrappedWasm") (result i32)
+    call $js_func
+  )
+  (func $threeTimes (export "threeTimes") (result i32)
+    call $wrappedWasm
+    call $wrappedWasm
+    i32.add
+    call $wrappedWasm
+    i32.add
+  )
+)`;
+
+async function testDeepCallChain() {
+    let stacks = [];
+
+    function captureAndReturn() {
+        stacks.push(new Error().stack);
+        return 10;
+    }
+
+    const instance = await instantiate(deepModule, {
+        env: {
+            js_func: new WebAssembly.Suspending(captureAndReturn)
+        }
+    });
+    const entry = WebAssembly.promising(instance.exports.threeTimes);
+
+    const result = await entry();
+    assert.eq(result, 30); // 10 + 10 + 10
+    assert.eq(stacks.length, 3);
+
+    // Check each captured stack
+    for (let i = 0; i < stacks.length; i++) {
+        const frames = stacks[i].split("\n").map(f => f.trim()).filter(f => f.length > 0);
+
+        // Should contain captureAndReturn, wrappedWasm, threeTimes, but not promising/Suspending
+        let captureIdx = frames.findIndex(f => f.startsWith("captureAndReturn@"));
+        assert.truthy(captureIdx >= 0, `Stack ${i}: should find captureAndReturn frame in: ` + stacks[i]);
+
+        for (const frame of frames) {
+            assert.falsy(frame.includes("promising"), `Stack ${i}: should not contain 'promising', got: ` + frame);
+            assert.falsy(frame.includes("Suspending"), `Stack ${i}: should not contain 'Suspending', got: ` + frame);
+            assert.falsy(frame.includes("pinball"), `Stack ${i}: should not contain 'pinball', got: ` + frame);
+        }
+    }
+}
+
+// Test 6: Deep call chain with suspension (async import that awaits).
+
+async function testDeepCallChainWithSuspension() {
+    let stacks = [];
+    let callCount = 0;
+
+    async function captureAndReturnAsync() {
+        callCount++;
+        await Promise.resolve(); // Force suspension
+        stacks.push(new Error().stack);
+        return 10;
+    }
+
+    const instance = await instantiate(deepModule, {
+        env: {
+            js_func: new WebAssembly.Suspending(captureAndReturnAsync)
+        }
+    });
+    const entry = WebAssembly.promising(instance.exports.threeTimes);
+
+    const result = await entry();
+    assert.eq(result, 30);
+    assert.eq(callCount, 3);
+    assert.eq(stacks.length, 3);
+
+    for (let i = 0; i < stacks.length; i++) {
+        const frames = stacks[i].split("\n").map(f => f.trim()).filter(f => f.length > 0);
+
+        for (const frame of frames) {
+            assert.falsy(frame.includes("promising"), `Async stack ${i}: should not contain 'promising', got: ` + frame);
+            assert.falsy(frame.includes("Suspending"), `Async stack ${i}: should not contain 'Suspending', got: ` + frame);
+            assert.falsy(frame.includes("pinball"), `Async stack ${i}: should not contain 'pinball', got: ` + frame);
+        }
+    }
+}
+
+await testSyncStackTrace();
+await testAsyncStackTrace();
+await testExceptionStackTrace();
+await testAsyncExceptionStackTrace();
+await testDeepCallChain();
+await testDeepCallChainWithSuspension();

--- a/Source/JavaScriptCore/runtime/PinballCompletion.cpp
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.cpp
@@ -117,7 +117,7 @@ extern "C" {
 
 static JSFunctionWithFields* createHandler(VM& vm, JSGlobalObject* globalObject, PinballCompletion* pinballCompletion, NativeFunction function, const String name)
 {
-    NativeExecutable* executable = vm.getHostFunction(function, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
+    NativeExecutable* executable = vm.getHostFunction(function, ImplementationVisibility::Private, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
     constexpr unsigned length = 1;
     JSFunctionWithFields* handler = JSFunctionWithFields::create(vm, globalObject, executable, length, name);
     handler->setField(vm, JSFunctionWithFields::Field::PromiseHandlerPinballCompletion, pinballCompletion);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
@@ -91,7 +91,7 @@ JSC_DEFINE_HOST_FUNCTION(runWebAssemblyPromisingFunction, (JSGlobalObject* globa
 JSFunctionWithFields* createWebAssemblyPromisingFunction(VM& vm, JSGlobalObject* globalObject, JSFunction* wrappedFunction)
 {
     const String name = "WebAssembly.promising"_s;
-    NativeExecutable* executable = vm.getHostFunction(runWebAssemblyPromisingFunction, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
+    NativeExecutable* executable = vm.getHostFunction(runWebAssemblyPromisingFunction, ImplementationVisibility::Private, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
     constexpr unsigned length = 1;
     JSFunctionWithFields* function = JSFunctionWithFields::create(vm, globalObject, executable, length, name);
     function->setField(vm, JSFunctionWithFields::Field::WebAssemblyPromisingWrappedFunction, wrappedFunction);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
@@ -194,7 +194,7 @@ void* runWebAssemblySuspendingFunction(JSGlobalObject* globalObject, CallFrame* 
 JSFunctionWithFields* createWebAssemblySuspendingFunction(VM& vm, JSGlobalObject* globalObject, JSValue callable)
 {
     const String name = "WebAssembly.Suspending"_s;
-    NativeExecutable* executable = vm.getHostFunction(enterWebAssemblySuspendingFunction, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
+    NativeExecutable* executable = vm.getHostFunction(enterWebAssemblySuspendingFunction, ImplementationVisibility::Private, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);
     constexpr unsigned length = 0;
     JSFunctionWithFields* function = JSFunctionWithFields::create(vm, globalObject, executable, length, name);
     function->setField(vm, JSFunctionWithFields::Field::WebAssemblySuspendingWrappedCallable, callable);


### PR DESCRIPTION
#### 98c50963bfa21c9427d6e06abfcbe9672a707541
<pre>
[JSC][JSPI] Hide JSPI wrapper functions from stack traces
<a href="https://bugs.webkit.org/show_bug.cgi?id=307567">https://bugs.webkit.org/show_bug.cgi?id=307567</a>
<a href="https://rdar.apple.com/170157485">rdar://170157485</a>

Reviewed by Keith Miller.

This patch changes the ImplementationVisibility of JSPI wrapper functions
(WebAssembly.promising, WebAssembly.Suspending, pinball completion handler) from Public to
Private so they do not appear in stack traces. This matches V8&apos;s behavior.

Test: JSTests/wasm/stress/jspi-stack-traces.js
    - verifies that wrapper functions do not appear in stack traces

Canonical link: <a href="https://commits.webkit.org/311145@main">https://commits.webkit.org/311145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/560ffc93da91404f9e4a4a2950d327ed09637825

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164894 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120846 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101530 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22133 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20279 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12666 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148123 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167373 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16907 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11489 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128962 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129092 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34985 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139791 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86698 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23919 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16589 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187956 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28640 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92597 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48326 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28167 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28395 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28291 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->