### PR TITLE
[JSC] Unroll zero-fill for `NewTypedArray` with small constant length

### DIFF
--- a/JSTests/stress/new-typed-array-constant-size-zero-fill.js
+++ b/JSTests/stress/new-typed-array-constant-size-zero-fill.js
@@ -1,0 +1,113 @@
+//@ requireOptions("--useConcurrentJIT=0")
+
+function shouldBeZeroFilled(array, length, name) {
+    if (array.length !== length)
+        throw new Error(name + ": length expected " + length + " but got " + array.length);
+    for (let i = 0; i < length; ++i) {
+        if (array[i] !== (typeof array[i] === "bigint" ? 0n : 0))
+            throw new Error(name + ": element " + i + " is " + array[i]);
+    }
+}
+noInline(shouldBeZeroFilled);
+
+// Zero length.
+function f64_0() { return new Float64Array(0); }
+noInline(f64_0);
+function i8_0() { return new Int8Array(0); }
+noInline(i8_0);
+
+// Single element.
+function f64_1() { return new Float64Array(1); }
+noInline(f64_1);
+function u8_1() { return new Uint8Array(1); }
+noInline(u8_1);
+
+// Odd byte sizes (round-up to 8).
+function i8_3() { return new Int8Array(3); }
+noInline(i8_3);
+function i8_7() { return new Int8Array(7); }
+noInline(i8_7);
+function i8_9() { return new Int8Array(9); }
+noInline(i8_9);
+function u16_5() { return new Uint16Array(5); }
+noInline(u16_5);
+function f32_3() { return new Float32Array(3); }
+noInline(f32_3);
+
+// DFG unroll word-limit boundary (16 words).
+function f64_16() { return new Float64Array(16); }
+noInline(f64_16);
+function f64_17() { return new Float64Array(17); }
+noInline(f64_17);
+function u32_32() { return new Uint32Array(32); }
+noInline(u32_32);
+function u32_33() { return new Uint32Array(33); }
+noInline(u32_33);
+function i8_128() { return new Int8Array(128); }
+noInline(i8_128);
+function i8_129() { return new Int8Array(129); }
+noInline(i8_129);
+
+// FTL splatWords unroll boundary (10 words).
+function f64_10() { return new Float64Array(10); }
+noInline(f64_10);
+function f64_11() { return new Float64Array(11); }
+noInline(f64_11);
+
+// fastSizeLimit boundary (1000).
+function f64_1000() { return new Float64Array(1000); }
+noInline(f64_1000);
+function f64_1001() { return new Float64Array(1001); }
+noInline(f64_1001);
+
+// BigInt typed arrays.
+function bi64_2() { return new BigInt64Array(2); }
+noInline(bi64_2);
+function bu64_16() { return new BigUint64Array(16); }
+noInline(bu64_16);
+
+// Negative constant must throw.
+function i32_neg() { return new Int32Array(-1); }
+noInline(i32_neg);
+
+// Allocator-reuse: dirty storage then verify fresh allocation is zero.
+function dirty() {
+    let a = new Float64Array(4);
+    a[0] = 1.5; a[1] = -2.5; a[2] = 3.5; a[3] = -4.5;
+    return a;
+}
+noInline(dirty);
+function fresh() { return new Float64Array(4); }
+noInline(fresh);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBeZeroFilled(f64_0(), 0, "f64_0");
+    shouldBeZeroFilled(i8_0(), 0, "i8_0");
+    shouldBeZeroFilled(f64_1(), 1, "f64_1");
+    shouldBeZeroFilled(u8_1(), 1, "u8_1");
+    shouldBeZeroFilled(i8_3(), 3, "i8_3");
+    shouldBeZeroFilled(i8_7(), 7, "i8_7");
+    shouldBeZeroFilled(i8_9(), 9, "i8_9");
+    shouldBeZeroFilled(u16_5(), 5, "u16_5");
+    shouldBeZeroFilled(f32_3(), 3, "f32_3");
+    shouldBeZeroFilled(f64_16(), 16, "f64_16");
+    shouldBeZeroFilled(f64_17(), 17, "f64_17");
+    shouldBeZeroFilled(u32_32(), 32, "u32_32");
+    shouldBeZeroFilled(u32_33(), 33, "u32_33");
+    shouldBeZeroFilled(i8_128(), 128, "i8_128");
+    shouldBeZeroFilled(i8_129(), 129, "i8_129");
+    shouldBeZeroFilled(f64_10(), 10, "f64_10");
+    shouldBeZeroFilled(f64_11(), 11, "f64_11");
+    shouldBeZeroFilled(f64_1000(), 1000, "f64_1000");
+    shouldBeZeroFilled(f64_1001(), 1001, "f64_1001");
+    shouldBeZeroFilled(bi64_2(), 2, "bi64_2");
+    shouldBeZeroFilled(bu64_16(), 16, "bu64_16");
+
+    let threw = false;
+    try { i32_neg(); } catch (e) { threw = e instanceof RangeError; }
+    if (!threw)
+        throw new Error("i32_neg: expected RangeError");
+
+    dirty();
+    shouldBeZeroFilled(fresh(), 4, "fresh-after-dirty");
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -11875,44 +11875,62 @@ void SpeculativeJIT::emitNewTypedArrayWithSizeInRegister(Node* node, TypedArrayT
     
     move(TrustedImmPtr(nullptr), storageGPR);
 
+    std::optional<size_t> constantByteSize;
+    if (node->child1()->isInt32Constant()) {
+        int32_t length = node->child1()->asInt32();
+        if (length >= 0 && static_cast<size_t>(length) <= JSArrayBufferView::fastSizeLimit)
+            constantByteSize = WTF::roundUpToMultipleOf<8>(static_cast<size_t>(length) << logElementSize(typedArrayType));
+    }
+
+    if (constantByteSize)
+        move(TrustedImm32(*constantByteSize), scratchGPR);
+    else {
 #if USE(LARGE_TYPED_ARRAYS)
-    slowCases.append(branch64(
-        Above, sizeGPR, TrustedImm64(JSArrayBufferView::fastSizeLimit)));
-    // We assume through the rest of the fast path that the size is a 32-bit number.
-    static_assert(isInBounds<int32_t>(JSArrayBufferView::fastSizeLimit));
+        slowCases.append(branch64(
+            Above, sizeGPR, TrustedImm64(JSArrayBufferView::fastSizeLimit)));
+        // We assume through the rest of the fast path that the size is a 32-bit number.
+        static_assert(isInBounds<int32_t>(JSArrayBufferView::fastSizeLimit));
 #else
-    slowCases.append(branch32(
-        Above, sizeGPR, TrustedImm32(JSArrayBufferView::fastSizeLimit)));
+        slowCases.append(branch32(
+            Above, sizeGPR, TrustedImm32(JSArrayBufferView::fastSizeLimit)));
 #endif
-    
-    lshift32(sizeGPR, TrustedImm32(logElementSize(typedArrayType)), scratchGPR);
-    if (elementSize(typedArrayType) < 8) {
-        add32(TrustedImm32(7), scratchGPR);
-        and32(TrustedImm32(~7), scratchGPR);
+        lshift32(sizeGPR, TrustedImm32(logElementSize(typedArrayType)), scratchGPR);
+        if (elementSize(typedArrayType) < 8) {
+            add32(TrustedImm32(7), scratchGPR);
+            and32(TrustedImm32(~7), scratchGPR);
+        }
     }
     emitAllocateVariableSized(
         storageGPR, vm().primitiveGigacageAuxiliarySpace(), scratchGPR, scratchGPR,
         scratchGPR2, slowCases);
     
-    Jump done = branchTest32(Zero, sizeGPR);
-    move(sizeGPR, scratchGPR);
-    if (elementSize(typedArrayType) != 4) {
-        if (elementSize(typedArrayType) > 4)
-            lshift32(TrustedImm32(logElementSize(typedArrayType) - 2), scratchGPR);
-        else {
-            if (elementSize(typedArrayType) > 1)
-                lshift32(TrustedImm32(logElementSize(typedArrayType)), scratchGPR);
-            add32(TrustedImm32(3), scratchGPR);
-            urshift32(TrustedImm32(2), scratchGPR);
+#if USE(JSVALUE64)
+    constexpr unsigned zeroFillUnrollWordLimit = 16;
+    if (constantByteSize && *constantByteSize / sizeof(UCPURegister) <= zeroFillUnrollWordLimit)
+        emitFillStorageWithJSEmpty(storageGPR, 0, *constantByteSize / sizeof(UCPURegister), scratchGPR);
+    else
+#endif
+    {
+        Jump done = branchTest32(Zero, sizeGPR);
+        move(sizeGPR, scratchGPR);
+        if (elementSize(typedArrayType) != 4) {
+            if (elementSize(typedArrayType) > 4)
+                lshift32(TrustedImm32(logElementSize(typedArrayType) - 2), scratchGPR);
+            else {
+                if (elementSize(typedArrayType) > 1)
+                    lshift32(TrustedImm32(logElementSize(typedArrayType)), scratchGPR);
+                add32(TrustedImm32(3), scratchGPR);
+                urshift32(TrustedImm32(2), scratchGPR);
+            }
         }
+        Label loop = label();
+        sub32(TrustedImm32(1), scratchGPR);
+        store32(
+            TrustedImm32(0),
+            BaseIndex(storageGPR, scratchGPR, TimesFour));
+        branchTest32(NonZero, scratchGPR).linkTo(loop, this);
+        done.link(this);
     }
-    Label loop = label();
-    sub32(TrustedImm32(1), scratchGPR);
-    store32(
-        TrustedImm32(0),
-        BaseIndex(storageGPR, scratchGPR, TimesFour));
-    branchTest32(NonZero, scratchGPR).linkTo(loop, this);
-    done.link(this);
 
     auto butterfly = TrustedImmPtr(nullptr);
     switch (typedArrayType) {

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -10597,12 +10597,15 @@ IGNORE_CLANG_WARNINGS_END
         LValue allocator = allocatorForSize(vm().primitiveGigacageAuxiliarySpace(), byteSize, slowCase);
         LValue storage = allocateHeapCell(allocator, slowCase);
 
-        splatWords(
-            storage,
-            m_out.int32Zero,
-            m_out.castToInt32(m_out.lShr(byteSize, m_out.constIntPtr(3))),
-            m_out.int64Zero,
-            m_heaps.TypedArrayProperties);
+        LValue zeroFillEnd = nullptr;
+        if (m_node->child1()->isInt32Constant()) {
+            int32_t length = m_node->child1()->asInt32();
+            if (length >= 0 && static_cast<size_t>(length) <= JSArrayBufferView::fastSizeLimit)
+                zeroFillEnd = m_out.constInt32(WTF::roundUpToMultipleOf<8>(static_cast<size_t>(length) << logElementSize(typedArrayType)) / sizeof(UCPURegister));
+        }
+        if (!zeroFillEnd)
+            zeroFillEnd = m_out.castToInt32(m_out.lShr(byteSize, m_out.constIntPtr(3)));
+        splatWords(storage, m_out.int32Zero, zeroFillEnd, m_out.int64Zero, m_heaps.TypedArrayProperties);
 
         ValueFromBlock haveStorage = m_out.anchor(storage);
 


### PR DESCRIPTION
#### d54aaf250be959db593d49672fccc7a2d490d8ce
<pre>
[JSC] Unroll zero-fill for `NewTypedArray` with small constant length
<a href="https://bugs.webkit.org/show_bug.cgi?id=312225">https://bugs.webkit.org/show_bug.cgi?id=312225</a>

Reviewed by Yusuke Suzuki.

When the length of `new TypedArray(N)` is a small Int32 constant, DFG/FTL
still emitted a runtime zero-fill loop and fastSizeLimit branch even
though the byte size is known at compile time.

This patch derives the constant byte size in emitNewTypedArrayWithSizeInRegister
and, when set, skips the fastSizeLimit branch, materializes the byte size as
an immediate, and zero-fills via emitFillStorageWithJSEmpty (unrolled
`stp xzr, xzr` on ARM64) for up to 16 words. Guarded by USE(JSVALUE64) since
JSEmpty is non-zero on JSVALUE32_64. In FTL, a constInt32 word count is passed
to splatWords so its existing unroll path is taken and Air fuses the stores
into stp.

For `new Float64Array(4)` on ARM64, the NewTypedArray fast path goes from
74 to 47 dynamic instructions in DFG (-36%) and 52 to 36 in FTL (-31%):

    DFG before: cmp x0,#0x3e8; b.hi; lsl w4,w0,#3; ...
                cbz w0; mov; lsl; (sub; str wzr; cbnz) x8
    DFG after:  orr w4,wzr,#0x20; ...
                stp xzr,xzr,[x3]; stp xzr,xzr,[x3,#0x10]

Test: JSTests/stress/new-typed-array-constant-size-zero-fill.js

* JSTests/stress/new-typed-array-constant-size-zero-fill.js: Added.
(shouldBeZeroFilled):
(f64_0):
(i8_0):
(f64_1):
(u8_1):
(i8_3):
(i8_7):
(i8_9):
(u16_5):
(f32_3):
(f64_16):
(f64_17):
(u32_32):
(u32_33):
(i8_128):
(i8_129):
(f64_10):
(f64_11):
(f64_1000):
(f64_1001):
(bi64_2):
(bu64_16):
(i32_neg):
(dirty):
(fresh):
(i.catch):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::emitNewTypedArrayWithSize):

Canonical link: <a href="https://commits.webkit.org/312432@main">https://commits.webkit.org/312432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea1b36f68d1cfcd3bf7cf18ba99b314f24784ce2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113612 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123485 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86618 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104038 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24697 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23117 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15836 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151284 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134383 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170558 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20067 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16522 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131568 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131679 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35777 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32295 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142605 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90374 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19414 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191517 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31806 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98166 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49211 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31599 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31481 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->