### PR TITLE
Retry process launch if custom flag ENABLE_RETRY_LAUNCHES is set

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -29,6 +29,7 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/Function.h>
 #include <wtf/HashMap.h>
 #include <wtf/ProcessID.h>
 #include <wtf/RefPtr.h>
@@ -166,7 +167,8 @@ private:
     ProcessLauncher(Client*, LaunchOptions&&);
 
     void launchProcess();
-    void finishLaunchingProcess(ASCIILiteral name);
+    void finishLaunchingProcess(ASCIILiteral name, int retriesRemaining = 2);
+    void tryFinishLaunchingProcess(ASCIILiteral name, Function<void()>&& onFailure);
     void didFinishLaunchingProcess(ProcessID, IPC::Connection::Identifier&&);
 
     void platformInvalidate();

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -284,7 +284,36 @@ void ProcessLauncher::launchProcess()
 #endif
 }
 
-void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
+void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name, int retriesRemaining)
+{
+    tryFinishLaunchingProcess(name, [weakThis = ThreadSafeWeakPtr { *this }, name, retriesRemaining]() mutable {
+        // FIXME(rdar://173715411): optional workaround for intermittent launch failures
+        // if binaries are huge (for example if code coverage has been enabled)
+#if !USE(EXTENSIONKIT) && ENABLE(RETRY_LAUNCHES)
+        if (retriesRemaining > 0) {
+            RefPtr processLauncher = weakThis.get();
+            if (!processLauncher)
+                return;
+            LOG_ERROR("Retrying launch of %s (%d retries remaining)", name.characters(), retriesRemaining - 1);
+            // Each new launch requires a new XPC connection. tryFinishLaunchingProcess destroyed
+            // the previous one.
+            // FIXME: This is a false positive. <rdar://164843889>
+            SUPPRESS_RETAINPTR_CTOR_ADOPT processLauncher->m_xpcConnection = adoptOSObject(xpc_connection_create(name, nullptr));
+            processLauncher->finishLaunchingProcess(name, retriesRemaining - 1);
+            return;
+        }
+#else
+        UNUSED_PARAM(retriesRemaining);
+        UNUSED_PARAM(name);
+#endif
+        RefPtr processLauncher = weakThis.get();
+        if (!processLauncher)
+            return;
+        processLauncher->didFinishLaunchingProcess(0, IPC::Connection::Identifier());
+    });
+}
+
+void ProcessLauncher::tryFinishLaunchingProcess(ASCIILiteral name, Function<void()>&& onFailure)
 {
     uuid_t uuid;
     uuid_generate(uuid);
@@ -420,7 +449,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
 
     xpc_dictionary_set_value(bootstrapMessage.get(), "extra-initialization-data", extraInitializationData.get());
 
-    Function<void(xpc_object_t)> errorHandlerImpl = [weakProcessLauncher = ThreadSafeWeakPtr { *this }, listeningPort, logName = CString(name)] (xpc_object_t event) {
+    Function<void(xpc_object_t)> errorHandlerImpl = [weakProcessLauncher = ThreadSafeWeakPtr { *this }, listeningPort, logName = CString(name), onFailure = WTF::move(onFailure)] (xpc_object_t event) mutable {
         ASSERT(!event || xpc_get_type(event) == XPC_TYPE_ERROR);
 
         auto processLauncher = weakProcessLauncher.get();
@@ -455,7 +484,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
             xpc_connection_cancel(processLauncher->m_xpcConnection.get());
         processLauncher->m_xpcConnection = nullptr;
 
-        processLauncher->didFinishLaunchingProcess(0, IPC::Connection::Identifier());
+        onFailure();
     };
 
     Function<void(xpc_object_t)> eventHandler = [errorHandlerImpl = WTF::move(errorHandlerImpl), xpcEventHandler = client->xpcEventHandler()] (xpc_object_t event) mutable {


### PR DESCRIPTION
#### 8c1776bc8803ab907dd89b22830c3e14f560b65f
<pre>
Retry process launch if custom flag ENABLE_RETRY_LAUNCHES is set
<a href="https://bugs.webkit.org/show_bug.cgi?id=312265">https://bugs.webkit.org/show_bug.cgi?id=312265</a>
<a href="https://rdar.apple.com/173715411">rdar://173715411</a>

Reviewed by Elliott Williams.

If and only if ENABLE_RETRY_LAUNCHES is specified on the build command line,
retry any failed launches of child processes. If they fail to launch it&apos;s
probably because of <a href="https://rdar.apple.com/173715411">rdar://173715411</a>, a sporadic bug which occurs only when
extremely large binaries are involved. Two retries appears to make this
sufficiently rare that it isn&apos;t troublesome in practice.

This option will never be enabled for production builds - but it&apos;s necessary as
a workaround to run test suites with code coverage enabled. The code coverage
instrumentation pushes the sizes of WebKit binaries over the threshold where we
run into this problem.

Canonical link: <a href="https://commits.webkit.org/311264@main">https://commits.webkit.org/311264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87724d5d8c15265fe835849e3699acc7126b3817

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110419 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121069 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85132 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101740 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22361 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20527 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12932 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132034 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167642 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11755 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129194 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29275 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24593 "Found 1 new test failure: imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/form.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129307 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35053 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86993 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24134 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16818 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28906 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92863 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28433 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28661 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->