### PR TITLE
FontFace family attribute should return the serialization of the parsed value

### DIFF
--- a/LayoutTests/fast/text/font-face-empty-string-expected.txt
+++ b/LayoutTests/fast/text/font-face-empty-string-expected.txt
@@ -15,7 +15,6 @@ PASS fontface.unicodeRange = '' threw exception SyntaxError: The string did not 
 PASS fontface = new FontFace('WebFont', 'url(\'asdf\')', {featureSettings: ''}) did not throw exception.
 PASS fontface.featureSettings is "normal"
 PASS fontface.featureSettings = '' threw exception SyntaxError: The string did not match the expected pattern..
-PASS fontface.family = '' threw exception SyntaxError: The string did not match the expected pattern..
 PASS fontface.family = '""' did not throw exception.
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/text/font-face-empty-string.html
+++ b/LayoutTests/fast/text/font-face-empty-string.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -21,9 +21,7 @@ shouldNotThrow("fontface = new FontFace('WebFont', 'url(\\\'asdf\\\')', {feature
 shouldBeEqualToString("fontface.featureSettings", "normal");
 shouldThrow("fontface.featureSettings = ''");
 
-shouldThrow("fontface.family = ''");
 shouldNotThrow("fontface.family = '\"\"'");
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/text/font-face-family-expected.txt
+++ b/LayoutTests/fast/text/font-face-family-expected.txt
@@ -1,13 +1,13 @@
 PASS (new FontFace('a', 'url(garbage.otf)')).family is "a"
-PASS (new FontFace('4a', 'url(garbage.otf)')).family is "4a"
-PASS (new FontFace('4"a', 'url(garbage.otf)')).family is "4\"a"
-PASS (new FontFace('4\'a', 'url(garbage.otf)')).family is "4'a"
-PASS (new FontFace('4\'a"b', 'url(garbage.otf)')).family is "4'a\"b"
+PASS (new FontFace('4a', 'url(garbage.otf)')).family is "\"4a\""
+PASS (new FontFace('4"a', 'url(garbage.otf)')).family is "\"4\\\"a\""
+PASS (new FontFace('4\'a', 'url(garbage.otf)')).family is "\"4'a\""
+PASS (new FontFace('4\'a"b', 'url(garbage.otf)')).family is "\"4'a\\\"b\""
 PASS (new FontFace('ab', 'url(garbage.otf)')).family is "ab"
-PASS (new FontFace('"ab"', 'url(garbage.otf)')).family is "\"ab\""
-PASS (new FontFace('a b', 'url(garbage.otf)')).family is "a b"
-PASS (new FontFace('a b, c', 'url(garbage.otf)')).family is "a b, c"
-PASS (new FontFace('ab,c', 'url(garbage.otf)')).family is "ab,c"
+PASS (new FontFace('"ab"', 'url(garbage.otf)')).family is "\"\\\"ab\\\"\""
+PASS (new FontFace('a b', 'url(garbage.otf)')).family is "\"a b\""
+PASS (new FontFace('a b, c', 'url(garbage.otf)')).family is "\"a b, c\""
+PASS (new FontFace('ab,c', 'url(garbage.otf)')).family is "\"ab,c\""
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/text/font-face-family.html
+++ b/LayoutTests/fast/text/font-face-family.html
@@ -5,17 +5,17 @@
 </head>
 <body>
 <script>
-// The family name passed in to create a FontFace should not be parsed or serialized, but just treated as a family name string.
+// The family attribute should return the serialization of the parsed value.
 shouldBeEqualToString("(new FontFace('a', 'url(garbage.otf)')).family", "a");
-shouldBeEqualToString("(new FontFace('4a', 'url(garbage.otf)')).family", "4a");
-shouldBeEqualToString("(new FontFace('4\"a', 'url(garbage.otf)')).family", "4\"a");
-shouldBeEqualToString("(new FontFace('4\\'a', 'url(garbage.otf)')).family", "4'a");
-shouldBeEqualToString("(new FontFace('4\\'a\"b', 'url(garbage.otf)')).family", "4'a\"b");
+shouldBeEqualToString("(new FontFace('4a', 'url(garbage.otf)')).family", "\"4a\"");
+shouldBeEqualToString("(new FontFace('4\"a', 'url(garbage.otf)')).family", "\"4\\\"a\"");
+shouldBeEqualToString("(new FontFace('4\\'a', 'url(garbage.otf)')).family", "\"4'a\"");
+shouldBeEqualToString("(new FontFace('4\\'a\"b', 'url(garbage.otf)')).family", "\"4'a\\\"b\"");
 shouldBeEqualToString("(new FontFace('ab', 'url(garbage.otf)')).family", "ab");
-shouldBeEqualToString("(new FontFace('\"ab\"', 'url(garbage.otf)')).family", "\"ab\"");
-shouldBeEqualToString("(new FontFace('a b', 'url(garbage.otf)')).family", "a b");
-shouldBeEqualToString("(new FontFace('a b, c', 'url(garbage.otf)')).family", "a b, c");
-shouldBeEqualToString("(new FontFace('ab,c', 'url(garbage.otf)')).family", "ab,c");
+shouldBeEqualToString("(new FontFace('\"ab\"', 'url(garbage.otf)')).family", "\"\\\"ab\\\"\"");
+shouldBeEqualToString("(new FontFace('a b', 'url(garbage.otf)')).family", "\"a b\"");
+shouldBeEqualToString("(new FontFace('a b, c', 'url(garbage.otf)')).family", "\"a b, c\"");
+shouldBeEqualToString("(new FontFace('ab,c', 'url(garbage.otf)')).family", "\"ab,c\"");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-family.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-family.tentative-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL family: content:Segoe UI assert_equals: FontFace.family should be the quoted string after construction with invalid family name content:Segoe UI expected "\"content:Segoe UI\"" but got "content:Segoe UI"
-FAIL family: sans-serif assert_equals: FontFace.family should be the quoted string after construction with invalid family name sans-serif expected "\"sans-serif\"" but got "sans-serif"
-FAIL family: A, B assert_equals: FontFace.family should be the quoted string after construction with invalid family name A, B expected "\"A, B\"" but got "A, B"
-FAIL family: inherit assert_equals: FontFace.family should be the quoted string after construction with invalid family name inherit expected "\"inherit\"" but got "inherit"
-FAIL family: a 1 assert_equals: FontFace.family should be the quoted string after construction with invalid family name a 1 expected "\"a 1\"" but got "a 1"
-FAIL family:  assert_not_equals: FontFace should be quoted after construction with invalid family name  got disallowed value "error"
+PASS family: content:Segoe UI
+PASS family: sans-serif
+PASS family: A, B
+PASS family: inherit
+PASS family: a 1
+PASS family:
 

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -32,6 +32,7 @@
 #include "CSSFontFeatureValue.h"
 #include "CSSFontSelector.h"
 #include "CSSFontStyleRangeValue.h"
+#include "CSSMarkup.h"
 #include "CSSPrimitiveValueMappings.h"
 #include "CSSUnicodeRangeValue.h"
 #include "CSSValue.h"
@@ -369,7 +370,7 @@ AtomString CSSFontFace::family() const
     RefPtr value = dynamicDowncast<CSSFontFamilyNameValue>(properties().getPropertyCSSValue(CSSPropertyFontFamily));
     if (!value)
         return { };
-    return value->fontFamilyName().value;
+    return AtomString(serializeFontFamily(value->fontFamilyName().value));
 }
 
 String CSSFontFace::style() const

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -185,8 +185,6 @@ FontFace::~FontFace()
 
 ExceptionOr<void> FontFace::setFamily(ScriptExecutionContext& context, const AtomString& family)
 {
-    if (family.isEmpty())
-        return Exception { ExceptionCode::SyntaxError };
     m_backing->setFamily(context.cssValuePool().createFontFamilyNameValue(family));
     return { };
 }


### PR DESCRIPTION
#### 1f08e982988ac8f614a8dfe55c41050797e2986c
<pre>
FontFace family attribute should return the serialization of the parsed value
<a href="https://bugs.webkit.org/show_bug.cgi?id=312209">https://bugs.webkit.org/show_bug.cgi?id=312209</a>
<a href="https://rdar.apple.com/174698351">rdar://174698351</a>

Reviewed by Vitor Roriz.

This patch aligns WebKit with Gecko / Firefox and Blink / Gecko.

The CSS Font Loading spec requires that FontFace attributes be set to
&quot;the serialization of the parsed values.&quot;

The constructor spec [1] states:

&quot;Parse the family argument, and the members of the descriptors argument,
 according to the grammars of the corresponding descriptors of the CSS
 @font-face rule. [...] set font face&apos;s corresponding attributes to the
 serialization of the parsed values.&quot;

And the attribute setter spec [2] states:

&quot;On setting, parse the string according to the grammar for the
 corresponding @font-face descriptor. If it does not match the grammar,
 throw a SyntaxError; otherwise, set the attribute to the serialization
 of the parsed value.&quot;

The CSSWG resolved [3] that if a FontFace is constructed with an invalid
font-family name, it should be treated as a quoted string rather than
throwing.

Currently, CSSFontFace::family() returns the raw string via stringValue()
instead of the properly serialized form. This means values like
&quot;sans-serif&quot; or &quot;inherit&quot; are returned as-is rather than being quoted per
CSS serialization rules.

Use serializeFontFamily() (which already exists in CSSMarkup.h and is used
by CSSPrimitiveValue::customCSSText()) in CSSFontFace::family() to produce
the correct serialized output. Also remove the empty-string rejection in
FontFace::setFamily().

[1] <a href="https://drafts.csswg.org/css-font-loading/#font-face-constructor">https://drafts.csswg.org/css-font-loading/#font-face-constructor</a>
[2] <a href="https://drafts.csswg.org/css-font-loading/#fontface-interface">https://drafts.csswg.org/css-font-loading/#fontface-interface</a>
[3] <a href="https://github.com/w3c/csswg-drafts/issues/6236">https://github.com/w3c/csswg-drafts/issues/6236</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/fontface-invalid-family.tentative-expected.txt: Progressions
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::family const):
* Source/WebCore/css/FontFace.cpp:
(WebCore::FontFace::setFamily):

* LayoutTests/fast/text/font-face-empty-string.html: Removed subtest (covered by WPT)
* LayoutTests/fast/text/font-face-empty-string-expected.txt: Updated Expectation.
* LayoutTests/fast/text/font-face-family.html: Updated based on new behavior (matching other browsers)
* LayoutTests/fast/text/font-face-family-expected.txt: Updated Expectation.

Canonical link: <a href="https://commits.webkit.org/311478@main">https://commits.webkit.org/311478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/420186f86f2bee28dd39e23a61e28f005a93df7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111075 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121581 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85369 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102249 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22874 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21106 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13588 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168301 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12460 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129708 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129816 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35190 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87658 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24638 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17404 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29565 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93579 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29087 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29317 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29213 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->