### PR TITLE
Remove unnecessary unsafe annotations in CryptoKit+UnsafeOverlays.swift

### DIFF
--- a/Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift
@@ -34,6 +34,7 @@ private enum UnsafeErrors: Error {
 
 extension Data {
     fileprivate static func temporaryDataFromSpan(spanNoCopy: PAL.Crypto.SpanConstUInt8) -> Data {
+        #if hasFeature(StrictMemorySafety)
         guard unsafe spanNoCopy.empty() else {
             return unsafe Data(
                 bytesNoCopy: UnsafeMutablePointer(mutating: spanNoCopy.__dataUnsafe()),
@@ -41,6 +42,15 @@ extension Data {
                 deallocator: .none
             )
         }
+        #else
+        guard spanNoCopy.empty() else {
+            return unsafe Data(
+                bytesNoCopy: UnsafeMutablePointer(mutating: spanNoCopy.__dataUnsafe()),
+                count: spanNoCopy.size(),
+                deallocator: .none
+            )
+        }
+        #endif
 
         // CryptoKit does not support a null pointer with zero length. We instead need to pass an empty Data. This class provides that.
         return Data()
@@ -49,6 +59,7 @@ extension Data {
 
 extension CryptoKit.HashFunction {
     mutating func update(data: PAL.Crypto.SpanConstUInt8) {
+        #if hasFeature(StrictMemorySafety)
         if unsafe data.empty() {
             self.update(data: Data())
         } else {
@@ -59,6 +70,18 @@ extension CryptoKit.HashFunction {
                 )
             )
         }
+        #else
+        if data.empty() {
+            self.update(data: Data())
+        } else {
+            unsafe self.update(
+                bufferPointer: UnsafeRawBufferPointer(
+                    start: data.__dataUnsafe(),
+                    count: data.size()
+                )
+            )
+        }
+        #endif
     }
 }
 
@@ -69,6 +92,7 @@ extension AES.GCM {
         iv: PAL.Crypto.SpanConstUInt8,
         ad: PAL.Crypto.SpanConstUInt8
     ) throws -> AES.GCM.SealedBox {
+        #if hasFeature(StrictMemorySafety)
         guard unsafe ad.size() > 0 else {
             return try unsafe AES.GCM.seal(
                 Data.temporaryDataFromSpan(spanNoCopy: message),
@@ -76,6 +100,15 @@ extension AES.GCM {
                 nonce: AES.GCM.Nonce(data: Data.temporaryDataFromSpan(spanNoCopy: iv))
             )
         }
+        #else
+        guard ad.size() > 0 else {
+            return try unsafe AES.GCM.seal(
+                Data.temporaryDataFromSpan(spanNoCopy: message),
+                using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)),
+                nonce: AES.GCM.Nonce(data: Data.temporaryDataFromSpan(spanNoCopy: iv))
+            )
+        }
+        #endif
         return try unsafe AES.GCM.seal(
             Data.temporaryDataFromSpan(spanNoCopy: message),
             using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)),
@@ -105,43 +138,73 @@ extension AES.KeyWrap {
 
 extension P256.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 }
 
 extension P384.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 }
 
 extension P521.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 }
 
 extension P256.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if spanCompressed.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(
             compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed)
         )
@@ -150,16 +213,28 @@ extension P256.Signing.PublicKey {
 
 extension P384.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if spanCompressed.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(
             compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed)
         )
@@ -168,16 +243,28 @@ extension P384.Signing.PublicKey {
 
 extension P521.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if spanCompressed.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(
             compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed)
         )
@@ -186,43 +273,73 @@ extension P521.Signing.PublicKey {
 
 extension P256.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 }
 
 extension P384.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 }
 
 extension P521.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 }
 
 extension Curve25519.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func signature(span: PAL.Crypto.SpanConstUInt8) throws -> PAL.Crypto.VectorUInt8 {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             return try self.signature(for: Data()).copyToVectorUInt8()
         }
+        #else
+        if span.empty() {
+            return try self.signature(for: Data()).copyToVectorUInt8()
+        }
+        #endif
         return try unsafe self.signature(for: Data.temporaryDataFromSpan(spanNoCopy: span))
             .copyToVectorUInt8()
     }
@@ -230,16 +347,28 @@ extension Curve25519.Signing.PrivateKey {
 
 extension Curve25519.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func isValidSignature(signature: PAL.Crypto.SpanConstUInt8, data: PAL.Crypto.SpanConstUInt8) -> Bool {
+        #if hasFeature(StrictMemorySafety)
         if unsafe (signature.empty() || data.empty()) {
             return false
         }
+        #else
+        if signature.empty() || data.empty() {
+            return false
+        }
+        #endif
 
         return unsafe self.isValidSignature(
             Data.temporaryDataFromSpan(spanNoCopy: signature),
@@ -250,16 +379,28 @@ extension Curve25519.Signing.PublicKey {
 
 extension Curve25519.KeyAgreement.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func sharedSecretFromKeyAgreement(pubSpan: PAL.Crypto.SpanConstUInt8) throws -> PAL.Crypto.VectorUInt8 {
+        #if hasFeature(StrictMemorySafety)
         if unsafe pubSpan.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if pubSpan.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         let pub = try unsafe Curve25519.KeyAgreement.PublicKey(
             rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: pubSpan)
         )
@@ -269,9 +410,15 @@ extension Curve25519.KeyAgreement.PrivateKey {
 
 extension Curve25519.KeyAgreement.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
+        #if hasFeature(StrictMemorySafety)
         if unsafe span.empty() {
             throw UnsafeErrors.emptySpan
         }
+        #else
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        #endif
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 }


### PR DESCRIPTION
#### 53417064ef18e1e043bfb8bce00b8ed9472f71d6
<pre>
Remove unnecessary unsafe annotations in CryptoKit+UnsafeOverlays.swift
<a href="https://rdar.apple.com/174679913">rdar://174679913</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312181">https://bugs.webkit.org/show_bug.cgi?id=312181</a>

Reviewed by NOBODY (OOPS!).

These unsafe blocks that don&apos;t contain unsafe code cause warnings on some
swift compilers and errors on others. This patch removes the keyword where
appropriate.

* Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift:
(Data.temporaryDataFromSpan(_:)):
(CryptoKit.update(_:)):
(Curve25519.signature(_:)):
(Curve25519.isValidSignature(_:data:)):
(Curve25519.sharedSecretFromKeyAgreement(_:)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53417064ef18e1e043bfb8bce00b8ed9472f71d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156253 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165074 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29591 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159211 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/101669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12846 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148303 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167553 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19757 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29189 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/129235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29111 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/139938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24056 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92777 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28347 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28575 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28471 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->