### PR TITLE
Update Serialization for CoreIPCError to have additional members

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.h
@@ -30,6 +30,7 @@
 #import <CoreFoundation/CoreFoundation.h>
 #import <wtf/ArgumentCoder.h>
 #import <wtf/TZoneMalloc.h>
+#import <wtf/Vector.h>
 #import <wtf/text/WTFString.h>
 
 OBJC_CLASS NSError;
@@ -39,6 +40,18 @@ namespace WebKit {
 class CoreIPCError {
     WTF_MAKE_TZONE_ALLOCATED(CoreIPCError);
 public:
+    struct NetworkResolutionReportInterface {
+        String type;
+        String name;
+    };
+
+    struct NetworkResolutionReport {
+        String provider;
+        String dnsFailureReason;
+        String extendedDNSErrorExtraText;
+        Vector<NetworkResolutionReportInterface> interfaces;
+    };
+
     CoreIPCError(CoreIPCError&&) = default;
     CoreIPCError& operator=(CoreIPCError&&) = default;
 
@@ -47,7 +60,7 @@ public:
 #if USE(NSURL_ERROR_FAILING_URL_STRING_KEY)
         String&& failingURLStringError,
 #endif
-        String&& filePathError, String&& networkTaskDescription, String&& networkTaskMetricsPrivacyStance, String&& description)
+        String&& filePathError, String&& networkTaskDescription, String&& networkTaskMetricsPrivacyStance, std::optional<NetworkResolutionReport>&& networkResolutionReport, String&& description)
         : m_domain(WTF::move(domain))
         , m_code(WTF::move(code))
         , m_underlyingError(WTF::move(underlyingError))
@@ -70,6 +83,7 @@ public:
         , m_filePathError(WTF::move(filePathError))
         , m_networkTaskDescription(WTF::move(networkTaskDescription))
         , m_networkTaskMetricsPrivacyStance(WTF::move(networkTaskMetricsPrivacyStance))
+        , m_networkResolutionReport(WTF::move(networkResolutionReport))
         , m_description(WTF::move(description))
     {
     }
@@ -107,6 +121,7 @@ private:
 
     String m_networkTaskDescription;
     String m_networkTaskMetricsPrivacyStance;
+    std::optional<NetworkResolutionReport> m_networkResolutionReport;
 
     String m_description;
 };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
@@ -91,6 +91,23 @@ RetainPtr<id> CoreIPCError::toID() const
     INJECT_STRING_VALUE(@"networkTaskDescription", m_networkTaskDescription)
     INJECT_STRING_VALUE(@"networkTaskMetricsPrivacyStance", m_networkTaskMetricsPrivacyStance)
 
+    if (m_networkResolutionReport) {
+        RetainPtr interfaces = adoptNS([[NSMutableArray alloc] initWithCapacity:m_networkResolutionReport->interfaces.size()]);
+        for (auto& interface : m_networkResolutionReport->interfaces) {
+            [interfaces addObject:@{
+                @"type" : interface.type.createNSString().get() ?: @"",
+                @"name" : interface.name.createNSString().get() ?: @"",
+            }];
+        }
+        RetainPtr report = @{
+            @"provider" : m_networkResolutionReport->provider.createNSString().get() ?: @"",
+            @"dnsFailureReason" : m_networkResolutionReport->dnsFailureReason.createNSString().get() ?: @"",
+            @"extendedDNSErrorExtraText" : m_networkResolutionReport->extendedDNSErrorExtraText.createNSString().get() ?: @"",
+            @"interfaces" : interfaces.get(),
+        };
+        INJECT_VALUE(@"networkResolutionReport", report)
+    }
+
     INJECT_STRING_VALUE(@"NSDescription", m_description)
 
     if (m_underlyingError) {
@@ -208,6 +225,30 @@ CoreIPCError::CoreIPCError(NSError *nsError)
 
     EXTRACT_STRING_VALUE(@"networkTaskDescription", m_networkTaskDescription)
     EXTRACT_STRING_VALUE(@"networkTaskMetricsPrivacyStance", m_networkTaskMetricsPrivacyStance)
+
+    if (RetainPtr resolutionReport = dynamic_objc_cast<NSDictionary>([userInfo objectForKey:@"networkResolutionReport"])) {
+        NetworkResolutionReport report;
+        if (RetainPtr value = dynamic_objc_cast<NSString>([resolutionReport objectForKey:@"provider"]))
+            report.provider = value.get();
+        if (RetainPtr value = dynamic_objc_cast<NSString>([resolutionReport objectForKey:@"dnsFailureReason"]))
+            report.dnsFailureReason = value.get();
+        if (RetainPtr value = dynamic_objc_cast<NSString>([resolutionReport objectForKey:@"extendedDNSErrorExtraText"]))
+            report.extendedDNSErrorExtraText = value.get();
+        if (RetainPtr interfaces = dynamic_objc_cast<NSArray>([resolutionReport objectForKey:@"interfaces"])) {
+            for (id entry in interfaces.get()) {
+                RetainPtr interfaceDictionary = dynamic_objc_cast<NSDictionary>(entry);
+                if (!interfaceDictionary)
+                    continue;
+                NetworkResolutionReportInterface interface;
+                if (RetainPtr value = dynamic_objc_cast<NSString>([interfaceDictionary objectForKey:@"type"]))
+                    interface.type = value.get();
+                if (RetainPtr value = dynamic_objc_cast<NSString>([interfaceDictionary objectForKey:@"name"]))
+                    interface.name = value.get();
+                report.interfaces.append(WTF::move(interface));
+            }
+        }
+        m_networkResolutionReport = WTF::move(report);
+    }
 
     EXTRACT_STRING_VALUE(@"NSDescription", m_description)
 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in
@@ -24,6 +24,18 @@
 
 webkit_platform_headers: "CoreIPCError.h"
 
+[Nested, WebKitPlatform] struct WebKit::CoreIPCError::NetworkResolutionReportInterface {
+    String type;
+    String name;
+}
+
+[Nested, WebKitPlatform] struct WebKit::CoreIPCError::NetworkResolutionReport {
+    String provider;
+    String dnsFailureReason;
+    String extendedDNSErrorExtraText;
+    Vector<WebKit::CoreIPCError::NetworkResolutionReportInterface> interfaces;
+}
+
 [WebKitPlatform] class WebKit::CoreIPCError {
     String m_domain;
     int64_t m_code;
@@ -54,6 +66,7 @@ webkit_platform_headers: "CoreIPCError.h"
     
     String m_networkTaskDescription;
     String m_networkTaskMetricsPrivacyStance;
+    std::optional<WebKit::CoreIPCError::NetworkResolutionReport> m_networkResolutionReport;
 
     String m_description;
 }

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -1326,6 +1326,41 @@ TEST(IPCSerialization, Basic)
     runTestNS({ [NSURLCredential credentialWithUser:@"user" password:@"password" persistence:NSURLCredentialPersistenceSynchronizable] });
 }
 
+TEST(IPCSerialization, NSErrorNetworkResolutionReport)
+{
+    NSDictionary *resolutionReport = @{
+        @"provider" : @"Cloudflare DNS",
+        @"dnsFailureReason" : @"censored",
+        @"extendedDNSErrorExtraText" : @"some extra text",
+        @"interfaces" : @[
+            @{ @"type" : @"wifi", @"name" : @"en0" },
+            @{ @"type" : @"wired", @"name" : @"en1" },
+        ],
+    };
+    NSError *originalError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCannotFindHost userInfo:@{
+        NSLocalizedDescriptionKey : @"A server with the specified hostname could not be found.",
+        @"networkResolutionReport" : resolutionReport,
+    }];
+
+    WebKit::CoreIPCError ipcError = WebKit::CoreIPCError(originalError);
+    RetainPtr<id> roundTripped = ipcError.toID();
+    NSDictionary *roundTrippedReport = [[roundTripped userInfo] objectForKey:@"networkResolutionReport"];
+    ASSERT_TRUE([roundTrippedReport isKindOfClass:NSDictionary.class]);
+    EXPECT_TRUE([[roundTrippedReport objectForKey:@"dnsFailureReason"] isEqual:@"censored"]);
+    EXPECT_TRUE([[roundTrippedReport objectForKey:@"provider"] isEqual:@"Cloudflare DNS"]);
+    EXPECT_TRUE([[roundTrippedReport objectForKey:@"extendedDNSErrorExtraText"] isEqual:@"some extra text"]);
+
+    NSArray *roundTrippedInterfaces = [roundTrippedReport objectForKey:@"interfaces"];
+    ASSERT_TRUE([roundTrippedInterfaces isKindOfClass:NSArray.class]);
+    ASSERT_EQ([roundTrippedInterfaces count], (NSUInteger)2);
+    EXPECT_TRUE([[[roundTrippedInterfaces objectAtIndex:0] objectForKey:@"type"] isEqual:@"wifi"]);
+    EXPECT_TRUE([[[roundTrippedInterfaces objectAtIndex:0] objectForKey:@"name"] isEqual:@"en0"]);
+    EXPECT_TRUE([[[roundTrippedInterfaces objectAtIndex:1] objectForKey:@"type"] isEqual:@"wired"]);
+    EXPECT_TRUE([[[roundTrippedInterfaces objectAtIndex:1] objectForKey:@"name"] isEqual:@"en1"]);
+
+    runTestNS({ (NSError *)roundTripped.get() });
+}
+
 #if HAVE(WK_SECURE_CODING_SECTRUST)
 String cert1(""
     "MIIHezCCBmOgAwIBAgIQfrZYqgaHdOKdEb5ZVqa0LTANBgkqhkiG9w0BAQsFADBRMQswCQYDVQQGEw"


### PR DESCRIPTION
#### fce3e918286667d8d0844306adddf21c4a1f5067
<pre>
Update Serialization for CoreIPCError to have additional members
<a href="https://bugs.webkit.org/show_bug.cgi?id=312235">https://bugs.webkit.org/show_bug.cgi?id=312235</a>
<a href="https://rdar.apple.com/164660765">rdar://164660765</a>

Reviewed by NOBODY (OOPS!).

This changes adds some members which were removed in <a href="https://commits.webkit.org/302861@main">302861@main</a>

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm

* Source/WebKit/Shared/Cocoa/CoreIPCError.h:
(WebKit::CoreIPCError::CoreIPCError):
* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
(WebKit::CoreIPCError::toID const):
(WebKit::CoreIPCError::CoreIPCError):
* Source/WebKit/Shared/Cocoa/CoreIPCError.serialization.in:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, NSErrorNetworkResolutionReport)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fce3e918286667d8d0844306adddf21c4a1f5067

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156248 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110328 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120992 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85126 "Build is in progress. Recent messages:") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140312 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101663 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22277 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20448 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12841 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167548 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11664 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129115 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129228 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139937 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86873 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24057 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16736 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28815 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92772 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28342 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28570 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28466 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->