### PR TITLE
[JSC] test262 failure: test/staging/sm/extensions/DataView-construct-arguments-detaching.js

### DIFF
--- a/JSTests/stress/dataview-constructor-bug-311903-weird-bytelength-detach-buffer.js
+++ b/JSTests/stress/dataview-constructor-bug-311903-weird-bytelength-detach-buffer.js
@@ -1,0 +1,51 @@
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const TEST_TARGET = [
+    DataView,
+];
+
+for (const targetCtor of TEST_TARGET) {
+    const name = targetCtor.name;
+    const label = name;
+
+    const buffer = new ArrayBuffer(4096);
+    const byteLength = {
+        valueOf: function () {
+            $.detachArrayBuffer(buffer);
+            $.gc();
+            return 2048;
+        }
+    };
+
+    //  By the spec (ECMA-262/April 10, 2026),
+    //
+    //  This behavior is deduced from the step 9 ~ 11 of the section _25.3.2.1_.
+    //  https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength
+    shouldThrow(`${label}: throw as expected`, () => {
+        new targetCtor(buffer, 2048, byteLength);
+    }, TypeError, 'Buffer is already detached');
+    sameValue(buffer.detached, true, `${label}: arrayBuffer is detached as expectedly`);
+    // The detached ArrayBuffer.byteLength should be set to 0.
+    //
+    //  - https://tc39.es/ecma262/#sec-detacharraybuffer
+    //  - https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength
+    sameValue(buffer.byteLength, 0, `${label}: arrayBuffer.byteLength is 0`);
+}

--- a/JSTests/stress/dataview-constructor-bug-311903-weird-byteoffset-detach-buffer.js
+++ b/JSTests/stress/dataview-constructor-bug-311903-weird-byteoffset-detach-buffer.js
@@ -1,0 +1,49 @@
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const TEST_TARGET = [
+    DataView,
+];
+
+for (const targetCtor of TEST_TARGET) {
+    const name = targetCtor.name;
+    const buffer = new ArrayBuffer(0x1000);
+    const byteOffset = {
+        valueOf: function () {
+            $.detachArrayBuffer(buffer);
+            $.gc();
+            return 0x800;
+        }
+    };
+
+    //  By the spec (ECMA-262/April 10, 2026),
+    //
+    //  This behavior is deduced from the step 3 ~ 4 of the section _25.3.2.1_ of the spec (ECMA-262/April 10, 2026)
+    //  https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength
+    shouldThrow(`${name}: should throw as the arrayBuffer is detached`, () => {
+        new targetCtor(buffer, byteOffset);
+    }, TypeError, 'Buffer is already detached');
+    sameValue(buffer.detached, true, `${name}: arrayBuffer is detached as expectedly`);
+    // The detached ArrayBuffer.byteLength should be set to 0.
+    //
+    //  - https://tc39.es/ecma262/#sec-detacharraybuffer
+    //  - https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength
+    sameValue(buffer.byteLength, 0, `${name}: arrayBuffer.byteLength is 0`);
+}

--- a/JSTests/stress/typedarray-constructor-bug-311903-weird-bytelength-detach-buffer.js
+++ b/JSTests/stress/typedarray-constructor-bug-311903-weird-bytelength-detach-buffer.js
@@ -1,0 +1,65 @@
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const targetCtor of TEST_TARGET) {
+    const name = targetCtor.name;
+    const label = name;
+
+    const buffer = new ArrayBuffer(4096);
+    const byteLength = {
+        valueOf: function () {
+            $.detachArrayBuffer(buffer);
+            $.gc();
+            return 2048;
+        }
+    };
+
+    //  By the spec (ECMA-262/April 10, 2026),
+    //  This behavior is deduced from the step 6 of
+    //  the section [23.2.5.1.3 InitializeTypedArrayFromArrayBuffer ( O, buffer, byteOffset, length )][initializetypedarrayfromarraybuffer],
+    //  which is called from the step 7-c-iii of the section [23.2.5.1 TypedArray ( ...args )][typedarray].
+    //
+    //  [initializetypedarrayfromarraybuffer]: https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer
+    //  [typedarray]: https://tc39.es/ecma262/#sec-typedarray
+    shouldThrow(`${label}: throw as expected`, () => {
+        new targetCtor(buffer, 2048, byteLength);
+    }, TypeError, 'Buffer is already detached');
+    sameValue(buffer.detached, true, `${label}: arrayBuffer is detached as expectedly`);
+    // The detached ArrayBuffer.byteLength should be set to 0.
+    //
+    //  - https://tc39.es/ecma262/#sec-detacharraybuffer
+    //  - https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength
+    sameValue(buffer.byteLength, 0, `${label}: arrayBuffer.byteLength is 0`);
+}

--- a/JSTests/stress/typedarray-constructor-bug-311903-weird-byteoffset-detach-buffer.js
+++ b/JSTests/stress/typedarray-constructor-bug-311903-weird-byteoffset-detach-buffer.js
@@ -1,0 +1,63 @@
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const targetCtor of TEST_TARGET) {
+    const name = targetCtor.name;
+    const buffer = new ArrayBuffer(0x1000);
+    const byteOffset = {
+        valueOf: function () {
+            $.detachArrayBuffer(buffer);
+            $.gc();
+            return 0x800;
+        }
+    };
+
+    //  By the spec (ECMA-262/April 10, 2026),
+    //  This behavior is deduced from the step 6 of
+    //  the section [23.2.5.1.3 InitializeTypedArrayFromArrayBuffer ( O, buffer, byteOffset, length )][initializetypedarrayfromarraybuffer],
+    //  which is called from the step 7-c-iii of the section [23.2.5.1 TypedArray ( ...args )][typedarray].
+    //
+    //  [initializetypedarrayfromarraybuffer]: https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer
+    //  [typedarray]: https://tc39.es/ecma262/#sec-typedarray
+    shouldThrow(`${name}: should throw as the arrayBuffer is detached`, () => {
+        new targetCtor(buffer, byteOffset);
+    }, TypeError, 'Buffer is already detached');
+    sameValue(buffer.detached, true, `${name}: arrayBuffer is detached as expectedly`);
+    // The detached ArrayBuffer.byteLength should be set to 0.
+    //
+    //  - https://tc39.es/ecma262/#sec-detacharraybuffer
+    //  - https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength
+    sameValue(buffer.byteLength, 0, `${name}: arrayBuffer.byteLength is 0`);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -920,9 +920,6 @@ test/staging/sm/expressions/object-literal-computed-property-evaluation.js:
 test/staging/sm/expressions/short-circuit-compound-assignment-anon-fns.js:
   default: 'Test262Error: Expected SameValue(«"a"», «""») to be true'
   strict mode: 'Test262Error: Expected SameValue(«"a"», «""») to be true'
-test/staging/sm/extensions/DataView-construct-arguments-detaching.js:
-  default: 'Test262Error: byteOffset weirdness should have thrown Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: byteOffset weirdness should have thrown Expected a TypeError but got a RangeError'
 test/staging/sm/extensions/function-caller-skips-eval-frames.js:
   default: 'Test262Error: Expected SameValue(«null», «function nest() { return eval("innermost();"); }») to be true'
 test/staging/sm/extensions/new-cross-compartment.js:

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -37,6 +37,7 @@
 #include "JSGlobalObject.h"
 #include "JSTypedArrays.h"
 #include "StructureInlines.h"
+#include <wtf/text/ASCIILiteral.h>
 
 namespace JSC {
 
@@ -111,6 +112,8 @@ inline JSObject* constructGenericTypedArrayViewFromIterator(JSGlobalObject* glob
     return result;
 }
 
+constinit const ASCIILiteral typedArrayErrorMessageBufferIsAlreadyDetached = "Buffer is already detached"_s;
+
 template<typename ViewClass>
 inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* globalObject, Structure* structure, JSValue firstValue, size_t offset, std::optional<size_t> lengthOpt)
 {
@@ -121,7 +124,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
     if (JSArrayBuffer* jsBuffer = jsDynamicCast<JSArrayBuffer*>(firstValue)) {
         RefPtr<ArrayBuffer> buffer = jsBuffer->impl();
         if (buffer->isDetached()) {
-            throwTypeError(globalObject, scope, "Buffer is already detached"_s);
+            throwTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
             return nullptr;
         }
 
@@ -275,6 +278,11 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
 
             if constexpr (ViewClass::TypedArrayStorageType == TypeDataView) {
                 RefPtr<ArrayBuffer> buffer = arrayBuffer->impl();
+                if (buffer->isDetached()) [[unlikely]] {
+                    throwVMTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
+                    RETURN_IF_EXCEPTION(scope, { });
+                }
+
                 if (offset > buffer->byteLength()) [[unlikely]] {
                     throwRangeError(globalObject, scope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
                     RETURN_IF_EXCEPTION(scope, { });

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CloseWebViewAfterEnterFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CloseWebViewAfterEnterFullscreen.mm
@@ -77,6 +77,8 @@ TEST(CloseWebViewAfterEnterFullscreen, VideoFullscreen)
     [webView _close];
 
     TestWebKitAPI::Util::run(&didExitFullscreen);
+
+    TestWebKitAPI::Util::runFor(0.5_s);
 }
 
 TEST(CloseWebViewAfterEnterFullscreen, ElementFullscreen)
@@ -99,6 +101,8 @@ TEST(CloseWebViewAfterEnterFullscreen, ElementFullscreen)
     [webView _close];
 
     TestWebKitAPI::Util::run(&didExitFullscreen);
+
+    TestWebKitAPI::Util::runFor(0.5_s);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 9b78bb8b0e74b98ba7ddabd484c879b1d0446db1
<pre>
[JSC] test262 failure: test/staging/sm/extensions/DataView-construct-arguments-detaching.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=311903">https://bugs.webkit.org/show_bug.cgi?id=311903</a>

Reviewed by Yusuke Suzuki.

By the spec (ECMA-262/April 10, 2026),
on invoking `new DataView(buffer, byteOffset)`,
if the 2nd argument `byteOffset` detachs `buffer` in `ToIndex(byteOffset)` step,
it should throw TypeError caused by buffer *first* is detached rather than RangeError
about `offset &gt; bufferByteLength`.

This corresponds to step 3 &amp; 4 of the section _25.3.2.1_ of the spec.
<a href="https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength">https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength</a>

-----

`DataView` and other TypedArrays&apos;s constructors behave different spec mechanism,
but they behave similarly and we share a part of underlying implementations.
This patch adds some tests:

1. `new DataView(buffer, byteOffset)` but `ToIndex(byteOffset)` detach the `buffer`.
    This fix this test&apos;s result. Without this change, JSC fails this test.

2. `new DataView(buffer, byteOffset, byteLength)` but `ToIndex(byteOffset)` detach the `buffer`.
    This is a later part of test/staging/sm/extensions/DataView-construct-arguments-detaching.js.
    as a regression test.
    JSC passes this test without this fix

3. `new SomeTypedArray(buffer, byteOffset)` but `ToIndex(byteOffset)` detach the `buffer`.
    This is just for regression test to keep the exist implementation which shares many parts with `DataView`&apos;s one.
    JSC passes this test without this fix

4. `new SomeTypedArray(buffer, byteOffset, byteLength)` but `ToIndex(byteLength)` detach the `buffer`.
    This is just for regression test to keep the exist implementation which shares many parts with `DataView`&apos;s one.
    JSC passes this test without this fix.

Tests: JSTests/stress/dataview-constructor-bug-311903-weird-bytelength-detach-buffer.js
       JSTests/stress/dataview-constructor-bug-311903-weird-byteoffset-detach-buffer.js
       JSTests/stress/typedarray-constructor-bug-311903-weird-bytelength-detach-buffer.js
       JSTests/stress/typedarray-constructor-bug-311903-weird-byteoffset-detach-buffer.js

Canonical link: <a href="https://commits.webkit.org/311188@main">https://commits.webkit.org/311188@main</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b78bb8b0e74b98ba7ddabd484c879b1d0446db1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29702 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/165188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/158238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/29835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29705 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/165188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/159325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/29835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/22884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/165188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/155686 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/29835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/12960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/148417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/29835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/22884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/17202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/167670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/29225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/22884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/29225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/188250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/28935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/92891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/188250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28461 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->