### PR TITLE
AX: Resolving aria-labelledby and aria-describedby can cause infinite recursion, eventually crashing

### DIFF
--- a/LayoutTests/accessibility/aria-labelledby-cycle-multi-element-expected.txt
+++ b/LayoutTests/accessibility/aria-labelledby-cycle-multi-element-expected.txt
@@ -1,0 +1,11 @@
+This tests that multi-element aria-labelledby cycles do not cause infinite recursion or a crash.
+
+PASS: typeof platformValueForW3CName(a1) === 'string'
+PASS: typeof platformValueForW3CName(a2) === 'string'
+PASS: typeof platformValueForW3CName(a3) === 'string'
+PASS: typeof platformValueForW3CName(a4) === 'string'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+A content E content A content E content A content E content A content E content

--- a/LayoutTests/accessibility/aria-labelledby-cycle-multi-element.html
+++ b/LayoutTests/accessibility/aria-labelledby-cycle-multi-element.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<!-- This file tests various multi-element aria-labelledby cycles, causing infinite recursion
+     if our implementation is incorrectly coded.
+
+     The cycle: computing A's accessible name requires D's text content.
+     D contains E. E's accessible name requires F's text content.
+     F contains A. So computing A's name requires computing A's name -> infinite recursion.
+
+     This test passes if it runs without crashing or hanging.
+-->
+
+<!-- Test 1: Three-element aria-labelledby cycle via DOM containment. -->
+<span id="F1">
+    <span id="A1" aria-labelledby="D1">A content</span>
+</span>
+<span id="D1">
+    <span id="E1" aria-labelledby="F1">E content</span>
+</span>
+
+<!-- Test 2: Four-element cycle: A->D->E->G->F->A. -->
+<span id="F2">
+    <span id="A2" aria-labelledby="D2">A content</span>
+</span>
+<span id="D2">
+    <span id="G2">
+        <span id="E2" aria-labelledby="F2">E content</span>
+    </span>
+</span>
+
+<!-- Test 3: Cycle through aria-labelledby and aria-describedby. -->
+<span id="F3">
+    <span id="A3" aria-labelledby="D3">A content</span>
+</span>
+<span id="D3">
+    <span id="E3" aria-describedby="F3">E content</span>
+</span>
+
+<!-- Test 4: Dynamic cycle creation via JavaScript. -->
+<span id="F4">
+    <span id="A4" aria-labelledby="D4">A content</span>
+</span>
+<span id="D4">
+    <span id="E4">E content</span>
+</span>
+
+<script>
+var output = "This tests that multi-element aria-labelledby cycles do not cause infinite recursion or a crash.\n\n";
+
+if (window.accessibilityController) {
+    // Test 1: Static 3-element cycle. Accessing the name should not hang or crash.
+    var a1 = accessibilityController.accessibleElementById("A1");
+
+    // The main assertion is that we reach this point without crashing.
+    // Whatever name is computed (possibly empty due to the cycle), it should be finite.
+    output += expect("typeof platformValueForW3CName(a1)", "'string'");
+
+    // Test 2: Static 4-element cycle.
+    var a2 = accessibilityController.accessibleElementById("A2");
+    output += expect("typeof platformValueForW3CName(a2)", "'string'");
+
+    // Test 3: Cycle through describedby.
+    var a3 = accessibilityController.accessibleElementById("A3");
+    output += expect("typeof platformValueForW3CName(a3)", "'string'");
+
+    // Test 4: Create a cycle dynamically.
+    document.getElementById("E4").setAttribute("aria-labelledby", "F4");
+    var a4 = accessibilityController.accessibleElementById("A4");
+    output += expect("typeof platformValueForW3CName(a4)", "'string'");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4513,6 +4513,20 @@ String AccessibilityNodeObject::descriptionForElements(const Vector<Ref<Element>
 
 String AccessibilityNodeObject::ariaDescribedByAttribute() const
 {
+    // Per the W3C accname spec, if the current node is already part of an
+    // aria-describedby traversal, do not follow its aria-describedby. This
+    // prevents infinite recursion in multi-element cycles.
+    RefPtr element = this->element();
+    if (!element)
+        return { };
+
+    static NeverDestroyed<HashSet<const Element*>> elementsCurrentlyResolving;
+    if (!elementsCurrentlyResolving->add(element.get()).isNewEntry)
+        return { };
+    auto removeOnExit = makeScopeExit([&] {
+        elementsCurrentlyResolving->remove(element.get());
+    });
+
     return descriptionForElements(elementsFromAttribute(aria_describedbyAttr));
 }
 
@@ -4528,6 +4542,21 @@ Vector<Ref<Element>> AccessibilityNodeObject::ariaLabeledByElements() const
 
 String AccessibilityNodeObject::ariaLabeledByAttribute() const
 {
+    // Per the W3C accname spec, if the current node is already part of an
+    // aria-labelledby traversal, do not follow its aria-labelledby. This
+    // prevents infinite recursion in multi-element cycles (e.g., A labelledby
+    // D which contains E which is labelledby F which contains A).
+    RefPtr element = this->element();
+    if (!element)
+        return { };
+
+    static NeverDestroyed<HashSet<const Element*>> elementsCurrentlyResolving;
+    if (!elementsCurrentlyResolving->add(element.get()).isNewEntry)
+        return { };
+    auto removeOnExit = makeScopeExit([&] {
+        elementsCurrentlyResolving->remove(element.get());
+    });
+
     return descriptionForElements(ariaLabeledByElements());
 }
 


### PR DESCRIPTION
#### a7d0c47159318aea357997cd6a387444af4c8ffe
<pre>
AX: Resolving aria-labelledby and aria-describedby can cause infinite recursion, eventually crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=312187">https://bugs.webkit.org/show_bug.cgi?id=312187</a>
<a href="https://rdar.apple.com/174683836">rdar://174683836</a>

Reviewed by Chris Fleizach.

The accessible name computation had no recursion guard against cycles
involving 3+ elements. The existing ignoredChildNode guard only prevented
direct 2-element cycles. Cycles through intermediary elements bypassed it
because each descriptionForElements call created a fresh TextUnderElementMode
with a different ignoredChildNode.

Added a visited-element set (via static NeverDestroyed&lt;HashSet&gt;) to both
ariaLabeledByAttribute() and ariaDescribedByAttribute(). If we re-enter
either function for an element already being resolved, we return an empty
string, breaking the cycle. This follows the W3C accname spec: &quot;If the
current node is already part of an aria-labelledby traversal, do not
follow its aria-labelledby.&quot;

* LayoutTests/accessibility/aria-labelledby-cycle-multi-element-expected.txt: Added.
* LayoutTests/accessibility/aria-labelledby-cycle-multi-element.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::ariaDescribedByAttribute const):
(WebCore::AccessibilityNodeObject::ariaLabeledByAttribute const):

Canonical link: <a href="https://commits.webkit.org/311172@main">https://commits.webkit.org/311172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63d02db82d387322e1504e40539733a928e7c8bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164957 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120894 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101573 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22176 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20331 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12729 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167436 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11552 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129012 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129136 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35006 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86761 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23958 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16633 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28703 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92660 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28230 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28458 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28354 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->