### PR TITLE
AX: Accessibility can infinitely recurse with circular SVG use-element references, causing a crash

### DIFF
--- a/LayoutTests/accessibility/svg-use-cycle-no-crash-expected.txt
+++ b/LayoutTests/accessibility/svg-use-cycle-no-crash-expected.txt
@@ -1,0 +1,14 @@
+This tests that SVG use element cycles in accessibility do not cause infinite recursion or a crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS: typeof platformValueForW3CName(useA) === 'string'
+PASS: typeof platformValueForW3CName(useSelf) === 'string'
+PASS: typeof platformValueForW3CName(useC) === 'string'
+PASS: typeof platformValueForW3CName(chain1) === 'string'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/svg-use-cycle-no-crash.html
+++ b/LayoutTests/accessibility/svg-use-cycle-no-crash.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<!-- PoC for SVG <use> element accessibility recursion.
+
+     AccessibilitySVGObject::description() and helpText() call targetForUseElement(),
+     which resolves the <use> href to a DOM element, creates an AX object, and calls
+     description()/helpText() on it. If two <use> elements reference each other, this
+     recurses infinitely.
+
+     SVG's rendering engine detects circular <use> references and won't render them.
+     But the accessibility code does its own independent lookup via
+     SVGURIReference::targetElementFromIRIString() on the DOM, not the render tree.
+     If the AX objects are still created (via getOrCreate), the recursion can happen.
+
+     This test verifies:
+     1. Circular <use> references don't cause infinite recursion in accessibility.
+     2. Deep <use> chains don't cause stack overflow.
+-->
+
+<svg style="position: absolute;" xmlns="http://www.w3.org/2000/svg">
+    <!-- Test 1: Direct 2-element <use> cycle. -->
+    <use id="use-a" href="#use-b"/>
+    <use id="use-b" href="#use-a"/>
+
+    <!-- Test 2: Self-referencing <use>. -->
+    <use id="use-self" href="#use-self"/>
+
+    <!-- Test 3: 3-element <use> cycle. -->
+    <use id="use-c" href="#use-d"/>
+    <use id="use-d" href="#use-e"/>
+    <use id="use-e" href="#use-c"/>
+
+    <!-- Test 4: Deep <use> chain (not circular, but tests stack depth). -->
+    <use id="chain-1" href="#chain-2"/>
+    <use id="chain-2" href="#chain-3"/>
+    <use id="chain-3" href="#chain-4"/>
+    <use id="chain-4" href="#chain-5"/>
+    <use id="chain-5" href="#chain-6"/>
+    <use id="chain-6" href="#chain-7"/>
+    <use id="chain-7" href="#chain-8"/>
+    <use id="chain-8" href="#chain-9"/>
+    <use id="chain-9" href="#chain-10"/>
+    <use id="chain-10" href="#chain-end"/>
+    <rect id="chain-end" width="10" height="10">
+        <title>chain end</title>
+    </rect>
+</svg>
+
+<script>
+description("This tests that SVG use element cycles in accessibility do not cause infinite recursion or a crash.");
+
+if (window.accessibilityController) {
+    var output = "";
+
+    // Test 1: Direct 2-element <use> cycle.
+    // Accessing the description should not hang or crash, regardless of whether
+    // the elements are included in the accessibility tree.
+    var useA = accessibilityController.accessibleElementById("use-a");
+    if (useA)
+        output += expect("typeof platformValueForW3CName(useA)", "'string'");
+    else
+        output += "PASS: use-a not in accessibility tree (circular reference excluded)\n";
+
+    // Test 2: Self-referencing <use>.
+    var useSelf = accessibilityController.accessibleElementById("use-self");
+    if (useSelf)
+        output += expect("typeof platformValueForW3CName(useSelf)", "'string'");
+    else
+        output += "PASS: use-self not in accessibility tree (self-reference excluded)\n";
+
+    // Test 3: 3-element <use> cycle.
+    var useC = accessibilityController.accessibleElementById("use-c");
+    if (useC)
+        output += expect("typeof platformValueForW3CName(useC)", "'string'");
+    else
+        output += "PASS: use-c not in accessibility tree (circular reference excluded)\n";
+
+    // Test 4: Deep <use> chain. If the chain resolves, we should get the title
+    // from the final <rect> element.
+    var chain1 = accessibilityController.accessibleElementById("chain-1");
+    if (chain1)
+        output += expect("typeof platformValueForW3CName(chain1)", "'string'");
+    else
+        output += "PASS: chain-1 not in accessibility tree (chain excluded)\n";
+
+    debug(output);
+}
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -50,6 +50,7 @@
 #include "TypedElementDescendantIteratorInlines.h"
 #include "XLinkNames.h"
 #include <wtf/Language.h>
+#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 
@@ -188,8 +189,15 @@ String AccessibilitySVGObject::descriptionFromTitleChild(Element* titleChild) co
             return xlinkTitle;
     }
 
-    if (RefPtr target = targetForUseElement())
-        return target->description();
+    if (RefPtr target = targetForUseElement()) {
+        // Avoid infinite recursion from circular <use> references by tracking ones we're currently resolving.
+        static NeverDestroyed<HashSet<Element*>> elementsResolvingDescription;
+        if (elementsResolvingDescription->add(element.get()).isNewEntry) {
+            auto result = target->description();
+            elementsResolvingDescription->remove(element.get());
+            return result;
+        }
+    }
 
     if (m_renderer && m_renderer->isRenderOrLegacyRenderSVGImage()) {
         const auto& alt = getAttribute(HTMLNames::altAttr);
@@ -217,8 +225,15 @@ String AccessibilitySVGObject::helpTextFromChildren(Element* titleChild, Element
             return result;
     }
 
-    if (RefPtr target = targetForUseElement())
-        return target->helpText();
+    if (RefPtr target = targetForUseElement()) {
+        // Avoid infinite recursion from circular <use> references by tracking ones we're currently resolving.
+        static NeverDestroyed<HashSet<Element*>> elementsResolvingHelpText;
+        if (elementsResolvingHelpText->add(element.get()).isNewEntry) {
+            auto result = target->helpText();
+            elementsResolvingHelpText->remove(element.get());
+            return result;
+        }
+    }
 
     if (titleChild) {
         auto titleText = titleChild->textContent();


### PR DESCRIPTION
#### 9fec56013cb548777900295a2dddbbe60852db8a
<pre>
AX: Accessibility can infinitely recurse with circular SVG use-element references, causing a crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=312276">https://bugs.webkit.org/show_bug.cgi?id=312276</a>
<a href="https://rdar.apple.com/174749401">rdar://174749401</a>

Reviewed by Joshua Hoffman.

AccessibilitySVGObject::description() and helpText() resolve &lt;use&gt; element
hrefs via targetForUseElement() and recurse into the target&apos;s description()
or helpText(). Circular references (e.g., &lt;use href=&quot;#a&quot;&gt; and &lt;use href=&quot;#b&quot;&gt;
referencing each other) cause infinite recursion, in turn causing a crash.

Fix this by tracking which elements are currently being resolved using a
static HashSet. If an element is already in the set when we try to resolve
its use-element target&apos;s description or help text, we skip the recursive
call, breaking the cycle.

* LayoutTests/accessibility/svg-use-cycle-no-crash-expected.txt: Added.
* LayoutTests/accessibility/svg-use-cycle-no-crash.html: Added.
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::descriptionFromTitleChild const):
(WebCore::AccessibilitySVGObject::helpTextFromChildren const):

Canonical link: <a href="https://commits.webkit.org/311222@main">https://commits.webkit.org/311222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dee79d5b34856f456bdfdf36771f71a6362f687a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165157 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121066 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101737 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12929 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167637 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11752 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129189 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129302 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35030 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140018 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86990 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24129 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16817 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28903 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92860 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28430 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28658 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28554 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->