### PR TITLE
Review feedback for 311114@main.

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.mm
@@ -186,20 +186,18 @@ static RetainPtr<NSArray<_WTTextPreview *>> textPreviewsFromIndicator(const RefP
         }
 
 #if PLATFORM(IOS_FAMILY)
-        CocoaView *rootView = webView->_contentView.get();
+        RetainPtr rootView = webView->_contentView.get();
 #else
-        CocoaView *rootView = webView.get();
+        RetainPtr rootView = webView.get();
 #endif
-        CocoaView *containerView = webView.get();
-
-        RetainPtr textPreviews = textPreviewsFromIndicator(textIndicator, rootView, containerView);
+        RetainPtr textPreviews = textPreviewsFromIndicator(textIndicator, rootView, webView);
         if (!textPreviews) {
             completionHandler(nil, nil);
             return;
         }
 
-        [webView _page]->decorationIndicatorForTextEffectID(textEffectUUID, [textPreviews = WTF::move(textPreviews), rootView = retainPtr(rootView), containerView = retainPtr(containerView), completionHandler](RefPtr<WebCore::TextIndicator> decorationIndicator) {
-            auto underlinePreviews = textPreviewsFromIndicator(decorationIndicator, rootView.get(), containerView.get());
+        [webView _page]->decorationIndicatorForTextEffectID(textEffectUUID, [textPreviews = WTF::move(textPreviews), rootView, webView, completionHandler](RefPtr<WebCore::TextIndicator> decorationIndicator) {
+            auto underlinePreviews = textPreviewsFromIndicator(decorationIndicator, rootView.get(), webView.get());
             completionHandler(textPreviews.get(), underlinePreviews.get());
         });
     });


### PR DESCRIPTION
#### 34da51f10f8fbeab2a895529c76a091629ca6774
<pre>
Review feedback for 311114@main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=312200">https://bugs.webkit.org/show_bug.cgi?id=312200</a>
<a href="https://rdar.apple.com/174690841">rdar://174690841</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Forgot to incorporate review feedback before landing.

* Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.mm:
(-[WKTextEffectManager previewsForSuggestionWithUUID:completion:]):

Canonical link: <a href="https://commits.webkit.org/311348@main">https://commits.webkit.org/311348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/050a7bce8232ec33b1db4b752fbff059df53cafb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165550 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121395 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102063 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13322 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132339 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168033 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129508 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29665 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129617 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35108 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140358 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87389 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24433 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17162 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29296 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28821 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29051 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->