### PR TITLE
[CMake] Fix null builds taking ~90 seconds on Mac

### DIFF
--- a/Source/ThirdParty/ANGLE/CMakeLists.txt
+++ b/Source/ThirdParty/ANGLE/CMakeLists.txt
@@ -237,14 +237,21 @@ if (ENABLE_WEBGL)
         add_dependencies(GLESv2 LibGLESv2EntryPointsHeaders)
     endif ()
 
-    add_custom_target(ANGLE-webgl-headers
-        DEPENDS LibGLESv2EntryPointsHeaders ANGLEWebGLHeaders
+    set(_angle_webgl_stamp ${CMAKE_CURRENT_BINARY_DIR}/ANGLE-webgl-headers.stamp)
+    add_custom_command(
+        OUTPUT ${_angle_webgl_stamp}
         COMMAND ${CMAKE_COMMAND} -E env
             BUILT_PRODUCTS_DIR=${ANGLE_FRAMEWORK_HEADERS_DIR}
             PUBLIC_HEADERS_FOLDER_PATH=/ANGLE
             ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/adjust-angle-include-paths.py
+        COMMAND ${CMAKE_COMMAND} -E touch ${_angle_webgl_stamp}
+        DEPENDS
+            ${CMAKE_CURRENT_SOURCE_DIR}/adjust-angle-include-paths.py
+            ${libglesv2_entry_points_headers}
         VERBATIM
     )
+    add_custom_target(ANGLE-webgl-headers DEPENDS ${_angle_webgl_stamp})
+    add_dependencies(ANGLE-webgl-headers LibGLESv2EntryPointsHeaders ANGLEWebGLHeaders)
     add_dependencies(GLESv2Framework ANGLE-webgl-headers)
 endif ()
 

--- a/Source/WebCore/WebCoreMacros.cmake
+++ b/Source/WebCore/WebCoreMacros.cmake
@@ -133,20 +133,44 @@ function(GENERATE_BINDINGS target)
         list(APPEND gen_headers ${arg_DESTINATION}/JS${_name}.h)
     endforeach ()
     set(${arg_OUTPUT_SOURCE} ${${arg_OUTPUT_SOURCE}} ${gen_sources} PARENT_SCOPE)
-    set(act_args)
     if (SHOW_BINDINGS_GENERATION_PROGRESS)
         list(APPEND args --showProgress)
     endif ()
-    list(APPEND act_args BYPRODUCTS ${gen_sources} ${gen_headers})
-    if (SHOW_BINDINGS_GENERATION_PROGRESS)
-        list(APPEND act_args USES_TERMINAL)
+
+    # Use a stamp file so the build system only runs the generator when inputs
+    # actually change, instead of on every build (add_custom_target is always
+    # considered out of date).
+    set(_stamp_file ${arg_DESTINATION}/${target}.stamp)
+
+    set(_byproducts ${gen_sources} ${gen_headers})
+    if (arg_PP_EXTRA_OUTPUT)
+        list(APPEND _byproducts ${arg_PP_EXTRA_OUTPUT})
     endif ()
-    add_custom_target(${target}
+    if (arg_SUPPLEMENTAL_DEPFILE)
+        list(APPEND _byproducts ${arg_SUPPLEMENTAL_DEPFILE})
+    endif ()
+
+    set(_uses_terminal)
+    if (SHOW_BINDINGS_GENERATION_PROGRESS)
+        set(_uses_terminal USES_TERMINAL)
+    endif ()
+
+    add_custom_command(
+        OUTPUT ${_stamp_file}
         COMMAND ${PERL_EXECUTABLE} ${binding_generator} ${args}
-        DEPENDS ${arg_INPUT_FILES} ${arg_PP_INPUT_FILES}
+        COMMAND ${CMAKE_COMMAND} -E touch ${_stamp_file}
+        DEPENDS
+            ${arg_INPUT_FILES}
+            ${arg_PP_INPUT_FILES}
+            ${common_generator_dependencies}
+            ${binding_generator}
+            ${idl_attributes_file}
         WORKING_DIRECTORY ${arg_BASE_DIR}
         COMMENT "Generate bindings (${target})"
-        VERBATIM ${act_args})
+        VERBATIM
+        BYPRODUCTS ${_byproducts}
+        ${_uses_terminal})
+    add_custom_target(${target} DEPENDS ${_stamp_file})
 endfunction()
 
 

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -607,6 +607,7 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
             set(_swift_sdk_flag -sdk ${CMAKE_OSX_SYSROOT})
         endif ()
 
+        set(_header_tmp_path "${_header_path}.tmp")
         add_custom_command(
             OUTPUT ${_header_path}
             DEPENDS ${_swift_sources}
@@ -619,8 +620,12 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
                 ${_swift_include_dirs}
                 ${_swift_sources}
                 -module-name ${_module_name}
-                -emit-clang-header-path ${_header_path}
+                -emit-clang-header-path ${_header_tmp_path}
                 -emit-dependencies
+            COMMAND
+                ${CMAKE_COMMAND} -E copy_if_different ${_header_tmp_path} ${_header_path}
+            COMMAND
+                ${CMAKE_COMMAND} -E rm -f ${_header_tmp_path}
             DEPFILE ${_depfile_path}
             COMMENT
                 "Generating ${_target} C++ bindings to Swift at '${_header_path}'"

--- a/Tools/Scripts/swift/swiftc-wrapper.sh
+++ b/Tools/Scripts/swift/swiftc-wrapper.sh
@@ -31,9 +31,14 @@ for arg in "$@"; do
         "-output-file-map")
             if [[ -n "$is_link" ]]; then
                 skip_next=1
+                output_file_map_next=1
             else
                 args+=("$arg")
             fi
+            ;;
+        "-emit-module-path")
+            args+=("$arg")
+            emit_module_path_next=1
             ;;
         # Standalone -I: CMake INCLUDES use "-I" "/path" as separate args.
         # In link mode, wrap with -Xcc so the path goes to the Clang importer
@@ -62,7 +67,15 @@ for arg in "$@"; do
             ;;
         *)
             if [[ -n "$skip_next" ]]; then
+                if [[ -n "$output_file_map_next" ]]; then
+                    stripped_output_file_map="$arg"
+                    output_file_map_next=
+                fi
                 skip_next=
+            elif [[ -n "$emit_module_path_next" ]]; then
+                emit_module_path="$arg"
+                args+=("$arg")
+                emit_module_path_next=
             elif [[ -n "$skip_next_as_xlinker" ]]; then
                 args+=("-Xlinker" "$arg")
                 skip_next_as_xlinker=
@@ -76,4 +89,27 @@ for arg in "$@"; do
     esac
 done
 
-exec "$REAL_SWIFTC" "${args[@]}"
+"$REAL_SWIFTC" "${args[@]}" || swiftc_status=$?
+swiftc_status=${swiftc_status:-0}
+
+# In the combined compile+link step, we strip -output-file-map to prevent ld
+# from receiving the .json as an input file.  However, without it swiftc in WMO
+# mode does not produce individual .o files that CMake's Ninja generator declares
+# as build outputs.  Touch the expected .o paths so Ninja does not consider the
+# rule perpetually out-of-date.  Also touch the .swiftmodule since swiftc may
+# skip writing it when content is unchanged.
+if [[ $swiftc_status -eq 0 && -n "$stripped_output_file_map" && -f "$stripped_output_file_map" ]]; then
+    python3 -c "
+import json, pathlib, sys
+with open(sys.argv[1]) as f:
+    for v in json.load(f).values():
+        o = v.get('object')
+        if o:
+            pathlib.Path(o).touch()
+" "$stripped_output_file_map" 2>/dev/null || true
+fi
+if [[ $swiftc_status -eq 0 && -n "$emit_module_path" && -f "$emit_module_path" ]]; then
+    touch "$emit_module_path" 2>/dev/null || true
+fi
+
+exit $swiftc_status


### PR DESCRIPTION
#### 96cc0562a2a0b98061a00f4915f05043bd2afaaf
<pre>
[CMake] Fix null builds taking ~90 seconds on Mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=312192">https://bugs.webkit.org/show_bug.cgi?id=312192</a>
<a href="https://rdar.apple.com/174687295">rdar://174687295</a>

Reviewed by Pascoe.

CMake Mac null builds were taking ~90 seconds due to three independent
  issues that cascaded into relinking most of the project on every build.

  1. GENERATE_BINDINGS used add_custom_target which is always considered
     out-of-date by Ninja, invoking the Perl binding generator on every
     build even when no IDL files changed. Convert to add_custom_command
     with a stamp file so the generator only runs when inputs change.
     Also promote generator script dependencies to CMake-level DEPENDS.

  2. The swiftc-wrapper strips -output-file-map in link mode to prevent
     ld from receiving the JSON as an input file, but this means swiftc
     in WMO mode does not produce the individual .o files or update the
     .swiftmodule that CMake&apos;s Ninja generator declares as build outputs.
     Touch these paths after a successful build so Ninja does not
     consider the rule perpetually out-of-date.

  3. The Swift-to-C++ interop header was written directly to its final
     path, so the timestamp always changed even when content was
     identical, triggering recompilation of all includers. Write to a
     temporary file first and use copy_if_different.

  4. ANGLE-webgl-headers used add_custom_target, running
     adjust-angle-include-paths.py on every build. Convert to
     add_custom_command with a stamp file.

* Source/ThirdParty/ANGLE/CMakeLists.txt:
* Source/WebCore/WebCoreMacros.cmake:
* Source/cmake/WebKitMacros.cmake:
* Tools/Scripts/swift/swiftc-wrapper.sh:

Canonical link: <a href="https://commits.webkit.org/311154@main">https://commits.webkit.org/311154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a154f9de0a4fec0a09eeb91f340b1bfb6b851dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164969 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120907 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101585 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12741 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148198 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167448 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16982 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11564 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129024 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129147 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139842 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86773 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23776 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16641 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188031 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92672 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48340 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28242 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28470 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28366 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->