### PR TITLE
AX: aria-owns cycle detection is unbounded, which can cause hangs for deep aria-owns chains

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1072,6 +1072,8 @@ imported/w3c/web-platform-tests/content-security-policy/font-src/font-match-allo
 [ Debug ] imported/w3c/web-platform-tests/html/dom/idlharness.https.html [ Skip ]
 [ Debug ] imported/w3c/web-platform-tests/html/dom/idlharness.worker.html [ Skip ]
 [ Debug ] accessibility/visible-character-range-scrolling.html [ Skip ]
+# This test does too much work (and thus runs too slowly) to work in debug.
+[ Debug ] accessibility/aria-owns-deep-chain-no-timeout.html [ Skip ]
 
 # These tests rely on virtual authenticators being supported, which only works in WebDriver, not WKTR.
 imported/w3c/web-platform-tests/webauthn/createcredential-abort.https.html [ Skip ]

--- a/LayoutTests/accessibility/aria-owns-deep-chain-no-timeout-expected.txt
+++ b/LayoutTests/accessibility/aria-owns-deep-chain-no-timeout-expected.txt
@@ -1,0 +1,9 @@
+This test ensures deeply chained aria-owns relations don't cause a timeout due to quadratic cycle detection.
+
+PASS: axContainer.childrenCount > 0 === true
+PASS: Did not timeout.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/aria-owns-deep-chain-no-timeout.html
+++ b/LayoutTests/accessibility/aria-owns-deep-chain-no-timeout.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+#container { height: 0; overflow: hidden; }
+</style>
+</head>
+<body>
+
+<div id="container" role="group"></div>
+
+<script>
+var output = "This test ensures deeply chained aria-owns relations don't cause a timeout due to quadratic cycle detection.\n\n";
+
+if (window.accessibilityController) {
+    const container = document.getElementById("container");
+    const count = 3000;
+
+    // Create a flat list of sibling elements chained via aria-owns:
+    // e0 owns e1, e1 owns e2, ..., eN-1 owns eN.
+    // This produces an AX tree much deeper than the DOM tree,
+    // stress-testing the parent-chain walk in aria-owns cycle detection.
+    for (let i = 0; i < count; i++) {
+        const div = document.createElement("div");
+        div.id = `e${i}`;
+        div.setAttribute("role", "group");
+        if (i < count - 1)
+            div.setAttribute("aria-owns", `e${i + 1}`);
+        container.appendChild(div);
+    }
+
+    // Accessing the AX tree triggers relation processing, including cycle detection.
+    var axContainer = accessibilityController.accessibleElementById("container");
+    output += expect("axContainer.childrenCount > 0", "true");
+
+    output += "PASS: Did not timeout.\n";
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -6098,14 +6098,19 @@ static bool NODELETE canHaveRelations(Element& element)
 static bool relationCausesCycle(AccessibilityObject* origin, AccessibilityObject* target, AXRelation relation)
 {
     // Validate that we're not creating an aria-owns cycle.
+    // Cap the parent chain walk to avoid O(n * depth) behavior with adversarial aria-owns content.
+    // If we can't verify the relation is cycle-free within maxDepth, reject it.
+    static constexpr unsigned maxDepth = SettingsBase::defaultMaximumHTMLParserDOMTreeDepth * 3;
     if (relation == AXRelation::OwnerFor) {
-        for (auto* verifyOrigin = origin; verifyOrigin; verifyOrigin = verifyOrigin->parentObject()) {
-            if (verifyOrigin == target)
+        unsigned depth = 0;
+        for (auto* verifyOrigin = origin; verifyOrigin; verifyOrigin = verifyOrigin->parentObject(), ++depth) {
+            if (verifyOrigin == target || depth >= maxDepth)
                 return true;
         }
     } else if (relation == AXRelation::OwnedBy) {
-        for (auto* verifyTarget = target; verifyTarget; verifyTarget = verifyTarget->parentObject()) {
-            if (verifyTarget == origin)
+        unsigned depth = 0;
+        for (auto* verifyTarget = target; verifyTarget; verifyTarget = verifyTarget->parentObject(), ++depth) {
+            if (verifyTarget == origin || depth >= maxDepth)
                 return true;
         }
     }


### PR DESCRIPTION
#### 092bf6b43083d87f223ed76ba011cc7153b0c9a2
<pre>
AX: aria-owns cycle detection is unbounded, which can cause hangs for deep aria-owns chains
<a href="https://bugs.webkit.org/show_bug.cgi?id=312284">https://bugs.webkit.org/show_bug.cgi?id=312284</a>
<a href="https://rdar.apple.com/174753621">rdar://174753621</a>

Reviewed by Joshua Hoffman.

relationCausesCycle() walks the AX parent chain linearly for each aria-owns relation.
Through aria-owns chaining (e0 owns e1, e1 owns e2, ...), the AX tree can grow much
deeper than the DOM, making the total cost of cycle detection O(n^2). Cap the walk at
1536 (512, the DOM parser limit, * 3) steps and reject the relation if we can&apos;t verify
it is cycle-free within that limit.

This protects user against adversarially authored content, e.g. someone
intentionally trying to create a denial-of-service attack targeted at
assistive technology users, as it&apos;s extremely unlikely any web developer
would do something like this legitamately.

* LayoutTests/accessibility/aria-owns-deep-chain-no-timeout-expected.txt: Added.
* LayoutTests/accessibility/aria-owns-deep-chain-no-timeout.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::relationCausesCycle):

Canonical link: <a href="https://commits.webkit.org/311288@main">https://commits.webkit.org/311288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2cd96fdd833494d4bde40892d1b676a3410b2fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110499 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158290 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29887 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121144 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85158 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101813 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22431 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20604 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13012 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167722 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11835 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129267 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129378 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35070 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140096 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87073 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16895 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28987 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92943 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28513 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28741 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28637 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->