### PR TITLE
[AI Experiment, Do Not Review, Next Gen Model Generated] DFG compilePeepHoleBranch missing HeapBigIntUse causes doesGC assertion failure

### DIFF
--- a/JSTests/stress/dfg-peephole-heap-bigint-compare-does-gc.js
+++ b/JSTests/stress/dfg-peephole-heap-bigint-compare-does-gc.js
@@ -1,0 +1,36 @@
+//@ requireOptions("--validateDoesGC=1", "--jitPolicyScale=0", "--useConcurrentJIT=0")
+
+// rdar://172191300
+// 308054@main marked CompareLess/LessEq/Greater/GreaterEq with HeapBigIntUse as
+// doesGC()==false and added compileHeapBigIntCompare() for the non-peep-hole
+// path, but forgot the peep-hole branch path, which fell through to
+// genericJSValuePeepholeBranch() and called the generic operationCompareLess
+// (with throw scope and exception check) under expectDoesGC==false.
+//
+// In a Debug build (ENABLE_DFG_DOES_GC_VALIDATION) this trips
+// RELEASE_ASSERT(expectDoesGC()) when the watchdog/termination unwinds out of
+// the JIT frame without resetting the DoesGC marker.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+// HeapBigInt operands (out of BigInt32 range so FixupPhase picks HeapBigIntUse).
+var a = 2n ** 64n;
+var b = a + 1n;
+
+function lt(x, y)  { if (x < y)  return 1; return 0; }
+function le(x, y)  { if (x <= y) return 1; return 0; }
+function gt(x, y)  { if (x > y)  return 1; return 0; }
+function ge(x, y)  { if (x >= y) return 1; return 0; }
+function eq(x, y)  { if (x == y) return 1; return 0; }
+noInline(lt); noInline(le); noInline(gt); noInline(ge); noInline(eq);
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(lt(a, b), 1);
+    shouldBe(le(a, b), 1);
+    shouldBe(gt(a, b), 0);
+    shouldBe(ge(a, b), 0);
+    shouldBe(eq(a, a), 1);
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2027,6 +2027,13 @@ bool SpeculativeJIT::compilePeepHoleBranch(Node* node, RelationalCondition condi
         else if (node->isBinaryUseKind(StringUse) || node->isBinaryUseKind(StringIdentUse)) {
             // Use non-peephole comparison, for now.
             return false;
+        } else if (node->isBinaryUseKind(HeapBigIntUse)) {
+            // Use non-peephole comparison so we go through compileHeapBigIntCompare,
+            // which calls the no-throw/no-GC operationCompareHeapBigInt* helpers.
+            // Falling through to genericJSValuePeepholeBranch would call the generic
+            // operationCompare* (with throw scope and exception check), violating the
+            // doesGC()==false claim made for HeapBigIntUse in DFGDoesGC.cpp.
+            return false;
         } else if (node->isBinaryUseKind(DoubleRepUse))
             compilePeepHoleDoubleBranch(node, branchNode, doubleCondition);
         else if (node->op() == CompareEq) {


### PR DESCRIPTION
#### d9a5d3342bd777e49e22e0fb4f1b76475ddf7d95
<pre>
[AI Experiment, Do Not Review, Next Gen Model Generated] DFG compilePeepHoleBranch missing HeapBigIntUse causes doesGC assertion failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=312183">https://bugs.webkit.org/show_bug.cgi?id=312183</a>
<a href="https://rdar.apple.com/174681530">rdar://174681530</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/308054@main">308054@main</a> added HeapBigIntUse to the doesGC()==false list for relational
comparisons and added compileHeapBigIntCompare() for the non-peep-hole path,
but compilePeepHoleBranch() had no HeapBigIntUse arm. Peep-hole
CompareLess(HeapBigInt, HeapBigInt)+Branch fell through to
genericJSValuePeepholeBranch(), which called the generic operationCompareLess
(with throw scope and exception check) under expectDoesGC==false. In Debug
builds, the watchdog/termination unwind path triggers
RELEASE_ASSERT(expectDoesGC()) in DFGDoesGCCheck.cpp.

Add a HeapBigIntUse arm to compilePeepHoleBranch() that returns false,
mirroring the existing StringUse/StringIdentUse bailout. The compare then
goes through compileHeapBigIntCompare() and the no-GC
operationCompareHeapBigInt* helpers.

Test: JSTests/stress/dfg-peephole-heap-bigint-compare-does-gc.js

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compilePeepHoleBranch):
* JSTests/stress/dfg-peephole-heap-bigint-compare-does-gc.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9a5d3342bd777e49e22e0fb4f1b76475ddf7d95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110206 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120887 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85099 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101567 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22172 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20322 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12721 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148178 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131832 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167428 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16962 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129006 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/155526 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129132 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86753 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23952 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16639 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188011 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28695 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92652 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48334 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28222 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28450 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28346 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->