### PR TITLE
[Quirk] Mirror YouTube in-page captions in native fullscreen modes

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -511,6 +511,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/mediasession/MediaSessionAction.idl
     Modules/mediasession/MediaSessionActionDetails.idl
     Modules/mediasession/MediaSessionActionHandler.idl
+    Modules/mediasession/MediaSessionCaptionTrack.idl
     Modules/mediasession/MediaSessionCoordinator.idl
     Modules/mediasession/MediaSessionCoordinatorMixin.idl
     Modules/mediasession/MediaSessionCoordinatorState.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -566,6 +566,7 @@ $(PROJECT_DIR)/Modules/mediasession/MediaSession.idl
 $(PROJECT_DIR)/Modules/mediasession/MediaSessionAction.idl
 $(PROJECT_DIR)/Modules/mediasession/MediaSessionActionDetails.idl
 $(PROJECT_DIR)/Modules/mediasession/MediaSessionActionHandler.idl
+$(PROJECT_DIR)/Modules/mediasession/MediaSessionCaptionTrack.idl
 $(PROJECT_DIR)/Modules/mediasession/MediaSessionCoordinator.idl
 $(PROJECT_DIR)/Modules/mediasession/MediaSessionCoordinatorMixin.idl
 $(PROJECT_DIR)/Modules/mediasession/MediaSessionCoordinatorState.idl
@@ -764,6 +765,7 @@ $(PROJECT_DIR)/Modules/modern-media-controls/gesture-recognizers/gesture-recogni
 $(PROJECT_DIR)/Modules/modern-media-controls/gesture-recognizers/pinch.js
 $(PROJECT_DIR)/Modules/modern-media-controls/gesture-recognizers/tap.js
 $(PROJECT_DIR)/Modules/modern-media-controls/main.js
+$(PROJECT_DIR)/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/airplay-support.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/audio-support.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/close-support.js

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1949,6 +1949,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSessionActionDetails.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSessionActionDetails.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSessionActionHandler.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSessionActionHandler.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSessionCaptionTrack.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSessionCaptionTrack.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSessionCoordinator.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSessionCoordinator.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaSessionCoordinatorMixin.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -441,6 +441,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/mediasession/MediaSessionAction.idl \
     $(WebCore)/Modules/mediasession/MediaSessionActionDetails.idl \
     $(WebCore)/Modules/mediasession/MediaSessionActionHandler.idl \
+    $(WebCore)/Modules/mediasession/MediaSessionCaptionTrack.idl \
     $(WebCore)/Modules/mediasession/MediaSessionCoordinator.idl \
     $(WebCore)/Modules/mediasession/MediaSessionCoordinatorMixin.idl \
     $(WebCore)/Modules/mediasession/MediaSessionCoordinatorState.idl \
@@ -2342,6 +2343,7 @@ ModernMediaControls.js : $(MODERN_MEDIA_CONTROLS_SCRIPTS)
 
 USER_AGENT_SCRIPTS = \
     ModernMediaControls.js \
+	$(WebCore)/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js \
 #
 
 USER_AGENT_SCRIPTS_FILES = \

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -41,9 +41,11 @@
 #include "LocalDOMWindow.h"
 #include "Logging.h"
 #include "MediaMetadata.h"
+#include "MediaSessionCaptionTrack.h"
 #include "MediaSessionCoordinator.h"
 #include "Navigator.h"
 #include "NowPlayingInfo.h"
+#include "PageGroup.h"
 #include "PlatformMediaSessionManager.h"
 #include "Settings.h"
 #include "UserMediaController.h"
@@ -132,6 +134,8 @@ static std::optional<std::pair<PlatformMediaSession::RemoteControlCommandType, P
     case MediaSessionAction::Togglemicrophone:
     case MediaSessionAction::Togglescreenshare:
     case MediaSessionAction::Voiceactivity:
+    case MediaSessionAction::Togglecaptions:
+    case MediaSessionAction::Selectcaptiontrack:
         break;
     }
     if (command == PlatformMediaSession::RemoteControlCommandType::NoCommand)
@@ -661,6 +665,77 @@ std::optional<MediaSessionGroupIdentifier> MediaSession::mediaSessionGroupIdenti
     auto* document = this->document();
     return document && document->page() ? document->page()->mediaSessionGroupIdentifier() : std::nullopt;
 }
+
+RefPtr<CaptionUserPreferences> MediaSession::captionPreferences()
+{
+    if (RefPtr document = this->document()) {
+        if (RefPtr page = document->page())
+            return &protect(page->group())->ensureCaptionPreferences();
+    }
+
+    return nullptr;
+}
+
+void MediaSession::captionPreferencesChanged()
+{
+    RefPtr captionPreferences = this->captionPreferences();
+    if (!captionPreferences)
+        return;
+
+    auto newDisplayMode = captionPreferences->captionDisplayMode();
+    if (newDisplayMode == captionDisplayMode())
+        return;
+    m_captionDisplayMode = newDisplayMode;
+
+    switch (newDisplayMode) {
+    case CaptionUserPreferencesDisplayMode::AlwaysOn:
+        if (!m_captionsEnabled)
+            callActionHandler({ .action = MediaSessionAction::Togglecaptions }, { });
+        break;
+    case CaptionUserPreferencesDisplayMode::ForcedOnly:
+        if (m_captionsEnabled)
+            callActionHandler({ .action = MediaSessionAction::Togglecaptions }, { });
+        break;
+    case CaptionUserPreferencesDisplayMode::Automatic:
+    case CaptionUserPreferencesDisplayMode::Manual:
+        // No-op
+        break;
+    }
+}
+
+CaptionUserPreferencesDisplayMode MediaSession::captionDisplayMode()
+{
+    if (m_captionDisplayMode)
+        return *m_captionDisplayMode;
+
+    if (RefPtr captionPreferences = this->captionPreferences()) {
+        m_captionDisplayMode = captionPreferences->captionDisplayMode();
+        return *m_captionDisplayMode;
+    }
+
+    return CaptionUserPreferencesDisplayMode::ForcedOnly;
+}
+
+void MediaSession::setCaptionTracks(Vector<MediaSessionCaptionTrack>&& tracks)
+{
+    m_captionTracks = WTF::move(tracks);
+    if (RefPtr mediaElement = activeMediaElement())
+        mediaElement->mediaSessionCaptionTracksChanged();
+}
+
+void MediaSession::setCaptionsEnabled(bool enabled)
+{
+    m_captionsEnabled = enabled;
+
+    if (RefPtr captionPreferences = this->captionPreferences()) {
+        auto displayMode = enabled ? CaptionUserPreferences::CaptionDisplayMode::AlwaysOn : CaptionUserPreferences::CaptionDisplayMode::ForcedOnly;
+        captionPreferences->setCaptionDisplayMode(displayMode);
+    }
+
+    if (RefPtr mediaElement = activeMediaElement())
+        mediaElement->mediaSessionCaptionsEnabledChanged();
+}
+
 
 }
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -45,6 +45,7 @@
 
 namespace WebCore {
 
+class CaptionUserPreferences;
 class Document;
 class HTMLMediaElement;
 class MediaMetadata;
@@ -53,9 +54,12 @@ class MediaSessionCoordinatorPrivate;
 class MediaSessionManagerInterface;
 class Navigator;
 class PlatformMediaSession;
+struct MediaSessionCaptionTrack;
 struct NowPlayingInfo;
 template<typename> class DOMPromiseDeferred;
 template<typename> class ExceptionOr;
+
+enum class CaptionUserPreferencesDisplayMode : uint8_t;
 
 class MediaSessionObserver : public AbstractRefCountedAndCanMakeWeakPtr<MediaSessionObserver> {
 public:
@@ -146,6 +150,16 @@ public:
 
     WEBCORE_EXPORT bool hasActionHandler(const MediaSessionAction) const;
 
+    RefPtr<CaptionUserPreferences> captionPreferences();
+    void captionPreferencesChanged();
+    CaptionUserPreferencesDisplayMode captionDisplayMode();
+
+    void setCaptionTracks(Vector<MediaSessionCaptionTrack>&&);
+    const Vector<MediaSessionCaptionTrack>& captionTracks() const { return m_captionTracks; }
+
+    void setCaptionsEnabled(bool);
+    bool captionsEnabled() const { return m_captionsEnabled; }
+
 private:
     explicit MediaSession(Navigator&);
 
@@ -209,6 +223,10 @@ private:
 #endif
     mutable Lock m_actionHandlersLock;
     mutable bool m_defaultArtworkAttempted { false };
+
+    std::optional<CaptionUserPreferencesDisplayMode> m_captionDisplayMode;
+    Vector<MediaSessionCaptionTrack> m_captionTracks;
+    bool m_captionsEnabled { false };
 };
 
 String convertEnumerationToString(MediaSessionPlaybackState);

--- a/Source/WebCore/Modules/mediasession/MediaSession.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSession.idl
@@ -44,6 +44,9 @@
     [Conditional=MEDIA_STREAM, EnabledBySetting=MediaSessionCaptureToggleAPIEnabled] Promise<undefined> setMicrophoneActive(boolean active);
     [Conditional=MEDIA_STREAM, EnabledBySetting=MediaSessionCaptureToggleAPIEnabled] Promise<undefined> setCameraActive(boolean active);
     [Conditional=MEDIA_STREAM, EnabledBySetting=MediaSessionCaptureToggleAPIEnabled] Promise<undefined> setScreenshareActive(boolean active);
+
+    [EnabledByQuirk=needsYouTubeCaptions] attribute sequence<MediaSessionCaptionTrack> captionTracks;
+    [EnabledByQuirk=needsYouTubeCaptions] attribute boolean captionsEnabled;
 };
 
 MediaSession includes MediaSessionCoordinatorMixin;

--- a/Source/WebCore/Modules/mediasession/MediaSessionAction.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionAction.h
@@ -43,6 +43,8 @@ enum class MediaSessionAction : uint8_t {
     Togglecamera,
     Togglescreenshare,
     Voiceactivity,
+    Togglecaptions,
+    Selectcaptiontrack,
     Settrack,
 };
 

--- a/Source/WebCore/Modules/mediasession/MediaSessionAction.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSessionAction.idl
@@ -38,7 +38,9 @@
     "togglemicrophone",
     "togglecamera",
     "togglescreenshare",
-    "voiceactivity"
+    "voiceactivity",
+    "togglecaptions",
+    "selectcaptiontrack"
 #if defined(ENABLE_MEDIA_SESSION_PLAYLIST) && ENABLE_MEDIA_SESSION_PLAYLIST
     , "settrack"
 #endif

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionDetails.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionDetails.h
@@ -40,6 +40,7 @@ struct MediaSessionActionDetails {
 #if ENABLE(MEDIA_SESSION_PLAYLIST)
     String trackIdentifier { };
 #endif
+    std::optional<unsigned long> trackIndex { };
 };
 
 }

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionDetails.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionDetails.idl
@@ -40,4 +40,5 @@
     // MediaSessionEnterPictureInPictureReason enterPictureInPictureReason;
 
     [Conditional=MEDIA_SESSION_PLAYLIST, EnabledBySetting=MediaSessionPlaylistEnabled] DOMString trackIdentifier;
+    [EnabledByQuirk=needsYouTubeCaptions] unsigned long trackIndex;
 };

--- a/Source/WebCore/Modules/mediasession/MediaSessionCaptionTrack.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCaptionTrack.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+struct MediaSessionCaptionTrack {
+    String label;
+    String language;
+    String identifier;
+    std::optional<bool> enabled { false };
+};
+
+}

--- a/Source/WebCore/Modules/mediasession/MediaSessionCaptionTrack.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCaptionTrack.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=MEDIA_SESSION,
+    ExportMacro=WEBCORE_EXPORT,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject,
+] dictionary MediaSessionCaptionTrack {
+    DOMString label;
+    DOMString language;
+    DOMString identifier;
+    boolean enabled;
+};

--- a/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/YouTubeCaptionQuirk.js
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+(function() {
+    "use strict";
+
+    class CaptionMirror {
+        static _instances = new WeakMap();
+
+        // Public methods:
+        constructor(video) {
+            // If there was a previous instance of CaptionMirror associated with the same video
+            // invalidate the previous instance, which removes all event listeners and mutation
+            // observers:
+            let oldMirror = CaptionMirror._instances.get(video);
+            if (oldMirror) {
+                oldMirror.invalidate();
+                CaptionMirror._instances.delete(video);
+            }
+            CaptionMirror._instances.set(video, this);
+
+            this._video = video;
+            this._player = video.parentElement.parentElement;
+            this._captionWindowSelector = '.ytp-caption-window-container';
+            this._mirrorTrack = video.addTextTrack('forced', 'YouTube Captions');
+            this._mirrorTrack.mode = 'hidden';
+            this._captionObserver = null;
+            this._waitObserver = null;
+
+            this._onCaptionsTrackListChanged = () => this._syncTrackList();
+            this._onCaptionsChanged = () => this._syncTrackList();
+            this._player.addEventListener('onCaptionsTrackListChanged', this._onCaptionsTrackListChanged);
+            this._player.addEventListener('captionschanged', this._onCaptionsChanged);
+
+            navigator.mediaSession.setActionHandler('togglecaptions', details => this._handleMediaSessionAction(details));
+            navigator.mediaSession.setActionHandler('selectcaptiontrack', details => this._handleMediaSessionAction(details));
+
+            this._onPresentationModeChanged = () => this._handlePresentationModeChanged();
+            this._video.addEventListener('webkitpresentationmodechanged', this._onPresentationModeChanged);
+
+            this._attachCaptionWindowObserver();
+
+            this._syncTrackList();
+        }
+
+        invalidate() {
+            if (this._captionObserver) {
+                this._captionObserver.disconnect();
+                this._captionObserver = null;
+            }
+            if (this._waitObserver) {
+                this._waitObserver.disconnect();
+                this._waitObserver = null;
+            }
+            this._mirrorTrack.mode = 'disabled';
+            this._player.removeEventListener('onCaptionsTrackListChanged', this._onCaptionsTrackListChanged);
+            this._player.removeEventListener('captionschanged', this._onCaptionsChanged);
+            this._video.removeEventListener('webkitpresentationmodechanged', this._onPresentationModeChanged);
+        }
+
+        // Private methods:
+        _syncTrackList() {
+            var trackList = this._getTrackList();
+            var activeTrack = this._getActiveTrack();
+            navigator.mediaSession.captionTracks = trackList?.map(track => {
+                return { label: track.displayName, language: track.languageCode, enabled: this._areTracksEqual(track, activeTrack) };
+            }) ?? [];
+            navigator.mediaSession.captionsEnabled = this._player.isSubtitlesOn();
+        }
+
+        _syncCues(captionWindowContainer) {
+            while (this._mirrorTrack.cues?.length)
+                this._mirrorTrack.removeCue(this._mirrorTrack.cues[0]);
+            for (var captionWindow of captionWindowContainer.querySelectorAll('.caption-window')) {
+                var text = Array.from(captionWindow.querySelectorAll('.captions-text > span')).map(span => span.textContent).join('\n');
+                if (!text)
+                    continue;
+                var cue = new VTTCue(0, 10e7, text);
+                switch (captionWindow.style.textAlign) {
+                case 'left':
+                case 'start':
+                    cue.align = 'start';
+                    cue.positionAlign = 'line-left'
+                    break;
+                case 'end':
+                case 'right':
+                    cue.align = 'end';
+                    cue.positionAlign = 'line-right';
+                    break;
+                default:
+                    cue.align = 'center';
+                    cue.positionAlign = = 'center';
+                }
+                var topPercent = parseFloat(captionWindow.style.top);
+                var bottomPercent = parseFloat(captionWindow.style.bottom);
+                var leftPercent = parseFloat(captionWindow.style.left);
+                var rightPercent = parseFloat(captionWindow.style.right);
+                if (!isNaN(topPercent)) {
+                    cue.snapToLines = false;
+                    cue.line = topPercent;
+                } else if (!isNaN(bottomPercent)) {
+                    cue.snapToLines = false;
+                    cue.line = 100 - bottomPercent;
+                }
+                if (!isNaN(leftPercent))
+                    cue.position = leftPercent;
+                else if (!isNaN(rightPercent))
+                    cue.position = 100 - rightPercent;
+                this._mirrorTrack.addCue(cue);
+            }
+        }
+
+        _attachCaptionWindowObserver() {
+            var container = this._player.querySelector(this._captionWindowSelector);
+            if (container)
+                this._attachCaptionObserver(container);
+            else {
+                this._waitObserver = new MutationObserver(() => {
+                    var container = this._player.querySelector(this._captionWindowSelector);
+                    if (container) {
+                        this._attachCaptionObserver(container);
+                        this._waitObserver.disconnect();
+                        this._waitObserver = null;
+                    }
+                });
+                this._waitObserver.observe(this._player, { childList: true, subtree: true });
+            }
+        }
+
+        _attachCaptionObserver(container) {
+            if (this._captionObserver)
+                this._captionObserver.disconnect();
+            this._captionObserver = new MutationObserver(() => {
+                var container = this._player.querySelector(this._captionWindowSelector);
+                if (container) this._syncCues(container);
+            });
+            this._captionObserver.observe(container, {
+                childList: true,
+                subtree: true,
+                characterData: true,
+            });
+        }
+
+        _handlePresentationModeChanged() {
+            this._mirrorTrack.mode = this._video.webkitPresentationMode == 'inline' ? 'hidden' : 'showing';
+        }
+
+        _handleMediaSessionAction(details) {
+            switch (details.action) {
+            case 'togglecaptions':
+                this._player.toggleSubtitles();
+                break;
+            case 'selectcaptiontrack': {
+                var list = this._getTrackList();
+                var index = details.trackIndex;
+                if (index >= 0 && index < list.length)
+                    this._player.setOption('captions', 'track', list[index]);
+                else
+                    this._player.setOption('captions', 'track', {});
+                break;
+            }
+            }
+        }
+
+        // Utility methods:
+        _getTrackList() { return this._player.getOption('captions', 'tracklist') || []; }
+        _getActiveTrack() { return this._player.getOption('captions', 'track'); }
+        _areTracksEqual(a, b) { return a && b && a.vss_id === b.vss_id;  }
+    }
+
+    window.setupCaptionMirroring = function(video) {
+        new CaptionMirror(video);
+    }
+}());

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4540,6 +4540,7 @@ JSMediaSession.cpp
 JSMediaSessionAction.cpp
 JSMediaSessionActionDetails.cpp
 JSMediaSessionActionHandler.cpp
+JSMediaSessionCaptionTrack.cpp
 JSMediaSessionCoordinator.cpp
 JSMediaSessionCoordinatorState.cpp
 JSMediaSessionPlaybackState.cpp

--- a/Source/WebCore/dom/DocumentMediaElement.cpp
+++ b/Source/WebCore/dom/DocumentMediaElement.cpp
@@ -75,7 +75,17 @@ bool DocumentMediaElement::setupAndCallMediaControlsJS(NOESCAPE const JSSetupFun
     if (!ensureMediaControlsScript())
         return false;
 
-    return setupAndCallJS(task);
+    Ref world = ensureIsolatedWorld();
+    return setupAndCallJS(task, world);
+}
+
+bool DocumentMediaElement::setupAndCallYouTubeQuirkJS(NOESCAPE const JSSetupFunction& task)
+{
+    if (!ensureYouTubeQuirkScript())
+        return false;
+
+    Ref world = mainThreadNormalWorldSingleton();
+    return setupAndCallJS(task, world);
 }
 
 DOMWrapperWorld& DocumentMediaElement::ensureIsolatedWorld()
@@ -97,6 +107,7 @@ bool DocumentMediaElement::ensureMediaControlsScript()
     if (mediaControlsScripts.isEmpty() || document->activeDOMObjectsAreSuspended() || document->activeDOMObjectsAreStopped())
         return false;
 
+    Ref world = ensureIsolatedWorld();
     m_haveParsedMediaControlsScript = setupAndCallJS([mediaControlsScripts = WTF::move(mediaControlsScripts)](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject&, ScriptController& scriptController, DOMWrapperWorld& world) {
         auto& vm = globalObject.vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
@@ -109,13 +120,35 @@ bool DocumentMediaElement::ensureMediaControlsScript()
         }
 
         return true;
-    });
+    }, world);
     return m_haveParsedMediaControlsScript;
 }
 
-bool DocumentMediaElement::setupAndCallJS(NOESCAPE const JSSetupFunction& task)
+bool DocumentMediaElement::ensureYouTubeQuirkScript()
 {
-    Ref world = ensureIsolatedWorld();
+    if (m_haveParsedYouTubeQuirkScript)
+        return true;
+
+    Ref document = this->document();
+    auto youTubeQuirkScript = RenderTheme::singleton().youTubeQuirkScript();
+    if (youTubeQuirkScript.isEmpty() || document->activeDOMObjectsAreSuspended() || document->activeDOMObjectsAreStopped())
+        return false;
+
+    Ref world = mainThreadNormalWorldSingleton();
+    m_haveParsedYouTubeQuirkScript = setupAndCallJS([youTubeQuirkScript = WTF::move(youTubeQuirkScript)](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject&, ScriptController& scriptController, DOMWrapperWorld& world) {
+        auto& vm = globalObject.vm();
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        scriptController.evaluateInWorldIgnoringException(ScriptSourceCode(youTubeQuirkScript, JSC::SourceTaintedOrigin::Untainted), world);
+        RETURN_IF_EXCEPTION(scope, false);
+
+        return true;
+    }, world);
+    return m_haveParsedYouTubeQuirkScript;
+}
+
+bool DocumentMediaElement::setupAndCallJS(NOESCAPE const JSSetupFunction& task, DOMWrapperWorld& world)
+{
     Ref protectedDocument = this->document();
     RefPtr protectedFrame = protectedDocument->frame();
     if (!protectedFrame)

--- a/Source/WebCore/dom/DocumentMediaElement.h
+++ b/Source/WebCore/dom/DocumentMediaElement.h
@@ -52,6 +52,7 @@ public:
 
     using JSSetupFunction = Function<bool(JSDOMGlobalObject&, JSC::JSGlobalObject&, ScriptController&, DOMWrapperWorld&)>;
     bool setupAndCallMediaControlsJS(NOESCAPE const JSSetupFunction&);
+    bool setupAndCallYouTubeQuirkJS(NOESCAPE const JSSetupFunction&);
 
 private:
     bool isDocumentMediaElement() const final { return true; }
@@ -61,11 +62,14 @@ private:
 
     DOMWrapperWorld& ensureIsolatedWorld();
     bool ensureMediaControlsScript();
-    bool setupAndCallJS(NOESCAPE const JSSetupFunction&);
+    bool setupAndCallJS(NOESCAPE const JSSetupFunction&, DOMWrapperWorld&);
+
+    bool ensureYouTubeQuirkScript();
 
     CheckedRef<Document> m_document;
     RefPtr<DOMWrapperWorld> m_isolatedWorld;
     bool m_haveParsedMediaControlsScript { false };
+    bool m_haveParsedYouTubeQuirkScript { false };
 };
 
 }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -103,9 +103,11 @@
 #include "MediaQueryEvaluator.h"
 #include "MediaResourceLoader.h"
 #include "MediaResourceSniffer.h"
+#include "MediaSession.h"
 #include "MessageClientForTesting.h"
 #include "Navigator.h"
 #include "NavigatorMediaDevices.h"
+#include "NavigatorMediaSession.h"
 #include "NetworkingContext.h"
 #include "NodeInlines.h"
 #include "NodeName.h"
@@ -1138,6 +1140,36 @@ void HTMLMediaElement::postConnectionSteps()
     }
 
     configureMediaControls();
+
+    if (protect(document())->quirks().needsYouTubeCaptionsQuirk()) {
+        DocumentMediaElement::from(protect(document())).setupAndCallYouTubeQuirkJS([this](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject& lexicalGlobalObject, ScriptController&, DOMWrapperWorld&) {
+            auto& vm = globalObject.vm();
+            auto scope = DECLARE_THROW_SCOPE(vm);
+
+            auto functionValue = globalObject.get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, "setupCaptionMirroring"_s));
+            if (scope.exception()) [[unlikely]]
+                return false;
+            if (functionValue.isUndefinedOrNull())
+                return false;
+
+            auto mediaJSWrapper = toJS(&lexicalGlobalObject, &globalObject, *this);
+
+            JSC::MarkedArgumentBuffer argList;
+            argList.append(mediaJSWrapper);
+            ASSERT(!argList.hasOverflowed());
+
+            auto* function = functionValue.toObject(&lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+            auto callData = JSC::getCallData(function);
+            if (callData.type == JSC::CallData::Type::None)
+                return false;
+
+            JSC::call(&lexicalGlobalObject, function, callData, &globalObject, argList);
+
+            RETURN_IF_EXCEPTION(scope, false);
+            return true;
+        });
+    }
 }
 
 void HTMLMediaElement::pauseAfterDetachedTask()
@@ -2633,7 +2665,7 @@ void HTMLMediaElement::textTrackModeChanged(TextTrack& track)
     if (track.mode() != TextTrack::Mode::Disabled && trackIsLoaded)
         textTrackAddCues(track, *protect(track.cues()));
 
-    configureTextTrackDisplay(AssumeTextTrackVisibilityChanged);
+    configureTextTrackDisplay();
 
     if (m_textTracks && m_textTracks->contains(track))
         m_textTracks->scheduleChangeEvent();
@@ -7815,6 +7847,13 @@ bool HTMLMediaElement::hasClosedCaptions() const
     if (player && player->hasClosedCaptions())
         return true;
 
+#if ENABLE(MEDIA_SESSION)
+    if (RefPtr mediaSession = mediaSessionIfNeededAndExists()) {
+        if (mediaSession->captionsEnabled())
+            return true;
+    }
+#endif
+
     if (!m_textTracks)
         return false;
 
@@ -7940,6 +7979,7 @@ void HTMLMediaElement::setClosedCaptionsVisible(bool closedCaptionVisible)
 
     markCaptionAndSubtitleTracksAsUnconfigured(Immediately);
     updateTextTrackDisplay();
+    configureTextTrackDisplay();
 }
 
 #if ENABLE(MEDIA_STATISTICS)
@@ -9822,6 +9862,33 @@ void HTMLMediaElement::audioSessionCategoryChanged(AudioSessionCategory category
 {
     m_clients.forEach([category, mode, policy] (auto& client) {
         client.audioSessionCategoryChanged(category, mode, policy);
+    });
+}
+
+#if ENABLE(MEDIA_SESSION)
+RefPtr<MediaSession> HTMLMediaElement::mediaSessionIfNeededAndExists() const
+{
+    if (!protect(document())->quirks().needsYouTubeCaptionsQuirk())
+        return nullptr;
+
+    if (RefPtr window = document().window())
+        return NavigatorMediaSession::mediaSessionIfExists(protect(window->navigator()));
+
+    return nullptr;
+}
+#endif
+
+void HTMLMediaElement::mediaSessionCaptionTracksChanged()
+{
+    m_clients.forEach([](auto& client) {
+        client.captionTracksChanged();
+    });
+}
+
+void HTMLMediaElement::mediaSessionCaptionsEnabledChanged()
+{
+    m_clients.forEach([](auto& client) {
+        client.captionsEnabledChanged();
     });
 }
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -159,6 +159,9 @@ public:
 
     virtual void audioSessionCategoryChanged(AudioSessionCategory, AudioSessionMode, RouteSharingPolicy) { }
     virtual void routingContextUIDChanged(const String&) { }
+
+    virtual void captionTracksChanged() { }
+    virtual void captionsEnabledChanged() { }
 };
 
 class HTMLMediaElement
@@ -737,6 +740,14 @@ public:
     }
 
     void forceStereoDecoding() { m_forceStereoDecoding = true; }
+
+#if ENABLE(MEDIA_SESSION)
+    RefPtr<MediaSession> mediaSessionIfNeededAndExists() const;
+#endif
+
+    void mediaSessionCaptionTracksChanged();
+    void mediaSessionCaptionsEnabledChanged();
+
 protected:
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLMediaElement();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -124,11 +124,13 @@
 #include "LoginStatus.h"
 #include "LowPowerModeNotifier.h"
 #include "MediaCanStartListener.h"
+#include "MediaSession.h"
 #include "MemoryCache.h"
 #include "ModelPlayerProvider.h"
 #include "NavigationScheduler.h"
 #include "Navigator.h"
 #include "NavigatorGamepad.h"
+#include "NavigatorMediaSession.h"
 #include "OpportunisticTaskScheduler.h"
 #include "PageColorSampler.h"
 #include "PageConfiguration.h"
@@ -3901,6 +3903,15 @@ void Page::captionPreferencesChanged()
     forEachDocument([] (Document& document) {
         document.captionPreferencesChanged();
     });
+
+#if ENABLE(MEDIA_SESSION)
+    if (RefPtr localMainFrame = this->localMainFrame()) {
+        if (RefPtr window = localMainFrame->window()) {
+            if (RefPtr navigator = window->optionalNavigator())
+                protect(NavigatorMediaSession::mediaSession(*navigator))->captionPreferencesChanged();
+        }
+    }
+#endif
 }
 
 #endif

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -387,6 +387,17 @@ bool Quirks::needsYouTubeMouseOutQuirk() const
 #endif
 }
 
+bool Quirks::needsYouTubeCaptionsQuirk() const
+{
+#if PLATFORM(COCOA)
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsYouTubeCaptionQuirk);
+#else
+    return false;
+#endif
+}
+
 // safe.menlosecurity.com rdar://135114489
 // FIXME (rdar://138585709): Remove this quirk for safe.menlosecurity.com once investigation into text corruption on the site is completed and the issue is resolved.
 bool Quirks::shouldDisableWritingSuggestionsByDefault() const
@@ -3563,6 +3574,9 @@ static void handleYouTubeQuirks(QuirksData& quirksData, const URL& quirksURL, co
         QuirksData::SiteSpecificQuirk::NeedsScrollbarWidthThinDisabledQuirk,
         // youtube.com rdar://66242343
         QuirksData::SiteSpecificQuirk::NeedsVP9FullRangeFlagQuirk,
+#if PLATFORM(COCOA)
+        QuirksData::SiteSpecificQuirk::NeedsYouTubeCaptionQuirk,
+#endif
 #if PLATFORM(IOS) || PLATFORM(VISION)
         // youtube.com: rdar://110097836
         QuirksData::SiteSpecificQuirk::ShouldSilenceResizeObservers,

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -109,6 +109,7 @@ public:
     WEBCORE_EXPORT bool shouldAllowNotificationPermissionWithoutUserGesture() const;
     WEBCORE_EXPORT static bool shouldAllowNavigationToCustomProtocolWithoutUserGesture(StringView protocol, const SecurityOriginData& requesterOrigin);
 
+    WEBCORE_EXPORT bool needsYouTubeCaptionsQuirk() const;
     WEBCORE_EXPORT bool NODELETE needsYouTubeMouseOutQuirk() const;
 
     WEBCORE_EXPORT bool shouldDisableWritingSuggestionsByDefault() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -121,6 +121,9 @@ struct QuirksData {
         NeedsVP9FullRangeFlagQuirk,
         NeedsVideoShouldMaintainAspectRatioQuirk,
         NeedsWebKitMediaTextTrackDisplayQuirk,
+#if PLATFORM(COCOA)
+        NeedsYouTubeCaptionQuirk,
+#endif
 #if ENABLE(TWO_PHASE_CLICKS)
         NeedsYouTubeMouseOutQuirk,
 #endif

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -29,6 +29,7 @@
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
 
 #include <WebCore/EventListener.h>
+#include <WebCore/HTMLMediaElement.h>
 #include <WebCore/HTMLMediaElementEnums.h>
 #include <WebCore/ImmersiveVideoMetadata.h>
 #include <WebCore/PlaybackSessionModel.h>
@@ -43,12 +44,13 @@
 namespace WebCore {
 
 class AudioTrack;
-class HTMLMediaElement;
+class MediaSession;
 class TextTrack;
 
 class PlaybackSessionModelMediaElement final
     : public PlaybackSessionModel
     , public EventListener
+    , public HTMLMediaElementClient
     , public CanMakeCheckedPtr<PlaybackSessionModelMediaElement> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(PlaybackSessionModelMediaElement, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionModelMediaElement);
@@ -60,6 +62,9 @@ public:
     WEBCORE_EXPORT virtual ~PlaybackSessionModelMediaElement();
 
     USING_CAN_MAKE_WEAKPTR(PlaybackSessionModel);
+
+    void ref() const final { EventListener::ref(); }
+    void deref() const final { EventListener::deref(); }
 
     // CheckedPtr interface
     uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
@@ -153,6 +158,8 @@ private:
     void updateRate();
 
     void videoTrackConfigurationChanged();
+    void captionTracksChanged() final;
+    void captionsEnabledChanged() final;
 
 #if !RELEASE_LOG_DISABLED
     uint64_t logIdentifier() const final;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -30,16 +30,23 @@
 
 #import "AudioTrackList.h"
 #import "DocumentPage.h"
+#import "DocumentQuirks.h"
 #import "Event.h"
 #import "EventListener.h"
 #import "EventNames.h"
 #import "ExceptionOr.h"
 #import "HTMLVideoElement.h"
+#import "LocalDOMWindow.h"
 #import "Logging.h"
 #import "MediaControlsHost.h"
 #import "MediaSelectionOption.h"
+#import "MediaSession.h"
+#import "MediaSessionCaptionTrack.h"
+#import "Navigator.h"
+#import "NavigatorMediaSession.h"
 #import "NodeDocument.h"
 #import "PageGroup.h"
+#import "Quirks.h"
 #import "TextTrackList.h"
 #import "TimeRanges.h"
 #import "UserGestureIndicator.h"
@@ -105,12 +112,15 @@ void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaEl
     }
     m_isListening = false;
 
-    if (oldMediaElement)
+    if (oldMediaElement) {
         oldMediaElement->resetPlaybackSessionState();
+        oldMediaElement->removeClient(*this);
+    }
 
     m_mediaElement = newMediaElement;
 
     if (newMediaElement) {
+        newMediaElement->addClient(*this);
         for (auto& eventName : observedEventNames())
             newMediaElement->addEventListener(eventName, *this);
 
@@ -366,6 +376,18 @@ void PlaybackSessionModelMediaElement::selectLegibleMediaOption(uint64_t index)
     RefPtr mediaElement = m_mediaElement;
     if (!mediaElement)
         return;
+
+#if ENABLE(MEDIA_SESSION)
+    if (RefPtr mediaSession = mediaElement->mediaSessionIfNeededAndExists()) {
+        if (index >= mediaSession->captionTracks().size())
+            return;
+        MediaSessionActionDetails details = {
+            .action = MediaSessionAction::Selectcaptiontrack,
+            .trackIndex = index };
+        mediaSession->callActionHandler(details, { });
+        return;
+    }
+#endif
 
     RefPtr<TextTrack> textTrack;
     if (index < m_legibleTracksForMenu.size())
@@ -731,6 +753,14 @@ Vector<MediaSelectionOption> PlaybackSessionModelMediaElement::legibleMediaSelec
     if (!mediaElement || !mediaElement->document().page())
         return { };
 
+#if ENABLE(MEDIA_SESSION)
+    if (RefPtr mediaSession = mediaElement->mediaSessionIfNeededAndExists()) {
+        return mediaSession->captionTracks().map([](auto& track) -> MediaSelectionOption {
+            return MediaSelectionOption(MediaSelectionOption::MediaType::Captions, track.label, MediaSelectionOption::LegibleType::Regular, track.language);
+        });
+    }
+#endif
+
     Ref captionPreferences = protect(mediaElement->document().page()->group())->ensureCaptionPreferences();
     return m_legibleTracksForMenu.map([&](auto& track) {
         return captionPreferences->mediaSelectionOptionForTrack(track.get());
@@ -740,9 +770,20 @@ Vector<MediaSelectionOption> PlaybackSessionModelMediaElement::legibleMediaSelec
 uint64_t PlaybackSessionModelMediaElement::legibleMediaSelectedIndex() const
 {
     RefPtr mediaElement = m_mediaElement;
-    auto host = mediaElement ? mediaElement->mediaControlsHost() : nullptr;
+    if (!mediaElement)
+        return std::numeric_limits<uint64_t>::max();
+
+    auto host = mediaElement->mediaControlsHost();
     if (!host)
         return std::numeric_limits<uint64_t>::max();
+
+#if ENABLE(MEDIA_SESSION)
+    if (RefPtr mediaSession = mediaElement->mediaSessionIfNeededAndExists()) {
+        return mediaSession->captionTracks().findIf([](auto& track) {
+            return track.enabled.value_or(false);
+        });
+    }
+#endif
 
     AtomString displayMode = host->captionDisplayMode();
 
@@ -847,6 +888,16 @@ bool PlaybackSessionModelMediaElement::isInWindowFullscreenActive() const
         return false;
 
     return (mediaElement->fullscreenMode() & HTMLMediaElementEnums::VideoFullscreenModeInWindow) == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
+}
+
+void PlaybackSessionModelMediaElement::captionTracksChanged()
+{
+    updateMediaSelectionOptions();
+}
+
+void PlaybackSessionModelMediaElement::captionsEnabledChanged()
+{
+    updateMediaSelectionOptions();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -128,6 +128,7 @@ public:
     virtual RefPtr<FragmentedSharedBuffer> mediaControlsImageDataForIconNameAndType(const String&, const String&) { return nullptr; }
     virtual String mediaControlsBase64StringForIconNameAndType(const String&, const String&) { return String(); }
     virtual String mediaControlsFormattedStringForDuration(double) { return String(); }
+    virtual String youTubeQuirkScript() { return { }; }
 #endif // ENABLE(VIDEO)
 #if ENABLE(ATTACHMENT_ELEMENT)
     virtual String attachmentStyleSheet() const;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -86,6 +86,7 @@ public:
     Vector<String, 2> mediaControlsScripts() final;
     RefPtr<FragmentedSharedBuffer> mediaControlsImageDataForIconNameAndType(const String&, const String&) final;
     String mediaControlsFormattedStringForDuration(double) final;
+    String youTubeQuirkScript() final;
 #endif
 
 #if ENABLE(FORM_CONTROL_REFRESH)
@@ -301,6 +302,7 @@ private:
     String m_mediaControlsScript;
     String m_mediaControlsStyleSheet;
     RetainPtr<NSDateComponentsFormatter> m_durationFormatter;
+    String m_youTubeCaptionQuirkScript;
 #endif // ENABLE(VIDEO)
 };
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -866,6 +866,7 @@ void RenderThemeCocoa::purgeCaches()
     m_mediaControlsLocalizedStringsScript.clearImplIfNotShared();
     m_mediaControlsScript.clearImplIfNotShared();
     m_mediaControlsStyleSheet.clearImplIfNotShared();
+    m_youTubeCaptionQuirkScript.clearImplIfNotShared();
 #endif // ENABLE(VIDEO)
 
     RenderTheme::purgeCaches();
@@ -1334,6 +1335,14 @@ String RenderThemeCocoa::mediaControlsFormattedStringForDuration(const double du
     }
     return [m_durationFormatter stringFromTimeInterval:durationInSeconds];
     END_BLOCK_OBJC_EXCEPTIONS
+}
+
+String RenderThemeCocoa::youTubeQuirkScript()
+{
+    if (!m_youTubeCaptionQuirkScript)
+        m_youTubeCaptionQuirkScript = StringImpl::createWithoutCopying(YouTubeCaptionQuirkJavaScript);
+
+    return m_youTubeCaptionQuirkScript;
 }
 
 #endif // ENABLE(VIDEO)


### PR DESCRIPTION
#### 7de5451e6e8e2bce65575c7feb8fd945b07b004f
<pre>
[Quirk] Mirror YouTube in-page captions in native fullscreen modes
<a href="https://bugs.webkit.org/show_bug.cgi?id=312229">https://bugs.webkit.org/show_bug.cgi?id=312229</a>
<a href="https://rdar.apple.com/174708144">rdar://174708144</a>

Reviewed by Jean-Yves Avenard.

Add a quirked behavior for YouTube which allows captions rendered atop the
video element to be &quot;mirrored&quot; into the video itself when in out-of-page
rendering modes like fullscreen and picture-in-picture. This quirk also
supports pushing track information down from YouTube&apos;s player API via
a quirked MediaSession metadata, and supports pushing track changes up
to that same player API via a quirked MediaSession action handler.

Key Changes:
- MediaSessionAction.{h,idl}: add two new action enum values.
- MediaSessionCaptionTrack.{h,idl}: add a new dictionary definition
  used by the quirk to pass caption track information down to WebCore.
- MediaSession.{h,cpp,idl}: add new action handlers for sending commands
  up to the YouTube player API via the quirk.
- MediaSessionActionDetails,{h,cpp}: add a new trackIndex value to the
  MediaSessionActionDetails dictionary when sending a &quot;selectcaptiontrack&quot;
  action.
- YouTubeCaptionQuirk.js: this is the main quirk script; it bridges the
  YouTube player API and the MediaSession, and implements the &quot;mirror&quot;
  by using a MutationObserver to detect cues being added and removed from
  YouTube&apos;s caption window.
- Page.cpp: notify the MediaSession object when caption preferences change.
- DocumentMediaElement.{h,cpp}: add convienience methods for setting up the
  quirk script and for calling methods on that script.
- Quirks{.h,.cpp,Data.h}: add the quirk itself.
- PlaybackSessionModelMediaElement.{h,cpp}: when the quirk is active, returns
  caption track data from MediaSession rather than the media element.

Canonical link: <a href="https://commits.webkit.org/311248@main">https://commits.webkit.org/311248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca0b4f3e1aaf72183646f65e5fe5166f474c3ccb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165212 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121114 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101785 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12984 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167694 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11807 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129238 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129350 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35044 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140068 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87045 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24180 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16867 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28959 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92915 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28485 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28713 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28609 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->