### PR TITLE
[Smart Lists] Numbered list starting number clipped off-screen when using a large number

### DIFF
--- a/Source/WebCore/editing/TextListParser.cpp
+++ b/Source/WebCore/editing/TextListParser.cpp
@@ -59,19 +59,19 @@ namespace WebCore {
 template<typename Character>
 constexpr std::optional<int> NODELETE consumeNumber(StringParsingBuffer<Character>& input)
 {
-    // Parse the digits until there is no more input left or a non-ASCII digit character has been encountered.
-    Checked<int, RecordOverflow> value;
-    do {
-        auto c = input.consume();
-        int digitValue = c - '0';
-        value = (value * 10) + digitValue;
-    } while (!input.atEnd() && WTF::isASCIIDigit(*input));
+    static constexpr size_t maximumNumberOfDigits = 3;
 
-    if (value.hasOverflowed())
-        return std::nullopt;
+    int value = 0;
+    for (size_t i = 0; !input.atEnd() && isASCIIDigit(*input); ++i) {
+        if (i >= maximumNumberOfDigits)
+            return std::nullopt;
 
-    ASSERT(value.value() > 0);
-    return value.value();
+        value = (value * 10) + (input.consume() - '0');
+    }
+
+    ASSERT(value > 0 && value < std::pow(10, maximumNumberOfDigits));
+
+    return value;
 }
 
 template<typename Character>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm
@@ -316,14 +316,14 @@ TEST(SmartLists, InsertingSpaceAfterMultipleDigitNumberGeneratesOrderedList)
 {
     static constexpr auto expectedHTML = R"""(
     <body contenteditable="">
-        <ol start="1234" style="list-style-type: decimal;">
+        <ol start="123" style="list-style-type: decimal;">
             <li>Hello</li>
             <li>World</li>
         </ol>
     </body>
     )"""_s;
 
-    runTest(@"1234. Hello\n1235. World", expectedHTML.createNSString().get(), @"//body/ol/li[2]/text()", @"World".length);
+    runTest(@"123. Hello\n125. World", expectedHTML.createNSString().get(), @"//body/ol/li[2]/text()", @"World".length);
 }
 
 TEST(SmartLists, InsertingSpaceAfterInvalidNumberDoesNotGenerateOrderedList)
@@ -350,10 +350,10 @@ TEST(SmartLists, InsertingSpaceAfterInvalidNumberDoesNotGenerateOrderedList)
 TEST(SmartLists, InsertingSpaceAfterLargeNumberDoesNotGenerateOrderedList)
 {
     static constexpr auto expectedHTML = R"""(
-    <body>1000000000000000. hi</body>
+    <body>1000. hi</body>
     )"""_s;
 
-    NSString *input = @"1000000000000000. hi";
+    NSString *input = @"1000. hi";
 
     runTest(input, expectedHTML.createNSString().get(), @"//body/text()", input.length);
 }


### PR DESCRIPTION
#### 26d1738c5650abdf49be7bd2187598cb0bd40e9c
<pre>
[Smart Lists] Numbered list starting number clipped off-screen when using a large number
<a href="https://bugs.webkit.org/show_bug.cgi?id=312321">https://bugs.webkit.org/show_bug.cgi?id=312321</a>
<a href="https://rdar.apple.com/172515216">rdar://172515216</a>

Reviewed by Aditya Keerthi, Tim Horton, and Abrar Rahman Protyasha.

Don&apos;t create a Smart List if the starting ordinal is more than three digits.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm

* Source/WebCore/editing/TextListParser.cpp:
(WebCore::consumeNumber):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm:
((SmartLists, InsertingSpaceAfterLargeNumberDoesNotGenerateOrderedList)):

Canonical link: <a href="https://commits.webkit.org/311332@main">https://commits.webkit.org/311332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae1c43ca1eb0bc933bc4cc26c1e0ac0abc4e904b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165519 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158567 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/30168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30035 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159654 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/30168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102036 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/30168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13291 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/30168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168002 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20161 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129593 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35095 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/29557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140336 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/29557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29265 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->