### PR TITLE
[JSC] Do CSE with dominating WasmStructGet and WasmArrayGet

### DIFF
--- a/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
@@ -833,7 +833,8 @@ private:
     void handleMemoryValue(
         Value* ptr, HeapRange range, const Filter& filter, const Replace& replace)
     {
-        MemoryMatches matches = findMemoryValue(ptr, range, filter);
+        // FIXME: Currently we observed some performance regression in this case.
+        MemoryMatches matches = findMemoryValue(ptr, range, filter /* , m_value->as<MemoryValue>()->readsMutability() */);
         if (replaceMemoryValue(matches, replace))
             return;
         m_data.memoryValuesAtTail.add(m_value->as<MemoryValue>());
@@ -898,7 +899,7 @@ private:
     }
 
     template<typename Filter>
-    MemoryMatches findMemoryValue(Value* ptr, HeapRange range, const Filter& filter)
+    MemoryMatches findMemoryValue(Value* ptr, HeapRange range, const Filter& filter, Mutability readsMutability = Mutability::Mutable)
     {
         if constexpr (B3EliminateCommonSubexpressionsInternal::verbose) {
             dataLogLn(*m_value, ": looking backward for ", *ptr, "...");
@@ -915,7 +916,7 @@ private:
             return { match };
         }
 
-        if (m_data.writes.overlaps(range)) {
+        if (readsMutability != Mutability::Immutable && m_data.writes.overlaps(range)) {
             dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Giving up because of writes.");
             return { };
         }
@@ -938,7 +939,7 @@ private:
                 continue;
             }
 
-            if (data.writes.overlaps(range)) {
+            if (readsMutability != Mutability::Immutable && data.writes.overlaps(range)) {
                 dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Giving up because of writes.");
                 return { };
             }
@@ -1019,14 +1020,14 @@ private:
         uint64_t fieldHeapKey = structGet->fieldHeapKey();
 
         dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Processing WasmStructGet: ", *structGet, " fieldHeapKey=", fieldHeapKey);
-        WasmStructMatches matches = findWasmStructValue(structPtr, range, fieldHeapKey, [&](WasmStructFieldValue*) { return true; });
+        WasmStructMatches matches = findWasmStructValue(structPtr, range, fieldHeapKey, [&](WasmStructFieldValue*) { return true; }, structGet->mutability());
         if (replaceWasmStructValue(matches, structGet))
             return;
         m_data.wasmStructValuesAtTail.add(structGet);
     }
 
     template<typename Filter>
-    WasmStructMatches findWasmStructValue(Value* structPtr, HeapRange range, uint64_t fieldHeapKey, const Filter& filter)
+    WasmStructMatches findWasmStructValue(Value* structPtr, HeapRange range, uint64_t fieldHeapKey, const Filter& filter, Mutability readsMutability = Mutability::Mutable)
     {
         if constexpr (B3EliminateCommonSubexpressionsInternal::verbose) {
             dataLogLn(*m_value, ": looking backward for WasmStruct structPtr=", *structPtr, " fieldHeapKey=", fieldHeapKey);
@@ -1040,7 +1041,7 @@ private:
         }
 
         // Check if current block has clobbering writes
-        if (m_data.writes.overlaps(range)) {
+        if (readsMutability != Mutability::Immutable && m_data.writes.overlaps(range)) {
             dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Giving up because of writes.");
             return { };
         }
@@ -1064,7 +1065,7 @@ private:
                 continue;
             }
 
-            if (data.writes.overlaps(range)) {
+            if (readsMutability != Mutability::Immutable && data.writes.overlaps(range)) {
                 dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Giving up because of writes.");
                 return { };
             }
@@ -1260,14 +1261,14 @@ private:
         HeapRange range = arrayGet->range();
 
         dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Processing WasmArrayGet: ", *arrayGet);
-        WasmArrayMatches matches = findWasmArrayValue(arrayPtr, indexValue, range, [&](WasmArrayElementValue*) { return true; });
+        WasmArrayMatches matches = findWasmArrayValue(arrayPtr, indexValue, range, [&](WasmArrayElementValue*) { return true; }, arrayGet->mutability());
         if (replaceWasmArrayValue(matches, arrayGet))
             return;
         m_data.wasmArrayValuesAtTail.add(arrayGet);
     }
 
     template<typename Filter>
-    WasmArrayMatches findWasmArrayValue(Value* arrayPtr, Value* indexValue, HeapRange range, const Filter& filter)
+    WasmArrayMatches findWasmArrayValue(Value* arrayPtr, Value* indexValue, HeapRange range, const Filter& filter, Mutability readsMutability = Mutability::Mutable)
     {
         // Check local block first
         if (auto* match = m_data.wasmArrayValuesAtTail.find(arrayPtr, indexValue, filter)) {
@@ -1275,7 +1276,7 @@ private:
             return { match };
         }
 
-        if (m_data.writes.overlaps(range)) {
+        if (readsMutability != Mutability::Immutable && m_data.writes.overlaps(range)) {
             dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Giving up because of writes.");
             return { };
         }
@@ -1294,7 +1295,7 @@ private:
                 continue;
             }
 
-            if (data.writes.overlaps(range)) {
+            if (readsMutability != Mutability::Immutable && data.writes.overlaps(range)) {
                 dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Giving up because of writes.");
                 return { };
             }


### PR DESCRIPTION
#### ba9a7345f3d072f56b77159c91da80047c35dfee
<pre>
[JSC] Do CSE with dominating WasmStructGet and WasmArrayGet
<a href="https://bugs.webkit.org/show_bug.cgi?id=312246">https://bugs.webkit.org/show_bug.cgi?id=312246</a>
<a href="https://rdar.apple.com/174722429">rdar://174722429</a>

Reviewed by Yijia Huang.

If WasmStructGet and WasmArrayGet are annotated with Immutable, then
regardless of what memory gets clobbered, we can perform CSE with dominating
values.

* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:

Canonical link: <a href="https://commits.webkit.org/311219@main">https://commits.webkit.org/311219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39803a38c057a91b8cb8e0138a9fae16e9aa7f53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165091 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121013 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101684 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22293 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20464 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12863 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148320 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131959 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167570 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17105 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129136 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129249 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139954 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86895 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23806 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24072 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16753 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188153 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28837 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92794 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48374 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28364 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28592 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28488 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->