### PR TITLE
dir=auto on slot elements should update when slotted content changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt
@@ -2,22 +2,19 @@
 PASS dynamic insertion of RTL text in a child element
 PASS dir=auto changes for content insertion and removal, in and out of document
 PASS dir=auto changes for slot reassignment
-FAIL text changes affecting both slot and ancestor with dir=auto assert_false: slot after first text change expected false got true
+PASS text changes affecting both slot and ancestor with dir=auto
 PASS dynamic changes to subtrees excluded as a result of the dir attribute
 PASS dynamic changes inside of non-HTML elements
-FAIL slotted non-HTML elements assert_true: state after first change (slot) expected true got false
+PASS slotted non-HTML elements
 PASS slotted non-HTML elements after dynamically assigning dir=auto, and dir attribute ignored on non-HTML elements
 PASS dir=auto ancestor considers text in subtree after removing dir=ltr from it
 PASS Slotted content affects multiple dir=auto slots
 PASS Removing slotted content resets direction on dir=auto slot
-FAIL Removing child of slotted content changes direction on dir=auto slot assert_equals: slot is reset to ltr expected "ltr" but got "rtl"
+PASS Removing child of slotted content changes direction on dir=auto slot
 PASS Child directionality gets updated when dir=auto is set on parent
-FAIL dir=auto slot is not affected by text in value of input element children assert_equals: expected "ltr" but got "rtl"
+PASS dir=auto slot is not affected by text in value of input element children
 PASS input direction changes if it stops being auto-directionality form-associated
 PASS slot provides updated directionality from host to a dir=auto container
 PASS text input and textarea value changes should only be reflected in :dir() when dir=auto (value changes)
 א
-א א
-א
-
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.js
@@ -383,7 +383,7 @@ test(() => {
   `);
   let inp = tree.querySelector("input");
   assert_equals(html_direction(inp), "rtl");
-  inp.type = "month";
+  inp.type = "number";
   assert_equals(html_direction(inp), "ltr");
   tree.remove();
 }, 'input direction changes if it stops being auto-directionality form-associated');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-slots-directionality-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-slots-directionality-expected.txt
@@ -2,8 +2,6 @@
 Text
 اختبر
 
-     abc
-
 PASS Slots: Directionality: dir=rtl on slot
 PASS Slots: Directionality: dir=rtl on host
 PASS Slots: Directionality: dir=auto on host with Arabic shadow tree content
@@ -15,8 +13,8 @@ PASS children with dir attribute are skipped by dir=auto
 PASS slot with dir attribute is skipped by dir=auto
 FAIL dir=auto slot ignores assigned nodes with dir attribute assert_equals: expected "ltr" but got "rtl"
 FAIL dir=auto slot ignores text in bdi assigned nodes assert_equals: expected "ltr" but got "rtl"
-FAIL dir=auto slot ignores text in value of input element children assert_equals: expected "ltr" but got "rtl"
-FAIL dir=auto slot is not affected by value of auto-directionality form associated elements assert_equals: expected "ltr" but got "rtl"
+PASS dir=auto slot ignores text in value of input element children
+PASS dir=auto slot is not affected by value of auto-directionality form associated elements
 PASS inner slot is given directionality from slotted content
 PASS dir=auto slot is not affected by content inside inner slot (version 1)
 PASS dir=auto slot is not affected by content inside inner slot (version 2)

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3691,6 +3691,16 @@ void Element::childrenChanged(const ChildChange& change)
             }
             if (!allInsertedElementsAreTreatedAsNeutralCharacter)
                 updateEffectiveTextDirection();
+        } else {
+            // No light DOM dir=auto ancestor, but this element may be slotted
+            // into a dir=auto slot whose direction depends on slotted content.
+            for (Ref ancestor : composedTreeAncestors(*this)) {
+                if (auto* slot = dynamicDowncast<HTMLSlotElement>(ancestor.get())) {
+                    if (slot->selfOrPrecedingNodesAffectDirAuto())
+                        slot->updateEffectiveTextDirection();
+                    break;
+                }
+            }
         }
     }
 }

--- a/Source/WebCore/dom/ElementTextDirection.cpp
+++ b/Source/WebCore/dom/ElementTextDirection.cpp
@@ -226,7 +226,7 @@ static std::optional<TextDirection> computeTextDirectionOfSlotElement(const HTML
 std::optional<TextDirection> computeAutoDirectionality(const Element& element)
 {
     if (auto* textFormControl = dynamicDowncast<HTMLTextFormControlElement>(element)) {
-        if (!textFormControl->dirAutoUsesValue())
+        if (!textFormControl->dirAutoUsesValue() || !elementHasAutoTextDirectionState(element))
             return computeContainedTextAutoDirection(*textFormControl);
 
         // Specs: The directionality of the auto-directionality form-associated
@@ -319,7 +319,16 @@ void updateEffectiveTextDirectionOfDescendants(Element& element, std::optional<T
     for (auto it = descendantsOfType<Element>(element).begin(); it; ) {
         Ref child = *it;
 
-        if (child.ptr() == initiator || elementHasValidTextDirectionState(child)) {
+        if (child.ptr() == initiator) {
+            it.traverseNextSkippingChildren();
+            continue;
+        }
+
+        if (elementHasValidTextDirectionState(child)) {
+            // Slot elements with dir=auto depend on slotted light DOM content,
+            // so recompute their direction when propagating changes through the shadow tree.
+            if (RefPtr slotElement = dynamicDowncast<HTMLSlotElement>(child.get()); slotElement && slotElement->isInShadowTree() && elementHasAutoTextDirectionState(child))
+                updateEffectiveTextDirectionOfElementAndDescendants(child, TextDirectionState::Auto);
             it.traverseNextSkippingChildren();
             continue;
         }


### PR DESCRIPTION
#### 4977821844cb9aefdea657ead8c65921bc8b93b6
<pre>
dir=auto on slot elements should update when slotted content changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=312240">https://bugs.webkit.org/show_bug.cgi?id=312240</a>

Reviewed by Ryosuke Niwa.

Fix several issues with dir=auto directionality on slot elements in shadow DOM:

  1. When text changes in slotted content triggered an ancestor dir=auto
     recomputation, updateEffectiveTextDirectionOfDescendants would skip slot
     elements with dir=auto (treating them like dir=ltr/rtl). Now recompute
     their direction since it depends on slotted content that may have changed.

  2. When no light DOM dir=auto ancestor exists (selfOrPrecedingNodesAffectDirAuto
     is false), text changes in slotted elements had no path to notify a dir=auto
     slot. Now Element::childrenChanged walks up to find an assigned slot and
     updates it.

  3. computeAutoDirectionality would use an input element&apos;s value for
     directionality even when the input didn&apos;t have dir=auto. Per spec, the value
     should only be used when the element has dir=auto.

No new tests, rebaselined existing WPT test.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.js:
Resync test from upstream and rebaseline now that all subtests are passing.
Firefox and Chrome were already passing this whole test so this aligns
our havior with them.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::childrenChanged):
Walk up to find assigned dir=auto slot when selfOrPrecedingNodesAffectDirAuto
is false.

* Source/WebCore/dom/ElementTextDirection.cpp:
(WebCore::computeAutoDirectionality):
Recompute dir=auto slot elements instead of skipping them.

(WebCore::updateEffectiveTextDirectionOfDescendants):
Only use form control value when the element has dir=auto.

Canonical link: <a href="https://commits.webkit.org/311325@main">https://commits.webkit.org/311325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9f62c3c0e731738438847853751d9ce7b68c3ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165316 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110575 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121208 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85185 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101877 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22491 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20675 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13088 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132170 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167798 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11911 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129330 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129441 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35093 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140164 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87149 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24259 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16963 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29063 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93019 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28589 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28713 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->