### PR TITLE
REGRESSION (Safari 26.4): Scaling the page resulting in length unit `ic` error

### DIFF
--- a/LayoutTests/fast/css/ic-unit-zoom-expected.txt
+++ b/LayoutTests/fast/css/ic-unit-zoom-expected.txt
@@ -1,0 +1,13 @@
+Tests that 'ic' unit remains proportional to 'em' when the frame text zoom factor is applied (simulating Safari's browser zoom). 1ic must equal 1em regardless of text zoom. Regression test for https://bugs.webkit.org/show_bug.cgi?id=279086.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+--- text zoom: 1.5, letter-spacing ---
+PASS getComputedStyle(icEl).letterSpacing is getComputedStyle(emEl).letterSpacing
+--- text zoom: 1.5, line-height ---
+PASS getComputedStyle(icEl).lineHeight is getComputedStyle(emEl).lineHeight
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/ic-unit-zoom.html
+++ b/LayoutTests/fast/css/ic-unit-zoom.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS ic unit with text zoom: ic equals em regardless of text zoom factor</title>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script>
+        description("Tests that 'ic' unit remains proportional to 'em' when the frame text zoom " +
+            "factor is applied (simulating Safari's browser zoom). 1ic must equal 1em regardless " +
+            "of text zoom. Regression test for https://bugs.webkit.org/show_bug.cgi?id=279086.");
+    </script>
+</head>
+<body>
+<script>
+    function makeLetterSpacingEl(parent, lengthSpec) {
+        var el = document.createElement('div');
+        el.style.letterSpacing = lengthSpec;
+        parent.appendChild(el);
+        return el;
+    }
+
+    var container, icEl, emEl;
+
+    if (window.internals) {
+        internals.setTextZoomFactor(1.5);
+
+        debug('--- text zoom: 1.5, letter-spacing ---');
+        container = document.createElement('div');
+        container.style.cssText = 'font-size: 20px; position: absolute; visibility: hidden;';
+        document.body.appendChild(container);
+        icEl = makeLetterSpacingEl(container, '1ic');
+        emEl = makeLetterSpacingEl(container, '1em');
+        shouldBe('getComputedStyle(icEl).letterSpacing', 'getComputedStyle(emEl).letterSpacing');
+        document.body.removeChild(container);
+
+        debug('--- text zoom: 1.5, line-height ---');
+        container = document.createElement('div');
+        container.style.cssText = 'font-size: 20px; position: absolute; visibility: hidden;';
+        document.body.appendChild(container);
+        icEl = document.createElement('div');
+        icEl.style.lineHeight = '1ic';
+        emEl = document.createElement('div');
+        emEl.style.lineHeight = '1em';
+        container.appendChild(icEl);
+        container.appendChild(emEl);
+        shouldBe('getComputedStyle(icEl).lineHeight', 'getComputedStyle(emEl).lineHeight');
+        document.body.removeChild(container);
+
+        internals.setTextZoomFactor(1.0);
+    } else {
+        testFailed('This test requires window.internals');
+    }
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/ic-unit-016-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/ic-unit-016-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test Reference File</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<style>
+div {
+  height: 10px;
+  background-color: blue;
+  margin-top: 10px;
+  width: 100px;
+}
+</style>
+<p>The test passes if there are two blue rectangles of equal length.</p>
+<div></div>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/ic-unit-016.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/ic-unit-016.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test: ic unit fallback to 1em</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#ic">
+<link rel="match" href="reference/ic-unit-016-ref.html">
+<meta name="assert" content="The ic unit should fallback to 1em when it is impossible to determine the advance measure of the 水 (CJK water ideograph, U+6C34) glyph in the font used to render it">
+<style>
+@font-face {
+  font-family: "icon-font";
+  src: url("data:font/woff2;base64,d09GMgABAAAAAAngAAoAAAAAGagAAAmTAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAABmAAgkIKpCiZEAtSAAE2AiQDgR4EIAUGB4c4GwcTUZRuUo/sx2HsZqnF1Ss+lo/VoBPFm3bORkgye4CbdpcESkOCaKDFK5aqUjHbYGKWTMxZ5/zE5c2c+/lT7mXjVgWS1L7JWnGZ6oNz2lw2vxvYI0lMaw+OWM7YxLY24f+qtPVE8Ofap2RSJVCdGkXj62T2ZScvm3xIc0S0W/wErsDyXG98gVmYGlOhK2ytrNpwFbgue9FMHHzf3P5liGoq87CmwInm9vUFgMLPyQUgASC2Ek8AYPXq1vgNmGABAAHBJIwPQBXcsbC9uRZufIgfRuLjwFmAp4bq22lQgIXSfuAmZzIUygByJbbKKLCXU0C1fRgZCIypWGUH1H8goBTGMgrSGlILciX7iqRJGTJJ0AcTSbRMkCT44okXB0Gxxi6/AUVpKLuM4xSci+MSbCouXqXn9CpapX3tYk0K4gyccjHmDrSeaeAYDadL0iU4Na5WpzHoKItcwlJt+B50976oQxzIUR4NcpwbE+OnO4FBr3y5cTPithh/BHP1W4n6jXI5bB1PXcwr4jZN42GQWRTNh0Cfx5jDRL0n46O9URyITrAYcb0CiHBTT6Pjta9LHeaCstGgGNYpztFEDL97l1ev6N+8H1y//O1fXb957/Jl9+KJaE6PjBhWjFVl4WZ5uKh9JSk1/CPKZEB9XBeWLlpnouMSP7Q+c/PzQtPWyenUqkct+eU0ZUmVbco4dw6m6XfMATCzM83IPExAIGSMqYs6S+VxakkX6Kgf9bVYrEAhsQRbX4ia2zURhnUxLFaUKBGmAAhduVdoHgDAgQv3bh5Zsog+fM4Go2++eDQlDIMFabZsXV0JgR3l7rB3+r5YAhoH/nURWC4OnXlCEuIVCm0xjTjRJP1WHPdsyjBYqRczJ7N/r173Lp9+dqnLFT5e11f+7r+esZP/D65v3l+o0afAn9uPx9+7z6f7jeORMuOsL7KucZ2Ly5fHv+u3/av/BGrAaNpp1w0K0Gsmpk1nk31XKpNVkpVHTSlOWAkLoQBkhy5skK9qOzDUGufIteuU9aF1QeH0rUYn19EgcWbqW/JoOWCik7ZMkg7DRlNKKvo9FjbpeqPxBHC/evaI/sXzuA5kWDt/8t7pQ7fyialWD4xaP/IVkLjaOM6rtcO6+f+lrHGsRQh/Ol7PMCOmQ4I6KY8xjHWiwMhPeKFC60hlL/VHRfXMI390RqkyyAY9YsdlpFFGlPI+o1XwjF4dCvMqc4UQ/VJoTVwOeMRMyJskxEnpt/PzMCiHTWaB94ooaiDJlPHLUl1s04XlplQl7n/k+wVWD1S2Va7qA2cIFPogyAVCoLwHAuoG0JCOo7Rx1wlrz1p3iDBWkYjEC5ylAnQRJ+3GFPb6Qt7M1MnGW8bRfLm6C1jSlEZaXMq+0d2wM0t/1QEStiJbO8yGXfHGwETaXGKsXaQwsCws80L7+yV1M/UW2bKiqcHXkCaJBKCeRkJdDrwPX07I6mp5G7sPg5ft7z1840l87tE/mVfwbqNwd0plnK2xLNvl9+VfK7uTe0UPE2Tp9RsaMWDq39vpV/m/czwZ8gSE6z61mva4PZ88KXYXm51PnObQ/h7wFNjsiiVLFB5arfaJ12Ff292NdBijvN+o1zfyCvBl2xaW3XL9+lKIpRt16PAP+nBIEvsb9abjVC++KAgsG3jxRZb9fswYFm5AabDp9M3i4punTcG7o9W2qJQeUtE6ZOoQermXS4sEkiQiiVqXIBzfx7+tpWQovKhi2Rdf/P57a77f747Y7OwDopZMmTJ0a0kVDEi1CCzJoX3olMD3bXqGWIB3ceq0BAnvF3hfxpLMknWETpr9Ihs88eI5VkHE/J8+Jmk1+LgAUfbZESf8LAc1CA1vvaXN9qmBJj9OSj531szfFCRVnLuYpNGSBAEEqkuk2VIdsb40EwKuYZU0tZYnqu6QVYZomF8y5+Ya40t6LQ+dsHd0hrUxKBNi3DyhceqVO8joylOeE55TlbS84o2xm2o4NZ6owxZ3T03GRfV6+GB340PKYe5aEwflUCYbeevU2XNxsd3LKGxsbW1EkmaVmUxz15bBjUc6qxoxTFJm6yXdBw9tq8qhUlPUgDBRptltWre2HKzVCzYRO160/dCoT0wsEBkJ7TsNouu6fAiv3Y0T9B+Lwh1aSzDueyZhdCRR1dAChzG5Y5TFThmqc4uSUod6CFSVz57jB38+Z3Y0/Lh27Rgjz8iQM8euZe2u1D8z0m7XaiIiNNrZNxJ+LWSVbg78ZIxtjtV2+SH/Qr8vCXbJZac7yUeTOtfIEUtY+6p+fqhId/oFwfu+JXwFW/O8YsbuZ9teGV8w/ULey8UGQ8rHeRemF4x/Zduz1eWiN2/r+RCWDTmPKShfvW3axbyPU3YWv5x3cVrJ7owrXS0z9/TcvWcy3bvrfM21hXD9OvnxTz99TPZngxOrNI4q7OmVQ7M9Ebt4GruAnbYY+he4GOalF53OF1+afV09DR8SKtxz2+bfDLsfjCV2dApWb+K7T0kJ9Y1aMYI4ckQjZVcy5NN3E9cUTQ1JOX48JVGifvQwydwnDo4Dj41rho9l4waLfeaUv/9OQbeHTC1aY6+XWclKNd14YoRC/Q0lgXleq9C5A5YcKr9qQXhczZUVp12cn96xbKs97gtsfVbg3OtauiDAJHGDU173Jokg3HX1+oREdyK2DVapBrfhY21Cpy2+eXPxNOV9XN/Txq6hDRy7cHbNvuQ/ri8oc3+TIQFwzidPuqtWtwxcEG7CDwAyIDRGkXGBOOiJwb4xJkAY90fiFHDeaTDLnjY3Ddx7Vln7sm7s8eFuKIIHxTSvEcvFagC6S6sUjF4u3jDo9oDHtzJ8l3gZozQoayDc5mfsGkbBMKBgvEkKBISQ/AkHrd8NCSSRQglKMQhlGIw0ypFBFhWoRBWqUYNa1KEeDWhEDk1oxhAMRQta0YZ2dKATXRiG4RiBkRgl+T2gWw0cNnjKhLFj+MnjmC182Lt1vwMpeSnBzYsJ/oYzGCRgOGta3gFYs0OWkYUWWCeg6RKOsrQgejCkn/4UUTL0iyEOjhkKNXhahnvfDuPBrVdQr0U/cdy/fJd8GIUpBDBeQKRQh2sEL6owlI/2BBEZGichvrpj7Hu5f6k+Ycj04WOG8lIYawQ0n7XbFQPkIcHLTyn2YwTBSIzsplTs2S5DGCiFAoJUS149E/nJ4wqHJwg4ALZgtTgiBG4mn3Ch4mE7P2ksH1RidwcLPY86GRZTvhS8NOXsBLfdsLMSAnbt/MjB08OxKc4zCP6mAchcbBAkZIQDAAA=") format("woff2");
+}
+
+div {
+  height: 10px;
+  background-color: blue;
+  margin-top: 10px;
+}
+
+div::before {
+  content: "\e00b";
+  display: none;
+}
+
+.test {
+  /* 50px + 5 * (1em) */
+  /* 50px + 5 * (1 * 10px) = 100px */
+  width: calc(50px + 5ic);
+}
+
+.ref {
+  width: 100px;
+}
+</style>
+<p>The test passes if there are two blue rectangles of equal length.</p>
+<!-- In the cases where it is impossible or impractical to determine
+     the measure of the "水" (CJK water ideograph, U+6C34) glyph,
+     it must be assumed to be 1em wide and 1em tall.
+     The icon-font has no CJK glyphs, so the ic unit must fall back to 1em. -->
+<div class="test" style="font: 10px icon-font"></div>
+<div class="ref"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/reference/ic-unit-016-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/reference/ic-unit-016-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test Reference File</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<style>
+div {
+  height: 10px;
+  background-color: blue;
+  margin-top: 10px;
+  width: 100px;
+}
+</style>
+<p>The test passes if there are two blue rectangles of equal length.</p>
+<div></div>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/ic-unit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/ic-unit-expected.txt
@@ -1,0 +1,11 @@
+ic letter-spacing with zoom 1.5
+em letter-spacing with zoom 1.5
+ic letter-spacing with zoom 2
+em letter-spacing with zoom 2
+ic line-height with zoom 1.5
+em line-height with zoom 1.5
+
+PASS ic equals em for letter-spacing under CSS zoom 1.5
+PASS ic equals em for letter-spacing under CSS zoom 2
+PASS ic equals em for line-height under CSS zoom 1.5
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/ic-unit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/ic-unit.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="author" title="WebKit" href="https://webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#ic">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<style>
+.zoom-1-5 { zoom: 1.5; font-size: 20px; }
+.zoom-2   { zoom: 2;   font-size: 20px; }
+</style>
+
+<div class="zoom-1-5">
+  <div id="ls-ic-zoom-1-5" style="letter-spacing: 1ic">ic letter-spacing with zoom 1.5</div>
+  <div id="ls-em-zoom-1-5" style="letter-spacing: 1em">em letter-spacing with zoom 1.5</div>
+</div>
+
+<div class="zoom-2">
+  <div id="ls-ic-zoom-2" style="letter-spacing: 1ic">ic letter-spacing with zoom 2</div>
+  <div id="ls-em-zoom-2" style="letter-spacing: 1em">em letter-spacing with zoom 2</div>
+</div>
+
+<div class="zoom-1-5">
+  <div id="lh-ic-zoom-1-5" style="line-height: 1ic">ic line-height with zoom 1.5</div>
+  <div id="lh-em-zoom-1-5" style="line-height: 1em">em line-height with zoom 1.5</div>
+</div>
+
+<script>
+// Per CSS Values 4, 1ic equals the advance measure of U+6C34, or falls back to 1em.
+// CSS zoom must not distort the ic-to-em ratio: both are font-relative and scale identically.
+
+test(() => {
+    assert_equals(
+        getComputedStyle(document.getElementById("ls-ic-zoom-1-5")).letterSpacing,
+        getComputedStyle(document.getElementById("ls-em-zoom-1-5")).letterSpacing,
+        "1ic should equal 1em for letter-spacing under zoom: 1.5"
+    );
+}, "ic equals em for letter-spacing under CSS zoom 1.5");
+
+test(() => {
+    assert_equals(
+        getComputedStyle(document.getElementById("ls-ic-zoom-2")).letterSpacing,
+        getComputedStyle(document.getElementById("ls-em-zoom-2")).letterSpacing,
+        "1ic should equal 1em for letter-spacing under zoom: 2"
+    );
+}, "ic equals em for letter-spacing under CSS zoom 2");
+
+test(() => {
+    assert_equals(
+        getComputedStyle(document.getElementById("lh-ic-zoom-1-5")).lineHeight,
+        getComputedStyle(document.getElementById("lh-em-zoom-1-5")).lineHeight,
+        "1ic should equal 1em for line-height under zoom: 1.5"
+    );
+}, "ic equals em for line-height under CSS zoom 1.5");
+</script>

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -119,8 +119,11 @@ LayoutUnit toUserUnits(const MathMLElement::Length& length, const RenderStyle& s
     // Zoom for logical units is accounted for either in the font info or referenceValue.
     case MathMLElement::LengthType::Em:
         return LayoutUnit(length.value * style.fontCascade().size());
-    case MathMLElement::LengthType::Ex:
-        return LayoutUnit(length.value * style.metricsOfPrimaryFont().xHeight().value_or(0) * style.usedZoom());
+    case MathMLElement::LengthType::Ex: {
+        // When evaluation-time zoom is enabled, font metrics already include the zoom factor.
+        auto zoomFactor = style.fontDescription().evaluationTimeZoomEnabled() ? 1.0f : style.usedZoom();
+        return LayoutUnit(length.value * style.metricsOfPrimaryFont().xHeight().value_or(0) * zoomFactor);
+    }
     case MathMLElement::LengthType::MathUnit:
         return LayoutUnit(length.value * style.fontCascade().size() / 18);
     case MathMLElement::LengthType::Percentage:

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -85,6 +86,18 @@ static double NODELETE lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis
     return lengthOfViewportPhysicalAxisForLogicalAxis(logicalAxis, size, rootElement->renderStyle());
 }
 
+// Raw font metrics include the usedZoomFactor. In evaluation-time zoom mode with the Unzoomed
+// range option, normalize by usedZoomFactor so that font-relative units (ex, cap, ch, ic) scale
+// consistently with em.
+static double unzoomFontMetricIfNeeded(double metric, const FontDescription& fontDescription, CSS::RangeZoomOptions rangeZoomOption)
+{
+    if (fontDescription.evaluationTimeZoomEnabled() && rangeZoomOption == CSS::RangeZoomOptions::Unzoomed) {
+        if (auto usedZoomFactor = fontDescription.usedZoomFactor(); usedZoomFactor > 0)
+            return metric / usedZoomFactor;
+    }
+    return metric;
+}
+
 double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, CSSPropertyID propertyToCompute, const FontCascade* fontCascadeForUnit, CSS::RangeZoomOptions rangeZoomOption, const RenderView* renderView)
 {
     using enum CSS::LengthUnit;
@@ -117,28 +130,36 @@ double computeUnzoomedNonCalcLengthDouble(double value, CSS::LengthUnit lengthUn
     case Ex:
     case Rex: {
         ASSERT(fontCascadeForUnit);
+        auto& fontDescription = fontCascadeForUnit->fontDescription();
         auto& fontMetrics = fontCascadeForUnit->metricsOfPrimaryFont();
         if (fontMetrics.xHeight())
-            return fontMetrics.xHeight().value() * value;
-        auto& fontDescription = fontCascadeForUnit->fontDescription();
+            return unzoomFontMetricIfNeeded(fontMetrics.xHeight().value(), fontDescription, rangeZoomOption) * value;
         return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() : fontDescription.computedSizeForRangeZoomOption(rangeZoomOption)) / 2.0 * value;
     }
     case Cap:
     case Rcap: {
         ASSERT(fontCascadeForUnit);
+        auto& fontDescription = fontCascadeForUnit->fontDescription();
         auto& fontMetrics = fontCascadeForUnit->metricsOfPrimaryFont();
         if (fontMetrics.capHeight())
-            return fontMetrics.capHeight().value() * value;
-        return fontMetrics.intAscent() * value;
+            return unzoomFontMetricIfNeeded(fontMetrics.capHeight().value(), fontDescription, rangeZoomOption) * value;
+        return unzoomFontMetricIfNeeded(fontMetrics.intAscent(), fontDescription, rangeZoomOption) * value;
     }
     case Ch:
-    case Rch:
+    case Rch: {
         ASSERT(fontCascadeForUnit);
-        return fontCascadeForUnit->zeroWidth() * value;
+        auto& fontDescription = fontCascadeForUnit->fontDescription();
+        return unzoomFontMetricIfNeeded(fontCascadeForUnit->zeroWidth(), fontDescription, rangeZoomOption) * value;
+    }
     case Ic:
-    case Ric:
+    case Ric: {
         ASSERT(fontCascadeForUnit);
-        return fontCascadeForUnit->metricsOfPrimaryFont().ideogramWidth().value_or(0) * value;
+        auto& fontDescription = fontCascadeForUnit->fontDescription();
+        auto ideogramWidth = fontCascadeForUnit->metricsOfPrimaryFont().ideogramWidth();
+        if (!ideogramWidth)
+            return fontDescription.computedSizeForRangeZoomOption(rangeZoomOption) * value;
+        return unzoomFontMetricIfNeeded(ideogramWidth.value(), fontDescription, rangeZoomOption) * value;
+    }
 
     // MARK: "viewport percentage" resolution
 
@@ -299,9 +320,6 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
     case Cap:
     case Ch:
     case Ic:
-        // FIXME: We have a bug right now where the zoom will be applied twice to EX units.
-        // We really need to compute EX using fontMetrics for the original specifiedSize and not use
-        // our actual constructed rendering font.
         value = computeUnzoomedNonCalcLengthDouble(value, lengthUnit, conversionData.propertyToCompute(), &conversionData.fontCascadeForFontUnits(), conversionData.rangeZoomOption());
         value = adjustZoomStateForFontRelativeUnitsIfNeeded(value, conversionData);
         break;


### PR DESCRIPTION
#### a9cd5d29888419974166525de906ac199183781b
<pre>
REGRESSION (Safari 26.4): Scaling the page resulting in length unit `ic` error
<a href="https://bugs.webkit.org/show_bug.cgi?id=310580">https://bugs.webkit.org/show_bug.cgi?id=310580</a>
<a href="https://rdar.apple.com/173198587">rdar://173198587</a>

Reviewed by Vitor Roriz.

This bug report was already a FIXME in the code.

In computeUnzoomedNonCalcLengthDouble, raw font metrics (ideogramWidth, xHeight, zeroWidth,
capHeight) are measured from the zoomed rendered font. In the new evaluation-time zoom
path, these metrics must be divided by usedZoomFactor to match how em strips zoom via
computedSizeForRangeZoomOption(Unzoomed). Without this, 1ic (and 1ex, 1ch, 1cap) would
scale with CSS zoom while 1em did not.

This work exposed the presence of an existing bug in the ic unit: We were falling back to
0, rather than 1em when the font lacked the relevant ideograph glyph. This was fixed, and
a new WPT created to guard against this regressing in the future.

This patch converts the existing fast/css/ic-unit-zoom.html test into a WPT that covers
the four length types under CSS Zoom beheavior. It also adds a new WPT to confirm that
the engine properly handles the case of a font lacking the ideograph glyph.

Tests: imported/w3c/web-platform-tests/css/css-values/ic-unit-016.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/ic-unit.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/ic-unit-016-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/ic-unit-016.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/reference/ic-unit-016-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/ic-unit-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/ic-unit.html: Added.
* Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp:
(WebCore::toUserUnits): Correct regression with evaluation time zoom (avoid double-zoom).
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::Style::unzoomFontMetricIfNeeded): Added.
(WebCore::Style::computeUnzoomedNonCalcLengthDouble): Adopt unzoomFontMetricIfNeeded to use
correct zoom state. Also fix a fallback bug for the ic unit when a font lacks the necessary
glyphs.
(WebCore::Style::computeNonCalcLengthDouble): Remove unnecessary comment.

Canonical link: <a href="https://commits.webkit.org/311238@main">https://commits.webkit.org/311238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d08dd94e492638b1cb6de2658d203d2be04c59da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165206 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121109 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101780 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12978 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167688 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11801 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129233 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29321 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35039 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140061 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87039 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24171 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16860 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28953 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92909 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28479 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->