### PR TITLE
StabilityTracer: Crash in NetworkProcess::findPendingDownloadLocation

### DIFF
--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
@@ -262,6 +262,9 @@ bool ServiceWorkerNavigationPreloader::convertToDownload(DownloadManager& manage
     if (!m_networkLoad)
         return false;
 
+    if (!m_responseCompletionHandler)
+        return false;
+
     auto networkLoad = std::exchange(m_networkLoad, nullptr);
     manager.convertNetworkLoadToDownload(downloadID, networkLoad.releaseNonNull(), WTF::move(m_responseCompletionHandler), { }, request, response);
     return true;


### PR DESCRIPTION
#### 4e1728b582499cb80f19ebb24b05a77119060a6e
<pre>
StabilityTracer: Crash in NetworkProcess::findPendingDownloadLocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=312219">https://bugs.webkit.org/show_bug.cgi?id=312219</a>
<a href="https://rdar.apple.com/174045941">rdar://174045941</a>

Reviewed by Chris Dumez.

NetworkProcess::findPendingDownloadLocation passes a lambda to
DownloadProxy::DecideDestinationWithSuggestedFilename which contians a
completionHandler. When this completionHandler is called, we crash because the
underlying function is null. It&apos;s possible that when the completionHandler
was passed in to NetworkProcess::findPendingDownloadLocation(), it was already
null.

One of the ways this completionHandler ends up here is:

1. DownloadManager::convertNetworkLoadToDownload()
2. PendingDownload::PendingDownload()
3. NetworkLoad::convertTaskToDownload()
4. NetworkProcess::findPendingDownloadLocation()

There are three callsites to convertNetworkLoadToDownload() that pass in a
completionHandler. One of them constructs the completionHandler right before
passing it in. The other null checks the completionHandler before passing it
in. The third callsite, ServiceWorkerNavigationPreloader::convertToDownload(),
does neither.

So, as a speculative fix, we amend the this third callsite to null check its
completionHandler before passing it to convertNetworkLoadToDownload().

* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp:
(WebKit::ServiceWorkerNavigationPreloader::convertToDownload):

Canonical link: <a href="https://commits.webkit.org/311165@main">https://commits.webkit.org/311165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49b02199999b3c4357efe90c35094b1570395f74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165030 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120958 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101631 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12802 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167509 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11625 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129075 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29145 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129194 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35000 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139890 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86834 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24013 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16689 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92733 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28303 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28531 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28427 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->