### PR TITLE
GPU process leaks RemoteRenderingBackend due to retain cycle with RemoteDisplayListRecorder and RemoteSnapshotRecorder maps

### DIFF
--- a/LayoutTests/ipc/display-list-recorder-leak-expected.txt
+++ b/LayoutTests/ipc/display-list-recorder-leak-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash. Check --leaks output for RemoteRenderingBackend leak.

--- a/LayoutTests/ipc/display-list-recorder-leak.html
+++ b/LayoutTests/ipc/display-list-recorder-leak.html
@@ -1,0 +1,69 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<!--
+    rdar://174706941
+    Test for RemoteRenderingBackend leak via unsunk RemoteDisplayListRecorder
+    entries in m_remoteDisplayListRecorders.
+
+    workQueueUninitialize() clears m_remoteImageBuffers and
+    m_remoteImageBufferSets but not m_remoteDisplayListRecorders.
+    RemoteDisplayListRecorder holds a Ref<RemoteRenderingBackend> via its
+    RemoteGraphicsContext base class, creating a retain cycle that leaks
+    the backend when recorders are present at teardown.
+
+    Run with: run-webkit-tests --leaks --debug ipc/display-list-recorder-leak.html
+    Expect "leaks found" for RemoteRenderingBackend / RemoteDisplayListRecorder
+    objects in the GPU process if the bug is present.
+-->
+<p>PASS if no crash. Check --leaks output for RemoteRenderingBackend leak.</p>
+<script src="../resources/ipc.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.setTimeout(async () => {
+    if (!window.IPC) { window.testRunner?.notifyDone(); return; }
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const renderingBackendIdentifier = randomIPCID();
+    const connection = CoreIPC.newStreamConnection();
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+        renderingBackendIdentifier,
+        connectionHandle: connection
+    });
+    const remoteBackend = connection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+    const didInit = connection.connection.waitForMessage(renderingBackendIdentifier,
+        IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1);
+    connection.connection.setSemaphores(didInit[0].value, didInit[1].value);
+
+    // Create display list recorders without sinking them.
+    // Each CreateDisplayListRecorder adds an entry to
+    // m_remoteDisplayListRecorders with a ScopedActiveMessageReceiveQueue
+    // holding a Ref<RemoteDisplayListRecorder>, which in turn holds a
+    // Ref<RemoteRenderingBackend> (via RemoteGraphicsContext base class).
+    //
+    // When the connection is invalidated, workQueueUninitialize() does NOT
+    // clear m_remoteDisplayListRecorders, so these entries form a retain
+    // cycle that prevents the RemoteRenderingBackend from being freed.
+    for (let i = 0; i < 10; ++i) {
+        const id = randomIPCID();
+        remoteBackend.CreateDisplayListRecorder({ identifier: id });
+    }
+
+    // Explicitly release the rendering backend via IPC. This triggers
+    // GPUConnectionToWebProcess::releaseRenderingBackend() which destroys
+    // the ScopedActiveMessageReceiveQueue, calling stopListeningForIPC()
+    // then workQueueUninitialize(). Without the fix, the display list
+    // recorders remain in the map, forming a retain cycle that prevents
+    // the RemoteRenderingBackend from being freed.
+    CoreIPC.GPU.GPUConnectionToWebProcess.ReleaseRenderingBackend(0, {
+        renderingBackendIdentifier
+    });
+
+    // Give the GPU process time to process the release, then finish.
+    connection.connection.invalidate();
+    setTimeout(() => window.testRunner?.notifyDone(), 500);
+}, 0);
+</script>

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -159,6 +159,8 @@ void RemoteRenderingBackend::workQueueUninitialize()
     assertIsCurrent(workQueue());
     m_remoteImageBuffers.clear();
     m_remoteImageBufferSets.clear();
+    m_remoteDisplayListRecorders.clear();
+    m_remoteSnapshotRecorders.clear();
     // Make sure we destroy the ResourceCache on the WorkQueue since it gets populated on the WorkQueue.
     m_remoteResourceCache.releaseAllResources();
 


### PR DESCRIPTION
#### 0de81382cce8cbc2f85c06a21cb277a0d17666d4
<pre>
GPU process leaks RemoteRenderingBackend due to retain cycle with RemoteDisplayListRecorder and RemoteSnapshotRecorder maps
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=312228">https://bugs.webkit.org/show_bug.cgi?id=312228</a>&gt;
&lt;<a href="https://rdar.apple.com/174706941">rdar://174706941</a>&gt;

Reviewed by Matt Woodrow.

Clear `m_remoteDisplayListRecorders` and `m_remoteSnapshotRecorders`
in `workQueueUninitialize()` to break a retain cycle that leaks the
`RemoteRenderingBackend` and all its unsunk recorders.

Each `RemoteDisplayListRecorder` and `RemoteSnapshotRecorder` holds
a `Ref&lt;RemoteRenderingBackend&gt;` via the `RemoteGraphicsContext` base
class.  When `workQueueUninitialize()` runs during backend teardown,
the existing code clears `m_remoteImageBuffers` and
`m_remoteImageBufferSets` (breaking their cycles) but not the
recorder maps.  The surviving `Ref` back-references keep the
backend&apos;s reference count above zero, so the backend, its
`StreamServerConnection`, `StreamConnectionWorkQueue`, and all
remaining recorders are never freed.

The `m_remoteDisplayListRecorders` map was introduced in Bug 297727
(299747@main) and `m_remoteSnapshotRecorders` in Bug 282664
(300358@main); neither added the corresponding `clear()` call.

Add layout test that creates unsunk display list recorders via the
IPC Testing API and explicitly releases the rendering backend.  Run
with `--leaks` to verify the retain cycle is broken; without the
fix, the `leaks` tool reports a `ROOT CYCLE` through
`RemoteRenderingBackend` and `RemoteDisplayListRecorder`.

* LayoutTests/ipc/display-list-recorder-leak-expected.txt: Add.
* LayoutTests/ipc/display-list-recorder-leak.html: Add.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::workQueueUninitialize):

Canonical link: <a href="https://commits.webkit.org/311189@main">https://commits.webkit.org/311189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/539f4571e7dcf751f96e4df889e3d59c397ee9dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165047 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120973 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101645 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12819 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167526 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11642 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19733 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129093 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129210 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139914 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86851 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23785 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24032 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16713 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28793 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92750 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28320 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28548 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28444 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->