### PR TITLE
CloseWebViewAfterEnterFullscreen API tests may sometimes timeout

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -181,6 +181,16 @@ void WebFullScreenManagerProxy::close()
 void WebFullScreenManagerProxy::detachFromClient()
 {
     close();
+
+    // If we were in fullscreen, notify the client that fullscreen has exited,
+    // since the normal IPC round-trip through the web process won't complete
+    // after the page is closed.
+    if (m_fullscreenState != FullscreenState::NotInFullscreen) {
+        m_fullscreenState = FullscreenState::NotInFullscreen;
+        if (RefPtr page = m_page.get())
+            page->fullscreenClient().didExitFullscreen(page.get());
+    }
+
     m_client = nullptr;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CloseWebViewAfterEnterFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CloseWebViewAfterEnterFullscreen.mm
@@ -68,14 +68,16 @@ TEST(CloseWebViewAfterEnterFullscreen, VideoFullscreen)
     [webView synchronouslyLoadHTMLString:@"<video src=\"video-with-audio.mp4\" controls></video>"];
 
     didEnterFullscreen = false;
-    [webView evaluateJavaScript:@"document.querySelector('video').webkitEnterFullscreen()" completionHandler: nil];
+    didExitFullscreen = false;
+
+    [webView evaluateJavaScript:@"document.querySelector('video').webkitEnterFullscreen()" completionHandler:nil];
     TestWebKitAPI::Util::run(&didEnterFullscreen);
-    ASSERT_TRUE(didEnterFullscreen);
 
     // Should not crash:
     [webView _close];
-}
 
+    TestWebKitAPI::Util::run(&didExitFullscreen);
+}
 
 TEST(CloseWebViewAfterEnterFullscreen, ElementFullscreen)
 {
@@ -88,12 +90,15 @@ TEST(CloseWebViewAfterEnterFullscreen, ElementFullscreen)
     [webView synchronouslyLoadHTMLString:@"<div style=\"width:100px;height:100px;background-color:red;\"></div>"];
 
     didEnterFullscreen = false;
-    [webView evaluateJavaScript:@"document.querySelector('div').webkitRequestFullscreen()" completionHandler: nil];
+    didExitFullscreen = false;
+
+    [webView evaluateJavaScript:@"document.querySelector('div').webkitRequestFullscreen()" completionHandler:nil];
     TestWebKitAPI::Util::run(&didEnterFullscreen);
-    ASSERT_TRUE(didEnterFullscreen);
 
     // Should not crash:
     [webView _close];
+
+    TestWebKitAPI::Util::run(&didExitFullscreen);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### a8a3e445d53b440be0636a7858fa70f34835baf1
<pre>
CloseWebViewAfterEnterFullscreen API tests may sometimes timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=312230">https://bugs.webkit.org/show_bug.cgi?id=312230</a>
<a href="https://rdar.apple.com/174708985">rdar://174708985</a>

Reviewed by Jer Noble.

These tests were not waiting for full screen to exit. Fix by modifying the tests to do so, and also
fix an underlying issue where the delegate callback was not getting called in the first place since
the normal IPC round-trip through the web process won&apos;t complete after the page is closed.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CloseWebViewAfterEnterFullscreen.mm

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::detachFromClient):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CloseWebViewAfterEnterFullscreen.mm:
(TestWebKitAPI::TEST(CloseWebViewAfterEnterFullscreen, VideoFullscreen)):
(TestWebKitAPI::TEST(CloseWebViewAfterEnterFullscreen, ElementFullscreen)):

Canonical link: <a href="https://commits.webkit.org/311176@main">https://commits.webkit.org/311176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c50af2af7e4ae2fe76a255b1d730ceb140e90e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165049 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120977 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140290 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101648 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12821 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167528 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11644 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19734 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129095 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/155626 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24484 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129212 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35009 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139915 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86853 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24034 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188111 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92752 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/188111 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28322 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28550 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28446 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->