### PR TITLE
Make InspectorBackendCommands.js compiler independent

### DIFF
--- a/Source/JavaScriptCore/inspector/scripts/codegen/preprocess.pl
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/preprocess.pl
@@ -44,7 +44,7 @@ if (!$preprocessor) {
         push(@args, qw(/nologo /EP /TP /C));
     } else {
         $preprocessor = $ENV{CC} || (-x "/usr/bin/clang" ? "/usr/bin/clang" : "/usr/bin/gcc");
-        push(@args, qw(-E -P -x c++ -C));
+        push(@args, qw(-E -P -x c++ -C -ffreestanding));
     }
 }
 


### PR DESCRIPTION
#### 2012029f8a6759ec7d695c82f885ef81bfb093a8
<pre>
Make InspectorBackendCommands.js compiler independent
<a href="https://bugs.webkit.org/show_bug.cgi?id=312258">https://bugs.webkit.org/show_bug.cgi?id=312258</a>

Reviewed by Adrian Perez de Castro and Devin Rousso.

preprocess.pl generates InspectorBackendCommands.js by passing it
first through the C preprocessor, using the &apos;-C&apos; flag to preserve the
comments. gcc implicitly includes &lt;stdc-predef.h&gt;, whose comments then
leak into the generated output, while clang does not.

Pass -ffreestanding so gcc skips the stdc-predef.h preinclusion,
matching clang&apos;s behavior and producing identical output everywhere.

* Source/JavaScriptCore/inspector/scripts/codegen/preprocess.pl:

Canonical link: <a href="https://commits.webkit.org/311268@main">https://commits.webkit.org/311268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e3ce3a3807b91ce88fd9c03b7fb9a4c928937a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165106 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110365 "An unexpected error occured. Recent messages:Printed configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121027 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/110365 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140345 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22311 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20479 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12878 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148335 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167585 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17120 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129151 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129264 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35056 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139970 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86919 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24089 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16769 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188168 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92809 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48379 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28379 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->