### PR TITLE
AX: SVG accname computation expensive in Speedometer runs with accessibility enabled

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2836,7 +2836,7 @@ void AccessibilityRenderObject::updateRoleAfterChildrenCreation()
         if (!hasMenuItemDescendant)
             m_role = AccessibilityRole::Generic;
     }
-    if (role == AccessibilityRole::SVGRoot && unignoredChildren().isEmpty())
+    if (role == AccessibilityRole::SVGRoot && !hasUnignoredChild())
         m_role = AccessibilityRole::Image;
 
     if (isAccessibilityList()) {

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -92,73 +92,96 @@ AccessibilityObject* AccessibilitySVGObject::targetForUseElement() const
     return cache ? cache->getOrCreate(target.element.get()) : nullptr;
 }
 
-template <typename ChildrenType>
-Element* AccessibilitySVGObject::childElementWithMatchingLanguage(ChildrenType& children) const
-{
-    String languageCode = languageIncludingAncestors();
-    if (languageCode.isEmpty())
-        languageCode = defaultLanguage();
-
-    // The best match for a group of child SVG2 'title' or 'desc' elements may be the one
-    // which lacks a 'lang' attribute value. However, indexOfBestMatchingLanguageInList()
-    // currently bases its decision on non-empty strings. Furthermore, we cannot count on
-    // that child element having a given position. So we'll look for such an element while
-    // building the language list and save it as our fallback.
-
-    RefPtr<Element> fallback;
-    Vector<String> childLanguageCodes;
-    Vector<Element*> elements;
-    for (Ref child : children) {
-        auto& lang = child->attributeWithoutSynchronization(SVGNames::langAttr);
-        childLanguageCodes.append(lang);
-        elements.append(child.ptr());
-
-        // The current draft of the SVG2 spec states if there are multiple equally-valid
-        // matches, the first match should be used.
-        if (lang.isEmpty() && !fallback)
-            fallback = child.ptr();
-    }
-
-    bool exactMatch;
-    size_t index = indexOfBestMatchingLanguageInList(languageCode, childLanguageCodes, exactMatch);
-    if (index < childLanguageCodes.size())
-        return elements[index];
-
-    return fallback.unsafeGet();
-}
-
 void AccessibilitySVGObject::accessibilityText(Vector<AccessibilityText>& textOrder) const
 {
-    String description = this->description();
-    if (!description.isEmpty())
-        textOrder.append(AccessibilityText(WTF::move(description), AccessibilityTextSource::Alternative));
+    // Compute both description and help text together to avoid redundant language
+    // matching, which showed up on samples taken on Speedometer 3.1.
+    auto [titleChild, descChild] = matchingTitleAndDescChildren();
 
-    String helptext = helpText();
+    String descriptionText = descriptionFromTitleChild(titleChild.get());
+    if (!descriptionText.isEmpty())
+        textOrder.append(AccessibilityText(descriptionText, AccessibilityTextSource::Alternative));
+
+    String helptext = helpTextFromChildren(titleChild.get(), descChild.get(), descriptionText);
     if (!helptext.isEmpty())
         textOrder.append(AccessibilityText(WTF::move(helptext), AccessibilityTextSource::Help));
 }
 
-String AccessibilitySVGObject::description() const
+auto AccessibilitySVGObject::matchingTitleAndDescChildren() const -> MatchingLanguageChildren
 {
-    // According to the SVG Accessibility API Mappings spec, the order of priority is:
-    // 1. aria-labelledby
-    // 2. aria-label
-    // 3. a direct child title element (selected according to language)
-    // 4. xlink:title attribute
-    // 5. for a use element, the accessible name calculated for the re-used content
-    // 6. for text container elements, the text content
-
-    String ariaDescription = ariaAccessibilityDescription();
-    if (!ariaDescription.isEmpty())
-        return ariaDescription;
-
     RefPtr element = this->element();
-    if (element) {
-        auto titleElements = childrenOfType<SVGTitleElement>(*element);
-        if (RefPtr titleChild = childElementWithMatchingLanguage(titleElements))
-            return titleChild->textContent();
+    if (!element)
+        return { };
+
+    // Iterate over SVG children once, bucketing <title> and <desc> elements,
+    // then do language matching with a single languageIncludingAncestors() call.
+    // This is an optimization based on a profile taken on Speedometer.
+    Vector<String> titleLangs;
+    Vector<Element*> titleElements;
+    RefPtr<Element> titleFallback;
+    bool hasTitleWithLang = false;
+    Vector<String> descLangs;
+    Vector<Element*> descElements;
+    RefPtr<Element> descFallback;
+    bool hasDescWithLang = false;
+
+    for (Ref child : childrenOfType<SVGElement>(*element)) {
+        const auto& lang = child->attributeWithoutSynchronization(SVGNames::langAttr);
+        if (is<SVGTitleElement>(child.get())) {
+            titleLangs.append(lang);
+            titleElements.append(const_cast<Element*>(static_cast<const Element*>(child.ptr())));
+            if (lang.isEmpty()) {
+                if (!titleFallback)
+                    titleFallback = child.ptr();
+            } else
+                hasTitleWithLang = true;
+        } else if (is<SVGDescElement>(child.get())) {
+            descLangs.append(lang);
+            descElements.append(const_cast<Element*>(static_cast<const Element*>(child.ptr())));
+            if (lang.isEmpty()) {
+                if (!descFallback)
+                    descFallback = child.ptr();
+            } else
+                hasDescWithLang = true;
+        }
     }
 
+    // If no child has a lang attribute, language matching can't improve on the
+    // fallback. Skip the expensive languageIncludingAncestors() and NSLocale calls.
+    if (!hasTitleWithLang && !hasDescWithLang)
+        return { WTF::move(titleFallback), WTF::move(descFallback) };
+
+    String languageCode = languageIncludingAncestors();
+    if (languageCode.isEmpty())
+        languageCode = defaultLanguage();
+
+    auto matchInList = [&](Vector<String>& langs, Vector<Element*>& elements, RefPtr<Element>& fallback) -> RefPtr<Element> {
+        bool exactMatch;
+        size_t index = indexOfBestMatchingLanguageInList(languageCode, langs, exactMatch);
+        if (index < langs.size())
+            return elements[index];
+        return fallback;
+    };
+
+    RefPtr titleChild = hasTitleWithLang ? matchInList(titleLangs, titleElements, titleFallback) : WTF::move(titleFallback);
+    RefPtr descChild = hasDescWithLang ? matchInList(descLangs, descElements, descFallback) : WTF::move(descFallback);
+    return { WTF::move(titleChild), WTF::move(descChild) };
+}
+
+String AccessibilitySVGObject::descriptionFromTitleChild(Element* titleChild) const
+{
+    // Priority per SVG AAM: aria-labelledby/label, title child, xlink:title, use target, alt.
+    String result = ariaAccessibilityDescription();
+    if (!result.isEmpty())
+        return result;
+
+    if (titleChild) {
+        result = titleChild->textContent();
+        if (!result.isEmpty())
+            return result;
+    }
+
+    RefPtr element = this->element();
     if (is<SVGAElement>(element.get())) {
         const auto& xlinkTitle = element->attributeWithoutSynchronization(XLinkNames::titleAttr);
         if (!xlinkTitle.isEmpty())
@@ -168,9 +191,6 @@ String AccessibilitySVGObject::description() const
     if (RefPtr target = targetForUseElement())
         return target->description();
 
-    // FIXME: This is here to not break the svg-image.html test. But 'alt' is not
-    // listed as a supported attribute of the 'image' element in the SVG spec:
-    // https://www.w3.org/TR/SVG/struct.html#ImageElement
     if (m_renderer && m_renderer->isRenderOrLegacyRenderSVGImage()) {
         const auto& alt = getAttribute(HTMLNames::altAttr);
         if (!alt.isNull())
@@ -180,36 +200,46 @@ String AccessibilitySVGObject::description() const
     return { };
 }
 
-String AccessibilitySVGObject::helpText() const
+String AccessibilitySVGObject::helpTextFromChildren(Element* titleChild, Element* descChild, const String& descriptionText) const
 {
+    // Priority per SVG AAM: aria-describedby, desc child, use target, title child (if != description).
     RefPtr element = this->element();
     if (!element)
         return { };
 
-    // According to the SVG Accessibility API Mappings spec, the order of priority is:
-    // 1. aria-describedby
-    // 2. a direct child desc element
-    // 3. for a use element, the accessible description calculated for the re-used content
-    // 4. for text container elements, the text content, if not used for the name
-    // 5. a direct child title element that provides a tooltip, if not used for the name
+    String result = ariaDescribedByAttribute();
+    if (!result.isEmpty())
+        return result;
 
-    String describedBy = ariaDescribedByAttribute();
-    if (!describedBy.isEmpty())
-        return describedBy;
-
-    auto descriptionElements = childrenOfType<SVGDescElement>(*element);
-    if (RefPtr descriptionChild = childElementWithMatchingLanguage(descriptionElements))
-        return descriptionChild->textContent();
+    if (descChild) {
+        result = descChild->textContent();
+        if (!result.isEmpty())
+            return result;
+    }
 
     if (RefPtr target = targetForUseElement())
         return target->helpText();
 
-    auto titleElements = childrenOfType<SVGTitleElement>(*element);
-    if (RefPtr titleChild = childElementWithMatchingLanguage(titleElements)) {
-        if (titleChild->textContent() != description())
-            return titleChild->textContent();
+    if (titleChild) {
+        auto titleText = titleChild->textContent();
+        if (titleText != descriptionText)
+            return titleText;
     }
+
     return { };
+}
+
+String AccessibilitySVGObject::description() const
+{
+    auto [titleChild, descChild] = matchingTitleAndDescChildren();
+    return descriptionFromTitleChild(titleChild.get());
+}
+
+String AccessibilitySVGObject::helpText() const
+{
+    auto [titleChild, descChild] = matchingTitleAndDescChildren();
+    String descriptionText = descriptionFromTitleChild(titleChild.get());
+    return helpTextFromChildren(titleChild.get(), descChild.get(), descriptionText);
 }
 
 bool AccessibilitySVGObject::hasTitleOrDescriptionChild() const

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.h
@@ -63,8 +63,14 @@ private:
 
     // Returns true if the SVG element associated with this object has a <title> or <desc> child.
     bool hasTitleOrDescriptionChild() const;
-    template <typename ChildrenType>
-    Element* childElementWithMatchingLanguage(ChildrenType&) const;
+
+    struct MatchingLanguageChildren {
+        RefPtr<Element> title;
+        RefPtr<Element> desc;
+    };
+    MatchingLanguageChildren matchingTitleAndDescChildren() const;
+    String descriptionFromTitleChild(Element* titleChild) const;
+    String helpTextFromChildren(Element* titleChild, Element* descChild, const String& descriptionText) const;
 
     // Set for remote SVG resources, on the root.
     WeakPtr<AccessibilityRenderObject> m_parent;


### PR DESCRIPTION
#### 71471a58fedd5b39f591f59fd35b13e35827e915
<pre>
AX: SVG accname computation expensive in Speedometer runs with accessibility enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=312163">https://bugs.webkit.org/show_bug.cgi?id=312163</a>
<a href="https://rdar.apple.com/174665355">rdar://174665355</a>

Reviewed by Joshua Hoffman.

Profiling a Speedometer benchmark run shows AccessibilitySVGObject::accessibilityText() as a significant hotspot during
isolated tree creation (~2,500 samples / ~7.5% of all AX work on the main thread). The cost comes from
childElementWithMatchingLanguage(), which calls indexOfBestMatchingLanguageInList(), an expensive Cocoa NSLocale/ICU
locale matching operation.

This PR greatly optimizes accessibilityText() by reducing repeated and unnecessary work:

   4 → 0-2 indexOfBestMatchingLanguageInList calls per element in accessibilityText() (the hot path during tree building)
   4 → 1 languageIncludingAncestors() call
   4 → 1 defaultLanguage() call
   0 calls to any of the above when no child has a lang attribute. This is the common case for Chart.js SVGs.
   0 calls to any of the above when there are no &lt;title&gt;/&lt;desc&gt; children at all.

This yields a 1.25% improvement in our Speedometer runtime with accessibility enabled.

* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::updateRoleAfterChildrenCreation):
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::childElementWithMatchingLanguage const):
(WebCore::AccessibilitySVGObject::accessibilityText const):
(WebCore::AccessibilitySVGObject::matchingTitleAndDescChildren const):
(WebCore::AccessibilitySVGObject::descriptionFromTitleChild const):
(WebCore::AccessibilitySVGObject::helpTextFromChildren const):
* Source/WebCore/accessibility/AccessibilitySVGObject.h:

Canonical link: <a href="https://commits.webkit.org/311174@main">https://commits.webkit.org/311174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9718c3d6eeb3aff340b07f6c4849160bdffc5006

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164996 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101607 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12768 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167475 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11591 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129050 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129171 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35005 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139873 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86800 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23989 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16672 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28742 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92699 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28269 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28497 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->