### PR TITLE
AX: Opendeck crashes webkitgtk with Orca running

### DIFF
--- a/LayoutTests/accessibility/gtk/text-attribute-empty-li-expected.txt
+++ b/LayoutTests/accessibility/gtk/text-attribute-empty-li-expected.txt
@@ -1,0 +1,10 @@
+option
+Retrieving text attributes for a list item with role='option' should not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/gtk/text-attribute-empty-li.html
+++ b/LayoutTests/accessibility/gtk/text-attribute-empty-li.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body id="body">
+<ul>
+<li id="option" role="option">option</li>
+</ul>
+<div id="console"></div>
+<script>
+ description("Retrieving text attributes for a list item with role='option' should not crash.");
+
+ if (window.accessibilityController) {
+     var option = accessibilityController.accessibleElementById("option");
+     var optionRuns = option.attributedStringForRange(0, 6);
+ }
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -838,7 +838,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
     if (!m_coreObject->node())
         return { WTF::move(defaultAttributes), -1, -1 };
 
-    if (!*utf16Offset && m_hasListMarkerAtStart) {
+    if (!*utf16Offset && m_hasListMarkerAtStart && !m_coreObject->children().isEmpty()) {
         // Always consider list marker an independent run.
         auto attributes = accessibilityTextAttributes(m_coreObject->children()[0].get(), defaultAttributes);
         if (!includeDefault)


### PR DESCRIPTION
#### 500ca457c0fd7079aefc96f5579b131e1eedb288
<pre>
AX: Opendeck crashes webkitgtk with Orca running
<a href="https://bugs.webkit.org/show_bug.cgi?id=311427">https://bugs.webkit.org/show_bug.cgi?id=311427</a>

Reviewed by Michael Catanzaro.

Check that the accessible has a child before accessing it.

* LayoutTests/accessibility/gtk/text-attribute-empty-li-expected.txt: Added.
* LayoutTests/accessibility/gtk/text-attribute-empty-li.html: Added.
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::textAttributes const):

Canonical link: <a href="https://commits.webkit.org/316720@main">https://commits.webkit.org/316720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0b5417657d848d81461d58efcb12e7dceb0f17c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134350 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94828 "2 flakes 21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36385 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34701 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30800 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184734 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143142 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143020 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47011 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31241 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111977 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26303 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38024 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118763 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45528 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9352 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44928 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45160 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->