### PR TITLE
[scroll-animations] null deref under `WebAnimation::range()` when a scroll-driven animation has no effect target

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/effect-target-set-to-null.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/effect-target-set-to-null.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>This test passes if it does not crash</title>
+<link rel="help" src="https://drafts.csswg.org/scroll-animations-1/">
+<script src="/web-animations/testcommon.js"></script>
+<body>
+
+<script>
+
+(async function() {
+    document.body.style.height = '4000px';
+
+    const target = document.body.appendChild(document.createElement('div'));
+    target.style.cssText = 'width:100px; height:100px; background:black;';
+
+    const timeline = new ScrollTimeline({ source: document.documentElement });
+    const animation = target.animate([{ opacity: 0 }], { timeline });
+
+    await animation.ready;
+    animation.effect.target = null;
+})();
+</script>

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+DeprecatedCSSValueConversion.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+DeprecatedCSSValueConversion.cpp
@@ -33,6 +33,8 @@ namespace Style {
 
 std::optional<CSSToLengthConversionData> deprecatedLengthConversionCreateCSSToLengthConversionData(RefPtr<Element> element)
 {
+    if (!element)
+        return std::nullopt;
     CheckedPtr elementRenderer = element->renderer();
     if (!elementRenderer)
         return std::nullopt;


### PR DESCRIPTION
#### 9cc00aab3dc8e52d29eb3227f4096658cb2b873a
<pre>
[scroll-animations] null deref under `WebAnimation::range()` when a scroll-driven animation has no effect target
<a href="https://bugs.webkit.org/show_bug.cgi?id=312263">https://bugs.webkit.org/show_bug.cgi?id=312263</a>
<a href="https://rdar.apple.com/174738722">rdar://174738722</a>

Reviewed by Anne van Kesteren.

Ensure the calls to `Style::deprecatedToStyleFromCSSValue()` from `WebAnimation::range()` run an early
check on whether the context element is defined.

Test: imported/w3c/web-platform-tests/scroll-animations/crashtests/effect-target-set-to-null.html

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/crashtests/effect-target-set-to-null.html: Added.
* Source/WebCore/style/values/primitives/StyleLengthWrapper+DeprecatedCSSValueConversion.cpp:
(WebCore::Style::deprecatedLengthConversionCreateCSSToLengthConversionData):

Canonical link: <a href="https://commits.webkit.org/311262@main">https://commits.webkit.org/311262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8610c239c55d776c435f6a0868580f85d80d34d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165219 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121118 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101789 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22406 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20580 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12991 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167701 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11814 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19891 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129242 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129354 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87052 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23828 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24181 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16871 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28966 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92922 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28492 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28720 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28616 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->