### PR TITLE
[JSC] Add `VectorShr(VectorZipLower(x, x), 8)` strength reduction

### DIFF
--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3543,6 +3543,39 @@ private:
             break;
         }
 
+        case VectorShr: {
+            // Turn this: VectorShr(VectorZipLower(x, x), shiftAmount) where shr is Signed
+            // Into this: VectorExtendLow(x, lane, Signed)
+            //
+            // Turn this: VectorShr(VectorZipHigher(x, x), shiftAmount) where shr is Signed
+            // Into this: VectorExtendHigh(x, lane, Signed)
+            //
+            // VectorZip{Lower,Higher}(x, x) interleaves elements: [x[i],x[i],...]
+            // Interpreted as the wider lane and shifted right by the source element's bit width,
+            // this sign-extends the narrower element to the wider one.
+            //
+            // Supported combinations:
+            //   shr i16x8 by 8  + zip i8x16  -> i8->i16 sign extension
+            //   shr i32x4 by 16 + zip i16x8  -> i16->i32 sign extension
+            //   shr i64x2 by 32 + zip i32x4  -> i32->i64 sign extension
+            SIMDValue* shr = m_value->as<SIMDValue>();
+            if (shr->signMode() == SIMDSignMode::Signed) {
+                SIMDLane lane = shr->simdLane();
+                bool matches = (lane == SIMDLane::i16x8 && m_value->child(1)->isInt32(8))
+                    || (lane == SIMDLane::i32x4 && m_value->child(1)->isInt32(16))
+                    || (lane == SIMDLane::i64x2 && m_value->child(1)->isInt32(32));
+                if (matches) {
+                    Value* child0 = m_value->child(0);
+                    if ((child0->opcode() == VectorZipLower || child0->opcode() == VectorZipHigher) && child0->child(0) == child0->child(1)) {
+                        Opcode extendOp = child0->opcode() == VectorZipLower ? VectorExtendLow : VectorExtendHigh;
+                        replaceWithNew<SIMDValue>(m_value->origin(), extendOp, B3::V128, lane, SIMDSignMode::Signed, child0->child(0));
+                        break;
+                    }
+                }
+            }
+            break;
+        }
+
         case VectorDotProduct: {
             handleCommutativity();
 

--- a/Source/JavaScriptCore/b3/B3SIMDValue.cpp
+++ b/Source/JavaScriptCore/b3/B3SIMDValue.cpp
@@ -32,8 +32,13 @@ namespace JSC { namespace B3 {
 
 SIMDValue::~SIMDValue() = default;
 
-void SIMDValue::dumpMeta(CommaPrinter&, PrintStream&) const
+void SIMDValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {
+    out.print(comma, m_simdInfo.lane);
+    if (m_simdInfo.signMode != SIMDSignMode::None)
+        out.print(comma, m_simdInfo.signMode);
+    if (m_immediate)
+        out.print(comma, "imm = ", m_immediate);
 }
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1528,6 +1528,9 @@ void testFCCmpNegatedAndDouble(double, double, double, double);
 void testVectorXorRotateRight64();
 void testVectorXor3();
 void testVectorDotProductSplatOne();
+void testVectorShrZipToExtend();
+void testVectorShrZipToExtendI32();
+void testVectorShrZipToExtendI64();
 
 // SIMD VectorUnzip/Zip/Transpose/Reverse B3 opcodes
 void testVectorUnzipEven();

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1153,6 +1153,9 @@ void run(const TestConfig* config)
         RUN(testVectorMulHigh());
         RUN(testVectorMulLow());
         RUN(testVectorDotProductSplatOne());
+        RUN(testVectorShrZipToExtend());
+        RUN(testVectorShrZipToExtendI32());
+        RUN(testVectorShrZipToExtendI64());
         RUN_UNARY(testVectorXorOrAllOnesConstantToVectorAndXor, v128Operands());
         RUN_UNARY(testVectorXorAndAllOnesConstantToVectorOrXor, v128Operands());
         RUN_BINARY(testVectorOrConstants, v128Operands(), v128Operands());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -4714,6 +4714,259 @@ void testVectorSwizzleCompositionMultiUse()
         CHECK(vectors[3].u8x16[i] == 0x80 + i);
 }
 
+// Test VectorShr(VectorZip{Lower,Higher}(x, x), 8) → VectorExtend{Low,High}(x, i16x8, Signed)
+void testVectorShrZipToExtend()
+{
+    // Test ExtendLow: VectorShr(VectorZipLower(x, x), 8) → VectorExtendLow(x, i16x8, Signed)
+    {
+        alignas(16) v128_t vectors[2];
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<void*>(proc, root);
+        Value* address = arguments[0];
+        Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+        Value* shiftAmount = root->appendNew<Const32Value>(proc, Origin(), 8);
+
+        // VectorZipLower(input, input) on i8x16
+        Value* zipped = root->appendNew<SIMDValue>(proc, Origin(), VectorZipLower, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, input, input);
+        // VectorShr(zipped, 8) on i16x8 Signed
+        Value* shifted = root->appendNew<SIMDValue>(proc, Origin(), VectorShr, B3::V128, SIMDLane::i16x8, SIMDSignMode::Signed, zipped, shiftAmount);
+
+        root->appendNew<MemoryValue>(proc, Store, Origin(), shifted, address, static_cast<int32_t>(sizeof(v128_t)));
+        root->appendNewControlValue(proc, Return, Origin());
+
+        auto code = compileProc(proc);
+
+        // Input i8x16: {-5, 127, -128, 0, 1, -1, 42, -42, 99, 100, 101, 102, 103, 104, 105, 106}
+        vectors[0].u8x16[0] = static_cast<uint8_t>(-5);   // 0xFB → sign-extend to 0xFFFB = -5
+        vectors[0].u8x16[1] = 127;                          // 0x7F → 0x007F = 127
+        vectors[0].u8x16[2] = static_cast<uint8_t>(-128); // 0x80 → 0xFF80 = -128
+        vectors[0].u8x16[3] = 0;                            // 0x00 → 0x0000 = 0
+        vectors[0].u8x16[4] = 1;                            // 0x01 → 0x0001 = 1
+        vectors[0].u8x16[5] = static_cast<uint8_t>(-1);   // 0xFF → 0xFFFF = -1
+        vectors[0].u8x16[6] = 42;                           // 0x2A → 0x002A = 42
+        vectors[0].u8x16[7] = static_cast<uint8_t>(-42);  // 0xD6 → 0xFFD6 = -42
+        // Upper 8 bytes (not used by ExtendLow, but fill them)
+        for (unsigned i = 8; i < 16; ++i)
+            vectors[0].u8x16[i] = 99 + (i - 8);
+
+        invoke<void>(*code, vectors);
+
+        // Result: sign-extended lower 8 i8 values to i16x8
+        CHECK(vectors[1].u16x8[0] == static_cast<uint16_t>(-5));
+        CHECK(vectors[1].u16x8[1] == static_cast<uint16_t>(127));
+        CHECK(vectors[1].u16x8[2] == static_cast<uint16_t>(-128));
+        CHECK(vectors[1].u16x8[3] == static_cast<uint16_t>(0));
+        CHECK(vectors[1].u16x8[4] == static_cast<uint16_t>(1));
+        CHECK(vectors[1].u16x8[5] == static_cast<uint16_t>(-1));
+        CHECK(vectors[1].u16x8[6] == static_cast<uint16_t>(42));
+        CHECK(vectors[1].u16x8[7] == static_cast<uint16_t>(-42));
+    }
+
+    // Test ExtendHigh: VectorShr(VectorZipHigher(x, x), 8) → VectorExtendHigh(x, i16x8, Signed)
+    {
+        alignas(16) v128_t vectors[2];
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<void*>(proc, root);
+        Value* address = arguments[0];
+        Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+        Value* shiftAmount = root->appendNew<Const32Value>(proc, Origin(), 8);
+
+        // VectorZipHigher(input, input) on i8x16
+        Value* zipped = root->appendNew<SIMDValue>(proc, Origin(), VectorZipHigher, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, input, input);
+        // VectorShr(zipped, 8) on i16x8 Signed
+        Value* shifted = root->appendNew<SIMDValue>(proc, Origin(), VectorShr, B3::V128, SIMDLane::i16x8, SIMDSignMode::Signed, zipped, shiftAmount);
+
+        root->appendNew<MemoryValue>(proc, Store, Origin(), shifted, address, static_cast<int32_t>(sizeof(v128_t)));
+        root->appendNewControlValue(proc, Return, Origin());
+
+        auto code = compileProc(proc);
+
+        // Input: lower 8 bytes don't matter for ExtendHigh, upper 8 bytes are tested
+        for (unsigned i = 0; i < 8; ++i)
+            vectors[0].u8x16[i] = 0;
+        vectors[0].u8x16[8] = static_cast<uint8_t>(-10);   // 0xF6 → -10
+        vectors[0].u8x16[9] = 50;                            // 0x32 → 50
+        vectors[0].u8x16[10] = static_cast<uint8_t>(-128); // 0x80 → -128
+        vectors[0].u8x16[11] = 127;                          // 0x7F → 127
+        vectors[0].u8x16[12] = 0;                            // 0x00 → 0
+        vectors[0].u8x16[13] = static_cast<uint8_t>(-1);   // 0xFF → -1
+        vectors[0].u8x16[14] = 1;                            // 0x01 → 1
+        vectors[0].u8x16[15] = static_cast<uint8_t>(-100); // 0x9C → -100
+
+        invoke<void>(*code, vectors);
+
+        // Result: sign-extended upper 8 i8 values to i16x8
+        CHECK(vectors[1].u16x8[0] == static_cast<uint16_t>(-10));
+        CHECK(vectors[1].u16x8[1] == static_cast<uint16_t>(50));
+        CHECK(vectors[1].u16x8[2] == static_cast<uint16_t>(-128));
+        CHECK(vectors[1].u16x8[3] == static_cast<uint16_t>(127));
+        CHECK(vectors[1].u16x8[4] == static_cast<uint16_t>(0));
+        CHECK(vectors[1].u16x8[5] == static_cast<uint16_t>(-1));
+        CHECK(vectors[1].u16x8[6] == static_cast<uint16_t>(1));
+        CHECK(vectors[1].u16x8[7] == static_cast<uint16_t>(-100));
+    }
+}
+
+// Test VectorShr(VectorZip{Lower,Higher}(x, x), 16) -> VectorExtend{Low,High}(x, i32x4, Signed)
+void testVectorShrZipToExtendI32()
+{
+    // Test ExtendLow: VectorShr(VectorZipLower(x, x), 16) on i32x4 -> VectorExtendLow(x, i32x4, Signed)
+    {
+        alignas(16) v128_t vectors[2];
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<void*>(proc, root);
+        Value* address = arguments[0];
+        Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+        Value* shiftAmount = root->appendNew<Const32Value>(proc, Origin(), 16);
+
+        // VectorZipLower(input, input) on i16x8
+        Value* zipped = root->appendNew<SIMDValue>(proc, Origin(), VectorZipLower, B3::V128, SIMDLane::i16x8, SIMDSignMode::None, input, input);
+        // VectorShr(zipped, 16) on i32x4 Signed
+        Value* shifted = root->appendNew<SIMDValue>(proc, Origin(), VectorShr, B3::V128, SIMDLane::i32x4, SIMDSignMode::Signed, zipped, shiftAmount);
+
+        root->appendNew<MemoryValue>(proc, Store, Origin(), shifted, address, static_cast<int32_t>(sizeof(v128_t)));
+        root->appendNewControlValue(proc, Return, Origin());
+
+        auto code = compileProc(proc);
+
+        // Input i16x8: {-5, 32767, -32768, 0, 1, -1, 42, -42}
+        vectors[0].u16x8[0] = static_cast<uint16_t>(-5);      // 0xFFFB -> sign-extend to 0xFFFFFFFB = -5
+        vectors[0].u16x8[1] = 32767;                            // 0x7FFF -> 0x00007FFF = 32767
+        vectors[0].u16x8[2] = static_cast<uint16_t>(-32768);  // 0x8000 -> 0xFFFF8000 = -32768
+        vectors[0].u16x8[3] = 0;                                // 0x0000 -> 0x00000000 = 0
+        // Upper 4 i16 values (not used by ExtendLow)
+        vectors[0].u16x8[4] = 1;
+        vectors[0].u16x8[5] = static_cast<uint16_t>(-1);
+        vectors[0].u16x8[6] = 42;
+        vectors[0].u16x8[7] = static_cast<uint16_t>(-42);
+
+        invoke<void>(*code, vectors);
+
+        // Result: sign-extended lower 4 i16 values to i32x4
+        CHECK(vectors[1].u32x4[0] == static_cast<uint32_t>(-5));
+        CHECK(vectors[1].u32x4[1] == static_cast<uint32_t>(32767));
+        CHECK(vectors[1].u32x4[2] == static_cast<uint32_t>(-32768));
+        CHECK(vectors[1].u32x4[3] == static_cast<uint32_t>(0));
+    }
+
+    // Test ExtendHigh: VectorShr(VectorZipHigher(x, x), 16) on i32x4 -> VectorExtendHigh(x, i32x4, Signed)
+    {
+        alignas(16) v128_t vectors[2];
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<void*>(proc, root);
+        Value* address = arguments[0];
+        Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+        Value* shiftAmount = root->appendNew<Const32Value>(proc, Origin(), 16);
+
+        // VectorZipHigher(input, input) on i16x8
+        Value* zipped = root->appendNew<SIMDValue>(proc, Origin(), VectorZipHigher, B3::V128, SIMDLane::i16x8, SIMDSignMode::None, input, input);
+        // VectorShr(zipped, 16) on i32x4 Signed
+        Value* shifted = root->appendNew<SIMDValue>(proc, Origin(), VectorShr, B3::V128, SIMDLane::i32x4, SIMDSignMode::Signed, zipped, shiftAmount);
+
+        root->appendNew<MemoryValue>(proc, Store, Origin(), shifted, address, static_cast<int32_t>(sizeof(v128_t)));
+        root->appendNewControlValue(proc, Return, Origin());
+
+        auto code = compileProc(proc);
+
+        // Input: lower 4 i16 values don't matter for ExtendHigh
+        for (unsigned i = 0; i < 4; ++i)
+            vectors[0].u16x8[i] = 0;
+        vectors[0].u16x8[4] = static_cast<uint16_t>(-10);     // 0xFFF6 -> -10
+        vectors[0].u16x8[5] = 50;                               // 0x0032 -> 50
+        vectors[0].u16x8[6] = static_cast<uint16_t>(-32768);  // 0x8000 -> -32768
+        vectors[0].u16x8[7] = 32767;                            // 0x7FFF -> 32767
+
+        invoke<void>(*code, vectors);
+
+        // Result: sign-extended upper 4 i16 values to i32x4
+        CHECK(vectors[1].u32x4[0] == static_cast<uint32_t>(-10));
+        CHECK(vectors[1].u32x4[1] == static_cast<uint32_t>(50));
+        CHECK(vectors[1].u32x4[2] == static_cast<uint32_t>(-32768));
+        CHECK(vectors[1].u32x4[3] == static_cast<uint32_t>(32767));
+    }
+}
+
+// Test VectorShr(VectorZip{Lower,Higher}(x, x), 32) -> VectorExtend{Low,High}(x, i64x2, Signed)
+void testVectorShrZipToExtendI64()
+{
+    // Test ExtendLow: VectorShr(VectorZipLower(x, x), 32) on i64x2 -> VectorExtendLow(x, i64x2, Signed)
+    {
+        alignas(16) v128_t vectors[2];
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<void*>(proc, root);
+        Value* address = arguments[0];
+        Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+        Value* shiftAmount = root->appendNew<Const32Value>(proc, Origin(), 32);
+
+        // VectorZipLower(input, input) on i32x4
+        Value* zipped = root->appendNew<SIMDValue>(proc, Origin(), VectorZipLower, B3::V128, SIMDLane::i32x4, SIMDSignMode::None, input, input);
+        // VectorShr(zipped, 32) on i64x2 Signed
+        Value* shifted = root->appendNew<SIMDValue>(proc, Origin(), VectorShr, B3::V128, SIMDLane::i64x2, SIMDSignMode::Signed, zipped, shiftAmount);
+
+        root->appendNew<MemoryValue>(proc, Store, Origin(), shifted, address, static_cast<int32_t>(sizeof(v128_t)));
+        root->appendNewControlValue(proc, Return, Origin());
+
+        auto code = compileProc(proc);
+
+        // Input i32x4: {-5, 2147483647}  (lower 2 used by ExtendLow)
+        vectors[0].u32x4[0] = static_cast<uint32_t>(-5);           // 0xFFFFFFFB -> sign-extend to 0xFFFFFFFFFFFFFFFB = -5
+        vectors[0].u32x4[1] = static_cast<uint32_t>(2147483647);   // 0x7FFFFFFF -> 0x000000007FFFFFFF
+        // Upper 2 i32 values (not used by ExtendLow)
+        vectors[0].u32x4[2] = static_cast<uint32_t>(-2147483648LL);
+        vectors[0].u32x4[3] = 0;
+
+        invoke<void>(*code, vectors);
+
+        // Result: sign-extended lower 2 i32 values to i64x2
+        CHECK(vectors[1].u64x2[0] == static_cast<uint64_t>(static_cast<int64_t>(-5)));
+        CHECK(vectors[1].u64x2[1] == static_cast<uint64_t>(static_cast<int64_t>(2147483647)));
+    }
+
+    // Test ExtendHigh: VectorShr(VectorZipHigher(x, x), 32) on i64x2 -> VectorExtendHigh(x, i64x2, Signed)
+    {
+        alignas(16) v128_t vectors[2];
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<void*>(proc, root);
+        Value* address = arguments[0];
+        Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+        Value* shiftAmount = root->appendNew<Const32Value>(proc, Origin(), 32);
+
+        // VectorZipHigher(input, input) on i32x4
+        Value* zipped = root->appendNew<SIMDValue>(proc, Origin(), VectorZipHigher, B3::V128, SIMDLane::i32x4, SIMDSignMode::None, input, input);
+        // VectorShr(zipped, 32) on i64x2 Signed
+        Value* shifted = root->appendNew<SIMDValue>(proc, Origin(), VectorShr, B3::V128, SIMDLane::i64x2, SIMDSignMode::Signed, zipped, shiftAmount);
+
+        root->appendNew<MemoryValue>(proc, Store, Origin(), shifted, address, static_cast<int32_t>(sizeof(v128_t)));
+        root->appendNewControlValue(proc, Return, Origin());
+
+        auto code = compileProc(proc);
+
+        // Input: lower 2 i32 values don't matter for ExtendHigh
+        vectors[0].u32x4[0] = 0;
+        vectors[0].u32x4[1] = 0;
+        vectors[0].u32x4[2] = static_cast<uint32_t>(-2147483648LL);  // 0x80000000 -> -2147483648
+        vectors[0].u32x4[3] = static_cast<uint32_t>(-1);             // 0xFFFFFFFF -> -1
+
+        invoke<void>(*code, vectors);
+
+        // Result: sign-extended upper 2 i32 values to i64x2
+        CHECK(vectors[1].u64x2[0] == static_cast<uint64_t>(static_cast<int64_t>(-2147483648LL)));
+        CHECK(vectors[1].u64x2[1] == static_cast<uint64_t>(static_cast<int64_t>(-1)));
+    }
+}
+
 #endif // ENABLE(B3_JIT)
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 9355413a9415cbd472367e33453da19c9ea999cf
<pre>
[JSC] Add `VectorShr(VectorZipLower(x, x), 8)` strength reduction
<a href="https://bugs.webkit.org/show_bug.cgi?id=312308">https://bugs.webkit.org/show_bug.cgi?id=312308</a>
<a href="https://rdar.apple.com/174773227">rdar://174773227</a>

Reviewed by Justin Michaud.

This patch adds two rules to B3 strength reduction, which detects a
pattern used in wasm to sign-extend an element to the wider lane.

Example is,

1. `VectorShr(VectorZipLower(x, x), 8)` =&gt; `VectorExtendLow(x, i16x8, Signed)`
2. `VectorShr(VectorZipHigher(x, x), 8)` =&gt; `VectorExtendHigh(x, i16x8, Signed)`

We also add SIMDValue::dumpMeta to generate more information in B3 dump.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3SIMDValue.cpp:
(JSC::B3::SIMDValue::dumpMeta const):
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testVectorShrZipToExtend):
(testVectorShrZipToExtendI32):
(testVectorShrZipToExtendI64):

Canonical link: <a href="https://commits.webkit.org/311255@main">https://commits.webkit.org/311255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/603bf42d370aa559a887482c0db9b53bbf8afcb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156417 "25 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165238 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121141 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101810 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13010 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148467 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167720 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17252 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11833 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129265 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129376 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140092 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87071 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23824 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24205 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16891 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188300 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28985 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92941 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48406 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28511 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28739 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28635 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->