### PR TITLE
[JSC] Cache `JSString` cells for short `JSON.parse` string values

### DIFF
--- a/JSTests/microbenchmarks/json-parse-repeated-short-strings.js
+++ b/JSTests/microbenchmarks/json-parse-repeated-short-strings.js
@@ -1,0 +1,6 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
+const json = '{"widgets":[{"id":"btn-1","kind":"button","size":"md","theme":"dark","events":["click","focus","blur"],"states":["idle","hover","active"]},{"id":"btn-2","kind":"button","size":"sm","theme":"light","events":["click","focus"],"states":["idle","hover","active","disabled"]},{"id":"inp-1","kind":"input","size":"md","theme":"dark","events":["input","change","focus","blur"],"states":["idle","focus","error"]},{"id":"sel-1","kind":"select","size":"lg","theme":"dark","events":["change","focus","blur"],"states":["idle","open","disabled"]},{"id":"mod-1","kind":"modal","size":"lg","theme":"light","events":["open","close"],"states":["hidden","shown"]},{"id":"tab-1","kind":"tabs","size":"md","theme":"dark","events":["change","click"],"states":["idle","active"]},{"id":"chk-1","kind":"checkbox","size":"sm","theme":"light","events":["change","click","focus"],"states":["off","on","mixed"]}],"themes":["dark","light","auto"],"sizes":["sm","md","lg"],"version":"2.1"}';
+
+for (let i = 0; i < 1e4; ++i)
+    JSON.parse(json);

--- a/JSTests/stress/json-parse-jsstring-cache-coherence.js
+++ b/JSTests/stress/json-parse-jsstring-cache-coherence.js
@@ -1,0 +1,119 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error("FAIL " + msg + ": got " + JSON.stringify(actual) + ", expected " + JSON.stringify(expected));
+}
+
+// JSONAtomStringCache hashes by (firstChar, lastChar, length), so strings that
+// differ only in the middle collide on the same slot. makeIdentifier (keys) and
+// makeJSString (values) share m_cache; makeIdentifier must invalidate the
+// parallel m_jsStrings entry on eviction so makeJSString never returns a stale
+// JSString cell.
+
+// 1. value -> colliding key -> value (the original repro)
+{
+    let r = JSON.parse('["axb",{"ayb":1},"ayb"]');
+    shouldBe(r[2], "ayb", "value/key/value collision (axb/ayb)");
+    let r2 = JSON.parse('["foo_x_bar",{"foo_y_bar":1},"foo_y_bar"]');
+    shouldBe(r2[2], "foo_y_bar", "value/key/value collision (foo_?_bar)");
+}
+
+// 2. key -> value -> key -> value (reverse order)
+{
+    let r = JSON.parse('{"aXb":["aYb",{"aZb":2},"aZb","aYb"]}');
+    shouldBe(r.aXb[2], "aZb", "key/value/key/value (aZb)");
+    shouldBe(r.aXb[3], "aYb", "key/value/key/value (aYb)");
+}
+
+// 3. value <-> value collision without an intervening key
+{
+    let r = JSON.parse('["aaaa","abba","aaaa","abba"]');
+    shouldBe(r[0], "aaaa", "value/value thrash 0");
+    shouldBe(r[1], "abba", "value/value thrash 1");
+    shouldBe(r[2], "aaaa", "value/value thrash 2");
+    shouldBe(r[3], "abba", "value/value thrash 3");
+}
+
+// 4. 50x alternating thrash on one slot (key and value interleaved)
+{
+    let parts = [];
+    for (let i = 0; i < 50; ++i)
+        parts.push(i & 1 ? '{"aQb":0}' : '"aPb"');
+    let r = JSON.parse('[' + parts.join(',') + ']');
+    for (let i = 0; i < 50; ++i) {
+        if (i & 1)
+            shouldBe(r[i].aQb, 0, "thrash key " + i);
+        else
+            shouldBe(r[i], "aPb", "thrash value " + i);
+    }
+}
+
+// 5. length boundaries (cache active for len 2-10 only)
+{
+    for (let len of [0, 1, 2, 9, 10, 11, 27, 28]) {
+        let s = "v".repeat(len);
+        let r = JSON.parse('["' + s + '","' + s + '"]');
+        shouldBe(r[0], s, "len=" + len + " content");
+        shouldBe(r[0].length, len, "len=" + len + " length");
+        shouldBe(r[1], s, "len=" + len + " repeat");
+    }
+}
+
+// 6. 16-bit value with middle-differs collision
+{
+    let r = JSON.parse('["a\u3042b",{"a\u3044b":1},"a\u3044b"]');
+    shouldBe(r[2], "a\u3044b", "16-bit collision");
+    shouldBe(r[0], "a\u3042b", "16-bit original");
+}
+
+// 7. value identical to a key in the same object
+{
+    let r = JSON.parse('{"hello":"hello","world":"hello"}');
+    shouldBe(r.hello, "hello", "key==value same");
+    shouldBe(r.world, "hello", "key==value cross");
+}
+
+// 8. across GC (cache is cleared on every collection)
+{
+    let r1 = JSON.parse('["click","focus","click"]');
+    fullGC();
+    let r2 = JSON.parse('["click","focus","click"]');
+    shouldBe(r1[0], "click", "pre-GC");
+    shouldBe(r2[0], "click", "post-GC content");
+    shouldBe(r2[2], "click", "post-GC repeat");
+    edenGC();
+    let r3 = JSON.parse('["axb",{"ayb":1},"ayb"]');
+    shouldBe(r3[2], "ayb", "post-edenGC collision");
+}
+
+// 9. eval('(...)') SloppyJSON path goes through the same makeJSString
+{
+    let r = eval('(["axb",{"ayb":1},"ayb"])');
+    shouldBe(r[2], "ayb", "eval SloppyJSON collision");
+    let r2 = eval('({"k":["idle","hover","idle"]})');
+    shouldBe(r2.k[2], "idle", "eval repeat value");
+}
+
+// 10. reviver path (non-recursive parse) also uses makeJSString
+{
+    let r = JSON.parse('["axb",{"ayb":1},"ayb"]', (k, v) => v);
+    shouldBe(r[2], "ayb", "reviver collision");
+}
+
+// 11. many distinct (first,last,len) keys evicting cached values
+{
+    let values = [];
+    let keys = [];
+    for (let i = 0; i < 20; ++i) {
+        values.push("v" + String.fromCharCode(65 + i) + "x");
+        keys.push("v" + String.fromCharCode(97 + i) + "x");
+    }
+    let json = '[';
+    for (let i = 0; i < 20; ++i)
+        json += '"' + values[i] + '",{"' + keys[i] + '":0},"' + keys[i] + '",';
+    json += '0]';
+    let r = JSON.parse(json);
+    for (let i = 0; i < 20; ++i) {
+        shouldBe(r[i * 3], values[i], "many-evict value " + i);
+        shouldBe(r[i * 3 + 2], keys[i], "many-evict key-as-value " + i);
+    }
+}

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2299,6 +2299,7 @@ void Heap::finalize()
     }
     vm().keyAtomStringCache.clear();
     vm().stringSplitCache.clear();
+    vm().jsonAtomStringCache.clearJSStrings();
 
     m_possiblyAccessedStringsFromConcurrentThreads.clear();
 

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
@@ -30,6 +30,7 @@
 
 namespace JSC {
 
+class JSString;
 class VM;
 
 class JSONAtomStringCache {
@@ -45,6 +46,7 @@ public:
     static_assert(sizeof(Slot) <= 64);
 
     using Cache = std::array<Slot, capacity>;
+    using JSStringCache = std::array<JSString*, capacity>;
 
     template<typename CharacterType>
     ALWAYS_INLINE Ref<AtomStringImpl> makeIdentifier(std::span<const CharacterType> characters);
@@ -52,23 +54,38 @@ public:
     template<typename CharacterType>
     ALWAYS_INLINE AtomStringImpl* existingIdentifier(std::span<const CharacterType> characters);
 
+    template<typename CharacterType>
+    ALWAYS_INLINE JSString* makeJSString(std::span<const CharacterType> characters);
+
     ALWAYS_INLINE void clear()
     {
         m_cache.fill({ });
+        m_jsStrings.fill(nullptr);
+    }
+
+    ALWAYS_INLINE void clearJSStrings()
+    {
+        m_jsStrings.fill(nullptr);
     }
 
     VM& vm() const;
 
 private:
-    ALWAYS_INLINE Slot& cacheSlot(char16_t firstCharacter, char16_t lastCharacter, char16_t length)
+    ALWAYS_INLINE unsigned cacheIndex(char16_t firstCharacter, char16_t lastCharacter, char16_t length)
     {
         unsigned hash = (firstCharacter << 6) ^ ((lastCharacter << 14) ^ firstCharacter);
         hash += (hash >> 14) + (length << 14);
         hash ^= hash << 14;
-        return m_cache[(hash + (hash >> 6)) % capacity];
+        return (hash + (hash >> 6)) % capacity;
+    }
+
+    ALWAYS_INLINE Slot& cacheSlot(char16_t firstCharacter, char16_t lastCharacter, char16_t length)
+    {
+        return m_cache[cacheIndex(firstCharacter, lastCharacter, length)];
     }
 
     Cache m_cache { };
+    JSStringCache m_jsStrings { };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
@@ -26,7 +26,9 @@
 #pragma once
 
 #include "Identifier.h"
+#include "JSCJSValueInlines.h"
 #include "JSONAtomStringCache.h"
+#include "JSString.h"
 #include "SmallStrings.h"
 #include "VM.h"
 
@@ -46,12 +48,14 @@ ALWAYS_INLINE Ref<AtomStringImpl> JSONAtomStringCache::makeIdentifier(std::span<
         return AtomStringImpl::add(characters).releaseNonNull();
 
     auto lastCharacter = characters.back();
-    auto& slot = cacheSlot(firstCharacter, lastCharacter, characters.size());
+    unsigned index = cacheIndex(firstCharacter, lastCharacter, characters.size());
+    auto& slot = m_cache[index];
     if (slot.m_length != characters.size() || !equal(slot.m_buffer, characters)) [[unlikely]] {
         auto result = AtomStringImpl::add(characters);
         slot.m_impl = result;
         slot.m_length = characters.size();
         WTF::copyElements(std::span<char16_t> { slot.m_buffer }, characters);
+        m_jsStrings[index] = nullptr;
         return result.releaseNonNull();
     }
 
@@ -77,6 +81,41 @@ ALWAYS_INLINE AtomStringImpl* JSONAtomStringCache::existingIdentifier(std::span<
         return nullptr;
 
     return slot.m_impl.get();
+}
+
+template<typename CharacterType>
+ALWAYS_INLINE JSString* JSONAtomStringCache::makeJSString(std::span<const CharacterType> characters)
+{
+    VM& vm = this->vm();
+    if (characters.empty())
+        return jsEmptyString(vm);
+
+    constexpr unsigned maxAtomizeStringLength = 10;
+    auto firstCharacter = characters.front();
+    if (characters.size() == 1) {
+        if (firstCharacter <= maxSingleCharacterString)
+            return jsSingleCharacterString(vm, firstCharacter);
+    } else if (characters.size() > maxAtomizeStringLength)
+        return jsNontrivialString(vm, String(characters));
+
+    auto lastCharacter = characters.back();
+    unsigned index = cacheIndex(firstCharacter, lastCharacter, characters.size());
+    auto& slot = m_cache[index];
+    if (slot.m_length == characters.size() && equal(slot.m_buffer, characters)) [[likely]] {
+        if (JSString* cached = m_jsStrings[index])
+            return cached;
+        JSString* result = jsString(vm, String { slot.m_impl.get() });
+        m_jsStrings[index] = result;
+        return result;
+    }
+
+    auto impl = AtomStringImpl::add(characters);
+    slot.m_impl = impl;
+    slot.m_length = characters.size();
+    WTF::copyElements(std::span<char16_t> { slot.m_buffer }, characters);
+    JSString* result = jsString(vm, String { WTF::move(impl) });
+    m_jsStrings[index] = result;
+    return result;
 }
 
 ALWAYS_INLINE VM& JSONAtomStringCache::vm() const

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -183,15 +183,9 @@ ALWAYS_INLINE Identifier LiteralParser<CharType, reviverMode>::makeIdentifier(VM
 template<typename CharType, JSONReviverMode reviverMode>
 ALWAYS_INLINE JSString* LiteralParser<CharType, reviverMode>::makeJSString(VM& vm, typename Lexer::LiteralParserTokenPtr token)
 {
-    constexpr unsigned maxAtomizeStringLength = 10;
-    if (token->stringIs8Bit) {
-        if (token->stringOrIdentifierLength > maxAtomizeStringLength)
-            return jsNontrivialString(vm, String({ token->stringStart8, token->stringOrIdentifierLength }));
-        return jsString(vm, Identifier::fromString(vm, token->string8()).releaseImpl());
-    }
-    if (token->stringOrIdentifierLength > maxAtomizeStringLength)
-        return jsNontrivialString(vm, String({ token->stringStart16, token->stringOrIdentifierLength }));
-    return jsString(vm, Identifier::fromString(vm, token->string16()).releaseImpl());
+    if (token->stringIs8Bit)
+        return vm.jsonAtomStringCache.makeJSString(token->string8());
+    return vm.jsonAtomStringCache.makeJSString(token->string16());
 }
 
 [[maybe_unused]] static ALWAYS_INLINE bool NODELETE cannotBeIdentPartOrEscapeStart(Latin1Character)


### PR DESCRIPTION
#### 128591e637758eb30386fdad64d648ee08535581
<pre>
[JSC] Cache `JSString` cells for short `JSON.parse` string values
<a href="https://bugs.webkit.org/show_bug.cgi?id=312224">https://bugs.webkit.org/show_bug.cgi?id=312224</a>

Reviewed by Yusuke Suzuki.

JSONAtomStringCache caches AtomStringImpl for object keys, but string
*values* still allocated a fresh JSString cell on every occurrence via
jsString(), even for repeated short strings like &quot;type&quot;:&quot;text&quot; or
enum-style arrays.

Add a parallel std::array&lt;JSString*, 256&gt; m_jsStrings keyed by the same
slot index. makeJSString() returns the cached cell on a buffer hit;
makeIdentifier() nulls the parallel entry on slot eviction to keep them
coherent. The array is cleared in Heap::finalize() alongside the other
raw-pointer string caches, so no visiting is needed.

The cache range stays at len&lt;=10 to avoid AtomString table churn on
payloads with many unique medium-length values (todomvc-style).

                                           TipOfTree                  Patched

json-parse-repeated-short-strings       25.6922+-0.1853     ^     17.1671+-0.4399        ^ definitely 1.4966x faster

* JSTests/microbenchmarks/json-parse-repeated-short-strings.js: Added.
* JSTests/stress/json-parse-jsstring-cache-coherence.js: Added.
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::finalize): Clear m_jsStrings on every collection.
* Source/JavaScriptCore/runtime/JSONAtomStringCache.h:
Add m_jsStrings parallel array, cacheIndex() helper, clearJSStrings().
* Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h:
(JSC::JSONAtomStringCache::makeIdentifier): Null m_jsStrings[index] on
slot eviction.
(JSC::JSONAtomStringCache::makeJSString): Added.
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser::makeJSString): Delegate to the new cache API.

Canonical link: <a href="https://commits.webkit.org/311426@main">https://commits.webkit.org/311426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/737e3ec46263b5edfb5bea48bbfe136af2ca03f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165749 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30265 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102216 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22822 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21050 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13521 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148976 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168234 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17761 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129667 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129789 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35150 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140544 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87591 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17348 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/188888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93512 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/188888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29250 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->