### PR TITLE
[GBM] REGRESSION(310393@main): Always use DRM_RDWR when exporting dma-buf FDs for GPU buffer mapping

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp
@@ -32,6 +32,8 @@
 #include "GLDisplay.h"
 #include <atomic>
 #include <drm_fourcc.h>
+#include <fcntl.h>
+#include <xf86drm.h>
 
 #if USE(LIBEPOXY)
 #include <epoxy/egl.h>
@@ -89,8 +91,18 @@ std::optional<DMABufBufferAttributes> DMABufBufferAttributes::fromGBMBufferObjec
     attributes.fourcc = gbm_bo_get_format(bo);
     attributes.modifier = enableModifiers == EnableModifiers::Yes ? gbm_bo_get_modifier(bo) : DRM_FORMAT_MOD_INVALID;
 
+    auto getMappableFDForPlane = [](struct gbm_bo* bo, int plane) {
+        auto handle = gbm_bo_get_handle_for_plane(bo, plane);
+        if (handle.s32 == -1)
+            return -1;
+
+        int fd;
+        int ret = drmPrimeHandleToFD(gbm_device_get_fd(gbm_bo_get_device(bo)), handle.u32, DRM_CLOEXEC | DRM_RDWR, &fd);
+        return ret < 0 ? -1 : fd;
+    };
+
     for (int i = 0; i < planeCount; ++i) {
-        int fd = gbm_bo_get_fd_for_plane(bo, i);
+        int fd = getMappableFDForPlane(bo, i);
         if (fd < 0) {
             LOG_ERROR("DMABufBufferAttributes::fromGBMBufferObject(), failed to export dma-buf for plane %d", i);
             return std::nullopt;

--- a/Source/WebCore/platform/graphics/gbm/GBMVersioning.h
+++ b/Source/WebCore/platform/graphics/gbm/GBMVersioning.h
@@ -29,28 +29,10 @@
 
 #include <gbm.h>
 
-#if !HAVE(GBM_BO_GET_FD_FOR_PLANE)
-#include <fcntl.h>
-#include <xf86drm.h>
-#endif
-
 #if !HAVE(GBM_BO_CREATE_WITH_MODIFIERS2)
 static inline struct gbm_bo* gbm_bo_create_with_modifiers2(struct gbm_device* gbm, uint32_t width, uint32_t height, uint32_t format, const uint64_t* modifiers, const unsigned count, uint32_t)
 {
     return gbm_bo_create_with_modifiers(gbm, width, height, format, modifiers, count);
-}
-#endif
-
-#if !HAVE(GBM_BO_GET_FD_FOR_PLANE)
-static inline int gbm_bo_get_fd_for_plane(struct gbm_bo* bo, int plane)
-{
-    auto handle = gbm_bo_get_handle_for_plane(bo, plane);
-    if (handle.s32 == -1)
-        return -1;
-
-    int fd;
-    int ret = drmPrimeHandleToFD(gbm_device_get_fd(gbm_bo_get_device(bo)), handle.u32, DRM_CLOEXEC | DRM_RDWR, &fd);
-    return ret < 0 ? -1 : fd;
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -123,8 +123,7 @@ bool SkiaGPUAtlas::uploadImages()
     if (auto* gpuBuffer = m_atlasTexture->memoryMappedGPUBuffer()) {
         if (gpuBuffer->isLinear() || gpuBuffer->isVivanteSuperTiled()) {
             auto writeScope = makeGPUBufferWriteScope(*gpuBuffer);
-            if (!writeScope)
-                return false;
+            RELEASE_ASSERT_WITH_MESSAGE(writeScope, "Failed to map GPU buffer for atlas upload");
 
             for (const auto& entry : m_layout->entries()) {
                 if (auto pixels = pixelDataInSRGB(entry.rasterImage))

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -312,7 +312,6 @@ if (USE_GBM)
     endif ()
 
     set(CMAKE_REQUIRED_LIBRARIES GBM::GBM)
-    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_GET_FD_FOR_PLANE gbm_bo_get_fd_for_plane gbm.h)
     WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_CREATE_WITH_MODIFIERS2 gbm_bo_create_with_modifiers2 gbm.h)
     unset(CMAKE_REQUIRED_LIBRARIES)
 endif ()

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -438,7 +438,6 @@ if (USE_GBM)
     endif ()
 
     set(CMAKE_REQUIRED_LIBRARIES GBM::GBM)
-    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_GET_FD_FOR_PLANE gbm_bo_get_fd_for_plane gbm.h)
     WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_CREATE_WITH_MODIFIERS2 gbm_bo_create_with_modifiers2 gbm.h)
     unset(CMAKE_REQUIRED_LIBRARIES)
 endif ()


### PR DESCRIPTION
#### 31dab2d9da5a0b131f329b57f774e24d1266f1b9
<pre>
[GBM] REGRESSION(310393@main): Always use DRM_RDWR when exporting dma-buf FDs for GPU buffer mapping
<a href="https://bugs.webkit.org/show_bug.cgi?id=312266">https://bugs.webkit.org/show_bug.cgi?id=312266</a>

Reviewed by Adrian Perez de Castro.

gbm_bo_get_fd_for_plane() in older Mesa versions does not always pass
DRM_RDWR to drmPrimeHandleToFD, which results in FDs that cannot be
mmap&apos;d for writing. This silently breaks GPU buffer write operations.

Remove the conditional polyfill for gbm_bo_get_fd_for_plane() and
instead use a local getMappableFDForPlane() lambda that always goes
through drmPrimeHandleToFD with DRM_CLOEXEC | DRM_RDWR, ensuring
mmap support regardless of the Mesa version.

Also upgrade the GPU buffer write scope failure in SkiaGPUAtlas to a
RELEASE_ASSERT, since a failed mmap now indicates a hard error that
should not be silently ignored.

Not testable using the current CI infra.

 * Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp:
 (WebCore::DMABufBufferAttributes::fromGBMBufferObject):
 * Source/WebCore/platform/graphics/gbm/GBMVersioning.h:
 (gbm_bo_get_fd_for_plane): Deleted.
 * Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
 (WebCore::SkiaGPUAtlas::uploadImages):
 * Source/cmake/OptionsGTK.cmake:
 * Source/cmake/OptionsWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/311266@main">https://commits.webkit.org/311266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2975f0f37ef161c7f939a40b092e171ebd31e8f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110493 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121138 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22423 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20597 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13006 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148463 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167716 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17248 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129259 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129370 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35055 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140085 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87067 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24201 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16884 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188296 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28981 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92937 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48404 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28507 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->