### PR TITLE
[WTF] SIMD-accelerate appendEscapedJSONStringContent for sparse escapes

### DIFF
--- a/JSTests/microbenchmarks/json-stringify-long-string-16bit-sparse-escape.js
+++ b/JSTests/microbenchmarks/json-stringify-long-string-16bit-sparse-escape.js
@@ -1,0 +1,25 @@
+// Long 16-bit strings (non-Latin1 content) with sparsely distributed escape
+// characters. Exercises the 16-bit SIMD path including the surrogate check.
+
+function makeParagraph(words, escapeEvery)
+{
+    let s = "";
+    for (let i = 0; i < words; ++i) {
+        s += "\u3042\u3044\u3046\u3048\u304a\u304b\u304d\u304f\u3051\u3053 ";
+        if (!(i % escapeEvery))
+            s += "\n";
+    }
+    return s;
+}
+
+const body = {
+    items: [],
+};
+for (let i = 0; i < 20; ++i)
+    body.items.push({ id: i, content: makeParagraph(300, 5) });
+
+const expectedLength = JSON.stringify(body).length;
+for (let i = 0; i < 1000; ++i) {
+    if (JSON.stringify(body).length !== expectedLength)
+        throw new Error("bad result");
+}

--- a/JSTests/microbenchmarks/json-stringify-long-string-dense-escape.js
+++ b/JSTests/microbenchmarks/json-stringify-long-string-dense-escape.js
@@ -1,0 +1,12 @@
+// Long strings where every character requires JSON escaping. This is the
+// pathological case for any "scan for the next escape" strategy and should
+// not regress compared to per-character processing.
+
+const chunk = "\n\t\"\\".repeat(3000);
+const body = { a: chunk, b: chunk, c: chunk };
+
+const expectedLength = JSON.stringify(body).length;
+for (let i = 0; i < 2000; ++i) {
+    if (JSON.stringify(body).length !== expectedLength)
+        throw new Error("bad result");
+}

--- a/JSTests/microbenchmarks/json-stringify-long-string-no-escape.js
+++ b/JSTests/microbenchmarks/json-stringify-long-string-no-escape.js
@@ -1,0 +1,15 @@
+// Long 8-bit strings containing no characters that require JSON escaping.
+// Exercises the pure bulk-copy path of appendEscapedJSONStringContent.
+
+const chunk = "abcdefghijklmnopqrstuvwxyz0123456789 ".repeat(300);
+const body = {
+    items: [],
+};
+for (let i = 0; i < 20; ++i)
+    body.items.push({ id: i, content: chunk });
+
+const expectedLength = JSON.stringify(body).length;
+for (let i = 0; i < 1000; ++i) {
+    if (JSON.stringify(body).length !== expectedLength)
+        throw new Error("bad result");
+}

--- a/JSTests/microbenchmarks/json-stringify-long-string-sparse-escape.js
+++ b/JSTests/microbenchmarks/json-stringify-long-string-sparse-escape.js
@@ -1,0 +1,33 @@
+// Long 8-bit strings with sparsely distributed characters that require JSON
+// escaping (~1.5% density). This is representative of stringifying large text
+// payloads such as documents, logs, or chat transcripts where most content is
+// plain ASCII prose with occasional newlines and quotes.
+
+function makeParagraph(words, escapeEvery)
+{
+    let s = "";
+    for (let i = 0; i < words; ++i) {
+        s += "lorem ipsum dolor sit amet ";
+        if (!(i % escapeEvery))
+            s += i % 2 ? "\n" : '"';
+    }
+    return s;
+}
+
+const body = {
+    version: 1,
+    items: [],
+};
+for (let i = 0; i < 20; ++i) {
+    body.items.push({
+        id: "item-" + i,
+        kind: "text",
+        content: makeParagraph(200, 4),
+    });
+}
+
+const expectedLength = JSON.stringify(body).length;
+for (let i = 0; i < 1000; ++i) {
+    if (JSON.stringify(body).length !== expectedLength)
+        throw new Error("bad result");
+}

--- a/JSTests/stress/json-stringify-string-escape-simd.js
+++ b/JSTests/stress/json-stringify-string-escape-simd.js
@@ -1,0 +1,98 @@
+// Exhaustively verify that JSON.stringify produces correct output for every
+// code unit, with the special character placed at every offset within a
+// 16-byte SIMD stride and across stride boundaries. This guards the SIMD
+// fast path in WTF::appendEscapedJSONStringContent.
+
+function shouldBe(actual, expected, message)
+{
+    if (actual !== expected)
+        throw new Error("FAIL: " + message + "\n  expected: " + expected + "\n  actual:   " + actual);
+}
+
+function needsEscape(code)
+{
+    return code < 0x20 || code === 0x22 || code === 0x5C;
+}
+
+function isSurrogate(code)
+{
+    return code >= 0xD800 && code <= 0xDFFF;
+}
+
+function expectedSingle(code)
+{
+    if (code === 0x08) return '\\b';
+    if (code === 0x09) return '\\t';
+    if (code === 0x0A) return '\\n';
+    if (code === 0x0C) return '\\f';
+    if (code === 0x0D) return '\\r';
+    if (code === 0x22) return '\\"';
+    if (code === 0x5C) return '\\\\';
+    if (code < 0x20 || isSurrogate(code))
+        return "\\u" + code.toString(16).padStart(4, "0");
+    return String.fromCharCode(code);
+}
+
+const stride = 16;
+const pad8 = "a";
+const pad16 = "\u3042";
+
+// 1. Every Latin1 code unit at every offset in [0, 2*stride], with 8-bit padding.
+for (let code = 0; code <= 0xFF; ++code) {
+    const ch = String.fromCharCode(code);
+    const exp = expectedSingle(code);
+    for (let prefix = 0; prefix <= 2 * stride + 1; ++prefix) {
+        for (let suffix of [0, 1, stride - 1, stride, stride + 1]) {
+            const s = pad8.repeat(prefix) + ch + pad8.repeat(suffix);
+            const expected = '"' + pad8.repeat(prefix) + exp + pad8.repeat(suffix) + '"';
+            shouldBe(JSON.stringify(s), expected, "latin1 code=" + code + " prefix=" + prefix + " suffix=" + suffix);
+            if (!isSurrogate(code))
+                shouldBe(JSON.parse(JSON.stringify(s)), s, "round-trip code=" + code);
+        }
+    }
+}
+
+// 2. Boundary code units for the 16-bit path (around surrogate range and BMP edges).
+for (let code of [0x0100, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x5B, 0x5C, 0x5D, 0x7F, 0x80, 0xFF, 0xD7FE, 0xD7FF, 0xD800, 0xD801, 0xDBFF, 0xDC00, 0xDFFE, 0xDFFF, 0xE000, 0xE001, 0xFFFE, 0xFFFF]) {
+    const ch = String.fromCharCode(code);
+    const exp = expectedSingle(code);
+    for (let prefix = 0; prefix <= 2 * stride + 1; ++prefix) {
+        const s = pad16.repeat(prefix) + ch + pad16.repeat(stride);
+        const expected = '"' + pad16.repeat(prefix) + exp + pad16.repeat(stride) + '"';
+        shouldBe(JSON.stringify(s), expected, "16bit code=0x" + code.toString(16) + " prefix=" + prefix);
+    }
+}
+
+// 3. Valid surrogate pairs at every offset must be passed through unescaped.
+{
+    const pair = "\uD83D\uDE00";
+    for (let prefix = 0; prefix <= 2 * stride + 1; ++prefix) {
+        const s = pad16.repeat(prefix) + pair + pad16.repeat(stride);
+        shouldBe(JSON.stringify(s), '"' + s + '"', "valid surrogate pair prefix=" + prefix);
+        shouldBe(JSON.parse(JSON.stringify(s)), s, "valid surrogate pair round-trip prefix=" + prefix);
+    }
+}
+
+// 4. Escape characters straddling a stride boundary, including runs.
+for (let len of [1, 2, stride - 1, stride, stride + 1, 2 * stride]) {
+    for (let prefix of [0, 1, stride - 1, stride, stride + 1]) {
+        const s = pad8.repeat(prefix) + "\n".repeat(len) + pad8.repeat(stride);
+        const expected = '"' + pad8.repeat(prefix) + "\\n".repeat(len) + pad8.repeat(stride) + '"';
+        shouldBe(JSON.stringify(s), expected, "run len=" + len + " prefix=" + prefix);
+    }
+}
+
+// 5. Two escape characters separated by exactly N clean bytes (tests resume-after-escape).
+for (let gap = 0; gap <= 2 * stride + 1; ++gap) {
+    const s = pad8.repeat(stride) + "\n" + pad8.repeat(gap) + '"' + pad8.repeat(stride);
+    const expected = '"' + pad8.repeat(stride) + "\\n" + pad8.repeat(gap) + '\\"' + pad8.repeat(stride) + '"';
+    shouldBe(JSON.stringify(s), expected, "gap=" + gap);
+}
+
+// 6. Idempotency under repeated stringify on the same input (guards any per-string caching).
+{
+    const s = pad8.repeat(100) + "\n" + pad8.repeat(100);
+    const first = JSON.stringify(s);
+    for (let i = 0; i < 3; ++i)
+        shouldBe(JSON.stringify(s), first, "idempotent");
+}

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1098,6 +1098,7 @@ ALWAYS_INLINE void FastStringifier<CharType, bufferMode>::appendInt32(int32_t nu
     }
 }
 
+// FIXME: WTF::appendEscapedJSONStringContent now has a SIMD fast path, so this prepass is redundant for strings with escapes.
 template<typename CharType>
 static ALWAYS_INLINE bool stringCopySameType(std::span<const CharType> span, CharType* cursor)
 {

--- a/Source/WTF/wtf/text/StringBuilderJSON.h
+++ b/Source/WTF/wtf/text/StringBuilderJSON.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <wtf/SIMDHelpers.h>
 #include <wtf/text/EscapedFormsForJSON.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilderInternals.h>
@@ -21,59 +22,100 @@ namespace WTF {
 template<typename OutputCharacterType, typename InputCharacterType>
 ALWAYS_INLINE static bool appendEscapedJSONStringContent(std::span<OutputCharacterType>& output, std::span<const InputCharacterType> input)
 {
-    for (; !input.empty(); skip(input, 1)) {
-        auto character = input.front();
-        if (character <= 0xFF) [[likely]] {
-            auto escaped = escapedFormsForJSON[character];
-            if (!escaped) [[likely]] {
+    while (!input.empty()) {
+        size_t scalarBudget = std::numeric_limits<size_t>::max();
+#if (CPU(ARM64) || CPU(X86_64)) && COMPILER(CLANG)
+        if constexpr (sizeof(OutputCharacterType) >= sizeof(InputCharacterType)) {
+            using UnsignedType = SameSizeUnsignedInteger<InputCharacterType>;
+            constexpr size_t stride = SIMD::stride<InputCharacterType>;
+            constexpr auto quoteMask = SIMD::splat<UnsignedType>('"');
+            constexpr auto escapeMask = SIMD::splat<UnsignedType>('\\');
+            constexpr auto controlMask = SIMD::splat<UnsignedType>(' ');
+            while (input.size() >= stride) {
+                auto chunk = SIMD::load(std::bit_cast<const UnsignedType*>(input.data()));
+                auto mask = SIMD::bitOr(SIMD::equal(chunk, quoteMask), SIMD::equal(chunk, escapeMask), SIMD::lessThan(chunk, controlMask));
+                if constexpr (sizeof(InputCharacterType) != 1) {
+                    constexpr auto surrogateMask = SIMD::splat<UnsignedType>(0xf800);
+                    constexpr auto surrogateCheckMask = SIMD::splat<UnsignedType>(0xd800);
+                    mask = SIMD::bitOr(mask, SIMD::equal(SIMD::bitAnd(chunk, surrogateMask), surrogateCheckMask));
+                }
+                if (auto index = SIMD::findFirstNonZeroIndex(mask)) {
+                    unsigned cleanCount = index.value();
+                    for (unsigned i = 0; i < cleanCount; ++i)
+                        output[i] = input[i];
+                    skip(output, cleanCount);
+                    skip(input, cleanCount);
+                    break;
+                }
+                if constexpr (sizeof(OutputCharacterType) == sizeof(InputCharacterType))
+                    SIMD::store(chunk, std::bit_cast<UnsignedType*>(output.data()));
+                else {
+                    constexpr auto zeros = SIMD::splat<UnsignedType>(0);
+                    simde_vst2q_u8(std::bit_cast<uint8_t*>(output.data()), (simde_uint8x16x2_t { chunk, zeros }));
+                }
+                skip(input, stride);
+                skip(output, stride);
+            }
+            if (input.empty())
+                return true;
+            scalarBudget = stride;
+        }
+#endif
+        for (; scalarBudget && !input.empty(); --scalarBudget) {
+            auto character = input.front();
+            skip(input, 1);
+            if (character <= 0xFF) [[likely]] {
+                auto escaped = escapedFormsForJSON[character];
+                if (!escaped) [[likely]] {
+                    consume(output) = character;
+                    continue;
+                }
+
+                output[0] = '\\';
+                output[1] = escaped;
+                skip(output, 2);
+                if (escaped == 'u') [[unlikely]] {
+                    output[0] = '0';
+                    output[1] = '0';
+                    output[2] = upperNibbleToLowercaseASCIIHexDigit(character);
+                    output[3] = lowerNibbleToLowercaseASCIIHexDigit(character);
+                    skip(output, 4);
+                }
+                continue;
+            }
+
+            // We can end up calling appendEscapedJSONStringContent if we've already proven the string has only Latin1 characters when stringifying JSONs.
+            // This optimization prevents us from bailing out mid-stream just because we saw e.g. a UTF-16 substring that was actually Latin1.
+            if constexpr (std::same_as<OutputCharacterType, Latin1Character>)
+                return false;
+
+            if (!U16_IS_SURROGATE(character)) [[likely]] {
                 consume(output) = character;
                 continue;
             }
 
+            if (!input.empty()) {
+                auto next = input.front();
+                bool isValidSurrogatePair = U16_IS_SURROGATE_LEAD(character) && U16_IS_TRAIL(next);
+                if (isValidSurrogatePair) {
+                    output[0] = character;
+                    output[1] = next;
+                    skip(output, 2);
+                    skip(input, 1);
+                    continue;
+                }
+            }
+
+            uint8_t upper = static_cast<uint32_t>(character) >> 8;
+            uint8_t lower = static_cast<uint8_t>(character);
             output[0] = '\\';
-            output[1] = escaped;
-            skip(output, 2);
-            if (escaped == 'u') [[unlikely]] {
-                output[0] = '0';
-                output[1] = '0';
-                output[2] = upperNibbleToLowercaseASCIIHexDigit(character);
-                output[3] = lowerNibbleToLowercaseASCIIHexDigit(character);
-                skip(output, 4);
-            }
-            continue;
+            output[1] = 'u';
+            output[2] = upperNibbleToLowercaseASCIIHexDigit(upper);
+            output[3] = lowerNibbleToLowercaseASCIIHexDigit(upper);
+            output[4] = upperNibbleToLowercaseASCIIHexDigit(lower);
+            output[5] = lowerNibbleToLowercaseASCIIHexDigit(lower);
+            skip(output, 6);
         }
-
-        // We can end up calling appendEscapedJSONStringContent if we've already proven the string has only Latin1 characters when stringifying JSONs.
-        // This optimization prevents us from bailing out mid-stream just because we saw e.g. a UTF-16 substring that was actually Latin1.
-        if constexpr (std::same_as<OutputCharacterType, Latin1Character>)
-            return false;
-
-        if (!U16_IS_SURROGATE(character)) [[likely]] {
-            consume(output) = character;
-            continue;
-        }
-
-        if (input.size() > 1) {
-            auto next = input[1];
-            bool isValidSurrogatePair = U16_IS_SURROGATE_LEAD(character) && U16_IS_TRAIL(next);
-            if (isValidSurrogatePair) {
-                output[0] = character;
-                output[1] = next;
-                skip(output, 2);
-                skip(input, 1);
-                continue;
-            }
-        }
-
-        uint8_t upper = static_cast<uint32_t>(character) >> 8;
-        uint8_t lower = static_cast<uint8_t>(character);
-        output[0] = '\\';
-        output[1] = 'u';
-        output[2] = upperNibbleToLowercaseASCIIHexDigit(upper);
-        output[3] = lowerNibbleToLowercaseASCIIHexDigit(upper);
-        output[4] = upperNibbleToLowercaseASCIIHexDigit(lower);
-        output[5] = lowerNibbleToLowercaseASCIIHexDigit(lower);
-        skip(output, 6);
     }
 
     return true;


### PR DESCRIPTION
#### ef92461e8f54d5a9603e256a9d1c87d454ab63c9
<pre>
[WTF] SIMD-accelerate appendEscapedJSONStringContent for sparse escapes
<a href="https://bugs.webkit.org/show_bug.cgi?id=312250">https://bugs.webkit.org/show_bug.cgi?id=312250</a>

Reviewed by NOBODY (OOPS!).

JSON.stringify spends most of its time in appendEscapedJSONStringContent
when serializing long strings that contain at least one character
requiring escaping. The existing implementation processes such strings
one character at a time via a table lookup, even though typically only
1-3% of characters actually need escaping.

This patch adds a SIMD inner loop that scans 16 bytes at a time using
the same comparison masks already used by stringCopySameType in
JSONObject.cpp (== &apos;&quot;&apos;, == &apos;\\&apos;, &lt; 0x20, plus surrogate detection for
16-bit input). Chunks containing no special characters are bulk-copied.
When a special character is found, findFirstNonZeroIndex locates it,
the clean prefix is copied, and a bounded scalar loop (one stride of
characters) handles the escaping before returning to SIMD.

Trade-off: strings where ~25% or more of characters require escaping
regress by 15-23% because each SIMD probe advances only a few characters.
The scalar budget bounds this to one SIMD probe per stride characters.
Measuring real payloads, strings in this density range account for 0% of
bytes in LLM API request bodies and 0.2% of bytes in the JetStream3
inspector payload, so we expect this case to be rare in practice.

I confirmed JetStream3 json-stringify-inspector is neutral locally.

                                                  TipOfTree                  Patched

json-stringify-long-string-dense-escape        69.4337+-2.3170     !     79.9072+-0.6972        ! definitely 1.1508x slower
json-stringify-long-string-16bit-sparse-escape
                                               72.4734+-2.9775     ^     30.1862+-0.9790        ^ definitely 2.4009x faster
json-stringify-long-string-no-escape           25.6204+-1.0934           24.6354+-0.4016          might be 1.0400x faster
json-stringify-long-string-sparse-escape       66.9027+-1.1100     ^     29.9640+-2.2112        ^ definitely 2.2328x faster

Tests: JSTests/microbenchmarks/json-stringify-long-string-16bit-sparse-escape.js
       JSTests/microbenchmarks/json-stringify-long-string-dense-escape.js
       JSTests/microbenchmarks/json-stringify-long-string-no-escape.js
       JSTests/microbenchmarks/json-stringify-long-string-sparse-escape.js
       JSTests/stress/json-stringify-string-escape-simd.js

* JSTests/microbenchmarks/json-stringify-long-string-16bit-sparse-escape.js: Added.
(makeParagraph):
* JSTests/microbenchmarks/json-stringify-long-string-dense-escape.js: Added.
* JSTests/microbenchmarks/json-stringify-long-string-no-escape.js: Added.
* JSTests/microbenchmarks/json-stringify-long-string-sparse-escape.js: Added.
(makeParagraph):
* JSTests/stress/json-stringify-string-escape-simd.js: Added.
(shouldBe):
(needsEscape):
(isSurrogate):
(expectedSingle):
(string_appeared_here.code.toString):
(shouldBe.JSON.stringify):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
* Source/WTF/wtf/text/StringBuilderJSON.h:
(WTF::appendEscapedJSONStringContent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef92461e8f54d5a9603e256a9d1c87d454ab63c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165095 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110354 "An unexpected error occured. Recent messages:Printed configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121017 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/110354 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159232 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23225 "Found 1 new test failure: media/track/track-in-band-chapters.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22301 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20469 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12867 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148324 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167574 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17109 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11690 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129141 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129254 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86902 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24080 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16759 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188157 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28841 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92798 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48376 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28368 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28596 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->