### PR TITLE
WebKitLegacy: printing a WebView embedded in an enclosing NSPrintOperation drops all text

### DIFF
--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -714,7 +714,14 @@ void LocalFrame::setPrinting(bool printing, FloatSize pageSize, FloatSize origin
         return;
 
     Ref frameView = *view();
-    if (shouldUsePrintingLayout())
+    // A zero pageSize.width() means the caller is entering printing state without a known
+    // page geometry (e.g. WebKitLegacy's -[WebHTMLView adjustPageHeightNew:...] path used
+    // when the view participates in a larger enclosing NSPrintOperation). In that case we
+    // must not run pagination layout, since forceLayoutForPagination -> resizePageRectsKeepingRatio
+    // asserts on a zero original width (and in release produces a degenerate layout that
+    // drops text runs). Height may legitimately be zero here (e.g. the render-tree dump path
+    // in RenderTreeAsText passes only a width), so don't treat that as "no geometry".
+    if (shouldUsePrintingLayout() && pageSize.width() > 0)
         frameView->forceLayoutForPagination(pageSize, originalPageSize, maximumShrinkRatio, shouldAdjustViewSize);
     else {
         frameView->forceLayout();

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1101,6 +1101,7 @@
 				WebKitLegacy/mac/CustomProtocolsTest.mm,
 				WebKitLegacy/mac/DeallocWebViewInEventListener.mm,
 				WebKitLegacy/mac/DownloadThread.mm,
+				WebKitLegacy/mac/EmbeddedPrintPagination.mm,
 				WebKitLegacy/mac/PreventImageLoadWithAutoResizing.mm,
 				WebKitLegacy/mac/URLExtras.mm,
 				WebKitLegacy/mac/UserContentTest.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/EmbeddedPrintPagination.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/EmbeddedPrintPagination.mm
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "Helpers/DeprecatedGlobalValues.h"
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
+#import <WebKit/WebFrame.h>
+#import <WebKit/WebFrameView.h>
+#import <WebKit/WebHTMLView.h>
+#import <WebKit/WebView.h>
+#import <wtf/RetainPtr.h>
+
+@interface EmbeddedPrintPaginationLoadDelegate : NSObject <WebFrameLoadDelegate>
+@end
+
+@implementation EmbeddedPrintPaginationLoadDelegate
+- (void)webView:(WebView *)sender didFinishLoadForFrame:(WebFrame *)frame
+{
+    didFinishLoad = true;
+}
+@end
+
+namespace TestWebKitAPI {
+
+// Regression test for webkit.org/b/303713 follow-up: when a WebHTMLView
+// is a subview of a larger view hierarchy being printed, AppKit invokes
+// -adjustPageHeightNew:top:bottom:limit: on it, which calls
+// -_setPrinting: with all page dimensions equal to zero. After
+// 304253@main that bottomed out in LocalFrame::setPrinting, which ran
+// forceLayoutForPagination with a zero page size — asserting in debug
+// and silently dropping text runs from the CG print context in release.
+// This test exercises the same entry point and asserts that it does not
+// crash.
+TEST(WebKitLegacy, EmbeddedPrintPaginationWithZeroPageSize)
+{
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
+    auto *webHTMLView = (WebHTMLView *)[[[webView mainFrame] frameView] documentView];
+
+    RetainPtr loadDelegate = adoptNS([[EmbeddedPrintPaginationLoadDelegate alloc] init]);
+    [webView setFrameLoadDelegate:loadDelegate.get()];
+
+    didFinishLoad = false;
+    [[webView mainFrame] loadHTMLString:@"<html><body><p>Hello, printing world.</p></body></html>" baseURL:nil];
+    Util::run(&didFinishLoad);
+
+    // This is the AppKit-driven call path used when a WebHTMLView is a
+    // subview of a larger view hierarchy being printed. Before the fix
+    // this asserted in debug (LocalFrame.cpp:resizePageRectsKeepingRatio)
+    // and silently dropped text runs in release; reaching the
+    // EXPECT_GT below without crashing is the pass condition.
+    CGFloat newBottom = 0;
+    [webHTMLView adjustPageHeightNew:&newBottom top:0 bottom:400 limit:400];
+    EXPECT_GT(newBottom, 0);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### d70314bc51faaa3e661228bb8bd932fbe5bd723b
<pre>
WebKitLegacy: printing a WebView embedded in an enclosing NSPrintOperation drops all text
<a href="https://bugs.webkit.org/show_bug.cgi?id=312280">https://bugs.webkit.org/show_bug.cgi?id=312280</a>

Reviewed by Simon Fraser and Matt Woodrow.

304253@main (5f8a1e5) routed WebHTMLView&apos;s _setPrinting: through
LocalFrame::setPrinting unconditionally. The embedded-print path
(-[WebHTMLView adjustPageHeightNew:...], used when the WebHTMLView is a
subview of a larger view tree being printed) calls _setPrinting: with all
page dimensions equal to zero. Before 304253@main, WK1&apos;s layout helper
explicitly gated forceLayoutForPagination on a nonzero minPageLogicalWidth
and fell back to forceLayout(). That gate was lost in the refactor.

With zero pageSize, shouldUsePrintingLayout() still returns true for the
top frame, so forceLayoutForPagination runs with a zero page, which
asserts in resizePageRectsKeepingRatio in debug and produces a degenerate
paginated layout in release — line boxes collapse and text runs are
never emitted to the CG print context, while raster content (images,
backgrounds) still paints. Users see print/export output with images but
no text.

Restore the pre-304253@main behavior by gating on pageSize.width() &gt; 0,
falling through to forceLayout() as before. Note that height may
legitimately be zero here — RenderTreeAsText&apos;s printing-mode dump calls
PrintContext::begin(renderer-&gt;width()) with the default height=0, and
WK1&apos;s -setPageWidthForPrinting: does the same — so FloatSize::isEmpty()
(which is true when either dimension is &lt;= 0) is too broad.

Tests: Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/EmbeddedPrintPagination.mm

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::setPrinting):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/EmbeddedPrintPagination.mm: Added.
(-[EmbeddedPrintPaginationLoadDelegate webView:didFinishLoadForFrame:]):
(TestWebKitAPI::TEST(WebKitLegacy, EmbeddedPrintPaginationWithZeroPageSize)):

Canonical link: <a href="https://commits.webkit.org/312629@main">https://commits.webkit.org/312629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d4a1c6df0188c2284ed9cb58309cebed07d01db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115545 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124435 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87889 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105034 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25735 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24234 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17101 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171860 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18302 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132696 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132715 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35887 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143709 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95392 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27308 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20523 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33120 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99955 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32620 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->