### PR TITLE
IPInt nonzero memory bounds check still doesn't check last accessed byte

### DIFF
--- a/JSTests/wasm/stress/ipint-multimem-oob.js
+++ b/JSTests/wasm/stress/ipint-multimem-oob.js
@@ -1,11 +1,18 @@
 //@ skip if !$isWasmPlatform
 //@ runDefault("--useWasmMultiMemory=1", "--useWasmFastMemory=0")
 
+// Tests multi-memory OOB bounds checking in IPInt across three code paths:
+//   - i32.load (scalar)        -> loadStoreMakePointerSlow .memoryIsNotZero
+//   - v128.load (SIMD bulk)    -> metadataMemoryMakePointer .memoryIsNotZero
+//   - v128.load64_lane (SIMD lane) -> ipintCheckMemoryBoundAndMakePointer
+
 function leb128(v) {
     const r = [];
     do { let b = v & 0x7F; v >>>= 7; if (v) b |= 0x80; r.push(b); } while (v);
     return r;
 }
+
+function str(s) { return [...s].map(c => c.charCodeAt(0)); }
 
 function buildModule() {
     const b = [];
@@ -14,31 +21,90 @@ function buildModule() {
         push(id); push(...leb128(content.length)); push(...content);
     };
 
+    // Header
     push(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00);
-    pushSec(1, [1, 0x60, 1, 0x7F, 1, 0x7F]);
-    pushSec(3, [1, 0]);
+
+    // Type section: 2 types
+    pushSec(1, [
+        2,
+        0x60, 1, 0x7F, 1, 0x7F,  // type 0: (i32) -> (i32)
+        0x60, 1, 0x7F, 0,        // type 1: (i32) -> ()
+    ]);
+
+    // Function section: 3 functions
+    pushSec(3, [3, 0, 1, 1]);
+
+    // Memory section: mem0 (10 pages), mem1 (1 page)
     pushSec(5, [2, 0x00, 10, 0x00, 1]);
-    pushSec(7, [1, 5, 0x6C, 0x6F, 0x61, 0x64, 0x31, 0x00, 0x00]);
-    const f0 = [0x00, 0x20, 0x00, 0x28, 0x42, 0x01, 0x00, 0x0B];
-    pushSec(10, [1, ...leb128(f0.length), ...f0]);
+
+    // Export section
+    const n0 = str("scalarLoad"), n1 = str("simdLoad"), n2 = str("simdLane64Load");
+    pushSec(7, [
+        3,
+        n0.length, ...n0, 0x00, 0x00,
+        n1.length, ...n1, 0x00, 0x01,
+        n2.length, ...n2, 0x00, 0x02,
+    ]);
+
+    // Code section
+
+    // func 0: i32.load from memory 1 (4-byte access)
+    //   -> loadStoreMakePointerSlow
+    const f0 = [
+        0x00,                    // 0 locals
+        0x20, 0x00,              // local.get 0
+        0x28,                    // i32.load
+        0x42, 0x01, 0x00,        // memarg: align=2|0x40, memidx=1, offset=0
+        0x0B,                    // end
+    ];
+
+    // func 1: v128.load from memory 1, drop (16-byte access)
+    //   -> metadataMemoryMakePointer (via simdMemoryOp)
+    const f1 = [
+        0x00,                    // 0 locals
+        0x20, 0x00,              // local.get 0
+        0xFD, 0x00,              // v128.load
+        0x44, 0x01, 0x00,        // memarg: align=4|0x40, memidx=1, offset=0
+        0x1A,                    // drop
+        0x0B,                    // end
+    ];
+
+    // func 2: v128.load64_lane from memory 1, drop (8-byte access)
+    //   -> ipintCheckMemoryBoundAndMakePointer
+    //   Using 64-bit lane (not 8-bit) so size-1 != 0 and actually tests the
+    //   size accounting in the bounds check.
+    const f2 = [
+        0x00,                                                    // 0 locals
+        0x20, 0x00,                                              // local.get 0
+        0xFD, 0x0C, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,          // v128.const 0
+        0xFD, 0x57,                                              // v128.load64_lane
+        0x43, 0x01, 0x00,                                        // memarg: align=3|0x40, memidx=1, offset=0
+        0x00,                                                    // lane 0
+        0x1A,                                                    // drop
+        0x0B,                                                    // end
+    ];
+
+    pushSec(10, [
+        3,
+        ...leb128(f0.length), ...f0,
+        ...leb128(f1.length), ...f1,
+        ...leb128(f2.length), ...f2,
+    ]);
+
     return new Uint8Array(b);
 }
 
-const mod = new WebAssembly.Module(buildModule());
-const inst = new WebAssembly.Instance(mod);
+const inst = new WebAssembly.Instance(new WebAssembly.Module(buildModule()));
+const PAGE = 65536;
 
-// Memory 1 = 65536 bytes. i32.load = 4 bytes.
-// Max valid address = 65532 (65532 + 4 = 65536).
-inst.exports.load1(65532);
+// i32.load: 4 bytes -> last valid addr = PAGE-4, first invalid = PAGE-3
+inst.exports.scalarLoad(PAGE - 4);
+try { inst.exports.scalarLoad(PAGE - 3); $vm.abort(); } catch (e) {}
 
-// Address 65533: bounds check should fail because 65533 + 3 >= 65536.
-// Bug: IPInt checks 65533 >= 65536 (passes) instead of 65536 >= 65536 (fails).
-let trapped = false;
-try {
-    inst.exports.load1(65533);
-} catch(e) {
-    trapped = true;
-}
+// v128.load: 16 bytes -> last valid addr = PAGE-16, first invalid = PAGE-15
+inst.exports.simdLoad(PAGE - 16);
+try { inst.exports.simdLoad(PAGE - 15); $vm.abort(); } catch (e) {}
 
-if (!trapped)
-    throw new Error("expected trap");
+// v128.load64_lane: 8 bytes -> last valid addr = PAGE-8, first invalid = PAGE-7
+inst.exports.simdLane64Load(PAGE - 8);
+try { inst.exports.simdLane64Load(PAGE - 7); $vm.abort(); } catch (e) {}


### PR DESCRIPTION
#### ab77ec97e20a74eb3528a9aa78b708bee5d45f14
<pre>
IPInt nonzero memory bounds check still doesn&apos;t check last accessed byte
<a href="https://bugs.webkit.org/show_bug.cgi?id=312197">https://bugs.webkit.org/show_bug.cgi?id=312197</a>
<a href="https://rdar.apple.com/174688881">rdar://174688881</a>

Reviewed by Yusuke Suzuki.

When <a href="https://rdar.apple.com/174338638">rdar://174338638</a> (<a href="https://bugs.webkit.org/show_bug.cgi?id=311764)">https://bugs.webkit.org/show_bug.cgi?id=311764)</a>
was being fixed, the relevant macro in IPInt
(memoryOpAdvanceMCAndMakePointer) was split into multiple macros before
the bug was fixed. This patch adds that radar&apos;s fix to
loadStoreMakePointerSlow, since the other macros correctly handled the
case where the first accessed byte is in bounds but the last isn&apos;t.

Existing test is extended to exercise all macros that check bounds.

* JSTests/wasm/stress/ipint-multimem-oob.js:
(str):
(catch):
(buildModule): Deleted.
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/311243@main">https://commits.webkit.org/311243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55e95978ab112ad01a1116c3d0ed27472dc03117

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165172 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121080 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140408 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101751 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12944 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148401 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132039 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167654 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17186 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19852 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129204 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129316 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35041 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140033 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87005 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24141 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16832 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188234 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28919 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48394 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28445 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28673 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28569 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->