### PR TITLE
innerText getter: improve handling of replaced elements at block boundaries

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -43,7 +43,7 @@ PASS Whitespace around inline-flex should not be collapsed ("<div>abc <span styl
 PASS Trailing space at end of inline-flex should be collapsed ("<div>abc <span style='display:inline-flex'> def </span> ghi")
 PASS Whitespace around inline-grid should not be collapsed ("<div>abc <span style='display:inline-grid'></span> def")
 PASS Trailing space at end of grid-flex should be collapsed ("<div>abc <span style='display:inline-grid'> def </span> ghi")
-FAIL Whitespace between <input> and block should be collapsed ("<div><input> <div>abc</div>") assert_equals: innerText expected "abc" but got "\nabc"
+PASS Whitespace between <input> and block should be collapsed ("<div><input> <div>abc</div>")
 PASS Whitespace between inline-block and block should be collapsed ("<div><span style='inline-block'></span> <div>abc</div>")
 PASS Whitespace between inline-flex and block should be collapsed ("<div><span style='inline-flex'></span> <div>abc</div>")
 PASS Whitespace between inline-grid and block should be collapsed ("<div><span style='inline-grid'></span> <div>abc</div>")
@@ -54,8 +54,8 @@ PASS Trailing whitesapce should not be collapsed ("<div>abc <img>")
 PASS Whitespace around empty span should be collapsed ("<div>abc <b></b> def")
 PASS Whitespace around empty spans should be collapsed ("<div>abc <b><i></i></b> def")
 PASS <canvas> should not collapse following space ("<div><canvas></canvas> abc")
-FAIL Replaced element <img> with display:block should be treated as block-level ("<div>abc <img style='display:block'> def") assert_equals: innerText expected "abc\ndef" but got "abc def"
-FAIL Replaced element <canvas> with display:block should be treated as block-level ("<div>abc <canvas style='display:block'></canvas> def") assert_equals: innerText expected "abc\ndef" but got "abc def"
+PASS Replaced element <img> with display:block should be treated as block-level ("<div>abc <img style='display:block'> def")
+PASS Replaced element <canvas> with display:block should be treated as block-level ("<div>abc <canvas style='display:block'></canvas> def")
 PASS Soft line breaks ignored ("<div style='width:0'>abc def")
 PASS Soft line break at hyphen ignored ("<div style='width:0'>abc-def")
 PASS Whitespace text node preserved ("<div style='width:0'><span>abc</span> <span>def</span>")

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -61,6 +61,7 @@
 #include "RenderImage.h"
 #include "RenderIterator.h"
 #include "RenderObjectInlines.h"
+#include "RenderReplaced.h"
 #include "RenderTableCell.h"
 #include "RenderTableRow.h"
 #include "RenderTextControl.h"
@@ -527,7 +528,7 @@ void TextIterator::advance()
                     m_handledChildren = true;
                 else if (renderer->isRenderText() && m_currentNode->isTextNode())
                     m_handledNode = handleTextNode();
-                else if (isRendererReplacedElement(renderer.get(), m_behaviors))
+                else if (isRendererReplacedElement(renderer.get(), m_behaviors) && (renderer->isInline() || !m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec)))
                     m_handledNode = handleReplacedElement();
                 else
                     m_handledNode = handleNonTextNode();
@@ -821,7 +822,13 @@ bool TextIterator::handleReplacedElement()
         ASSERT_NOT_REACHED();
     }
 
-    m_hasEmitted = true;
+    // In innerText mode, replaced elements that produce no visible text (e.g.
+    // <input>) should not count as having emitted content. This prevents
+    // spurious block-boundary newlines when the only thing before a block
+    // element is a replaced element with no text output. For other modes,
+    // preserve the existing behavior to avoid changing test expectations.
+    if (!m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec))
+        m_hasEmitted = true;
 
     auto shouldEmitObjectReplacementCharacter = [&] {
         if (m_behaviors.contains(TextIteratorBehavior::EmitsObjectReplacementCharacters))
@@ -862,6 +869,7 @@ bool TextIterator::handleReplacedElement()
     if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(*renderer); renderImage && m_behaviors.contains(TextIteratorBehavior::EmitsImageAltText)) {
         auto altText = renderImage->altText();
         if (unsigned length = altText.length()) {
+            m_hasEmitted = true;
             m_lastCharacter = altText[length - 1];
             m_copyableText.set(WTF::move(altText));
             m_text = m_copyableText.text();
@@ -901,6 +909,13 @@ static bool NODELETE shouldEmitReplacementInsteadOfNode(const Node& node)
     // Placeholders should eventually disappear, so treating them as a line break doesn't make sense
     // as when they are removed the text after it is combined with the text before it.
     return is<TextPlaceholderElement>(node);
+}
+
+static bool isBlockLevelReplacedElement(Node& node)
+{
+    auto* renderer = node.renderer();
+    return renderer && !renderer->isInline() && is<RenderReplaced>(*renderer)
+        && !renderer->isFloatingOrOutOfFlowPositioned();
 }
 
 bool shouldEmitNewlinesBeforeAndAfterNode(Node& node)
@@ -1103,7 +1118,7 @@ void TextIterator::representNodeOffsetZero()
             RefPtr parentNode = currentNode->parentNode();
             emitCharacter('\t', WTF::move(parentNode), WTF::move(currentNode), 0, 0);
         }
-    } else if (shouldEmitNewlineBeforeNode(*currentNode)) {
+    } else if (shouldEmitNewlineBeforeNode(*currentNode) || (emitsNewlinesPerInnerTextSpec && isBlockLevelReplacedElement(*currentNode))) {
         if (shouldRepresentNodeOffsetZero()) {
             RefPtr parentNode = currentNode->parentNode();
             emitCharacter('\n', WTF::move(parentNode), WTF::move(currentNode), 0, 0);
@@ -1179,7 +1194,7 @@ void TextIterator::exitNode(Node* exitedNode)
     // the logic in _web_attributedStringFromRange match. We'll get that for free when we switch to use
     // TextIterator in _web_attributedStringFromRange.
     // See <rdar://problem/5428427> for an example of how this mismatch will cause problems.
-    if (m_lastTextNode && shouldEmitNewlineAfterNode(*protect(m_currentNode), m_behaviors.contains(TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions))) {
+    if (m_lastTextNode && (shouldEmitNewlineAfterNode(*protect(m_currentNode), m_behaviors.contains(TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions)) || (m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec) && isBlockLevelReplacedElement(*protect(m_currentNode))))) {
         // use extra newline to represent margin bottom, as needed
         bool addNewline = shouldEmitExtraNewlineForNode(*protect(m_currentNode), m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec));
 
@@ -1358,7 +1373,7 @@ void SimplifiedBackwardsTextIterator::advance()
             if (CheckedPtr renderText = dynamicDowncast<RenderText>(renderer.get())) {
                 if (renderText->style().visibility() == Visibility::Visible && m_offset > 0)
                     m_handledNode = handleTextNode();
-            } else if (isRendererReplacedElement(renderer.get(), m_behaviors)) {
+            } else if (isRendererReplacedElement(renderer.get(), m_behaviors) && (renderer->isInline() || !m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec))) {
                 if (downcast<RenderElement>(*renderer).style().visibility() == Visibility::Visible && m_offset > 0)
                     m_handledNode = handleReplacedElement();
             } else


### PR DESCRIPTION
#### 5520eab83264747fb8a678d3a69ed4deaf774dfb
<pre>
innerText getter: improve handling of replaced elements at block boundaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=312261">https://bugs.webkit.org/show_bug.cgi?id=312261</a>

Reviewed by Anne van Kesteren.

Fix three innerText getter failures related to replaced elements:

  1. Whitespace between &lt;input&gt; and a block element was not being collapsed.
     handleReplacedElement() unconditionally set m_hasEmitted even when no
     character was actually emitted, causing shouldRepresentNodeOffsetZero()
     to emit a spurious newline before the subsequent block. Move m_hasEmitted
     to only the paths that actually produce output (emitCharacter already sets
     it; only the image alt text path needed an explicit set).

  2. Replaced elements with display:block (e.g. &lt;img style=&apos;display:block&apos;&gt;)
     were not treated as block-level. Route non-inline replaced elements
     through handleNonTextNode instead of handleReplacedElement so they get
     proper block boundary newlines. Also extend shouldEmitNewlinesBeforeAndAfterNode
     to recognize RenderReplaced in addition to RenderBlock.

Gate the new behavior on the TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec
flag so that it only impacts Element.innerText and not regular tests text
dump. This would require rebaselining a lot of tests otherwise.

No new tests, rebaseline existing WPT tests. The subtests that are newly
passing are already passing in Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::advance):
(WebCore::TextIterator::handleReplacedElement):
(WebCore::isBlockLevelReplacedElement):
(WebCore::TextIterator::representNodeOffsetZero):
(WebCore::TextIterator::exitNode):
(WebCore::SimplifiedBackwardsTextIterator::advance):

Canonical link: <a href="https://commits.webkit.org/311269@main">https://commits.webkit.org/311269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2594fcab2078796da3f7030ca1ee47fb329695d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165299 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121192 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101861 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13071 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167781 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11894 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129315 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129426 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35057 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87132 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24243 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16947 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93002 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28572 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28801 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28696 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->