### PR TITLE
[AI Experiment, Do Not Review, Next Gen Model Generated] YARR JIT FixedCount-with-ParenContext corrupts nested ParenContext chain causing null deref

### DIFF
--- a/JSTests/stress/regexp-fixedcount-nested-paren-context.js
+++ b/JSTests/stress/regexp-fixedcount-nested-paren-context.js
@@ -1,0 +1,36 @@
+function shouldBe(actual, expected) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(`expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
+}
+
+// FixedCount generic paren containing a nested ParenContext-using paren.
+// The YARR JIT used to corrupt the nested paren's ParenContext freelist while
+// backtracking the outer FixedCount group, leading to a null/garbage deref.
+// rdar://173140757
+
+for (let i = 0; i < 100; ++i) {
+    // Non-greedy nested *?
+    shouldBe(/((a)*?b){2}x/.exec("ababa"), null);
+    shouldBe(/((a)*?b){2}x/.exec("ababax"), null);
+    shouldBe(/((a)*?b){2}x/.exec("ababx"), ["ababx", "ab", "a"]);
+    shouldBe(/((a)*?b){2}x/.exec("abaabx"), ["abaabx", "aab", "a"]);
+
+    // Greedy nested *
+    shouldBe(/((a)*b){2}x/.exec("aabaabab"), null);
+    shouldBe(/((a)*b){2}x/.exec("aabaababx"), ["aababx", "ab", "a"]);
+
+    // Bounded non-greedy
+    shouldBe(/((a){0,2}?b){2}x/.exec("ababa"), null);
+
+    // Non-capturing outer
+    shouldBe(/(?:(a)*?b){2}x/.exec("ababa"), null);
+    shouldBe(/(?:(a)*b){2}x/.exec("aabaabab"), null);
+
+    // {3}
+    shouldBe(/(((.)*?(.??))[a-c]){3}cp/.exec("aabbbccc"), null);
+
+    // FixedCount cases that should still JIT and work.
+    shouldBe(/(a+){2}b/.exec("aaab"), ["aaab", "a"]);
+    shouldBe(/(a|aaa){2}b/.exec("aaab"), ["aab", "a"]);
+    shouldBe(/(ab){2}c/.exec("ababc"), ["ababc", "ab"]);
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -5295,6 +5295,15 @@ class YarrGenerator final : public YarrJITInfo {
                 } else {
                     // Capturing FixedCount, FixedCount with backtrackable content, or multi-alt FixedCount:
                     // need ParenContext to save/restore state between iterations.
+                    // FIXME: saveParenContext at END snapshots nested frame slots,
+                    // including any nested ParenContext head pointer. Content
+                    // backtracking can free those nested records, leaving the
+                    // snapshot dangling and corrupting the shared freelist
+                    // (rdar://173140757). Fall back to the interpreter for now.
+                    if (disjunctionContainsParenContextSubpattern(term->parentheses.disjunction)) {
+                        m_failureReason = JITFailureReason::ParenthesizedSubpattern;
+                        return;
+                    }
                     m_containsNestedSubpatterns = true;
                     m_usesT2 = true;
                     parenthesesBeginOpCode = YarrOpCode::ParenthesesSubpatternBegin;
@@ -6618,6 +6627,33 @@ public:
                     if (disjunctionContainsBacktrackableContent(term.parentheses.disjunction))
                         return true;
                 }
+            }
+        }
+        return false;
+    }
+
+    // Returns true if the disjunction contains a parenthesized subpattern that
+    // will be compiled to ParenthesesSubpatternBegin/End (i.e. one that
+    // allocates ParenContext records). FixedCount-with-ParenContext groups
+    // save their nested frame slots — including any nested paren's
+    // parenContextHead pointer — at END. During content backtracking the
+    // nested paren can free those records, leaving the saved pointer dangling
+    // and corrupting the shared freelist. Until that interaction is fixed,
+    // bail to the interpreter for FixedCount groups whose body contains such
+    // a nested paren. See rdar://173140757.
+    static bool disjunctionContainsParenContextSubpattern(PatternDisjunction* disjunction)
+    {
+        for (auto& alternative : disjunction->m_alternatives) {
+            for (auto& term : alternative->m_terms) {
+                if (term.type != PatternTerm::Type::ParenthesesSubpattern)
+                    continue;
+                // Mirror the selection logic in opCompileParenthesesSubpattern():
+                // anything that is not the Once/Terminal/simple-FixedCount path
+                // ends up using ParenContext.
+                if (term.quantityMaxCount != 1 && !term.parentheses.isTerminal)
+                    return true;
+                if (disjunctionContainsParenContextSubpattern(term.parentheses.disjunction))
+                    return true;
             }
         }
         return false;


### PR DESCRIPTION
#### d715f0c612bc03209aeb5402dda6041d5b708b72
<pre>
[AI Experiment, Do Not Review, Next Gen Model Generated] YARR JIT FixedCount-with-ParenContext corrupts nested ParenContext chain causing null deref
<a href="https://bugs.webkit.org/show_bug.cgi?id=312185">https://bugs.webkit.org/show_bug.cgi?id=312185</a>
<a href="https://rdar.apple.com/174682071">rdar://174682071</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/306744@main">306744@main</a> taught the YARR JIT to compile (...){N} (FixedCount, N &gt; 1,
variable-width body) using ParenthesesSubpatternBegin/End with ParenContext
records. Unlike Greedy/NonGreedy parens, FixedCount calls saveParenContext
at END, so the snapshot includes nested paren frame slots — including the
nested paren&apos;s parenContextHeadIndex pointer.

When the FixedCount body contains a paren that also uses ParenContext,
backtracking frees the nested paren&apos;s ParenContext records while the outer
FixedCount&apos;s saved snapshot still holds a pointer into that chain. On the
next backtrack pass, restoreParenContext writes the stale pointer back,
causing freelist corruption, runaway match counts, and eventually a
null/garbage parenContextHead dereference.

A null-check alone is insufficient — the greedy variant crashes with
parenContextHead=0x2 (freelist-corrupted, not null). The proper fix requires
the FixedCount snapshot to own or deep-copy the nested chain.

As a safe targeted fix, decline to JIT this specific shape by adding
disjunctionContainsParenContextSubpattern() which detects nested
ParenContext-using parens, and bail to the (correct) interpreter. Cases
that motivated <a href="https://commits.webkit.org/306744@main">306744@main</a> (/(a+){2}b/, /(a|aaa){2}b/, /(ab){2}c/) remain
JIT-compiled.

Test: JSTests/stress/regexp-fixedcount-nested-paren-context.js

* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::YarrGenerator::opCompileParenthesesSubpattern):
(JSC::Yarr::YarrGenerator::disjunctionContainsParenContextSubpattern):
* JSTests/stress/regexp-fixedcount-nested-paren-context.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d715f0c612bc03209aeb5402dda6041d5b708b72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156130 "Failed to checkout and rebase branch from PR 62661") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29465 "Failed to checkout and rebase branch from PR 62661") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22647 "Failed to checkout and rebase branch from PR 62661") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164951 "Failed to checkout and rebase branch from PR 62661") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110208 "Failed to checkout and rebase branch from PR 62661") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29598 "Failed to checkout and rebase branch from PR 62661") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29466 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/164951 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/110208 "Failed to checkout and rebase branch from PR 62661") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159088 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/29598 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/22647 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/164951 "Failed to checkout and rebase branch from PR 62661") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/29598 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/29466 "Failed to checkout and rebase branch from PR 62661") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12723 "Failed to checkout and rebase branch from PR 62661") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148180 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/29598 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/22647 "Failed to checkout and rebase branch from PR 62661") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167430 "Failed to checkout and rebase branch from PR 62661") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16964 "Failed to checkout and rebase branch from PR 62661") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11546 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/22647 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/167430 "Failed to checkout and rebase branch from PR 62661") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29066 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/29466 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/167430 "Failed to checkout and rebase branch from PR 62661") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28988 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/22647 "Failed to checkout and rebase branch from PR 62661") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86755 "Failed to checkout and rebase branch from PR 62661") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/28988 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/22647 "Failed to checkout and rebase branch from PR 62661") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188013 "Failed to checkout and rebase branch from PR 62661") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28697 "Failed to checkout and rebase branch from PR 62661") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92654 "Failed to checkout and rebase branch from PR 62661") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/188013 "Failed to checkout and rebase branch from PR 62661") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28224 "Failed to checkout and rebase branch from PR 62661") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28452 "Failed to checkout and rebase branch from PR 62661") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28348 "Failed to checkout and rebase branch from PR 62661") | | | | 
<!--EWS-Status-Bubble-End-->