### PR TITLE
WebKitTestRunner leaks WKTypeRef out-parameter value from WKBundlePagePostSynchronousMessageForTesting()

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -203,7 +203,7 @@ bool InjectedBundle::shouldForceRepaint() const
 {
     WKTypeRef result = nullptr;
     WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("ShouldForceRepaint").get(), nullptr, &result);
-    return booleanValue(result);
+    return booleanValue(adoptWK(result).get());
 }
 
 void InjectedBundle::reportLiveDocuments(WKBundlePageRef page)
@@ -514,7 +514,7 @@ WKRetainPtr<WKStringRef> InjectedBundle::getBackgroundFetchIdentifier()
 {
     WKTypeRef result = nullptr;
     WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("GetBackgroundFetchIdentifier").get(), 0, &result);
-    return static_cast<WKStringRef>(result);
+    return adoptWK(static_cast<WKStringRef>(result));
 }
 
 unsigned InjectedBundle::imageCountInGeneralPasteboard() const
@@ -593,7 +593,7 @@ bool InjectedBundle::isPrinting() const
 {
     WKTypeRef result = nullptr;
     WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("GetIsPrinting").get(), nullptr, &result);
-    return booleanValue(result);
+    return booleanValue(adoptWK(result).get());
 }
 
 void InjectedBundle::processWorkQueue()
@@ -669,28 +669,28 @@ WKRetainPtr<WKStringRef> InjectedBundle::lastAddedBackgroundFetchIdentifier() co
 {
     WKTypeRef result = nullptr;
     WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("LastAddedBackgroundFetchIdentifier").get(), 0, &result);
-    return static_cast<WKStringRef>(result);
+    return adoptWK(static_cast<WKStringRef>(result));
 }
 
 WKRetainPtr<WKStringRef> InjectedBundle::lastRemovedBackgroundFetchIdentifier() const
 {
     WKTypeRef result = nullptr;
     WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("LastRemovedBackgroundFetchIdentifier").get(), 0, &result);
-    return static_cast<WKStringRef>(result);
+    return adoptWK(static_cast<WKStringRef>(result));
 }
 
 WKRetainPtr<WKStringRef> InjectedBundle::lastUpdatedBackgroundFetchIdentifier() const
 {
     WKTypeRef result = nullptr;
     WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("LastUpdatedBackgroundFetchIdentifier").get(), 0, &result);
-    return static_cast<WKStringRef>(result);
+    return adoptWK(static_cast<WKStringRef>(result));
 }
 
 WKRetainPtr<WKStringRef> InjectedBundle::backgroundFetchState(WKStringRef identifier)
 {
     WKTypeRef result = nullptr;
     WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("BackgroundFetchState").get(), identifier, &result);
-    return static_cast<WKStringRef>(result);
+    return adoptWK(static_cast<WKStringRef>(result));
 }
 
 void InjectedBundle::textDidChangeInTextField()


### PR DESCRIPTION
#### 112967a3c973c63c1bc702ee534c24b6b3090cbe
<pre>
WebKitTestRunner leaks WKTypeRef out-parameter value from WKBundlePagePostSynchronousMessageForTesting()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=312296">https://bugs.webkit.org/show_bug.cgi?id=312296</a>&gt;
&lt;<a href="https://rdar.apple.com/174764247">rdar://174764247</a>&gt;

Reviewed by Charlie Wolfe.

Adopt the +1 retained `WKTypeRef` returned via the out-parameter of
`WKBundlePagePostSynchronousMessageForTesting()`.  The C API
implementation uses `toAPILeakingRef()` to transfer ownership to
the caller, but seven callers in `InjectedBundle.cpp` never adopt
or release the result.

* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::shouldForceRepaint const):
(WTR::InjectedBundle::getBackgroundFetchIdentifier):
(WTR::InjectedBundle::isPrinting const):
(WTR::InjectedBundle::lastAddedBackgroundFetchIdentifier const):
(WTR::InjectedBundle::lastRemovedBackgroundFetchIdentifier const):
(WTR::InjectedBundle::lastUpdatedBackgroundFetchIdentifier const):
(WTR::InjectedBundle::backgroundFetchState):

Canonical link: <a href="https://commits.webkit.org/311347@main">https://commits.webkit.org/311347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8517fc019cf01e3bbfcc398c57c55e9600f55421

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110460 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121106 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85143 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101777 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22391 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20564 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12973 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167683 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129230 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129342 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140055 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87034 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23856 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24166 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16854 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28948 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28474 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28702 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->