### PR TITLE
HTMLElement.accessKeyLabel should return the empty string when the accesskey is invalid

### DIFF
--- a/LayoutTests/fast/css-grid-layout/setting-node-properties-to-null-during-layout-should-not-crash-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/setting-node-properties-to-null-during-layout-should-not-crash-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: An accessKey with more than one code point is not supported.
 This test passes if it does not crash.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/access-key-label-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/access-key-label-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Returns non empty string when accesskey is valid
+PASS Returns empty string when accesskey is invalid
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/access-key-label.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/access-key-label.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>accessKeyLabel attribute</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+function createButtonWithAccessKey(accessKey) {
+    const button = document.createElement('button');
+    button.setAttribute('accesskey', accessKey);
+    return button;
+}
+
+// The modifiers are not the same across all browser vendors.
+// Therefore, the test uses non empty.
+test(() => {
+    const element = createButtonWithAccessKey('b');
+    assert_not_equals(element.accessKeyLabel, '');
+}, 'Returns non empty string when accesskey is valid');
+
+test(() => {
+    const element = createButtonWithAccessKey('s 0');
+    assert_equals(element.accessKeyLabel, '');
+}, 'Returns empty string when accesskey is invalid');
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1222,25 +1222,25 @@ ExceptionOr<Ref<Document>> Document::parseHTMLUnsafe(Document& context, Variant<
 
 Element* Document::elementForAccessKey(const String& key)
 {
-    if (key.isEmpty())
+    if (key.length() != 1)
         return nullptr;
     if (!m_accessKeyCache)
         buildAccessKeyCache();
-    return m_accessKeyCache->get(key);
+    return m_accessKeyCache->get(toASCIILower(key[0]));
 }
 
 void Document::buildAccessKeyCache()
 {
     m_accessKeyCache = [this] {
-        HashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash> map;
+        HashMap<char16_t, WeakPtr<Element, WeakPtrImplWithEventTargetData>> map;
         for (CheckedRef node : composedTreeDescendants(*this)) {
             CheckedPtr element = dynamicDowncast<Element>(node);
             if (!element)
                 continue;
             auto& key = element->attributeWithoutSynchronization(accesskeyAttr);
-            if (key.isEmpty())
+            if (key.length() != 1)
                 continue;
-            map.add(key, *element);
+            map.add(toASCIILower(key[0]), *element);
         }
         return map;
     }();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2415,7 +2415,7 @@ private:
     WeakHashSet<VisibilityChangeClient> m_visibilityStateCallbackClients;
     bool m_deferResizeEventForVisibilityChange { false };
 
-    std::optional<HashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash>> m_accessKeyCache;
+    std::optional<HashMap<char16_t, WeakPtr<Element, WeakPtrImplWithEventTargetData>>> m_accessKeyCache;
 
     std::unique_ptr<ConstantPropertyMap> m_constantPropertyMap;
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -718,6 +718,11 @@ String HTMLElement::accessKeyLabel() const
     if (accessKey.isEmpty())
         return String();
 
+    if (accessKey.length() > 1) {
+        protect(document())->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "An accessKey with more than one code point is not supported."_s);
+        return String();
+    }
+
     StringBuilder result;
 
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### c05ba7580ab8e16e03501bc7048a4dc7e348da53
<pre>
HTMLElement.accessKeyLabel should return the empty string when the accesskey is invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=312259">https://bugs.webkit.org/show_bug.cgi?id=312259</a>

Reviewed by NOBODY (OOPS!).

Have HTMLElement.accessKeyLabel return the empty string when the accesskey
has more than one codepoint and log an warning message to the JS console,
just like Chrome does.

Also update our accessKey HashMap to use a char16_t as key instead of a
String for simplicity.

Test: imported/w3c/web-platform-tests/html/dom/access-key-label.html

* LayoutTests/imported/w3c/web-platform-tests/html/dom/access-key-label-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/dom/access-key-label.html: Added.
Import WPT from upstream. This test is failing in shipping Safari but
passing in both Chrome and Firefox.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::elementForAccessKey):
(WebCore::Document::buildAccessKeyCache):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::accessKeyLabel const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c05ba7580ab8e16e03501bc7048a4dc7e348da53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165116 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121035 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101706 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22321 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20488 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12888 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167595 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11711 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129159 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129272 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139981 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86943 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24099 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16780 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28862 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92819 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28389 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28617 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28513 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->