### PR TITLE
REGRESSION(308505@main) - Crash in WebCore::IOSurface::createPlatformContext

### DIFF
--- a/Source/WebCore/platform/graphics/ImageUtilities.cpp
+++ b/Source/WebCore/platform/graphics/ImageUtilities.cpp
@@ -69,7 +69,9 @@ Vector<uint8_t> encodeData(const RefPtr<NativeImage>& image, const String& mimeT
 
 Vector<uint8_t> encodeData(RefPtr<ImageBuffer>&& buffer, const String& mimeType, std::optional<double> quality)
 {
-    return encodeData(ImageBuffer::sinkIntoNativeImage(WTF::move(buffer)), mimeType, quality);
+    if (!buffer)
+        return { };
+    return encodeData(buffer->copyNativeImage(), mimeType, quality);
 }
 
 String encodeDataURL(const NativeImage& image, const String& mimeType, std::optional<double> quality)
@@ -91,7 +93,7 @@ String encodeDataURL(RefPtr<ImageBuffer>&& buffer, const String& mimeType, std::
 {
     if (!buffer)
         return "data:,"_s;
-    return encodeDataURL(ImageBuffer::sinkIntoNativeImage(WTF::move(buffer)), mimeType, quality);
+    return encodeDataURL(buffer->copyNativeImage(), mimeType, quality);
 }
 
 }


### PR DESCRIPTION
#### 89356ad2cb98c18ac4aa75db9d457cee5b3fe990
<pre>
REGRESSION(308505@main) - Crash in WebCore::IOSurface::createPlatformContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=312211">https://bugs.webkit.org/show_bug.cgi?id=312211</a>
<a href="https://rdar.apple.com/173305815">rdar://173305815</a>

Reviewed by Simon Fraser.

HTMLCanvasElement::toBlob calls encodeData(makeRenderingResultsAvailable()…
which passes a RefPtr&lt;ImageBuffer&gt;&amp;&amp;.

encodeData then calls ImageBuffer::sinkIntoNativeImage which consumes the
ImageBuffer, and takes m_surface out of the backend.

Later on we try to flush the ImageBuffer, and crash because it’s in an invalid
state.

sinkIntoNativeImage should only be used if the moved RefPtr is the only ref to
the buffer.

* Source/WebCore/platform/graphics/ImageUtilities.cpp:
(WebCore::encodeData):
(WebCore::encodeDataURL):

Canonical link: <a href="https://commits.webkit.org/311322@main">https://commits.webkit.org/311322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67570638ee05a503b0f6ae307ad0942d775a6101

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110506 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121147 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85161 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101816 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22433 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 new passes 2 flakes 13 failures; Uploaded test results; 4 new passes 1 flakes 14 failures; Compiled WebKit (warnings); layout-tests (cancelled)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20607 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13019 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167729 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11842 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129271 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129382 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35090 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87080 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24209 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16901 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28994 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92950 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28520 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28644 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->