### PR TITLE
Targeted font invalidation: replace full style rebuild with lazy font refresh

### DIFF
--- a/LayoutTests/fast/css/font-face-data-uri.html
+++ b/LayoutTests/fast/css/font-face-data-uri.html
@@ -17,7 +17,7 @@
 </style>
 <script src="../../resources/js-test-pre.js"></script>
 </head>
-<body onload="testMain()">
+<body>
 <div id="description"></div>
 <div id="console"></div>
 <hr/>
@@ -40,8 +40,11 @@ function testMain()
     finishJSTest();
 }
 
-// Force layout, so that fonts begin to load before the document finishes loading, and thus delay the load event.
-document.body.offsetTop;
+// Wait for all @font-face fonts to load before checking widths.
+Promise.all([
+    document.fonts.load("16px ahem-data"),
+    document.fonts.load("16px ahem-end-with-eot")
+]).then(testMain);
 
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/css/font-face-ex-unit-update-expected.txt
+++ b/LayoutTests/fast/css/font-face-ex-unit-update-expected.txt
@@ -1,0 +1,11 @@
+Tests that elements using ex units get restyled when a web font loads, so that the ex-based width is recalculated with the new font's metrics.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+Initial width (fallback font): 80
+Final width (after font load): 80
+PASS document.getElementById('target').offsetWidth is 80
+PASS successfullyParsed is true
+
+TEST COMPLETE
+X

--- a/LayoutTests/fast/css/font-face-ex-unit-update.html
+++ b/LayoutTests/fast/css/font-face-ex-unit-update.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Font load should trigger restyle for elements using ex units</title>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=311368">
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+@font-face {
+    font-family: 'TestExFont';
+    font-style: normal;
+    font-weight: 400;
+    src: url(../../resources/Ahem.ttf) format('truetype');
+}
+
+#target {
+    font-family: 'TestExFont', sans-serif;
+    font-size: 100px;
+    width: 1ex;
+    background: blue;
+}
+</style>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<div id="target">X</div>
+<script>
+description("Tests that elements using ex units get restyled when a web font loads, so that the ex-based width is recalculated with the new font's metrics.");
+
+jsTestIsAsync = true;
+
+// Ahem font has xHeight = ascent = 800 units out of 1000 unitsPerEm.
+// At font-size: 100px, 1ex = 80px.
+// The fallback sans-serif will have a different xHeight, so the width changes.
+
+var initialWidth;
+
+function runTest() {
+    initialWidth = document.getElementById('target').offsetWidth;
+    debug("Initial width (fallback font): " + initialWidth);
+
+    document.fonts.ready.then(function() {
+        requestAnimationFrame(function() {
+            var finalWidth = document.getElementById('target').offsetWidth;
+            debug("Final width (after font load): " + finalWidth);
+
+            // Ahem at 100px: 1ex = 80px
+            shouldBe("document.getElementById('target').offsetWidth", "80");
+
+            finishJSTest();
+        });
+    });
+}
+
+// Force initial layout with fallback font, then wait for font to load.
+document.body.offsetTop;
+runTest();
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/first-available-font-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/first-available-font-001.html
@@ -13,13 +13,14 @@
   font-style: normal;
   font-weight: 400;
   src:  url(/fonts/Revalia.woff) format('woff');
+  src:  url('../../fonts/Revalia.woff') format('woff');
   unicode-range: U+0061; /* Not including U+0020, so it cannot be the first available font*/
 }
 @font-face {
   font-family: 'B';
   font-style: normal;
   font-weight: 400;
-  src: url(/fonts/AD.woff) format('woff');
+  src: url(../../fonts/AD.woff) format('woff');
 }
 
 div {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-012-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-012-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="reftest-wait">
 <head>
     <meta charset="utf-8">
     <title>CSS Test: font-size-adjust property</title>
@@ -67,4 +67,13 @@
         <span>xx<span class="tall-inline-block"></span></span>
         </div>
     </div>
+<script>
+    Promise.all([
+        document.fonts.load("100px ahem-ex-500"),
+        document.fonts.load("100px ahem-ex-250")
+    ]).then(() => {
+        document.body.offsetHeight;
+        document.documentElement.classList.remove("reftest-wait");
+    });
+</script>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-013-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-013-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="reftest-wait">
 <head>
     <meta charset="utf-8">
     <title>CSS Test: font-size-adjust property</title>
@@ -57,4 +57,13 @@
             <span>xx<span class="tall-inline-block"></span></span>
         </div>
     </div>
+<script>
+    Promise.all([
+        document.fonts.load("100px primary-font-ahem-ex-500"),
+        document.fonts.load("100px secondary-font-ahem-ex-250")
+    ]).then(() => {
+        document.body.offsetHeight;
+        document.documentElement.classList.remove("reftest-wait");
+    });
+</script>
 </html>

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -282,6 +282,8 @@ void CSSFontSelector::dispatchInvalidationCallbacks()
 {
     ++m_version;
 
+    invalidateAssociatedFontCascadeFonts();
+
     for (auto& client : copyToVector(m_clients)) {
         if (m_clients.contains(client))
             client->fontsNeedUpdate(*this);

--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -140,6 +140,12 @@ void CSSToLengthConversionData::setUsesContainerUnits() const
         m_styleBuilderState->setUsesContainerUnits();
 }
 
+void CSSToLengthConversionData::setDependsOnFontMetrics() const
+{
+    if (m_styleBuilderState)
+        m_styleBuilderState->setDependsOnFontMetrics();
+}
+
 bool CSSToLengthConversionData::evaluationTimeZoomEnabled() const
 {
     ASSERT(m_style);

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -106,6 +106,7 @@ public:
     }
 
     void NODELETE setUsesContainerUnits() const;
+    void NODELETE setDependsOnFontMetrics() const;
 
     Style::BuilderState* styleBuilderState() const { return m_styleBuilderState.get(); }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -110,6 +110,7 @@
 #include "FocusController.h"
 #include "FocusEvent.h"
 #include "FocusOptions.h"
+#include "FontCascadeFonts.h"
 #include "FontFaceSet.h"
 #include "FormController.h"
 #include "FragmentDirective.h"
@@ -182,6 +183,7 @@
 #include "LargestContentfulPaint.h"
 #include "LargestContentfulPaintData.h"
 #include "LayoutDisallowedScope.h"
+#include "LayoutIntegrationLineLayout.h"
 #include "LazyLoadImageObserver.h"
 #include "LegacySchemeRegistry.h"
 #include "LoadableSpeculationRules.h"
@@ -247,6 +249,8 @@
 #include "Range.h"
 #include "RealtimeMediaSourceCenter.h"
 #include "RenderBoxInlines.h"
+#include "RenderBlockFlow.h"
+#include "RenderBlockFlowInlines.h"
 #include "RenderChildIterator.h"
 #include "RenderDescendantIterator.h"
 #include "RenderElementInlines.h"
@@ -256,6 +260,7 @@
 #include "RenderLineBreak.h"
 #include "RenderObjectInlines.h"
 #include "RenderStyle+SettersInlines.h"
+#include "RenderText.h"
 #include "RenderTreeUpdater.h"
 #include "RenderView.h"
 #include "RenderWidgetInlines.h"
@@ -3371,7 +3376,45 @@ void Document::invalidateMatchedPropertiesCacheAndForceStyleRecalc()
 
     if (backForwardCacheState() != NotInBackForwardCache || !renderView())
         return;
-    scheduleFullStyleRebuild();
+
+    performFontInvalidationWalk();
+}
+
+void Document::performFontInvalidationWalk()
+{
+    if (!renderView())
+        return;
+
+    // Walk the render tree with targeted invalidation. Elements with invalidated
+    // FontCascadeFonts get relayout (ensureFontsAreCurrent lazily refreshes font
+    // data). Elements that depend on font metrics also get restyle because their
+    // computed CSS values need re-resolution.
+    for (CheckedRef descendant : descendantsOfType<RenderElement>(*renderView())) {
+        auto* fontCascadeFonts = descendant->style().fontCascade().existingFonts();
+        if (!fontCascadeFonts || fontCascadeFonts->isValid())
+            continue;
+
+        bool needsRestyle = descendant->style().dependsOnFontMetrics()
+            || !descendant->style().fontDescription().fontSizeAdjust().isNone();
+        if (needsRestyle) {
+            if (RefPtr element = descendant->element())
+                element->invalidateStyleInternal();
+        }
+
+        descendant->setNeedsLayoutAndPreferredWidthsUpdate();
+
+        if (auto* blockFlow = dynamicDowncast<RenderBlockFlow>(descendant.get())) {
+            if (auto* lineLayout = blockFlow->inlineLayout())
+                lineLayout->fontsNeedUpdate();
+        }
+
+        for (auto* child = descendant->firstChild(); child; child = child->nextSibling()) {
+            if (auto* renderText = dynamicDowncast<RenderText>(*child)) {
+                renderText->setNeedsLayoutAndPreferredWidthsUpdate();
+                renderText->clearCanUseSimplifiedTextMeasuring();
+            }
+        }
+    }
 }
 
 void Document::setIsResolvingTreeStyle(bool value)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1609,6 +1609,7 @@ public:
     DocumentSharedObjectPool* sharedObjectPool() LIFETIME_BOUND { return m_sharedObjectPool.get(); }
 
     void invalidateMatchedPropertiesCacheAndForceStyleRecalc();
+    void performFontInvalidationWalk();
 
     void didRemoveAllPendingStylesheet();
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
@@ -606,6 +606,7 @@ void InlineFormattingContext::rebuildInlineItemListIfNeeded(InlineDamage* lineDa
 {
     auto& inlineContentCache = this->inlineContentCache();
     auto inlineItemListNeedsUpdate = inlineContentCache.inlineItems().isEmpty() || (lineDamage && lineDamage->isInlineItemListDirty());
+    // WTF_ALWAYS_LOG("@@@Vitor: rebuildInlineItemListIfNeeded needsUpdate=" << inlineItemListNeedsUpdate << " isEmpty=" << inlineContentCache.inlineItems().isEmpty() << " hasDamage=" << !!lineDamage << " isDirty=" << (lineDamage ? lineDamage->isInlineItemListDirty() : false));
     if (!inlineItemListNeedsUpdate)
         return;
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -80,10 +80,13 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
     auto useSimplifiedContentMeasuring = inlineTextBox.canUseSimplifiedContentMeasuring();
     if (useSimplifiedContentMeasuring) {
         auto view = StringView(text).substring(from, to - from);
-        if (fontCascade.canTakeFixedPitchFastContentMeasuring())
+        if (fontCascade.canTakeFixedPitchFastContentMeasuring()) {
             width = fontCascade.widthForSimpleTextWithFixedPitch(view, inlineTextBox.style().collapseWhiteSpace());
-        else
+            // WTF_ALWAYS_LOG("@@@Vitor: TextUtil::width FIXEDPITCH text='" << view << "' width=" << width << " fontGeneration=" << fontCascade.generation());
+        } else {
             width = fontCascade.widthForTextUsingSimplifiedMeasuring(view);
+            // WTF_ALWAYS_LOG("@@@Vitor: TextUtil::width SIMPLIFIED text='" << view << "' width=" << width << " fontGeneration=" << fontCascade.generation());
+        }
     } else {
         CheckedRef style = inlineTextBox.style();
         auto directionalOverride = isOverride(style->unicodeBidi());
@@ -93,6 +96,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
         // FIXME: consider moving this to TextRun ctor
         run.setTextSpacingState(spacingState);
         width = fontCascade.width(run, { }, glyphOverflow);
+        // WTF_ALWAYS_LOG("@@@Vitor: TextUtil::width COMPLEX text='" << StringView(text).substring(from, to - from) << "' width=" << width << " fontGeneration=" << fontCascade.generation());
     }
 
     if (extendedMeasuring)

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -457,14 +457,17 @@ static inline std::optional<Layout::BlockLayoutState::LineGrid> lineGrid(const R
 
 std::optional<LayoutRect> LineLayout::layout(RenderBlockFlow::MarginInfo& marginInfo, ForceFullLayout forcedFullLayout)
 {
+    // WTF_ALWAYS_LOG("@@@Vitor: LineLayout::layout forcedFullLayout=" << (forcedFullLayout == ForceFullLayout::Yes) << " hasLineDamage=" << !!m_lineDamage << " hasInlineContent=" << !!m_inlineContent);
     if (forcedFullLayout == ForceFullLayout::Yes && m_lineDamage)
         Layout::InlineInvalidation::resetInlineDamage(*m_lineDamage);
 
     preparePlacedFloats();
 
     auto isPartialLayout = Layout::InlineInvalidation::mayOnlyNeedPartialLayout(m_lineDamage.get());
+    // WTF_ALWAYS_LOG("@@@Vitor: LineLayout::layout isPartialLayout=" << isPartialLayout);
     if (!isPartialLayout) {
         // FIXME: Partial layout should not rely on previous inline display content.
+        // WTF_ALWAYS_LOG("@@@Vitor: LineLayout::layout CLEARING INLINE CONTENT");
         clearInlineContent();
     }
 
@@ -1486,6 +1489,11 @@ void LineLayout::releaseCachesAndResetDamage()
         m_inlineContent->releaseCaches();
     if (m_lineDamage)
         Layout::InlineInvalidation::resetInlineDamage(*m_lineDamage);
+}
+
+void LineLayout::fontsNeedUpdate()
+{
+    releaseCachesAndResetDamage();
 }
 
 void LineLayout::clearInlineContent()

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -150,6 +150,9 @@ public:
 
     bool NODELETE hasBlocks() const;
 
+    // Called when fonts change to clear cached inline items and text measurements.
+    void fontsNeedUpdate();
+
 private:
     void preparePlacedFloats();
     FloatRect constructContent(const Layout::InlineLayoutState&, std::unique_ptr<Layout::InlineLayoutResult>&&);

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -174,6 +174,25 @@ void FontCascade::update(RefPtr<FontSelector>&& fontSelector) const
     protect(FontCache::forCurrentThread())->updateFontCascade(*this);
 }
 
+FontCascadeFonts* FontCascade::fonts() const
+{
+    ensureFontsAreCurrent();
+    return m_fonts.get();
+}
+
+void FontCascade::ensureFontsAreCurrent() const
+{
+    if (m_fonts && !m_fonts->isValid()) {
+        // WTF_ALWAYS_LOG("@@@Vitor: ensureFontsAreCurrent UPDATING oldFonts=" << m_fonts.get() << " generation=" << m_generation << " firstFamily=" << m_fontDescription.firstFamily().name);
+        update(RefPtr<FontSelector> { m_fontSelector });
+        // Clear the per-character simplified text measuring cache — it was
+        // computed with the old font's glyph-to-font mapping which may
+        // have changed (e.g. unicode-range fallback to a different font).
+        m_canUseSimplifiedTextMeasuringForAutoVariantCache.clearAll();
+        // WTF_ALWAYS_LOG("@@@Vitor: ensureFontsAreCurrent DONE newFonts=" << m_fonts.get() << " newGeneration=" << m_generation);
+    }
+}
+
 TextShapingResult FontCascade::layoutText(CodePath codePathToUse, const TextRun& run, unsigned from, unsigned to, ForTextEmphasis forTextEmphasis) const
 {
     if (RefPtr fonts = this->fonts()) {

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -269,7 +269,9 @@ public:
     static String normalizeSpaces(StringView);
 
     bool useBackslashAsYenSymbol() const { return m_useBackslashAsYenSymbol; }
-    FontCascadeFonts* fonts() const { return m_fonts.get(); }
+    WEBCORE_EXPORT FontCascadeFonts* fonts() const;
+    FontCascadeFonts* existingFonts() const { return m_fonts.get(); }
+    WEBCORE_EXPORT void ensureFontsAreCurrent() const;
     bool isLoadingCustomFonts() const;
 
     static ResolvedEmojiPolicy resolveEmojiPolicy(FontVariantEmoji, char32_t);

--- a/Source/WebCore/platform/graphics/FontCascadeCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.cpp
@@ -122,7 +122,7 @@ Ref<FontCascadeFonts> FontCascadeCache::retrieveOrAddCachedFonts(const FontCasca
         return addResult.iterator->value->fonts.get();
 
     auto& newEntry = addResult.iterator->value;
-    newEntry = makeUnique<FontCascadeCacheEntry>(FontCascadeCacheEntry { WTF::move(key), FontCascadeFonts::create() });
+    newEntry = makeUnique<FontCascadeCacheEntry>(FontCascadeCacheEntry { WTF::move(key), FontCascadeFonts::create(fontSelector) });
     Ref<FontCascadeFonts> fonts = newEntry->fonts.get();
 
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -104,9 +104,10 @@ void FontCascadeFonts::GlyphPageCacheEntry::setSingleFontPage(RefPtr<GlyphPage>&
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FontCascadeFonts);
 
-FontCascadeFonts::FontCascadeFonts()
+FontCascadeFonts::FontCascadeFonts(FontSelector* fontSelector)
     : m_cachedPrimaryFont(nullptr)
     , m_generation(FontCache::forCurrentThread().generation())
+    , m_fontSelector(fontSelector)
 {
 #if ASSERT_ENABLED
     if (!isMainThread())
@@ -122,7 +123,21 @@ FontCascadeFonts::FontCascadeFonts(const FontPlatformData& platformData)
     m_realizedFallbackRanges.append(FontRanges(protect(FontCache::forCurrentThread())->fontForPlatformData(platformData)));
 }
 
-FontCascadeFonts::~FontCascadeFonts() = default;
+FontCascadeFonts::~FontCascadeFonts()
+{
+    if (m_registeredWithFontSelector) {
+        if (RefPtr fontSelector = m_fontSelector.get())
+            fontSelector->unregisterFontCascadeFonts(*this);
+    }
+}
+
+void FontCascadeFonts::registerWithFontSelectorIfNeeded(FontSelector* fontSelector)
+{
+    if (m_registeredWithFontSelector || !fontSelector)
+        return;
+    m_registeredWithFontSelector = true;
+    fontSelector->registerFontCascadeFonts(*this);
+}
 
 void FontCascadeFonts::determinePitch(const FontCascadeDescription& description, FontSelector* fontSelector)
 {
@@ -211,6 +226,11 @@ const FontRanges& FontCascadeFonts::realizeFallbackRangesAt(const FontCascadeDes
             fontRanges = fontSelector->fontRangesForFamily(description, FontFamily { *familyNamesData->at(FamilyNamesIndex::StandardFamily), FontFamilyKind::Generic });
         if (fontRanges.isNull())
             fontRanges = FontRanges(protect(FontCache::forCurrentThread())->lastResortFallbackFont(description));
+        // Register with the font selector if it was used during resolution.
+        // This matches Blink's has_loading_fallback_ pattern: registration
+        // happens at resolution time, not creation time.
+        if (fontSelector && !fontRanges.isNull())
+            registerWithFontSelectorIfNeeded(fontSelector);
         return fontRanges;
     }
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -106,12 +106,16 @@ class FontCascadeFonts : public RefCounted<FontCascadeFonts> {
     WTF_MAKE_NONCOPYABLE(FontCascadeFonts);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FontCascadeFonts, FontCascadeFonts);
 public:
-    static Ref<FontCascadeFonts> create() { return adoptRef(*new FontCascadeFonts()); }
+    static Ref<FontCascadeFonts> create(FontSelector* fontSelector) { return adoptRef(*new FontCascadeFonts(fontSelector)); }
     static Ref<FontCascadeFonts> createForPlatformFont(const FontPlatformData& platformData) { return adoptRef(*new FontCascadeFonts(platformData)); }
 
     WEBCORE_EXPORT ~FontCascadeFonts();
 
     bool isForPlatformFont() const { return m_isForPlatformFont; }
+
+    bool isValid() const { return m_isValid; }
+    void invalidate() { m_isValid = false; }
+    bool isRegisteredWithFontSelector() const { return m_registeredWithFontSelector; }
 
     GlyphData glyphDataForCharacter(char32_t, const FontCascadeDescription&, FontSelector*, FontVariant, ResolvedEmojiPolicy);
 
@@ -153,8 +157,10 @@ public:
     void pruneSystemFallbacks();
 
 private:
-    FontCascadeFonts();
+    FontCascadeFonts(FontSelector*);
     FontCascadeFonts(const FontPlatformData&);
+
+    void registerWithFontSelectorIfNeeded(FontSelector*);
 
     GlyphData glyphDataForSystemFallback(char32_t, const FontCascadeDescription&, FontSelector*, FontVariant, ResolvedEmojiPolicy, bool systemFallbackShouldBeInvisible);
     GlyphData glyphDataForVariant(char32_t, const FontCascadeDescription&, FontSelector*, FontVariant, ResolvedEmojiPolicy, unsigned fallbackIndex = 0);
@@ -196,7 +202,10 @@ private:
     unsigned short m_generation { 0 };
     PitchType m_pitch { PitchType::Unknown };
     bool m_isForPlatformFont { false };
+    bool m_isValid { true };
+    bool m_registeredWithFontSelector { false };
     TriState m_canTakeFixedPitchFastContentMeasuring : 2 { TriState::Indeterminate };
+    WeakPtr<FontSelector> m_fontSelector;
 #if ASSERT_ENABLED
     std::optional<Ref<Thread>> m_thread;
 #endif

--- a/Source/WebCore/platform/graphics/FontCascadeInlines.h
+++ b/Source/WebCore/platform/graphics/FontCascadeInlines.h
@@ -42,6 +42,7 @@ namespace WebCore {
 
 inline const Font& FontCascade::primaryFont() const
 {
+    ensureFontsAreCurrent();
     if (m_fonts->cachedPrimaryFont())
         return *m_fonts->cachedPrimaryFont();
     WeakRef font = protect(m_fonts)->primaryFont(m_fontDescription, protect(fontSelector()).get());
@@ -51,16 +52,19 @@ inline const Font& FontCascade::primaryFont() const
 
 inline const FontRanges& FontCascade::fallbackRangesAt(unsigned index) const
 {
+    ensureFontsAreCurrent();
     return protect(m_fonts)->realizeFallbackRangesAt(m_fontDescription, protect(fontSelector()).get(), index);
 }
 
 inline bool FontCascade::isFixedPitch() const
 {
+    ensureFontsAreCurrent();
     return protect(m_fonts)->isFixedPitch(m_fontDescription, protect(fontSelector()).get());
 }
 
 inline bool FontCascade::canTakeFixedPitchFastContentMeasuring() const
 {
+    ensureFontsAreCurrent();
     auto cachedCanTakeFixedPitch = m_fonts->cachedCanTakeFixedPitchFastContentMeasuring();
     if (cachedCanTakeFixedPitch != TriState::Indeterminate)
         return cachedCanTakeFixedPitch == TriState::True;
@@ -103,6 +107,7 @@ inline float FontCascade::widthForTextUsingSimplifiedMeasuring(StringView text, 
 
 inline bool FontCascade::isPlatformFont() const
 {
+    ensureFontsAreCurrent();
     return m_fonts->isForPlatformFont();
 }
 

--- a/Source/WebCore/platform/graphics/FontSelector.cpp
+++ b/Source/WebCore/platform/graphics/FontSelector.cpp
@@ -26,9 +26,17 @@
 #include "config.h"
 #include "FontSelector.h"
 
+#include "FontCascadeFonts.h"
+
 namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FontAccessor);
+
+void FontSelector::invalidateAssociatedFontCascadeFonts()
+{
+    for (auto* fonts : m_associatedFontCascadeFonts)
+        fonts->invalidate();
+}
 
 TextStream& operator<<(TextStream& ts, const FontSelector& fontSelector)
 {

--- a/Source/WebCore/platform/graphics/FontSelector.h
+++ b/Source/WebCore/platform/graphics/FontSelector.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/FontRanges.h>
 #include <wtf/Forward.h>
+#include <wtf/HashSet.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WTF {
@@ -36,6 +37,7 @@ class TextStream;
 namespace WebCore {
 
 class FontCache;
+class FontCascadeFonts;
 class FontCascadeDescription;
 class FontDescription;
 struct FontFamily;
@@ -75,6 +77,12 @@ public:
 
     virtual bool isCSSFontSelector() const { return false; }
 
+    void registerFontCascadeFonts(FontCascadeFonts& fonts) { m_associatedFontCascadeFonts.add(&fonts); }
+    void unregisterFontCascadeFonts(FontCascadeFonts& fonts) { m_associatedFontCascadeFonts.remove(&fonts); }
+    WEBCORE_EXPORT void invalidateAssociatedFontCascadeFonts();
+
+private:
+    HashSet<FontCascadeFonts*> m_associatedFontCascadeFonts;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const FontSelector&);

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -528,8 +528,11 @@ void RenderBlockFlow::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit 
 {
     ASSERT(needsLayout());
 
-    if (relayoutChildren == RelayoutChildren::No && simplifiedLayout())
+    if (relayoutChildren == RelayoutChildren::No && simplifiedLayout()) {
+        // WTF_ALWAYS_LOG("@@@Vitor: RenderBlockFlow::layoutBlock SIMPLIFIED firstFamily=" << style().fontDescription().firstFamily().name);
         return;
+    }
+    // WTF_ALWAYS_LOG("@@@Vitor: RenderBlockFlow::layoutBlock FULL firstFamily=" << style().fontDescription().firstFamily().name << " selfNeedsLayout=" << selfNeedsLayout() << " normalChildNeedsLayout=" << normalChildNeedsLayout());
 
     auto isPaginated = [&] {
         // FIXME: Grid calls into layout outside of regular layout phase (during preferred width computation).

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1042,8 +1042,11 @@ RenderText::Widths RenderText::trimmedPreferredWidths(float leadWidth, bool& str
     if (!collapseWhiteSpace)
         stripFrontSpaces = false;
 
-    if (m_hasTab || needsPreferredLogicalWidthsUpdate() || !m_minWidth || !m_maxWidth)
+    bool shouldRecompute = m_hasTab || needsPreferredLogicalWidthsUpdate() || !m_minWidth || !m_maxWidth;
+    if (shouldRecompute)
         computePreferredLogicalWidths(leadWidth, !m_minWidth || !m_maxWidth);
+    // else
+        // WTF_ALWAYS_LOG("@@@Vitor: RenderText SKIPPING computePreferredLogicalWidths this=" << (const void*)this << " needsUpdate=" << needsPreferredLogicalWidthsUpdate() << " hasMinWidth=" << !!m_minWidth << " hasMaxWidth=" << !!m_maxWidth);
 
     Widths widths;
 
@@ -1171,6 +1174,7 @@ TextBreakIterator::ContentAnalysis mapWordBreakToContentAnalysis(WordBreak wordB
 
 void RenderText::computePreferredLogicalWidths(float leadWidth, bool forcedMinMaxWidthComputation)
 {
+    // WTF_ALWAYS_LOG("@@@Vitor: RenderText::computePreferredLogicalWidths this=" << (const void*)this << " firstFamily=" << style().fontDescription().firstFamily().name << " needsUpdate=" << needsPreferredLogicalWidthsUpdate() << " fontGeneration=" << style().fontCascade().generation());
     SingleThreadWeakHashSet<const Font> fallbackFonts;
     GlyphOverflow glyphOverflow;
     computePreferredLogicalWidths(leadWidth, fallbackFonts, glyphOverflow, forcedMinMaxWidthComputation);

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -185,6 +185,7 @@ public:
     void resetMinMaxWidth();
 
     void setCanUseSimplifiedTextMeasuring(bool canUseSimplifiedTextMeasuring) { m_canUseSimplifiedTextMeasuring = canUseSimplifiedTextMeasuring; }
+    void clearCanUseSimplifiedTextMeasuring() { m_canUseSimplifiedTextMeasuring = { }; }
     std::optional<bool> canUseSimplifiedTextMeasuring() const { return m_canUseSimplifiedTextMeasuring; }
     void setHasPositionDependentContentWidth(bool hasPositionDependentContentWidth) { m_hasPositionDependentContentWidth = hasPositionDependentContentWidth; }
     std::optional<bool> hasPositionDependentContentWidth() const { return m_hasPositionDependentContentWidth; }

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -102,6 +102,11 @@ inline bool RenderStyle::usesViewportUnits() const
     return m_computedStyle.usesViewportUnits();
 }
 
+inline bool RenderStyle::dependsOnFontMetrics() const
+{
+    return m_computedStyle.dependsOnFontMetrics();
+}
+
 inline bool RenderStyle::usesContainerUnits() const
 {
     return m_computedStyle.usesContainerUnits();

--- a/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
@@ -82,6 +82,11 @@ inline void RenderStyle::setUsesViewportUnits()
     m_computedStyle.setUsesViewportUnits();
 }
 
+inline void RenderStyle::setDependsOnFontMetrics()
+{
+    m_computedStyle.setDependsOnFontMetrics();
+}
+
 inline void RenderStyle::setUsesContainerUnits()
 {
     m_computedStyle.setUsesContainerUnits();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -91,6 +91,9 @@ public:
     inline bool usesViewportUnits() const;
     inline void setUsesViewportUnits();
 
+    inline bool dependsOnFontMetrics() const;
+    inline void setDependsOnFontMetrics();
+
     inline bool usesContainerUnits() const;
     inline void setUsesContainerUnits();
 

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -299,6 +299,11 @@ void BuilderState::setUsesContainerUnits()
     m_style.setUsesContainerUnits();
 }
 
+void BuilderState::setDependsOnFontMetrics()
+{
+    m_style.setDependsOnFontMetrics();
+}
+
 double BuilderState::lookupCSSRandomBaseValue(const CSSCalc::RandomCachingKey& key, std::optional<CSS::Keyword::ElementScoped> elementScoped) const
 {
     if (elementScoped)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -174,6 +174,7 @@ public:
 
     void NODELETE setUsesViewportUnits();
     void NODELETE setUsesContainerUnits();
+    void NODELETE setDependsOnFontMetrics();
 
     double lookupCSSRandomBaseValue(const CSSCalc::RandomCachingKey&, std::optional<CSS::Keyword::ElementScoped>) const;
 

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
@@ -77,6 +77,7 @@ inline ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag)
     m_nonInheritedFlags.floating = static_cast<unsigned>(ComputedStyle::initialFloating());
     m_nonInheritedFlags.textDecorationLine = ComputedStyle::initialTextDecorationLine().toRaw();
     m_nonInheritedFlags.usesViewportUnits = false;
+    m_nonInheritedFlags.dependsOnFontMetrics = false;
     m_nonInheritedFlags.usesContainerUnits = false;
     m_nonInheritedFlags.useTreeCountingFunctions = false;
     m_nonInheritedFlags.hasExplicitlyInheritedProperties = false;
@@ -126,6 +127,7 @@ inline void ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom(const Non
     floating = other.floating;
     textDecorationLine = other.textDecorationLine;
     usesViewportUnits = other.usesViewportUnits;
+    dependsOnFontMetrics = other.dependsOnFontMetrics;
     usesContainerUnits = other.usesContainerUnits;
     useTreeCountingFunctions = other.useTreeCountingFunctions;
     hasExplicitlyInheritedProperties = other.hasExplicitlyInheritedProperties;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -104,6 +104,11 @@ inline bool ComputedStyleBase::usesViewportUnits() const
     return m_nonInheritedFlags.usesViewportUnits;
 }
 
+inline bool ComputedStyleBase::dependsOnFontMetrics() const
+{
+    return m_nonInheritedFlags.dependsOnFontMetrics;
+}
+
 inline bool ComputedStyleBase::usesContainerUnits() const
 {
     return m_nonInheritedFlags.usesContainerUnits;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -63,6 +63,11 @@ inline void ComputedStyleBase::setUsesViewportUnits()
     m_nonInheritedFlags.usesViewportUnits = true;
 }
 
+inline void ComputedStyleBase::setDependsOnFontMetrics()
+{
+    m_nonInheritedFlags.dependsOnFontMetrics = true;
+}
+
 inline void ComputedStyleBase::setUsesContainerUnits()
 {
     m_nonInheritedFlags.usesContainerUnits = true;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -465,6 +465,9 @@ public:
     inline bool usesViewportUnits() const;
     inline void setUsesViewportUnits();
 
+    inline bool dependsOnFontMetrics() const;
+    inline void setDependsOnFontMetrics();
+
     inline bool usesContainerUnits() const;
     inline void setUsesContainerUnits();
 
@@ -747,6 +750,7 @@ public:
         PREFERRED_TYPE(Float) unsigned floating : 3;
 
         PREFERRED_TYPE(bool) unsigned usesViewportUnits : 1;
+        PREFERRED_TYPE(bool) unsigned dependsOnFontMetrics : 1;
         PREFERRED_TYPE(bool) unsigned usesContainerUnits : 1;
         PREFERRED_TYPE(bool) unsigned useTreeCountingFunctions : 1;
         PREFERRED_TYPE(bool) unsigned hasExplicitlyInheritedProperties : 1; // Explicitly inherits a non-inherited property.

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -302,11 +302,14 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
         // FIXME: We have a bug right now where the zoom will be applied twice to EX units.
         // We really need to compute EX using fontMetrics for the original specifiedSize and not use
         // our actual constructed rendering font.
+        if (lengthUnit == Ex || lengthUnit == Cap || lengthUnit == Ch || lengthUnit == Ic)
+            conversionData.setDependsOnFontMetrics();
         value = computeUnzoomedNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), &conversionData.fontCascadeForFontUnits(), conversionData.rangeZoomOption());
         value = adjustZoomStateForFontRelativeUnitsIfNeeded(value, conversionData);
         break;
 
     case Lh:
+        conversionData.setDependsOnFontMetrics();
         if (conversionData.computingLineHeight() || conversionData.computingFontSize()) {
             // Try to get the parent's computed line-height, or fall back to the initial line-height of this element's font spacing.
             value *= conversionData.parentStyle() ? conversionData.parentStyle()->computedLineHeight() : conversionData.fontCascadeForFontUnits().metricsOfPrimaryFont().intLineSpacing();
@@ -325,11 +328,14 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
     case Rem:
     case Rex:
     case Ric:
+        if (lengthUnit == Rcap || lengthUnit == Rch || lengthUnit == Rex || lengthUnit == Ric)
+            conversionData.setDependsOnFontMetrics();
         value = computeUnzoomedNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), conversionData.rootStyle() ? &conversionData.rootStyle()->fontCascade() : &conversionData.fontCascadeForFontUnits(), conversionData.rangeZoomOption());
         value = adjustZoomStateForFontRelativeUnitsIfNeeded(value, conversionData);
         break;
 
     case Rlh:
+        conversionData.setDependsOnFontMetrics();
         if (auto* rootStyle = conversionData.rootStyle()) {
             if (conversionData.computingLineHeight() || conversionData.computingFontSize())
                 value *= Style::evaluate<float>(rootStyle->specifiedLineHeight(), Style::LineHeightEvaluationContext { rootStyle->computedFontSize(), rootStyle->metricsOfPrimaryFont().lineSpacing() }, rootStyle->usedZoomForLength());


### PR DESCRIPTION
#### e74b0b8c2dc1741d7911941924bb21cae07cc8ef
<pre>
Targeted font invalidation: replace full style rebuild with lazy font refresh
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

When a web font loads, replace scheduleFullStyleRebuild() with targeted
invalidation. FontCascadeFonts objects register with the FontSelector
during font resolution, and get explicitly invalidated when fonts change.
FontCascade::ensureFontsAreCurrent() lazily refreshes stale font data
on access. Only elements with font-metric-dependent CSS values (ex, ch,
cap, ic, lh, rlh units, font-size-adjust) get full restyle. Others get
relayout only.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e74b0b8c2dc1741d7911941924bb21cae07cc8ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110192 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29450 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120886 "Found 48 new test failures: fast/text/text-combine-placement.html fullscreen/fullscreen-env.html imported/w3c/web-platform-tests/css/css-font-loading/fontface-load-in-modal-dialog.html imported/w3c/web-platform-tests/css/css-fonts/math-script-level-and-math-style/math-script-level-004.tentative.html imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace.html imported/w3c/web-platform-tests/css/css-inline/text-box-trim/text-box-trim-float-clear-br-002.html imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-svg-text-font-loading.html imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-join-002.html imported/w3c/web-platform-tests/css/css-values/ch-empty-pseudo-recalc-on-font-load.html imported/w3c/web-platform-tests/css/css-values/ch-pseudo-recalc-on-font-load.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85100 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159072 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23098 "Found 3 new test failures: fast/css/variables/env/ios/safe-area-inset-env-set.html fast/text/text-combine-placement.html mathml/presentation/non-bmp-operators-spacing.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101566 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22199 "Found 43 new test failures: imported/w3c/web-platform-tests/css/css-font-loading/fontface-load-in-modal-dialog.html imported/w3c/web-platform-tests/css/css-fonts/math-script-level-and-math-style/math-script-level-004.tentative.html imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace.html imported/w3c/web-platform-tests/css/css-inline/text-box-trim/text-box-trim-float-clear-br-002.html imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-svg-text-font-loading.html imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-join-002.html imported/w3c/web-platform-tests/css/css-values/ch-empty-pseudo-recalc-on-font-load.html imported/w3c/web-platform-tests/css/css-values/ch-pseudo-recalc-on-font-load.html imported/w3c/web-platform-tests/css/css-values/ch-recalc-on-font-load.html imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-parameters-gap-001.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20319 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12707 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131837 "Found 1 new API test failure: TestWebKitAPI.WKScrollViewTests.SafeAreaEnvironmentVariablesAccountForObscuredContentInsets (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167414 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11530 "Found 2 new failures in dom/Document.cpp, platform/graphics/FontSelector.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19640 "Found 50 new test failures: fast/text/text-combine-placement.html fullscreen/fullscreen-env.html imported/w3c/web-platform-tests/css/css-font-loading/fontface-load-in-modal-dialog.html imported/w3c/web-platform-tests/css/css-fonts/math-script-level-and-math-style/math-script-level-004.tentative.html imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace.html imported/w3c/web-platform-tests/css/css-inline/text-box-trim/text-box-trim-float-clear-br-002.html imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-svg-text-font-loading.html imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-join-002.html imported/w3c/web-platform-tests/css/css-values/ch-empty-pseudo-recalc-on-font-load.html imported/w3c/web-platform-tests/css/css-values/ch-pseudo-recalc-on-font-load.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129005 "Found 49 new test failures: fast/text/text-combine-placement.html fullscreen/fullscreen-env.html imported/w3c/web-platform-tests/css/css-font-loading/fontface-load-in-modal-dialog.html imported/w3c/web-platform-tests/css/css-fonts/math-script-level-and-math-style/math-script-level-004.tentative.html imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace.html imported/w3c/web-platform-tests/css/css-inline/text-box-trim/text-box-trim-float-clear-br-002.html imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-svg-text-font-loading.html imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-join-002.html imported/w3c/web-platform-tests/css/css-values/ch-empty-pseudo-recalc-on-font-load.html imported/w3c/web-platform-tests/css/css-values/ch-pseudo-recalc-on-font-load.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29050 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24387 "Found 60 new test failures: css3/font-synthesis-small-caps.html fast/mediastream/enumerateDevices-camera-denied-expose-with-capture.html fast/text/text-combine-placement.html fullscreen/fullscreen-env.html http/tests/navigation/redirect-to-random-url-versus-memory-cache.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.worker.html imported/w3c/web-platform-tests/IndexedDB/nested-cloning-large-multiple.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/nested-cloning-large-multiple.any.worker.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129131 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28972 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139822 "1 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86739 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23960 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16621 "Found 60 new test failures: css3/blending/blend-mode-clip-rect-accelerated-blending.html css3/font-synthesis-small-caps.html css3/masking/mask-luminance-gradient.html fast/canvas/webgl/gl-teximage-imagebitmap-memory.html fast/inline/blocks-in-inline-layout-with-margin-after3.html fast/lists/list-marker-outside-inside-flex-item.html fast/text/text-combine-placement.html fullscreen/fullscreen-env.html http/tests/privateClickMeasurement/expired-attribution-report-gets-sent-on-session-start.html imported/w3c/web-platform-tests/IndexedDB/idbversionchangeevent.any.sharedworker.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28681 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92638 "Found 2 new failures in dom/Document.cpp, platform/graphics/FontSelector.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28208 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28436 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28332 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->