### PR TITLE
:focus-visible incorrectly shown after programmatic focus() when trigger button has child elements

### DIFF
--- a/LayoutTests/fast/selectors/focus-visible-script-focus-from-click-expected.txt
+++ b/LayoutTests/fast/selectors/focus-visible-script-focus-from-click-expected.txt
@@ -1,0 +1,17 @@
+Test that calling element.focus() from a button's click handler does not show :focus-visible, regardless of whether the button has child elements.
+
+
+Click
+  Click
+Click
+
+
+Click
+  Focus target
+
+PASS Button with <div> child: focus() from click handler should not show :focus-visible
+PASS Button with text only: focus() from click handler should not show :focus-visible
+PASS Button with pointer-events:none child: focus() from click handler should not show :focus-visible
+PASS Button with shadow DOM child: focus() from click handler should not show :focus-visible
+PASS Button with slotted content: focus() from click handler should not show :focus-visible
+

--- a/LayoutTests/fast/selectors/focus-visible-script-focus-from-click.html
+++ b/LayoutTests/fast/selectors/focus-visible-script-focus-from-click.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>:focus-visible should not match when element.focus() is called from a click handler</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        *:focus,
+        *:focus-visible {
+            outline: none;
+        }
+        #target:focus-visible {
+            outline: 3px solid red;
+        }
+    </style>
+</head>
+<body>
+    <p>Test that calling element.focus() from a button's click handler does not show :focus-visible,
+    regardless of whether the button has child elements.</p>
+
+    <button id="trigger-with-child" type="button"><div>Click</div></button>
+    <button id="trigger-text-only" type="button">Click</button>
+    <button id="trigger-pe-none" type="button"><div style="pointer-events:none">Click</div></button>
+    <button id="trigger-shadow" type="button"><div id="shadow-host"></div></button>
+    <button id="trigger-slot" type="button"><div id="slot-host"><span>Click</span></div></button>
+    <button id="target" type="button">Focus target</button>
+
+    <script>
+    const shadowHost = document.getElementById("shadow-host");
+    const shadowRoot = shadowHost.attachShadow({ mode: "open" });
+    shadowRoot.innerHTML = "<div>Click</div>";
+
+    const slotHost = document.getElementById("slot-host");
+    const slotRoot = slotHost.attachShadow({ mode: "open" });
+    slotRoot.innerHTML = "<slot></slot>";
+
+    const target = document.getElementById("target");
+    for (const btn of document.querySelectorAll("[id^=trigger]"))
+        btn.addEventListener("click", () => { target.focus(); });
+
+    function clickCenter(element) {
+        const rect = element.getBoundingClientRect();
+        return UIHelper.activateAt(rect.x + rect.width / 2, rect.y + rect.height / 2);
+    }
+
+    promise_test(async t => {
+        const trigger = document.getElementById("trigger-with-child");
+        await clickCenter(trigger);
+        assert_equals(document.activeElement, target, "target should be focused");
+        assert_false(target.matches(":focus-visible"),
+            ":focus-visible should not match on target when triggered from button with child element");
+        target.blur();
+    }, "Button with <div> child: focus() from click handler should not show :focus-visible");
+
+    promise_test(async t => {
+        const trigger = document.getElementById("trigger-text-only");
+        await clickCenter(trigger);
+        assert_equals(document.activeElement, target, "target should be focused");
+        assert_false(target.matches(":focus-visible"),
+            ":focus-visible should not match on target when triggered from text-only button");
+        target.blur();
+    }, "Button with text only: focus() from click handler should not show :focus-visible");
+
+    promise_test(async t => {
+        const trigger = document.getElementById("trigger-pe-none");
+        await clickCenter(trigger);
+        assert_equals(document.activeElement, target, "target should be focused");
+        assert_false(target.matches(":focus-visible"),
+            ":focus-visible should not match on target when triggered from button with pointer-events:none child");
+        target.blur();
+    }, "Button with pointer-events:none child: focus() from click handler should not show :focus-visible");
+
+    promise_test(async t => {
+        const trigger = document.getElementById("trigger-shadow");
+        await clickCenter(trigger);
+        assert_equals(document.activeElement, target, "target should be focused");
+        assert_false(target.matches(":focus-visible"),
+            ":focus-visible should not match on target when triggered from button with shadow DOM child");
+        target.blur();
+    }, "Button with shadow DOM child: focus() from click handler should not show :focus-visible");
+
+    promise_test(async t => {
+        const trigger = document.getElementById("trigger-slot");
+        await clickCenter(trigger);
+        assert_equals(document.activeElement, target, "target should be focused");
+        assert_false(target.matches(":focus-visible"),
+            ":focus-visible should not match on target when triggered from button with slotted content");
+        target.blur();
+    }, "Button with slotted content: focus() from click handler should not show :focus-visible");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3395,8 +3395,14 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
     // Form control elements are not mouse focusable on some platforms (see HTMLFormControlElement::isMouseFocusable())
     // which makes us behave differently than other browsers when a button is clicked,
     // because the button is not actually focused so we don't set the latest FocusTrigger.
-    if (m_elementUnderMouse && !m_elementUnderMouse->isMouseFocusable() && is<HTMLFormControlElement>(m_elementUnderMouse))
-        frame->document()->setLatestFocusTrigger(FocusTrigger::Click);
+    if (!element && m_elementUnderMouse) {
+        for (auto* ancestor = m_elementUnderMouse.get(); ancestor; ancestor = ancestor->parentElementInComposedTree()) {
+            if (is<HTMLFormControlElement>(*ancestor) && !ancestor->isMouseFocusable()) {
+                frame->document()->setLatestFocusTrigger(FocusTrigger::Click);
+                break;
+            }
+        }
+    }
 #endif
 
     // If focus shift is blocked, we eat the event.


### PR DESCRIPTION
#### cde532e2aee67f1878a4ca34f4476545988dfb29
<pre>
:focus-visible incorrectly shown after programmatic focus() when trigger button has child elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=278019">https://bugs.webkit.org/show_bug.cgi?id=278019</a>
<a href="https://rdar.apple.com/134337357">rdar://134337357</a>

Reviewed by Ryosuke Niwa.

On macOS/iOS, buttons are not mouse-focusable. A workaround records
that the last focus trigger was a click, so that a subsequent
programmatic focus() call hides :focus-visible. However, the
workaround only checked the innermost element under the mouse. When
a button has child elements (e.g. &lt;button&gt;&lt;div&gt;text&lt;/div&gt;&lt;/button&gt;),
the hit-test target is the &lt;div&gt;, not the &lt;button&gt;, so the workaround
did not fire and :focus-visible incorrectly appeared.

Walk up from the hit-test target to find a non-mouse-focusable form
control ancestor instead of only checking the innermost element.

Test: fast/selectors/focus-visible-script-focus-from-click.html

* LayoutTests/fast/selectors/focus-visible-script-focus-from-click-expected.txt: Added.
* LayoutTests/fast/selectors/focus-visible-script-focus-from-click.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dispatchMouseEvent):

Canonical link: <a href="https://commits.webkit.org/311768@main">https://commits.webkit.org/311768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bd0781a2ec89fe0dc6c201ff55699aa3e59f5ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166715 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111970 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122260 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85843 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102926 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23609 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14488 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169205 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14066 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21218 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130437 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130551 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35371 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141389 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88761 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25289 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18195 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30460 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95480 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29981 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30211 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30108 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->