### PR TITLE
Revert back from CGContextGetColorSpace to CGContextCopyDeviceColorSpace

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebCore/Configurations/AllowedSPI-legacy.toml
@@ -540,6 +540,7 @@ symbols = [
     "CGColorSpaceEqualToColorSpace",
     "CGColorTransformConvertColorComponents",
     "CGColorTransformCreate",
+    "CGContextCopyDeviceColorSpace",
     "CGContextCreateWithDelegate",
     "CGContextDelegateCreate",
     "CGContextDelegateGetInfo",

--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -76,13 +76,6 @@ symbols = [
 requires-sdk = ["iOS <= 26.*"]
 
 [[temporary-usage]]
-request = "rdar://168834967"
-cleanup = "rdar://168834815"
-symbols = [
-    "CGContextGetColorSpace",
-]
-
-[[temporary-usage]]
 request = "rdar://161402565"
 cleanup = "rdar://161402756"
 symbols = [

--- a/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
@@ -81,12 +81,12 @@ typedef struct CGFontHMetrics CGFontHMetrics;
 
 typedef CF_ENUM (int32_t, CGContextDelegateCallbackName)
 {
+    deGetColorTransform = 1,
     deDrawPath = 6,
     deDrawImage = 7,
     deDrawGlyphs = 8,
     deBeginLayer = 17,
     deEndLayer = 18,
-    deGetColorSpace = 30,
 };
 
 typedef const struct CGColorTransform* CGColorTransformRef;
@@ -401,7 +401,7 @@ typedef bool (^CGPDFAnnotationDrawCallbackType)(CGContextRef context, CGPDFPageR
 void CGContextDrawPDFPageWithAnnotations(CGContextRef, CGPDFPageRef, CGPDFAnnotationDrawCallbackType);
 void CGContextDrawPathDirect(CGContextRef, CGPathDrawingMode, CGPathRef, const CGRect* boundingBox);
 
-CGColorSpaceRef CGContextGetColorSpace(CGContextRef);
+CGColorSpaceRef CGContextCopyDeviceColorSpace(CGContextRef);
 CGError CGSNewRegionWithRect(const CGRect*, CGRegionRef*);
 CGError CGSPackagesEnableConnectionOcclusionNotifications(CGSConnectionID, bool flag, bool* outCurrentVisibilityState);
 CGError CGSPackagesEnableConnectionWindowModificationNotifications(CGSConnectionID, bool flag, bool* outConnectionIsCurrentlyIdle);

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -257,7 +257,7 @@ const DestinationColorSpace& GraphicsContextCG::colorSpace() const
     else if (contextType == kCGContextTypeBitmap)
         colorSpace = CGBitmapContextGetColorSpace(context);
     else
-        colorSpace = CGContextGetColorSpace(context);
+        colorSpace = CGContextCopyDeviceColorSpace(context);
 
     // FIXME: Need to ASSERT(colorSpace). For now fall back to sRGB if colorSpace is nil.
     m_colorSpace = colorSpace ? DestinationColorSpace(colorSpace) : DestinationColorSpace::SRGB();

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp
@@ -80,7 +80,7 @@ static CGError drawPath(CGContextDelegateRef delegate, CGRenderingStateRef rstat
     return kCGErrorSuccess;
 }
 
-static CGColorSpaceRef getColorSpace(CGContextDelegateRef delegate, CGRenderingStateRef, CGGStateRef)
+static CGColorSpaceRef getColorTransform(CGContextDelegateRef delegate, CGRenderingStateRef, CGGStateRef)
 {
     DrawGlyphsRecorder& recorder = *static_cast<DrawGlyphsRecorder*>(CGContextDelegateGetInfo(delegate));
     return recorder.colorSpace();
@@ -94,7 +94,7 @@ UniqueRef<GraphicsContext> DrawGlyphsRecorder::createInternalContext()
     CGContextDelegateSetCallback(contextDelegate.get(), deDrawGlyphs, reinterpret_cast<CGContextDelegateCallback>(&WebCore::drawGlyphs));
     CGContextDelegateSetCallback(contextDelegate.get(), deDrawImage, reinterpret_cast<CGContextDelegateCallback>(&drawImage));
     CGContextDelegateSetCallback(contextDelegate.get(), deDrawPath, reinterpret_cast<CGContextDelegateCallback>(&drawPath));
-    CGContextDelegateSetCallback(contextDelegate.get(), deGetColorSpace, reinterpret_cast<CGContextDelegateCallback>(&getColorSpace));
+    CGContextDelegateSetCallback(contextDelegate.get(), deGetColorTransform, reinterpret_cast<CGContextDelegateCallback>(&getColorTransform));
 
     auto contextType = kCGContextTypeUnknown;
     auto context = adoptCF(CGContextCreateWithDelegate(contextDelegate.get(), contextType, nullptr, nullptr));


### PR DESCRIPTION
#### a41179116ecfb226bc46e0d591afebbab852dc32
<pre>
Revert back from CGContextGetColorSpace to CGContextCopyDeviceColorSpace
<a href="https://bugs.webkit.org/show_bug.cgi?id=312217">https://bugs.webkit.org/show_bug.cgi?id=312217</a>
<a href="https://rdar.apple.com/169022562">rdar://169022562</a>

Reviewed by NOBODY (OOPS!).

In <a href="https://commits.webkit.org/306261@main">306261@main</a> I started using CGContextGetColorSpace() SPI, because
DrawGlyphsRecorder needed to be able to control the CGContext&apos;s colorspace.
`CGContextGetColorSpace` seemed like the natural fit, but it&apos;s fairly
recent SPI. It turns out that `CGContextCopyDeviceColorSpace` works fine,
and you can override in a custom context via `deGetColorTransform`,
so revert back to using that.

* Source/WebCore/Configurations/AllowedSPI-legacy.toml:
* Source/WebCore/Configurations/AllowedSPI.toml:
* Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::colorSpace const):
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp:
(WebCore::getColorTransform):
(WebCore::DrawGlyphsRecorder::createInternalContext):
(WebCore::getColorSpace): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a41179116ecfb226bc46e0d591afebbab852dc32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110286 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120955 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101628 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22247 "Found 1 new test failure: imported/w3c/web-platform-tests/html/canvas/element/wide-gamut-canvas/2d.color.space.p3.fillText.shadow.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20405 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12801 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131909 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167508 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11624 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19718 "Found 1 new test failure: imported/w3c/web-platform-tests/html/canvas/element/wide-gamut-canvas/2d.color.space.p3.fillText.shadow.html (failure)") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29144 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24468 "Found 1 new test failure: imported/w3c/web-platform-tests/html/canvas/element/wide-gamut-canvas/2d.color.space.p3.fillText.shadow.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129191 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86833 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24021 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16698 "Found 1 new test failure: imported/w3c/web-platform-tests/html/canvas/element/wide-gamut-canvas/2d.color.space.p3.fillText.shadow.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28775 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92732 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28302 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28530 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28426 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->