### PR TITLE
[libpas] Rebaseline ThingyHeapAllocationTests.cpp

### DIFF
--- a/Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp
@@ -3026,7 +3026,7 @@ void addLargeHeapTests()
 }
 
 #if SEGHEAP
-void addMediumHeapTests()
+void addMediumSegregatedHeapTests()
 {
     DisableBitfit disableBitfit;
     
@@ -3050,15 +3050,15 @@ void addMediumHeapTests()
                  SIZE_CLASS_PROGRAM(
                      PrimitiveAllocator(2048), 2048, pas_medium_segregated_object_kind, 10, 2),
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(2072), 2296, pas_small_segregated_object_kind, 10, 3),
+                     PrimitiveAllocator(2072), 2560, pas_medium_segregated_object_kind, 10, 2),
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(1600), 1608, pas_small_segregated_object_kind, 10, 2),
+                     PrimitiveAllocator(1600), 2048, pas_medium_segregated_object_kind, 10, 1),
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(1617), 2048, pas_medium_segregated_object_kind, 10, 1),
+                     PrimitiveAllocator(1617), 2048, pas_medium_segregated_object_kind, 10, 0),
                  SIZE_CLASS_PROGRAM(
                      AlignedPrimitiveAllocator(2048, 2048), 2048, pas_medium_segregated_object_kind, 10, 0),
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(2072), 2296, pas_small_segregated_object_kind, 10, 1),
+                     PrimitiveAllocator(2072), 2560, pas_medium_segregated_object_kind, 10, 0),
                  SIZE_CLASS_PROGRAM(
                      PrimitiveAllocator(1617), 2048, pas_medium_segregated_object_kind, 10, 0)));
     ADD_TEST(testSizeClassCreation(
@@ -3078,41 +3078,55 @@ void addMediumHeapTests()
                      PrimitiveAllocator(4096), 4096, pas_medium_segregated_object_kind, 5, 0)));
     ADD_TEST(testSizeClassCreation(
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(16384), 16384, pas_medium_segregated_object_kind, 4, 2),
+                     PrimitiveAllocator(8192), 8192, pas_medium_segregated_object_kind, 4, 2),
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(16000), 16384, pas_medium_segregated_object_kind, 3, 1)));
+                     PrimitiveAllocator(10100), 10752, pas_medium_segregated_object_kind, 3, 2)));
     ADD_TEST(testSizeClassCreation(
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(16384), 16384, pas_medium_segregated_object_kind, 4, 2),
+                     PrimitiveAllocator(10240), 10752, pas_medium_segregated_object_kind, 4, 2),
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(18712), 21504, pas_medium_segregated_object_kind, 3, 2)));
+                     PrimitiveAllocator(11730), 11776, pas_medium_segregated_object_kind, 3, 2)));
+}
+
+void addMediumBitfitHeapTests()
+{
     ADD_TEST(testSizeClassCreation(
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(16384), 16384, pas_medium_segregated_object_kind, 3, 2),
+                     PrimitiveAllocator(16384), 16384, pas_medium_bitfit_object_kind, 4, 1),
                  SIZE_CLASS_PROGRAM(
-                     AlignedPrimitiveAllocator(16384, 16384), 16384, pas_medium_segregated_object_kind, 3, 0),
-                 SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(18712), 21504, pas_medium_segregated_object_kind, 3, 2),
-                 SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(16384), 16384, pas_medium_segregated_object_kind, 3, 1)));
+                     PrimitiveAllocator(16000), 16384, pas_medium_bitfit_object_kind, 3, 1)));
     ADD_TEST(testSizeClassCreation(
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(16896), 18432, pas_medium_segregated_object_kind, 3, 2),
+                     PrimitiveAllocator(16384), 16384, pas_medium_bitfit_object_kind, 4, 1),
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(16384), 18432, pas_medium_segregated_object_kind, 3, 1),
-                 SIZE_CLASS_PROGRAM(
-                     AlignedPrimitiveAllocator(16384, 16384), 16384, pas_medium_segregated_object_kind, 4, 2),
-                 SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(16896), 18432, pas_medium_segregated_object_kind, 3, 1),
-                 SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(16384), 16384, pas_medium_segregated_object_kind, 3, 0)));
+                     PrimitiveAllocator(18712), 18944, pas_medium_bitfit_object_kind, 3, 1)));
     ADD_TEST(testSizeClassCreation(
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(16384), 16384, pas_medium_segregated_object_kind, 3, 2),
+                     PrimitiveAllocator(16384), 16384, pas_medium_bitfit_object_kind, 3, 1),
                  SIZE_CLASS_PROGRAM(
-                     AlignedPrimitiveAllocator(16384, 16384), 16384, pas_medium_segregated_object_kind, 1, 0),
+                     AlignedPrimitiveAllocator(16384, 16384), 16384, pas_medium_bitfit_object_kind, 3, 0),
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(16000), 16384, pas_medium_segregated_object_kind, 3, 1)));
+                     PrimitiveAllocator(18712), 18944, pas_medium_bitfit_object_kind, 3, 1),
+                 SIZE_CLASS_PROGRAM(
+                     PrimitiveAllocator(16384), 16384, pas_medium_bitfit_object_kind, 3, 0)));
+    ADD_TEST(testSizeClassCreation(
+                 SIZE_CLASS_PROGRAM(
+                     PrimitiveAllocator(16880), 16896, pas_medium_bitfit_object_kind, 3, 1),
+                 SIZE_CLASS_PROGRAM(
+                     PrimitiveAllocator(16384), 16384, pas_medium_bitfit_object_kind, 3, 1),
+                 SIZE_CLASS_PROGRAM(
+                     AlignedPrimitiveAllocator(16384, 16384), 16384, pas_medium_bitfit_object_kind, 4, 0),
+                 SIZE_CLASS_PROGRAM(
+                     PrimitiveAllocator(16896), 16896, pas_medium_bitfit_object_kind, 3, 0),
+                 SIZE_CLASS_PROGRAM(
+                     PrimitiveAllocator(16384), 16384, pas_medium_bitfit_object_kind, 3, 0)));
+    ADD_TEST(testSizeClassCreation(
+                 SIZE_CLASS_PROGRAM(
+                     PrimitiveAllocator(16384), 16384, pas_medium_bitfit_object_kind, 3, 1),
+                 SIZE_CLASS_PROGRAM(
+                     AlignedPrimitiveAllocator(16384, 16384), 16384, pas_medium_bitfit_object_kind, 1, 0),
+                 SIZE_CLASS_PROGRAM(
+                     PrimitiveAllocator(16000), 16384, pas_medium_bitfit_object_kind, 3, 1)));
 }
 
 void addLargerThanMediumHeapTests()
@@ -3130,11 +3144,17 @@ void addMargeBitfitTests()
 {
     ADD_TEST(testSizeClassCreation(
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(20000), 21504, pas_medium_segregated_object_kind, 5, 2),
+                     PrimitiveAllocator(8000), 8192, pas_medium_segregated_object_kind, 5, 2),
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(30000), 32768, pas_marge_bitfit_object_kind, 5, 1),
+                     PrimitiveAllocator(16384), 16384, pas_medium_bitfit_object_kind, 5, 1),
                  SIZE_CLASS_PROGRAM(
-                     PrimitiveAllocator(29000), 32768, pas_marge_bitfit_object_kind, 5, 1)));
+                     PrimitiveAllocator(20000), 20480, pas_medium_bitfit_object_kind, 5, 1),
+                 SIZE_CLASS_PROGRAM(
+                     PrimitiveAllocator(30000), 30208, pas_medium_bitfit_object_kind, 5, 1),
+                 SIZE_CLASS_PROGRAM(
+                     PrimitiveAllocator(29000), 29184, pas_medium_bitfit_object_kind, 5, 1),
+                 SIZE_CLASS_PROGRAM(
+                     PrimitiveAllocator(32770), 36864, pas_marge_bitfit_object_kind, 5, 1)));
     ADD_TEST(testSizeClassCreation(
                  SIZE_CLASS_PROGRAM(
                      PrimitiveAllocator(300000), 303104, pas_marge_bitfit_object_kind, 5, 1),
@@ -3192,7 +3212,8 @@ void addAllTestsImpl()
     if (hasScope("only-small"))
         addLargeHeapTests();
     else {
-        addMediumHeapTests();
+        addMediumSegregatedHeapTests();
+        addMediumBitfitHeapTests();
         addMargeBitfitTests();
         addLargerThanMediumHeapTests();
         addLargerThanMargeBitfitTests();


### PR DESCRIPTION
#### 1e97ddecd4e68772a006181e39d2017e8c07260e
<pre>
[libpas] Rebaseline ThingyHeapAllocationTests.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=311674">https://bugs.webkit.org/show_bug.cgi?id=311674</a>
<a href="https://rdar.apple.com/174265947">rdar://174265947</a>

Reviewed by Dan Hecht.

Recent changes to libpas (307140@main, 294862@main) changed
PAS_MIN_OBJECTS_PER_PAGE from 6 to 10, then 11, as well as changing the
page-size of medium-bitfit pages from 128k to 512k.
This patch rebaselines libpas tests to accomodate that.

Canonical link: <a href="https://commits.webkit.org/311156@main">https://commits.webkit.org/311156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01ef6befa150441d5231632cc2a00043bc48e1e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165027 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29544 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159164 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101626 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12799 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148256 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167506 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17040 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19719 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29142 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129190 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34991 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139900 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24010 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188089 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28773 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48355 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28300 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28528 "Failed to checkout and rebase branch from PR 62691") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28424 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->