### PR TITLE
prepare-commit-msg: add unit test for git hook's get_bugs_string() to prevent future regressions

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/prepare_commit_msg_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/prepare_commit_msg_unittest.py
@@ -1,0 +1,152 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Regression tests for the prepare-commit-msg git hook.
+
+Prevents removal of radar.Tracker.RES from breaking get_bugs_string().
+See: https://bugs.webkit.org/show_bug.cgi?id=312300
+     https://commits.webkit.org/311158@main (follow-up fix)
+"""
+
+import importlib.machinery
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+
+from unittest.mock import MagicMock, patch
+
+from webkitbugspy import mocks as bugspy_mocks
+from webkitcorepy import testing
+
+
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPTS_DIR = _TEST_DIR[:_TEST_DIR.rindex(os.sep + os.path.join('Tools', 'Scripts') + os.sep)] + os.sep + os.path.join('Tools', 'Scripts')
+_HOOKS_DIR = os.path.join(_SCRIPTS_DIR, 'hooks')
+_HOOK_TEMPLATE = os.path.join(_HOOKS_DIR, 'prepare-commit-msg')
+
+
+def _render_hook_template():
+    """Render the prepare-commit-msg Jinja2 template into valid Python.
+
+    Uses the same template variables as InstallHooks.main()
+    (see webkitscmpy/program/install_hooks.py).
+    """
+    from jinja2 import Template
+
+    with open(_HOOK_TEMPLATE, 'r') as f:
+        return Template(f.read()).render(
+            location='Tools/Scripts/hooks/prepare-commit-msg',
+            perl=repr(shutil.which('perl') or '/usr/bin/perl'),
+            python=os.path.basename(sys.executable),
+            prefer_radar=True,
+            default_branch='main',
+            source_remotes=['origin'],
+            trailers_to_strip=[],
+        )
+
+
+class TestGetBugsString(testing.PathTestCase):
+    """Regression tests for prepare-commit-msg get_bugs_string().
+
+    Loads the real hook template via jinja2 + importlib.util and tests
+    get_bugs_string() to ensure radar.Tracker.RES is present and
+    correctly matches radar URL formats.
+
+    See: https://bugs.webkit.org/show_bug.cgi?id=312300
+    """
+    basepath = 'mock/prepare-commit-msg'
+
+    def setUp(self):
+        super(TestGetBugsString, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        # Ensure webkitpy is importable (hook imports DiffParser at module level)
+        if _SCRIPTS_DIR not in sys.path:
+            sys.path.insert(0, _SCRIPTS_DIR)
+
+    def _load_hook_module(self):
+        """Load the rendered hook as a Python module via importlib.util.
+
+        Mocks subprocess.run for the module-level git rev-parse call.
+
+        FIXME: Replace the subprocess.run patch with mocks.local.Git(cwd=None)
+        once mocks.local.Git supports a cwd parameter. Currently all 83 route
+        definitions in webkitscmpy/mocks/local/git.py use cwd=self.path, so
+        they don't match subprocess calls made without an explicit cwd. To fix:
+        1. Add a cwd=_UNSET parameter to Git.__init__()
+        2. Store self._route_cwd = self.path if cwd is _UNSET else cwd
+        3. Replace all 83 cwd=self.path with cwd=self._route_cwd in routes
+        """
+        rendered_source = _render_hook_template()
+
+        tmp_path = os.path.join(self.path, 'prepare-commit-msg.py')
+        with open(tmp_path, 'w') as f:
+            f.write(rendered_source)
+
+        spec = importlib.util.spec_from_file_location(
+            'prepare_commit_msg', tmp_path,
+            loader=importlib.machinery.SourceFileLoader('prepare_commit_msg', tmp_path))
+        module = importlib.util.module_from_spec(spec)
+
+        original_run = subprocess.run
+
+        def _mock_run(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get('args', [])
+            if cmd[:3] == ['git', 'rev-parse', '--show-toplevel']:
+                mock_result = MagicMock()
+                mock_result.stdout = self.path
+                return mock_result
+            return original_run(*args, **kwargs)
+
+        with patch('subprocess.run', side_effect=_mock_run):
+            spec.loader.exec_module(module)
+
+        return module
+
+    def test_radar_url_detected(self):
+        """get_bugs_string() detects radar URLs via radar.Tracker.RES."""
+        hook = self._load_hook_module()
+        with patch.dict(os.environ, {'COMMIT_MESSAGE_BUG': 'rdar://problem/123456'}), \
+                bugspy_mocks.Radar():
+            result = hook.get_bugs_string()
+        self.assertEqual(result, 'rdar://problem/123456')
+
+    def test_non_radar_url_prompts_for_radar(self):
+        """Non-radar bug URL with radarclient available prompts for radar."""
+        hook = self._load_hook_module()
+        bug_url = 'https://bugs.webkit.org/show_bug.cgi?id=12345'
+        with patch.dict(os.environ, {'COMMIT_MESSAGE_BUG': bug_url}), \
+                bugspy_mocks.Radar():
+            result = hook.get_bugs_string()
+        self.assertEqual(result, bug_url + '\nInclude a Radar link (OOPS!).')
+
+    def test_no_bug_url(self):
+        """No COMMIT_MESSAGE_BUG with radarclient available shows both prompts."""
+        hook = self._load_hook_module()
+        env = os.environ.copy()
+        env.pop('COMMIT_MESSAGE_BUG', None)
+        with patch.dict(os.environ, env, clear=True), \
+                bugspy_mocks.Radar():
+            result = hook.get_bugs_string()
+        self.assertEqual(result, 'Need the bug URL (OOPS!).\nInclude a Radar link (OOPS!).')


### PR DESCRIPTION
#### 97f987bedded3529cdda458f3436a6958910af0f
<pre>
prepare-commit-msg: add unit test for git hook&apos;s get_bugs_string() to prevent future regressions
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=312300">https://bugs.webkit.org/show_bug.cgi?id=312300</a>&gt;
&lt;<a href="https://rdar.apple.com/174765471">rdar://174765471</a>&gt;

Reviewed by Jonathan Bedard.

Add regression tests for `get_bugs_string()` function in
the `prepare-commit-msg` git hook, which references
`radar.Tracker.RES` to detect radar URLs in commit messages.

Commit 311151@main accidentally removed the `RES` attribute during a
refactor, breaking the hook with an `AttributeError`. Commit
311158@main restored it, but no test existed to prevent
recurrence.

The test renders the real `prepare-commit-msg` Jinja2 template using the
same variables as `InstallHooks.main()`, loads the result via
`importlib.util`, and exercises `get_bugs_string()` under three
scenarios: radar URL present, non-radar URL present, and no URL
set.  Use `mocks.Radar()` so `radarclient()` returns a truthy
value, ensuring the `has_radar` code path through
`radar.Tracker.RES` is actually exercised.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/prepare_commit_msg_unittest.py: Add.
(TestGetBugsString):
(TestGetBugsString.setUp):
(TestGetBugsString._load_hook_module):
(TestGetBugsString.test_radar_url_detected):
(TestGetBugsString.test_non_radar_url_prompts_for_radar):
(TestGetBugsString.test_no_bug_url):

Canonical link: <a href="https://commits.webkit.org/311223@main">https://commits.webkit.org/311223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed238e8501aef53ec72ddd8a8733f0eac0591573

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165208 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29726 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159345 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101781 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/155706 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12980 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167690 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19881 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/155785 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29323 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129346 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140062 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23808 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/24173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28955 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28481 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28605 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->