### PR TITLE
[GTK][WPE] Introduce SkiaCompositingLayer

### DIFF
--- a/LayoutTests/compositing/reflections/opacity-in-reflection.html
+++ b/LayoutTests/compositing/reflections/opacity-in-reflection.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-62800">
+        <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-62800">
         <style>
             .right {
                 position: relative;

--- a/LayoutTests/css3/filters/backdrop/backdrop-filter-nested.html
+++ b/LayoutTests/css3/filters/backdrop/backdrop-filter-nested.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-15128" />
+  <meta name="fuzzy" content="maxDifference=0-4; totalPixels=0-15128" />
   <style>
     .container {
       display: grid;

--- a/LayoutTests/css3/filters/backdrop/backdrop-filter-with-reflection-value-change.html
+++ b/LayoutTests/css3/filters/backdrop/backdrop-filter-with-reflection-value-change.html
@@ -1,5 +1,6 @@
 <head>
     <meta name="viewport" content="width=device-width">
+    <meta name="fuzzy" content="maxDifference=2; totalPixels=398-399" />
     <title>This tests that the reflection of an element with a backdrop-filter applied updates its rendering when the reflected layer has a change of backdrop-filter value.</title>
     <style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-2.html
@@ -4,7 +4,7 @@
 <link rel="author" href="mailto:Hironori.Fujii@sony.com">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
 <link rel="match"  href="reference/backdrop-filter-clip-rect-2-ref.html">
-<meta name="fuzzy" content="maxDifference=0-80; totalPixels=0-1000" />
+<meta name="fuzzy" content="maxDifference=0-155; totalPixels=0-1000" />
 <style>
 .box {
   display: inline-block;

--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -378,6 +378,7 @@ add_library(Skia STATIC
     src/gpu/ganesh/GrWaitRenderTask.cpp
     src/gpu/ganesh/GrWritePixelsRenderTask.cpp
     src/gpu/ganesh/GrXferProcessor.cpp
+    src/gpu/ganesh/GrYUVABackendTextures.cpp
     src/gpu/ganesh/GrYUVATextureProxies.cpp
     src/gpu/ganesh/PathRenderer.cpp
     src/gpu/ganesh/PathRenderer.cpp

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8716,6 +8716,20 @@ UsePreHTML5ParserQuirks:
     WebCore:
       default: false
 
+UseSkiaForComposition:
+  type: bool
+  status: internal
+  humanReadableName: "Use Skia for composition"
+  humanReadableDescription: "Use Skia instead of TextureMapper for layer composition"
+  condition: PLATFORM(GTK) || PLATFORM(WPE)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 UseSystemAppearance:
   type: bool
   status: embedder

--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -15,6 +15,9 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/GraphicsContextSkia.h
     platform/graphics/skia/ImageBufferSkiaBackend.h
     platform/graphics/skia/PathSkia.h
+    platform/graphics/skia/SkiaCompositingLayer.h
+    platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h
+    platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h
     platform/graphics/skia/SkiaGPUAtlas.h
     platform/graphics/skia/SkiaHarfBuzzFont.h
     platform/graphics/skia/SkiaHarfBuzzFontCache.h

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -58,6 +58,9 @@ platform/graphics/skia/PathSkia.cpp
 platform/graphics/skia/PatternSkia.cpp
 platform/graphics/skia/PlatformDisplaySkia.cpp
 platform/graphics/skia/ShareableBitmapSkia.cpp
+platform/graphics/skia/SkiaCompositingLayer.cpp
+platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp
+platform/graphics/skia/SkiaCompositingLayerOverlapRegions.cpp
 platform/graphics/skia/SkiaGPUAtlas.cpp
 platform/graphics/skia/SkiaHarfBuzzFont.cpp
 platform/graphics/skia/SkiaHarfBuzzFontCache.cpp

--- a/Source/WebCore/platform/graphics/ColorMatrix.h
+++ b/Source/WebCore/platform/graphics/ColorMatrix.h
@@ -188,6 +188,16 @@ inline ColorMatrix<3, 3> hueRotateColorMatrix(float angleInDegrees)
     };
 }
 
+constexpr ColorMatrix<5, 4> swapRedBlueMatrix()
+{
+    return ColorMatrix<5, 4> {
+        0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
+        0.0f, 1.0f, 0.0f, 0.0f, 0.0f,
+        1.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f, 0.0f,
+    };
+}
+
 template<size_t ColumnCount, size_t RowCount>
 template<size_t NumberOfComponents>
 constexpr auto ColorMatrix<ColumnCount, RowCount>::transformedColorComponents(const ColorComponents<float, NumberOfComponents>& inputVector) const -> ColorComponents<float, NumberOfComponents>

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -130,7 +130,7 @@ static RepaintMap& NODELETE repaintRectMap()
     return map;
 }
 
-#if !USE(CA)
+#if !USE(CA) && !USE(COORDINATED_GRAPHICS)
 bool GraphicsLayer::supportsLayerType(Type type)
 {
     switch (type) {
@@ -532,7 +532,7 @@ void GraphicsLayer::setVideoGravity(MediaPlayerVideoGravity gravity)
 
 Path GraphicsLayer::shapeLayerPath() const
 {
-#if USE(CA)
+#if USE(CA) || USE(COORDINATED_GRAPHICS)
     return m_shapeLayerPath;
 #else
     return Path();
@@ -541,7 +541,7 @@ Path GraphicsLayer::shapeLayerPath() const
 
 void GraphicsLayer::setShapeLayerPath(const Path& path)
 {
-#if USE(CA)
+#if USE(CA) || USE(COORDINATED_GRAPHICS)
     m_shapeLayerPath = path;
 #else
     UNUSED_PARAM(path);
@@ -550,7 +550,7 @@ void GraphicsLayer::setShapeLayerPath(const Path& path)
 
 WindRule GraphicsLayer::shapeLayerWindRule() const
 {
-#if USE(CA)
+#if USE(CA) || USE(COORDINATED_GRAPHICS)
     return m_shapeLayerWindRule;
 #else
     return WindRule::NonZero;
@@ -559,7 +559,7 @@ WindRule GraphicsLayer::shapeLayerWindRule() const
 
 void GraphicsLayer::setShapeLayerWindRule(WindRule windRule)
 {
-#if USE(CA)
+#if USE(CA) || USE(COORDINATED_GRAPHICS)
     m_shapeLayerWindRule = windRule;
 #else
     UNUSED_PARAM(windRule);

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -696,6 +696,9 @@ protected:
 #if USE(CA)
     Path m_shadowPath;
     MediaPlayerVideoGravity m_videoGravity { MediaPlayerVideoGravity::ResizeAspect };
+#endif
+
+#if USE(CA) || USE(COORDINATED_GRAPHICS)
     WindRule m_shapeLayerWindRule { WindRule::NonZero };
     Path m_shapeLayerPath;
 #endif

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -1,0 +1,1008 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaCompositingLayer.h"
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "ColorMatrix.h"
+#include "CoordinatedAnimatedBackingStoreClient.h"
+#include "CoordinatedBackingStore.h"
+#include "CoordinatedImageBackingStore.h"
+#include "CoordinatedPlatformLayerBuffer.h"
+#include "CoordinatedTileBuffer.h"
+#include "FilterOperations.h"
+#include "FontCache.h"
+#include "PlatformDisplay.h"
+#include "Region.h"
+#include "SkiaCompositingLayer3DRenderingContext.h"
+#include "SkiaCompositingLayerOverlapRegions.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkFont.h>
+#include <skia/core/SkPathBuilder.h>
+#include <skia/core/SkRRect.h>
+#include <skia/effects/SkImageFilters.h>
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+#include <skia/gpu/ganesh/gl/GrGLDirectContext.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/Scope.h>
+#include <wtf/SetForScope.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaCompositingLayer);
+
+static constexpr float s_opacityVisibilityThreshold = 0.01;
+
+Ref<SkiaCompositingLayer> SkiaCompositingLayer::create()
+{
+    return adoptRef(*new SkiaCompositingLayer());
+}
+
+SkiaCompositingLayer::~SkiaCompositingLayer() = default;
+
+void SkiaCompositingLayer::invalidate()
+{
+    m_backingStore = nullptr;
+    m_animatedBackingStoreClient = nullptr;
+    m_imageBackingStore = nullptr;
+    m_contentsBuffer = nullptr;
+
+    m_mask = nullptr;
+    m_replica = nullptr;
+    m_replicatedLayer = nullptr;
+
+    for (auto& child : m_children)
+        child->m_parent = nullptr;
+    removeFromParent();
+}
+
+void SkiaCompositingLayer::setSize(const FloatSize& size)
+{
+#if ENABLE(DAMAGE_TRACKING)
+    if (frameDamagePropagationEnabled() && m_size != size) {
+        m_size = size;
+        damageWholeLayer();
+        addPreviousRectToSharedFrameDamage();
+        return;
+    }
+#endif
+    m_size = size;
+}
+
+void SkiaCompositingLayer::setOpacity(float opacity)
+{
+#if ENABLE(DAMAGE_TRACKING)
+    if (frameDamagePropagationEnabled() && m_opacity != opacity)
+        damageWholeLayer();
+#endif
+    m_opacity = opacity;
+}
+
+void SkiaCompositingLayer::setChildren(Vector<Ref<SkiaCompositingLayer>>&& newChildren)
+{
+    if (m_children == newChildren)
+        return;
+
+    while (!m_children.isEmpty()) {
+        auto child = m_children.takeLast();
+        child->m_parent = nullptr;
+    }
+
+    m_children = WTF::move(newChildren);
+    for (auto& child : m_children) {
+        child->removeFromParent();
+        child->m_parent = this;
+    }
+}
+
+void SkiaCompositingLayer::removeFromParent()
+{
+    RefPtr parent = std::exchange(m_parent, nullptr);
+    if (!parent)
+        return;
+
+    parent->m_children.removeFirstMatching([this](auto& layer) {
+        return layer.ptr() == this;
+    });
+
+#if ENABLE(DAMAGE_TRACKING)
+    if (parent->frameDamagePropagationEnabled())
+        recursiveAddPreviousRectToSharedFrameDamage(Ref { *this });
+#endif
+}
+
+void SkiaCompositingLayer::setUseBackingStore(bool useBackingStore, CoordinatedAnimatedBackingStoreClient* animatedBackingStoreClient)
+{
+    if (!useBackingStore) {
+        m_backingStore = nullptr;
+        m_animatedBackingStoreClient = nullptr;
+        return;
+    }
+
+    if (!m_backingStore)
+        m_backingStore = CoordinatedBackingStore::create();
+    m_animatedBackingStoreClient = animatedBackingStoreClient;
+}
+
+void SkiaCompositingLayer::updateBackingStore(CoordinatedBackingStoreProxy::Update&& update, float scale)
+{
+    ASSERT(m_backingStore);
+    m_backingStore->resize(m_size, scale);
+    for (auto tileID : update.tilesToCreate())
+        m_backingStore->createTile(tileID);
+    for (auto tileID : update.tilesToRemove())
+        m_backingStore->removeTile(tileID);
+    for (const auto& tileUpdate : update.tilesToUpdate())
+        m_backingStore->updateTile(tileUpdate.tileID, tileUpdate.dirtyRect, tileUpdate.tileRect, tileUpdate.buffer.copyRef(), { });
+    m_backingStore->processPendingUpdates();
+}
+
+void SkiaCompositingLayer::setImageBackingStore(CoordinatedImageBackingStore* imageBackingStore)
+{
+    m_imageBackingStore = imageBackingStore;
+}
+
+void SkiaCompositingLayer::setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&& contentsBuffer)
+{
+    m_contentsBuffer = WTF::move(contentsBuffer);
+}
+
+void SkiaCompositingLayer::setContentsSolidColor(const Color& color)
+{
+#if ENABLE(DAMAGE_TRACKING)
+    if (frameDamagePropagationEnabled() && m_contentsSolidColor != color)
+        damageWholeLayer();
+#endif
+    m_contentsSolidColor = color;
+}
+
+void SkiaCompositingLayer::setMask(RefPtr<SkiaCompositingLayer>&& mask)
+{
+    m_mask = WTF::move(mask);
+}
+
+void SkiaCompositingLayer::setReplica(RefPtr<SkiaCompositingLayer>&& replica)
+{
+    m_replica = WTF::move(replica);
+    if (m_replica)
+        m_replica->m_replicatedLayer = this;
+}
+
+static sk_sp<SkImageFilter> createFilter(const FilterOperation& filterOperation, sk_sp<SkImageFilter> input, SkTileMode blurTileMode = SkTileMode::kDecal)
+{
+    switch (filterOperation.type()) {
+    case FilterOperation::Type::Grayscale: {
+        ColorMatrix<5, 4> matrix(grayscaleColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Sepia: {
+        ColorMatrix<5, 4> matrix(sepiaColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Saturate: {
+        ColorMatrix<5, 4> matrix(saturationColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::HueRotate: {
+        ColorMatrix<5, 4> matrix(hueRotateColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Invert: {
+        const auto matrix = invertColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount());
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Opacity: {
+        const auto matrix = opacityColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount());
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Brightness: {
+        ColorMatrix<5, 4> matrix(brightnessColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount()));
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Contrast: {
+        const auto matrix = contrastColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount());
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Blur: {
+        auto sigma = downcast<BlurFilterOperation>(filterOperation).stdDeviation();
+        // FIXME: do we need to add crop rect?
+        return SkImageFilters::Blur(sigma, sigma, blurTileMode, input);
+    }
+    case FilterOperation::Type::DropShadow: {
+        auto& dropShadow = downcast<DropShadowFilterOperation>(filterOperation);
+        return SkImageFilters::DropShadow(dropShadow.x(), dropShadow.y(), dropShadow.stdDeviation(), dropShadow.stdDeviation(), dropShadow.color(), input);
+    }
+    case FilterOperation::Type::Passthrough:
+    case FilterOperation::Type::Default:
+    case FilterOperation::Type::None:
+        break;
+    }
+
+    return nullptr;
+}
+
+static sk_sp<SkImageFilter> createFilters(const FilterOperations& filterOperations, SkTileMode blurTileMode = SkTileMode::kDecal)
+{
+    sk_sp<SkImageFilter> filter;
+    for (const auto& filterOperation : filterOperations)
+        filter = createFilter(filterOperation, filter, blurTileMode);
+    return filter;
+}
+
+void SkiaCompositingLayer::setFilters(const FilterOperations& filterOperations)
+{
+    if (filterOperations.isEmpty())
+        m_filter = std::nullopt;
+    else
+        m_filter = { createFilters(filterOperations), filterOperations.outsets() };
+}
+
+void SkiaCompositingLayer::setBackdropFilters(const FilterOperations& filterOperations)
+{
+    m_backdrop.filter = createFilters(filterOperations, SkTileMode::kClamp);
+}
+
+void SkiaCompositingLayer::setBackdropFiltersRect(const FloatRoundedRect& clipRect)
+{
+    m_backdrop.clipRect = clipRect;
+}
+
+Ref<SkiaCompositingLayer> SkiaCompositingLayer::backdropRoot()
+{
+    if (m_isBackdropRoot)
+        return *this;
+
+    if (m_parent)
+        return m_parent->backdropRoot();
+
+    if (m_replicatedLayer)
+        return m_replicatedLayer->backdropRoot();
+
+    return *this;
+}
+
+#if ENABLE(DAMAGE_TRACKING)
+void SkiaCompositingLayer::addDamage(Damage&& damage)
+{
+    // The damage is added not to override the damage that could be inferred from other set* operations.
+    if (m_layerDamage)
+        m_layerDamage->add(damage);
+    else
+        m_layerDamage = WTF::move(damage);
+}
+
+void SkiaCompositingLayer::addPreviousRectToSharedFrameDamage()
+{
+    if (!m_previousLayerRectInFrameCoordinates)
+        return;
+
+    // In many cases, damaging the whole layer in the "new" state is not enough.
+    // When e.g. changing size, transform, etc. the layer (or its parts) effectively disappears from one place
+    // and re-appears in another. Therefore the damaging of a layer in the "old" state is required as well.
+    ASSERT(m_sharedFrameDamage);
+    m_sharedFrameDamage->add(*m_previousLayerRectInFrameCoordinates);
+}
+
+void SkiaCompositingLayer::recursiveAddPreviousRectToSharedFrameDamage(Ref<SkiaCompositingLayer> layer)
+{
+    layer->addPreviousRectToSharedFrameDamage();
+
+    for (auto& child : layer->m_children)
+        recursiveAddPreviousRectToSharedFrameDamage(child);
+}
+#endif
+
+void SkiaCompositingLayer::setDebugIndicators(Color&& debugBorderColor, std::optional<float> debugBorderWidth, std::optional<unsigned> repaintCount)
+{
+    if (debugBorderColor.isValid())
+        m_debugBorder = { WTF::move(debugBorderColor), debugBorderWidth.value_or(1) };
+    else
+        m_debugBorder = std::nullopt;
+
+    m_repaintCount = repaintCount;
+}
+
+const TransformationMatrix& SkiaCompositingLayer::localTransform() const
+{
+    if (!m_animationsState || !m_animationsState->isRunning)
+        return m_transform;
+
+    return m_animationsState->transform ? m_animationsState->transform.value() : m_transform;
+}
+
+const TransformationMatrix& SkiaCompositingLayer::futureLocalTransform() const
+{
+    if (!m_animationsState || !m_animationsState->isRunning)
+        return m_transform;
+
+    return m_animationsState->futureTransform ? m_animationsState->futureTransform.value() : localTransform();
+}
+
+float SkiaCompositingLayer::opacity() const
+{
+    if (!m_animationsState || !m_animationsState->isRunning)
+        return m_opacity;
+
+    return m_animationsState->opacity.value_or(m_opacity);
+}
+
+const std::optional<SkiaCompositingLayer::Filter> SkiaCompositingLayer::filter() const
+{
+    if (!m_animationsState || !m_animationsState->isRunning)
+        return m_filter;
+
+    return m_animationsState->filter ? m_animationsState->filter : m_filter;
+}
+
+std::optional<SkiaCompositingLayer::AnimationsState> SkiaCompositingLayer::syncAnimations(MonotonicTime time)
+{
+    if (m_animations.isEmpty())
+        return std::nullopt;
+
+    TextureMapperAnimation::ApplicationResult applicationResults;
+    m_animations.apply(applicationResults, time);
+
+    AnimationsState state;
+    state.transform = applicationResults.transform;
+    if (state.transform) {
+        // Calculate localTransform 50ms in the future.
+        TextureMapperAnimation::ApplicationResult futureResults;
+        m_animations.apply(futureResults, time + 50_ms, TextureMapperAnimation::KeepInternalState::Yes);
+        state.futureTransform = futureResults.transform;
+    }
+    state.opacity = applicationResults.opacity;
+#if ENABLE(DAMAGE_TRACKING)
+    const bool currentOpacity = opacity();
+    const bool newOpacity = state.opacity.value_or(m_opacity);
+    if (frameDamagePropagationEnabled() && currentOpacity != newOpacity) {
+        damageWholeLayer();
+        // FIXME: add collectFrameDamageDespiteBeingInvisible?
+    }
+#endif
+    if (applicationResults.filters)
+        state.filter = { createFilters(*applicationResults.filters), applicationResults.filters->outsets() };
+    state.isRunning = applicationResults.hasRunningAnimations;
+    return state;
+}
+
+bool SkiaCompositingLayer::computeTransformsAndAnimations(RefPtr<SkiaCompositingLayer> parent, MonotonicTime time)
+{
+    m_animationsState = syncAnimations(time);
+    bool hasRunningAnimations = m_animationsState ? m_animationsState->isRunning : false;
+
+    if (!m_size.isEmpty() || !m_masksToBounds) {
+        TransformationMatrix parentTransform;
+        if (parent)
+            parentTransform = parent == m_parent ? parent->m_transforms.combinedForChildren : parent->m_transforms.combined;
+
+#if ENABLE(DAMAGE_TRACKING)
+        TransformationMatrix previousTransform = m_transforms.combined;
+#endif
+
+        FloatPoint origin(m_anchorPoint.x(), m_anchorPoint.y());
+        origin.scale(m_size.width(), m_size.height());
+        m_transforms.combined = parentTransform;
+        m_transforms.combined
+            .translate3d(origin.x() + (m_position.x() - m_boundsOrigin.x()), origin.y() + (m_position.y() - m_boundsOrigin.y()), m_anchorPoint.z())
+            .multiply(localTransform());
+
+        m_transforms.combinedForChildren = m_transforms.combined;
+        m_transforms.combined.translate3d(-origin.x(), -origin.y(), -m_anchorPoint.z());
+
+        if (isReplica())
+            m_transforms.combined.translate(-m_position.x(), -m_position.y());
+
+        if (!m_preserves3D)
+            m_transforms.combinedForChildren.flatten();
+        m_transforms.combinedForChildren.multiply(m_childrenTransform);
+        m_transforms.combinedForChildren.translate3d(-origin.x(), -origin.y(), -m_anchorPoint.z());
+
+        TransformationMatrix futureParentTransform;
+        if (parent)
+            futureParentTransform = parent == m_parent ? parent->m_transforms.futureCombinedForChildren : parent->m_transforms.futureCombined;
+
+        m_transforms.futureCombined = futureParentTransform;
+        m_transforms.futureCombined
+            .translate3d(origin.x() + (m_position.x() - m_boundsOrigin.x()), origin.y() + (m_position.y() - m_boundsOrigin.y()), m_anchorPoint.z())
+            .multiply(futureLocalTransform());
+
+        m_transforms.futureCombinedForChildren = m_transforms.futureCombined;
+        m_transforms.futureCombined.translate3d(-origin.x(), -origin.y(), -m_anchorPoint.z());
+
+        if (isReplica())
+            m_transforms.futureCombined.translate(-m_position.x(), -m_position.y());
+
+        if (!m_preserves3D)
+            m_transforms.futureCombinedForChildren.flatten();
+        m_transforms.futureCombinedForChildren.multiply(m_childrenTransform);
+        m_transforms.futureCombinedForChildren.translate3d(-origin.x(), -origin.y(), -m_anchorPoint.z());
+
+#if ENABLE(DAMAGE_TRACKING)
+        if (frameDamagePropagationEnabled() && previousTransform != m_transforms.combined) {
+            damageWholeLayer();
+            addPreviousRectToSharedFrameDamage();
+        }
+#endif
+
+        m_visible = m_backfaceVisibility || !m_transforms.combined.isBackFaceVisible();
+
+        if (m_animatedBackingStoreClient)
+            m_animatedBackingStoreClient->requestBackingStoreUpdateIfNeeded(m_transforms.futureCombined);
+    }
+
+    if (m_mask)
+        hasRunningAnimations |= m_mask->computeTransformsAndAnimations(m_replicatedLayer ? m_replicatedLayer.get() : this, time);
+    if (m_replica)
+        hasRunningAnimations |= m_replica->computeTransformsAndAnimations(m_replica->m_replicatedLayer, time);
+
+    for (auto& child : m_children)
+        hasRunningAnimations |= child->computeTransformsAndAnimations(this, time);
+
+    // If the layer is invisible because of opacity and there's no opacity animation, the content won't
+    // be visible ever, so triggering repaints doesn't make sense.
+    if (!m_opacity && !(m_animationsState && m_animationsState->opacity))
+        return false;
+
+    return hasRunningAnimations;
+}
+
+bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& damage)
+{
+    bool hasRunningAnimations = computeTransformsAndAnimations(nullptr, MonotonicTime::now());
+    PaintContext context(damage);
+    recursivePaint(canvas, context);
+
+#if ENABLE(DAMAGE_TRACKING)
+    if (damage && frameDamagePropagationEnabled()) {
+        damage->add(*m_sharedFrameDamage);
+        *m_sharedFrameDamage = Damage(m_size);
+    }
+#endif
+
+    return hasRunningAnimations;
+}
+
+void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
+{
+#if ENABLE(DAMAGE_TRACKING)
+    m_previousLayerRectInFrameCoordinates = std::nullopt;
+    auto cleanup = WTF::makeScopeExit([&] {
+        m_layerDamage = std::nullopt;
+    });
+#endif
+
+    if (m_size.isEmpty() || !m_visible || !m_contentsVisible || !hasVisualContent())
+        return;
+
+    TransformationMatrix transform(context.accumulatedReplicaTransform);
+    transform.multiply(m_transforms.combined);
+
+    canvas.save();
+    canvas.concat(SkM44(transform));
+
+    SkPaint paint;
+    paint.setStyle(SkPaint::kFill_Style);
+    paint.setAntiAlias(true);
+    paint.setAlphaf(context.opacity);
+    if (context.isMask)
+        paint.setBlendMode(SkBlendMode::kDstIn);
+    if (context.colorFilter)
+        paint.setColorFilter(context.colorFilter);
+
+    if (m_backingStore)
+        m_backingStore->paintToCanvas(canvas, paint);
+
+    if (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()) {
+        paint.setColor(SkColor(m_contentsSolidColor.colorWithAlphaMultipliedBy(context.opacity)));
+        canvas.drawRect(m_contentsRect, paint);
+    } else if (m_contentsBuffer || m_imageBackingStore) {
+        bool shouldClipContents = m_contentsClippingRect.isRounded() || !m_contentsClippingRect.rect().contains(m_contentsRect);
+        SkAutoCanvasRestore autoRestore(&canvas, shouldClipContents);
+        if (shouldClipContents) {
+            if (m_contentsClippingRect.isRounded())
+                canvas.clipRRect(SkRRect(m_contentsClippingRect), true);
+            else
+                canvas.clipRect(SkRect(m_contentsClippingRect.rect()));
+        }
+
+        if (m_contentsBuffer)
+            m_contentsBuffer->paintToCanvas(canvas, m_contentsRect, paint);
+        else if (auto* buffer = m_imageBackingStore->buffer()) {
+            if (m_contentsTiling.size.isEmpty())
+                buffer->paintToCanvas(canvas, m_contentsRect, paint);
+            else {
+                SkAutoCanvasRestore autoRestore(&canvas, true);
+                canvas.clipRect(SkRect(m_contentsRect));
+
+                float startX = m_contentsRect.x() + m_contentsTiling.phase.width();
+                float startY = m_contentsRect.y() + m_contentsTiling.phase.height();
+
+                // Adjust start position to cover the contentsRect from the beginning.
+                while (startX > m_contentsRect.x())
+                    startX -= m_contentsTiling.size.width();
+                while (startY > m_contentsRect.y())
+                    startY -= m_contentsTiling.size.height();
+
+                for (float y = startY; y < m_contentsRect.maxY(); y += m_contentsTiling.size.height()) {
+                    for (float x = startX; x < m_contentsRect.maxX(); x += m_contentsTiling.size.width()) {
+                        FloatRect tileRect(x, y, m_contentsTiling.size.width(), m_contentsTiling.size.height());
+                        buffer->paintToCanvas(canvas, tileRect, paint);
+                    }
+                }
+            }
+        }
+    }
+
+#if ENABLE(DAMAGE_TRACKING)
+    if (frameDamagePropagationEnabled() && context.frameDamage) {
+        m_previousLayerRectInFrameCoordinates = transform.mapRect(effectiveLayerRect());
+        auto clipBounds = FloatRect(this->clipBounds(canvas, context));
+        if (!clipBounds.isEmpty())
+            m_previousLayerRectInFrameCoordinates->intersect(clipBounds);
+
+        if (m_layerDamage) {
+            for (const auto& rect : *m_layerDamage) {
+                auto damageRect = transform.mapRect(FloatRect(rect));
+                if (!clipBounds.isEmpty())
+                    damageRect.intersect(clipBounds);
+                context.frameDamage->add(damageRect);
+            }
+        } else if ((m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()) || m_contentsBuffer || m_imageBackingStore)
+            context.frameDamage->add(*m_previousLayerRectInFrameCoordinates);
+    }
+#endif
+
+    if (m_debugBorder) {
+        SkPaint borderPaint;
+        borderPaint.setStyle(SkPaint::kStroke_Style);
+        borderPaint.setColor(SkColor(m_debugBorder->color));
+        borderPaint.setStrokeWidth(m_debugBorder->width);
+        borderPaint.setAntiAlias(true);
+
+        if (m_backingStore)
+            m_backingStore->drawDebugBorders(canvas, borderPaint);
+        if (m_contentsBuffer || m_imageBackingStore || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()))
+            canvas.drawRect(SkRect(m_contentsRect), borderPaint);
+    }
+
+    // Capture the full canvas-to-device position while the layer transform is still active.
+    SkPoint deviceOrigin { 0, 0 };
+    if (m_repaintCount) {
+        auto mapped = canvas.getLocalToDevice().map(0, 0, 0, 1);
+        if (std::abs(mapped.w) > std::numeric_limits<float>::epsilon())
+            deviceOrigin = { mapped.x / mapped.w, mapped.y / mapped.w };
+        else
+            deviceOrigin = { mapped.x, mapped.y };
+    }
+
+    canvas.restore();
+
+    if (m_repaintCount) {
+        constexpr float pointSize = 14;
+        constexpr float padding = 3;
+        auto counterString = String::number(*m_repaintCount).ascii();
+
+        static SkFont font = [] {
+            auto typeface = FontCache::forCurrentThread().fontManager().matchFamilyStyle("monospace", SkFontStyle::Bold());
+            SkFont f(typeface, pointSize);
+            f.setEdging(SkFont::Edging::kAntiAlias);
+            f.setSubpixel(true);
+            return f;
+        }();
+
+        SkRect textBounds;
+        font.measureText(counterString.data(), counterString.length(), SkTextEncoding::kUTF8, &textBounds);
+        float textWidth = textBounds.width() + padding * 2;
+        float textHeight = textBounds.height() + padding * 2;
+
+        SkAutoCanvasRestore autoRestore(&canvas, true);
+        canvas.resetMatrix();
+
+        SkPaint backgroundPaint;
+        backgroundPaint.setColor(m_debugBorder ? SkColor(m_debugBorder->color) : SK_ColorBLACK);
+        backgroundPaint.setStyle(SkPaint::kFill_Style);
+        canvas.drawRect(SkRect::MakeXYWH(deviceOrigin.x(), deviceOrigin.y(), textWidth, textHeight), backgroundPaint);
+
+        SkPaint textPaint;
+        textPaint.setColor(SK_ColorWHITE);
+        textPaint.setAntiAlias(true);
+        canvas.drawString(counterString.data(), deviceOrigin.x() + padding, deviceOrigin.y() - textBounds.fTop + padding, font, textPaint);
+    }
+}
+
+void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& context)
+{
+    if (m_backdrop.filter && context.paintingBackdropForLayer == this)
+        return;
+
+    if (m_backdrop.filter && !context.paintingBackdropForLayer) {
+        SkAutoCanvasRestore autoRestore(&canvas, true);
+        SkPathBuilder builder;
+        builder.addRRect(SkRRect(m_backdrop.clipRect));
+        TransformationMatrix clipTransform(context.accumulatedReplicaTransform);
+        clipTransform.multiply(m_transforms.combined);
+        canvas.clipPath(builder.detach().makeTransform(SkM44(clipTransform).asM33()), true);
+
+        // Paint the backdrop root's subtree into a fresh surface (spec step 1),
+        // apply the backdrop filter (step 2), and composite via SrcOver so the
+        // filtered result blends onto the canvas without destroying ancestor
+        // backgrounds that aren't part of the backdrop root's subtree.
+        //
+        // Use paintSelfAndChildren (not recursivePaint) on the backdrop root to
+        // exclude the root's own effects (replica, filter, mask) per the CSS spec.
+        SkPaint paint;
+        paint.setImageFilter(m_backdrop.filter);
+        paint.setAlphaf(context.opacity);
+        paintWithIntermediateSurface(canvas, context, enclosingIntRect(clipTransform.mapRect(m_backdrop.clipRect.rect())), &paint, [&](SkCanvas& canvas, PaintContext& context) {
+            SetForScope scopedPaintBackdropForLayer(context.paintingBackdropForLayer, this);
+            SetForScope scopedOpacity(context.opacity, 1.f);
+            SetForScope scopedReplicaTransform(context.accumulatedReplicaTransform, TransformationMatrix());
+            backdropRoot()->paintSelfAndChildren(canvas, context);
+        });
+    }
+
+    paintSelf(canvas, context);
+
+    if (m_children.isEmpty())
+        return;
+
+    bool shouldClip = (m_masksToBounds || m_contentsRectClipsDescendants) && !m_preserves3D;
+    SkAutoCanvasRestore autoRestore(&canvas, shouldClip);
+    if (shouldClip) {
+        if (m_contentsRectClipsDescendants) {
+            SkPathBuilder builder;
+            if (m_contentsClippingRect.isRounded())
+                builder.addRRect(SkRRect(m_contentsClippingRect));
+            else
+                builder.addRect(SkRect(m_contentsClippingRect.rect()));
+            canvas.clipPath(builder.detach().makeTransform(SkM44(m_transforms.combined).asM33()), true);
+        } else {
+            auto clipTransform = m_transforms.combined;
+            clipTransform.translate(m_boundsOrigin.x(), m_boundsOrigin.y());
+            SkPathBuilder builder;
+            builder.addRect(SkRect(effectiveLayerRect()));
+            canvas.clipPath(builder.detach().makeTransform(SkM44(clipTransform).asM33()));
+        }
+    }
+
+    for (auto& child : m_children)
+        child->recursivePaint(canvas, context);
+}
+
+bool SkiaCompositingLayer::isVisible() const
+{
+    if (m_size.isEmpty() && (m_masksToBounds || m_children.isEmpty()))
+        return false;
+    if (!m_visible && m_children.isEmpty())
+        return false;
+    if (!m_contentsVisible && m_children.isEmpty())
+        return false;
+    if (!hasVisualContent() && !m_backdrop.filter && m_children.isEmpty())
+        return false;
+    if (opacity() < s_opacityVisibilityThreshold)
+        return false;
+    return true;
+}
+
+TransformationMatrix SkiaCompositingLayer::replicaTransform() const
+{
+    return TransformationMatrix(m_replica->m_transforms.combined)
+        .multiply(m_transforms.combined.inverse().value_or(TransformationMatrix()));
+}
+
+IntRect SkiaCompositingLayer::clipBounds(const SkCanvas& canvas, const PaintContext& context) const
+{
+    IntRect clip = canvas.getDeviceClipBounds();
+    clip.move(context.offset);
+    return clip;
+}
+
+void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintContext& context, const IntRect& contentsRect, SkPaint* paint, PaintFunction&& paintFunction)
+{
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    auto imageInfo = SkImageInfo::Make(contentsRect.width(), contentsRect.height(), kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, nullptr);
+    if (!surface)
+        return;
+
+    auto* surfaceCanvas = surface->getCanvas();
+    if (!surfaceCanvas)
+        return;
+
+    surfaceCanvas->clear(SK_ColorTRANSPARENT);
+    surfaceCanvas->translate(-contentsRect.x(), -contentsRect.y());
+    SetForScope scopedOffset(context.offset, toIntSize(contentsRect.location()));
+    paintFunction(*surfaceCanvas, context);
+    grContext->flushAndSubmit(surface.get(), GrSyncCpu::kNo);
+
+    canvas.drawImageRect(surface->makeImageSnapshot(), SkRect::MakeWH(contentsRect.width(), contentsRect.height()), SkRect::Make(SkIRect(contentsRect)), SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), paint, SkCanvas::kFast_SrcRectConstraint);
+}
+
+void SkiaCompositingLayer::paintSelfAndChildrenWithFilterAndMask(SkCanvas& canvas, PaintContext& context)
+{
+    auto mask = m_mask;
+    const bool shouldClipPath = mask && !mask->m_clipPath.isEmpty();
+    SkAutoCanvasRestore autoRestore(&canvas, shouldClipPath);
+    if (shouldClipPath) {
+        canvas.clipPath(mask->m_clipPath.makeTransform(SkM44(mask->m_transforms.combined).asM33()), true);
+        mask = nullptr;
+    }
+
+    auto filter = this->filter();
+    if (!filter && !mask) {
+        paintSelfAndChildren(canvas, context);
+        return;
+    }
+
+    if (filter && !mask) {
+        SkColorFilter* colorFilterPtr = nullptr;
+        if (filter->filter->asAColorFilter(&colorFilterPtr)) {
+            // If we have a filter (and no mask) that can be simplified as a color filter
+            // we don't need to create an intermediate surface.
+            sk_sp<SkColorFilter> colorFilter(colorFilterPtr);
+            SetForScope scopedColorFilter(context.colorFilter, colorFilter);
+            paintSelfAndChildren(canvas, context);
+            return;
+        }
+    }
+
+    // Restrict intermediate surface size to the consolidated overlap region rects,
+    // matching TextureMapperLayer::paintSelfChildrenFilterAndMask behavior.
+    auto mode = mask ? ComputeOverlapRegionMode::Mask : ComputeOverlapRegionMode::Union;
+    auto overlapRects = computeConsolidatedOverlapRegionRects(canvas, context, mode);
+
+#if ENABLE(DAMAGE_TRACKING)
+    auto clipBounds = FloatRect(this->clipBounds(canvas, context));
+#endif
+
+    SkPaint paint;
+    if (filter)
+        paint.setImageFilter(filter->filter);
+
+    for (const auto& rect : overlapRects) {
+#if ENABLE(DAMAGE_TRACKING)
+        if (frameDamagePropagationEnabled() && context.frameDamage) {
+            FloatRect damageRect(rect);
+            if (!clipBounds.isEmpty())
+                damageRect.intersect(clipBounds);
+
+            m_accumulatedOverlapRegionFrameDamage.unite(damageRect);
+        }
+#endif
+        if (mask && filter) {
+            // Mask and filter: the filter should be applied first and then the mask on the result.
+            paintWithIntermediateSurface(canvas, context, rect, nullptr, [&](SkCanvas& canvas, PaintContext& context) {
+                paintWithIntermediateSurface(canvas, context, rect, &paint, [&](SkCanvas& canvas, PaintContext& context) {
+                    paintSelfAndChildren(canvas, context);
+                });
+
+                SetForScope scopedMask(context.isMask, true);
+                mask->paintSelf(canvas, context);
+            });
+        } else {
+            paintWithIntermediateSurface(canvas, context, rect, &paint, [&](SkCanvas& canvas, PaintContext& context) {
+                paintSelfAndChildren(canvas, context);
+
+                if (mask) {
+                    SetForScope scopedMask(context.isMask, true);
+                    mask->paintSelf(canvas, context);
+                }
+            });
+        }
+    }
+
+#if ENABLE(DAMAGE_TRACKING)
+    if (frameDamagePropagationEnabled() && context.frameDamage && !m_accumulatedOverlapRegionFrameDamage.isEmpty())
+        context.frameDamage->add(m_accumulatedOverlapRegionFrameDamage);
+#endif
+}
+
+Vector<IntRect, 1> SkiaCompositingLayer::computeConsolidatedOverlapRegionRects(const SkCanvas& canvas, const PaintContext& context, ComputeOverlapRegionMode mode)
+{
+    ComputeOverlapRegionData data {
+        .mode = mode,
+        .clipBounds = clipBounds(canvas, context),
+        .overlapRegion = { },
+        .nonOverlapRegion = { }
+    };
+    computeOverlapRegions(data, context.accumulatedReplicaTransform, IncludesReplica::No);
+
+    auto rects = data.overlapRegion.rects();
+    static constexpr size_t cOverlapRegionConsolidationThreshold = 4;
+    if (rects.size() > cOverlapRegionConsolidationThreshold) {
+        rects.clear();
+        rects.append(data.overlapRegion.bounds());
+    }
+
+    return rects;
+}
+
+void SkiaCompositingLayer::paintSelfAndChildrenWithReplicaFilterAndMask(SkCanvas& canvas, PaintContext& context)
+{
+    if (m_replica) {
+        auto newAccumulatedReplicaTransform = TransformationMatrix(context.accumulatedReplicaTransform).multiply(replicaTransform());
+        SetForScope scopedReplicaTransform(context.accumulatedReplicaTransform, newAccumulatedReplicaTransform);
+        paintSelfAndChildrenWithFilterAndMask(canvas, context);
+    }
+
+    paintSelfAndChildrenWithFilterAndMask(canvas, context);
+}
+
+void SkiaCompositingLayer::recursivePaint(SkCanvas& canvas, PaintContext& context)
+{
+    if (!isVisible())
+        return;
+
+    SetForScope scopedOpacity(context.opacity, context.opacity * opacity());
+
+    if (m_preserves3D) {
+        paintUsing3DRenderingContext(canvas, context);
+        return;
+    }
+
+    if (opacity() < 1)
+        paintUsingOverlapRegions(canvas, context);
+    else
+        paintSelfAndChildrenWithReplicaFilterAndMask(canvas, context);
+}
+
+void SkiaCompositingLayer::computeOverlapRegions(ComputeOverlapRegionData& data, const TransformationMatrix& accumulatedReplicaTransform, IncludesReplica includesReplica)
+{
+    if (!m_visible || !m_contentsVisible)
+        return;
+
+    auto filter = this->filter();
+
+    FloatRect localBoundingRect;
+    if (m_backingStore || m_masksToBounds || m_mask || filter || m_backdrop.filter)
+        localBoundingRect = effectiveLayerRect();
+    else if (m_contentsBuffer || m_imageBackingStore || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible()))
+        localBoundingRect = m_contentsRect;
+
+    if (filter && !filter->outsets.isZero() && !m_masksToBounds && !m_mask && !m_backdrop.filter) {
+        localBoundingRect.move(-filter->outsets.left(), -filter->outsets.top());
+        localBoundingRect.expand(filter->outsets.left() + filter->outsets.right(), filter->outsets.top() + filter->outsets.bottom());
+    }
+
+    TransformationMatrix transform(accumulatedReplicaTransform);
+    transform.multiply(m_transforms.combined);
+
+    auto viewportBoundingRect = data.transformedBoundingBox(transform, localBoundingRect);
+
+    switch (data.mode) {
+    case ComputeOverlapRegionMode::Intersection:
+        data.resolveOverlaps(viewportBoundingRect);
+        break;
+    case ComputeOverlapRegionMode::Union:
+    case ComputeOverlapRegionMode::Mask:
+        data.overlapRegion.unite(viewportBoundingRect);
+        break;
+    }
+
+    if (m_replica && includesReplica == IncludesReplica::Yes) {
+        TransformationMatrix newReplicaTransform(accumulatedReplicaTransform);
+        newReplicaTransform.multiply(replicaTransform());
+        computeOverlapRegions(data, newReplicaTransform, IncludesReplica::No);
+    }
+
+    if (!m_masksToBounds && data.mode != ComputeOverlapRegionMode::Mask) {
+        for (auto& child : m_children)
+            child->computeOverlapRegions(data, accumulatedReplicaTransform);
+    }
+}
+
+void SkiaCompositingLayer::paintUsingOverlapRegions(SkCanvas& canvas, PaintContext& context)
+{
+    ComputeOverlapRegionData data {
+        .mode = ComputeOverlapRegionMode::Intersection,
+        .clipBounds = clipBounds(canvas, context),
+        .overlapRegion = { },
+        .nonOverlapRegion = { }
+    };
+    computeOverlapRegions(data, context.accumulatedReplicaTransform);
+
+    if (data.overlapRegion.isEmpty()) {
+        paintSelfAndChildrenWithReplicaFilterAndMask(canvas, context);
+        return;
+    }
+
+    // Having both overlap and non-overlap regions carries some overhead.
+    // Avoid it if the overlap area is big anyway.
+    if (data.overlapRegion.totalArea() > data.nonOverlapRegion.totalArea()) {
+        data.overlapRegion.unite(data.nonOverlapRegion);
+        data.nonOverlapRegion = Region();
+    }
+
+    for (const auto& rect : data.nonOverlapRegion.rects()) {
+        SkAutoCanvasRestore autoRestore(&canvas, true);
+        canvas.clipIRect(SkIRect::MakeLTRB(rect.x(), rect.y(), rect.maxX(), rect.maxY()));
+        paintSelfAndChildrenWithReplicaFilterAndMask(canvas, context);
+    }
+
+    auto overlapRects = data.overlapRegion.rects();
+    static constexpr size_t cOverlapRegionConsolidationThreshold = 4;
+    if (data.nonOverlapRegion.isEmpty() && overlapRects.size() > cOverlapRegionConsolidationThreshold) {
+        overlapRects.clear();
+        overlapRects.append(data.overlapRegion.bounds());
+    }
+
+    SkPaint layerPaint;
+    layerPaint.setAlphaf(context.opacity);
+    for (const auto& rect : overlapRects) {
+        SkAutoCanvasRestore autoRestore(&canvas, true);
+        paintWithIntermediateSurface(canvas, context, rect, &layerPaint, [&](SkCanvas& canvas, PaintContext& context) {
+            SetForScope scopedOpacity(context.opacity, 1);
+            paintSelfAndChildrenWithReplicaFilterAndMask(canvas, context);
+        });
+    }
+}
+
+bool SkiaCompositingLayer::hasVisualContent() const
+{
+    return m_backingStore || m_imageBackingStore || m_contentsBuffer
+        || (m_contentsSolidColor.isValid() && m_contentsSolidColor.isVisible());
+}
+
+void SkiaCompositingLayer::collect3DRenderingContextLayers(Vector<Ref<SkiaCompositingLayer>>& layers)
+{
+    if (m_preserves3D || isLeafOf3DRenderingContext()) {
+        // Add layers to 3d rendering context only if they get actually painted.
+        bool hasVisualContentOrFilters = hasVisualContent() || filter() || m_backdrop.filter;
+        if (isVisible() && (hasVisualContentOrFilters || (isLeafOf3DRenderingContext() && !m_children.isEmpty())))
+            layers.append(Ref { *this });
+
+        // Stop recursion on 3d rendering context leaf
+        if (isLeafOf3DRenderingContext())
+            return;
+    }
+
+    for (auto& child : m_children)
+        child->collect3DRenderingContextLayers(layers);
+}
+
+void SkiaCompositingLayer::paintUsing3DRenderingContext(SkCanvas& canvas, PaintContext& context)
+{
+    Vector<Ref<SkiaCompositingLayer>> layers;
+    collect3DRenderingContextLayers(layers);
+
+    SkiaCompositingLayer3DRenderingContext::paint(layers, [&](SkiaCompositingLayer& layer, std::optional<SkPath> clipPath) {
+        SkAutoCanvasRestore autoRestore(&canvas, clipPath.has_value());
+        if (clipPath)
+            canvas.clipPath(*clipPath);
+
+        if (layer.m_preserves3D)
+            layer.paintSelf(canvas, context);
+        else
+            layer.recursivePaint(canvas, context);
+    });
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "BoxExtents.h"
+#include "Color.h"
+#include "CoordinatedBackingStoreProxy.h"
+#include "Damage.h"
+#include "FloatPoint.h"
+#include "FloatPoint3D.h"
+#include "FloatRect.h"
+#include "FloatRoundedRect.h"
+#include "SkiaCompositingLayerOverlapRegions.h"
+#include "TextureMapperAnimation.h"
+#include "TransformationMatrix.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkCanvas.h>
+#include <skia/core/SkColorFilter.h>
+#include <skia/core/SkM44.h>
+#include <skia/core/SkPath.h>
+#include <skia/effects/SkImageFilters.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/MonotonicTime.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+class CoordinatedAnimatedBackingStoreClient;
+class CoordinatedBackingStore;
+class CoordinatedImageBackingStore;
+class CoordinatedPlatformLayerBuffer;
+class FilterOperations;
+
+class SkiaCompositingLayer final : public RefCountedAndCanMakeWeakPtr<SkiaCompositingLayer> {
+    WTF_MAKE_TZONE_ALLOCATED(SkiaCompositingLayer);
+public:
+    static Ref<SkiaCompositingLayer> create();
+    ~SkiaCompositingLayer();
+
+    void invalidate();
+
+    void setSize(const FloatSize&);
+    void setPosition(const FloatPoint& point) { m_position = point; }
+    void setAnchorPoint(const FloatPoint3D& point) { m_anchorPoint = point; }
+    void setBoundsOrigin(const FloatPoint& point) { m_boundsOrigin = point; }
+    void setTransform(const TransformationMatrix& matrix) { m_transform = matrix; }
+    void setChildrenTransform(const TransformationMatrix& matrix) { m_childrenTransform = matrix; }
+    void setPreserves3D(bool preserves3D) { m_preserves3D = preserves3D; }
+    void setBackfaceVisibility(bool visible) { m_backfaceVisibility = visible; }
+    void setContentsVisible(bool visible) { m_contentsVisible = visible; }
+    void setMasksToBounds(bool masksToBounds) { m_masksToBounds = masksToBounds; }
+    void setContentsClippingRect(const FloatRoundedRect& rect) { m_contentsClippingRect = rect; }
+    void setContentsRectClipsDescendants(bool clips) { m_contentsRectClipsDescendants = clips; }
+    void setOpacity(float);
+    void setContentsRect(const FloatRect& rect) { m_contentsRect = rect; }
+    void setAnimations(const TextureMapperAnimations& animations) { m_animations = animations; }
+    void setContentsTiling(const FloatSize& size, const FloatSize& phase) { m_contentsTiling = { size, phase }; }
+    void setClipPath(SkPath&& clipPath) { m_clipPath = WTF::move(clipPath); }
+    void setMask(RefPtr<SkiaCompositingLayer>&&);
+    void setReplica(RefPtr<SkiaCompositingLayer>&&);
+    void setFilters(const FilterOperations&);
+    void setBackdropFilters(const FilterOperations&);
+    void setBackdropFiltersRect(const FloatRoundedRect&);
+    void setIsBackdropRoot(bool isBackdropRoot) { m_isBackdropRoot = isBackdropRoot; }
+    void setChildren(Vector<Ref<SkiaCompositingLayer>>&&);
+
+#if ENABLE(DAMAGE_TRACKING)
+    void setSharedFrameDamage(std::shared_ptr<Damage> frameDamage) { m_sharedFrameDamage = WTF::move(frameDamage); }
+    void addDamage(Damage&&);
+#endif
+
+    void setUseBackingStore(bool, CoordinatedAnimatedBackingStoreClient* = nullptr);
+    void updateBackingStore(CoordinatedBackingStoreProxy::Update&&, float);
+    void setImageBackingStore(CoordinatedImageBackingStore*);
+    void setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&);
+    CoordinatedPlatformLayerBuffer* contentsBuffer() const { return m_contentsBuffer.get(); }
+    void setContentsSolidColor(const Color&);
+
+    void setDebugIndicators(Color&& debugBorderColor, std::optional<float> debugBorderWidth, std::optional<unsigned> repaintCount);
+
+    const TransformationMatrix& toSurfaceTransform() const { return m_transforms.combined; }
+    FloatRect effectiveLayerRect() const { return FloatRect({ }, m_size); }
+
+    bool paint(SkCanvas&, std::optional<Damage>&);
+
+private:
+    SkiaCompositingLayer() = default;
+
+    void removeFromParent();
+    bool isVisible() const;
+    bool isLeafOf3DRenderingContext() const { return !m_preserves3D && (m_parent && m_parent->m_preserves3D); }
+    bool isReplica() const { return !!m_replicatedLayer; }
+    bool hasVisualContent() const;
+    Ref<SkiaCompositingLayer> backdropRoot();
+
+    bool computeTransformsAndAnimations(RefPtr<SkiaCompositingLayer>, MonotonicTime);
+
+    struct PaintContext {
+        explicit PaintContext(std::optional<Damage>& damage)
+            : frameDamage(damage)
+        {
+        }
+
+        float opacity { 1 };
+        bool isMask { false };
+        IntSize offset;
+        sk_sp<SkColorFilter> colorFilter;
+        TransformationMatrix accumulatedReplicaTransform;
+        RefPtr<SkiaCompositingLayer> paintingBackdropForLayer;
+        std::optional<Damage>& frameDamage;
+    };
+
+    struct Filter {
+        sk_sp<SkImageFilter> filter;
+        IntOutsets outsets;
+    };
+    using PaintFunction = Function<void(SkCanvas&, PaintContext&)>;
+
+    void recursivePaint(SkCanvas&, PaintContext&);
+    void paintSelf(SkCanvas&, PaintContext&);
+    void paintSelfAndChildren(SkCanvas&, PaintContext&);
+    void paintSelfAndChildrenWithReplicaFilterAndMask(SkCanvas&, PaintContext&);
+    void paintSelfAndChildrenWithFilterAndMask(SkCanvas&, PaintContext&);
+    void paintWithIntermediateSurface(SkCanvas&, PaintContext&, const IntRect&, SkPaint*, PaintFunction&&);
+    void paintUsingOverlapRegions(SkCanvas&, PaintContext&);
+    void paintUsing3DRenderingContext(SkCanvas&, PaintContext&);
+    Vector<IntRect, 1> computeConsolidatedOverlapRegionRects(const SkCanvas&, const PaintContext&, ComputeOverlapRegionMode);
+    TransformationMatrix replicaTransform() const;
+    IntRect clipBounds(const SkCanvas&, const PaintContext&) const;
+    void collect3DRenderingContextLayers(Vector<Ref<SkiaCompositingLayer>>&);
+
+    enum class IncludesReplica : bool { No, Yes };
+    void computeOverlapRegions(ComputeOverlapRegionData&, const TransformationMatrix& accumulatedReplicaTransform, IncludesReplica = IncludesReplica::Yes);
+
+#if ENABLE(DAMAGE_TRACKING)
+    bool frameDamagePropagationEnabled() const { return !!m_sharedFrameDamage; }
+    void damageWholeLayer()
+    {
+        m_accumulatedOverlapRegionFrameDamage = { };
+        if (m_size.isEmpty())
+            return;
+
+        if (!m_layerDamage)
+            m_layerDamage = Damage(m_size, Damage::Mode::Full);
+        else
+            m_layerDamage->makeFull();
+    }
+    void addPreviousRectToSharedFrameDamage();
+    void recursiveAddPreviousRectToSharedFrameDamage(Ref<SkiaCompositingLayer>);
+#endif
+
+    struct AnimationsState {
+        std::optional<TransformationMatrix> transform;
+        std::optional<TransformationMatrix> futureTransform;
+        std::optional<float> opacity;
+        std::optional<Filter> filter;
+        bool isRunning { false };
+    };
+    std::optional<AnimationsState> syncAnimations(MonotonicTime);
+
+    const TransformationMatrix& localTransform() const;
+    const TransformationMatrix& futureLocalTransform() const;
+    float opacity() const;
+    const std::optional<Filter> filter() const;
+
+    struct DebugBorder {
+        Color color;
+        float width { 0 };
+    };
+
+    Vector<Ref<SkiaCompositingLayer>> m_children;
+    WeakPtr<SkiaCompositingLayer> m_parent;
+    FloatSize m_size;
+    FloatPoint m_position;
+    FloatPoint3D m_anchorPoint { 0.5f, 0.5f, 0 };
+    FloatPoint m_boundsOrigin;
+    FloatRect m_contentsRect;
+    struct {
+        FloatSize size;
+        FloatSize phase;
+    } m_contentsTiling;
+    TransformationMatrix m_transform;
+    TransformationMatrix m_childrenTransform;
+    bool m_preserves3D { false };
+    bool m_backfaceVisibility { true };
+    bool m_contentsVisible { true };
+    bool m_visible { true };
+    bool m_masksToBounds { false };
+    bool m_contentsRectClipsDescendants { false };
+    FloatRoundedRect m_contentsClippingRect;
+    float m_opacity { 1 };
+    SkPath m_clipPath;
+    RefPtr<SkiaCompositingLayer> m_mask;
+    RefPtr<SkiaCompositingLayer> m_replica;
+    WeakPtr<SkiaCompositingLayer> m_replicatedLayer;
+    RefPtr<CoordinatedBackingStore> m_backingStore;
+    RefPtr<CoordinatedAnimatedBackingStoreClient> m_animatedBackingStoreClient;
+    RefPtr<CoordinatedImageBackingStore> m_imageBackingStore;
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> m_contentsBuffer;
+    Color m_contentsSolidColor;
+    std::optional<DebugBorder> m_debugBorder;
+    std::optional<unsigned> m_repaintCount;
+    std::optional<Filter> m_filter;
+    struct {
+        sk_sp<SkImageFilter> filter;
+        FloatRoundedRect clipRect;
+    } m_backdrop;
+    bool m_isBackdropRoot { false };
+    TextureMapperAnimations m_animations;
+    std::optional<AnimationsState> m_animationsState;
+    struct {
+        TransformationMatrix combined;
+        TransformationMatrix combinedForChildren;
+        TransformationMatrix futureCombined;
+        TransformationMatrix futureCombinedForChildren;
+    } m_transforms;
+#if ENABLE(DAMAGE_TRACKING)
+    std::shared_ptr<Damage> m_sharedFrameDamage;
+    std::optional<Damage> m_layerDamage;
+    std::optional<FloatRect> m_previousLayerRectInFrameCoordinates;
+    FloatRect m_accumulatedOverlapRegionFrameDamage;
+#endif
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2024 Jani Hautakangas <jani@kodegood.com>
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaCompositingLayer3DRenderingContext.h"
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "FloatPlane3D.h"
+#include "FloatPolygon3D.h"
+#include "FloatQuad.h"
+#include "GeometryUtilities.h"
+#include "SkiaCompositingLayer.h"
+#include <numeric>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkM44.h>
+#include <skia/core/SkPathBuilder.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+static inline FloatQuad projectPolygonToZYPlane(const FloatPolygon3D& polygon)
+{
+    auto p1 = polygon.vertexAt(0);
+    auto p2 = polygon.vertexAt(1);
+    auto p3 = polygon.vertexAt(2);
+    auto p4 = polygon.vertexAt(3);
+    return { { p1.z(), p1.y() }, { p2.z(), p2.y() }, { p3.z(), p3.y() }, { p4.z(), p4.y() } };
+}
+
+// Given two points defining an edge, returns the perpendicular axis (normalized)
+static inline FloatPoint edgeNormal(const FloatPoint& p1, const FloatPoint& p2)
+{
+    auto edge = p2 - p1;
+
+    // A perpendicular to (x,y) is (y,-x)
+    FloatPoint normal = { edge.height(), -edge.width() };
+    normal.normalize();
+
+    return normal;
+}
+
+// Project a convex polygon onto an axis and return min/max scalar values
+static inline std::pair<float, float> projectQuadOnAxis(const FloatQuad& quad, const FloatPoint& axis)
+{
+    float p1 = quad.p1().dot(axis);
+    float p2 = quad.p2().dot(axis);
+    float p3 = quad.p3().dot(axis);
+    float p4 = quad.p4().dot(axis);
+
+    float min = min4(p1, p2, p3, p4);
+    float max = max4(p1, p2, p3, p4);
+
+    return { min, max };
+}
+
+// Intersection check using Separating Axis Theorem
+// For more information:
+// https://en.wikipedia.org/wiki/Hyperplane_separation_theorem
+static inline bool quadsIntersect(const FloatQuad& quadA, const FloatQuad& quadB)
+{
+    std::array<FloatPoint, 8> axes;
+
+    // QuadA edges: (1->2), (2->3), (3->4), (4->0)
+    axes[0] = edgeNormal(quadA.p1(), quadA.p2());
+    axes[1] = edgeNormal(quadA.p2(), quadA.p3());
+    axes[2] = edgeNormal(quadA.p3(), quadA.p4());
+    axes[3] = edgeNormal(quadA.p4(), quadA.p1());
+
+    // QuadB edges: (1->2), (2->3), (3->4), (4->0)
+    axes[4] = edgeNormal(quadB.p1(), quadB.p2());
+    axes[5] = edgeNormal(quadB.p2(), quadB.p3());
+    axes[6] = edgeNormal(quadB.p3(), quadB.p4());
+    axes[7] = edgeNormal(quadB.p4(), quadB.p1());
+
+    for (auto& axis : axes) {
+        auto [minA, maxA] = projectQuadOnAxis(quadA, axis);
+        auto [minB, maxB] = projectQuadOnAxis(quadB, axis);
+
+        // Check if two intervals [minA, maxA] and [minB, maxB] do not overlap
+        if (maxA < minB || maxB < minA)
+            return false; // Separating axis found
+    }
+
+    return true; // No separating axis found
+}
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(SkiaCompositingLayer3DRenderingContext::LayerNode);
+
+void SkiaCompositingLayer3DRenderingContext::paint(const Vector<Ref<SkiaCompositingLayer>>& compositingLayers, const std::function<void(SkiaCompositingLayer&, std::optional<SkPath>)>& paintLayerFunction)
+{
+    if (compositingLayers.isEmpty())
+        return;
+
+    Vector<Layer> layers;
+    for (auto& compositingLayer : compositingLayers) {
+        FloatPolygon3D geometry(compositingLayer->effectiveLayerRect(), compositingLayer->toSurfaceTransform());
+        BoundingBox boundingBox = computeBoundingBox(geometry);
+        layers.append({ geometry, boundingBox, compositingLayer });
+    }
+
+    // Perform a broad-phase sweep-and-prune to identify potential intersections.
+    // By determining which layers might intersect, we can limit BSP cutting planes to those areas only,
+    // preventing unnecessary splitting of layers that are spatially distant.
+    // Reducing unnecessary splits helps improve performance, as each split layer fragment requires
+    // an additional clip path and paint call.
+    auto potentialIntersections = sweepAndPrune(layers);
+
+    // Determine if any layer pairs intersect on the ZY plane. An intersection implies that the rendering
+    // order is either ambiguous or overlapping, necessitating the use of a BSP tree for proper ordering.
+    bool hasIntersections = false;
+    for (const auto& p : potentialIntersections) {
+        auto quadA = projectPolygonToZYPlane(layers[p.first].geometry);
+        auto quadB = projectPolygonToZYPlane(layers[p.second].geometry);
+        if (quadsIntersect(quadA, quadB)) {
+            hasIntersections = true;
+            break;
+        }
+    }
+
+    // If no intersections are detected, the BSP tree building process is skipped and a fast path is taken.
+    // Other scenarios are not currently considered for optimization.
+    if (!hasIntersections) {
+        // Sort back to front
+        std::sort(layers.begin(), layers.end(), [](const Layer& layerA, const Layer& layerB) {
+            return layerA.boundingBox.min.z() < layerB.boundingBox.min.z();
+        });
+
+        for (auto& layer : layers)
+            paintLayerFunction(layer.compositingLayer.get(), std::nullopt);
+        return;
+    }
+
+    Deque<Layer> layerDeque;
+    for (auto& layer : layers)
+        layerDeque.append(WTF::move(layer));
+    layers.clear();
+
+    auto root = makeUnique<LayerNode>(layerDeque.takeFirst());
+    buildTree(*root, layerDeque);
+
+    auto buildClipPath = [](const Layer& layer) -> std::optional<SkPath> {
+        auto toLayerTransform = layer.compositingLayer->toSurfaceTransform().inverse();
+        unsigned numVertices = layer.geometry.numberOfVertices();
+        if (!toLayerTransform || numVertices < 3)
+            return std::nullopt;
+
+        SkPathBuilder builder;
+        auto v = toLayerTransform->mapPoint(layer.geometry.vertexAt(0));
+        builder.moveTo(v.x(), v.y());
+        for (unsigned i = 1; i < numVertices; ++i) {
+            v = toLayerTransform->mapPoint(layer.geometry.vertexAt(i));
+            builder.lineTo(v.x(), v.y());
+        }
+        builder.close();
+
+        return builder.detach().makeTransform(SkM44(layer.compositingLayer->toSurfaceTransform()).asM33());
+    };
+
+    // Paint in BSP order, building SkPath clip paths for split layers.
+    traverseTree(*root, [&paintLayerFunction, &buildClipPath](LayerNode& node) {
+        for (auto& layer : node.layers) {
+            if (!layer.isSplit) {
+                paintLayerFunction(layer.compositingLayer.get(), std::nullopt);
+                continue;
+            }
+
+            paintLayerFunction(layer.compositingLayer.get(), buildClipPath(layer));
+        }
+    });
+}
+
+SkiaCompositingLayer3DRenderingContext::BoundingBox SkiaCompositingLayer3DRenderingContext::computeBoundingBox(const FloatPolygon3D& polygon)
+{
+    auto minCorner = polygon.vertexAt(0);
+    auto maxCorner = polygon.vertexAt(0);
+
+    for (unsigned i = 1; i < polygon.numberOfVertices(); i++) {
+        auto point = polygon.vertexAt(i);
+        minCorner.setX(std::min(minCorner.x(), point.x()));
+        minCorner.setY(std::min(minCorner.y(), point.y()));
+        minCorner.setZ(std::min(minCorner.z(), point.z()));
+
+        maxCorner.setX(std::max(maxCorner.x(), point.x()));
+        maxCorner.setY(std::max(maxCorner.y(), point.y()));
+        maxCorner.setZ(std::max(maxCorner.z(), point.z()));
+    }
+
+    return { minCorner, maxCorner };
+}
+
+SkiaCompositingLayer3DRenderingContext::SweepAndPrunePairs SkiaCompositingLayer3DRenderingContext::sweepAndPrune(const Vector<Layer>& layers)
+{
+    Vector<size_t> indices(layers.size());
+    std::iota(indices.begin(), indices.end(), 0);
+
+    // Sort left to right along axis
+    std::sort(indices.begin(), indices.end(), [&layers](size_t a, size_t b) {
+        return layers[a].boundingBox.min.x() < layers[b].boundingBox.min.x();
+    });
+
+    SweepAndPrunePairs potentialIntersectionPairs;
+    for (size_t i = 0; i < indices.size(); ++i) {
+        for (size_t j = i + 1; j < indices.size(); ++j) {
+            auto firstIndex = indices[i];
+            auto secondIndex = indices[j];
+
+            // Check overlap on sorted X-axis
+            if (layers[secondIndex].boundingBox.min.x() >= layers[firstIndex].boundingBox.max.x())
+                break; // No further overlap possible
+
+            // Check overlap on Y-axis
+            if (layers[firstIndex].boundingBox.min.y() >= layers[secondIndex].boundingBox.max.y()
+                || layers[firstIndex].boundingBox.max.y() <= layers[secondIndex].boundingBox.min.y())
+                continue;
+
+            // Check overlap on Z-axis
+            if (layers[firstIndex].boundingBox.min.z() >= layers[secondIndex].boundingBox.max.z()
+                || layers[firstIndex].boundingBox.max.z() <= layers[secondIndex].boundingBox.min.z())
+                continue;
+
+            // Ensure canonical order (smaller index first)
+            if (firstIndex > secondIndex)
+                std::swap(firstIndex, secondIndex);
+
+            potentialIntersectionPairs.add({ firstIndex, secondIndex });
+        }
+    }
+    return potentialIntersectionPairs;
+}
+
+// Build BSP tree for rendering layers with painter's algorithm.
+// For more information:
+// https://en.wikipedia.org/wiki/Binary_space_partitioning
+void SkiaCompositingLayer3DRenderingContext::buildTree(LayerNode& root, Deque<Layer>& layers)
+{
+    if (layers.isEmpty())
+        return;
+
+    auto& rootGeometry = root.firstLayer().geometry;
+    FloatPlane3D rootPlane(rootGeometry.normal(), rootGeometry.vertexAt(0));
+
+    Deque<Layer> backList, frontList;
+    for (auto& layer : layers) {
+        switch (classifyLayer(layer, rootPlane)) {
+        case LayerPosition::InFront:
+            frontList.append(WTF::move(layer));
+            break;
+        case LayerPosition::Behind:
+            backList.append(WTF::move(layer));
+            break;
+        case LayerPosition::Coplanar:
+            root.layers.append(WTF::move(layer));
+            break;
+        case LayerPosition::Intersecting:
+            auto [backGeometry, frontGeometry] = layer.geometry.split(rootPlane);
+            if (backGeometry.numberOfVertices() > 2)
+                backList.append({ backGeometry, { }, layer.compositingLayer, true });
+            if (frontGeometry.numberOfVertices() > 2)
+                frontList.append({ frontGeometry, { }, layer.compositingLayer, true });
+            break;
+        }
+    }
+
+    if (!frontList.isEmpty()) {
+        root.frontNode = makeUnique<LayerNode>(frontList.takeFirst());
+        buildTree(*root.frontNode, frontList);
+    }
+
+    if (!backList.isEmpty()) {
+        root.backNode = makeUnique<LayerNode>(backList.takeFirst());
+        buildTree(*root.backNode, backList);
+    }
+}
+
+void SkiaCompositingLayer3DRenderingContext::traverseTree(LayerNode& node, const std::function<void(LayerNode&)>& processNode)
+{
+    auto& geometry = node.firstLayer().geometry;
+    FloatPlane3D plane(geometry.normal(), geometry.vertexAt(0));
+
+    auto* frontNode = node.frontNode.get();
+    auto* backNode = node.backNode.get();
+
+    // if polygon is facing away from camera then swap nodes to reverse
+    // the traversal order
+    if (plane.normal().z() < 0)
+        std::swap(frontNode, backNode);
+
+    if (backNode)
+        traverseTree(*backNode, processNode);
+
+    processNode(node);
+
+    if (frontNode)
+        traverseTree(*frontNode, processNode);
+}
+
+SkiaCompositingLayer3DRenderingContext::LayerPosition SkiaCompositingLayer3DRenderingContext::classifyLayer(const Layer& layer, const FloatPlane3D& plane)
+{
+    const float epsilon = 0.05f; // Tolerance for intersection check
+
+    int inFrontCount = 0;
+    int behindCount = 0;
+    for (unsigned i = 0; i < layer.geometry.numberOfVertices(); ++i) {
+        const auto& vertex = layer.geometry.vertexAt(i);
+        float distance = plane.distanceToPoint(vertex);
+
+        if (distance > epsilon)
+            inFrontCount++;
+        else if (distance < -epsilon)
+            behindCount++;
+    }
+
+    if (inFrontCount > 0 && behindCount > 0)
+        return LayerPosition::Intersecting;
+    if (inFrontCount > 0)
+        return LayerPosition::InFront;
+    if (behindCount > 0)
+        return LayerPosition::Behind;
+    return LayerPosition::Coplanar;
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 Jani Hautakangas <jani@kodegood.com>
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "FloatPolygon3D.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkPath.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/Deque.h>
+#include <wtf/HashSet.h>
+#include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class FloatPlane3D;
+class SkiaCompositingLayer;
+
+class SkiaCompositingLayer3DRenderingContext {
+public:
+    static void paint(const Vector<Ref<SkiaCompositingLayer>>&,
+        const std::function<void(SkiaCompositingLayer&, std::optional<SkPath>)>&);
+
+private:
+    enum class LayerPosition {
+        InFront,
+        Behind,
+        Coplanar,
+        Intersecting
+    };
+
+    struct BoundingBox {
+        FloatPoint3D min;
+        FloatPoint3D max;
+    };
+
+    struct Layer {
+        FloatPolygon3D geometry;
+        BoundingBox boundingBox;
+        Ref<SkiaCompositingLayer> compositingLayer;
+        bool isSplit { false };
+    };
+
+    struct LayerNode {
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(LayerNode);
+
+        explicit LayerNode(Layer&& layer)
+        {
+            layers.append(WTF::move(layer));
+        }
+
+        const Layer& firstLayer() const { return layers[0]; }
+
+        Vector<Layer> layers;
+        std::unique_ptr<LayerNode> frontNode;
+        std::unique_ptr<LayerNode> backNode;
+    };
+
+    using SweepAndPrunePairs = HashSet<std::pair<size_t, size_t>>;
+
+    static BoundingBox computeBoundingBox(const FloatPolygon3D&);
+    static SweepAndPrunePairs sweepAndPrune(const Vector<Layer>&);
+    static void buildTree(LayerNode&, Deque<Layer>&);
+    static void traverseTree(LayerNode&, const std::function<void(LayerNode&)>&);
+    static LayerPosition classifyLayer(const Layer&, const FloatPlane3D&);
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerOverlapRegions.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerOverlapRegions.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
+ * Copyright (C) 2022 Sony Interactive Entertainment Inc.
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaCompositingLayerOverlapRegions.h"
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "FloatRect.h"
+#include "TransformationMatrix.h"
+#include <array>
+
+namespace WebCore {
+
+template<typename T>
+struct Point4D {
+    T x;
+    T y;
+    T z;
+    T w;
+};
+
+template<typename T>
+Point4D<T> operator+(const Point4D<T>& s, const Point4D<T>& t)
+{
+    return { s.x + t.x, s.y + t.y, s.z + t.z, s.w + t.w };
+}
+
+template<typename T>
+Point4D<T> operator-(const Point4D<T>& s, const Point4D<T>& t)
+{
+    return { s.x - t.x, s.y - t.y, s.z - t.z, s.w - t.w };
+}
+
+template<typename T>
+Point4D<T> operator*(T s, const Point4D<T>& t)
+{
+    return { s * t.x, s * t.y, s * t.z, s * t.w };
+}
+
+template<typename T>
+struct MinMax {
+    T min;
+    T max;
+};
+
+void ComputeOverlapRegionData::resolveOverlaps(const IntRect& newRegion)
+{
+    Region newOverlapRegion(newRegion);
+    newOverlapRegion.intersect(nonOverlapRegion);
+    nonOverlapRegion.subtract(newOverlapRegion);
+    overlapRegion.unite(newOverlapRegion);
+
+    Region newNonOverlapRegion(newRegion);
+    newNonOverlapRegion.subtract(overlapRegion);
+    nonOverlapRegion.unite(newNonOverlapRegion);
+}
+
+IntRect ComputeOverlapRegionData::transformedBoundingBox(const TransformationMatrix& transform, const FloatRect& rect) const
+{
+    using Point = Point4D<double>;
+    auto mapPoint = [&](const FloatPoint& p) -> Point {
+        double x = p.x();
+        double y = p.y();
+        double z = 0;
+        double w = 1;
+        transform.map4ComponentPoint(x, y, z, w);
+        return { x, y, z, w };
+    };
+
+    std::array<Point, 4> vertex = {
+        mapPoint(rect.minXMinYCorner()),
+        mapPoint(rect.maxXMinYCorner()),
+        mapPoint(rect.maxXMaxYCorner()),
+        mapPoint(rect.minXMaxYCorner())
+    };
+    std::array<bool, 4> isPositive = {
+        vertex[0].w >= 0,
+        vertex[1].w >= 0,
+        vertex[2].w >= 0,
+        vertex[3].w >= 0
+    };
+
+    auto findFirstPositiveVertex = [&]() {
+        int i = 0;
+        for (; i < 4; i++) {
+            if (isPositive[i])
+                return i;
+        }
+        return i;
+    };
+    auto findFirstNegativeVertex = [&]() {
+        int i = 0;
+        for (; i < 4; i++) {
+            if (!isPositive[i])
+                return i;
+        }
+        return i;
+    };
+
+    auto leftVertexIndex = [](int i) {
+        return (i + 1) % 4;
+    };
+    auto diagonalVertexIndex = [](int i) {
+        return (i + 2) % 4;
+    };
+    auto rightVertexIndex = [](int i) {
+        return (i + 3) % 4;
+    };
+
+    auto minMax2 = [](double d1, double d2) -> MinMax<double> {
+        if (d1 < d2)
+            return { d1, d2 };
+        return { d2, d1 };
+    };
+    auto minMax3 = [&](double d1, double d2, double d3) -> MinMax<double> {
+        auto minmax = minMax2(d1, d2);
+        return { std::min(minmax.min, d3), std::max(minmax.max, d3) };
+    };
+    auto minMax4 = [&](double d1, double d2, double d3, double d4) -> MinMax<double> {
+        auto minmax1 = minMax2(d1, d2);
+        auto minmax2 = minMax2(d3, d4);
+        return { std::min(minmax1.min, minmax2.min), std::max(minmax1.max, minmax2.max) };
+    };
+
+    auto clipped = [&](const MinMax<double>& xMinMax, const MinMax<double>& yMinMax) -> IntRect {
+        int minX = std::max<double>(xMinMax.min, clipBounds.x());
+        int minY = std::max<double>(yMinMax.min, clipBounds.y());
+        int maxX = std::min<double>(xMinMax.max, clipBounds.maxX());
+        int maxY = std::min<double>(yMinMax.max, clipBounds.maxY());
+        return { minX, minY, maxX - minX, maxY - minY };
+    };
+
+    auto toPositive = [&](const Point& positive, const Point& negative) -> Point {
+        ASSERT(positive.w > 0);
+        ASSERT(negative.w <= 0);
+        auto v = positive.w * negative - negative.w * positive;
+        v.w = 0;
+        return v;
+    };
+    auto boundingBoxPPP = [&](const Point& p1, const Point& p2, const Point& p3) -> IntRect {
+        ASSERT(p1.w >= 0);
+        ASSERT(p2.w >= 0);
+        ASSERT(p3.w >= 0);
+        auto xMinMax = minMax3(p1.x / p1.w, p2.x / p2.w, p3.x / p3.w);
+        auto yMinMax = minMax3(p1.y / p1.w, p2.y / p2.w, p3.y / p3.w);
+        return clipped(xMinMax, yMinMax);
+    };
+    auto boundingBoxPPN = [&](const Point& p1, const Point& p2, const Point& n3) -> IntRect {
+        return boundingBoxPPP(p1, p2, toPositive(p1, n3));
+    };
+    auto boundingBoxPNN = [&](const Point& p1, const Point& n2, const Point& n3) -> IntRect {
+        return boundingBoxPPP(p1, toPositive(p1, n2), toPositive(p1, n3));
+    };
+
+    auto boundingBoxPPPByIndex = [&](int i1, int i2, int i3) {
+        return boundingBoxPPP(vertex[i1], vertex[i2], vertex[i3]);
+    };
+    auto boundingBoxPPNByIndex = [&](int i1, int i2, int i3) {
+        return boundingBoxPPN(vertex[i1], vertex[i2], vertex[i3]);
+    };
+    auto boundingBoxPNNByIndex = [&](int i1, int i2, int i3) {
+        return boundingBoxPNN(vertex[i1], vertex[i2], vertex[i3]);
+    };
+
+    int count = isPositive[0] + isPositive[1] + isPositive[2] + isPositive[3];
+    switch (count) {
+    case 0:
+        return { };
+    case 1: {
+        int i = findFirstPositiveVertex();
+        ASSERT(i < 4);
+        return boundingBoxPNNByIndex(i, rightVertexIndex(i), leftVertexIndex(i));
+    }
+    case 2: {
+        int i = findFirstPositiveVertex();
+        ASSERT(i < 3);
+        if (!i && isPositive[3])
+            i = 3;
+        int positiveRightIndex = i;
+        int positiveLeftIndex = leftVertexIndex(i);
+        ASSERT(isPositive[positiveLeftIndex]);
+        return unionRect(boundingBoxPPNByIndex(positiveRightIndex, positiveLeftIndex, leftVertexIndex(positiveLeftIndex)), boundingBoxPPNByIndex(positiveRightIndex, positiveLeftIndex, rightVertexIndex(positiveRightIndex)));
+    }
+    case 3: {
+        int i = findFirstNegativeVertex();
+        ASSERT(i < 4);
+        return unionRect(boundingBoxPPNByIndex(leftVertexIndex(i), rightVertexIndex(i), i), boundingBoxPPPByIndex(leftVertexIndex(i), rightVertexIndex(i), diagonalVertexIndex(i)));
+    }
+    case 4: {
+        auto xMinMax = minMax4(vertex[0].x / vertex[0].w, vertex[1].x / vertex[1].w, vertex[2].x / vertex[2].w, vertex[3].x / vertex[3].w);
+        auto yMinMax = minMax4(vertex[0].y / vertex[0].w, vertex[1].y / vertex[1].w, vertex[2].y / vertex[2].w, vertex[3].y / vertex[3].w);
+        return clipped(xMinMax, yMinMax);
+    }
+    }
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "IntRect.h"
+#include "Region.h"
+
+namespace WebCore {
+class FloatRect;
+class TransformationMatrix;
+
+enum class ComputeOverlapRegionMode : uint8_t {
+    Intersection,
+    Union,
+    Mask
+};
+
+struct ComputeOverlapRegionData {
+    ComputeOverlapRegionMode mode { ComputeOverlapRegionMode::Intersection };
+    IntRect clipBounds;
+    Region overlapRegion;
+    Region nonOverlapRegion;
+
+    void resolveOverlaps(const IntRect&);
+    IntRect transformedBoundingBox(const TransformationMatrix&, const FloatRect&) const;
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -22,10 +22,18 @@
 
 #if USE(COORDINATED_GRAPHICS)
 #include "BitmapTexture.h"
+#include "ColorMatrix.h"
 #include "CoordinatedTileBuffer.h"
 #include "GraphicsLayer.h"
 #include "TextureMapper.h"
+#include "TextureMapperFlags.h"
 #include <wtf/SystemTracing.h>
+
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorFilter.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
 
 namespace WebCore {
 
@@ -115,6 +123,47 @@ void CoordinatedBackingStore::drawRepaintCounter(TextureMapper& textureMapper, i
     for (const auto& tile : m_tiles.values())
         textureMapper.drawNumber(repaintCount, borderColor, tile.rect().location(), adjustedTransform);
 }
+
+#if USE(SKIA)
+void CoordinatedBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint)
+{
+    if (m_tiles.isEmpty())
+        return;
+
+    FloatRect layerRect = { { }, m_size };
+
+    sk_sp<SkColorFilter> bgraFilter;
+    auto tilePaint = paint;
+    for (auto& tile : m_tiles.values()) {
+        if (canvas.quickReject(tile.rect()))
+            continue;
+
+        const auto& image = tile.ensureSkImage();
+        if (!image)
+            continue;
+
+        tilePaint.setAntiAlias(allTileEdgesExposed(layerRect, tile.rect()));
+
+        if (tile.texture().colorConvertFlags().contains(TextureMapperFlags::ShouldConvertTextureBGRAToRGBA)) {
+            if (!bgraFilter) {
+                const auto matrix = swapRedBlueMatrix();
+                bgraFilter = SkColorFilters::Matrix(matrix.data().data());
+            }
+            if (auto* colorFilter = paint.getColorFilter())
+                tilePaint.setColorFilter(colorFilter->makeComposed(bgraFilter));
+            else
+                tilePaint.setColorFilter(bgraFilter);
+        }
+        canvas.drawImageRect(image, SkRect::MakeWH(image->width(), image->height()), tile.rect(), SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &tilePaint, SkCanvas::kFast_SrcRectConstraint);
+    }
+}
+
+void CoordinatedBackingStore::drawDebugBorders(SkCanvas& canvas, const SkPaint& paint)
+{
+    for (const auto& tile : m_tiles.values())
+        canvas.drawRect(SkRect(tile.rect()), paint);
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -25,6 +25,12 @@
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkCanvas.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
+
 namespace WebCore {
 class CoordinatedTileBuffer;
 class TextureMapper;
@@ -48,6 +54,11 @@ public:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float) override;
     void drawBorder(TextureMapper&, const Color&, float borderWidth, const FloatRect&, const TransformationMatrix&) override;
     void drawRepaintCounter(TextureMapper&, int repaintCount, const Color&, const FloatRect&, const TransformationMatrix&) override;
+
+#if USE(SKIA)
+    void paintToCanvas(SkCanvas&, const SkPaint&);
+    void drawDebugBorders(SkCanvas&, const SkPaint&);
+#endif
 
 private:
     CoordinatedBackingStore() = default;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
@@ -28,7 +28,14 @@
 #include <wtf/SystemTracing.h>
 
 #if USE(SKIA)
+#include "BitmapTexture.h"
+#include "PlatformDisplay.h"
 #include "SkiaPaintingEngine.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 namespace WebCore {
@@ -51,6 +58,11 @@ void CoordinatedBackingStoreTile::processPendingUpdates()
     auto updatesCount = updates.size();
     if (!updatesCount)
         return;
+
+#if USE(SKIA)
+    // The underlying GL texture is about to be updated; the cached SkImage wrapping it is now stale.
+    m_cachedSkImage = nullptr;
+#endif
 
     WTFBeginSignpost(this, CoordinatedSwapBuffers, "%zu updates", updatesCount);
     for (unsigned updateIndex = 0; updateIndex < updatesCount; ++updateIndex) {
@@ -114,6 +126,23 @@ void CoordinatedBackingStoreTile::processPendingUpdates()
     }
     WTFEndSignpost(this, CoordinatedSwapBuffers);
 }
+
+#if USE(SKIA)
+const sk_sp<SkImage>& CoordinatedBackingStoreTile::ensureSkImage()
+{
+    if (!m_cachedSkImage && m_texture) {
+        auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+        GrGLTextureInfo externalTexture;
+        externalTexture.fTarget = GL_TEXTURE_2D;
+        externalTexture.fID = m_texture->id();
+        externalTexture.fFormat = GL_RGBA8;
+        const auto& size = m_texture->size();
+        auto backendTexture = GrBackendTextures::MakeGL(size.width(), size.height(), skgpu::Mipmapped::kNo, externalTexture);
+        m_cachedSkImage = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    }
+    return m_cachedSkImage;
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
@@ -25,6 +25,12 @@
 #include "IntRect.h"
 #include <wtf/Vector.h>
 
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkImage.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
+
 namespace WebCore {
 class BitmapTexture;
 class CoordinatedTileBuffer;
@@ -50,11 +56,18 @@ public:
 
     bool canBePainted() const { return !!m_texture; }
 
+#if USE(SKIA)
+    const sk_sp<SkImage>& ensureSkImage();
+#endif
+
 private:
     RefPtr<BitmapTexture> m_texture;
     Vector<Update> m_updates;
     float m_scale { 1. };
     FloatRect m_rect;
+#if USE(SKIA)
+    sk_sp<SkImage> m_cachedSkImage;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -38,6 +38,7 @@
 #include "GraphicsContext.h"
 #include "GraphicsLayerCoordinated.h"
 #include "NativeImage.h"
+#include "NotImplemented.h"
 #include "TextureMapperLayer.h"
 #include <wtf/MainThread.h>
 
@@ -47,6 +48,7 @@
 #endif
 
 #if USE(SKIA)
+#include "SkiaCompositingLayer.h"
 #include "SkiaPaintingEngine.h"
 #include "SkiaRecordingResult.h"
 #endif
@@ -110,11 +112,19 @@ TextureMapperLayer& CoordinatedPlatformLayer::ensureTarget()
     return *m_target;
 }
 
-TextureMapperLayer* CoordinatedPlatformLayer::target() const
+#if USE(SKIA)
+SkiaCompositingLayer& CoordinatedPlatformLayer::ensureSkiaTarget()
 {
     ASSERT(!isMainThread());
-    return m_target.get();
+    if (!m_skiaTarget)
+        m_skiaTarget = SkiaCompositingLayer::create();
+#if ENABLE(DAMAGE_TRACKING)
+    if (m_damagePropagationEnabled)
+        m_skiaTarget->setSharedFrameDamage(m_damageInGlobalCoordinateSpace);
+#endif
+    return *m_skiaTarget;
 }
+#endif
 
 static bool shouldReleaseBuffer(CoordinatedPlatformLayerBuffer* buffer)
 {
@@ -141,6 +151,12 @@ void CoordinatedPlatformLayer::invalidateTarget()
             m_contentsBuffer.committed = nullptr;
     }
     m_target = nullptr;
+#if USE(SKIA)
+    if (m_skiaTarget) {
+        m_skiaTarget->invalidate();
+        m_skiaTarget = nullptr;
+    }
+#endif
 }
 
 void CoordinatedPlatformLayer::invalidateClient()
@@ -481,10 +497,21 @@ void CoordinatedPlatformLayer::setContentsScale(float contentsScale)
     notifyCompositionRequired();
 }
 
+bool CoordinatedPlatformLayer::hasCommittedContentsBuffer() const
+{
+    ASSERT(m_lock.isHeld());
+#if USE(SKIA)
+    if (m_skiaTarget)
+        return !!m_skiaTarget->contentsBuffer();
+#endif
+
+    return !!m_contentsBuffer.committed;
+}
+
 void CoordinatedPlatformLayer::setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&& buffer, std::optional<Damage>&& dirtyRegion, RequireComposition requireComposition)
 {
     ASSERT(m_lock.isHeld());
-    if (!buffer && !m_contentsBuffer.pending && !m_contentsBuffer.committed)
+    if (!buffer && !m_contentsBuffer.pending && !hasCommittedContentsBuffer())
         return;
 
     m_contentsBuffer.pending = WTF::move(buffer);
@@ -503,10 +530,21 @@ void CoordinatedPlatformLayer::setContentsBuffer(std::unique_ptr<CoordinatedPlat
 void CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy()
 {
     Locker locker { m_lock };
-    if (!m_contentsBuffer.committed)
+    if (!hasCommittedContentsBuffer())
         return;
 
     m_contentsBuffer.pending = nullptr;
+
+#if USE(SKIA)
+    if (m_skiaTarget) {
+        if (auto* buffer = m_skiaTarget->contentsBuffer()) {
+            if (is<CoordinatedPlatformLayerBufferVideo>(*buffer))
+                m_contentsBuffer.pending = downcast<CoordinatedPlatformLayerBufferVideo>(*buffer).copyBuffer();
+            m_skiaTarget->setContentsBuffer(WTF::move(m_contentsBuffer.pending));
+        }
+        return;
+    }
+#endif
     if (is<CoordinatedPlatformLayerBufferVideo>(*m_contentsBuffer.committed))
         m_contentsBuffer.pending = downcast<CoordinatedPlatformLayerBufferVideo>(*m_contentsBuffer.committed).copyBuffer();
     m_contentsBuffer.committed = WTF::move(m_contentsBuffer.pending);
@@ -630,6 +668,12 @@ void CoordinatedPlatformLayer::setBackdrop(CoordinatedPlatformLayer* backdrop)
         return;
 
     m_backdrop = backdrop;
+    notifyBackdropFiltersChanged();
+}
+
+void CoordinatedPlatformLayer::notifyBackdropFiltersChanged()
+{
+    ASSERT(m_lock.isHeld());
     m_pendingChanges.add(Change::Backdrop);
     notifyCompositionRequired();
 }
@@ -642,6 +686,17 @@ void CoordinatedPlatformLayer::setBackdropRect(const FloatRoundedRect& backdropR
 
     m_backdropRect = backdropRect;
     m_pendingChanges.add(Change::BackdropRect);
+    notifyCompositionRequired();
+}
+
+void CoordinatedPlatformLayer::setIsBackdropRoot(bool isBackdropRoot)
+{
+    ASSERT(m_lock.isHeld());
+    if (m_isBackdropRoot == isBackdropRoot)
+        return;
+
+    m_isBackdropRoot = isBackdropRoot;
+    m_pendingChanges.add(Change::BackdropRoot);
     notifyCompositionRequired();
 }
 
@@ -680,6 +735,14 @@ const EventRegion& CoordinatedPlatformLayer::eventRegion() const
 {
     ASSERT(m_lock.isHeld());
     return m_eventRegion;
+}
+
+void CoordinatedPlatformLayer::setClipPath(const Path& path, WindRule windRule)
+{
+    ASSERT(m_lock.isHeld());
+    m_clipPath.path = path;
+    m_clipPath.windRule = windRule;
+    m_pendingChanges.add(Change::ClipPath);
 }
 
 void CoordinatedPlatformLayer::setDebugBorder(Color&& borderColor, float borderWidth)
@@ -893,14 +956,27 @@ void CoordinatedPlatformLayer::waitUntilPaintingComplete()
         m_backingStoreProxy->waitUntilPaintingComplete();
 }
 
-void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<CompositionReason>& reasons)
+void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<CompositionReason>& reasons, bool useSkiaTarget)
 {
     ASSERT(!isMainThread());
     Locker locker { m_lock };
     if (m_pendingChanges.isEmpty() && (!reasons.contains(CompositionReason::RenderingUpdate) || !m_backingStoreProxy))
         return;
 
-    auto& layer = ensureTarget();
+#if USE(SKIA)
+    if (useSkiaTarget) {
+        flushCompositingStateOnSkiaTarget(reasons, ensureSkiaTarget());
+        return;
+    }
+#else
+    UNUSED_PARAM(useSkiaTarget);
+#endif
+
+    flushCompositingStateOnTarget(reasons, ensureTarget());
+}
+
+void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<CompositionReason>& reasons, TextureMapperLayer& layer)
+{
     if (reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::AsyncScrolling })) {
         if (m_pendingChanges.contains(Change::Position)) {
             layer.setPosition(m_position);
@@ -1096,6 +1172,194 @@ void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<Composition
             layer.setContentsLayer(nullptr);
     }
 }
+
+#if USE(SKIA)
+void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet<CompositionReason>& reasons, SkiaCompositingLayer& layer)
+{
+    if (reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::AsyncScrolling })) {
+        if (m_pendingChanges.contains(Change::Position)) {
+            layer.setPosition(m_position);
+            m_pendingChanges.remove(Change::Position);
+        }
+
+        if (m_pendingChanges.contains(Change::BoundsOrigin)) {
+            layer.setBoundsOrigin(m_boundsOrigin);
+            m_pendingChanges.remove(Change::BoundsOrigin);
+        }
+
+        if (m_pendingChanges.contains(Change::ContentsRect)) {
+            layer.setContentsRect(m_contentsRect);
+            m_pendingChanges.remove(Change::ContentsRect);
+        }
+
+        if (m_pendingChanges.contains(Change::ContentsClippingRect)) {
+            layer.setContentsClippingRect(m_contentsClippingRect);
+            m_pendingChanges.remove(Change::ContentsClippingRect);
+        }
+
+        if (m_pendingChanges.contains(Change::ContentsImage)) {
+            layer.setImageBackingStore(m_imageBackingStore.current);
+            m_pendingChanges.remove(Change::ContentsImage);
+        }
+    }
+
+    if (reasons.contains(CompositionReason::RenderingUpdate)) {
+        if (m_pendingChanges.contains(Change::AnchorPoint)) {
+            layer.setAnchorPoint(m_anchorPoint);
+            m_pendingChanges.remove(Change::AnchorPoint);
+        }
+
+        if (m_pendingChanges.contains(Change::Size)) {
+            layer.setSize(m_size);
+            m_pendingChanges.remove(Change::Size);
+        }
+
+        if (m_pendingChanges.contains(Change::Transform)) {
+            layer.setTransform(m_transform);
+            m_pendingChanges.remove(Change::Transform);
+        }
+
+        if (m_pendingChanges.contains(Change::ChildrenTransform)) {
+            layer.setChildrenTransform(m_childrenTransform);
+            m_pendingChanges.remove(Change::ChildrenTransform);
+        }
+
+        if (m_pendingChanges.contains(Change::Preserves3D)) {
+            layer.setPreserves3D(m_preserves3D);
+            m_pendingChanges.remove(Change::Preserves3D);
+        }
+
+        if (m_pendingChanges.contains(Change::MasksToBounds)) {
+            layer.setMasksToBounds(m_masksToBounds);
+            m_pendingChanges.remove(Change::MasksToBounds);
+        }
+
+        if (m_pendingChanges.contains(Change::BackfaceVisibility)) {
+            layer.setBackfaceVisibility(m_backfaceVisibility);
+            m_pendingChanges.remove(Change::BackfaceVisibility);
+        }
+
+        if (m_pendingChanges.contains(Change::Opacity)) {
+            layer.setOpacity(m_opacity);
+            m_pendingChanges.remove(Change::Opacity);
+        }
+
+        if (m_pendingChanges.contains(Change::BackingStore)) {
+            layer.setUseBackingStore(!!m_backingStoreProxy, m_backingStoreProxy && m_animatedBackingStoreClient ? m_animatedBackingStoreClient.get() : nullptr);
+            m_pendingChanges.remove(Change::BackingStore);
+        }
+
+        if (m_pendingChanges.contains(Change::ContentsVisible)) {
+            layer.setContentsVisible(m_contentsVisible);
+            m_pendingChanges.remove(Change::ContentsVisible);
+        }
+
+        if (m_pendingChanges.contains(Change::ContentsOpaque)) {
+            // FIXME: do we need this in SkiaCompositingLayer?
+            notImplemented();
+            m_pendingChanges.remove(Change::ContentsOpaque);
+        }
+
+        if (m_pendingChanges.contains(Change::ContentsRectClipsDescendants)) {
+            layer.setContentsRectClipsDescendants(m_contentsRectClipsDescendants);
+            m_pendingChanges.remove(Change::ContentsRectClipsDescendants);
+        }
+
+        if (m_pendingChanges.contains(Change::ContentsTiling)) {
+            layer.setContentsTiling(m_contentsTileSize, m_contentsTilePhase);
+            m_pendingChanges.remove(Change::ContentsTiling);
+        }
+
+        if (m_pendingChanges.contains(Change::ContentsColor)) {
+            layer.setContentsSolidColor(m_contentsColor);
+            m_pendingChanges.remove(Change::ContentsColor);
+        }
+
+#if ENABLE(DAMAGE_TRACKING)
+        if (m_pendingChanges.contains(Change::Damage)) {
+            ASSERT(m_damage.has_value());
+            layer.addDamage(*std::exchange(m_damage, std::nullopt));
+            m_pendingChanges.remove(Change::Damage);
+        }
+#endif
+        if (m_pendingChanges.contains(Change::ClipPath)) {
+            auto clipPath = *m_clipPath.path.platformPath();
+            clipPath.setFillType(m_clipPath.windRule == WindRule::EvenOdd ? SkPathFillType::kEvenOdd : SkPathFillType::kWinding);
+            layer.setClipPath(WTF::move(clipPath));
+        }
+
+        if (m_pendingChanges.contains(Change::Filters)) {
+            layer.setFilters(m_filters);
+            m_pendingChanges.remove(Change::Filters);
+        }
+
+        if (m_pendingChanges.contains(Change::Mask)) {
+            layer.setMask(m_mask ? RefPtr { &m_mask->ensureSkiaTarget() } : nullptr);
+            m_pendingChanges.remove(Change::Mask);
+        }
+
+        if (m_pendingChanges.contains(Change::Replica)) {
+            layer.setReplica(m_replica ? RefPtr { &m_replica->ensureSkiaTarget() } : nullptr);
+            m_pendingChanges.remove(Change::Replica);
+        }
+
+        if (m_pendingChanges.contains(Change::Backdrop) || (m_backdrop && m_backdrop->m_pendingChanges.contains(Change::Filters))) {
+            // FIXME: stop creating a layer for backdrop filters when switching to SkiaCompositingLayer.
+            layer.setBackdropFilters(m_backdrop ? m_backdrop->m_filters : FilterOperations());
+            m_pendingChanges.remove(Change::Backdrop);
+            if (m_backdrop)
+                m_backdrop->m_pendingChanges.remove(Change::Filters);
+        }
+
+        if (m_pendingChanges.contains(Change::BackdropRect)) {
+            layer.setBackdropFiltersRect(m_backdropRect);
+            m_pendingChanges.remove(Change::BackdropRect);
+        }
+
+        if (m_pendingChanges.contains(Change::BackdropRoot)) {
+            layer.setIsBackdropRoot(m_isBackdropRoot);
+            m_pendingChanges.remove(Change::BackdropRoot);
+        }
+
+        if (m_pendingChanges.contains(Change::Animations)) {
+            layer.setAnimations(m_animations);
+            m_pendingChanges.remove(Change::Animations);
+        }
+
+        if (m_pendingChanges.contains(Change::DebugIndicators)) {
+            Color color;
+            std::optional<float> width;
+            if (m_debugBorderColor.isVisible()) {
+                color = m_debugBorderColor;
+                width = m_debugBorderWidth;
+            }
+            std::optional<unsigned> repaintCount;
+            if (m_repaintCount != -1)
+                repaintCount = m_repaintCount;
+
+            layer.setDebugIndicators(WTF::move(color), width, repaintCount);
+            m_pendingChanges.remove(Change::DebugIndicators);
+        }
+
+        if (m_pendingChanges.contains(Change::Children)) {
+            layer.setChildren(WTF::map(m_children, [](auto& child) {
+                return Ref { child->ensureSkiaTarget() };
+            }));
+            m_pendingChanges.remove(Change::Children);
+        }
+
+        if (m_backingStoreProxy)
+            layer.updateBackingStore(m_backingStoreProxy->takePendingUpdate(), m_contentsScale);
+    }
+
+    if (reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::VideoFrame, CompositionReason::AsyncScrolling })) {
+        if (m_pendingChanges.contains(Change::ContentsBuffer)) {
+            layer.setContentsBuffer(WTF::move(m_contentsBuffer.pending));
+            m_pendingChanges.remove(Change::ContentsBuffer);
+        }
+    }
+}
+#endif // USE(SKIA)
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -50,6 +50,7 @@ class NativeImage;
 class TextureMapperLayer;
 
 #if USE(SKIA)
+class SkiaCompositingLayer;
 class SkiaPaintingEngine;
 class SkiaRecordingResult;
 #endif
@@ -96,7 +97,9 @@ public:
     GraphicsLayerCoordinated* owner() const;
 
     TextureMapperLayer& ensureTarget();
-    TextureMapperLayer* target() const;
+#if USE(SKIA)
+    SkiaCompositingLayer& ensureSkiaTarget();
+#endif
     void invalidateTarget();
 
 #if ENABLE(DAMAGE_TRACKING)
@@ -163,7 +166,9 @@ public:
     void setMask(CoordinatedPlatformLayer*);
     void setReplica(CoordinatedPlatformLayer*);
     void setBackdrop(CoordinatedPlatformLayer*);
+    void notifyBackdropFiltersChanged();
     void setBackdropRect(const FloatRoundedRect&);
+    void setIsBackdropRoot(bool);
 
     void setAnimations(const TextureMapperAnimations&);
 
@@ -173,13 +178,15 @@ public:
     void setEventRegion(const EventRegion&);
     const EventRegion& eventRegion() const;
 
+    void setClipPath(const Path&, WindRule);
+
     void setDebugBorder(Color&&, float);
     void setShowRepaintCounter(bool);
 
     void updateContents(bool affectedByTransformAnimation);
     void updateBackingStore();
 
-    void flushCompositingState(const OptionSet<CompositionReason>&);
+    void flushCompositingState(const OptionSet<CompositionReason>&, bool = false);
 
     bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }
     bool isCompositionRequiredOrOngoing() const;
@@ -204,45 +211,54 @@ private:
     bool needsBackingStore() const;
     void purgeBackingStores();
 
+    bool hasCommittedContentsBuffer() const;
+
 #if ENABLE(DAMAGE_TRACKING)
     void addDamage(Damage&&);
 #endif
 
-    enum class Change : uint32_t {
-        Position                     = 1 << 0,
-        BoundsOrigin                 = 1 << 1,
-        AnchorPoint                  = 1 << 2,
-        Size                         = 1 << 3,
-        Transform                    = 1 << 4,
-        ChildrenTransform            = 1 << 5,
-        DrawsContent                 = 1 << 6,
-        MasksToBounds                = 1 << 7,
-        Preserves3D                  = 1 << 8,
-        BackfaceVisibility           = 1 << 9,
-        Opacity                      = 1 << 10,
-        Children                     = 1 << 11,
-        BackingStore                 = 1 << 12,
-        ContentsVisible              = 1 << 13,
-        ContentsOpaque               = 1 << 14,
-        ContentsRect                 = 1 << 15,
-        ContentsRectClipsDescendants = 1 << 16,
-        ContentsClippingRect         = 1 << 17,
-        ContentsTiling               = 1 << 18,
-        ContentsBuffer               = 1 << 19,
-        ContentsImage                = 1 << 20,
-        ContentsColor                = 1 << 21,
-        Filters                      = 1 << 22,
-        Mask                         = 1 << 23,
-        Replica                      = 1 << 24,
-        Backdrop                     = 1 << 25,
-        BackdropRect                 = 1 << 26,
-        Animations                   = 1 << 27,
-        DebugIndicators              = 1 << 28,
+    void flushCompositingStateOnTarget(const OptionSet<CompositionReason>&, TextureMapperLayer&);
+#if USE(SKIA)
+    void flushCompositingStateOnSkiaTarget(const OptionSet<CompositionReason>&, SkiaCompositingLayer&);
+#endif
+
+    enum class Change : uint64_t {
+        Position                     = 1LLU << 0,
+        BoundsOrigin                 = 1LLU << 1,
+        AnchorPoint                  = 1LLU << 2,
+        Size                         = 1LLU << 3,
+        Transform                    = 1LLU << 4,
+        ChildrenTransform            = 1LLU << 5,
+        DrawsContent                 = 1LLU << 6,
+        MasksToBounds                = 1LLU << 7,
+        Preserves3D                  = 1LLU << 8,
+        BackfaceVisibility           = 1LLU << 9,
+        Opacity                      = 1LLU << 10,
+        Children                     = 1LLU << 11,
+        BackingStore                 = 1LLU << 12,
+        ContentsVisible              = 1LLU << 13,
+        ContentsOpaque               = 1LLU << 14,
+        ContentsRect                 = 1LLU << 15,
+        ContentsRectClipsDescendants = 1LLU << 16,
+        ContentsClippingRect         = 1LLU << 17,
+        ContentsTiling               = 1LLU << 18,
+        ContentsBuffer               = 1LLU << 19,
+        ContentsImage                = 1LLU << 20,
+        ContentsColor                = 1LLU << 21,
+        ClipPath                     = 1LLU << 22,
+        Filters                      = 1LLU << 23,
+        Mask                         = 1LLU << 24,
+        Replica                      = 1LLU << 25,
+        Backdrop                     = 1LLU << 26,
+        BackdropRect                 = 1LLU << 27,
+        BackdropRoot                 = 1LLU << 28,
+        Animations                   = 1LLU << 29,
+        DebugIndicators              = 1LLU << 30,
 #if ENABLE(DAMAGE_TRACKING)
-        Damage                       = 1 << 29,
+        Damage                       = 1LLU << 31,
 #endif
 #if ENABLE(SCROLLING_THREAD)
-        ScrollingNode                = 1 << 30
+        ScrollingNode                = 1LLU << 32
 #endif
     };
 
@@ -253,6 +269,9 @@ private:
 
     GraphicsLayerCoordinated* m_owner { nullptr };
     std::unique_ptr<TextureMapperLayer> m_target;
+#if USE(SKIA)
+    RefPtr<SkiaCompositingLayer> m_skiaTarget;
+#endif
     bool m_pendingTilesCreation { false };
     bool m_needsTilesUpdate { false };
 
@@ -297,12 +316,17 @@ private:
         std::unique_ptr<CoordinatedPlatformLayerBuffer> pending;
         std::unique_ptr<CoordinatedPlatformLayerBuffer> committed;
     } m_contentsBuffer WTF_GUARDED_BY_LOCK(m_lock);
+    struct {
+        Path path;
+        WindRule windRule;
+    } m_clipPath WTF_GUARDED_BY_LOCK(m_lock);
     Vector<IntRect, 1> m_dirtyRegion WTF_GUARDED_BY_LOCK(m_lock);
     FilterOperations m_filters WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedPlatformLayer> m_mask WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedPlatformLayer> m_replica WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedPlatformLayer> m_backdrop WTF_GUARDED_BY_LOCK(m_lock);
     FloatRoundedRect m_backdropRect WTF_GUARDED_BY_LOCK(m_lock);
+    bool m_isBackdropRoot WTF_GUARDED_BY_LOCK(m_lock) { false };
     TextureMapperAnimations m_animations WTF_GUARDED_BY_LOCK(m_lock);
     Vector<Ref<CoordinatedPlatformLayer>> m_children WTF_GUARDED_BY_LOCK(m_lock);
     EventRegion m_eventRegion WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
@@ -31,6 +31,12 @@
 #include "TextureMapperPlatformLayer.h"
 #include <wtf/OptionSet.h>
 
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkCanvas.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
+
 namespace WebCore {
 
 class CoordinatedPlatformLayerBuffer : public TextureMapperPlatformLayer {
@@ -58,6 +64,10 @@ public:
         if (auto fence = WTF::move(m_fence))
             fence->serverWait();
     }
+
+#if USE(SKIA)
+    virtual void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) { }
+#endif
 
 protected:
     CoordinatedPlatformLayerBuffer(Type type, const IntSize& size, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -157,6 +157,29 @@ static const HashMap<uint32_t, Vector<YUVPlaneInfo>>& yuvFormatPlaneInfo()
     return yuvFormatsMap;
 }
 
+static CoordinatedPlatformLayerBufferYUV::Format yuvFormatFromDRMFourcc(uint32_t fourcc)
+{
+    switch (fourcc) {
+    case DRM_FORMAT_AYUV:
+        return CoordinatedPlatformLayerBufferYUV::Format::AYUV;
+    case DRM_FORMAT_NV12:
+        return CoordinatedPlatformLayerBufferYUV::Format::NV12;
+    case DRM_FORMAT_P010:
+        return CoordinatedPlatformLayerBufferYUV::Format::P010;
+    case DRM_FORMAT_YUV420:
+        return CoordinatedPlatformLayerBufferYUV::Format::YUV420;
+    case DRM_FORMAT_YVU420:
+        return CoordinatedPlatformLayerBufferYUV::Format::YVU420;
+    case DRM_FORMAT_YUV444:
+        return CoordinatedPlatformLayerBufferYUV::Format::YUV444;
+    case DRM_FORMAT_YUV411:
+        return CoordinatedPlatformLayerBufferYUV::Format::YUV411;
+    case DRM_FORMAT_YUV422:
+        return CoordinatedPlatformLayerBufferYUV::Format::YUV422;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDMABuf::importYUV() const
 {
     OptionSet<BitmapTexture::Flags> textureFlags;
@@ -189,6 +212,8 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDM
     if (textures.isEmpty())
         return nullptr;
 
+    auto format = yuvFormatFromDRMFourcc(attributes.fourcc.value);
+
     CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace yuvToRgbColorSpace;
     switch (m_dmabuf->colorSpace().value_or(DMABufBuffer::ColorSpace::Bt601)) {
     case DMABufBuffer::ColorSpace::Bt601:
@@ -216,7 +241,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDM
     }
 
     unsigned numberOfPlanes = textures.size();
-    return CoordinatedPlatformLayerBufferYUV::create(numberOfPlanes, WTF::move(textures), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), yuvToRgbColorSpace, transferFunction, m_size, m_flags, nullptr);
+    return CoordinatedPlatformLayerBufferYUV::create(format, numberOfPlanes, WTF::move(textures), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), yuvToRgbColorSpace, transferFunction, m_size, m_flags, nullptr);
 }
 
 std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDMABuf::importDMABuf() const
@@ -247,6 +272,24 @@ void CoordinatedPlatformLayerBufferDMABuf::paintToTextureMapper(TextureMapper& t
     if (auto* buffer = m_dmabuf->buffer())
         buffer->paintToTextureMapper(textureMapper, targetRect, modelViewMatrix, opacity);
 }
+
+#if USE(SKIA)
+void CoordinatedPlatformLayerBufferDMABuf::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+{
+    waitForContentsIfNeeded();
+
+    if (m_fenceFD) {
+        if (auto fence = GLFence::importFD(PlatformDisplay::sharedDisplay().glDisplay(), WTF::move(m_fenceFD)))
+            fence->serverWait();
+    }
+
+    if (!m_dmabuf->buffer())
+        m_dmabuf->setBuffer(importDMABuf());
+
+    if (auto* buffer = m_dmabuf->buffer())
+        buffer->paintToCanvas(canvas, targetRect, paint);
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
@@ -45,6 +45,10 @@ public:
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
+#if USE(SKIA)
+    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+#endif
+
     std::unique_ptr<CoordinatedPlatformLayerBuffer> importDMABuf() const;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> importYUV() const;
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
@@ -40,6 +40,15 @@
 #include <gst/video/gstvideometa.h>
 #endif
 
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkImage.h>
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
+
 namespace WebCore {
 
 std::unique_ptr<CoordinatedPlatformLayerBufferExternalOES> CoordinatedPlatformLayerBufferExternalOES::create(unsigned textureID, const IntSize& size, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence)
@@ -155,6 +164,27 @@ void CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper(TextureMapp
     display.destroyEGLImage(image);
 #endif // USE(GSTREAMER) && USE(GBM)
 }
+
+#if USE(SKIA)
+void CoordinatedPlatformLayerBufferExternalOES::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+{
+    waitForContentsIfNeeded();
+
+    if (!m_textureID) {
+        // FIXME: support Qualcomm decoder.
+        return;
+    }
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    GrGLTextureInfo externalTexture;
+    externalTexture.fTarget = GL_TEXTURE_EXTERNAL_OES;
+    externalTexture.fID = m_textureID;
+    externalTexture.fFormat = GL_RGBA8;
+    auto backendTexture = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+    sk_sp<SkImage> image = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    canvas.drawImageRect(image, SkRect::MakeWH(m_size.width(), m_size.height()), targetRect, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.h
@@ -48,6 +48,10 @@ public:
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
+#if USE(SKIA)
+    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+#endif
+
     unsigned m_textureID { 0 };
 #if USE(GSTREAMER) && USE(GBM)
     uint32_t m_fourcc { 0 };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.cpp
@@ -72,6 +72,21 @@ void CoordinatedPlatformLayerBufferHolePunch::paintToTextureMapper(TextureMapper
     textureMapper.drawSolidColor(targetRect, modelViewMatrix, Color::transparentBlack, false);
 }
 
+#if USE(SKIA)
+void CoordinatedPlatformLayerBufferHolePunch::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint&)
+{
+#if USE(GSTREAMER)
+    if (m_videoSink && m_quirksManager) {
+        TransformationMatrix matrix = canvas.getLocalToDevice();
+        m_quirksManager->setHolePunchVideoRectangle(m_videoSink.get(), enclosingIntRect(matrix.mapRect(targetRect)));
+    }
+#endif
+    SkPaint paint;
+    paint.setColor(SK_ColorTRANSPARENT);
+    canvas.drawRect(SkRect(targetRect), paint);
+}
+#endif
+
 } // namespace WebCore
 
 #endif // USE(COORDINATED_GRAPHICS) && ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.h
@@ -49,6 +49,10 @@ public:
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
+#if USE(SKIA)
+    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+#endif
+
 #if USE(GSTREAMER)
     GRefPtr<GstElement> m_videoSink;
     RefPtr<GStreamerQuirksManager> m_quirksManager;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -135,6 +135,18 @@ void CoordinatedPlatformLayerBufferNativeImage::paintToTextureMapper(TextureMapp
     m_buffer->paintToTextureMapper(textureMapper, targetRect, modelViewMatrix, opacity);
 }
 
+#if USE(SKIA)
+void CoordinatedPlatformLayerBufferNativeImage::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+{
+    waitForContentsIfNeeded();
+
+    if (!tryEnsureBuffer())
+        return;
+
+    m_buffer->paintToCanvas(canvas, targetRect, paint);
+}
+#endif
+
 } // namespace WebCore
 
 #endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
@@ -43,6 +43,10 @@ public:
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
+#if USE(SKIA)
+    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+#endif
+
     bool tryEnsureBuffer();
 
     RefPtr<NativeImage> m_image;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
@@ -28,7 +28,19 @@
 
 #if USE(COORDINATED_GRAPHICS)
 #include "BitmapTexture.h"
+#include "ColorMatrix.h"
+#include "PlatformDisplay.h"
 #include "TextureMapper.h"
+
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorFilter.h>
+#include <skia/core/SkImage.h>
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
 
 namespace WebCore {
 
@@ -65,6 +77,40 @@ void CoordinatedPlatformLayerBufferRGB::paintToTextureMapper(TextureMapper& text
     else
         textureMapper.drawTexture(m_textureID, m_flags, targetRect, modelViewMatrix, opacity);
 }
+
+#if USE(SKIA)
+void CoordinatedPlatformLayerBufferRGB::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+{
+    waitForContentsIfNeeded();
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    GrGLTextureInfo externalTexture;
+    externalTexture.fTarget = GL_TEXTURE_2D;
+    externalTexture.fID = m_texture ? m_texture->id() : m_textureID;
+    externalTexture.fFormat = GL_RGBA8;
+    auto backendTexture = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+    sk_sp<SkImage> image = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+
+    auto imagePaint = paint;
+    if (m_texture && m_texture->colorConvertFlags().contains(TextureMapperFlags::ShouldConvertTextureBGRAToRGBA)) {
+        const auto matrix = swapRedBlueMatrix();
+        auto bgraFilter = SkColorFilters::Matrix(matrix.data().data());
+        if (auto* colorFilter = paint.getColorFilter())
+            imagePaint.setColorFilter(colorFilter->makeComposed(bgraFilter));
+        else
+            imagePaint.setColorFilter(bgraFilter);
+    }
+    bool shouldFlip = m_flags.contains(TextureMapperFlags::ShouldFlipTexture);
+    SkAutoCanvasRestore autoRestore(&canvas, shouldFlip);
+    if (shouldFlip) {
+        canvas.translate(0, targetRect.height());
+        canvas.scale(1, -1);
+    }
+    SkRect srcRect = SkRect::MakeWH(m_size.width(), m_size.height());
+    SkRect dstRect = SkRect::MakeXYWH(targetRect.x(), shouldFlip ? -targetRect.y() : targetRect.y(), targetRect.width(), targetRect.height());
+    canvas.drawImageRect(image, srcRect, dstRect, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &imagePaint, SkCanvas::kFast_SrcRectConstraint);
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h
@@ -45,6 +45,10 @@ public:
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
+#if USE(SKIA)
+    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+#endif
+
     RefPtr<BitmapTexture> m_texture;
     unsigned m_textureID { 0 };
 };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
@@ -144,6 +144,37 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
 #endif // USE(GBM) && GST_CHECK_VERSION(1, 24, 0)
 
 #if USE(GSTREAMER_GL)
+static std::optional<CoordinatedPlatformLayerBufferYUV::Format> yuvFormatFromGstVideoFormat(GstVideoFormat format)
+{
+    switch (format) {
+    case GST_VIDEO_FORMAT_BGRx:
+    case GST_VIDEO_FORMAT_RGBx:
+    case GST_VIDEO_FORMAT_BGRA:
+    case GST_VIDEO_FORMAT_RGBA:
+        return CoordinatedPlatformLayerBufferYUV::Format::AYUV;
+    case GST_VIDEO_FORMAT_I420:
+        return CoordinatedPlatformLayerBufferYUV::Format::YUV420;
+    case GST_VIDEO_FORMAT_YV12:
+        return CoordinatedPlatformLayerBufferYUV::Format::YVU420;
+    case GST_VIDEO_FORMAT_NV12:
+        return CoordinatedPlatformLayerBufferYUV::Format::NV12;
+    case GST_VIDEO_FORMAT_NV21:
+        return CoordinatedPlatformLayerBufferYUV::Format::NV21;
+    case GST_VIDEO_FORMAT_Y444:
+        return CoordinatedPlatformLayerBufferYUV::Format::YUV444;
+    case GST_VIDEO_FORMAT_Y41B:
+        return CoordinatedPlatformLayerBufferYUV::Format::YUV411;
+    case GST_VIDEO_FORMAT_Y42B:
+        return CoordinatedPlatformLayerBufferYUV::Format::YUV422;
+    case GST_VIDEO_FORMAT_P010_10LE:
+        return CoordinatedPlatformLayerBufferYUV::Format::P010;
+    default:
+        break;
+    }
+
+    return std::nullopt;
+}
+
 std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferFromGLMemory()
 {
     const auto& sample = m_videoFrame->sample();
@@ -173,6 +204,10 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
             return CoordinatedPlatformLayerBufferRGB::create(m_mappedVideoFrame->textureID(0), m_size, m_flags, nullptr);
         }
 
+        auto format = yuvFormatFromGstVideoFormat(GST_VIDEO_INFO_FORMAT(m_mappedVideoFrame->info()));
+        if (!format)
+            return nullptr;
+
         unsigned numberOfPlanes = GST_VIDEO_INFO_N_PLANES(m_mappedVideoFrame->info());
         std::array<GLuint, 4> planes;
         std::array<unsigned, 4> yuvPlane;
@@ -197,54 +232,70 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
         } else if (gst_video_colorimetry_matches(&GST_VIDEO_INFO_COLORIMETRY(m_mappedVideoFrame->info()), GST_VIDEO_COLORIMETRY_SMPTE240M))
             yuvToRgbColorSpace = CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace::Smpte240M;
 
-        return CoordinatedPlatformLayerBufferYUV::create(numberOfPlanes, WTF::move(planes), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), yuvToRgbColorSpace, transferFunction, m_size, m_flags, nullptr);
+        return CoordinatedPlatformLayerBufferYUV::create(*format, numberOfPlanes, WTF::move(planes), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), yuvToRgbColorSpace, transferFunction, m_size, m_flags, nullptr);
     }
 
     return nullptr;
 }
 #endif
 
-void CoordinatedPlatformLayerBufferVideo::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity)
+void CoordinatedPlatformLayerBufferVideo::createBufferFromMappedFrameIfNeeded()
 {
-    if (m_mappedVideoFrame) {
-        RELEASE_ASSERT(*m_mappedVideoFrame);
+    if (!m_mappedVideoFrame)
+        return;
+
+    RELEASE_ASSERT(*m_mappedVideoFrame);
 #if USE(GSTREAMER_GL)
-        if (m_videoDecoderPlatform != GstVideoDecoderPlatform::OpenMAX) {
-            if (auto* meta = gst_buffer_get_gl_sync_meta(m_mappedVideoFrame->get()->buffer)) {
-                GstMemory* memory = gst_buffer_peek_memory(m_mappedVideoFrame->get()->buffer, 0);
-                GstGLContext* context = reinterpret_cast<GstGLBaseMemory*>(memory)->context;
-                gst_gl_sync_meta_wait_cpu(meta, context);
-            }
-        }
-#endif
-
-        if (!m_buffer) {
-            OptionSet<BitmapTexture::Flags> textureFlags;
-            if (GST_VIDEO_INFO_HAS_ALPHA(m_mappedVideoFrame->info()))
-                textureFlags.add(BitmapTexture::Flags::SupportsAlpha);
-            auto texture = BitmapTexturePool::singleton().acquireTexture(m_size, textureFlags);
-
-            auto* meta = gst_buffer_get_video_gl_texture_upload_meta(m_mappedVideoFrame->get()->buffer);
-            if (meta && meta->n_textures == 1) {
-                guint ids[4] = { texture->id(), 0, 0, 0 };
-                if (gst_video_gl_texture_upload_meta_upload(meta, ids))
-                    m_buffer = CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), m_flags, nullptr);
-            }
-
-            if (!m_buffer) {
-                int stride = m_mappedVideoFrame->planeStride(0);
-                auto srcData = m_mappedVideoFrame->planeData(0);
-                IntPoint origin { 0, 0 };
-                texture->updateContents(srcData.data(), IntRect(origin, m_size), origin, stride, PixelFormat::BGRA8);
-                m_buffer = CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), m_flags, nullptr);
-                m_mappedVideoFrame = std::nullopt;
-            }
+    if (m_videoDecoderPlatform != GstVideoDecoderPlatform::OpenMAX) {
+        if (auto* meta = gst_buffer_get_gl_sync_meta(m_mappedVideoFrame->get()->buffer)) {
+            GstMemory* memory = gst_buffer_peek_memory(m_mappedVideoFrame->get()->buffer, 0);
+            GstGLContext* context = reinterpret_cast<GstGLBaseMemory*>(memory)->context;
+            gst_gl_sync_meta_wait_cpu(meta, context);
         }
     }
+#endif
+
+    if (!m_buffer) {
+        OptionSet<BitmapTexture::Flags> textureFlags;
+        if (GST_VIDEO_INFO_HAS_ALPHA(m_mappedVideoFrame->info()))
+            textureFlags.add(BitmapTexture::Flags::SupportsAlpha);
+        auto texture = BitmapTexturePool::singleton().acquireTexture(m_size, textureFlags);
+
+        auto* meta = gst_buffer_get_video_gl_texture_upload_meta(m_mappedVideoFrame->get()->buffer);
+        if (meta && meta->n_textures == 1) {
+            guint ids[4] = { texture->id(), 0, 0, 0 };
+            if (gst_video_gl_texture_upload_meta_upload(meta, ids))
+                m_buffer = CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), m_flags, nullptr);
+        }
+
+        if (!m_buffer) {
+            int stride = m_mappedVideoFrame->planeStride(0);
+            auto srcData = m_mappedVideoFrame->planeData(0);
+            IntPoint origin { 0, 0 };
+            texture->updateContents(srcData.data(), IntRect(origin, m_size), origin, stride, PixelFormat::BGRA8);
+            m_buffer = CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), m_flags, nullptr);
+            m_mappedVideoFrame = std::nullopt;
+        }
+    }
+}
+
+void CoordinatedPlatformLayerBufferVideo::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity)
+{
+    createBufferFromMappedFrameIfNeeded();
 
     if (m_buffer)
         m_buffer->paintToTextureMapper(textureMapper, targetRect, modelViewMatrix, opacity);
 }
+
+#if USE(SKIA)
+void CoordinatedPlatformLayerBufferVideo::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+{
+    createBufferFromMappedFrameIfNeeded();
+
+    if (m_buffer)
+        m_buffer->paintToCanvas(canvas, targetRect, paint);
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
@@ -45,6 +45,10 @@ public:
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
+#if USE(SKIA)
+    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+#endif
+
     std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferIfNeeded(bool gstGLEnabled);
 #if USE(GBM) && GST_CHECK_VERSION(1, 24, 0)
     std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferFromDMABufMemory();
@@ -52,6 +56,7 @@ private:
 #if USE(GSTREAMER_GL)
     std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferFromGLMemory();
 #endif
+    void createBufferFromMappedFrameIfNeeded();
 
     Ref<VideoFrameGStreamer> m_videoFrame;
     std::optional<GstMappedFrame> m_mappedVideoFrame;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
@@ -28,22 +28,35 @@
 
 #if USE(COORDINATED_GRAPHICS)
 #include "BitmapTexturePool.h"
+#include "PlatformDisplay.h"
 #include "TextureMapper.h"
+
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkImage.h>
+#include <skia/core/SkYUVAInfo.h>
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/GrYUVABackendTextures.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
 
 namespace WebCore {
 
-std::unique_ptr<CoordinatedPlatformLayerBufferYUV> CoordinatedPlatformLayerBufferYUV::create(unsigned planeCount, std::array<unsigned, 4>&& planes, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace yuvToRgbColorSpace, TransferFunction transferFunction, const IntSize& size, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence)
+std::unique_ptr<CoordinatedPlatformLayerBufferYUV> CoordinatedPlatformLayerBufferYUV::create(Format format, unsigned planeCount, std::array<unsigned, 4>&& planes, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace yuvToRgbColorSpace, TransferFunction transferFunction, const IntSize& size, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence)
 {
-    return makeUnique<CoordinatedPlatformLayerBufferYUV>(planeCount, WTF::move(planes), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), yuvToRgbColorSpace, transferFunction, size, flags, WTF::move(fence));
+    return makeUnique<CoordinatedPlatformLayerBufferYUV>(format, planeCount, WTF::move(planes), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), yuvToRgbColorSpace, transferFunction, size, flags, WTF::move(fence));
 }
 
-std::unique_ptr<CoordinatedPlatformLayerBufferYUV> CoordinatedPlatformLayerBufferYUV::create(unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace yuvToRgbColorSpace, TransferFunction transferFunction, const IntSize& size, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence)
+std::unique_ptr<CoordinatedPlatformLayerBufferYUV> CoordinatedPlatformLayerBufferYUV::create(Format format, unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace yuvToRgbColorSpace, TransferFunction transferFunction, const IntSize& size, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence)
 {
-    return makeUnique<CoordinatedPlatformLayerBufferYUV>(planeCount, WTF::move(textures), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), yuvToRgbColorSpace, transferFunction, size, flags, WTF::move(fence));
+    return makeUnique<CoordinatedPlatformLayerBufferYUV>(format, planeCount, WTF::move(textures), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), yuvToRgbColorSpace, transferFunction, size, flags, WTF::move(fence));
 }
 
-CoordinatedPlatformLayerBufferYUV::CoordinatedPlatformLayerBufferYUV(unsigned planeCount, std::array<unsigned, 4>&& planes, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace yuvToRgbColorSpace, TransferFunction transferFunction, const IntSize& size, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence)
+CoordinatedPlatformLayerBufferYUV::CoordinatedPlatformLayerBufferYUV(Format format, unsigned planeCount, std::array<unsigned, 4>&& planes, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace yuvToRgbColorSpace, TransferFunction transferFunction, const IntSize& size, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence)
     : CoordinatedPlatformLayerBuffer(Type::YUV, size, flags, WTF::move(fence))
+    , m_format(format)
     , m_planeCount(planeCount)
     , m_planes(WTF::move(planes))
     , m_yuvPlane(WTF::move(yuvPlane))
@@ -53,8 +66,9 @@ CoordinatedPlatformLayerBufferYUV::CoordinatedPlatformLayerBufferYUV(unsigned pl
 {
 }
 
-CoordinatedPlatformLayerBufferYUV::CoordinatedPlatformLayerBufferYUV(unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace yuvToRgbColorSpace, TransferFunction transferFunction, const IntSize& size, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence)
+CoordinatedPlatformLayerBufferYUV::CoordinatedPlatformLayerBufferYUV(Format format, unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace yuvToRgbColorSpace, TransferFunction transferFunction, const IntSize& size, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& fence)
     : CoordinatedPlatformLayerBuffer(Type::YUV, size, flags, WTF::move(fence))
+    , m_format(format)
     , m_planeCount(planeCount)
     , m_textures(WTF::move(textures))
     , m_yuvPlane(WTF::move(yuvPlane))
@@ -123,6 +137,7 @@ void CoordinatedPlatformLayerBufferYUV::paintToTextureMapper(TextureMapper& text
 
     switch (m_planeCount) {
     case 1:
+        RELEASE_ASSERT(m_format == Format::AYUV);
         ASSERT(m_yuvPlane[0] == m_yuvPlane[1] && m_yuvPlane[1] == m_yuvPlane[2]);
         ASSERT(m_yuvPlaneOffset[0] == 2 && m_yuvPlaneOffset[1] == 1 && !m_yuvPlaneOffset[2]);
         textureMapper.drawTexturePackedYUV(m_planes[m_yuvPlane[0]], yuvToRgbMatrix, m_flags, targetRect, modelViewMatrix, opacity, textureMapperTransferFunction);
@@ -144,6 +159,124 @@ void CoordinatedPlatformLayerBufferYUV::paintToTextureMapper(TextureMapper& text
         break;
     }
 }
+
+#if USE(SKIA)
+void CoordinatedPlatformLayerBufferYUV::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+{
+    waitForContentsIfNeeded();
+
+    auto planeConfig = SkYUVAInfo::PlaneConfig::kUnknown;
+    auto subsampling = SkYUVAInfo::Subsampling::kUnknown;
+    GrGLTextureInfo externalTexture = { GL_TEXTURE_2D, 0, 0, skgpu::Protected::kNo };
+    std::array<GrBackendTexture, 4> backendTextures;
+
+    switch (m_planeCount) {
+    case 1:
+        RELEASE_ASSERT(m_format == Format::AYUV);
+        planeConfig = SkYUVAInfo::PlaneConfig::kYUVA;
+        subsampling = SkYUVAInfo::Subsampling::k444;
+
+        externalTexture.fID = m_planes[m_yuvPlane[0]];
+        externalTexture.fFormat = GL_RGBA8;
+        backendTextures[0] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+        break;
+    case 2:
+        RELEASE_ASSERT(m_format == Format::NV12 || m_format == Format::NV21 || m_format == Format::P010);
+        planeConfig = m_format == Format::NV21 ? SkYUVAInfo::PlaneConfig::kY_VU : SkYUVAInfo::PlaneConfig::kY_UV;
+        subsampling = SkYUVAInfo::Subsampling::k420;
+
+        externalTexture.fID = m_planes[m_yuvPlane[0]];
+        externalTexture.fFormat = m_format == Format::P010 ? GL_R16 : GL_R8;
+        backendTextures[0] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+
+        externalTexture.fID = m_planes[m_yuvPlane[1]];
+        externalTexture.fFormat = m_format == Format::P010 ? GL_RG16 : GL_RG8;
+        backendTextures[1] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height() / 2, skgpu::Mipmapped::kNo, externalTexture);
+        break;
+    case 3:
+        planeConfig = m_format == Format::YVU420 ? SkYUVAInfo::PlaneConfig::kY_V_U : SkYUVAInfo::PlaneConfig::kY_U_V;
+
+        externalTexture.fID = m_planes[m_yuvPlane[0]];
+        externalTexture.fFormat = GL_R8;
+        backendTextures[0] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+
+        switch (m_format) {
+        case Format::YUV420:
+        case Format::YVU420:
+            subsampling = SkYUVAInfo::Subsampling::k420;
+
+            externalTexture.fID = m_planes[m_yuvPlane[1]];
+            backendTextures[1] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height() / 2, skgpu::Mipmapped::kNo, externalTexture);
+            externalTexture.fID = m_planes[m_yuvPlane[2]];
+            backendTextures[2] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height() / 2, skgpu::Mipmapped::kNo, externalTexture);
+            break;
+        case Format::YUV444:
+            subsampling = SkYUVAInfo::Subsampling::k444;
+
+            externalTexture.fID = m_planes[m_yuvPlane[1]];
+            backendTextures[1] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+            externalTexture.fID = m_planes[m_yuvPlane[2]];
+            backendTextures[2] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+            break;
+        case Format::YUV411:
+            subsampling = SkYUVAInfo::Subsampling::k411;
+
+            externalTexture.fID = m_planes[m_yuvPlane[1]];
+            backendTextures[1] = GrBackendTextures::MakeGL(m_size.width() / 4, m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+            externalTexture.fID = m_planes[m_yuvPlane[2]];
+            backendTextures[2] = GrBackendTextures::MakeGL(m_size.width() / 4, m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+            break;
+        case Format::YUV422:
+            subsampling = SkYUVAInfo::Subsampling::k422;
+
+            externalTexture.fID = m_planes[m_yuvPlane[1]];
+            backendTextures[1] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+            externalTexture.fID = m_planes[m_yuvPlane[2]];
+            backendTextures[2] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        break;
+    }
+
+    if (planeConfig == SkYUVAInfo::PlaneConfig::kUnknown)
+        return;
+
+    SkYUVColorSpace yuvaColorSpace = [&] {
+        switch (m_yuvToRgbColorSpace) {
+        case YuvToRgbColorSpace::Bt601:
+            return kRec601_Limited_SkYUVColorSpace;
+        case YuvToRgbColorSpace::Bt709:
+            return kRec709_Full_SkYUVColorSpace;
+        case YuvToRgbColorSpace::Bt2020:
+            return kBT2020_8bit_Full_SkYUVColorSpace;
+        case YuvToRgbColorSpace::Smpte240M:
+            return kSMPTE240_Full_SkYUVColorSpace;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }();
+
+    SkYUVAInfo info(SkISize::Make(m_size.width(), m_size.height()), planeConfig, subsampling, yuvaColorSpace);
+    GrYUVABackendTextures yuvaBackendTextures(info, backendTextures.data(), kTopLeft_GrSurfaceOrigin);
+    if (!yuvaBackendTextures.isValid())
+        return;
+
+    sk_sp<SkColorSpace> colorSpace = [&] {
+        switch (m_transferFunction) {
+        case TransferFunction::Bt709:
+            return SkColorSpace::MakeRGB(SkNamedTransferFn::kRec709, SkNamedGamut::kSRGB);
+        case TransferFunction::Pq:
+            return SkColorSpace::MakeRGB(SkNamedTransferFn::kPQ, SkNamedGamut::kRec2020);
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }();
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    auto image = SkImages::TextureFromYUVATextures(grContext, yuvaBackendTextures, colorSpace);
+    canvas.drawImageRect(image, SkRect::MakeWH(m_size.width(), m_size.height()), targetRect, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h
@@ -34,17 +34,23 @@ class BitmapTexture;
 
 class CoordinatedPlatformLayerBufferYUV final : public CoordinatedPlatformLayerBuffer {
 public:
+    enum class Format : uint8_t { AYUV, NV12, NV21, P010, YUV420, YVU420, YUV444, YUV411, YUV422 };
     enum class YuvToRgbColorSpace : uint8_t { Bt601, Bt709, Bt2020, Smpte240M };
     enum class TransferFunction : uint8_t { Bt709, Pq };
-    static std::unique_ptr<CoordinatedPlatformLayerBufferYUV> create(unsigned planeCount, std::array<unsigned, 4>&& planes, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
-    static std::unique_ptr<CoordinatedPlatformLayerBufferYUV> create(unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
-    CoordinatedPlatformLayerBufferYUV(unsigned planeCount, std::array<unsigned, 4>&& planes, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
-    CoordinatedPlatformLayerBufferYUV(unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
+    static std::unique_ptr<CoordinatedPlatformLayerBufferYUV> create(Format, unsigned planeCount, std::array<unsigned, 4>&& planes, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
+    static std::unique_ptr<CoordinatedPlatformLayerBufferYUV> create(Format, unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
+    CoordinatedPlatformLayerBufferYUV(Format, unsigned planeCount, std::array<unsigned, 4>&& planes, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
+    CoordinatedPlatformLayerBufferYUV(Format, unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     virtual ~CoordinatedPlatformLayerBufferYUV();
 
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
+#if USE(SKIA)
+    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+#endif
+
+    Format m_format { Format::AYUV };
     unsigned m_planeCount { 0 };
     Vector<RefPtr<BitmapTexture>, 4> m_textures;
     std::array<unsigned, 4> m_planes;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -50,6 +50,22 @@ namespace WebCore {
 
 static constexpr uint32_t s_maxDamageRectanglesForHighResolutionDamage = 32;
 
+bool GraphicsLayer::supportsLayerType(Type type)
+{
+    switch (type) {
+    case Type::Normal:
+    case Type::Structural:
+    case Type::PageTiledBacking:
+    case Type::ScrollContainer:
+    case Type::ScrolledContents:
+    case Type::TiledBacking:
+        return true;
+    case Type::Shape:
+        return true;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 Ref<GraphicsLayer> GraphicsLayer::create(GraphicsLayerFactory* factory, GraphicsLayerClient& client, Type layerType)
 {
     if (factory)
@@ -491,6 +507,22 @@ void GraphicsLayerCoordinated::setEventRegion(EventRegion&& eventRegion)
     noteLayerPropertyChanged(Change::EventRegion, ScheduleFlush::Yes);
 }
 
+void GraphicsLayerCoordinated::setShapeLayerPath(const Path& path)
+{
+    // FIXME: need to check for path equality. No bool Path::operator==(const Path&)!.
+    GraphicsLayer::setShapeLayerPath(path);
+    noteLayerPropertyChanged(Change::Shape, ScheduleFlush::Yes);
+}
+
+void GraphicsLayerCoordinated::setShapeLayerWindRule(WindRule windRule)
+{
+    if (m_shapeLayerWindRule == windRule)
+        return;
+
+    GraphicsLayer::setShapeLayerWindRule(windRule);
+    noteLayerPropertyChanged(Change::Shape, ScheduleFlush::Yes);
+}
+
 void GraphicsLayerCoordinated::deviceOrPageScaleFactorChanged()
 {
     noteLayerPropertyChanged(Change::ContentsScale, ScheduleFlush::Yes);
@@ -587,6 +619,15 @@ void GraphicsLayerCoordinated::setBackdropFiltersRect(const FloatRoundedRect& ba
 
     GraphicsLayer::setBackdropFiltersRect(backdropFiltersRect);
     noteLayerPropertyChanged(Change::BackdropRect, ScheduleFlush::Yes);
+}
+
+void GraphicsLayerCoordinated::setIsBackdropRoot(bool isBackdropRoot)
+{
+    if (m_isBackdropRoot == isBackdropRoot)
+        return;
+
+    GraphicsLayer::setIsBackdropRoot(isBackdropRoot);
+    noteLayerPropertyChanged(Change::BackdropRoot, ScheduleFlush::Yes);
 }
 
 bool GraphicsLayerCoordinated::addAnimation(const GraphicsLayerKeyframeValueList& valueList, const GraphicsLayerAnimation* animation, const String& animationName, double timeOffset)
@@ -952,10 +993,11 @@ void GraphicsLayerCoordinated::updateBackdropFilters()
         m_backdropLayer->setFilters(m_backdropFilters);
     }
 
-    if (isNewLayer)
+    if (isNewLayer) {
         updateBackdropFiltersRect();
-
-    m_platformLayer->setBackdrop(m_backdropLayer.get());
+        m_platformLayer->setBackdrop(m_backdropLayer.get());
+    } else
+        m_platformLayer->notifyBackdropFiltersChanged();
 }
 
 void GraphicsLayerCoordinated::updateBackdropFiltersRect()
@@ -1099,11 +1141,17 @@ void GraphicsLayerCoordinated::commitLayerChanges(CommitState& commitState, floa
     if (m_pendingChanges.contains(Change::BackdropRect))
         updateBackdropFiltersRect();
 
+    if (m_pendingChanges.contains(Change::BackdropRoot))
+        m_platformLayer->setIsBackdropRoot(m_isBackdropRoot);
+
     if (m_pendingChanges.contains(Change::Animations))
         updateAnimations();
 
     if (m_pendingChanges.contains(Change::EventRegion))
         m_platformLayer->setEventRegion(m_eventRegion);
+
+    if (m_pendingChanges.contains(Change::Shape))
+        m_platformLayer->setClipPath(m_shapeLayerPath, m_shapeLayerWindRule);
 
     if (m_pendingChanges.contains(Change::DebugIndicators))
         updateIndicators();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -97,6 +97,9 @@ private:
 
     void setEventRegion(EventRegion&&) override;
 
+    void setShapeLayerPath(const Path&) override;
+    void setShapeLayerWindRule(WindRule) override;
+
     void deviceOrPageScaleFactorChanged() override;
 
     float rootRelativeScaleFactor() const { return m_rootRelativeScaleFactor; }
@@ -108,6 +111,7 @@ private:
     void setReplicatedByLayer(RefPtr<GraphicsLayer>&&) override;
     bool setBackdropFilters(const FilterOperations&) override;
     void setBackdropFiltersRect(const FloatRoundedRect&) override;
+    void setIsBackdropRoot(bool) override;
 
     bool addAnimation(const GraphicsLayerKeyframeValueList&, const GraphicsLayerAnimation*, const String&, double) override;
     void removeAnimation(const String&, std::optional<AnimatedProperty>) override;
@@ -129,39 +133,41 @@ private:
     void setShowRepaintCounter(bool) override;
     void dumpAdditionalProperties(TextStream&, OptionSet<LayerTreeAsTextOptions>) const override;
 
-    enum class Change : uint32_t {
-        Geometry                     = 1 << 0,
-        Transform                    = 1 << 1,
-        ChildrenTransform            = 1 << 2,
-        DrawsContent                 = 1 << 3,
-        MasksToBounds                = 1 << 4,
-        Preserves3D                  = 1 << 5,
-        BackfaceVisibility           = 1 << 6,
-        Opacity                      = 1 << 7,
-        Children                     = 1 << 8,
-        ContentsVisible              = 1 << 9,
-        ContentsOpaque               = 1 << 10,
-        ContentsRect                 = 1 << 11,
-        ContentsRectClipsDescendants = 1 << 12,
-        ContentsClippingRect         = 1 << 13,
-        ContentsScale                = 1 << 14,
-        ContentsTiling               = 1 << 15,
-        ContentsBuffer               = 1 << 16,
-        ContentsBufferNeedsDisplay   = 1 << 17,
-        ContentsImage                = 1 << 18,
-        ContentsColor                = 1 << 19,
-        DirtyRegion                  = 1 << 20,
-        EventRegion                  = 1 << 21,
-        Filters                      = 1 << 22,
-        Mask                         = 1 << 23,
-        Replica                      = 1 << 24,
-        Backdrop                     = 1 << 25,
-        BackdropRect                 = 1 << 26,
-        Animations                   = 1 << 27,
-        TileCoverage                 = 1 << 28,
-        DebugIndicators              = 1 << 29,
+    enum class Change : uint64_t {
+        Geometry                     = 1LLU << 0,
+        Transform                    = 1LLU << 1,
+        ChildrenTransform            = 1LLU << 2,
+        DrawsContent                 = 1LLU << 3,
+        MasksToBounds                = 1LLU << 4,
+        Preserves3D                  = 1LLU << 5,
+        BackfaceVisibility           = 1LLU << 6,
+        Opacity                      = 1LLU << 7,
+        Children                     = 1LLU << 8,
+        ContentsVisible              = 1LLU << 9,
+        ContentsOpaque               = 1LLU << 10,
+        ContentsRect                 = 1LLU << 11,
+        ContentsRectClipsDescendants = 1LLU << 12,
+        ContentsClippingRect         = 1LLU << 13,
+        ContentsScale                = 1LLU << 14,
+        ContentsTiling               = 1LLU << 15,
+        ContentsBuffer               = 1LLU << 16,
+        ContentsBufferNeedsDisplay   = 1LLU << 17,
+        ContentsImage                = 1LLU << 18,
+        ContentsColor                = 1LLU << 19,
+        DirtyRegion                  = 1LLU << 20,
+        EventRegion                  = 1LLU << 21,
+        Shape                        = 1LLU << 22,
+        Filters                      = 1LLU << 23,
+        Mask                         = 1LLU << 24,
+        Replica                      = 1LLU << 25,
+        Backdrop                     = 1LLU << 26,
+        BackdropRect                 = 1LLU << 27,
+        BackdropRoot                 = 1LLU << 28,
+        Animations                   = 1LLU << 29,
+        TileCoverage                 = 1LLU << 30,
+        DebugIndicators              = 1LLU << 31,
 #if ENABLE(SCROLLING_THREAD)
-        ScrollingNode                = 1 << 30
+        ScrollingNode                = 1LLU << 32
 #endif
     };
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2782,12 +2782,31 @@ bool RenderLayerBacking::updateMaskingLayer(bool hasMask, bool hasClipPath)
         OptionSet<GraphicsLayerPaintingPhase> maskPhases;
         if (hasMask)
             maskPhases = GraphicsLayerPaintingPhase::Mask;
-        
-        if (hasClipPath) {
+
+        auto shouldAddClipPathPaintingPhase = [&] {
+            if (!hasClipPath)
+                return false;
+
             // If we have a mask, we need to paint the combined clip-path and mask into the mask layer.
-            if (hasMask || WTF::holdsAlternative<Style::ReferencePath>(renderer().style().clipPath()) || !GraphicsLayer::supportsLayerType(GraphicsLayer::Type::Shape))
-                maskPhases.add(GraphicsLayerPaintingPhase::ClipPath);
-        }
+            if (hasMask)
+                return true;
+
+            if (WTF::holdsAlternative<Style::ReferencePath>(renderer().style().clipPath()))
+                return true;
+
+            if (!GraphicsLayer::supportsLayerType(GraphicsLayer::Type::Shape))
+                return true;
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+            Ref settings = renderer().settings();
+            if (!settings->useSkiaForComposition())
+                return true;
+#endif
+
+            return false;
+        };
+        if (shouldAddClipPathPaintingPhase())
+            maskPhases.add(GraphicsLayerPaintingPhase::ClipPath);
 
         bool paintsContent = !maskPhases.isEmpty();
         GraphicsLayer::Type requiredLayerType = paintsContent ? GraphicsLayer::Type::Normal : GraphicsLayer::Type::Shape;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -89,9 +89,9 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedSurface);
 
-Ref<AcceleratedSurface> AcceleratedSurface::create(WebPage& webPage, Function<void()>&& frameCompleteHandler, RenderingPurpose renderingPurpose)
+Ref<AcceleratedSurface> AcceleratedSurface::create(WebPage& webPage, Function<void()>&& frameCompleteHandler, RenderingPurpose renderingPurpose, bool useSkia)
 {
-    return adoptRef(*new AcceleratedSurface(webPage, WTF::move(frameCompleteHandler), renderingPurpose));
+    return adoptRef(*new AcceleratedSurface(webPage, WTF::move(frameCompleteHandler), renderingPurpose, useSkia));
 }
 
 static uint64_t generateID()
@@ -107,9 +107,10 @@ static bool useExplicitSync()
     return extensions.ANDROID_native_fence_sync && (display.eglCheckVersion(1, 5) || extensions.KHR_fence_sync);
 }
 
-AcceleratedSurface::AcceleratedSurface(WebPage& webPage, Function<void()>&& frameCompleteHandler, RenderingPurpose renderingPurpose)
+AcceleratedSurface::AcceleratedSurface(WebPage& webPage, Function<void()>&& frameCompleteHandler, RenderingPurpose renderingPurpose, bool useSkia)
     : m_webPage(webPage)
     , m_frameCompleteHandler(WTF::move(frameCompleteHandler))
+    , m_useSkia(useSkia)
     , m_id(generateID())
     , m_renderingPurpose(renderingPurpose)
     , m_hardwareAccelerationEnabled(webPage.corePage()->settings().hardwareAccelerationEnabled())
@@ -166,7 +167,7 @@ AcceleratedSurface::RenderTargetShareableBuffer::RenderTargetShareableBuffer(Acc
     : RenderTarget(surface)
     , m_initialSize(size)
 {
-    if (m_surface->renderingPurpose() == RenderingPurpose::NonComposited)
+    if (m_surface->useSkia())
         return;
 
     glGenFramebuffers(1, &m_fbo);
@@ -182,11 +183,13 @@ AcceleratedSurface::RenderTargetShareableBuffer::RenderTargetShareableBuffer(Acc
 
 AcceleratedSurface::RenderTargetShareableBuffer::~RenderTargetShareableBuffer()
 {
-    if (m_fbo)
-        glDeleteFramebuffers(1, &m_fbo);
+    if (!m_surface->useSkia()) {
+        if (m_fbo)
+            glDeleteFramebuffers(1, &m_fbo);
 
-    if (m_depthStencilBuffer)
-        glDeleteRenderbuffers(1, &m_depthStencilBuffer);
+        if (m_depthStencilBuffer)
+            glDeleteRenderbuffers(1, &m_depthStencilBuffer);
+    }
 
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidDestroyBuffer(m_id), m_surface->surfaceID());
 }
@@ -203,7 +206,7 @@ void AcceleratedSurface::RenderTargetShareableBuffer::willRenderFrame()
             fence->serverWait();
     }
 
-    if (!m_skiaSurface) {
+    if (!m_surface->useSkia()) {
         glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
         if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
             LOG_ERROR("AcceleratedSurface was unable to construct a complete framebuffer");
@@ -226,7 +229,7 @@ void AcceleratedSurface::RenderTargetShareableBuffer::sync(bool useExplicitSync)
         m_renderingFenceFD = fence->exportFD();
         if (!m_renderingFenceFD)
             fence->clientWait();
-    } else if (!m_skiaSurface)
+    } else if (!m_surface->useSkia())
         glFlush();
 }
 
@@ -293,7 +296,7 @@ AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage(AcceleratedSurfac
     : RenderTargetShareableBuffer(surface, size)
     , m_image(image)
 {
-    if (m_surface->renderingPurpose() == RenderingPurpose::NonComposited) {
+    if (m_surface->useSkia()) {
         m_texture = BitmapTexture::create(m_image, size);
         createSkiaSurfaceForTexture(*m_texture);
     } else
@@ -366,7 +369,11 @@ AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage(AcceleratedSurfac
     : RenderTargetShareableBuffer(surface, size)
     , m_image(image)
 {
-    initializeColorBuffer();
+    if (m_surface->useSkia()) {
+        m_texture = BitmapTexture::create(m_image, size);
+        createSkiaSurfaceForTexture(*m_texture);
+    } else
+        initializeColorBuffer();
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStore::DidCreateAndroidBuffer(m_id, WTF::move(hardwareBuffer)), m_surface->surfaceID());
 }
 #endif // OS(ANDROID)
@@ -374,6 +381,7 @@ AcceleratedSurface::RenderTargetEGLImage::RenderTargetEGLImage(AcceleratedSurfac
 #if USE(GBM) || OS(ANDROID)
 void AcceleratedSurface::RenderTargetEGLImage::initializeColorBuffer()
 {
+    ASSERT(!m_surface->useSkia());
     glGenRenderbuffers(1, &m_colorBuffer);
     glBindRenderbuffer(GL_RENDERBUFFER, m_colorBuffer);
     glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, m_image);
@@ -382,8 +390,10 @@ void AcceleratedSurface::RenderTargetEGLImage::initializeColorBuffer()
 
 AcceleratedSurface::RenderTargetEGLImage::~RenderTargetEGLImage()
 {
-    if (m_colorBuffer)
-        glDeleteRenderbuffers(1, &m_colorBuffer);
+    if (!m_surface->useSkia()) {
+        if (m_colorBuffer)
+            glDeleteRenderbuffers(1, &m_colorBuffer);
+    }
 
     if (m_image)
         PlatformDisplay::sharedDisplay().destroyEGLImage(m_image);
@@ -411,9 +421,13 @@ AcceleratedSurface::RenderTargetSHMImage::RenderTargetSHMImage(AcceleratedSurfac
     : RenderTargetShareableBuffer(surface, size)
     , m_bitmap(WTF::move(bitmap))
 {
-    if (m_surface->renderingPurpose() == RenderingPurpose::NonComposited)
-        m_skiaSurface = m_bitmap->createSurface();
-    else {
+    if (m_surface->useSkia()) {
+        if (m_surface->usesGL()) {
+            m_texture = BitmapTexture::create(size);
+            createSkiaSurfaceForTexture(*m_texture);
+        } else
+            m_skiaSurface = m_bitmap->createSurface();
+    } else {
         glGenRenderbuffers(1, &m_colorBuffer);
         glBindRenderbuffer(GL_RENDERBUFFER, m_colorBuffer);
         glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, size.width(), size.height());
@@ -425,15 +439,25 @@ AcceleratedSurface::RenderTargetSHMImage::RenderTargetSHMImage(AcceleratedSurfac
 
 AcceleratedSurface::RenderTargetSHMImage::~RenderTargetSHMImage()
 {
-    if (m_colorBuffer)
-        glDeleteRenderbuffers(1, &m_colorBuffer);
+    if (!m_surface->useSkia()) {
+        if (m_colorBuffer)
+            glDeleteRenderbuffers(1, &m_colorBuffer);
+    }
 }
 
 void AcceleratedSurface::RenderTargetSHMImage::didRenderFrame()
 {
-    if (m_skiaSurface) {
+    if (m_surface->useSkia()) {
+        if (!m_skiaSurface)
+            return;
+
         SkImageInfo info = SkImageInfo::Make(m_bitmap->size().width(), m_bitmap->size().height(), SkColorType::kBGRA_8888_SkColorType, SkAlphaType::kPremul_SkAlphaType);
-        m_skiaSurface->readPixels(info, m_bitmap->mutableSpan().data(), m_bitmap->bytesPerRow(), 0, 0);
+
+        if (m_surface->usesGL()) {
+            GLContext::ScopedGLContextCurrent scopedCurrent(*PlatformDisplay::sharedDisplay().skiaGLContext());
+            m_skiaSurface->readPixels(info, m_bitmap->mutableSpan().data(), m_bitmap->bytesPerRow(), 0, 0);
+        } else
+            m_skiaSurface->readPixels(info, m_bitmap->mutableSpan().data(), m_bitmap->bytesPerRow(), 0, 0);
         return;
     }
 
@@ -487,7 +511,7 @@ AcceleratedSurface::RenderTargetTexture::RenderTargetTexture(AcceleratedSurface&
     : RenderTargetShareableBuffer(surface, size)
     , m_texture(WTF::move(texture))
 {
-    if (m_surface->renderingPurpose() == RenderingPurpose::NonComposited)
+    if (m_surface->useSkia())
         createSkiaSurfaceForTexture(m_texture.get());
     else
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture->id(), 0);
@@ -957,8 +981,12 @@ bool AcceleratedSurface::isOpaque() const
 
 SkCanvas* AcceleratedSurface::canvas()
 {
+    if (!m_useSkia)
+        return nullptr;
+
     if (auto* surface = m_target ? m_target->skiaSurface() : nullptr)
         return surface->getCanvas();
+
     return nullptr;
 }
 
@@ -977,7 +1005,7 @@ void AcceleratedSurface::willRenderFrame(const IntSize& size)
     if (m_target)
         m_target->willRenderFrame();
 
-    if (sizeDidChange && !m_target->skiaSurface())
+    if (sizeDidChange && !m_useSkia)
         glViewport(0, 0, size.width(), size.height());
 }
 
@@ -989,11 +1017,13 @@ void AcceleratedSurface::clear(const OptionSet<WebCore::CompositionReason>& reas
         backgroundColor = m_backgroundColor;
     }
 
-    if (auto* canvas = this->canvas()) {
-        if (backgroundColor && !backgroundColor->isOpaque())
-            canvas->clear(SK_ColorTRANSPARENT);
-        else if (reasons.contains(CompositionReason::AsyncScrolling))
-            canvas->clear(backgroundColor ? SkColor(*backgroundColor) : SK_ColorWHITE);
+    if (m_useSkia) {
+        if (auto* canvas = this->canvas()) {
+            if (backgroundColor && !backgroundColor->isOpaque())
+                canvas->clear(SK_ColorTRANSPARENT);
+            else if (reasons.contains(CompositionReason::AsyncScrolling))
+                canvas->clear(backgroundColor ? SkColor(*backgroundColor) : SK_ColorWHITE);
+        }
         return;
     }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -98,10 +98,8 @@ public:
         NonComposited,
     };
 
-    static Ref<AcceleratedSurface> create(WebPage&, Function<void()>&& frameCompleteHandler, RenderingPurpose = RenderingPurpose::Composited);
+    static Ref<AcceleratedSurface> create(WebPage&, Function<void()>&& frameCompleteHandler, RenderingPurpose, bool useSkia);
     ~AcceleratedSurface();
-
-    using ColorComponents = WebCore::ColorComponents<float, 4>;
 
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
@@ -148,10 +146,11 @@ public:
     void backgroundColorDidChange();
 
 private:
-    AcceleratedSurface(WebPage&, Function<void()>&& frameCompleteHandler, RenderingPurpose);
+    AcceleratedSurface(WebPage&, Function<void()>&& frameCompleteHandler, RenderingPurpose, bool useSkia);
 
     RenderingPurpose renderingPurpose() const { return m_renderingPurpose; }
     bool hardwareAccelerationEnabled() const { return m_hardwareAccelerationEnabled; }
+    bool useSkia() const { return m_useSkia; }
     bool isOpaque() const;
 
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
@@ -297,6 +296,7 @@ private:
 
         unsigned m_colorBuffer { 0 };
         const Ref<WebCore::ShareableBitmap> m_bitmap;
+        RefPtr<WebCore::BitmapTexture> m_texture;
     };
 
     class RenderTargetTexture final : public RenderTargetShareableBuffer {
@@ -396,6 +396,7 @@ private:
 
     const WeakRef<WebPage> m_webPage;
     Function<void()> m_frameCompleteHandler;
+    bool m_useSkia { false };
     uint64_t m_id { 0 };
     RenderingPurpose m_renderingPurpose { RenderingPurpose::Composited };
     bool m_hardwareAccelerationEnabled { true };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
@@ -138,6 +138,12 @@ void DrawingAreaCoordinatedGraphics::updatePreferences(const WebPreferencesStore
         settings.setAsyncFrameScrollingEnabled(false);
         settings.setAsyncOverflowScrollingEnabled(false);
     }
+
+    if (!settings.useSkiaForComposition()) {
+        static auto useSkiaForComposition = String::fromLatin1(getenv("WEBKIT_USE_SKIA_FOR_COMPOSITION"));
+        if (!useSkiaForComposition.isEmpty() && useSkiaForComposition != "0"_s)
+            settings.setUseSkiaForComposition(true);
+    }
 }
 
 bool DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingModeIfNeeded()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
@@ -56,7 +56,7 @@ NonCompositedFrameRenderer::NonCompositedFrameRenderer(WebPage& webPage)
     : m_webPage(webPage)
     , m_surface(AcceleratedSurface::create(m_webPage, [this] {
         frameComplete();
-    }, AcceleratedSurface::RenderingPurpose::NonComposited))
+    }, AcceleratedSurface::RenderingPurpose::NonComposited, true))
 {
 #if ENABLE(DAMAGE_TRACKING)
     resetFrameDamage();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -35,7 +35,10 @@
 #include "WebProcess.h"
 #include <WebCore/CoordinatedPlatformLayer.h>
 #include <WebCore/Damage.h>
+#include <WebCore/Page.h>
 #include <WebCore/PlatformDisplay.h>
+#include <WebCore/Settings.h>
+#include <WebCore/SkiaCompositingLayer.h>
 #include <WebCore/TextureMapperLayer.h>
 #include <WebCore/TransformationMatrix.h>
 #include <wtf/SetForScope.h>
@@ -66,7 +69,8 @@ Ref<ThreadedCompositor> ThreadedCompositor::create(WebPage& webPage, LayerTreeHo
 ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTreeHost, CoordinatedSceneState& sceneState)
     : m_workQueue(WorkQueue::create("org.webkit.ThreadedCompositor"_s))
     , m_layerTreeHost(&layerTreeHost)
-    , m_surface(AcceleratedSurface::create(webPage, [this] { frameComplete(); }))
+    , m_useSkia(webPage.corePage()->settings().useSkiaForComposition())
+    , m_surface(AcceleratedSurface::create(webPage, [this] { frameComplete(); }, AcceleratedSurface::RenderingPurpose::Composited, m_useSkia))
     , m_sceneState(&sceneState)
     , m_flipY(m_surface->shouldPaintMirrored())
     , m_renderTimer(m_workQueue->runLoop(), "ThreadedCompositor::RenderTimer"_s, this, &ThreadedCompositor::renderLayerTree)
@@ -93,13 +97,25 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
         // a plain C cast expression in this one instance works in all cases.
         static_assert(sizeof(GLNativeWindowType) <= sizeof(uint64_t), "GLNativeWindowType must not be longer than 64 bits.");
         auto nativeSurfaceHandle = (GLNativeWindowType)m_surface->window();
+        if (m_useSkia && !nativeSurfaceHandle) {
+            // When using Skia for composition, use the thread-local SkiaGLContext from sharedDisplay()
+            // instead of creating a separate GLContext. This avoids expensive context switching between
+            // the compositor's context and Skia's context during paintToSkiaCanvas().
+            if (auto* context = PlatformDisplay::sharedDisplay().skiaGLContext()) {
+                context->makeContextCurrent();
+                glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
+            }
+            return;
+        }
+
         m_context = GLContext::create(PlatformDisplay::sharedDisplay(), nativeSurfaceHandle);
         if (m_context && m_context->makeContextCurrent()) {
             if (!nativeSurfaceHandle)
                 m_flipY = !m_flipY;
             glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
 
-            m_textureMapper = TextureMapper::create();
+            if (!m_useSkia)
+                m_textureMapper = TextureMapper::create();
         }
     });
 }
@@ -125,7 +141,7 @@ void ThreadedCompositor::invalidate()
 
     m_didCompositeRunLoopObserver->invalidate();
     m_workQueue->dispatchSync([this] {
-        if (!m_context || !m_context->makeContextCurrent())
+        if (m_textureMapper && (!m_context || !m_context->makeContextCurrent()))
             return;
 
         // Update the scene at this point ensures the layers state are correctly propagated.
@@ -257,12 +273,21 @@ void ThreadedCompositor::flushCompositingState(const OptionSet<CompositionReason
         ASSERT(!reasons.contains(CompositionReason::RenderingUpdate) || !m_state.isWaitingForTiles);
     }
 #endif
-    m_sceneState->rootLayer().flushCompositingState(reasons);
+
+    m_sceneState->rootLayer().flushCompositingState(reasons, m_useSkia);
     for (auto& layer : m_sceneState->committedLayers())
-        layer->flushCompositingState(reasons);
+        layer->flushCompositingState(reasons, m_useSkia);
 }
 
 void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
+{
+    if (m_textureMapper)
+        paintToTextureMapper(matrix, size, reasons);
+    else
+        paintToSkiaCanvas(matrix, size, reasons);
+}
+
+void ThreadedCompositor::paintToTextureMapper(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
 {
     FloatRect clipRect(FloatPoint { }, size);
     TextureMapperLayer& currentRootLayer = m_sceneState->rootLayer().ensureTarget();
@@ -330,6 +355,53 @@ void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& mat
         requestComposition(CompositionReason::Animation);
 }
 
+void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
+{
+    auto* canvas = m_surface->canvas();
+    if (!canvas)
+        return;
+
+    auto& rootLayer = m_sceneState->rootLayer().ensureSkiaTarget();
+    rootLayer.setTransform(matrix);
+
+    // We only need context switching here for the old API (indicated by m_context != nullptr).
+    auto& display = PlatformDisplay::sharedDisplay();
+    if (m_context)
+        display.skiaGLContext()->makeContextCurrent();
+
+    m_surface->clear(reasons);
+
+    canvas->save();
+
+    std::optional<Damage> frameDamage;
+#if ENABLE(DAMAGE_TRACKING)
+    if (m_damage.flags)
+        frameDamage = Damage(size, m_damage.flags->contains(DamagePropagationFlags::Unified) ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles);
+#endif
+
+    bool sceneHasRunningAnimations = rootLayer.paint(*canvas, frameDamage);
+    canvas->restore();
+
+#if ENABLE(DAMAGE_TRACKING)
+    if (frameDamage) {
+        if (m_damage.shouldNotifyFrameDamageForTesting && m_layerTreeHost)
+            m_layerTreeHost->notifyFrameDamageForTesting(frameDamage->regionForTesting());
+
+        if (!frameDamage->isEmpty())
+            m_surface->setFrameDamage(WTF::move(*frameDamage));
+    }
+#endif
+
+    if (auto* surface = canvas->getSurface())
+        display.skiaGrContext()->flushAndSubmit(surface, GrSyncCpu::kNo);
+
+    if (m_context)
+        m_context->makeContextCurrent();
+
+    if (sceneHasRunningAnimations)
+        requestComposition(CompositionReason::Animation);
+}
+
 #if HAVE(OS_SIGNPOST) || USE(SYSPROF_CAPTURE)
 static String reasonsToString(const OptionSet<CompositionReason>& reasons)
 {
@@ -377,7 +449,7 @@ void ThreadedCompositor::renderLayerTree()
         m_state.state = State::InProgress;
     }
 
-    if (!m_context || !m_context->makeContextCurrent())
+    if (m_textureMapper && (!m_context || !m_context->makeContextCurrent()))
         return;
 
     // Retrieve the scene attributes in a thread-safe manner.
@@ -417,7 +489,8 @@ void ThreadedCompositor::renderLayerTree()
 
     WTFEmitSignpost(this, DidRenderFrame, "reasons: %s", reasonsToString(reasons).ascii().data());
 
-    m_context->swapBuffers();
+    if (m_context)
+        m_context->swapBuffers();
 
     m_surface->didRenderFrame();
     m_surface->sendFrame();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -107,6 +107,8 @@ private:
     void flushCompositingState(const OptionSet<WebCore::CompositionReason>&);
     void renderLayerTree();
     void paintToCurrentGLContext(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
+    void paintToTextureMapper(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
+    void paintToSkiaCanvas(const WebCore::TransformationMatrix&, const WebCore::IntSize&, const OptionSet<WebCore::CompositionReason>&);
     void frameComplete();
 
     void didCompositeRunLoopObserverFired();
@@ -118,6 +120,7 @@ private:
 
     const Ref<WorkQueue> m_workQueue;
     CheckedPtr<LayerTreeHost> m_layerTreeHost;
+    bool m_useSkia { false };
     RefPtr<AcceleratedSurface> m_surface;
     RefPtr<CoordinatedSceneState> m_sceneState;
     std::unique_ptr<WebCore::GLContext> m_context;


### PR DESCRIPTION
#### 847ee784549371faa9df449d3e5a0da3bc182989
<pre>
[GTK][WPE] Introduce SkiaCompositingLayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=312262">https://bugs.webkit.org/show_bug.cgi?id=312262</a>

Reviewed by Miguel Gomez.

This patch introduces SkiaCompositingLayer that uses Skia API instead of
Texture Mapper to compose the layers into the final frame. It&apos;s disabled
by default, it can be enabled by the new runtime setting
UseSkiaForComposition or using the enviroment variable
WEBKIT_USE_SKIA_FOR_COMPOSITION. Both are temporary while we work on the
skia compositor, they will be removed eventually once we switch to new
compositor.

Co-Authored-By: Nikolas Zimmermann &lt;nzimmermann@igalia.com&gt;
Co-Authored-By: Vitaly Dyachkov &lt;vitaly@igalia.com&gt;
Canonical link: <a href="https://commits.webkit.org/311425@main">https://commits.webkit.org/311425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8065a6009d5cf9c4c2ba22e581cbe809c723719f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156766 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121426 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85284 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102094 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22704 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20913 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13361 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148816 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132383 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168072 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17601 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12233 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129541 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129650 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35149 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140401 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87428 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17205 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188727 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29336 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93352 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48467 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28860 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->