### PR TITLE
[WTF][GLib] Building with Clang 22 produces -Wunsafe-buffer-usage-in-format-attr-call warning spam in sysprof code

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -421,24 +421,30 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
 #define WTFEmitSignpost(pointer, name, ...) \
     do { \
         IGNORE_WARNINGS_BEGIN("format-zero-length") \
+        IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-format-attr-call") \
         if (auto* annotator = SysprofAnnotator::singletonIfCreated()) \
             annotator->instantMark(std::span(_STRINGIFY(name)), "" __VA_ARGS__); \
+        IGNORE_WARNINGS_END \
         IGNORE_WARNINGS_END \
     } while (0)
 
 #define WTFBeginSignpost(pointer, name, ...) \
     do { \
         IGNORE_WARNINGS_BEGIN("format-zero-length") \
+        IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-format-attr-call") \
         if (auto* annotator = SysprofAnnotator::singletonIfCreated()) \
             annotator->beginMark(reinterpret_cast<const void*>(pointer), std::span(_STRINGIFY(name)), "" __VA_ARGS__); \
+        IGNORE_WARNINGS_END \
         IGNORE_WARNINGS_END \
     } while (0)
 
 #define WTFEndSignpost(pointer, name, ...)  \
     do { \
         IGNORE_WARNINGS_BEGIN("format-zero-length") \
+        IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-format-attr-call") \
         if (auto* annotator = SysprofAnnotator::singletonIfCreated()) \
             annotator->endMark(reinterpret_cast<const void*>(pointer), std::span(_STRINGIFY(name)), "" __VA_ARGS__); \
+        IGNORE_WARNINGS_END \
         IGNORE_WARNINGS_END \
     } while (0)
 
@@ -449,8 +455,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
 #define WTFEmitSignpostWithTimeDelta(pointer, name, timeDelta, ...) \
     do { \
         IGNORE_WARNINGS_BEGIN("format-zero-length") \
+        IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-format-attr-call") \
         if (auto* annotator = SysprofAnnotator::singletonIfCreated()) \
             annotator->mark(SysprofAnnotator::currentContinuousTime(timeDelta), std::span(_STRINGIFY(name)), "" __VA_ARGS__); \
+        IGNORE_WARNINGS_END \
         IGNORE_WARNINGS_END \
     } while (0)
 
@@ -464,8 +472,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
 #define WTFEmitSignpostWithSpecificTime(pointer, name, specificTime, ...) \
     do { \
         IGNORE_WARNINGS_BEGIN("format-zero-length") \
+        IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage-in-format-attr-call") \
         if (auto* annotator = SysprofAnnotator::singletonIfCreated()) \
             annotator->mark(specificTime, std::span(_STRINGIFY(name)), "" __VA_ARGS__); \
+        IGNORE_WARNINGS_END \
         IGNORE_WARNINGS_END \
     } while (0)
 

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -51,7 +51,9 @@ public:
     {
         va_list args;
         va_start(args, description);
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         sysprof_collector_mark_vprintf(SYSPROF_CAPTURE_CURRENT_TIME, 0, m_processName, name.data(), description, args);
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         va_end(args);
     }
 
@@ -59,7 +61,9 @@ public:
     {
         va_list args;
         va_start(args, description);
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         sysprof_collector_mark_vprintf(time, 0, m_processName, name.data(), description, args);
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         va_end(args);
     }
 
@@ -141,7 +145,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         } else {
             va_list args;
             va_start(args, description);
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             sysprof_collector_mark_vprintf(time, 0, m_processName, name.data(), description, args);
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             va_end(args);
         }
     }


### PR DESCRIPTION
#### 24453f37f6593abafa5fa1fb9a2ea5710f8efab1
<pre>
[WTF][GLib] Building with Clang 22 produces -Wunsafe-buffer-usage-in-format-attr-call warning spam in sysprof code
<a href="https://bugs.webkit.org/show_bug.cgi?id=312303">https://bugs.webkit.org/show_bug.cgi?id=312303</a>

Reviewed by Yusuke Suzuki.

Sprinkle WTF_IGNORE_WARNINGS_BEGIN in Sysprof code to avoid the compiler warnings.

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/glib/SysprofAnnotator.h:

Canonical link: <a href="https://commits.webkit.org/311265@main">https://commits.webkit.org/311265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7db2f8b6f486cb0e8f90b0f6768b91b4d2bf353

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110492 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121136 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101805 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22426 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20598 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13005 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148462 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167715 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17247 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11828 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129261 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129372 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35054 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140090 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87066 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24199 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16889 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92936 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48403 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28506 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->