### PR TITLE
[WPT] reftest variants not obeyed

### DIFF
--- a/LayoutTests/fast/harness/full_results.json
+++ b/LayoutTests/fast/harness/full_results.json
@@ -180,7 +180,31 @@ ADD_RESULTS({
                     "reftest_type": ["!="]
                 }
             }
+        },
+        "imported": {
+            "w3c": {
+                "web-platform-tests": {
+                    "css": {
+                        "css-backgrounds": {
+                            "box-shadow-radius-generated.html?width=300&height=60&spread=30&radius=0px%200px%2030px%2030px": {
+                                "reftest_type": [
+                                    "=="
+                                ],
+                                "report": "REGRESSION",
+                                "expected": "PASS",
+                                "actual": "IMAGE",
+                                "image_diff_percent": 0.28308165,
+                                "image_difference": {
+                                    "max_difference": 255,
+                                    "total_pixels": 1792
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
+        
     },
     "skipped": 5367,
     "num_regressions": 7,

--- a/LayoutTests/fast/harness/results-expected.txt
+++ b/LayoutTests/fast/harness/results-expected.txt
@@ -10,7 +10,7 @@ Other crashes (2): flag all
 
 +DumpRenderTree-54888	crash log
 +DumpRenderTree-56804	crash log
-Tests that failed text/pixel/audio diff (9): flag all
+Tests that failed text/pixel/audio diff (10): flag all
 
  test 	results	image results	actual failure	expected failure	history
 +css1/font_properties/font_family.html	expected actual diff pretty diff	images	text missing		history
@@ -22,6 +22,7 @@ Tests that failed text/pixel/audio diff (9): flag all
 +http/wpt/cache-storage/image-fail.html		images diff (86.26%)	image	pass	history
 +http/wpt/cache-storage/leaky-worker.html			leak	pass	history
 +http/wpt/cache-storage/tiny-image-fail.html		images diff (0.01%)	image	pass	history
++imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-radius-generated.html?width=300&height=60&spread=30&radius=0px%200px%2030px%2030px		reference images diff (0.28%)	image	pass	history
 Tests that had no expected results (probably new) (1): flag all
 
 test	results	image results	actual failure	expected failure	history

--- a/LayoutTests/fast/harness/results.html
+++ b/LayoutTests/fast/harness/results.html
@@ -298,24 +298,34 @@ class Utils
         }
         return null;
     }
-
-    static testPrefix(testName)
+    
+    static testNameAndVariant(testName)
     {
         let variant = '';
         let variantSeparatorIndex = testName.indexOf('?');
         if (variantSeparatorIndex >= 0) {
-            variant = testName.substring(variantSeparatorIndex + 1);
+            variant = testName.substring(variantSeparatorIndex);
             testName = testName.substring(0, variantSeparatorIndex);
         }
+        
         variantSeparatorIndex = testName.indexOf('#');
         if (variantSeparatorIndex >= 0) {
-            variant = testName.substring(variantSeparatorIndex + 1);
+            variant = testName.substring(variantSeparatorIndex);
             testName = testName.substring(0, variantSeparatorIndex);
         }
+        
+        return [testName, variant];
+    }
 
-        let prefix = Utils.splitExtension(testName)[0];
-        if (variant.length)
-            prefix += '_' + variant.replace(/[\|\* <>:]/g, '_');
+    static testPrefix(testName)
+    {
+        let [baseName, variant] = Utils.testNameAndVariant(testName);
+
+        let prefix = Utils.splitExtension(baseName)[0];
+        if (variant.length) {
+            variant = variant.slice(1);
+            prefix += '_' + variant.replace(/[\|\* <>:\/\%]/g, '_');
+        }
         return prefix;
     }
 
@@ -323,11 +333,11 @@ class Utils
     {
         // Splits 'foo/bar/boo.html?blah' to ['foo/bar/boo', '.html', '?blah']. Last item can be
         // null if `testName` had no URL fragment or query separator.
-        let filenameIndex = testName.lastIndexOf("/");
-        let buffer = testName.substr(filenameIndex + 1);
-        buffer = buffer.split('?')[0];
-        buffer = buffer.split('#')[0];
-        let parts = buffer.split('.');
+        let [baseName, variant] = Utils.testNameAndVariant(testName);
+
+        let filenameIndex = baseName.lastIndexOf("/");
+        let buffer = baseName.substr(filenameIndex + 1);
+
         let extensionIndex = buffer.lastIndexOf(".");
         let filename = buffer.substr(0, extensionIndex);
         // Test names that are actually process names are treated like they don't have any extension
@@ -335,9 +345,7 @@ class Utils
             return [testName, '', ''];
         }
         let ext = buffer.substr(extensionIndex);
-        let remainsIndex = testName.lastIndexOf(ext);
-        let remains = testName.substr(remainsIndex + ext.length);
-        return [testName.substr(0, filenameIndex) + '/' + filename, ext, remains];
+        return [testName.substr(0, filenameIndex) + '/' + filename, ext, variant];
     }
 
     static forEach(nodeList, handler)
@@ -1460,14 +1468,17 @@ class FailuresSectionBuilder extends SectionBuilder {
     {
         let result = '';
         if (resultToken.indexOf('IMAGE') != -1) {
-            let testExtension = Utils.splitExtension(testResult.name)[1];
-
+            const nameParts = Utils.splitExtension(testResult.name);
+            const testBase = nameParts[0]
+            const testExtension = nameParts[1];
+            const variantParams = nameParts[2];
+            
             if (testResult.isMismatchRefTest()) {
-                result += this._resultsController.resultLink(this._resultsController.layoutTestsBasePath() + testPrefix, '-expected-mismatch' + testExtension, 'ref mismatch');
+                result += this._resultsController.resultLink(this._resultsController.layoutTestsBasePath() + testBase, '-expected-mismatch' + testExtension + variantParams, 'ref mismatch');
                 result += this._resultsController.resultLink(testPrefix, '-actual.png', 'actual');
             } else {
                 if (testResult.isMatchRefTest())
-                    result += this._resultsController.resultLink(this._resultsController.layoutTestsBasePath() + testPrefix, '-expected' + testExtension, 'reference');
+                    result += this._resultsController.resultLink(this._resultsController.layoutTestsBasePath() + testBase, '-expected' + testExtension + variantParams, 'reference');
 
                 if (this._resultsController.shouldToggleImages)
                     result += this._resultsController.resultLink(testPrefix, '-diffs.html', 'images');

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py
@@ -317,6 +317,7 @@ class LayoutTestFinder(object):
         current_layout_tests_path = self.fs.join(self.layout_tests_base_dir, path)
         non_test_files[current_layout_tests_path] = set()
 
+        # FIXME: Skip files like `.DS_Store`
         it = self.fs.scandir(current_layout_tests_path)
         try:
             for entry in it:
@@ -419,7 +420,7 @@ class LayoutTestFinder(object):
                 expected_audio_path,
                 reference_files,
             ) = self._expectations_for_test(
-                basename + variant, non_test_files_by_search_path
+                basename, variant, non_test_files_by_search_path
             )
 
             assert expected_text_path is None or self.fs.isabs(expected_text_path)
@@ -540,11 +541,11 @@ class LayoutTestFinder(object):
             len(variant) > 1 and variant[0] in ("?", "#") and variant != "?#"
         )
 
-    def _expectations_for_test(self, name, non_test_files_by_search_path):
+    def _expectations_for_test(self, basename, variant, non_test_files_by_search_path):
         """Given a test basename, find expectations in non_test_files_by_search_path"""
 
         expected_without_ext = TestResultWriter.expected_filename(
-            name, self.fs, suffix=""
+            basename + variant, self.fs, suffix=""
         )
         assert expected_without_ext[-1] == "."
         expected_without_ext = expected_without_ext[:-1]
@@ -560,15 +561,22 @@ class LayoutTestFinder(object):
         png_name = expected_without_ext + ".png"
         wav_name = expected_without_ext + ".wav"
 
-        match_reference_names = {
-            expected_without_ext + ext for ext in supported_reference_extensions
+        reference_base = TestResultWriter.expected_filename(
+            basename, self.fs, suffix=""
+        )
+        assert reference_base[-1] == "."
+        reference_base = reference_base[:-1]
+
+        match_reference_basenames = {
+            reference_base + ext for ext in supported_reference_extensions
         }
 
-        mismatch_reference_names = {
-            "".join((expected_without_ext, "-mismatch", ext))
+        mismatch_reference_basenames = {
+            "".join((reference_base, "-mismatch", ext))
             for ext in supported_reference_extensions
         }
 
+        # This is inefficient. We search all non-test files in the directory for each variant of each test!
         for dirname, basename_set in reversed(non_test_files_by_search_path.items()):
             if expected_text_path is None and txt_name in basename_set:
                 expected_text_path = self.fs.join(dirname, txt_name)
@@ -583,16 +591,16 @@ class LayoutTestFinder(object):
                 expected_audio_path = self.fs.join(dirname, wav_name)
 
             if reference_files is None:
-                matches = basename_set & match_reference_names
-                mismatches = basename_set & mismatch_reference_names
+                matches = basename_set & match_reference_basenames
+                mismatches = basename_set & mismatch_reference_basenames
                 if matches or mismatches:
                     # For historic reasons, we return matches first, and we sort them by
                     # the filename of the match. This is significant when we currently
                     # only run the first reference
                     # (https://bugs.webkit.org/show_bug.cgi?id=270794).
                     reference_files = [
-                        ("==", self.fs.join(dirname, m)) for m in sorted(matches)
-                    ] + [("!=", self.fs.join(dirname, m)) for m in sorted(mismatches)]
+                        ("==", self.fs.join(dirname, m + variant)) for m in sorted(matches)
+                    ] + [("!=", self.fs.join(dirname, m + variant)) for m in sorted(mismatches)]
 
         return (
             expected_text_path or expected_webarchive_path,

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
@@ -40,6 +40,7 @@ from webkitpy.layout_tests.models import test_expectations, test_failures
 from webkitpy.layout_tests.models.test_results import TestResult
 from webkitpy.port.driver import DriverInput, DriverOutput
 from webkitpy.thirdparty.BeautifulSoup import BeautifulSoup as Parser
+from webkitpy.port.base import Port
 
 _log = logging.getLogger(__name__)
 
@@ -602,7 +603,9 @@ class SingleTestRunner(object):
         return os.path.join(relative_path, reference_file_name)
 
     def _fuzzy_tolerance_for_reference(self, reference_full_path):
-        test_full_path = self._port.abspath_for_test(self._test_name)
+        test_path = Port.test_name_and_variant(self._test_name)[0]
+        test_full_path = self._port.abspath_for_test(test_path)
+
         fuzzy = self._fuzzy_metadata_for_file(test_full_path)
         if not fuzzy:
             return None

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer.py
@@ -30,6 +30,7 @@ import re
 import logging
 
 from webkitpy.common.wavediff import WaveDiff
+from webkitpy.port import Port
 
 
 _log = logging.getLogger(__name__)
@@ -65,11 +66,7 @@ class TestResultWriter(object):
 
     @classmethod
     def _modified_filename(cls, test_name, filesystem, modifier):
-        variant = ''
-        if '?' in test_name:
-            (test_name, variant) = test_name.split('?', 1)
-        if '#' in test_name:
-            (test_name, variant) = test_name.split('#', 1)
+        (test_name, variant) = Port.test_name_and_variant(test_name)
 
         # Test names that are actually process names are treated like they don't have any extension
         if cls.PROCESS_NAME_RE.match(filesystem.basename(test_name)):
@@ -79,7 +76,7 @@ class TestResultWriter(object):
         output_basename = ext_parts[0]
 
         if len(variant):
-            output_basename += "_" + re.sub(r'[|* <>:/%]', '_', variant)
+            output_basename += "_" + Port.sanitized_variant(variant[1:])
 
         return output_basename + modifier
 
@@ -133,7 +130,8 @@ class TestResultWriter(object):
 
     def _output_testname(self, modifier):
         fs = self._filesystem
-        return fs.splitext(fs.basename(self._test_name))[0] + modifier
+        file_name = self._modified_filename(self._test_name, fs, modifier)
+        return fs.splitext(fs.basename(file_name))[0] + modifier
 
     def write_output_files(self, file_type, output, expected):
         """Writes the test output, the expected output in the results directory.

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
@@ -83,6 +83,20 @@ class TestResultWriterTest(unittest.TestCase):
         writer = test_result_writer.TestResultWriter(fs, port, port.results_directory(), 'svg/W3C-SVG-1.1/animate-elem-02-t.svg')
         self.assertEqual(fs.join(port.results_directory(), 'svg/W3C-SVG-1.1/animate-elem-02-t-diff.txt'), writer.output_filename('-diff.txt'))
 
+    def test_output_testname(self):
+        host = MockHost()
+        port = TestPort(host)
+        fs = host.filesystem
+
+        writer = test_result_writer.TestResultWriter(fs, port, port.results_directory(), '/fast/dom/foo.html')
+        self.assertEqual(writer._output_testname(''), 'foo')
+
+        writer = test_result_writer.TestResultWriter(fs, port, port.results_directory(), '/fast/backgrounds/box-shadow-radius-generated.html?width=50&height=50&spread=50&radius=1px')
+        self.assertEqual(writer._output_testname(''), 'box-shadow-radius-generated_width=50&height=50&spread=50&radius=1px')
+
+        writer = test_result_writer.TestResultWriter(fs, port, port.results_directory(), '/fast/backgrounds/box-shadow-radius-generated.html?width=200&height=40&spread=50&radius=100px%20/%2020px')
+        self.assertEqual(writer._output_testname(''), 'box-shadow-radius-generated_width=200&height=40&spread=50&radius=100px_20__2020px')
+
     def test_expected_filename(self):
         host = MockHost()
         port = TestPort(host)

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_failures.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_failures.py
@@ -29,6 +29,7 @@
 import logging
 
 from webkitpy.layout_tests.models import test_expectations
+from webkitpy.port.base import Port
 
 _log = logging.getLogger(__name__)
 
@@ -260,7 +261,7 @@ class FailureReftestMismatch(TestFailure):
             writer.write_image_diff_files(diff_image, self.formatted_diff_percent(), self.formatted_fuzzy_data())
         else:
             _log.warn('ref test mismatch did not produce an image diff.')
-        writer.write_reftest(self.reference_filename)
+        writer.write_reftest(Port.test_name_and_variant(self.reference_filename)[0])
 
 
 class FailureReftestMismatchDidNotOccur(TestFailure):

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
@@ -33,6 +33,7 @@ import signal
 
 from webkitpy.common.iteration_compatibility import iteritems
 from webkitpy.layout_tests.models import test_expectations, test_failures
+from webkitpy.port.base import Port
 
 _log = logging.getLogger(__name__)
 
@@ -370,7 +371,9 @@ def summarize_results(port_obj, expectations_by_type, initial_results, retry_res
         #         baz1.html: test_dict
         #     }
         # }
-        parts = test_name.split('/')
+        (base_name, variant) = Port.test_name_and_variant(test_name)
+        parts = base_name.split('/')
+        parts[-1] += variant
         current_map = tests
         for i, part in enumerate(parts):
             if i == (len(parts) - 1):

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -132,6 +132,23 @@ class Port(object):
     def determine_driver_name(cls, options):
         return (getattr(options, 'driver_names', []) or cls.DRIVER_NAMES)[0]
 
+    @staticmethod
+    def test_name_and_variant(test_name):
+        """Splits a test name into the filename part and the variant part."""
+        if '?' in test_name:
+            name, sep, variant = test_name.partition('?')
+            return (name, sep + variant)
+
+        if '#' in test_name:
+            name, sep, variant = test_name.partition('#')
+            return (name, sep + variant)
+
+        return (test_name, '')
+
+    @staticmethod
+    def sanitized_variant(variant):
+        return re.sub(r'[|* <>:/%]', '_', variant)
+
     def __init__(self, host, port_name, options=None, **kwargs):
 
         # This value may be different from cls.port_name by having version modifiers
@@ -426,17 +443,13 @@ class Port(object):
         baseline_search_path = self.baseline_search_path(device_type=device_type) + [self.layout_tests_dir()]
         fs = self._filesystem
 
-        variant = ''
-        if '?' in test_name:
-            (test_name, variant) = test_name.split('?', 1)
-        if '#' in test_name:
-            (test_name, variant) = test_name.split('#', 1)
+        (test_name, variant) = Port.test_name_and_variant(test_name)
 
         baseline_ext_parts = fs.splitext(test_name)
 
         baseline_name_root = baseline_ext_parts[0]
         if len(variant):
-            baseline_name_root += "_" + re.sub(r'[|* <>:]', '_', variant)
+            baseline_name_root += "_" + Port.sanitized_variant(variant[1:])
         baseline_name_root += '-expected'
 
         baselines = []


### PR DESCRIPTION
#### 33bb8468a9c3e01eadf816004eed293967a6feae
<pre>
[WPT] reftest variants not obeyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=278243">https://bugs.webkit.org/show_bug.cgi?id=278243</a>
<a href="https://rdar.apple.com/134073271">rdar://134073271</a>

Reviewed by Alan Baradlay.

WPT supports tests with variants; these are declared in a meta tags, and cause the test
to be run with URL params, which may contain special characters including slashes.
This requires that various bits of test infrastructure handle test names containing
slashes.

Add static methods to `Port` to separate a test name into the base name and
variant part, and use that throughout the webkitpy code. Also add a helper
to sanitize the variant part for when we produce pathnames.

results.html also needs updating to handle variant pathnames.

This was tested manually by importing `css/css-backgrounds/box-shadow-radius-generated.html`
which includes variants with slashes. I verified that variant lines in `TestExpectations`
worked.

Unit tests are lacking; in particular, `layout_test_finder.py` needs much more.

* LayoutTests/fast/harness/full_results.json:
* LayoutTests/fast/harness/results-expected.txt:
* LayoutTests/fast/harness/results.html:
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py:
(LayoutTestFinder):
(LayoutTestFinder._expectations_for_test): The expectation for a variant test needs
to find the base filename; the expected test is then run with the same URL params
as the test.
* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py:
(SingleTestRunner._fuzzy_tolerance_for_reference): Need to find the base filename to look
for tolerance values.
* Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer.py:
(TestResultWriter._modified_filename): Use the helper function. It has a slightly
different behavior where the separator is included in the variant part, so strip
that off via `[1:]`.
(TestResultWriter._output_testname):
* Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py:
(TestResultWriterTest.test_output_testname):
* Tools/Scripts/webkitpy/layout_tests/models/test_failures.py:
(FailureReftestMismatch.write_failure):
* Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py:
(summarize_results): Need to look for the `/` in the basename, since it might appear
in the variant part.
* Tools/Scripts/webkitpy/port/base.py:
(Port):
(Port.test_name_and_variant):
(Port.sanitized_variant):
(Port._expected_baselines_for_suffixes):

Canonical link: <a href="https://commits.webkit.org/311511@main">https://commits.webkit.org/311511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f80e61cc82454551d69424edaa547b005e0562a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111231 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44e7b06a-ebbf-47a3-9249-a59c884df551) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121702 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8113c3c1-0a98-4ccc-91b0-61dff9ffe518) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102370 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7f36191-f66e-4b18-958b-634add04d9a5) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/156469 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22999 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21236 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13744 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132679 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168457 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20555 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129830 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129938 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35209 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140729 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87831 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24762 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17533 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29721 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29243 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29473 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29370 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->