### PR TITLE
Consider all shorthands when removing equivalent properties from styles

### DIFF
--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1618,14 +1618,14 @@ void EditingStyle::removeEquivalentProperties(T& style)
         if (!style.propertyMatches(property.id(), RefPtr { property.value() }.get()))
             continue;
 
-        // Only the text-decoration longhands support serializing with the shorthand in all editing properties.
+        // If this property was not set as part of a shorthand, it can be removed independently.
         auto shorthandID = property.shorthandID();
-        if (shorthandID != CSSPropertyTextDecoration) {
+        if (shorthandID == CSSPropertyInvalid) {
             propertiesToRemove.append(property.id());
             continue;
         }
 
-        // Do not remove equivalent properties when they share a shorthand with non-equivalent ones, and the removal would prevent them from being serialized with the shorthand.
+        // Do not remove equivalent properties when they share a shorthand with non-equivalent ones, as the removal would prevent them from being serialized with the shorthand.
         if (mutableStyle->getPropertyValue(shorthandID).isEmpty()) {
             propertiesToRemove.append(property.id());
             continue;


### PR DESCRIPTION
#### cae5f17a5d75e4f4d121a7dda5744852b0e348c8
<pre>
Consider all shorthands when removing equivalent properties from styles
<a href="https://bugs.webkit.org/show_bug.cgi?id=312294">https://bugs.webkit.org/show_bug.cgi?id=312294</a>
<a href="https://rdar.apple.com/174763127">rdar://174763127</a>

Reviewed by NOBODY (OOPS!).

We were previously only considering text-decoration, but we may want to also consider white-space now that it is a shorthand.

* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::removeEquivalentProperties):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cae5f17a5d75e4f4d121a7dda5744852b0e348c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165197 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110456 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29714 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121101 "Found 3 new test failures: cssom/cssvalue-comparison.html editing/deleting/paste-with-transparent-background-color-live-range.html editing/deleting/paste-with-transparent-background-color.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85142 "3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159334 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23319 "Found 2 new test failures: cssom/cssvalue-comparison.html editing/deleting/paste-with-transparent-background-color-live-range.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101772 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22386 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20559 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12969 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132062 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167679 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11792 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19869 "Found 3 new test failures: cssom/cssvalue-comparison.html editing/deleting/paste-with-transparent-background-color-live-range.html editing/deleting/paste-with-transparent-background-color.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129226 "Found 3 new test failures: cssom/cssvalue-comparison.html editing/deleting/paste-with-transparent-background-color-live-range.html editing/deleting/paste-with-transparent-background-color.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29312 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24626 "Found 3 new test failures: cssom/cssvalue-comparison.html editing/deleting/paste-with-transparent-background-color-live-range.html editing/deleting/paste-with-transparent-background-color.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129338 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140050 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87030 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24161 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16849 "Found 3 new test failures: cssom/cssvalue-comparison.html editing/deleting/paste-with-transparent-background-color-live-range.html editing/deleting/paste-with-transparent-background-color.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92900 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28470 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28698 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28594 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->