### PR TITLE
[JSC] Atomic instructions in IPInt should not have metadata if it does not call functions

### DIFF
--- a/JSTests/wasm/stress/atomic-cmpxchg-large-offset.js
+++ b/JSTests/wasm/stress/atomic-cmpxchg-large-offset.js
@@ -1,0 +1,116 @@
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+
+import * as assert from "../assert.js";
+import { instantiate } from "../wabt-wrapper.js";
+
+// Test atomic cmpxchg with offset >= 128 to exercise the IPInt slow path.
+// When offset >= 128 the LEB128 encoding is multi-byte (first byte >= 0x80),
+// causing loadStoreMakePointerFast to fall through to the slow path.
+// This specifically tests that expected and replacement are not swapped
+// in the slow path's push/pop save/restore sequence.
+
+let wat = `
+(module
+  (memory 1 1 shared)
+  (export "memory" (memory 0))
+
+  (func (export "i32_cmpxchg") (param i32 i32 i32) (result i32)
+    (local.get 0) (local.get 1) (local.get 2) (i32.atomic.rmw.cmpxchg offset=128))
+  (func (export "i64_cmpxchg") (param i32 i64 i64) (result i64)
+    (local.get 0) (local.get 1) (local.get 2) (i64.atomic.rmw.cmpxchg offset=128))
+  (func (export "i32_cmpxchg8") (param i32 i32 i32) (result i32)
+    (local.get 0) (local.get 1) (local.get 2) (i32.atomic.rmw8.cmpxchg_u offset=128))
+  (func (export "i32_cmpxchg16") (param i32 i32 i32) (result i32)
+    (local.get 0) (local.get 1) (local.get 2) (i32.atomic.rmw16.cmpxchg_u offset=128))
+  (func (export "i64_cmpxchg8") (param i32 i64 i64) (result i64)
+    (local.get 0) (local.get 1) (local.get 2) (i64.atomic.rmw8.cmpxchg_u offset=128))
+  (func (export "i64_cmpxchg16") (param i32 i64 i64) (result i64)
+    (local.get 0) (local.get 1) (local.get 2) (i64.atomic.rmw16.cmpxchg_u offset=128))
+  (func (export "i64_cmpxchg32") (param i32 i64 i64) (result i64)
+    (local.get 0) (local.get 1) (local.get 2) (i64.atomic.rmw32.cmpxchg_u offset=128))
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, { threads: true });
+    const e = instance.exports;
+    const mem = new DataView(e.memory.buffer);
+
+    // The effective address is param0 + 128. We use param0=0 so effective addr=128.
+    const addr = 0;
+    const effectiveAddr = 128;
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        // i32.atomic.rmw.cmpxchg - success: expected matches memory
+        mem.setInt32(effectiveAddr, 10, true);
+        assert.eq(e.i32_cmpxchg(addr, 10, 42), 10);    // returns old value
+        assert.eq(mem.getInt32(effectiveAddr, true), 42); // memory updated to replacement
+
+        // i32.atomic.rmw.cmpxchg - failure: expected doesn't match memory
+        mem.setInt32(effectiveAddr, 10, true);
+        assert.eq(e.i32_cmpxchg(addr, 99, 42), 10);     // returns old value (no match)
+        assert.eq(mem.getInt32(effectiveAddr, true), 10); // memory unchanged
+
+        // i64.atomic.rmw.cmpxchg - success
+        mem.setBigInt64(effectiveAddr, 10n, true);
+        assert.eq(e.i64_cmpxchg(addr, 10n, 42n), 10n);
+        assert.eq(mem.getBigInt64(effectiveAddr, true), 42n);
+
+        // i64.atomic.rmw.cmpxchg - failure
+        mem.setBigInt64(effectiveAddr, 10n, true);
+        assert.eq(e.i64_cmpxchg(addr, 99n, 42n), 10n);
+        assert.eq(mem.getBigInt64(effectiveAddr, true), 10n);
+
+        // i32.atomic.rmw8.cmpxchg_u - success
+        mem.setUint8(effectiveAddr, 10);
+        assert.eq(e.i32_cmpxchg8(addr, 10, 42), 10);
+        assert.eq(mem.getUint8(effectiveAddr), 42);
+
+        // i32.atomic.rmw8.cmpxchg_u - failure
+        mem.setUint8(effectiveAddr, 10);
+        assert.eq(e.i32_cmpxchg8(addr, 99, 42), 10);
+        assert.eq(mem.getUint8(effectiveAddr), 10);
+
+        // i32.atomic.rmw16.cmpxchg_u - success
+        mem.setUint16(effectiveAddr, 10, true);
+        assert.eq(e.i32_cmpxchg16(addr, 10, 42), 10);
+        assert.eq(mem.getUint16(effectiveAddr, true), 42);
+
+        // i32.atomic.rmw16.cmpxchg_u - failure
+        mem.setUint16(effectiveAddr, 10, true);
+        assert.eq(e.i32_cmpxchg16(addr, 99, 42), 10);
+        assert.eq(mem.getUint16(effectiveAddr, true), 10);
+
+        // i64.atomic.rmw8.cmpxchg_u - success
+        mem.setUint8(effectiveAddr, 10);
+        assert.eq(e.i64_cmpxchg8(addr, 10n, 42n), 10n);
+        assert.eq(mem.getUint8(effectiveAddr), 42);
+
+        // i64.atomic.rmw8.cmpxchg_u - failure
+        mem.setUint8(effectiveAddr, 10);
+        assert.eq(e.i64_cmpxchg8(addr, 99n, 42n), 10n);
+        assert.eq(mem.getUint8(effectiveAddr), 10);
+
+        // i64.atomic.rmw16.cmpxchg_u - success
+        mem.setUint16(effectiveAddr, 10, true);
+        assert.eq(e.i64_cmpxchg16(addr, 10n, 42n), 10n);
+        assert.eq(mem.getUint16(effectiveAddr, true), 42);
+
+        // i64.atomic.rmw16.cmpxchg_u - failure
+        mem.setUint16(effectiveAddr, 10, true);
+        assert.eq(e.i64_cmpxchg16(addr, 99n, 42n), 10n);
+        assert.eq(mem.getUint16(effectiveAddr, true), 10);
+
+        // i64.atomic.rmw32.cmpxchg_u - success
+        mem.setUint32(effectiveAddr, 10, true);
+        assert.eq(e.i64_cmpxchg32(addr, 10n, 42n), 10n);
+        assert.eq(mem.getUint32(effectiveAddr, true), 42);
+
+        // i64.atomic.rmw32.cmpxchg_u - failure
+        mem.setUint32(effectiveAddr, 10, true);
+        assert.eq(e.i64_cmpxchg32(addr, 99n, 42n), 10n);
+        assert.eq(mem.getUint32(effectiveAddr, true), 10);
+    }
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -902,31 +902,6 @@ macro baddpc(src, dst, label)
     bpb dst, src, label # unsigned overflow check
 end
 
-macro atomicMemoryMakePointerAndAdvanceMC(instrLenReg, wasmAddrReg, size, scratch, scratch2)
-    loadq IPInt::AtomicMemoryAccessMetadata::offset[MC], scratch2
-    baddpc(scratch2, wasmAddrReg, _ipint_throw_OutOfBoundsMemoryAccess)
-
-    move size - 1, scratch2
-    baddpc(wasmAddrReg, scratch2, _ipint_throw_OutOfBoundsMemoryAccess)
-
-    loadb IPInt::AtomicMemoryAccessMetadata::memoryIndex[MC], scratch
-    btinz scratch, .memoryIsNotZero
-    bpaeq scratch2, boundsCheckingSize, _ipint_throw_OutOfBoundsMemoryAccess # scratch2 contains wasm address + size - 1
-    addp memoryBase, wasmAddrReg
-    jmp .done
-
-.memoryIsNotZero:
-    mulp constexpr (sizeof(JSWebAssemblyInstance::WasmMemoryBaseAndSize)), scratch
-    # FIXME: it's probably worth trying to use a loadpair here, but that requires a separate x86 codepath
-    loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0) + sizeof(void*))) [wasmInstance, scratch], scratch2 # bounds checking size
-    subp size - 1, scratch2 # wasmAddrReg + (size-1) >= scratch2 is equivalent to wasmAddrReg >= scratch2 - (size-1)
-    bpaeq wasmAddrReg, scratch2, _ipint_throw_OutOfBoundsMemoryAccess
-    loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0))) [wasmInstance, scratch], scratch2 # memory base
-    addp scratch2, wasmAddrReg
-.done:
-    loadb IPInt::AtomicMemoryAccessMetadata::instructionLength[MC], instrLenReg
-    advanceMC(constexpr (sizeof(IPInt::AtomicMemoryAccessMetadata)))
-end
 
 macro loadStoreMakePointerFast(alignAccess, offsetAccess, wasmAddrReg, size, scratch, scratch2, slowLabel)
     # overwrites wasmAddrReg with computed pointer.
@@ -8497,6 +8472,1119 @@ macro checkAlignment8(mem, label)
     btpnz mem, 7, label
 end
 
+macro weakCASLoopByte(mem, value, scratch1AndOldValue, scratch2, fn)
+    validateOpcodeConfig(scratch1AndOldValue)
+    if X86_64
+        loadb [mem], scratch1AndOldValue
+    .loop:
+        move scratch1AndOldValue, scratch2
+        fn(value, scratch2)
+        batomicweakcasb scratch1AndOldValue, scratch2, [mem], .loop
+    else
+    .loop:
+        loadlinkacqb [mem], scratch1AndOldValue
+        fn(value, scratch1AndOldValue, scratch2)
+        storecondrelb ws2, scratch2, [mem]
+        bineq ws2, 0, .loop
+    end
+end
+
+macro weakCASLoopHalf(mem, value, scratch1AndOldValue, scratch2, fn)
+    validateOpcodeConfig(scratch1AndOldValue)
+    if X86_64
+        loadh [mem], scratch1AndOldValue
+    .loop:
+        move scratch1AndOldValue, scratch2
+        fn(value, scratch2)
+        batomicweakcash scratch1AndOldValue, scratch2, [mem], .loop
+    else
+    .loop:
+        loadlinkacqh [mem], scratch1AndOldValue
+        fn(value, scratch1AndOldValue, scratch2)
+        storecondrelh ws2, scratch2, [mem]
+        bineq ws2, 0, .loop
+    end
+end
+
+macro weakCASLoopInt(mem, value, scratch1AndOldValue, scratch2, fn)
+    validateOpcodeConfig(scratch1AndOldValue)
+    if X86_64
+        loadi [mem], scratch1AndOldValue
+    .loop:
+        move scratch1AndOldValue, scratch2
+        fn(value, scratch2)
+        batomicweakcasi scratch1AndOldValue, scratch2, [mem], .loop
+    else
+    .loop:
+        loadlinkacqi [mem], scratch1AndOldValue
+        fn(value, scratch1AndOldValue, scratch2)
+        storecondreli ws2, scratch2, [mem]
+        bineq ws2, 0, .loop
+    end
+end
+
+macro weakCASLoopQuad(mem, value, scratch1AndOldValue, scratch2, fn)
+    validateOpcodeConfig(scratch1AndOldValue)
+    if X86_64
+        loadq [mem], scratch1AndOldValue
+    .loop:
+        move scratch1AndOldValue, scratch2
+        fn(value, scratch2)
+        batomicweakcasq scratch1AndOldValue, scratch2, [mem], .loop
+    else
+    .loop:
+        loadlinkacqq [mem], scratch1AndOldValue
+        fn(value, scratch1AndOldValue, scratch2)
+        storecondrelq ws2, scratch2, [mem]
+        bineq ws2, 0, .loop
+    end
+end
+
+macro doI32AtomicLoad(mem, dst)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    if ARM64 or ARM64E or X86_64
+        atomicloadi [mem], dst
+    else
+        error
+    end
+end
+
+macro doI64AtomicLoad(mem, dst)
+    checkAlignment8(mem, _ipint_throw_UnalignedMemoryAccess)
+    if ARM64 or ARM64E or X86_64
+        atomicloadq [mem], dst
+    else
+        error
+    end
+end
+
+macro doI32AtomicLoad8(mem, dst)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    if ARM64 or ARM64E or X86_64
+        atomicloadb [mem], dst
+    else
+        error
+    end
+end
+
+macro doI32AtomicLoad16(mem, dst)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    if ARM64 or ARM64E or X86_64
+        atomicloadh [mem], dst
+    else
+        error
+    end
+end
+
+macro doI64AtomicLoad8(mem, dst)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    if ARM64 or ARM64E or X86_64
+        atomicloadb [mem], dst
+    else
+        error
+    end
+end
+
+macro doI64AtomicLoad16(mem, dst)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    if ARM64 or ARM64E or X86_64
+        atomicloadh [mem], dst
+    else
+        error
+    end
+end
+
+macro doI64AtomicLoad32(mem, dst)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    if ARM64 or ARM64E or X86_64
+        atomicloadi [mem], dst
+    else
+        error
+    end
+end
+
+macro doI32AtomicStore(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgi val, [memCopy], val
+    elsif X86_64
+        atomicxchgi val, [memCopy]
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicStore(mem, val, memCopy, scratch)
+    checkAlignment8(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgq val, [memCopy], val
+    elsif X86_64
+        atomicxchgq val, [memCopy]
+    elsif ARM64
+        weakCASLoopQuad(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicStore8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgb val, [memCopy], val
+    elsif X86_64
+        atomicxchgb val, [memCopy]
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicStore16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgh val, [memCopy], val
+    elsif X86_64
+        atomicxchgh val, [memCopy]
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicStore8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgb val, [memCopy], val
+    elsif X86_64
+        atomicxchgb val, [memCopy]
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicStore16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgh val, [memCopy], val
+    elsif X86_64
+        atomicxchgh val, [memCopy]
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicStore32(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgi val, [memCopy], val
+    elsif X86_64
+        atomicxchgi val, [memCopy]
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwAdd(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgaddi val, [memCopy], mem
+    elsif X86_64
+        atomicxchgaddi val, [memCopy]
+        move val, mem
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwAdd(mem, val, memCopy, scratch)
+    checkAlignment8(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgaddq val, [memCopy], mem
+    elsif X86_64
+        atomicxchgaddq val, [memCopy]
+        move val, mem
+    elsif ARM64
+        weakCASLoopQuad(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            addq value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwAdd8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgaddb val, [memCopy], mem
+    elsif X86_64
+        atomicxchgaddb val, [memCopy]
+        move val, mem
+        andi 0xff, mem
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwAdd16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgaddh val, [memCopy], mem
+    elsif X86_64
+        atomicxchgaddh val, [memCopy]
+        move val, mem
+        andi 0xffff, mem
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwAdd8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgaddb val, [memCopy], mem
+    elsif X86_64
+        atomicxchgaddb val, [memCopy]
+        move val, mem
+        andi 0xff, mem
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwAdd16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgaddh val, [memCopy], mem
+    elsif X86_64
+        atomicxchgaddh val, [memCopy]
+        move val, mem
+        andi 0xffff, mem
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwAdd32(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgaddi val, [memCopy], mem
+    elsif X86_64
+        atomicxchgaddi val, [memCopy]
+        move val, mem
+        ori 0, mem
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwSub(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        negi val
+        atomicxchgaddi val, [memCopy], mem
+    elsif X86_64
+        negi val
+        atomicxchgaddi val, [memCopy]
+        move val, mem
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwSub(mem, val, memCopy, scratch)
+    checkAlignment8(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        negq val
+        atomicxchgaddq val, [memCopy], mem
+    elsif X86_64
+        negq val
+        atomicxchgaddq val, [memCopy]
+        move val, mem
+    elsif ARM64
+        weakCASLoopQuad(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            subq oldValue, value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwSub8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        negi val
+        atomicxchgaddb val, [memCopy], mem
+    elsif X86_64
+        negi val
+        atomicxchgaddb val, [memCopy]
+        move val, mem
+        andi 0xff, mem
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwSub16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        negi val
+        atomicxchgaddh val, [memCopy], mem
+    elsif X86_64
+        negi val
+        atomicxchgaddh val, [memCopy]
+        move val, mem
+        andi 0xffff, mem
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwSub8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        negq val
+        atomicxchgaddb val, [memCopy], mem
+    elsif X86_64
+        negq val
+        atomicxchgaddb val, [memCopy]
+        move val, mem
+        andi 0xff, mem
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwSub16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        negq val
+        atomicxchgaddh val, [memCopy], mem
+    elsif X86_64
+        negq val
+        atomicxchgaddh val, [memCopy]
+        move val, mem
+        andi 0xffff, mem
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwSub32(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        negq val
+        atomicxchgaddi val, [memCopy], mem
+    elsif X86_64
+        negq val
+        atomicxchgaddi val, [memCopy]
+        move val, mem
+        ori 0, mem
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwAnd(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        noti val
+        atomicxchgcleari val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwAnd(mem, val, memCopy, scratch)
+    checkAlignment8(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        notq val
+        atomicxchgclearq val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopQuad(memCopy, val, mem, scratch, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopQuad(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            andq value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwAnd8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        noti val
+        atomicxchgclearb val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwAnd16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        noti val
+        atomicxchgclearh val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwAnd8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        notq val
+        atomicxchgclearb val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwAnd16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        notq val
+        atomicxchgclearh val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwAnd32(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        notq val
+        atomicxchgcleari val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwOr(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgori val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro (value, dst)
+            ori value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwOr(mem, val, memCopy, scratch)
+    checkAlignment8(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgorq val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopQuad(memCopy, val, mem, scratch, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopQuad(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            orq value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwOr8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgorb val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwOr16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgorh val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwOr8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgorb val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwOr16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgorh val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwOr32(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgori val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwXor(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgxori val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwXor(mem, val, memCopy, scratch)
+    checkAlignment8(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgxorq val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopQuad(memCopy, val, mem, scratch, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopQuad(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            xorq value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwXor8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgxorb val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwXor16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgxorh val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwXor8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgxorb val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwXor16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgxorh val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwXor32(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgxori val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwXchg(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgi val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwXchg(mem, val, memCopy, scratch)
+    checkAlignment8(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgq val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopQuad(memCopy, val, mem, scratch, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopQuad(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwXchg8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgb val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicRmwXchg16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgh val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwXchg8(mem, val, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgb val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwXchg16(mem, val, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgh val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI64AtomicRmwXchg32(mem, val, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    if ARM64E
+        atomicxchgi val, [memCopy], mem
+    elsif X86_64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(memCopy, val, mem, scratch, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+end
+
+macro doI32AtomicCmpxchg(mem, expected, newVal, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    move expected, mem
+    andq 0xffffffff, mem
+    if ARM64E or X86_64
+        atomicweakcasi mem, newVal, [memCopy]
+    elsif ARM64
+        weakCASExchangeInt(memCopy, newVal, mem, scratch, expected)
+    else
+        error
+    end
+end
+
+macro doI64AtomicCmpxchg(mem, expected, newVal, memCopy, scratch)
+    checkAlignment8(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    move expected, mem
+    if ARM64E or X86_64
+        atomicweakcasq mem, newVal, [memCopy]
+    elsif ARM64
+        weakCASExchangeQuad(memCopy, newVal, mem, scratch, expected)
+    else
+        error
+    end
+end
+
+macro doI32AtomicCmpxchg8(mem, expected, newVal, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    move expected, mem
+    andq 0xff, mem
+    if ARM64E or X86_64
+        atomicweakcasb mem, newVal, [memCopy]
+    elsif ARM64
+        weakCASExchangeByte(memCopy, newVal, mem, scratch, expected)
+    else
+        error
+    end
+end
+
+macro doI32AtomicCmpxchg16(mem, expected, newVal, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    move expected, mem
+    andq 0xffff, mem
+    if ARM64E or X86_64
+        atomicweakcash mem, newVal, [memCopy]
+    elsif ARM64
+        weakCASExchangeHalf(memCopy, newVal, mem, scratch, expected)
+    else
+        error
+    end
+end
+
+macro doI64AtomicCmpxchg8(mem, expected, newVal, memCopy, scratch)
+    noAlignmentCheck(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    move expected, mem
+    andq 0xff, mem
+    if ARM64E or X86_64
+        atomicweakcasb mem, newVal, [memCopy]
+    elsif ARM64
+        weakCASExchangeByte(memCopy, newVal, mem, scratch, expected)
+    else
+        error
+    end
+end
+
+macro doI64AtomicCmpxchg16(mem, expected, newVal, memCopy, scratch)
+    checkAlignment2(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    move expected, mem
+    andq 0xffff, mem
+    if ARM64E or X86_64
+        atomicweakcash mem, newVal, [memCopy]
+    elsif ARM64
+        weakCASExchangeHalf(memCopy, newVal, mem, scratch, expected)
+    else
+        error
+    end
+end
+
+macro doI64AtomicCmpxchg32(mem, expected, newVal, memCopy, scratch)
+    checkAlignment4(mem, _ipint_throw_UnalignedMemoryAccess)
+    move mem, memCopy
+    move expected, mem
+    andq 0xffffffff, mem
+    if ARM64E or X86_64
+        atomicweakcasi mem, newVal, [memCopy]
+    elsif ARM64
+        weakCASExchangeInt(memCopy, newVal, mem, scratch, expected)
+    else
+        error
+    end
+end
+
 ipintAtomicOp(_memory_atomic_notify, macro()
     # starting at sp: count, pointer
     loadb IPInt::AtomicMemoryAccessMetadata::memoryIndex[MC], t0
@@ -8566,10 +9654,7 @@ end)
 
 ipintAtomicOp(_atomic_fence, macro()
     fence
-
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -8588,1340 +9673,547 @@ reservedAtomicOpcode(atomic_0xf)
 
 ipintAtomicOp(_i32_atomic_load, macro()
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    if ARM64 or ARM64E or X86_64
-        atomicloadi [t0], t2
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i32_atomic_load_slow_path)
+    doI32AtomicLoad(t0, t2)
     pushInt32(t2)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_load, macro()
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
-    if ARM64 or ARM64E or X86_64
-        atomicloadq [t0], t2
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .ipint_i64_atomic_load_slow_path)
+    doI64AtomicLoad(t0, t2)
     pushInt64(t2)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_load8_u, macro()
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    if ARM64 or ARM64E or X86_64
-        atomicloadb [t0], t2
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i32_atomic_load8_u_slow_path)
+    doI32AtomicLoad8(t0, t2)
     pushInt32(t2)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_load16_u, macro()
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    if ARM64 or ARM64E or X86_64
-        atomicloadh [t0], t2
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i32_atomic_load16_u_slow_path)
+    doI32AtomicLoad16(t0, t2)
     pushInt32(t2)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_load8_u, macro()
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    if ARM64 or ARM64E or X86_64
-        atomicloadb [t0], t2
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i64_atomic_load8_u_slow_path)
+    doI64AtomicLoad8(t0, t2)
     pushInt64(t2)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_load16_u, macro()
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    if ARM64 or ARM64E or X86_64
-        atomicloadh [t0], t2
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i64_atomic_load16_u_slow_path)
+    doI64AtomicLoad16(t0, t2)
     pushInt64(t2)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_load32_u, macro()
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    if ARM64 or ARM64E or X86_64
-        atomicloadi [t0], t2
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i64_atomic_load32_u_slow_path)
+    doI64AtomicLoad32(t0, t2)
     pushInt64(t2)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
-
-macro weakCASLoopByte(mem, value, scratch1AndOldValue, scratch2, fn)
-    validateOpcodeConfig(scratch1AndOldValue)
-    if X86_64
-        loadb [mem], scratch1AndOldValue
-    .loop:
-        move scratch1AndOldValue, scratch2
-        fn(value, scratch2)
-        batomicweakcasb scratch1AndOldValue, scratch2, [mem], .loop
-    else
-    .loop:
-        loadlinkacqb [mem], scratch1AndOldValue
-        fn(value, scratch1AndOldValue, scratch2)
-        storecondrelb ws2, scratch2, [mem]
-        bineq ws2, 0, .loop
-    end
-end
-
-macro weakCASLoopHalf(mem, value, scratch1AndOldValue, scratch2, fn)
-    validateOpcodeConfig(scratch1AndOldValue)
-    if X86_64
-        loadh [mem], scratch1AndOldValue
-    .loop:
-        move scratch1AndOldValue, scratch2
-        fn(value, scratch2)
-        batomicweakcash scratch1AndOldValue, scratch2, [mem], .loop
-    else
-    .loop:
-        loadlinkacqh [mem], scratch1AndOldValue
-        fn(value, scratch1AndOldValue, scratch2)
-        storecondrelh ws2, scratch2, [mem]
-        bineq ws2, 0, .loop
-    end
-end
-
-macro weakCASLoopInt(mem, value, scratch1AndOldValue, scratch2, fn)
-    validateOpcodeConfig(scratch1AndOldValue)
-    if X86_64
-        loadi [mem], scratch1AndOldValue
-    .loop:
-        move scratch1AndOldValue, scratch2
-        fn(value, scratch2)
-        batomicweakcasi scratch1AndOldValue, scratch2, [mem], .loop
-    else
-    .loop:
-        loadlinkacqi [mem], scratch1AndOldValue
-        fn(value, scratch1AndOldValue, scratch2)
-        storecondreli ws2, scratch2, [mem]
-        bineq ws2, 0, .loop
-    end
-end
-
-macro weakCASLoopQuad(mem, value, scratch1AndOldValue, scratch2, fn)
-    validateOpcodeConfig(scratch1AndOldValue)
-    if X86_64
-        loadq [mem], scratch1AndOldValue
-    .loop:
-        move scratch1AndOldValue, scratch2
-        fn(value, scratch2)
-        batomicweakcasq scratch1AndOldValue, scratch2, [mem], .loop
-    else
-    .loop:
-        loadlinkacqq [mem], scratch1AndOldValue
-        fn(value, scratch1AndOldValue, scratch2)
-        storecondrelq ws2, scratch2, [mem]
-        bineq ws2, 0, .loop
-    end
-end
-
 
 ipintAtomicOp(_i32_atomic_store, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgi t3, [t2], t3
-    elsif X86_64
-        atomicxchgi t3, [t2]
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
-    advancePCByReg(t4)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i32_atomic_store_slow_path)
+    doI32AtomicStore(t0, t3, t2, t1)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_store, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgq t3, [t2], t3
-    elsif X86_64
-        atomicxchgq t3, [t2]
-    elsif ARM64
-        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
-    advancePCByReg(t4)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .ipint_i64_atomic_store_slow_path)
+    doI64AtomicStore(t0, t3, t2, t1)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_store8_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgb t3, [t2], t3
-    elsif X86_64
-        atomicxchgb t3, [t2]
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
-    advancePCByReg(t4)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i32_atomic_store8_u_slow_path)
+    doI32AtomicStore8(t0, t3, t2, t1)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_store16_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgh t3, [t2], t3
-    elsif X86_64
-        atomicxchgh t3, [t2]
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
-    advancePCByReg(t4)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i32_atomic_store16_u_slow_path)
+    doI32AtomicStore16(t0, t3, t2, t1)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_store8_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgb t3, [t2], t3
-    elsif X86_64
-        atomicxchgb t3, [t2]
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
-    advancePCByReg(t4)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i64_atomic_store8_u_slow_path)
+    doI64AtomicStore8(t0, t3, t2, t1)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_store16_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgh t3, [t2], t3
-    elsif X86_64
-        atomicxchgh t3, [t2]
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
-    advancePCByReg(t4)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i64_atomic_store16_u_slow_path)
+    doI64AtomicStore16(t0, t3, t2, t1)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_store32_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgi t3, [t2], t3
-    elsif X86_64
-        atomicxchgi t3, [t2]
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
-    advancePCByReg(t4)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i64_atomic_store32_u_slow_path)
+    doI64AtomicStore32(t0, t3, t2, t1)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_add, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgaddi t3, [t2], t0
-    elsif X86_64
-        atomicxchgaddi t3, [t2]
-        move t3, t0
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            addi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i32_atomic_rmw_add_slow_path)
+    doI32AtomicRmwAdd(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_add, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgaddq t3, [t2], t0
-    elsif X86_64
-        atomicxchgaddq t3, [t2]
-        move t3, t0
-    elsif ARM64
-        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            addq value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .ipint_i64_atomic_rmw_add_slow_path)
+    doI64AtomicRmwAdd(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_add_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgaddb t3, [t2], t0
-    elsif X86_64
-        atomicxchgaddb t3, [t2]
-        move t3, t0
-        andi 0xff, t0
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            addi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i32_atomic_rmw8_add_u_slow_path)
+    doI32AtomicRmwAdd8(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_add_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgaddh t3, [t2], t0
-    elsif X86_64
-        atomicxchgaddh t3, [t2]
-        move t3, t0
-        andi 0xffff, t0
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            addi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i32_atomic_rmw16_add_u_slow_path)
+    doI32AtomicRmwAdd16(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_add_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgaddb t3, [t2], t0
-    elsif X86_64
-        atomicxchgaddb t3, [t2]
-        move t3, t0
-        andi 0xff, t0
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            addi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i64_atomic_rmw8_add_u_slow_path)
+    doI64AtomicRmwAdd8(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_add_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgaddh t3, [t2], t0
-    elsif X86_64
-        atomicxchgaddh t3, [t2]
-        move t3, t0
-        andi 0xffff, t0
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            addi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i64_atomic_rmw16_add_u_slow_path)
+    doI64AtomicRmwAdd16(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_add_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgaddi t3, [t2], t0
-    elsif X86_64
-        atomicxchgaddi t3, [t2]
-        move t3, t0
-        ori 0, t0
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            addi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i64_atomic_rmw32_add_u_slow_path)
+    doI64AtomicRmwAdd32(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_sub, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        negi t3
-        atomicxchgaddi t3, [t2], t0
-    elsif X86_64
-        negi t3
-        atomicxchgaddi t3, [t2]
-        move t3, t0
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            subi oldValue, value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i32_atomic_rmw_sub_slow_path)
+    doI32AtomicRmwSub(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_sub, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        negq t3
-        atomicxchgaddq t3, [t2], t0
-    elsif X86_64
-        negq t3
-        atomicxchgaddq t3, [t2]
-        move t3, t0
-    elsif ARM64
-        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            subq oldValue, value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .ipint_i64_atomic_rmw_sub_slow_path)
+    doI64AtomicRmwSub(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_sub_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        negi t3
-        atomicxchgaddb t3, [t2], t0
-    elsif X86_64
-        negi t3
-        atomicxchgaddb t3, [t2]
-        move t3, t0
-        andi 0xff, t0
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            subi oldValue, value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i32_atomic_rmw8_sub_u_slow_path)
+    doI32AtomicRmwSub8(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_sub_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        negi t3
-        atomicxchgaddh t3, [t2], t0
-    elsif X86_64
-        negi t3
-        atomicxchgaddh t3, [t2]
-        move t3, t0
-        andi 0xffff, t0
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            subi oldValue, value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i32_atomic_rmw16_sub_u_slow_path)
+    doI32AtomicRmwSub16(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_sub_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        negq t3
-        atomicxchgaddb t3, [t2], t0
-    elsif X86_64
-        negq t3
-        atomicxchgaddb t3, [t2]
-        move t3, t0
-        andi 0xff, t0
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            subi oldValue, value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i64_atomic_rmw8_sub_u_slow_path)
+    doI64AtomicRmwSub8(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_sub_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        negq t3
-        atomicxchgaddh t3, [t2], t0
-    elsif X86_64
-        negq t3
-        atomicxchgaddh t3, [t2]
-        move t3, t0
-        andi 0xffff, t0
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            subi oldValue, value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i64_atomic_rmw16_sub_u_slow_path)
+    doI64AtomicRmwSub16(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_sub_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        negq t3
-        atomicxchgaddi t3, [t2], t0
-    elsif X86_64
-        negq t3
-        atomicxchgaddi t3, [t2]
-        move t3, t0
-        ori 0, t0
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            subi oldValue, value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i64_atomic_rmw32_sub_u_slow_path)
+    doI64AtomicRmwSub32(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_and, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        noti t3
-        atomicxchgcleari t3, [t2], t0
-    elsif X86_64
-        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
-            andq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            andi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i32_atomic_rmw_and_slow_path)
+    doI32AtomicRmwAnd(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_and, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        notq t3
-        atomicxchgclearq t3, [t2], t0
-    elsif X86_64
-        weakCASLoopQuad(t2, t3, t0, t1, macro (value, dst)
-            andq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            andq value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .ipint_i64_atomic_rmw_and_slow_path)
+    doI64AtomicRmwAnd(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_and_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        noti t3
-        atomicxchgclearb t3, [t2], t0
-    elsif X86_64
-        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
-            andq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            andi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i32_atomic_rmw8_and_u_slow_path)
+    doI32AtomicRmwAnd8(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_and_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        noti t3
-        atomicxchgclearh t3, [t2], t0
-    elsif X86_64
-        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
-            andq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            andi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i32_atomic_rmw16_and_u_slow_path)
+    doI32AtomicRmwAnd16(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_and_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        notq t3
-        atomicxchgclearb t3, [t2], t0
-    elsif X86_64
-        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
-            andq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            andi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i64_atomic_rmw8_and_u_slow_path)
+    doI64AtomicRmwAnd8(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_and_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        notq t3
-        atomicxchgclearh t3, [t2], t0
-    elsif X86_64
-        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
-            andq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            andi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i64_atomic_rmw16_and_u_slow_path)
+    doI64AtomicRmwAnd16(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_and_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        notq t3
-        atomicxchgcleari t3, [t2], t0
-    elsif X86_64
-        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
-            andq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            andi value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i64_atomic_rmw32_and_u_slow_path)
+    doI64AtomicRmwAnd32(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_or, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgori t3, [t2], t0
-    elsif X86_64
-        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
-            ori value, dst
-        end)
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            ori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i32_atomic_rmw_or_slow_path)
+    doI32AtomicRmwOr(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_or, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgorq t3, [t2], t0
-    elsif X86_64
-        weakCASLoopQuad(t2, t3, t0, t1, macro (value, dst)
-            orq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            orq value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .ipint_i64_atomic_rmw_or_slow_path)
+    doI64AtomicRmwOr(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_or_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgorb t3, [t2], t0
-    elsif X86_64
-        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
-            orq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            ori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i32_atomic_rmw8_or_u_slow_path)
+    doI32AtomicRmwOr8(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_or_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgorh t3, [t2], t0
-    elsif X86_64
-        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
-            orq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            ori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i32_atomic_rmw16_or_u_slow_path)
+    doI32AtomicRmwOr16(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_or_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgorb t3, [t2], t0
-    elsif X86_64
-        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
-            orq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            ori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i64_atomic_rmw8_or_u_slow_path)
+    doI64AtomicRmwOr8(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_or_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgorh t3, [t2], t0
-    elsif X86_64
-        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
-            orq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            ori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i64_atomic_rmw16_or_u_slow_path)
+    doI64AtomicRmwOr16(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_or_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgori t3, [t2], t0
-    elsif X86_64
-        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
-            orq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            ori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i64_atomic_rmw32_or_u_slow_path)
+    doI64AtomicRmwOr32(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_xor, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgxori t3, [t2], t0
-    elsif X86_64
-        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
-            xorq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            xori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i32_atomic_rmw_xor_slow_path)
+    doI32AtomicRmwXor(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_xor, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgxorq t3, [t2], t0
-    elsif X86_64
-        weakCASLoopQuad(t2, t3, t0, t1, macro (value, dst)
-            xorq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            xorq value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .ipint_i64_atomic_rmw_xor_slow_path)
+    doI64AtomicRmwXor(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_xor_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgxorb t3, [t2], t0
-    elsif X86_64
-        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
-            xorq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            xori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i32_atomic_rmw8_xor_u_slow_path)
+    doI32AtomicRmwXor8(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_xor_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgxorh t3, [t2], t0
-    elsif X86_64
-        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
-            xorq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            xori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i32_atomic_rmw16_xor_u_slow_path)
+    doI32AtomicRmwXor16(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_xor_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgxorb t3, [t2], t0
-    elsif X86_64
-        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
-            xorq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            xori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i64_atomic_rmw8_xor_u_slow_path)
+    doI64AtomicRmwXor8(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_xor_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgxorh t3, [t2], t0
-    elsif X86_64
-        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
-            xorq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            xori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i64_atomic_rmw16_xor_u_slow_path)
+    doI64AtomicRmwXor16(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_xor_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgxori t3, [t2], t0
-    elsif X86_64
-        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
-            xorq value, dst
-        end)
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            xori value, oldValue, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i64_atomic_rmw32_xor_u_slow_path)
+    doI64AtomicRmwXor32(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_xchg, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgi t3, [t2], t0
-    elsif X86_64
-        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
-            move value, dst
-        end)
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i32_atomic_rmw_xchg_slow_path)
+    doI32AtomicRmwXchg(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_xchg, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgq t3, [t2], t0
-    elsif X86_64
-        weakCASLoopQuad(t2, t3, t0, t1, macro (value, dst)
-            move value, dst
-        end)
-    elsif ARM64
-        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .ipint_i64_atomic_rmw_xchg_slow_path)
+    doI64AtomicRmwXchg(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_xchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgb t3, [t2], t0
-    elsif X86_64
-        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
-            move value, dst
-        end)
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i32_atomic_rmw8_xchg_u_slow_path)
+    doI32AtomicRmwXchg8(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_xchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgh t3, [t2], t0
-    elsif X86_64
-        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
-            move value, dst
-        end)
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i32_atomic_rmw16_xchg_u_slow_path)
+    doI32AtomicRmwXchg16(t0, t3, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_xchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgb t3, [t2], t0
-    elsif X86_64
-        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
-            move value, dst
-        end)
-    elsif ARM64
-        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i64_atomic_rmw8_xchg_u_slow_path)
+    doI64AtomicRmwXchg8(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_xchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgh t3, [t2], t0
-    elsif X86_64
-        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
-            move value, dst
-        end)
-    elsif ARM64
-        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i64_atomic_rmw16_xchg_u_slow_path)
+    doI64AtomicRmwXchg16(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_xchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    if ARM64E
-        atomicxchgi t3, [t2], t0
-    elsif X86_64
-        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
-            move value, dst
-        end)
-    elsif ARM64
-        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
-            move value, newValue
-        end)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i64_atomic_rmw32_xchg_u_slow_path)
+    doI64AtomicRmwXchg32(t0, t3, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -10011,20 +10303,10 @@ ipintAtomicOp(_i32_atomic_rmw_cmpxchg, macro()
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    move t3, t0
-    andq 0xffffffff, t0
-    if ARM64E or X86_64
-        atomicweakcasi t0, t7, [t2]
-    elsif ARM64
-        weakCASExchangeInt(t2, t7, t0, t1, t3)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i32_atomic_rmw_cmpxchg_slow_path)
+    doI32AtomicCmpxchg(t0, t3, t7, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -10034,19 +10316,10 @@ ipintAtomicOp(_i64_atomic_rmw_cmpxchg, macro()
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    move t3, t0
-    if ARM64E or X86_64
-        atomicweakcasq t0, t7, [t2]
-    elsif ARM64
-        weakCASExchangeQuad(t2, t7, t0, t1, t3)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .ipint_i64_atomic_rmw_cmpxchg_slow_path)
+    doI64AtomicCmpxchg(t0, t3, t7, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -10056,20 +10329,10 @@ ipintAtomicOp(_i32_atomic_rmw8_cmpxchg_u, macro()
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    move t3, t0
-    andq 0xff, t0
-    if ARM64E or X86_64
-        atomicweakcasb t0, t7, [t2]
-    elsif ARM64
-        weakCASExchangeByte(t2, t7, t0, t1, t3)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i32_atomic_rmw8_cmpxchg_u_slow_path)
+    doI32AtomicCmpxchg8(t0, t3, t7, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -10079,20 +10342,10 @@ ipintAtomicOp(_i32_atomic_rmw16_cmpxchg_u, macro()
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    move t3, t0
-    andq 0xffff, t0
-    if ARM64E or X86_64
-        atomicweakcash t0, t7, [t2]
-    elsif ARM64
-        weakCASExchangeHalf(t2, t7, t0, t1, t3)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i32_atomic_rmw16_cmpxchg_u_slow_path)
+    doI32AtomicCmpxchg16(t0, t3, t7, t2, t1)
     pushInt32(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -10102,20 +10355,10 @@ ipintAtomicOp(_i64_atomic_rmw8_cmpxchg_u, macro()
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    move t3, t0
-    andq 0xff, t0
-    if ARM64E or X86_64
-        atomicweakcasb t0, t7, [t2]
-    elsif ARM64
-        weakCASExchangeByte(t2, t7, t0, t1, t3)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .ipint_i64_atomic_rmw8_cmpxchg_u_slow_path)
+    doI64AtomicCmpxchg8(t0, t3, t7, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -10125,20 +10368,10 @@ ipintAtomicOp(_i64_atomic_rmw16_cmpxchg_u, macro()
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    move t3, t0
-    andq 0xffff, t0
-    if ARM64E or X86_64
-        atomicweakcash t0, t7, [t2]
-    elsif ARM64
-        weakCASExchangeHalf(t2, t7, t0, t1, t3)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .ipint_i64_atomic_rmw16_cmpxchg_u_slow_path)
+    doI64AtomicCmpxchg16(t0, t3, t7, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -10148,20 +10381,10 @@ ipintAtomicOp(_i64_atomic_rmw32_cmpxchg_u, macro()
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
-    atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
-    move t0, t2
-    move t3, t0
-    andq 0xffffffff, t0
-    if ARM64E or X86_64
-        atomicweakcasi t0, t7, [t2]
-    elsif ARM64
-        weakCASExchangeInt(t2, t7, t0, t1, t3)
-    else
-        error
-    end
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .ipint_i64_atomic_rmw32_cmpxchg_u_slow_path)
+    doI64AtomicCmpxchg32(t0, t3, t7, t2, t1)
     pushInt64(t0)
-    advancePCByReg(t4)
+    leap 2[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -10597,6 +10820,464 @@ end
     addp V128ISize, sp
     storeq t1, [t0]
     leap 1[t4], PC
+    nextIPIntInstruction()
+
+#########################################################
+## Out-of-line slow paths for atomic memory operations ##
+#########################################################
+
+# t0 = wasm address (from popMemoryIndex before branching).
+# t4 = cursor pointing to start of memarg (past atomic sub-opcode, set by atomic_prefix).
+# t3 = data value (for store/RMW ops, survives loadStoreMakePointerSlow).
+# t7 = new value for CAS (must be push/popped around loadStoreMakePointerSlow).
+# After loadStoreMakePointerSlow, t4 points past the memarg.
+
+.ipint_i32_atomic_load_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI32AtomicLoad(t0, t2)
+    pushInt32(t2)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_load_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    doI64AtomicLoad(t0, t2)
+    pushInt64(t2)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_load8_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI32AtomicLoad8(t0, t2)
+    pushInt32(t2)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_load16_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI32AtomicLoad16(t0, t2)
+    pushInt32(t2)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_load8_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI64AtomicLoad8(t0, t2)
+    pushInt64(t2)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_load16_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI64AtomicLoad16(t0, t2)
+    pushInt64(t2)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_load32_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI64AtomicLoad32(t0, t2)
+    pushInt64(t2)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_store_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI32AtomicStore(t0, t3, t2, t1)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_store_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    doI64AtomicStore(t0, t3, t2, t1)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_store8_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI32AtomicStore8(t0, t3, t2, t1)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_store16_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI32AtomicStore16(t0, t3, t2, t1)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_store8_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI64AtomicStore8(t0, t3, t2, t1)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_store16_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI64AtomicStore16(t0, t3, t2, t1)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_store32_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI64AtomicStore32(t0, t3, t2, t1)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw_add_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI32AtomicRmwAdd(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw_add_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    doI64AtomicRmwAdd(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw8_add_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI32AtomicRmwAdd8(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw16_add_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI32AtomicRmwAdd16(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw8_add_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI64AtomicRmwAdd8(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw16_add_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI64AtomicRmwAdd16(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw32_add_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI64AtomicRmwAdd32(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw_sub_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI32AtomicRmwSub(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw_sub_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    doI64AtomicRmwSub(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw8_sub_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI32AtomicRmwSub8(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw16_sub_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI32AtomicRmwSub16(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw8_sub_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI64AtomicRmwSub8(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw16_sub_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI64AtomicRmwSub16(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw32_sub_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI64AtomicRmwSub32(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw_and_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI32AtomicRmwAnd(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw_and_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    doI64AtomicRmwAnd(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw8_and_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI32AtomicRmwAnd8(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw16_and_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI32AtomicRmwAnd16(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw8_and_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI64AtomicRmwAnd8(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw16_and_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI64AtomicRmwAnd16(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw32_and_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI64AtomicRmwAnd32(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw_or_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI32AtomicRmwOr(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw_or_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    doI64AtomicRmwOr(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw8_or_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI32AtomicRmwOr8(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw16_or_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI32AtomicRmwOr16(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw8_or_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI64AtomicRmwOr8(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw16_or_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI64AtomicRmwOr16(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw32_or_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI64AtomicRmwOr32(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw_xor_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI32AtomicRmwXor(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw_xor_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    doI64AtomicRmwXor(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw8_xor_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI32AtomicRmwXor8(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw16_xor_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI32AtomicRmwXor16(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw8_xor_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI64AtomicRmwXor8(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw16_xor_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI64AtomicRmwXor16(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw32_xor_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI64AtomicRmwXor32(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw_xchg_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI32AtomicRmwXchg(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw_xchg_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    doI64AtomicRmwXchg(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw8_xchg_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI32AtomicRmwXchg8(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw16_xchg_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI32AtomicRmwXchg16(t0, t3, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw8_xchg_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    doI64AtomicRmwXchg8(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw16_xchg_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    doI64AtomicRmwXchg16(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw32_xchg_u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    doI64AtomicRmwXchg32(t0, t3, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw_cmpxchg_slow_path:
+    push t3, t7
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    pop t7, t3
+    doI32AtomicCmpxchg(t0, t3, t7, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw_cmpxchg_slow_path:
+    push t3, t7
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    pop t7, t3
+    doI64AtomicCmpxchg(t0, t3, t7, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw8_cmpxchg_u_slow_path:
+    push t3, t7
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    pop t7, t3
+    doI32AtomicCmpxchg8(t0, t3, t7, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i32_atomic_rmw16_cmpxchg_u_slow_path:
+    push t3, t7
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    pop t7, t3
+    doI32AtomicCmpxchg16(t0, t3, t7, t2, t1)
+    pushInt32(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw8_cmpxchg_u_slow_path:
+    push t3, t7
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    pop t7, t3
+    doI64AtomicCmpxchg8(t0, t3, t7, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw16_cmpxchg_u_slow_path:
+    push t3, t7
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    pop t7, t3
+    doI64AtomicCmpxchg16(t0, t3, t7, t2, t1)
+    pushInt64(t0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.ipint_i64_atomic_rmw32_cmpxchg_u_slow_path:
+    push t3, t7
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    pop t7, t3
+    doI64AtomicCmpxchg32(t0, t3, t7, t2, t1)
+    pushInt64(t0)
+    move t4, PC
     nextIPIntInstruction()
 
 ##################################

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -1121,30 +1121,26 @@ IPIntGenerator::ExpressionType IPIntGenerator::addSIMDConstant(v128_t)
 
 // Atomics
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t offset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t, uint8_t)
 {
-    m_metadata->addAtomicMemoryAccess(memoryIndex, offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t offset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t, uint8_t)
 {
     changeStackSize(-2);
-    m_metadata->addAtomicMemoryAccess(memoryIndex, offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t)
 {
     changeStackSize(-1);
-    m_metadata->addAtomicMemoryAccess(memoryIndex, offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t)
 {
     changeStackSize(-2);
-    m_metadata->addAtomicMemoryAccess(memoryIndex, offset, getCurrentInstructionLength());
     return { };
 }
 
@@ -1164,7 +1160,6 @@ IPIntGenerator::ExpressionType IPIntGenerator::addSIMDConstant(v128_t)
 
 [[nodiscard]] PartialResult IPIntGenerator::atomicFence(ExtAtomicOpType, uint8_t)
 {
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 


### PR DESCRIPTION
#### ef40cabc28d25081afe7474d263f089752cedc2d
<pre>
[JSC] Atomic instructions in IPInt should not have metadata if it does not call functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=312227">https://bugs.webkit.org/show_bug.cgi?id=312227</a>
<a href="https://rdar.apple.com/174706330">rdar://174706330</a>

Reviewed by Keith Miller.

This patch drops most of metadata for atomic instructions by using the
same mechanism in normal load/store and SIMD load/store. We add a fast
path and a slow path which handles complicated LEB decoding completely.
Also now pointer construction code is completely unified by using the
helper macros defined for fast and slow path of these memory related
operations.

* JSTests/wasm/stress/atomic-cmpxchg-large-offset.js: Added.
(async test):
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::atomicLoad):
(JSC::Wasm::IPIntGenerator::atomicStore):
(JSC::Wasm::IPIntGenerator::atomicBinaryRMW):
(JSC::Wasm::IPIntGenerator::atomicCompareExchange):
(JSC::Wasm::IPIntGenerator::atomicFence):

Canonical link: <a href="https://commits.webkit.org/311183@main">https://commits.webkit.org/311183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/252b55a6005cafd83c923caaf75bfe6e575c7401

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165075 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120999 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101670 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12847 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148304 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167554 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17089 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11670 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19761 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129123 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129236 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139942 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86879 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23782 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24060 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16741 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188137 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28821 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92778 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48369 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28348 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28576 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28472 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->