### PR TITLE
REGRESSION(306364@main): [macOS] PDF text selection color becomes darker when system is in dark appearance

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -950,7 +950,7 @@ void UnifiedPDFPlugin::paintPDFSelection(const GraphicsLayer* layer, GraphicsCon
         auto& renderTheme = renderer ? renderer->theme() : RenderTheme::singleton();
         OptionSet<StyleColorOptions> styleColorOptions;
         if (renderer)
-            styleColorOptions = renderer->styleColorOptions();
+            styleColorOptions = renderer->styleColorOptions() - WebCore::StyleColorOptions::UseDarkAppearance;
         auto selectionColor = isVisibleAndActive ? renderTheme.activeSelectionBackgroundColor(styleColorOptions) : renderTheme.inactiveSelectionBackgroundColor(styleColorOptions);
         return blendSourceOver(Color::white, selectionColor);
     }();

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
@@ -211,6 +211,7 @@ class Color;
 - (void)focus;
 - (std::optional<CGPoint>)getElementMidpoint:(NSString *)selector;
 - (Vector<WebCore::Color>)sampleColors;
+- (Vector<WebCore::Color>)sampleColorsInRect:(CGRect)rect;
 - (Vector<WebCore::Color>)sampleColorsWithInterval:(unsigned)interval;
 - (RetainPtr<_WKFrameTreeNode>)frameTree;
 - (void)typeCharacter:(char)character;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
@@ -823,9 +823,15 @@ static IterationStatus forEachCALayer(CALayer *layer, IterationStatus(^visitor)(
 
 - (CGImageRef)snapshotAfterScreenUpdates
 {
+    return [self snapshotAfterScreenUpdatesInRect:CGRectNull];
+}
+
+- (CGImageRef)snapshotAfterScreenUpdatesInRect:(CGRect)rect
+{
     __block RetainPtr<CGImage> result;
     __block bool done = false;
     RetainPtr configuration = adoptNS([WKSnapshotConfiguration new]);
+    [configuration setRect:rect];
     [configuration setAfterScreenUpdates:YES];
     [self takeSnapshotWithConfiguration:configuration.get() completionHandler:^(TestWebKitAPI::Util::PlatformImage *snapshot, NSError *) {
         result = TestWebKitAPI::Util::convertToCGImage(snapshot);
@@ -1389,11 +1395,21 @@ static UIWindowScene *windowScene()
     return [self sampleColorsWithInterval:TestWebKitAPI::CGImagePixelReader::defaultWebViewSamplingInterval];
 }
 
+- (Vector<WebCore::Color>)sampleColorsInRect:(CGRect)rect
+{
+    return [self sampleColorsInRect:rect withInterval:TestWebKitAPI::CGImagePixelReader::defaultWebViewSamplingInterval];
+}
+
 - (Vector<WebCore::Color>)sampleColorsWithInterval:(unsigned)interval
+{
+    return [self sampleColorsInRect:CGRectNull withInterval:TestWebKitAPI::CGImagePixelReader::defaultWebViewSamplingInterval];
+}
+
+- (Vector<WebCore::Color>)sampleColorsInRect:(CGRect)rect withInterval:(unsigned)interval
 {
     [self waitForNextPresentationUpdate];
     Vector<WebCore::Color> samples;
-    TestWebKitAPI::CGImagePixelReader reader { [self snapshotAfterScreenUpdates] };
+    TestWebKitAPI::CGImagePixelReader reader { [self snapshotAfterScreenUpdatesInRect:rect] };
     for (unsigned x = interval; x < reader.width() - interval; x += interval) {
         for (unsigned y = interval; y < reader.height() - interval; y += interval)
             samples.append(reader.at(x, y));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -412,6 +412,43 @@ UNIFIED_PDF_TEST(TextAnnotationBackgroundColorDoesNotAdaptToColorScheme)
     EXPECT_WK_STREQ(lightModeColor, darkModeColor);
 }
 
+UNIFIED_PDF_TEST(SelectionHighlightColorDoesNotAdaptToColorScheme)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get() addToWindow:YES]);
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]]];
+    [[webView window] makeFirstResponder:webView.get()];
+    [[webView window] makeKeyAndOrderFront:nil];
+    [[webView window] orderFrontRegardless];
+
+    CGRect webViewBounds = [webView bounds];
+    auto webViewWidth = CGRectGetWidth(webViewBounds);
+    auto webViewHeight = CGRectGetHeight(webViewBounds);
+
+    // We sample the inner 20% of the web view since
+    // the plugin background does adapt to color scheme.
+    CGRect snapshotRect = CGRectMake(webViewWidth * .4, webViewHeight * .4, webViewWidth * .2, webViewHeight * .2);
+
+    [webView forceLightMode];
+    [webView waitForNextPresentationUpdate];
+
+    [webView sendClickAtPoint:NSMakePoint(100, 100)];
+    [webView selectAll:nil];
+    [webView waitForNextPresentationUpdate];
+    auto lightModeColors = [webView sampleColorsInRect:snapshotRect];
+
+    [webView sendClickAtPoint:NSMakePoint(50, 50)];
+    [webView waitForNextPresentationUpdate];
+    [webView forceDarkMode];
+    [webView waitForNextPresentationUpdate];
+
+    [webView sendClickAtPoint:NSMakePoint(100, 100)];
+    [webView selectAll:nil];
+    [webView waitForNextPresentationUpdate];
+    auto darkModeColors = [webView sampleColorsInRect:snapshotRect];
+
+    EXPECT_EQ(lightModeColors, darkModeColors);
+}
+
 #endif // PLATFORM(MAC)
 
 #if ENABLE(PDF_HUD)


### PR DESCRIPTION
#### 098787f88f637b0502012859a539860e2bd3f2be
<pre>
REGRESSION(306364@main): [macOS] PDF text selection color becomes darker when system is in dark appearance
<a href="https://bugs.webkit.org/show_bug.cgi?id=312186">https://bugs.webkit.org/show_bug.cgi?id=312186</a>
<a href="https://rdar.apple.com/174654854">rdar://174654854</a>

Reviewed by Aditya Keerthi and Megan Gardner.

In 306364@main, we added a &lt;meta color-scheme=&quot;light dark&quot;&gt; element to
(main frame) plugin documents, which opted us into appearance change
adaptations. While this is generally correct, this bucks the established
behavior where text selection colors do not adapt.

In this patch, we revert the behavior change introduced in the
regressing commit for PDF text selections only by removing the relevant
style color option (UseDarkAppearance) when querying RenderStyle for the
platform selection color.

Tests: TestWebKitAPI.UnifiedPDF.SelectionHighlightColorDoesNotAdaptToColorScheme

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::paintPDFSelection):
* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm:
(-[WKWebView snapshotAfterScreenUpdates]):
(-[WKWebView snapshotAfterScreenUpdatesInRect:]):
(-[TestWKWebView sampleColorsInRect:]):
(-[TestWKWebView sampleColorsWithInterval:]):
(-[TestWKWebView sampleColorsInRect:withInterval:]):

To service the new test case, we introduce API support to sample colors
within a given rect in the web view.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):

Canonical link: <a href="https://commits.webkit.org/311173@main">https://commits.webkit.org/311173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/944fc3112ed26f860b6a9f5d459cb618d4aa18bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164956 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120892 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101571 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22175 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20330 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12728 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167435 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11551 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19649 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129009 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129134 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35004 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86760 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16630 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28702 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92659 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28229 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28457 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28353 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->