### PR TITLE
Provide a mechanism to get source location for worker scripts, similar to Document::scriptableDocumentParser

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1163,9 +1163,6 @@ imported/w3c/web-platform-tests/css/css-ui/caret-color-020.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/svg/scripted.svg [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/svg/including.sub.svg [ Skip ]
 
-# FIXME (304193): CSP violation reporting from workers is not yet supported.
-imported/w3c/web-platform-tests/content-security-policy/reporting-api/dedicated-worker-correct-url-in-report.html [ Skip ]
-
 # Skip Content Security Policy tests that time out
 imported/w3c/web-platform-tests/content-security-policy/child-src/child-src-cross-origin-load.sub.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-cross-none-block.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-from-guid.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-from-guid.sub-expected.txt
@@ -1,5 +1,5 @@
 This test loads a worker, from a guid. The worker should be blocked from making an XHR to www1 as this resource's policy is connect-src 'self and a guid Worker should inherit is parent's policy. A report should be sent to the report-uri specified with this resource.
 
 
-FAIL Expecting logs: ["violated-directive=connect-src","xhr blocked","TEST COMPLETE"] assert_unreached: Logging timeout, expected logs violated-directive=connect-src not sent. Reached unreachable code
+PASS Expecting logs: ["violated-directive=connect-src","xhr blocked","TEST COMPLETE"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inside-worker/dedicatedworker-worker-src-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inside-worker/dedicatedworker-worker-src-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Nested worker with worker-src is disallowed. Test timed out
+PASS Nested worker with worker-src is disallowed.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/dedicated-worker-correct-url-in-report-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/dedicated-worker-correct-url-in-report-expected.txt
@@ -1,0 +1,6 @@
+
+PASS dedicated-worker-correct-url-in-report
+PASS dedicated-worker-correct-url-in-report 1
+PASS URL in report should point to worker where violation occurs
+PASS URL in report should point to worker where violation occurs' (with redirect)'
+

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -57,6 +57,7 @@
 #include "SecurityPolicyViolationEvent.h"
 #include "Settings.h"
 #include "SubresourceIntegrity.h"
+#include "TaskSource.h"
 #include "ViolationReportType.h"
 #include "WorkerGlobalScope.h"
 #include <JavaScriptCore/HeapCellInlines.h>
@@ -920,7 +921,6 @@ void ContentSecurityPolicy::reportViolation(const String& effectiveViolatedDirec
     if (!m_isReportingEnabled)
         return;
 
-    // FIXME: Support sending reports from worker.
     CSPInfo info;
 
     bool usesReportTo = !violatedDirectiveList.reportToTokens().isEmpty();
@@ -942,12 +942,16 @@ void ContentSecurityPolicy::reportViolation(const String& effectiveViolatedDirec
         info.columnNumber = sourcePosition.m_column.oneBasedInt();
     }
 
+    RefPtr document = dynamicDowncast<Document>(m_scriptExecutionContext.get());
+
     if (!m_client) {
-        RefPtr<Document> document = dynamicDowncast<Document>(m_scriptExecutionContext.get());
-        if (!document || !document->frame())
+        if (document && !document->frame())
             return;
 
-        info.documentURI = shouldReportProtocolOnly(document->url()) ? document->url().protocol().toString() : document->url().strippedForUseAsReferrer().string;
+        if (m_scriptExecutionContext) {
+            auto& contextURL = m_scriptExecutionContext->url();
+            info.documentURI = shouldReportProtocolOnly(contextURL) ? contextURL.protocol().toString() : contextURL.strippedForUseAsReferrer().string;
+        }
 
         auto stack = createScriptCallStack(JSExecState::currentState(), 2);
         auto* callFrame = stack->firstNonNativeCallFrame();
@@ -957,7 +961,7 @@ void ContentSecurityPolicy::reportViolation(const String& effectiveViolatedDirec
             info.columnNumber = callFrame->columnNumber();
         }
     }
-    ASSERT(m_client || is<Document>(m_scriptExecutionContext.get()));
+    ASSERT(m_client || m_scriptExecutionContext);
 
     // FIXME: Is it policy to not use the status code for HTTPS, or is that a bug?
     unsigned short httpStatusCode = m_selfSourceProtocol == "http"_s ? m_httpStatusCode : 0;
@@ -999,12 +1003,18 @@ void ContentSecurityPolicy::reportViolation(const String& effectiveViolatedDirec
 
     if (m_client)
         m_client->enqueueSecurityPolicyViolationEvent(WTF::move(violationEventInit));
-    else {
-        Ref document = downcast<Document>(*m_scriptExecutionContext);
-        if (element && &element->document() == document.ptr())
-            element->enqueueSecurityPolicyViolationEvent(WTF::move(violationEventInit));
-        else
-            document->enqueueSecurityPolicyViolationEvent(WTF::move(violationEventInit));
+    else if (m_scriptExecutionContext) {
+        if (document) {
+            if (element && &element->document() == document.get())
+                element->enqueueSecurityPolicyViolationEvent(WTF::move(violationEventInit));
+            else
+                document->enqueueSecurityPolicyViolationEvent(WTF::move(violationEventInit));
+        } else if (RefPtr workerScope = dynamicDowncast<WorkerGlobalScope>(m_scriptExecutionContext.get())) {
+            // Workers dispatch the violation event on the global scope.
+            workerScope->eventLoop().queueTask(TaskSource::DOMManipulation, [workerScope, violationEventInit = WTF::move(violationEventInit)]() mutable {
+                workerScope->dispatchEvent(SecurityPolicyViolationEvent::create(eventNames().securitypolicyviolationEvent, WTF::move(violationEventInit), Event::IsTrusted::Yes));
+            });
+        }
     }
 
     // 2. Send violation report (if applicable).

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -46,11 +46,13 @@
 #include "ImageBitmapOptions.h"
 #include "InspectorInstrumentation.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSExecState.h"
 #include "Logging.h"
 #include "NotImplemented.h"
 #include "Performance.h"
 #include "RTCDataChannelRemoteHandlerConnection.h"
 #include "ReportingScope.h"
+#include "ResourceRequest.h"
 #include "ScheduledAction.h"
 #include "ScriptExecutionContextInlines.h"
 #include "ScriptSourceCode.h"
@@ -60,6 +62,7 @@
 #include "ServiceWorkerClientData.h"
 #include "ServiceWorkerGlobalScope.h"
 #include "SocketProvider.h"
+#include "ThreadableLoader.h"
 #include "TrustedType.h"
 #include "URLKeepingBlobAlive.h"
 #include "ViolationReportType.h"
@@ -80,6 +83,7 @@
 #include "WorkerThread.h"
 #include <JavaScriptCore/ScriptArguments.h>
 #include <JavaScriptCore/ScriptCallStack.h>
+#include <JavaScriptCore/ScriptCallStackFactory.h>
 #include <wtf/Lock.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WorkQueue.h>
@@ -436,9 +440,15 @@ ExceptionOr<void> WorkerGlobalScope::importScripts(const FixedVector<Variant<Ref
     for (auto& url : completedURLs) {
         // FIXME: Convert this to check the isolated world's Content Security Policy once webkit.org/b/104520 is solved.
         bool shouldBypassMainWorldContentSecurityPolicy = this->shouldBypassMainWorldContentSecurityPolicy();
-        // FIXME: Provide a source location for the blocked script URL load request.
-        if (!shouldBypassMainWorldContentSecurityPolicy && !protect(contentSecurityPolicy())->allowScriptFromSource(url, { }))
-            return Exception { ExceptionCode::NetworkError };
+        if (!shouldBypassMainWorldContentSecurityPolicy) {
+            auto stack = Inspector::createScriptCallStack(JSExecState::currentState(), 1);
+            auto* callFrame = stack->firstNonNativeCallFrame();
+            std::optional<TextPosition> sourcePosition;
+            if (callFrame && callFrame->lineNumber())
+                sourcePosition = TextPosition(OrdinalNumber::fromOneBasedInt(callFrame->lineNumber()), OrdinalNumber::fromOneBasedInt(callFrame->columnNumber()));
+            if (!protect(contentSecurityPolicy())->allowScriptFromSource(url, WTF::move(sourcePosition)))
+                return Exception { ExceptionCode::NetworkError };
+        }
 
         auto scriptLoader = WorkerScriptLoader::create();
         auto cspEnforcement = shouldBypassMainWorldContentSecurityPolicy ? ContentSecurityPolicyEnforcement::DoNotEnforce : ContentSecurityPolicyEnforcement::EnforceScriptSrcDirective;
@@ -769,9 +779,54 @@ String WorkerGlobalScope::endpointURIForToken(const String& token) const
     return reportingScope().endpointURIForToken(token);
 }
 
-void WorkerGlobalScope::sendReportToEndpoints(const URL&, std::span<const String> /*endpointURIs*/, std::span<const String> /*endpointTokens*/, Ref<FormData>&&, ViolationReportType)
+// A minimal ThreadableLoaderClient for fire-and-forget report delivery.
+// All callbacks are no-ops; the keepAlive option keeps the load alive.
+class ReportDeliveryClient final : public ThreadableLoaderClient {
+    void ref() const final { }
+    void deref() const final { }
+};
+
+void WorkerGlobalScope::sendReportToEndpoints(const URL& baseURL, std::span<const String> endpointURIs, std::span<const String> endpointTokens, Ref<FormData>&& report, ViolationReportType reportType)
 {
-    notImplemented();
+    Vector<URL> resolvedURLs;
+    for (auto& uri : endpointURIs)
+        resolvedURLs.append(URL { baseURL, uri });
+    for (auto& token : endpointTokens) {
+        if (auto uri = endpointURIForToken(token); !uri.isEmpty())
+            resolvedURLs.append(URL { baseURL, uri });
+    }
+
+    static NeverDestroyed<ReportDeliveryClient> client;
+
+    for (auto& reportURL : resolvedURLs) {
+        ResourceRequest request { URL { reportURL } };
+        request.setHTTPMethod("POST"_s);
+        request.setHTTPBody(report.copyRef());
+
+        if (reportType == ViolationReportType::ContentSecurityPolicy)
+            request.setHTTPContentType("application/csp-report"_s);
+        else
+            request.setHTTPContentType("application/reports+json"_s);
+
+        bool isSameOrigin = securityOrigin() && securityOrigin()->isSameSchemeHostPort(SecurityOrigin::create(reportURL).get());
+        if (!isSameOrigin)
+            request.setAllowCookies(false);
+
+        ThreadableLoaderOptions options;
+        options.contentSecurityPolicyEnforcement = ContentSecurityPolicyEnforcement::DoNotEnforce;
+        options.keepAlive = true;
+        options.cache = FetchOptions::Cache::NoCache;
+        options.redirect = FetchOptions::Redirect::Error;
+
+        if (reportType != ViolationReportType::ContentSecurityPolicy) {
+            options.credentials = FetchOptions::Credentials::SameOrigin;
+            options.mode = FetchOptions::Mode::Cors;
+            options.serviceWorkersMode = ServiceWorkersMode::None;
+            options.destination = FetchOptions::Destination::Report;
+        }
+
+        ThreadableLoader::create(*this, client.get(), WTF::move(request), options);
+    }
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### b3f4fe9145680bed63fa3ef49979835cdceb412a
<pre>
Provide a mechanism to get source location for worker scripts, similar to Document::scriptableDocumentParser
<a href="https://bugs.webkit.org/show_bug.cgi?id=304193">https://bugs.webkit.org/show_bug.cgi?id=304193</a>
<a href="https://rdar.apple.com/174690653">rdar://174690653</a>

Reviewed by NOBODY (OOPS!).

This patch updates Worker Content Security Policy logic to generate Reporting API
reports and to emit SecurityPolicyViolationEvents when CSP violations were encountered.

Tests: imported/w3c/web-platform-tests/content-security-policy/inside-worker/dedicatedworker-worker-src.html
       imported/w3c/web-platform-tests/content-security-policy/reporting-api/dedicated-worker-correct-url-in-report.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/worker-from-guid.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inside-worker/dedicatedworker-worker-src-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/dedicated-worker-correct-url-in-report-expected.txt: Added.
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::reportViolation const): Update to handle Worker event dispatching
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::importScripts): Adopt source position logic for reporting.
(WebCore::WorkerGlobalScope::sendReportToEndpoints): Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3f4fe9145680bed63fa3ef49979835cdceb412a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165046 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110305 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29563 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120974 "Found 2 new test failures: imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-create-policy.html imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-sink-mismatch.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85125 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101646 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22259 "4 new passes 1 flakes 1 failures") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20420 "Found 1 new API test failure: TestWebKitAPI.SOAuthorizationSubFrame.InterceptionSucceedWithCookieButCSPDeny (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12818 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167525 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11641 "Found 5 new failures in workers/WorkerGlobalScope.cpp, page/csp/ContentSecurityPolicy.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19732 "Found 2 new test failures: imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-create-policy.html imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-sink-mismatch.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129092 "Found 2 new test failures: imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-create-policy.html imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-sink-mismatch.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29161 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24482 "Found 3 new test failures: imported/w3c/web-platform-tests/background-fetch/content-security-policy.https.window.html imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-create-policy.html imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-sink-mismatch.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129209 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139913 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86850 "Hash b3f4fe91 for PR 62700 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24033 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16712 "Found 2 new test failures: imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-create-policy.html imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-sink-mismatch.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28792 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92749 "Found 5 new failures in workers/WorkerGlobalScope.cpp, page/csp/ContentSecurityPolicy.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28319 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28547 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28443 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->