### PR TITLE
REGRESSION(311150@main): TestWebKitAPI.WKWebExtensionContext.CallingMissingBrowserAPIInBackground is flakey.

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
@@ -75,6 +75,7 @@
 - (void)run;
 - (void)runForTimeInterval:(NSTimeInterval)interval;
 - (id)runUntilTestMessage:(NSString *)message;
+- (void)runUntilContextError;
 
 - (void)done;
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
@@ -294,6 +294,20 @@ static constexpr BOOL shouldEnableSiteIsolation = NO;
     TestWebKitAPI::Util::run(&_done);
 }
 
+- (void)runUntilContextError
+{
+    if (_context.errors.count)
+        return;
+
+    id observer = [NSNotificationCenter.defaultCenter addObserverForName:WKWebExtensionContextErrorsDidUpdateNotification object:_context queue:nil usingBlock:^(NSNotification *) {
+        self->_done = true;
+    }];
+
+    [self runForTimeInterval:5];
+
+    [NSNotificationCenter.defaultCenter removeObserver:observer];
+}
+
 - (id)runUntilTestMessage:(NSString *)message
 {
     id (^processMessage)(void) = ^id {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm
@@ -957,20 +957,13 @@ TEST(WKWebExtensionContext, LoadNonExistentImage)
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
 
-    EXPECT_NS_EQUAL(manager.get().context.errors, @[ ]);
+    [manager runUntilContextError];
 
-    [NSNotificationCenter.defaultCenter addObserverForName:WKWebExtensionContextErrorsDidUpdateNotification object:nil queue:nil usingBlock:^(NSNotification *notification) {
-        auto *extensionContext = dynamic_objc_cast<WKWebExtensionContext>(notification.object);
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
-        EXPECT_EQ(extensionContext.errors.count, 1ul);
-
-        auto *predicate = [NSPredicate predicateWithFormat:@"localizedDescription CONTAINS %@", @"Unable to find \"non-existent-image.png\" in the extension’s resources."];
-        auto *filteredErrors = [extensionContext.errors filteredArrayUsingPredicate:predicate];
-
-        EXPECT_NS_EQUAL(extensionContext.errors, filteredErrors);
-
-        [manager done];
-    }];
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionErrorResourceNotFound);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Unable to find \"non-existent-image.png\" in the extension’s resources. It is an invalid path.");
 }
 
 TEST(WKWebExtensionContext, TopLevelThrowInModuleBackground)
@@ -990,7 +983,8 @@ TEST(WKWebExtensionContext, TopLevelThrowInModuleBackground)
     auto *backgroundScript = @"throw new Error('Top level module error')";
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
-    [manager runForTimeInterval:2];
+
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1016,7 +1010,8 @@ TEST(WKWebExtensionContext, ReferenceErrorInBackground)
     auto *backgroundScript = @"undeclaredVariable.foo";
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
-    [manager runForTimeInterval:2];
+
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1042,7 +1037,8 @@ TEST(WKWebExtensionContext, CallingMissingBrowserAPIInBackground)
     auto *backgroundScript = @"browser.runtime.nonExistentMethod()";
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
-    [manager runForTimeInterval:2];
+
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1069,7 +1065,8 @@ TEST(WKWebExtensionContext, UncaughtScriptErrorInBackground)
     auto *backgroundScript = @"setTimeout(() => { throw new Error('Test uncaught error') }, 0)";
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
-    [manager runForTimeInterval:2];
+
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1095,7 +1092,8 @@ TEST(WKWebExtensionContext, UnhandledPromiseRejectionInBackground)
     auto *backgroundScript = @"Promise.reject(new Error('Test rejection'))";
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
-    [manager runForTimeInterval:2];
+
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1119,7 +1117,8 @@ TEST(WKWebExtensionContext, UncaughtScriptErrorInServiceWorkerBackground)
     auto *backgroundScript = @"setTimeout(() => { throw new Error('Service worker uncaught error') }, 0)";
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
-    [manager runForTimeInterval:2];
+
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1143,7 +1142,8 @@ TEST(WKWebExtensionContext, UnhandledPromiseRejectionInServiceWorkerBackground)
     auto *backgroundScript = @"Promise.reject(new Error('Service worker rejection'))";
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
-    [manager runForTimeInterval:2];
+
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1170,7 +1170,8 @@ TEST(WKWebExtensionContext, SyntaxErrorInBackground)
     auto *backgroundScript = @")(";
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
-    [manager runForTimeInterval:2];
+
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1234,7 +1235,7 @@ TEST(WKWebExtensionContext, UncaughtScriptErrorInContentScript)
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
-    [manager runForTimeInterval:2];
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1269,7 +1270,7 @@ TEST(WKWebExtensionContext, UncaughtScriptErrorInMainWorldContentScript)
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
-    [manager runForTimeInterval:2];
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1307,7 +1308,7 @@ TEST(WKWebExtensionContext, PageScriptErrorNotReportedToExtension)
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
-    [manager runForTimeInterval:2];
+    [manager runForTimeInterval:3];
 
     EXPECT_NS_EQUAL(manager.get().context.errors, @[ ]);
 }
@@ -1341,7 +1342,7 @@ TEST(WKWebExtensionContext, UncaughtScriptErrorInEventListener)
 
     [manager.get().context performActionForTab:manager.get().defaultTab];
 
-    [manager runForTimeInterval:2];
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1382,7 +1383,7 @@ TEST(WKWebExtensionContext, TopLevelThrowInPopup)
 
     [manager runUntilTestMessage:@"Ready"];
 
-    [manager runForTimeInterval:2];
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1417,7 +1418,7 @@ TEST(WKWebExtensionContext, ConsoleErrorReportedNotLogOrWarn)
 
     [manager runUntilTestMessage:@"Ready"];
 
-    [manager runForTimeInterval:2];
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1451,7 +1452,7 @@ TEST(WKWebExtensionContext, ConsoleAssertWithMessage)
 
     [manager runUntilTestMessage:@"Ready"];
 
-    [manager runForTimeInterval:2];
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 
@@ -1485,7 +1486,7 @@ TEST(WKWebExtensionContext, ConsoleAssertWithoutMessage)
 
     [manager runUntilTestMessage:@"Ready"];
 
-    [manager runForTimeInterval:2];
+    [manager runUntilContextError];
 
     EXPECT_EQ(manager.get().context.errors.count, 1ul);
 


### PR DESCRIPTION
#### aef0bf9034507ee85c5fd12404928781a7f78154
<pre>
REGRESSION(311150@main): TestWebKitAPI.WKWebExtensionContext.CallingMissingBrowserAPIInBackground is flakey.
<a href="https://webkit.org/b/312278">https://webkit.org/b/312278</a>
<a href="https://rdar.apple.com/174749864">rdar://174749864</a>

Reviewed by Brady Eidson.

Fix flaky extension script error tests by replacing fixed time interval waits with a notification-based `runUntilContextError`
helper that returns immediately if errors are already present, or waits up to 5 seconds before timeout.

* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager runUntilContextError]): Added.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm:
(TestWebKitAPI::TEST(WKWebExtensionContext, LoadNonExistentImage)):
(TestWebKitAPI::TEST(WKWebExtensionContext, TopLevelThrowInModuleBackground)):
(TestWebKitAPI::TEST(WKWebExtensionContext, ReferenceErrorInBackground)):
(TestWebKitAPI::TEST(WKWebExtensionContext, CallingMissingBrowserAPIInBackground)):
(TestWebKitAPI::TEST(WKWebExtensionContext, UncaughtScriptErrorInBackground)):
(TestWebKitAPI::TEST(WKWebExtensionContext, UnhandledPromiseRejectionInBackground)):
(TestWebKitAPI::TEST(WKWebExtensionContext, UncaughtScriptErrorInServiceWorkerBackground)):
(TestWebKitAPI::TEST(WKWebExtensionContext, UnhandledPromiseRejectionInServiceWorkerBackground)):
(TestWebKitAPI::TEST(WKWebExtensionContext, SyntaxErrorInBackground)):
(TestWebKitAPI::TEST(WKWebExtensionContext, UncaughtScriptErrorInContentScript)):
(TestWebKitAPI::TEST(WKWebExtensionContext, UncaughtScriptErrorInMainWorldContentScript)):
(TestWebKitAPI::TEST(WKWebExtensionContext, PageScriptErrorNotReportedToExtension)):
(TestWebKitAPI::TEST(WKWebExtensionContext, UncaughtScriptErrorInEventListener)):
(TestWebKitAPI::TEST(WKWebExtensionContext, TopLevelThrowInPopup)):
(TestWebKitAPI::TEST(WKWebExtensionContext, ConsoleErrorReportedNotLogOrWarn)):
(TestWebKitAPI::TEST(WKWebExtensionContext, ConsoleAssertWithMessage)):
(TestWebKitAPI::TEST(WKWebExtensionContext, ConsoleAssertWithoutMessage)):

Canonical link: <a href="https://commits.webkit.org/311251@main">https://commits.webkit.org/311251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ecc077c0232cc8fbfd2c2906ac5b6560357e9db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165178 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158228 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29825 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121086 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140411 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101757 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22374 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20543 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12950 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167660 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19855 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129211 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129323 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29215 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140036 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87011 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23821 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24148 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16835 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28925 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28451 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28679 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->