### PR TITLE
[Skia] Add deferred texture binding support for dma-buf backed GPU atlas textures

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -66,11 +66,32 @@ RefPtr<SkiaGPUAtlas> SkiaGPUAtlas::create(const SkiaImageAtlasLayout& layout, Re
 
     RELEASE_ASSERT(atlasSize == atlasTexture->size());
 
-    auto backendTexture = atlasTexture->createSkiaBackendTexture();
-    if (!backendTexture.isValid())
-        return nullptr;
+    ASSERT_IMPLIES(atlasTexture->usesDeferredTextureBinding(), !atlasTexture->id());
+
+    GrBackendTexture backendTexture;
+    if (!atlasTexture->usesDeferredTextureBinding()) {
+        backendTexture = atlasTexture->createSkiaBackendTexture();
+        if (!backendTexture.isValid())
+            return nullptr;
+    }
 
     return adoptRef(*new SkiaGPUAtlas(WTF::move(atlasTexture), WTF::move(backendTexture), layout, atlasSize));
+}
+
+bool SkiaGPUAtlas::ensureBackendTexture()
+{
+    if (!m_atlasTexture->usesDeferredTextureBinding())
+        return m_backendTexture.isValid();
+
+#if USE(GBM)
+    if (!m_atlasTexture->id()) {
+        if (!m_atlasTexture->bindDMABufToTexture())
+            return false;
+        m_backendTexture = m_atlasTexture->createSkiaBackendTexture();
+    }
+#endif
+
+    return m_backendTexture.isValid();
 }
 
 bool SkiaGPUAtlas::uploadImages()

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
@@ -60,6 +60,11 @@ public:
 
     virtual ~SkiaGPUAtlas();
 
+    // Ensures the EGLImage and GrBackendTexture are created. For dma-buf backed textures
+    // with deferred binding, this must be called after the upload is complete — typically
+    // from the upload work queue thread, before signaling the upload condition.
+    bool ensureBackendTexture();
+
     const GrBackendTexture& backendTexture() const LIFETIME_BOUND { return m_backendTexture; }
     const ImageToRectMap& imageToRect() const LIFETIME_BOUND { return m_imageToRect; }
     const IntSize& size() const LIFETIME_BOUND { return m_size; }

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -134,13 +134,13 @@ RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout&
 #if USE(GBM)
     if (shouldUseDMABufAtlasTextures()) {
         isDMABufBackedTexture = true;
-        textureFlags.add({ BitmapTexture::Flags::BackedByDMABuf, BitmapTexture::Flags::ForceLinearBuffer });
+        textureFlags.add({ BitmapTexture::Flags::BackedByDMABuf, BitmapTexture::Flags::ForceLinearBuffer, BitmapTexture::Flags::DeferTextureBinding });
     }
 #endif
 
     // Verify the texture actually has DMA-buf backing. BitmapTexture silently
-    // falls back to GL if DMA-buf allocation fails, but we must not dispatch
-    // GL operations to the upload worker thread (which has no GL context).
+    // falls back to GL if DMA-buf allocation fails, and we must use the
+    // synchronous GL upload path instead of the DMA-buf work queue path.
     auto texture = BitmapTexturePool::singleton().acquireTexture(atlasSize, textureFlags);
 #if USE(GBM)
     if (!texture->memoryMappedGPUBuffer())
@@ -152,17 +152,37 @@ RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout&
         return nullptr;
 
     // GL path: upload synchronously.
-    if (!isDMABufBackedTexture) [[unlikely]] {
+    if (!isDMABufBackedTexture) {
         atlas->uploadImages();
         return atlas;
     }
 
     // DMA-buf path: create atlas without uploading, dispatch pixel writes to worker.
+    // After uploading, bind the dma-buf to an EGLImage + GL texture on this single
+    // thread, so replay workers only need to rewrap the SkImage for their context.
     if (!m_uploadWorkQueue)
         m_uploadWorkQueue = WorkQueue::create("AtlasUpload"_s);
     uploadCondition.addPending();
     m_uploadWorkQueue->dispatch([atlas = Ref { *atlas }, condition = Ref { uploadCondition }]() mutable {
         atlas->uploadImages();
+
+        // Use a lightweight GL context (no GrDirectContext / Skia GPU backend)
+        // since we only need raw GL calls for EGLImage texture binding.
+        static thread_local auto glContext = GLContext::createOffscreen(PlatformDisplay::sharedDisplay());
+        if (!glContext || !glContext->makeContextCurrent()) {
+            WTFLogAlways("ERROR: Failed to create/activate GL context on atlas upload thread. Aborting ..."); // NOLINT
+            CRASH();
+        }
+
+        if (!atlas->ensureBackendTexture()) {
+            WTFLogAlways("ERROR: Failed to bind DMA-buf to GL texture on atlas upload thread. Aborting ..."); // NOLINT
+            CRASH();
+        }
+
+        // Flush GL commands so the texture object state (EGLImage binding)
+        // is visible to replay worker contexts in the same share group.
+        glFlush();
+
         condition->signal();
     });
     return atlas;
@@ -244,9 +264,13 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
             auto uploadCondition = AtlasUploadCondition::create();
             gpuAtlases.reserveInitialCapacity(result->atlasLayouts().size());
 
+            bool needsUploadFence = false;
             for (const auto& layout : result->atlasLayouts()) {
-                if (auto atlas = createAtlas(layout.get(), uploadCondition.get()))
+                if (auto atlas = createAtlas(layout.get(), uploadCondition.get())) {
+                    if (!atlas->atlasTexture().usesDeferredTextureBinding())
+                        needsUploadFence = true;
                     gpuAtlases.append(atlas.releaseNonNull());
+                }
             }
 
             if (!gpuAtlases.isEmpty()) {
@@ -261,11 +285,11 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
                     result->setGPUAtlases(WTF::move(gpuAtlases), WTF::move(uploadCondition));
                 }
 
-                // Flush and fence for the GL upload path, where
+                // Flush and fence for the GL upload fallback path, where
                 // BitmapTexture::updateContents() issues GL upload commands.
-                // On the DMA-buf path, uploading is CPU-side (memory-mapped),
-                // so this is a no-op flush but harmless.
-                result->setUploadFence(SkiaUtilities::flushAndSubmitWithFence(grContext));
+                // Not needed on the DMA-buf path where uploading is CPU-side (memory-mapped).
+                if (needsUploadFence)
+                    result->setUploadFence(SkiaUtilities::flushAndSubmitWithFence(grContext));
             }
         }
     } else {

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
@@ -39,7 +39,8 @@ SkiaReplayCanvas::SkiaReplayCanvas(const IntSize& size, const RefPtr<SkiaRecordi
     , m_recording(recording)
 {
     // Create atlas wrappers from pre-prepared GPU atlases.
-    // GPU atlases were uploaded on main thread; we just rewrap for this worker's context.
+    // GPU atlases were uploaded (and texture-bound) before signaling the upload condition;
+    // we just rewrap the SkImage for this worker's GrDirectContext.
     if (m_recording && m_recording->hasGPUAtlases()) {
         auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
         if (!glContext || !glContext->makeContextCurrent())

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -126,6 +126,13 @@ BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
 
         m_memoryMappedGPUBuffer = MemoryMappedGPUBuffer::create(m_size, bufferFlags);
 
+        // Defer EGLImage/GL texture creation until after CPU writes into the
+        // mapped buffer complete, so the GPU only sees final DMA-buf contents.
+        if (m_memoryMappedGPUBuffer && usesDeferredTextureBinding()) {
+            glBindTexture(m_renderTarget, boundTexture);
+            return;
+        }
+
         // Proceed as usual with GL texture creation if the dma-buf creation failed.
         // as we only want to allocate the dma-buf, but neither map it, nor create a texture now - but when we
         // need it (from the thread that needs it!).
@@ -135,6 +142,9 @@ BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
         }
 
         m_flags.remove(Flags::BackedByDMABuf);
+        m_flags.remove(Flags::ForceLinearBuffer);
+        m_flags.remove(Flags::ForceVivanteSuperTiledBuffer);
+        m_flags.remove(Flags::DeferTextureBinding);
     }
 #endif
 
@@ -196,6 +206,20 @@ bool BitmapTexture::allocateTextureFromMemoryMappedGPUBuffer()
     return false;
 }
 
+bool BitmapTexture::bindDMABufToTexture()
+{
+    ASSERT(usesDeferredTextureBinding());
+    ASSERT(!m_id);
+
+    GLint boundTexture = 0;
+    glGetIntegerv(m_binding, &boundTexture);
+
+    bool result = allocateTextureFromMemoryMappedGPUBuffer();
+
+    glBindTexture(m_renderTarget, boundTexture);
+    return result;
+}
+
 BitmapTexture::BitmapTexture(EGLImage image, const IntSize& size, OptionSet<Flags> flags)
     : m_flags(flags)
     , m_size(size)
@@ -238,6 +262,13 @@ void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
 #if USE(GBM)
     // We don't support switching from dmabuf backing to regular textures -- there is no use-case for that scenario.
     RELEASE_ASSERT(m_flags.contains(Flags::BackedByDMABuf) == flags.contains(Flags::BackedByDMABuf));
+
+    // When DeferTextureBinding is requested, destroy the existing GL texture so that
+    // a fresh EGLImage will be created.
+    if (flags.contains(Flags::DeferTextureBinding) && m_id) {
+        glDeleteTextures(1, &m_id);
+        m_id = 0;
+    }
 #endif
 
     m_flags = flags;
@@ -285,7 +316,8 @@ void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
         // Recreate MemoryMappedGPUBuffer with new size.
         m_memoryMappedGPUBuffer = MemoryMappedGPUBuffer::create(m_size, m_memoryMappedGPUBuffer->flags());
 
-        if (allocateTextureFromMemoryMappedGPUBuffer()) {
+        // Defer texture binding if requested -- bindDMABufToTexture() will create the EGLImage later.
+        if (usesDeferredTextureBinding() || allocateTextureFromMemoryMappedGPUBuffer()) {
             glBindTexture(m_renderTarget, boundTexture);
             return;
         }

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -62,17 +62,18 @@ enum class TextureMapperFlags : uint16_t;
 
 class BitmapTexture final : public ThreadSafeRefCounted<BitmapTexture> {
 public:
-    enum class Flags : uint8_t {
+    enum class Flags : uint16_t {
         SupportsAlpha = 1 << 0,
         DepthBuffer = 1 << 1,
 #if USE(GBM)
         BackedByDMABuf = 1 << 2,
         ForceLinearBuffer = 1 << 3,
         ForceVivanteSuperTiledBuffer = 1 << 4,
+        DeferTextureBinding = 1 << 5,
 #endif
-        UseBGRALayout = 1 << 5,
-        NearestFiltering = 1 << 6,
-        ExternalOESRenderTarget = 1 << 7,
+        UseBGRALayout = 1 << 6,
+        NearestFiltering = 1 << 7,
+        ExternalOESRenderTarget = 1 << 8,
     };
 
     static Ref<BitmapTexture> create(const IntSize& size, OptionSet<Flags> flags = { })
@@ -93,6 +94,15 @@ public:
     size_t sizeInBytes() const;
     OptionSet<Flags> flags() const { return m_flags; }
     bool isOpaque() const { return !m_flags.contains(Flags::SupportsAlpha); }
+
+    bool usesDeferredTextureBinding() const
+    {
+#if USE(GBM)
+        return m_flags.contains(Flags::DeferTextureBinding);
+#else
+        return false;
+#endif
+    }
 
     void bindAsSurface();
     void initializeStencil();
@@ -122,6 +132,7 @@ public:
 
 #if USE(GBM)
     MemoryMappedGPUBuffer* memoryMappedGPUBuffer() const LIFETIME_BOUND { return m_memoryMappedGPUBuffer.get(); }
+    bool bindDMABufToTexture();
     IntSize allocatedSize() const;
 #else
     IntSize allocatedSize() const { return m_size; }


### PR DESCRIPTION
#### 57a7b16feca309882b177e268b35d718421cba22
<pre>
[Skia] Add deferred texture binding support for dma-buf backed GPU atlas textures
<a href="https://bugs.webkit.org/show_bug.cgi?id=312166">https://bugs.webkit.org/show_bug.cgi?id=312166</a>

Reviewed by Miguel Gomez.

Introduce BitmapTexture::usesDeferredTextureBinding() and bindDMABufToTexture()
to support deferring EGLImage/GL texture creation until after CPU writes into
the mapped dma-buf buffer complete. This ensures the GPU only sees final contents.

SkiaGPUAtlas::ensureBackendTexture() binds the dma-buf to an EGLImage + GL texture
and creates the GrBackendTexture. It is called from the upload work queue thread
after uploadImages() completes, before signaling the upload condition. This ensures
texture creation happens on a single, well-defined thread — avoiding data races
that would occur if multiple replay worker threads tried to create the texture
concurrently. A glFlush() after texture binding ensures the GL state is visible
to replay worker contexts in the same EGL share group.

The upload work queue uses a lightweight GLContext (via GLContext::createOffscreen)
instead of PlatformDisplay::skiaGLContext(), avoiding the expensive GrDirectContext
creation since only raw GL calls are needed for EGLImage texture binding.

SkiaReplayAtlas::create() no longer calls ensureBackendTexture(). After
waitForUploadCondition() returns, the backend texture is guaranteed valid,
so replay workers only need to rewrap the SkImage for their GrDirectContext.

The upload fence (flushAndSubmitWithFence) is now conditional — only created
for the GL fallback upload path where BitmapTexture::updateContents() issues
GL commands on the main thread. On the DMA-buf path, the upload work queue
handles its own GL synchronization via glFlush().

Not testable using current CI infra.

* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
(WebCore::SkiaGPUAtlas::create):
(WebCore::SkiaGPUAtlas::ensureBackendTexture):
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h:
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::createAtlas):
(WebCore::SkiaPaintingEngine::record):
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp:
(WebCore::SkiaReplayCanvas::SkiaReplayCanvas):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::bindDMABufToTexture):
(WebCore::BitmapTexture::reset):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:

Canonical link: <a href="https://commits.webkit.org/311234@main">https://commits.webkit.org/311234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82ccc38b99087b0d38314b6113d7258e56bdb55a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164966 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120904 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101582 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22191 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20344 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12738 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167445 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11561 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129021 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129145 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35036 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86770 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23968 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16637 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28712 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92669 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28239 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28467 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->