### PR TITLE
[Scroll anchoring] Transform changes fail to suppress anchoring sometimes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-transform-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-transform-change-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Changing `transform` on an element in the path from the anchor to the scroller should suppress anchoring adjustment
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-transform-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-transform-change.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-anchoring/#suppression-triggers">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>    
+.scroller {
+  width: 300px;
+  height: 300px;
+  overflow-y: scroll;
+  border: 1px solid black;
+}
+
+.changer {
+  height: 50px;
+  background-color: cyan;
+}
+
+body.changed .changer {
+  height: 60px;
+}
+
+#adjuster {
+  position: relative;
+  transform: translateY(150px);
+}
+
+body.changed #adjuster {
+  transform: translateY(170px);
+}
+  
+#anchor {
+    background-color: green;
+    width: 100px;
+    height: 100px;
+}
+
+.filler {
+  height: 2000px;
+}
+</style>
+<div class="scroller">
+  <div id="adjuster">
+    <div class="changer"></div>
+    <div id="anchor"></div>
+    <div class="filler"></div>
+  </div>
+</div>
+<script>
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  scroller.scrollTop = 140;
+
+  const newScrollTop = 250;
+
+  scroller.scrollTop = newScrollTop;
+  document.body.classList.add('changed');
+
+  assert_equals(scroller.scrollTop, newScrollTop);
+}, "Changing `transform` on an element in the path from the anchor to the scroller should suppress anchoring adjustment");
+
+</script>

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1134,16 +1134,17 @@ void RenderElement::styleDidChange(Style::Difference diff, const RenderStyle* ol
         issueRepaintForOutlineAuto(hasOutlineAuto ? outlineStyleForRepaint().usedOutlineSize() : oldStyle->usedOutlineSize());
     }
 
-    auto isLayoutDiff = [](Style::DifferenceResult diff) {
-        switch (diff) {
+    auto isLayoutDiff = [](Style::Difference diff) {
+        switch (diff.result) {
         case Style::DifferenceResult::Equal:
-        case Style::DifferenceResult::RecompositeLayer:
         case Style::DifferenceResult::Repaint:
         case Style::DifferenceResult::RepaintIfText:
         case Style::DifferenceResult::RepaintLayer:
-        case Style::DifferenceResult::Overflow:
         case Style::DifferenceResult::NewStyle:
             return false;
+        case Style::DifferenceResult::Overflow:
+        case Style::DifferenceResult::RecompositeLayer:
+            return diff.contextSensitiveProperties.contains(Style::DifferenceContextSensitiveProperty::Transform);
         case Style::DifferenceResult::LayoutOutOfFlowMovementOnly:
         case Style::DifferenceResult::OverflowAndOutOfFlowMovement:
         case Style::DifferenceResult::Layout:
@@ -1152,7 +1153,7 @@ void RenderElement::styleDidChange(Style::Difference diff, const RenderStyle* ol
         return false;
     };
 
-    if (settings().cssScrollAnchoringEnabled() && isLayoutDiff(diff.result) && style().scrollAnchoringSuppressionStyleDidChange(oldStyle)) {
+    if (settings().cssScrollAnchoringEnabled() && isLayoutDiff(diff) && style().scrollAnchoringSuppressionStyleDidChange(oldStyle)) {
         auto findNearestScrollAnchoringController = [](const RenderElement& renderer) -> CheckedPtr<ScrollAnchoringController> {
             // At this point we can't find the appropriate enclosing ScrollAnchoringController, because we haven't done layout.
             // We will, however, have created a ScrollAnchoringController for potentially scrollable ancestors, so store


### PR DESCRIPTION
#### 71619b4d210d1297dc8b7e674c5fa7520c5ddb60
<pre>
[Scroll anchoring] Transform changes fail to suppress anchoring sometimes
<a href="https://bugs.webkit.org/show_bug.cgi?id=312277">https://bugs.webkit.org/show_bug.cgi?id=312277</a>
<a href="https://rdar.apple.com/174503821">rdar://174503821</a>

Reviewed by Alan Baradlay.

A transform change results in a `Style::DifferenceResult::Overflow` or `RecompositeLayer`,
so we need to all `scrollAnchoringSuppressionStyleDidChange()` for this diff type.

The test needs to change both height of a sibling, and transform on the wrapper,
because the transform change alone never results in anchoring adjustments; this is
because the before-layout transform already has the new state, since RenderLayer
updates its transform on style change. But this isn&apos;t a problem, since transform
changes suppress anchoring anyway.

Test: imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-transform-change.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-transform-change-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-transform-change.html: Added.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleDidChange):

Canonical link: <a href="https://commits.webkit.org/311253@main">https://commits.webkit.org/311253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bfcf26195cba5c40200a4437e281e23d1484f57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165211 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121113 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101784 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22399 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20572 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12983 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167693 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11806 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129237 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129349 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35046 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87044 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24179 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16864 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92914 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28484 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28712 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28608 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->