### PR TITLE
[HDR] Introduce ShareableCVPixelBuffer

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -450,6 +450,7 @@ platform/graphics/cocoa/AV1UtilitiesCocoa.mm @nonARC @no-unify
 platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
 platform/graphics/cocoa/CMUtilities.mm @nonARC @no-unify
 platform/graphics/cocoa/ColorCocoa.mm @nonARC
+platform/graphics/cocoa/CVPixelBufferUtilities.cpp
 platform/graphics/cocoa/FloatRectCocoa.mm @nonARC
 platform/graphics/cocoa/FontCacheCocoa.mm @nonARC
 platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -472,6 +473,8 @@ platform/graphics/cocoa/MediaPlayerCocoa.mm @nonARC
 platform/graphics/cocoa/MediaPlayerPrivateWebM.mm @nonARC @no-unify
 platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
 platform/graphics/cocoa/PlatformTimeRangesCocoa.mm @nonARC @no-unify
+platform/graphics/cocoa/ShareableCVPixelBuffer.cpp
+platform/graphics/cocoa/ShareableCVPixelFormat.cpp
 platform/graphics/cocoa/SourceBufferParser.cpp
 platform/graphics/cocoa/SourceBufferParserWebM.cpp
 platform/graphics/cocoa/SystemFontDatabaseCocoa.mm @nonARC

--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.cpp
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.cpp
@@ -69,6 +69,7 @@ SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferHeightKey, CFStr
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelFormatOpenGLCompatibility, CFStringRef)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelFormatOpenGLESCompatibility, CFStringRef)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferIOSurfaceCoreAnimationCompatibilityKey, CFStringRef)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferMetalCompatibilityKey, CFStringRef)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferIOSurfacePropertiesKey, CFStringRef)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferPoolMinimumBufferCountKey, CFStringRef)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferPoolAllocationThresholdKey, CFStringRef)
@@ -118,4 +119,4 @@ SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferPreferRealTimeCa
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVPixelBufferCreate, CVReturn, (CFAllocatorRef allocator, size_t width, size_t height, OSType pixelFormatType, CFDictionaryRef pixelBufferAttributes, CVPixelBufferRef *pixelBufferOut), (allocator, width, height, pixelFormatType, pixelBufferAttributes, pixelBufferOut))
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVPixelBufferCreateWithBytes, CVReturn, (CFAllocatorRef allocator, size_t width, size_t height, OSType pixelFormatType, void* data, size_t bytesPerRow, void (*releaseCallback)(void*, const void*), void* releasePointer, CFDictionaryRef pixelBufferAttributes, CVPixelBufferRef *pixelBufferOut), (allocator, width, height, pixelFormatType, data, bytesPerRow, releaseCallback, releasePointer, pixelBufferAttributes, pixelBufferOut))
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(WebCore, CoreVideo, CVPixelBufferCreateWithIOSurface, CVReturn, (CFAllocatorRef allocator, IOSurfaceRef surface, CFDictionaryRef pixelBufferAttributes, CVPixelBufferRef * pixelBufferOut), (allocator, surface, pixelBufferAttributes, pixelBufferOut), WEBCORE_EXPORT)
-
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(WebCore, CoreVideo, CVPixelBufferIsPlanar, Boolean, (CVPixelBufferRef pixelBuffer), (pixelBuffer), WEBCORE_EXPORT)

--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
@@ -107,6 +107,8 @@ SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreVideo, kCVPixelFormatOpenGLESCompatib
 #define kCVPixelFormatOpenGLESCompatibility get_CoreVideo_kCVPixelFormatOpenGLESCompatibilitySingleton()
 SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreVideo, kCVPixelBufferIOSurfaceCoreAnimationCompatibilityKey, CFStringRef)
 #define kCVPixelBufferIOSurfaceCoreAnimationCompatibilityKey get_CoreVideo_kCVPixelBufferIOSurfaceCoreAnimationCompatibilityKeySingleton()
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreVideo, kCVPixelBufferMetalCompatibilityKey, CFStringRef)
+#define kCVPixelBufferMetalCompatibilityKey get_CoreVideo_kCVPixelBufferMetalCompatibilityKeySingleton()
 SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreVideo, kCVPixelBufferIOSurfacePropertiesKey, CFStringRef)
 #define kCVPixelBufferIOSurfacePropertiesKey get_CoreVideo_kCVPixelBufferIOSurfacePropertiesKeySingleton()
 SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreVideo, kCVPixelBufferPoolMinimumBufferCountKey, CFStringRef)
@@ -202,6 +204,9 @@ SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferCreateWithBytes, 
 // FIXME: The system header does not have CV_RETURNS_RETAINED_PARAMETER specified for pixelBufferOut. See rdar://148084567.
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferCreateWithIOSurface, CVReturn, (CFAllocatorRef allocator, IOSurfaceRef surface, CFDictionaryRef pixelBufferAttributes, CF_RETURNS_RETAINED CVPixelBufferRef * pixelBufferOut), (allocator, surface, pixelBufferAttributes, pixelBufferOut))
 #define CVPixelBufferCreateWithIOSurface softLink_CoreVideo_CVPixelBufferCreateWithIOSurface
+
+SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferIsPlanar, Boolean, (CVPixelBufferRef pixelBuffer), (pixelBuffer))
+#define CVPixelBufferIsPlanar softLink_CoreVideo_CVPixelBufferIsPlanar
 
 namespace WebCore {
 inline std::span<uint8_t> CVPixelBufferGetSpanOfPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex)

--- a/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CVPixelBufferUtilities.h"
+
+#if PLATFORM(COCOA)
+
+#include "CVUtilities.h"
+#include "Logging.h"
+#include "ShareableCVPixelBuffer.h"
+#include <pal/spi/cg/ImageIOSPI.h>
+#include <wtf/FileHandle.h>
+#include <wtf/FileSystem.h>
+#include <wtf/text/StringBuilder.h>
+
+#include "CoreVideoSoftLink.h"
+
+namespace WebCore {
+
+RetainPtr<CVPixelBufferRef> createScratchCVPixelBuffer(unsigned width, unsigned height, OSType pixelFormat, CFDictionaryRef attributes, CGColorSpaceRef colorSpace)
+{
+    CVPixelBufferRef pixelBuffer = nullptr;
+    auto status = CVPixelBufferCreate(kCFAllocatorDefault, width, height, pixelFormat, attributes, &pixelBuffer);
+
+    if (status != kCVReturnSuccess) {
+        RELEASE_LOG_ERROR(Images, "%s: CVPixelBufferCreate() failed with status=%d", __FUNCTION__, static_cast<int>(status));
+        return nullptr;
+    }
+
+    if (colorSpace)
+        CVBufferSetAttachment(pixelBuffer, kCVImageBufferCGColorSpaceKey, colorSpace, kCVAttachmentMode_ShouldPropagate);
+
+    return adoptCF(pixelBuffer);
+}
+
+RetainPtr<CVPixelBufferRef> createScratchMetalCompatibleCVPixelBuffer(unsigned width, unsigned height, OSType pixelFormat, CGColorSpaceRef colorSpace)
+{
+    RetainPtr attributes = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    RetainPtr surfaceProperties = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    CFDictionarySetValue(attributes.get(), kCVPixelBufferIOSurfacePropertiesKey, surfaceProperties.get());
+    CFDictionarySetValue(attributes.get(), kCVPixelBufferMetalCompatibilityKey, kCFBooleanTrue);
+
+    return createScratchCVPixelBuffer(width, height, pixelFormat, attributes, colorSpace);
+}
+
+RetainPtr<CVPixelBufferRef> createScratchMetalCompatibleCVPixelBuffer(const ShareableCVPixelBuffer& pixelBuffer, CGColorSpaceRef colorSpace)
+{
+    unsigned width = pixelBuffer.configuration().width();
+    unsigned height = pixelBuffer.configuration().height();
+    ShareableCVPixelFormat pixelFormat = pixelBuffer.configuration().pixelFormat();
+    return createScratchMetalCompatibleCVPixelBuffer(width, height, toCVPixelFormat(pixelFormat), colorSpace);
+}
+
+#if ENABLE(DUMP_GAIN_MAP_IMAGES)
+void CVPixelBufferDumpToFile(CVPixelBufferRef pixelBuffer, const String& name)
+{
+    if (!pixelBuffer || name.length() < 3)
+        return;
+
+    String localName = name;
+
+    if (((localName[0] == '*') || (localName[0] == '+'))  && localName[1] == '/') {
+        StringBuilder builder;
+        builder.append("/tmp"_s);
+        builder.append(name.right(localName.length() - 1));
+        localName = builder.toString();
+    }
+
+    auto fileHandle = FileSystem::openFile(localName, FileSystem::FileOpenMode::Truncate);
+    if (!fileHandle)
+        return;
+
+    uint32_t magic       = 'CVPB';
+    uint32_t width       = static_cast<uint32_t>(CVPixelBufferGetWidth(pixelBuffer));
+    uint32_t height      = static_cast<uint32_t>(CVPixelBufferGetHeight(pixelBuffer));
+    uint32_t pixelFormat = static_cast<uint32_t>(CVPixelBufferGetPixelFormatType(pixelBuffer));
+    uint32_t isPlanar    = CVPixelBufferIsPlanar(pixelBuffer) ? 1 : 0;
+    uint32_t planeCount  = isPlanar ? static_cast<uint32_t>(CVPixelBufferGetPlaneCount(pixelBuffer)) : 1;
+
+    fileHandle.write(unsafeMakeSpan<const uint8_t>(reinterpret_cast<const uint8_t*>(&magic), sizeof(uint32_t)));
+    fileHandle.write(unsafeMakeSpan<const uint8_t>(reinterpret_cast<const uint8_t*>(&width), sizeof(uint32_t)));
+    fileHandle.write(unsafeMakeSpan<const uint8_t>(reinterpret_cast<const uint8_t*>(&height), sizeof(uint32_t)));
+    fileHandle.write(unsafeMakeSpan<const uint8_t>(reinterpret_cast<const uint8_t*>(&pixelFormat), sizeof(uint32_t)));
+    fileHandle.write(unsafeMakeSpan<const uint8_t>(reinterpret_cast<const uint8_t*>(&isPlanar), sizeof(uint32_t)));
+    fileHandle.write(unsafeMakeSpan<const uint8_t>(reinterpret_cast<const uint8_t*>(&planeCount), sizeof(uint32_t)));
+
+    CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+    {
+        uint32_t planeWidth;
+        uint32_t planeHeight;
+        uint32_t bytesPerRow;
+        uint8_t* baseAddress;
+
+        for (uint32_t i = 0; i < planeCount; i++) {
+            if (isPlanar) {
+                planeWidth  = static_cast<uint32_t>(CVPixelBufferGetWidthOfPlane(pixelBuffer, i));
+                planeHeight = static_cast<uint32_t>(CVPixelBufferGetHeightOfPlane(pixelBuffer, i));
+                bytesPerRow = static_cast<uint32_t>(CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, i));
+                baseAddress = static_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, i));
+            } else {
+                planeWidth  = width;
+                planeHeight = height;
+                bytesPerRow = static_cast<uint32_t>(CVPixelBufferGetBytesPerRow(pixelBuffer));
+                baseAddress = static_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer));
+            }
+
+            fileHandle.write(unsafeMakeSpan<const uint8_t>(reinterpret_cast<const uint8_t*>(&planeWidth), sizeof(uint32_t)));
+            fileHandle.write(unsafeMakeSpan<const uint8_t>(reinterpret_cast<const uint8_t*>(&planeHeight), sizeof(uint32_t)));
+            fileHandle.write(unsafeMakeSpan<const uint8_t>(reinterpret_cast<const uint8_t*>(&bytesPerRow), sizeof(uint32_t)));
+
+            fileHandle.write(unsafeMakeSpan(baseAddress, planeHeight * bytesPerRow));
+        }
+    }
+    CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+}
+#endif
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+#include <WebCore/PlatformImage.h>
+
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
+
+namespace WebCore {
+
+class ShareableCVPixelBuffer;
+
+RetainPtr<CVPixelBufferRef> createScratchCVPixelBuffer(unsigned width, unsigned height, OSType pixelFormat, CFDictionaryRef = nullptr, CGColorSpaceRef = nullptr);
+
+RetainPtr<CVPixelBufferRef> createScratchMetalCompatibleCVPixelBuffer(unsigned width, unsigned height, OSType pixelFormat, CGColorSpaceRef = nullptr);
+
+RetainPtr<CVPixelBufferRef> createScratchMetalCompatibleCVPixelBuffer(const ShareableCVPixelBuffer&, CGColorSpaceRef = nullptr);
+
+#if ENABLE(DUMP_GAIN_MAP_IMAGES)
+void CVPixelBufferDumpToFile(CVPixelBufferRef, const String& name);
+#endif
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/graphics/cocoa/ShareableCVPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/ShareableCVPixelBuffer.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ShareableCVPixelBuffer.h"
+
+#if PLATFORM(COCOA)
+
+#include "CVUtilities.h"
+#include <wtf/FileHandle.h>
+#include <wtf/FileSystem.h>
+#include <wtf/text/StringBuilder.h>
+
+#include "CoreVideoSoftLink.h"
+
+namespace WebCore {
+
+ShareableCVPixelBufferConfiguration::ShareableCVPixelBufferConfiguration(const RetainPtr<CVPixelBufferRef>& pixelBuffer)
+    : m_width(CVPixelBufferGetWidth(pixelBuffer.get()))
+    , m_height(CVPixelBufferGetHeight(pixelBuffer.get()))
+    , m_bytesPerRow(CVPixelBufferGetBytesPerRow(pixelBuffer.get()))
+    , m_pixelFormat(fromCVPixelFormat(CVPixelBufferGetPixelFormatType(pixelBuffer.get())))
+{
+}
+
+ShareableCVPixelBufferConfiguration::ShareableCVPixelBufferConfiguration(unsigned width, unsigned height, unsigned bytesPerRow, ShareableCVPixelFormat pixelFormat)
+    : m_width(width)
+    , m_height(height)
+    , m_bytesPerRow(bytesPerRow)
+    , m_pixelFormat(pixelFormat)
+{
+}
+
+// MARK: - ShareableCVPixelBufferBytesConfiguration.
+
+ShareableCVPixelBufferBytesConfiguration::ShareableCVPixelBufferBytesConfiguration(const RetainPtr<CVPixelBufferRef>& pixelBuffer, unsigned planeIndex)
+    : m_width(CVPixelBufferGetWidthOfPlane(pixelBuffer.get(), planeIndex))
+    , m_height(CVPixelBufferGetHeightOfPlane(pixelBuffer.get(), planeIndex))
+    , m_bytesPerRow(CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer.get(), planeIndex))
+{
+}
+
+ShareableCVPixelBufferBytesConfiguration::ShareableCVPixelBufferBytesConfiguration(const ShareableCVPixelBufferConfiguration& configuration)
+    : m_width(configuration.width())
+    , m_height(configuration.height())
+    , m_bytesPerRow(configuration.bytesPerRow())
+{
+}
+
+ShareableCVPixelBufferBytesConfiguration::ShareableCVPixelBufferBytesConfiguration(unsigned width, unsigned height, unsigned bytesPerRow)
+    : m_width(width)
+    , m_height(height)
+    , m_bytesPerRow(bytesPerRow)
+{
+}
+
+// MARK: - ShareableCVPixelBufferBytesHandle.
+
+ShareableCVPixelBufferBytesHandle::ShareableCVPixelBufferBytesHandle(SharedMemory::Handle&& handle, const ShareableCVPixelBufferBytesConfiguration& configuration)
+    : m_handle(WTF::move(handle))
+    , m_configuration(configuration)
+{
+}
+
+// MARK: - ShareableCVPixelBufferBytes.
+
+Ref<ShareableCVPixelBufferBytes> ShareableCVPixelBufferBytes::create(const ShareableCVPixelBufferBytesConfiguration& configuration, Ref<SharedMemory>&& sharedMemory)
+{
+    return adoptRef(*new ShareableCVPixelBufferBytes(configuration, WTF::move(sharedMemory)));
+}
+
+RefPtr<ShareableCVPixelBufferBytes> ShareableCVPixelBufferBytes::create(const ShareableCVPixelBufferBytesConfiguration& configuration, std::span<const uint8_t> sourceSpan)
+{
+    auto sizeInBytes = configuration.sizeInBytes();
+
+    ASSERT(sizeInBytes);
+    ASSERT(!sourceSpan.empty());
+
+    RefPtr sharedMemory = SharedMemory::allocate(sizeInBytes);
+    if (!sharedMemory)
+        return nullptr;
+
+    auto destinationSpan = sharedMemory->mutableSpan();
+    if (destinationSpan.empty())
+        return nullptr;
+
+    memcpySpan(destinationSpan, sourceSpan);
+
+    return create(configuration, sharedMemory.releaseNonNull());
+}
+
+RefPtr<ShareableCVPixelBufferBytes> ShareableCVPixelBufferBytes::create(Handle&& handle, SharedMemory::Protection protection)
+{
+    auto sharedMemory = SharedMemory::map(WTF::move(handle.m_handle), protection, SharedMemory::CopyOnWrite::No);
+    if (!sharedMemory)
+        return nullptr;
+
+    return create(handle.m_configuration, sharedMemory.releaseNonNull());
+}
+
+std::optional<Ref<ShareableCVPixelBufferBytes>> ShareableCVPixelBufferBytes::createReadOnly(std::optional<Handle>&& handle)
+{
+    if (!handle)
+        return std::nullopt;
+
+    auto sharedMemory = SharedMemory::map(WTF::move(handle->m_handle), SharedMemory::Protection::ReadOnly);
+    if (!sharedMemory)
+        return std::nullopt;
+
+    if (RefPtr bytes = create(WTF::move(*handle), SharedMemory::Protection::ReadOnly))
+        return { bytes.releaseNonNull() };
+
+    return std::nullopt;
+}
+
+ShareableCVPixelBufferBytes::ShareableCVPixelBufferBytes(const ShareableCVPixelBufferBytesConfiguration& configuration, Ref<SharedMemory>&& sharedMemory)
+    : m_configuration(configuration)
+    , m_sharedMemory(WTF::move(sharedMemory))
+{
+}
+
+std::optional<ShareableCVPixelBufferBytesHandle> ShareableCVPixelBufferBytes::createReadOnlyHandle() const
+{
+    auto memoryHandle = m_sharedMemory->createHandle(SharedMemory::Protection::ReadOnly);
+    if (!memoryHandle)
+        return std::nullopt;
+    return { Handle(WTF::move(*memoryHandle), m_configuration) };
+}
+
+void ShareableCVPixelBufferBytes::copyPixels(std::span<uint8_t> destinationSpan, unsigned destinationHeight, unsigned destinationBytesPerRow)
+{
+    ASSERT(destinationSpan.size() >= static_cast<size_t>(destinationHeight) * destinationBytesPerRow);
+
+    auto sourceHeight = m_configuration.height();
+    auto sourceBytesPerRow = m_configuration.bytesPerRow();
+    auto sourceSpan = m_sharedMemory->span();
+
+    auto clampedSourceHeight = std::min(sourceHeight, destinationHeight);
+    auto clampedSourceBytesPerRow = std::min(sourceBytesPerRow, destinationBytesPerRow);
+
+    for (unsigned row = 0; row < clampedSourceHeight; ++row) {
+        auto destinationSubSpan = destinationSpan.subspan(row * destinationBytesPerRow, destinationBytesPerRow);
+        auto sourceSubSpan = sourceSpan.subspan(row * sourceBytesPerRow, clampedSourceBytesPerRow);
+        memcpySpan(destinationSubSpan, sourceSubSpan);
+    }
+}
+
+// MARK: - ShareableCVPixelBuffer.
+
+RefPtr<ShareableCVPixelBuffer> ShareableCVPixelBuffer::create(const RetainPtr<CVPixelBufferRef>& pixelBuffer)
+{
+    if (CVPixelBufferIsPlanar(pixelBuffer.get()))
+        return ShareableCVPixelBufferWithPlanarBytes::create(pixelBuffer);
+    return ShareableCVPixelBufferWithBytes::create(pixelBuffer);
+}
+
+ShareableCVPixelBuffer::ShareableCVPixelBuffer(ShareableCVPixelBufferConfiguration&& configuration)
+    : m_configuration(WTF::move(configuration))
+{
+}
+
+// MARK: - ShareableCVPixelBufferWithBytes.
+
+Ref<ShareableCVPixelBufferWithBytes> ShareableCVPixelBufferWithBytes::create(ShareableCVPixelBufferConfiguration&& configuration, Ref<ShareableCVPixelBufferBytes>&& bytes)
+{
+    return adoptRef(*new ShareableCVPixelBufferWithBytes(WTF::move(configuration), WTF::move(bytes)));
+}
+
+RefPtr<ShareableCVPixelBufferWithBytes> ShareableCVPixelBufferWithBytes::create(const RetainPtr<CVPixelBufferRef>& pixelBuffer)
+{
+    ASSERT(!CVPixelBufferIsPlanar(pixelBuffer.get()));
+
+    auto configuration = ShareableCVPixelBufferConfiguration(pixelBuffer.get());
+
+    RefPtr<ShareableCVPixelBufferBytes> bytes;
+
+    CVPixelBufferLockBaseAddress(pixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
+    {
+        auto bytesConfiguration = ShareableCVPixelBufferBytesConfiguration(configuration);
+        auto baseAddress = static_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer.get()));
+
+        if (auto sizeInBytes = bytesConfiguration.sizeInBytes()) {
+            auto sourceSpan = unsafeMakeSpan(baseAddress, sizeInBytes);
+            bytes = ShareableCVPixelBufferBytes::create(bytesConfiguration, sourceSpan);
+        }
+    }
+    CVPixelBufferUnlockBaseAddress(pixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
+
+    if (!bytes)
+        return nullptr;
+
+    return create(WTF::move(configuration), bytes.releaseNonNull());
+}
+
+ShareableCVPixelBufferWithBytes::ShareableCVPixelBufferWithBytes(ShareableCVPixelBufferConfiguration&& configuration, Ref<ShareableCVPixelBufferBytes>&& bytes)
+    : ShareableCVPixelBuffer(WTF::move(configuration))
+    , m_bytes(WTF::move(bytes))
+{
+}
+
+RetainPtr<CVPixelBufferRef> ShareableCVPixelBufferWithBytes::createMetalCompatibleCVPixelBuffer() const
+{
+    RetainPtr pixelBuffer = createScratchMetalCompatibleCVPixelBuffer(*this);
+    if (!pixelBuffer)
+        return nullptr;
+
+    CVPixelBufferLockBaseAddress(pixelBuffer.get(), 0);
+    {
+        unsigned destinationHeight = CVPixelBufferGetHeight(pixelBuffer.get());
+        unsigned destinationBytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer.get());
+        auto* destinationBaseAddress = static_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer.get()));
+        auto destinationSpan = unsafeMakeSpan(destinationBaseAddress, destinationBytesPerRow * destinationHeight);
+        protect(m_bytes)->copyPixels(destinationSpan, destinationHeight, destinationBytesPerRow);
+    }
+    CVPixelBufferUnlockBaseAddress(pixelBuffer.get(), 0);
+
+    return WTF::move(pixelBuffer);
+}
+
+// MARK: - ShareableCVPixelBufferWithPlanarBytes.
+
+Ref<ShareableCVPixelBufferWithPlanarBytes> ShareableCVPixelBufferWithPlanarBytes::create(ShareableCVPixelBufferConfiguration&& configuration, Vector<Ref<ShareableCVPixelBufferBytes>>&& planes)
+{
+    return adoptRef(*new ShareableCVPixelBufferWithPlanarBytes(WTF::move(configuration), WTF::move(planes)));
+}
+
+RefPtr<ShareableCVPixelBufferWithPlanarBytes> ShareableCVPixelBufferWithPlanarBytes::create(const RetainPtr<CVPixelBufferRef>& pixelBuffer)
+{
+    ASSERT(CVPixelBufferIsPlanar(pixelBuffer.get()));
+
+    auto planesCount = static_cast<uint32_t>(CVPixelBufferGetPlaneCount(pixelBuffer.get()));
+    if (!planesCount)
+        return nullptr;
+
+    Vector<Ref<ShareableCVPixelBufferBytes>> planes;
+
+    CVPixelBufferLockBaseAddress(pixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
+    {
+        for (unsigned i = 0; i < planesCount; ++i) {
+            auto bytesConfiguration = ShareableCVPixelBufferBytesConfiguration(pixelBuffer, i);
+            auto baseAddress = static_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer.get(), i));
+
+            if (auto sizeInBytes = bytesConfiguration.sizeInBytes()) {
+                auto sourceSpan = unsafeMakeSpan(baseAddress, sizeInBytes);
+                if (RefPtr bytes = ShareableCVPixelBufferBytes::create(bytesConfiguration, sourceSpan))
+                    planes.append(bytes.releaseNonNull());
+            }
+        }
+    }
+    CVPixelBufferUnlockBaseAddress(pixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
+
+    if (planes.size() != planesCount)
+        return nullptr;
+
+    return create(ShareableCVPixelBufferConfiguration(pixelBuffer.get()), WTF::move(planes));
+}
+
+ShareableCVPixelBufferWithPlanarBytes::ShareableCVPixelBufferWithPlanarBytes(ShareableCVPixelBufferConfiguration&& configuration, Vector<Ref<ShareableCVPixelBufferBytes>>&& planes)
+    : ShareableCVPixelBuffer(WTF::move(configuration))
+    , m_planes(WTF::move(planes))
+{
+}
+
+RetainPtr<CVPixelBufferRef> ShareableCVPixelBufferWithPlanarBytes::createMetalCompatibleCVPixelBuffer() const
+{
+    RetainPtr pixelBuffer = createScratchMetalCompatibleCVPixelBuffer(*this);
+    if (!pixelBuffer)
+        return nullptr;
+
+    CVPixelBufferLockBaseAddress(pixelBuffer.get(), 0);
+    {
+        for (unsigned i = 0; i < m_planes.size(); ++i) {
+            unsigned destinationHeight = CVPixelBufferGetHeightOfPlane(pixelBuffer.get(), i);
+            unsigned destinationBytesPerRow = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer.get(), i);
+            auto* destinationBaseAddress = static_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer.get(), i));
+            auto destinationSpan = unsafeMakeSpan(destinationBaseAddress, destinationBytesPerRow * destinationHeight);
+            protect(m_planes[i])->copyPixels(destinationSpan, destinationHeight, destinationBytesPerRow);
+        }
+    }
+    CVPixelBufferUnlockBaseAddress(pixelBuffer.get(), 0);
+
+    return WTF::move(pixelBuffer);
+}
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/graphics/cocoa/ShareableCVPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/cocoa/ShareableCVPixelBuffer.h
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+#include <WebCore/CVPixelBufferUtilities.h>
+#include <WebCore/ShareableCVPixelFormat.h>
+#include <WebCore/SharedMemory.h>
+#include <wtf/ArgumentCoder.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+class ShareableCVPixelBufferConfiguration {
+public:
+    ShareableCVPixelBufferConfiguration(const ShareableCVPixelBufferConfiguration&) = default;
+    ShareableCVPixelBufferConfiguration(ShareableCVPixelBufferConfiguration&&) = default;
+    ShareableCVPixelBufferConfiguration(const RetainPtr<CVPixelBufferRef>&);
+    WEBCORE_EXPORT ShareableCVPixelBufferConfiguration(unsigned width, unsigned height, unsigned bytesPerRow, ShareableCVPixelFormat);
+
+    ShareableCVPixelBufferConfiguration& operator=(ShareableCVPixelBufferConfiguration&&) = default;
+
+    unsigned width() const { return m_width; }
+    unsigned height() const { ASSERT(!m_height.hasOverflowed()); return m_height; }
+    unsigned bytesPerRow() const { ASSERT(!m_bytesPerRow.hasOverflowed()); return m_bytesPerRow; }
+    ShareableCVPixelFormat pixelFormat() const { return m_pixelFormat; }
+
+private:
+    friend struct IPC::ArgumentCoder<ShareableCVPixelBufferConfiguration>;
+
+    CheckedUint32 m_width;
+    CheckedUint32 m_height;
+    CheckedUint32 m_bytesPerRow;
+    ShareableCVPixelFormat m_pixelFormat;
+};
+
+class ShareableCVPixelBufferBytesConfiguration {
+public:
+    ShareableCVPixelBufferBytesConfiguration(const ShareableCVPixelBufferBytesConfiguration&) = default;
+    WEBCORE_EXPORT ShareableCVPixelBufferBytesConfiguration(const RetainPtr<CVPixelBufferRef>&, unsigned planeIndex);
+    WEBCORE_EXPORT ShareableCVPixelBufferBytesConfiguration(const ShareableCVPixelBufferConfiguration&);
+    WEBCORE_EXPORT ShareableCVPixelBufferBytesConfiguration(unsigned width, unsigned height, unsigned bytesPerRow);
+
+    unsigned width() const { return m_width; }
+    unsigned height() const { return m_height; }
+    unsigned bytesPerRow() const { return m_bytesPerRow; }
+
+    CheckedUint32 sizeInBytes() const { return m_bytesPerRow * m_height; }
+
+private:
+    friend struct IPC::ArgumentCoder<ShareableCVPixelBufferBytesConfiguration>;
+
+    CheckedUint32 m_width;
+    CheckedUint32 m_height;
+    CheckedUint32 m_bytesPerRow;
+};
+
+class ShareableCVPixelBufferBytesHandle  {
+public:
+    ShareableCVPixelBufferBytesHandle(ShareableCVPixelBufferBytesHandle&&) = default;
+    explicit ShareableCVPixelBufferBytesHandle(const ShareableCVPixelBufferBytesHandle&) = default;
+    WEBCORE_EXPORT ShareableCVPixelBufferBytesHandle(SharedMemory::Handle&&, const ShareableCVPixelBufferBytesConfiguration&);
+
+    ShareableCVPixelBufferBytesHandle& operator=(ShareableCVPixelBufferBytesHandle&&) = default;
+
+    SharedMemory::Handle& handle() LIFETIME_BOUND { return m_handle; }
+
+private:
+    friend struct IPC::ArgumentCoder<ShareableCVPixelBufferBytesHandle>;
+    friend class ShareableCVPixelBufferBytes;
+
+    SharedMemory::Handle m_handle;
+    ShareableCVPixelBufferBytesConfiguration m_configuration;
+};
+
+class ShareableCVPixelBufferBytes : public ThreadSafeRefCounted<ShareableCVPixelBufferBytes> {
+public:
+    using Handle = ShareableCVPixelBufferBytesHandle;
+
+    WEBCORE_EXPORT static Ref<ShareableCVPixelBufferBytes> create(const ShareableCVPixelBufferBytesConfiguration&, Ref<SharedMemory>&&);
+    WEBCORE_EXPORT static RefPtr<ShareableCVPixelBufferBytes> create(const ShareableCVPixelBufferBytesConfiguration&, std::span<const uint8_t> sourceSpan);
+
+    WEBCORE_EXPORT static RefPtr<ShareableCVPixelBufferBytes> create(Handle&&, SharedMemory::Protection = SharedMemory::Protection::ReadWrite);
+    WEBCORE_EXPORT static std::optional<Ref<ShareableCVPixelBufferBytes>> createReadOnly(std::optional<Handle>&&);
+
+    WEBCORE_EXPORT std::optional<Handle> createReadOnlyHandle() const;
+
+    void copyPixels(std::span<uint8_t> destinationSpan, unsigned destinationHeight, unsigned destinationBytesPerRow);
+
+private:
+    ShareableCVPixelBufferBytes(const ShareableCVPixelBufferBytesConfiguration&, Ref<SharedMemory>&&);
+
+    ShareableCVPixelBufferBytesConfiguration m_configuration;
+    const Ref<SharedMemory> m_sharedMemory;
+};
+
+class ShareableCVPixelBuffer : public ThreadSafeRefCounted<ShareableCVPixelBuffer> {
+public:
+    WEBCORE_EXPORT static RefPtr<ShareableCVPixelBuffer> create(const RetainPtr<CVPixelBufferRef>&);
+
+    virtual ~ShareableCVPixelBuffer() = default;
+
+    virtual bool isPlanar() const { return false; }
+    const ShareableCVPixelBufferConfiguration& configuration() const { return m_configuration; }
+
+    virtual RetainPtr<CVPixelBufferRef> createMetalCompatibleCVPixelBuffer() const = 0;
+
+protected:
+    ShareableCVPixelBuffer(ShareableCVPixelBufferConfiguration&&);
+
+    ShareableCVPixelBufferConfiguration m_configuration;
+};
+
+class ShareableCVPixelBufferWithBytes : public ShareableCVPixelBuffer {
+public:
+    WEBCORE_EXPORT static Ref<ShareableCVPixelBufferWithBytes> create(ShareableCVPixelBufferConfiguration&&, Ref<ShareableCVPixelBufferBytes>&&);
+
+    WEBCORE_EXPORT static RefPtr<ShareableCVPixelBufferWithBytes> create(const RetainPtr<CVPixelBufferRef>&);
+
+private:
+    friend struct IPC::ArgumentCoder<ShareableCVPixelBufferWithBytes>;
+
+    ShareableCVPixelBufferWithBytes(ShareableCVPixelBufferConfiguration&&, Ref<ShareableCVPixelBufferBytes>&&);
+
+    WEBCORE_EXPORT RetainPtr<CVPixelBufferRef> createMetalCompatibleCVPixelBuffer() const final;
+
+    Ref<ShareableCVPixelBufferBytes> m_bytes;
+};
+
+class ShareableCVPixelBufferWithPlanarBytes : public ShareableCVPixelBuffer {
+public:
+    WEBCORE_EXPORT static Ref<ShareableCVPixelBufferWithPlanarBytes> create(ShareableCVPixelBufferConfiguration&&, Vector<Ref<ShareableCVPixelBufferBytes>>&&);
+
+    WEBCORE_EXPORT static RefPtr<ShareableCVPixelBufferWithPlanarBytes> create(const RetainPtr<CVPixelBufferRef>&);
+
+private:
+    friend struct IPC::ArgumentCoder<ShareableCVPixelBufferWithPlanarBytes>;
+
+    ShareableCVPixelBufferWithPlanarBytes(ShareableCVPixelBufferConfiguration&&, Vector<Ref<ShareableCVPixelBufferBytes>>&&);
+
+    bool isPlanar() const final { return true; }
+    WEBCORE_EXPORT RetainPtr<CVPixelBufferRef> createMetalCompatibleCVPixelBuffer() const final;
+
+    Vector<Ref<ShareableCVPixelBufferBytes>> m_planes;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ShareableCVPixelBufferWithBytes) \
+    static bool isType(const WebCore::ShareableCVPixelBuffer& pixelBuffer) { return !pixelBuffer.isPlanar(); } \
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ShareableCVPixelBufferWithPlanarBytes) \
+    static bool isType(const WebCore::ShareableCVPixelBuffer& pixelBuffer) { return pixelBuffer.isPlanar(); } \
+SPECIALIZE_TYPE_TRAITS_END()
+
+#endif

--- a/Source/WebCore/platform/graphics/cocoa/ShareableCVPixelFormat.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/ShareableCVPixelFormat.cpp
@@ -1,0 +1,446 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ShareableCVPixelFormat.h"
+
+#if PLATFORM(COCOA)
+
+#include <CoreVideo/CoreVideo.h>
+
+namespace WebCore {
+
+ShareableCVPixelFormat fromCVPixelFormat(OSType pixelFormat)
+{
+    switch (pixelFormat) {
+    case kCVPixelFormatType_1Monochrome:
+        return ShareableCVPixelFormat::Type_1Monochrome;
+    case kCVPixelFormatType_2Indexed:
+        return ShareableCVPixelFormat::Type_2Indexed;
+    case kCVPixelFormatType_4Indexed:
+        return ShareableCVPixelFormat::Type_4Indexed;
+    case kCVPixelFormatType_8Indexed:
+        return ShareableCVPixelFormat::Type_8Indexed;
+    case kCVPixelFormatType_1IndexedGray_WhiteIsZero:
+        return ShareableCVPixelFormat::Type_1IndexedGray_WhiteIsZero;
+    case kCVPixelFormatType_2IndexedGray_WhiteIsZero:
+        return ShareableCVPixelFormat::Type_2IndexedGray_WhiteIsZero;
+    case kCVPixelFormatType_4IndexedGray_WhiteIsZero:
+        return ShareableCVPixelFormat::Type_4IndexedGray_WhiteIsZero;
+    case kCVPixelFormatType_8IndexedGray_WhiteIsZero:
+        return ShareableCVPixelFormat::Type_8IndexedGray_WhiteIsZero;
+    case kCVPixelFormatType_16BE555:
+        return ShareableCVPixelFormat::Type_16BE555;
+    case kCVPixelFormatType_16LE555:
+        return ShareableCVPixelFormat::Type_16LE555;
+    case kCVPixelFormatType_16LE5551:
+        return ShareableCVPixelFormat::Type_16LE5551;
+    case kCVPixelFormatType_16BE565:
+        return ShareableCVPixelFormat::Type_16BE565;
+    case kCVPixelFormatType_16LE565:
+        return ShareableCVPixelFormat::Type_16LE565;
+    case kCVPixelFormatType_24RGB:
+        return ShareableCVPixelFormat::Type_24RGB;
+    case kCVPixelFormatType_24BGR:
+        return ShareableCVPixelFormat::Type_24BGR;
+    case kCVPixelFormatType_32ARGB:
+        return ShareableCVPixelFormat::Type_32ARGB;
+    case kCVPixelFormatType_32BGRA:
+        return ShareableCVPixelFormat::Type_32BGRA;
+    case kCVPixelFormatType_32ABGR:
+        return ShareableCVPixelFormat::Type_32ABGR;
+    case kCVPixelFormatType_32RGBA:
+        return ShareableCVPixelFormat::Type_32RGBA;
+    case kCVPixelFormatType_64ARGB:
+        return ShareableCVPixelFormat::Type_64ARGB;
+    case kCVPixelFormatType_64RGBALE:
+        return ShareableCVPixelFormat::Type_64RGBALE;
+    case kCVPixelFormatType_48RGB:
+        return ShareableCVPixelFormat::Type_48RGB;
+    case kCVPixelFormatType_32AlphaGray:
+        return ShareableCVPixelFormat::Type_32AlphaGray;
+    case kCVPixelFormatType_16Gray:
+        return ShareableCVPixelFormat::Type_16Gray;
+    case kCVPixelFormatType_30RGB:
+        return ShareableCVPixelFormat::Type_30RGB;
+    case kCVPixelFormatType_30RGB_r210:
+        return ShareableCVPixelFormat::Type_30RGB_r210;
+    case kCVPixelFormatType_422YpCbCr8:
+        return ShareableCVPixelFormat::Type_422YpCbCr8;
+    case kCVPixelFormatType_4444YpCbCrA8:
+        return ShareableCVPixelFormat::Type_4444YpCbCrA8;
+    case kCVPixelFormatType_4444YpCbCrA8R:
+        return ShareableCVPixelFormat::Type_4444YpCbCrA8R;
+    case kCVPixelFormatType_4444AYpCbCr8:
+        return ShareableCVPixelFormat::Type_4444AYpCbCr8;
+    case kCVPixelFormatType_4444AYpCbCr16:
+        return ShareableCVPixelFormat::Type_4444AYpCbCr16;
+    case kCVPixelFormatType_4444AYpCbCrFloat:
+        return ShareableCVPixelFormat::Type_4444AYpCbCrFloat;
+    case kCVPixelFormatType_444YpCbCr8:
+        return ShareableCVPixelFormat::Type_444YpCbCr8;
+    case kCVPixelFormatType_422YpCbCr16:
+        return ShareableCVPixelFormat::Type_422YpCbCr16;
+    case kCVPixelFormatType_422YpCbCr10:
+        return ShareableCVPixelFormat::Type_422YpCbCr10;
+    case kCVPixelFormatType_444YpCbCr10:
+        return ShareableCVPixelFormat::Type_444YpCbCr10;
+    case kCVPixelFormatType_420YpCbCr8Planar:
+        return ShareableCVPixelFormat::Type_420YpCbCr8Planar;
+    case kCVPixelFormatType_420YpCbCr8PlanarFullRange:
+        return ShareableCVPixelFormat::Type_420YpCbCr8PlanarFullRange;
+    case kCVPixelFormatType_422YpCbCr_4A_8BiPlanar:
+        return ShareableCVPixelFormat::Type_422YpCbCr_4A_8BiPlanar;
+    case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_420YpCbCr8BiPlanarVideoRange;
+    case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+        return ShareableCVPixelFormat::Type_420YpCbCr8BiPlanarFullRange;
+    case kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_422YpCbCr8BiPlanarVideoRange;
+    case kCVPixelFormatType_422YpCbCr8BiPlanarFullRange:
+        return ShareableCVPixelFormat::Type_422YpCbCr8BiPlanarFullRange;
+    case kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_444YpCbCr8BiPlanarVideoRange;
+    case kCVPixelFormatType_444YpCbCr8BiPlanarFullRange:
+        return ShareableCVPixelFormat::Type_444YpCbCr8BiPlanarFullRange;
+    case kCVPixelFormatType_422YpCbCr8_yuvs:
+        return ShareableCVPixelFormat::Type_422YpCbCr8_yuvs;
+    case kCVPixelFormatType_422YpCbCr8FullRange:
+        return ShareableCVPixelFormat::Type_422YpCbCr8FullRange;
+    case kCVPixelFormatType_OneComponent8:
+        return ShareableCVPixelFormat::Type_OneComponent8;
+    case kCVPixelFormatType_TwoComponent8:
+        return ShareableCVPixelFormat::Type_TwoComponent8;
+    case kCVPixelFormatType_30RGBLEPackedWideGamut:
+        return ShareableCVPixelFormat::Type_30RGBLEPackedWideGamut;
+    case kCVPixelFormatType_ARGB2101010LEPacked:
+        return ShareableCVPixelFormat::Type_ARGB2101010LEPacked;
+    case kCVPixelFormatType_40ARGBLEWideGamut:
+        return ShareableCVPixelFormat::Type_40ARGBLEWideGamut;
+    case kCVPixelFormatType_40ARGBLEWideGamutPremultiplied:
+        return ShareableCVPixelFormat::Type_40ARGBLEWideGamutPremultiplied;
+    case kCVPixelFormatType_OneComponent10:
+        return ShareableCVPixelFormat::Type_OneComponent10;
+    case kCVPixelFormatType_OneComponent12:
+        return ShareableCVPixelFormat::Type_OneComponent12;
+    case kCVPixelFormatType_OneComponent16:
+        return ShareableCVPixelFormat::Type_OneComponent16;
+    case kCVPixelFormatType_TwoComponent16:
+        return ShareableCVPixelFormat::Type_TwoComponent16;
+    case kCVPixelFormatType_OneComponent16Half:
+        return ShareableCVPixelFormat::Type_OneComponent16Half;
+    case kCVPixelFormatType_OneComponent32Float:
+        return ShareableCVPixelFormat::Type_OneComponent32Float;
+    case kCVPixelFormatType_TwoComponent16Half:
+        return ShareableCVPixelFormat::Type_TwoComponent16Half;
+    case kCVPixelFormatType_TwoComponent32Float:
+        return ShareableCVPixelFormat::Type_TwoComponent32Float;
+    case kCVPixelFormatType_64RGBAHalf:
+        return ShareableCVPixelFormat::Type_64RGBAHalf;
+    case kCVPixelFormatType_128RGBAFloat:
+        return ShareableCVPixelFormat::Type_128RGBAFloat;
+    case kCVPixelFormatType_14Bayer_GRBG:
+        return ShareableCVPixelFormat::Type_14Bayer_GRBG;
+    case kCVPixelFormatType_14Bayer_RGGB:
+        return ShareableCVPixelFormat::Type_14Bayer_RGGB;
+    case kCVPixelFormatType_14Bayer_BGGR:
+        return ShareableCVPixelFormat::Type_14Bayer_BGGR;
+    case kCVPixelFormatType_14Bayer_GBRG:
+        return ShareableCVPixelFormat::Type_14Bayer_GBRG;
+    case kCVPixelFormatType_DisparityFloat16:
+        return ShareableCVPixelFormat::Type_DisparityFloat16;
+    case kCVPixelFormatType_DisparityFloat32:
+        return ShareableCVPixelFormat::Type_DisparityFloat32;
+    case kCVPixelFormatType_DepthFloat16:
+        return ShareableCVPixelFormat::Type_DepthFloat16;
+    case kCVPixelFormatType_DepthFloat32:
+        return ShareableCVPixelFormat::Type_DepthFloat32;
+    case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_420YpCbCr10BiPlanarVideoRange;
+    case kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_422YpCbCr10BiPlanarVideoRange;
+    case kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_444YpCbCr10BiPlanarVideoRange;
+    case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange:
+        return ShareableCVPixelFormat::Type_420YpCbCr10BiPlanarFullRange;
+    case kCVPixelFormatType_422YpCbCr10BiPlanarFullRange:
+        return ShareableCVPixelFormat::Type_422YpCbCr10BiPlanarFullRange;
+    case kCVPixelFormatType_444YpCbCr10BiPlanarFullRange:
+        return ShareableCVPixelFormat::Type_444YpCbCr10BiPlanarFullRange;
+    case kCVPixelFormatType_420YpCbCr8VideoRange_8A_TriPlanar:
+        return ShareableCVPixelFormat::Type_420YpCbCr8VideoRange_8A_TriPlanar;
+    case kCVPixelFormatType_16VersatileBayer:
+        return ShareableCVPixelFormat::Type_16VersatileBayer;
+    case kCVPixelFormatType_96VersatileBayerPacked12:
+        return ShareableCVPixelFormat::Type_96VersatileBayerPacked12;
+    case kCVPixelFormatType_64RGBA_DownscaledProResRAW:
+        return ShareableCVPixelFormat::Type_64RGBA_DownscaledProResRAW;
+    case kCVPixelFormatType_422YpCbCr16BiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_422YpCbCr16BiPlanarVideoRange;
+    case kCVPixelFormatType_444YpCbCr16BiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_444YpCbCr16BiPlanarVideoRange;
+    case kCVPixelFormatType_444YpCbCr16VideoRange_16A_TriPlanar:
+        return ShareableCVPixelFormat::Type_444YpCbCr16VideoRange_16A_TriPlanar;
+    case kCVPixelFormatType_30RGBLE_8A_BiPlanar:
+        return ShareableCVPixelFormat::Type_30RGBLE_8A_BiPlanar;
+    case kCVPixelFormatType_Lossless_32BGRA:
+        return ShareableCVPixelFormat::Type_Lossless_32BGRA;
+    case kCVPixelFormatType_Lossless_64RGBAHalf:
+        return ShareableCVPixelFormat::Type_Lossless_64RGBAHalf;
+    case kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_Lossless_420YpCbCr8BiPlanarVideoRange;
+    case kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange:
+        return ShareableCVPixelFormat::Type_Lossless_420YpCbCr8BiPlanarFullRange;
+    case kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_Lossless_420YpCbCr10PackedBiPlanarVideoRange;
+    case kCVPixelFormatType_Lossless_422YpCbCr10PackedBiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_Lossless_422YpCbCr10PackedBiPlanarVideoRange;
+    case kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarFullRange:
+        return ShareableCVPixelFormat::Type_Lossless_420YpCbCr10PackedBiPlanarFullRange;
+    case kCVPixelFormatType_Lossless_30RGBLE_8A_BiPlanar:
+        return ShareableCVPixelFormat::Type_Lossless_30RGBLE_8A_BiPlanar;
+    case kCVPixelFormatType_Lossless_30RGBLEPackedWideGamut:
+        return ShareableCVPixelFormat::Type_Lossless_30RGBLEPackedWideGamut;
+    case kCVPixelFormatType_Lossy_32BGRA:
+        return ShareableCVPixelFormat::Type_Lossy_32BGRA;
+    case kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_Lossy_420YpCbCr8BiPlanarVideoRange;
+    case kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarFullRange:
+        return ShareableCVPixelFormat::Type_Lossy_420YpCbCr8BiPlanarFullRange;
+    case kCVPixelFormatType_Lossy_420YpCbCr10PackedBiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_Lossy_420YpCbCr10PackedBiPlanarVideoRange;
+    case kCVPixelFormatType_Lossy_422YpCbCr10PackedBiPlanarVideoRange:
+        return ShareableCVPixelFormat::Type_Lossy_422YpCbCr10PackedBiPlanarVideoRange;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+OSType toCVPixelFormat(ShareableCVPixelFormat pixelFormat)
+{
+    switch (pixelFormat) {
+    case ShareableCVPixelFormat::Type_1Monochrome:
+        return kCVPixelFormatType_1Monochrome;
+    case ShareableCVPixelFormat::Type_2Indexed:
+        return kCVPixelFormatType_2Indexed;
+    case ShareableCVPixelFormat::Type_4Indexed:
+        return kCVPixelFormatType_4Indexed;
+    case ShareableCVPixelFormat::Type_8Indexed:
+        return kCVPixelFormatType_8Indexed;
+    case ShareableCVPixelFormat::Type_1IndexedGray_WhiteIsZero:
+        return kCVPixelFormatType_1IndexedGray_WhiteIsZero;
+    case ShareableCVPixelFormat::Type_2IndexedGray_WhiteIsZero:
+        return kCVPixelFormatType_2IndexedGray_WhiteIsZero;
+    case ShareableCVPixelFormat::Type_4IndexedGray_WhiteIsZero:
+        return kCVPixelFormatType_4IndexedGray_WhiteIsZero;
+    case ShareableCVPixelFormat::Type_8IndexedGray_WhiteIsZero:
+        return kCVPixelFormatType_8IndexedGray_WhiteIsZero;
+    case ShareableCVPixelFormat::Type_16BE555:
+        return kCVPixelFormatType_16BE555;
+    case ShareableCVPixelFormat::Type_16LE555:
+        return kCVPixelFormatType_16LE555;
+    case ShareableCVPixelFormat::Type_16LE5551:
+        return kCVPixelFormatType_16LE5551;
+    case ShareableCVPixelFormat::Type_16BE565:
+        return kCVPixelFormatType_16BE565;
+    case ShareableCVPixelFormat::Type_16LE565:
+        return kCVPixelFormatType_16LE565;
+    case ShareableCVPixelFormat::Type_24RGB:
+        return kCVPixelFormatType_24RGB;
+    case ShareableCVPixelFormat::Type_24BGR:
+        return kCVPixelFormatType_24BGR;
+    case ShareableCVPixelFormat::Type_32ARGB:
+        return kCVPixelFormatType_32ARGB;
+    case ShareableCVPixelFormat::Type_32BGRA:
+        return kCVPixelFormatType_32BGRA;
+    case ShareableCVPixelFormat::Type_32ABGR:
+        return kCVPixelFormatType_32ABGR;
+    case ShareableCVPixelFormat::Type_32RGBA:
+        return kCVPixelFormatType_32RGBA;
+    case ShareableCVPixelFormat::Type_64ARGB:
+        return kCVPixelFormatType_64ARGB;
+    case ShareableCVPixelFormat::Type_64RGBALE:
+        return kCVPixelFormatType_64RGBALE;
+    case ShareableCVPixelFormat::Type_48RGB:
+        return kCVPixelFormatType_48RGB;
+    case ShareableCVPixelFormat::Type_32AlphaGray:
+        return kCVPixelFormatType_32AlphaGray;
+    case ShareableCVPixelFormat::Type_16Gray:
+        return kCVPixelFormatType_16Gray;
+    case ShareableCVPixelFormat::Type_30RGB:
+        return kCVPixelFormatType_30RGB;
+    case ShareableCVPixelFormat::Type_30RGB_r210:
+        return kCVPixelFormatType_30RGB_r210;
+    case ShareableCVPixelFormat::Type_422YpCbCr8:
+        return kCVPixelFormatType_422YpCbCr8;
+    case ShareableCVPixelFormat::Type_4444YpCbCrA8:
+        return kCVPixelFormatType_4444YpCbCrA8;
+    case ShareableCVPixelFormat::Type_4444YpCbCrA8R:
+        return kCVPixelFormatType_4444YpCbCrA8R;
+    case ShareableCVPixelFormat::Type_4444AYpCbCr8:
+        return kCVPixelFormatType_4444AYpCbCr8;
+    case ShareableCVPixelFormat::Type_4444AYpCbCr16:
+        return kCVPixelFormatType_4444AYpCbCr16;
+    case ShareableCVPixelFormat::Type_4444AYpCbCrFloat:
+        return kCVPixelFormatType_4444AYpCbCrFloat;
+    case ShareableCVPixelFormat::Type_444YpCbCr8:
+        return kCVPixelFormatType_444YpCbCr8;
+    case ShareableCVPixelFormat::Type_422YpCbCr16:
+        return kCVPixelFormatType_422YpCbCr16;
+    case ShareableCVPixelFormat::Type_422YpCbCr10:
+        return kCVPixelFormatType_422YpCbCr10;
+    case ShareableCVPixelFormat::Type_444YpCbCr10:
+        return kCVPixelFormatType_444YpCbCr10;
+    case ShareableCVPixelFormat::Type_420YpCbCr8Planar:
+        return kCVPixelFormatType_420YpCbCr8Planar;
+    case ShareableCVPixelFormat::Type_420YpCbCr8PlanarFullRange:
+        return kCVPixelFormatType_420YpCbCr8PlanarFullRange;
+    case ShareableCVPixelFormat::Type_422YpCbCr_4A_8BiPlanar:
+        return kCVPixelFormatType_422YpCbCr_4A_8BiPlanar;
+    case ShareableCVPixelFormat::Type_420YpCbCr8BiPlanarVideoRange:
+        return kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_420YpCbCr8BiPlanarFullRange:
+        return kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
+    case ShareableCVPixelFormat::Type_422YpCbCr8BiPlanarVideoRange:
+        return kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_422YpCbCr8BiPlanarFullRange:
+        return kCVPixelFormatType_422YpCbCr8BiPlanarFullRange;
+    case ShareableCVPixelFormat::Type_444YpCbCr8BiPlanarVideoRange:
+        return kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_444YpCbCr8BiPlanarFullRange:
+        return kCVPixelFormatType_444YpCbCr8BiPlanarFullRange;
+    case ShareableCVPixelFormat::Type_422YpCbCr8_yuvs:
+        return kCVPixelFormatType_422YpCbCr8_yuvs;
+    case ShareableCVPixelFormat::Type_422YpCbCr8FullRange:
+        return kCVPixelFormatType_422YpCbCr8FullRange;
+    case ShareableCVPixelFormat::Type_OneComponent8:
+        return kCVPixelFormatType_OneComponent8;
+    case ShareableCVPixelFormat::Type_TwoComponent8:
+        return kCVPixelFormatType_TwoComponent8;
+    case ShareableCVPixelFormat::Type_30RGBLEPackedWideGamut:
+        return kCVPixelFormatType_30RGBLEPackedWideGamut;
+    case ShareableCVPixelFormat::Type_ARGB2101010LEPacked:
+        return kCVPixelFormatType_ARGB2101010LEPacked;
+    case ShareableCVPixelFormat::Type_40ARGBLEWideGamut:
+        return kCVPixelFormatType_40ARGBLEWideGamut;
+    case ShareableCVPixelFormat::Type_40ARGBLEWideGamutPremultiplied:
+        return kCVPixelFormatType_40ARGBLEWideGamutPremultiplied;
+    case ShareableCVPixelFormat::Type_OneComponent10:
+        return kCVPixelFormatType_OneComponent10;
+    case ShareableCVPixelFormat::Type_OneComponent12:
+        return kCVPixelFormatType_OneComponent12;
+    case ShareableCVPixelFormat::Type_OneComponent16:
+        return kCVPixelFormatType_OneComponent16;
+    case ShareableCVPixelFormat::Type_TwoComponent16:
+        return kCVPixelFormatType_TwoComponent16;
+    case ShareableCVPixelFormat::Type_OneComponent16Half:
+        return kCVPixelFormatType_OneComponent16Half;
+    case ShareableCVPixelFormat::Type_OneComponent32Float:
+        return kCVPixelFormatType_OneComponent32Float;
+    case ShareableCVPixelFormat::Type_TwoComponent16Half:
+        return kCVPixelFormatType_TwoComponent16Half;
+    case ShareableCVPixelFormat::Type_TwoComponent32Float:
+        return kCVPixelFormatType_TwoComponent32Float;
+    case ShareableCVPixelFormat::Type_64RGBAHalf:
+        return kCVPixelFormatType_64RGBAHalf;
+    case ShareableCVPixelFormat::Type_128RGBAFloat:
+        return kCVPixelFormatType_128RGBAFloat;
+    case ShareableCVPixelFormat::Type_14Bayer_GRBG:
+        return kCVPixelFormatType_14Bayer_GRBG;
+    case ShareableCVPixelFormat::Type_14Bayer_RGGB:
+        return kCVPixelFormatType_14Bayer_RGGB;
+    case ShareableCVPixelFormat::Type_14Bayer_BGGR:
+        return kCVPixelFormatType_14Bayer_BGGR;
+    case ShareableCVPixelFormat::Type_14Bayer_GBRG:
+        return kCVPixelFormatType_14Bayer_GBRG;
+    case ShareableCVPixelFormat::Type_DisparityFloat16:
+        return kCVPixelFormatType_DisparityFloat16;
+    case ShareableCVPixelFormat::Type_DisparityFloat32:
+        return kCVPixelFormatType_DisparityFloat32;
+    case ShareableCVPixelFormat::Type_DepthFloat16:
+        return kCVPixelFormatType_DepthFloat16;
+    case ShareableCVPixelFormat::Type_DepthFloat32:
+        return kCVPixelFormatType_DepthFloat32;
+    case ShareableCVPixelFormat::Type_420YpCbCr10BiPlanarVideoRange:
+        return kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_422YpCbCr10BiPlanarVideoRange:
+        return kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_444YpCbCr10BiPlanarVideoRange:
+        return kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_420YpCbCr10BiPlanarFullRange:
+        return kCVPixelFormatType_420YpCbCr10BiPlanarFullRange;
+    case ShareableCVPixelFormat::Type_422YpCbCr10BiPlanarFullRange:
+        return kCVPixelFormatType_422YpCbCr10BiPlanarFullRange;
+    case ShareableCVPixelFormat::Type_444YpCbCr10BiPlanarFullRange:
+        return kCVPixelFormatType_444YpCbCr10BiPlanarFullRange;
+    case ShareableCVPixelFormat::Type_420YpCbCr8VideoRange_8A_TriPlanar:
+        return kCVPixelFormatType_420YpCbCr8VideoRange_8A_TriPlanar;
+    case ShareableCVPixelFormat::Type_16VersatileBayer:
+        return kCVPixelFormatType_16VersatileBayer;
+    case ShareableCVPixelFormat::Type_96VersatileBayerPacked12:
+        return kCVPixelFormatType_96VersatileBayerPacked12;
+    case ShareableCVPixelFormat::Type_64RGBA_DownscaledProResRAW:
+        return kCVPixelFormatType_64RGBA_DownscaledProResRAW;
+    case ShareableCVPixelFormat::Type_422YpCbCr16BiPlanarVideoRange:
+        return kCVPixelFormatType_422YpCbCr16BiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_444YpCbCr16BiPlanarVideoRange:
+        return kCVPixelFormatType_444YpCbCr16BiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_444YpCbCr16VideoRange_16A_TriPlanar:
+        return kCVPixelFormatType_444YpCbCr16VideoRange_16A_TriPlanar;
+    case ShareableCVPixelFormat::Type_30RGBLE_8A_BiPlanar:
+        return kCVPixelFormatType_30RGBLE_8A_BiPlanar;
+    case ShareableCVPixelFormat::Type_Lossless_32BGRA:
+        return kCVPixelFormatType_Lossless_32BGRA;
+    case ShareableCVPixelFormat::Type_Lossless_64RGBAHalf:
+        return kCVPixelFormatType_Lossless_64RGBAHalf;
+    case ShareableCVPixelFormat::Type_Lossless_420YpCbCr8BiPlanarVideoRange:
+        return kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_Lossless_420YpCbCr8BiPlanarFullRange:
+        return kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange;
+    case ShareableCVPixelFormat::Type_Lossless_420YpCbCr10PackedBiPlanarVideoRange:
+        return kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_Lossless_422YpCbCr10PackedBiPlanarVideoRange:
+        return kCVPixelFormatType_Lossless_422YpCbCr10PackedBiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_Lossless_420YpCbCr10PackedBiPlanarFullRange:
+        return kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarFullRange;
+    case ShareableCVPixelFormat::Type_Lossless_30RGBLE_8A_BiPlanar:
+        return kCVPixelFormatType_Lossless_30RGBLE_8A_BiPlanar;
+    case ShareableCVPixelFormat::Type_Lossless_30RGBLEPackedWideGamut:
+        return kCVPixelFormatType_Lossless_30RGBLEPackedWideGamut;
+    case ShareableCVPixelFormat::Type_Lossy_32BGRA:
+        return kCVPixelFormatType_Lossy_32BGRA;
+    case ShareableCVPixelFormat::Type_Lossy_420YpCbCr8BiPlanarVideoRange:
+        return kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_Lossy_420YpCbCr8BiPlanarFullRange:
+        return kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarFullRange;
+    case ShareableCVPixelFormat::Type_Lossy_420YpCbCr10PackedBiPlanarVideoRange:
+        return kCVPixelFormatType_Lossy_420YpCbCr10PackedBiPlanarVideoRange;
+    case ShareableCVPixelFormat::Type_Lossy_422YpCbCr10PackedBiPlanarVideoRange:
+        return kCVPixelFormatType_Lossy_422YpCbCr10PackedBiPlanarVideoRange;
+    }
+}
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/graphics/cocoa/ShareableCVPixelFormat.h
+++ b/Source/WebCore/platform/graphics/cocoa/ShareableCVPixelFormat.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+namespace WebCore {
+
+enum class ShareableCVPixelFormat : uint8_t {
+    Type_1Monochrome,
+    Type_2Indexed,
+    Type_4Indexed,
+    Type_8Indexed,
+    Type_1IndexedGray_WhiteIsZero,
+    Type_2IndexedGray_WhiteIsZero,
+    Type_4IndexedGray_WhiteIsZero,
+    Type_8IndexedGray_WhiteIsZero,
+    Type_16BE555,
+    Type_16LE555,
+    Type_16LE5551,
+    Type_16BE565,
+    Type_16LE565,
+    Type_24RGB,
+    Type_24BGR,
+    Type_32ARGB,
+    Type_32BGRA,
+    Type_32ABGR,
+    Type_32RGBA,
+    Type_64ARGB,
+    Type_64RGBALE,
+    Type_48RGB,
+    Type_32AlphaGray,
+    Type_16Gray,
+    Type_30RGB,
+    Type_30RGB_r210,
+    Type_422YpCbCr8,
+    Type_4444YpCbCrA8,
+    Type_4444YpCbCrA8R,
+    Type_4444AYpCbCr8,
+    Type_4444AYpCbCr16,
+    Type_4444AYpCbCrFloat,
+    Type_444YpCbCr8,
+    Type_422YpCbCr16,
+    Type_422YpCbCr10,
+    Type_444YpCbCr10,
+    Type_420YpCbCr8Planar,
+    Type_420YpCbCr8PlanarFullRange,
+    Type_422YpCbCr_4A_8BiPlanar,
+    Type_420YpCbCr8BiPlanarVideoRange,
+    Type_420YpCbCr8BiPlanarFullRange,
+    Type_422YpCbCr8BiPlanarVideoRange,
+    Type_422YpCbCr8BiPlanarFullRange,
+    Type_444YpCbCr8BiPlanarVideoRange,
+    Type_444YpCbCr8BiPlanarFullRange,
+    Type_422YpCbCr8_yuvs,
+    Type_422YpCbCr8FullRange,
+    Type_OneComponent8,
+    Type_TwoComponent8,
+    Type_30RGBLEPackedWideGamut,
+    Type_ARGB2101010LEPacked,
+    Type_40ARGBLEWideGamut,
+    Type_40ARGBLEWideGamutPremultiplied,
+    Type_OneComponent10,
+    Type_OneComponent12,
+    Type_OneComponent16,
+    Type_TwoComponent16,
+    Type_OneComponent16Half,
+    Type_OneComponent32Float,
+    Type_TwoComponent16Half,
+    Type_TwoComponent32Float,
+    Type_64RGBAHalf,
+    Type_128RGBAFloat,
+    Type_14Bayer_GRBG,
+    Type_14Bayer_RGGB,
+    Type_14Bayer_BGGR,
+    Type_14Bayer_GBRG,
+    Type_DisparityFloat16,
+    Type_DisparityFloat32,
+    Type_DepthFloat16,
+    Type_DepthFloat32,
+    Type_420YpCbCr10BiPlanarVideoRange,
+    Type_422YpCbCr10BiPlanarVideoRange,
+    Type_444YpCbCr10BiPlanarVideoRange,
+    Type_420YpCbCr10BiPlanarFullRange,
+    Type_422YpCbCr10BiPlanarFullRange,
+    Type_444YpCbCr10BiPlanarFullRange,
+    Type_420YpCbCr8VideoRange_8A_TriPlanar,
+    Type_16VersatileBayer,
+    Type_96VersatileBayerPacked12,
+    Type_64RGBA_DownscaledProResRAW,
+    Type_422YpCbCr16BiPlanarVideoRange,
+    Type_444YpCbCr16BiPlanarVideoRange,
+    Type_444YpCbCr16VideoRange_16A_TriPlanar,
+    Type_30RGBLE_8A_BiPlanar,
+    Type_Lossless_32BGRA,
+    Type_Lossless_64RGBAHalf,
+    Type_Lossless_420YpCbCr8BiPlanarVideoRange,
+    Type_Lossless_420YpCbCr8BiPlanarFullRange,
+    Type_Lossless_420YpCbCr10PackedBiPlanarVideoRange,
+    Type_Lossless_422YpCbCr10PackedBiPlanarVideoRange,
+    Type_Lossless_420YpCbCr10PackedBiPlanarFullRange,
+    Type_Lossless_30RGBLE_8A_BiPlanar,
+    Type_Lossless_30RGBLEPackedWideGamut,
+    Type_Lossy_32BGRA,
+    Type_Lossy_420YpCbCr8BiPlanarVideoRange,
+    Type_Lossy_420YpCbCr8BiPlanarFullRange,
+    Type_Lossy_420YpCbCr10PackedBiPlanarVideoRange,
+    Type_Lossy_422YpCbCr10PackedBiPlanarVideoRange,
+};
+
+ShareableCVPixelFormat fromCVPixelFormat(OSType);
+OSType toCVPixelFormat(ShareableCVPixelFormat);
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -395,6 +395,7 @@
 }
 
 # Shared Memory
+[SafeWrapper] StructureParam WebCore::ShareableCVPixelBufferBytesHandle.m_handle WebCore::SharedMemoryHandle
 [SafeWrapper] StructureParam WebCore::ShareableBitmapHandle.m_handle WebCore::SharedMemoryHandle
 [SafeWrapper] StructureParam IPC::StreamServerConnectionHandle.buffer WebCore::SharedMemoryHandle
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8398,6 +8398,151 @@ header: <WebCore/VideoTrackPrivate.h>
 
 #endif
 
+#if PLATFORM(COCOA)
+
+header: <WebCore/ShareableCVPixelFormat.h>
+enum class WebCore::ShareableCVPixelFormat : uint8_t {
+    Type_1Monochrome,
+    Type_2Indexed,
+    Type_4Indexed,
+    Type_8Indexed,
+    Type_1IndexedGray_WhiteIsZero,
+    Type_2IndexedGray_WhiteIsZero,
+    Type_4IndexedGray_WhiteIsZero,
+    Type_8IndexedGray_WhiteIsZero,
+    Type_16BE555,
+    Type_16LE555,
+    Type_16LE5551,
+    Type_16BE565,
+    Type_16LE565,
+    Type_24RGB,
+    Type_24BGR,
+    Type_32ARGB,
+    Type_32BGRA,
+    Type_32ABGR,
+    Type_32RGBA,
+    Type_64ARGB,
+    Type_64RGBALE,
+    Type_48RGB,
+    Type_32AlphaGray,
+    Type_16Gray,
+    Type_30RGB,
+    Type_30RGB_r210,
+    Type_422YpCbCr8,
+    Type_4444YpCbCrA8,
+    Type_4444YpCbCrA8R,
+    Type_4444AYpCbCr8,
+    Type_4444AYpCbCr16,
+    Type_4444AYpCbCrFloat,
+    Type_444YpCbCr8,
+    Type_422YpCbCr16,
+    Type_422YpCbCr10,
+    Type_444YpCbCr10,
+    Type_420YpCbCr8Planar,
+    Type_420YpCbCr8PlanarFullRange,
+    Type_422YpCbCr_4A_8BiPlanar,
+    Type_420YpCbCr8BiPlanarVideoRange,
+    Type_420YpCbCr8BiPlanarFullRange,
+    Type_422YpCbCr8BiPlanarVideoRange,
+    Type_422YpCbCr8BiPlanarFullRange,
+    Type_444YpCbCr8BiPlanarVideoRange,
+    Type_444YpCbCr8BiPlanarFullRange,
+    Type_422YpCbCr8_yuvs,
+    Type_422YpCbCr8FullRange,
+    Type_OneComponent8,
+    Type_TwoComponent8,
+    Type_30RGBLEPackedWideGamut,
+    Type_ARGB2101010LEPacked,
+    Type_40ARGBLEWideGamut,
+    Type_40ARGBLEWideGamutPremultiplied,
+    Type_OneComponent10,
+    Type_OneComponent12,
+    Type_OneComponent16,
+    Type_TwoComponent16,
+    Type_OneComponent16Half,
+    Type_OneComponent32Float,
+    Type_TwoComponent16Half,
+    Type_TwoComponent32Float,
+    Type_64RGBAHalf,
+    Type_128RGBAFloat,
+    Type_14Bayer_GRBG,
+    Type_14Bayer_RGGB,
+    Type_14Bayer_BGGR,
+    Type_14Bayer_GBRG,
+    Type_DisparityFloat16,
+    Type_DisparityFloat32,
+    Type_DepthFloat16,
+    Type_DepthFloat32,
+    Type_420YpCbCr10BiPlanarVideoRange,
+    Type_422YpCbCr10BiPlanarVideoRange,
+    Type_444YpCbCr10BiPlanarVideoRange,
+    Type_420YpCbCr10BiPlanarFullRange,
+    Type_422YpCbCr10BiPlanarFullRange,
+    Type_444YpCbCr10BiPlanarFullRange,
+    Type_420YpCbCr8VideoRange_8A_TriPlanar,
+    Type_16VersatileBayer,
+    Type_96VersatileBayerPacked12,
+    Type_64RGBA_DownscaledProResRAW,
+    Type_422YpCbCr16BiPlanarVideoRange,
+    Type_444YpCbCr16BiPlanarVideoRange,
+    Type_444YpCbCr16VideoRange_16A_TriPlanar,
+    Type_30RGBLE_8A_BiPlanar,
+    Type_Lossless_32BGRA,
+    Type_Lossless_64RGBAHalf,
+    Type_Lossless_420YpCbCr8BiPlanarVideoRange,
+    Type_Lossless_420YpCbCr8BiPlanarFullRange,
+    Type_Lossless_420YpCbCr10PackedBiPlanarVideoRange,
+    Type_Lossless_422YpCbCr10PackedBiPlanarVideoRange,
+    Type_Lossless_420YpCbCr10PackedBiPlanarFullRange,
+    Type_Lossless_30RGBLE_8A_BiPlanar,
+    Type_Lossless_30RGBLEPackedWideGamut,
+    Type_Lossy_32BGRA,
+    Type_Lossy_420YpCbCr8BiPlanarVideoRange,
+    Type_Lossy_420YpCbCr8BiPlanarFullRange,
+    Type_Lossy_420YpCbCr10PackedBiPlanarVideoRange,
+    Type_Lossy_422YpCbCr10PackedBiPlanarVideoRange
+};
+
+header: <WebCore/ShareableCVPixelBuffer.h>
+[CustomHeader] class WebCore::ShareableCVPixelBufferConfiguration {
+    [Validator='*width > 0'] unsigned width();
+    [Validator='*height > 0'] unsigned height();
+    [Validator='*bytesPerRow > 0'] unsigned bytesPerRow();
+    WebCore::ShareableCVPixelFormat m_pixelFormat;
+}
+
+[CustomHeader] class WebCore::ShareableCVPixelBufferBytesConfiguration {
+    [Validator='*width > 0'] unsigned width();
+    [Validator='*height > 0'] unsigned height();
+    [Validator='*bytesPerRow > 0'] unsigned bytesPerRow();
+}
+
+[CustomHeader, RValue] class WebCore::ShareableCVPixelBufferBytesHandle {
+    WebCore::SharedMemoryHandle m_handle;
+    [Validator='!m_configuration->sizeInBytes().hasOverflowed() && m_handle->size() >= m_configuration->sizeInBytes()'] WebCore::ShareableCVPixelBufferBytesConfiguration m_configuration;
+}
+
+[CustomHeader, RefCounted, CreateUsing=createReadOnly] class WebCore::ShareableCVPixelBufferBytes {
+    std::optional<WebCore::ShareableCVPixelBufferBytesHandle> createReadOnlyHandle()
+}
+
+[CustomHeader, RefCounted] class WebCore::ShareableCVPixelBufferWithBytes {
+    WebCore::ShareableCVPixelBufferConfiguration m_configuration;
+    Ref<WebCore::ShareableCVPixelBufferBytes> m_bytes;
+}
+    
+[CustomHeader, RefCounted] class WebCore::ShareableCVPixelBufferWithPlanarBytes {
+    WebCore::ShareableCVPixelBufferConfiguration m_configuration;
+    Vector<Ref<WebCore::ShareableCVPixelBufferBytes>> m_planes;
+};
+
+[CustomHeader, RefCounted] class WebCore::ShareableCVPixelBuffer subclasses {
+    WebCore::ShareableCVPixelBufferWithBytes
+    WebCore::ShareableCVPixelBufferWithPlanarBytes
+}
+
+#endif
+
 header: <WebCore/ShareableBitmap.h>
 [CustomHeader] class WebCore::ShareableBitmapConfiguration {
     [Validator='m_size->width() > 0 && m_size->height() > 0'] WebCore::IntSize m_size;


### PR DESCRIPTION
#### 95a3f2348f1ec9bad7da70883ac740a2c12c3d15
<pre>
[HDR] Introduce ShareableCVPixelBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=312198">https://bugs.webkit.org/show_bug.cgi?id=312198</a>
<a href="https://rdar.apple.com/174689652">rdar://174689652</a>

Reviewed by Cameron McCormack.

Applying the gain-map in the WebContent process is expensive and blocks the main
thread. But applying the gain-map in the GPU process is fast since it uses the
accelerated backing stores.

CGImageApplyHDRGainMap() requires all its three inputs to be CVPixelBuffers. The
gain-map is retrieved as CVPixelBuffer from CGImageSource. ShareableCVPixelBuffer
will be used to share the gain-map CVPixelBuffer between WebContent process and
GPUProcess.

CVPixelBuffer can contain more than one plane. If it is planar, it will be shared
through ShareableCVPixelBufferWithPlanarBytes otherwise it will be shared through
ShareableCVPixelBufferWithBytes. In both cases, the ShareableCVPixelBuffer will
have one or more of ShareableCVPixelBufferBytes which will have a SharedMemoy in
addition to ShareableCVPixelBufferBytesConfiguration.

ShareableCVPixelBuffer will be created from CVPixelBufferRef in WebContent process.
And it will be created from ShareableCVPixelBufferBytes in GPUProcess.

CVPixelBufferCreate() takes an argument for type OSType as the `pixelFormat`. To
validate ShareableCVPixelBufferConfiguration::m_pixelFormat by the IPC, an new
enum  type will be introduced which defines ShareableCVPixelFormat. Two functions
will be added to convert from ShareableCVPixelFormat to OSType and vice versa.

For now, the GPUProcess will create only metal compatible CVPixelBuffer which gain
map images need. For generic CVPixelBuffer sharing, the creation dictionary needs
to be serialized but this can be addressed in a future patch.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/cocoa/CoreVideoSoftLink.cpp:
* Source/WebCore/platform/cocoa/CoreVideoSoftLink.h:
* Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.cpp: Added.
(WebCore::createScratchCVPixelBuffer):
(WebCore::createScratchMetalCompatibleCVPixelBuffer):
(WebCore::CVPixelBufferDumpToFile):
* Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.h: Added.
* Source/WebCore/platform/graphics/cocoa/ShareableCVPixelBuffer.cpp: Added.
(WebCore::ShareableCVPixelBufferConfiguration::ShareableCVPixelBufferConfiguration):
(WebCore::ShareableCVPixelBufferBytesConfiguration::ShareableCVPixelBufferBytesConfiguration):
(WebCore::ShareableCVPixelBufferBytesHandle::ShareableCVPixelBufferBytesHandle):
(WebCore::ShareableCVPixelBufferBytes::create):
(WebCore::ShareableCVPixelBufferBytes::createReadOnly):
(WebCore::ShareableCVPixelBufferBytes::ShareableCVPixelBufferBytes):
(WebCore::ShareableCVPixelBufferBytes::createReadOnlyHandle const):
(WebCore::ShareableCVPixelBufferBytes::copyPixels):
(WebCore::ShareableCVPixelBuffer::create):
(WebCore::ShareableCVPixelBuffer::ShareableCVPixelBuffer):
(WebCore::ShareableCVPixelBufferWithBytes::create):
(WebCore::ShareableCVPixelBufferWithBytes::ShareableCVPixelBufferWithBytes):
(WebCore::ShareableCVPixelBufferWithBytes::createMetalCompatibleCVPixelBuffer const):
(WebCore::ShareableCVPixelBufferWithPlanarBytes::create):
(WebCore::ShareableCVPixelBufferWithPlanarBytes::ShareableCVPixelBufferWithPlanarBytes):
(WebCore::ShareableCVPixelBufferWithPlanarBytes::createMetalCompatibleCVPixelBuffer const):
* Source/WebCore/platform/graphics/cocoa/ShareableCVPixelBuffer.h: Added.
(WebCore::ShareableCVPixelBufferConfiguration::width const):
(WebCore::ShareableCVPixelBufferConfiguration::height const):
(WebCore::ShareableCVPixelBufferConfiguration::bytesPerRow const):
(WebCore::ShareableCVPixelBufferConfiguration::pixelFormat const):
(WebCore::ShareableCVPixelBufferBytesConfiguration::width const):
(WebCore::ShareableCVPixelBufferBytesConfiguration::height const):
(WebCore::ShareableCVPixelBufferBytesConfiguration::bytesPerRow const):
(WebCore::ShareableCVPixelBufferBytesConfiguration::sizeInBytes const):
(WebCore::ShareableCVPixelBuffer::isPlanar const):
(WebCore::ShareableCVPixelBuffer::configuration const):
(isType):
* Source/WebCore/platform/graphics/cocoa/ShareableCVPixelFormat.cpp: Added.
(WebCore::fromCVPixelFormat):
(WebCore::toCVPixelFormat):
* Source/WebCore/platform/graphics/cocoa/ShareableCVPixelFormat.h: Added.
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/311810@main">https://commits.webkit.org/311810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42323e415a12c38cee8da56ff1787db517a3081d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166922 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31399 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24688 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/103098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/157382 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14661 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169378 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14732 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130577 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31143 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130692 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35395 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31081 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141543 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25426 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18349 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30633 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96166 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30154 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30384 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30281 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->