### PR TITLE
[CMake] bmalloc build should match Xcode on Apple platforms

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -692,6 +692,7 @@ endif ()
 
 add_definitions(-D_GNU_SOURCE)
 add_definitions(-DPAS_BMALLOC=1)
+add_definitions(-DPAS_BMALLOC_HIDDEN=1)
 
 if (USE_MIMALLOC)
     add_definitions(-DUSE_MIMALLOC=1)

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -128,6 +128,7 @@ WEBKIT_OPTION_END()
 
 set(SWIFT_REQUIRED ON)
 
+
 # FIXME: AV1 decoding requires dav1d which uses meson and isn't built by CMake yet.
 SET_AND_EXPOSE_TO_BUILD(ENABLE_AV1 OFF)
 

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -281,6 +281,39 @@ if (COMPILER_IS_GCC_OR_CLANG AND NOT MSVC)
     WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wall -Wextra)
 endif ()
 
+# Match Apple Xcode xcconfig warnings.
+if (APPLE)
+    # Set -Werror directly to skip the flag-support check, which fails because
+    # -Werror turns existing warnings in the test compilation into errors.
+    set(CMAKE_C_FLAGS "-Werror ${CMAKE_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "-Werror ${CMAKE_CXX_FLAGS}")
+
+    WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(
+        -Wc99-designator
+        -Wconditional-uninitialized
+        -Wdeprecated-enum-enum-conversion
+        -Wdeprecated-enum-float-conversion
+        -Wenum-float-conversion
+        -Wfinal-dtor-non-final-class
+        -Wformat=2
+        -Wpointer-to-int-cast
+        -Wreorder-init-list
+        -Wunused-but-set-variable
+        -Wvla
+        -Werror=unguarded-availability
+        -Wcast-qual
+        -Wexit-time-destructors
+        -Wextra-tokens
+        -Wglobal-constructors
+        -Wmissing-noreturn
+        -Wpacked
+        -Wredundant-decls
+        -Wtautological-compare
+        -Wthread-safety
+        -Wwrite-strings
+    )
+endif ()
+
 # Ninja tricks compilers into turning off color support.
 if (CMAKE_GENERATOR STREQUAL "Ninja")
     WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-fcolor-diagnostics


### PR DESCRIPTION
#### 726d68cf77612026c4de5bb4a3730a736cd342c8
<pre>
[CMake] bmalloc build should match Xcode on Apple platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=312320">https://bugs.webkit.org/show_bug.cgi?id=312320</a>
&lt;<a href="https://rdar.apple.com/problem/174781392">rdar://problem/174781392</a>&gt;

Reviewed by NOBODY (OOPS!).

Set DPAS_BMALLOC_HIDDEN because we don&apos;t export bmalloc as API.

Added missing warnings.

Now we have this heads-up comparison with Xcodebuild:

Build Type   Xcodebuild   Ninja      Speedup
────────────────────────────────────────────
Clean             23.2s    3.9s     6x (19s)
No-op             13.3s    0.1s   133x (13s)

* Source/bmalloc/CMakeLists.txt:
* Source/cmake/OptionsMac.cmake:
* Source/cmake/WebKitCompilerFlags.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/726d68cf77612026c4de5bb4a3730a736cd342c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110505 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121148 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85160 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101817 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22437 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20606 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13018 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148475 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167728 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17260 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129269 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129380 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140101 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87079 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24207 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16900 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188308 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28993 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Running compile-webkit") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48407 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28519 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Running compile-webkit") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28747 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28643 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->