### PR TITLE
[Site Isolation] CSP frame-src-cross-origin-load.html test fails with site isolation due to incorrect onload assignment

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/frame-src-cross-origin-load-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/frame-src-cross-origin-load-expected.txt
@@ -1,6 +1,6 @@
 ALERT: PASS
-CONSOLE MESSAGE: Refused to load https://localhost:8443/security/contentSecurityPolicy/resources/alert-fail.html because it does not appear in the frame-src directive of the Content Security Policy.
 CONSOLE MESSAGE: PASS
+CONSOLE MESSAGE: Refused to load https://localhost:8443/security/contentSecurityPolicy/resources/alert-fail.html because it does not appear in the frame-src directive of the Content Security Policy.
 IFrames blocked by CSP should generate a 'load' event, regardless of blocked state. This means they appear to be normal cross-origin loads, thereby not leaking URL information directly to JS.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/frame-src-cross-origin-load.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/frame-src-cross-origin-load.html
@@ -11,7 +11,7 @@
         function loadIFrameWithSrc(srcURL)
         {
             var iframe = document.createElement("iframe");
-            iframe.onload = loadEvent();
+            iframe.onload = loadEvent;
             iframe.src = srcURL;
             document.body.appendChild(iframe);
         }

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -231,7 +231,6 @@ http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-se
 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-url-block.html [ Failure ]
 http/tests/security/contentSecurityPolicy/embed-redirect-allowed.html [ Failure ]
 http/tests/security/contentSecurityPolicy/embed-redirect-allowed2.html [ Failure ]
-http/tests/security/contentSecurityPolicy/frame-src-cross-origin-load.html [ Failure ]
 http/tests/security/cross-origin-local-storage.html [ Failure ]
 http/tests/security/video-poster-cross-origin-crash2.html [ Failure ]
 http/tests/security/window-events-clear-domain.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -250,7 +250,6 @@ http/tests/security/XFrameOptions/x-frame-options-multiple-headers-sameorigin-de
 http/tests/security/XFrameOptions/x-frame-options-parent-same-origin-deny.html [ Failure ]
 http/tests/security/contentSecurityPolicy/embed-redirect-allowed.html [ Failure ]
 http/tests/security/contentSecurityPolicy/embed-redirect-allowed2.html [ Failure ]
-http/tests/security/contentSecurityPolicy/frame-src-cross-origin-load.html [ Failure ]
 http/tests/security/cross-origin-local-storage.html [ Failure ]
 http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Pass ]


### PR DESCRIPTION
#### e12578547350f9e6b316afaf52bd90e88c0a7a70
<pre>
[Site Isolation] CSP frame-src-cross-origin-load.html test fails with site isolation due to incorrect onload assignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=312315">https://bugs.webkit.org/show_bug.cgi?id=312315</a>
<a href="https://rdar.apple.com/174778663">rdar://174778663</a>

Reviewed by Rupin Mittal.

Test http/tests/security/contentSecurityPolicy/frame-src-cross-origin-load.html uses iframe.onload = loadEvent(),
which invokes loadEvent immediately instead of only assigning it as a handler. Without site isolation this happened
to be passing because the expected output was aligning with the buggy test execution. With site isolation the iframe
loads in a separate process, and the extra IPC latency means a console message arrives after the test has already
finalized, causing a mismatch with the expected output.

Fix by assigning the iframe.onload handler correctly and update the expected output to reflect the correct load ordering.

* LayoutTests/http/tests/security/contentSecurityPolicy/frame-src-cross-origin-load-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/frame-src-cross-origin-load.html:
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/311290@main">https://commits.webkit.org/311290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/054900027d76327033b69a48022b02666426fef3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110523 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121161 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85168 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101830 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22444 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 4 new passes 1 flakes 13 failures; Uploaded test results; Running re-run-layout-tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20623 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13036 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167746 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129285 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129396 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35073 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140114 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87097 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16913 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29011 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28537 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28765 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28661 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->