### PR TITLE
Unregister service worker registrations with missing main script

### DIFF
--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -613,7 +613,7 @@ std::optional<ServiceWorkerScripts> SWRegistrationDatabase::retrieveWorkerScript
 {
     auto mainScript = scriptStorage().retrieve(registrationKey, mainScriptURL);
     if (!mainScript) {
-        RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::retrieveWorkerScripts failed to retrieve main script from disk");
+        RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::retrieveWorkerScripts failed to retrieve main script from disk for service worker %" PRIu64, identifier.toUInt64());
         return std::nullopt;
     }
 
@@ -622,7 +622,7 @@ std::optional<ServiceWorkerScripts> SWRegistrationDatabase::retrieveWorkerScript
         if (auto script = scriptStorage().retrieve(registrationKey, scriptURL))
             importedScripts.add(scriptURL, WTF::move(script));
         else
-            RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::retrieveWorkerScripts failed to retrieve imported script from disk");
+            RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::retrieveWorkerScripts failed to retrieve imported script from disk for service worker %" PRIu64, identifier.toUInt64());
     }
 
     return ServiceWorkerScripts { identifier, WTF::move(mainScript), WTF::move(importedScripts) };

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -235,11 +235,11 @@ void SWServer::addRegistrationFromStore(ServiceWorkerContextData&& data, Complet
     });
 }
 
-void SWServer::loadWorkerScripts(const SWServerWorker& worker, CompletionHandler<void()>&& callback)
+void SWServer::loadWorkerScripts(const SWServerWorker& worker, CompletionHandler<void(bool)>&& callback)
 {
     RefPtr store = m_registrationStore;
     if (!store) {
-        callback();
+        callback(false);
         return;
     }
 
@@ -247,15 +247,29 @@ void SWServer::loadWorkerScripts(const SWServerWorker& worker, CompletionHandler
         [weakThis = WeakPtr { *this }, workerIdentifier = worker.identifier(), callback = WTF::move(callback)](auto&& result) mutable {
             RefPtr protectedThis = weakThis;
             if (!protectedThis)
-                return callback();
+                return callback(false);
 
-            if (RefPtr worker = protectedThis->workerByID(workerIdentifier)) {
-                if (result)
-                    worker->setWorkerScripts(WTF::move(result->mainScript), WTF::move(result->importedScripts));
-                else
-                    worker->didFailToLoadWorkerScripts();
+            bool success = !!result;
+            auto scope = makeScopeExit([&] {
+                callback(success);
+            });
+
+            RefPtr worker = protectedThis->workerByID(workerIdentifier);
+            if (!worker)
+                return;
+
+            if (!success) {
+                if (RefPtr registration = worker->registration()) {
+                    RELEASE_LOG_ERROR(ServiceWorker, "Unregistering registration %" PRIu64 " due to worker script retrieval failure", registration->identifier().toUInt64());
+                    auto contextIdentifier = ServiceWorkerIdentifier::generate();
+                    ServiceWorkerJobDataIdentifier jobIdentifier { Process::identifier(), ServiceWorkerJobIdentifier::generate() };
+                    protectedThis->scheduleUnregisterJob(jobIdentifier, *registration, contextIdentifier, registration->scriptURL());
+                }
+                worker->didFailToLoadWorkerScripts();
+                return;
             }
-            callback();
+
+            worker->setWorkerScripts(WTF::move(result->mainScript), WTF::move(result->importedScripts));
         });
 }
 
@@ -1086,9 +1100,9 @@ void SWServer::runServiceWorkerIfNecessary(SWServerWorker& worker, RunServiceWor
     }
 
     if (worker.needsScriptLoading()) {
-        loadWorkerScripts(worker, [weakThis = WeakPtr { *this }, identifier = worker.identifier(), callback = WTF::move(callback)]() mutable {
+        loadWorkerScripts(worker, [weakThis = WeakPtr { *this }, identifier = worker.identifier(), callback = WTF::move(callback)](bool success) mutable {
             RefPtr protectedThis = weakThis;
-            if (!protectedThis)
+            if (!protectedThis || !success)
                 return callback(nullptr);
             protectedThis->runServiceWorkerIfNecessary(identifier, WTF::move(callback));
         });

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -236,7 +236,7 @@ public:
     void registrationStoreImportComplete();
     void registrationStoreDatabaseFailedToOpen();
     void storeRegistrationForWorker(SWServerWorker&);
-    void loadWorkerScripts(const SWServerWorker&, CompletionHandler<void()>&&);
+    void loadWorkerScripts(const SWServerWorker&, CompletionHandler<void(bool)>&&);
 
     WEBCORE_EXPORT void getOriginsWithRegistrations(CompletionHandler<void(const HashSet<SecurityOriginData>&)>&&);
 

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
@@ -100,7 +100,7 @@ void SWServerJobQueue::scriptFetchFinished(const ServiceWorkerJobDataIdentifier&
 
     // If the newest worker needs script loading (lazy import from store), load scripts before comparison.
     if (newestWorker && newestWorker->needsScriptLoading()) {
-        server->loadWorkerScripts(*newestWorker, [weakThis = WeakPtr { *this }, jobDataIdentifier, requestingProcessIdentifier, result = WTF::move(result)]() mutable {
+        server->loadWorkerScripts(*newestWorker, [weakThis = WeakPtr { *this }, jobDataIdentifier, requestingProcessIdentifier, result = WTF::move(result)](auto) mutable {
             if (CheckedPtr checkedThis = weakThis.get())
                 checkedThis->scriptFetchFinished(jobDataIdentifier, requestingProcessIdentifier, WTF::move(result));
         });

--- a/Source/WebCore/workers/service/server/SWServerRegistration.cpp
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.cpp
@@ -233,6 +233,8 @@ bool SWServerRegistration::tryClear()
 // https://w3c.github.io/ServiceWorker/#clear-registration
 void SWServerRegistration::clear()
 {
+    RELEASE_LOG(ServiceWorker, "SWServerRegistration::clear %" PRIu64, identifier().toUInt64());
+
     if (RefPtr preInstallationWorker = m_preInstallationWorker) {
         ASSERT(preInstallationWorker->state() == ServiceWorkerState::Parsed);
         preInstallationWorker->terminate();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -825,6 +825,86 @@ TEST(ServiceWorkers, UpdateCheckAfterRestoreFromDisk)
     done = false;
 }
 
+TEST(ServiceWorkers, CheckRegistrationWithoutScript)
+{
+    [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
+
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    RetainPtr<SWMessageHandlerForRestoreFromDiskTest> messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration was successful and service worker was activated"]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
+
+    TestWebKitAPI::HTTPServer server({
+        { "/scope/first.html"_s, { mainRegisteringWorkerInScopeBytes } },
+        { "/scope/second.html"_s, { mainUpdatingRestoredWorkerBytes } },
+        { "/scope/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+    });
+
+    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    // Register a service worker under /scope/ and wait for it to activate.
+    [webView loadRequest:server.request("/scope/first.html"_s)];
+    TestWebKitAPI::Util::run(&done);
+
+    // Flush registrations to disk and terminate the network process so that Phase 2 will
+    // import registrations from disk (with lazy script loading) in a fresh network process.
+    [[WKWebsiteDataStore defaultDataStore] _storeServiceWorkerRegistrations:^{
+        done = true;
+    }];
+    done = false;
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    webView = nullptr;
+    configuration = nullptr;
+    messageHandler = nullptr;
+
+    // Verify there is a registration
+    RetainPtr websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeServiceWorkerRegistrations]]);
+    done = false;
+    [[WKWebsiteDataStore defaultDataStore] fetchDataRecordsOfTypes:websiteDataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
+        EXPECT_EQ(1U, dataRecords.count);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    [[WKWebsiteDataStore defaultDataStore] _terminateNetworkProcess];
+
+    // We remove the registration script stored on disk. We do this by finding the Scripts folders and removing them.
+    NSURL *path = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/Default/" stringByExpandingTildeInPath]];
+    NSDirectoryEnumerator *enumerator = [[NSFileManager defaultManager] enumeratorAtURL:path includingPropertiesForKeys:@[NSURLIsDirectoryKey] options:NSDirectoryEnumerationSkipsHiddenFiles errorHandler:nil];
+    for (NSURL *url in enumerator) {
+        NSNumber *isDirectory;
+        [url getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:nil];
+        if ([isDirectory boolValue] && [[url lastPathComponent] isEqualToString:@"Scripts"])
+            [[NSFileManager defaultManager] removeItemAtURL:url error:nil];
+    }
+
+    // Create a new web view, restoring registration from disk with lazy script loading.
+    // Try launching the service worker, removal of script should trigger unregistration of the service worker.
+    configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"FAIL: No registrations found"]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
+
+    done = false;
+    webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadRequest:server.request("/scope/second.html"_s)];
+    TestWebKitAPI::Util::run(&done);
+
+    done = false;
+    [[WKWebsiteDataStore defaultDataStore] fetchDataRecordsOfTypes:websiteDataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
+        EXPECT_EQ(0U, dataRecords.count);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
 static constexpr auto scriptBytesWithFetchSupport = R"SWRESOURCE(
 
 self.addEventListener("message", (event) => {


### PR DESCRIPTION
#### dc17abd7018a7b8122b9f199584390e60778de7d
<pre>
Unregister service worker registrations with missing main script
<a href="https://rdar.apple.com/174755909">rdar://174755909</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312287">https://bugs.webkit.org/show_bug.cgi?id=312287</a>

Reviewed by Chris Dumez.

As seen in logs, service worker database may have registrations with missing service worker scripts.
In that case, it is best to clear the registration as we cannot run properly the service worker.
The web page is then expected to reregister the service worker as needed.

We implement this by having a load script callback returning true or false.
In case of failure, we schedule an unregister job.

We add some logging to help further diagnose.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
Canonical link: <a href="https://commits.webkit.org/311301@main">https://commits.webkit.org/311301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2e292b4cd24a4b403af9c42cb18c2637411603b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165410 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121282 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101949 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20751 "Build is in progress. Recent messages:") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13182 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18449 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167893 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12013 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129396 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129506 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35078 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87249 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24332 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17045 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29155 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93120 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28681 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28911 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28806 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->