### PR TITLE
[JSC][WASM][Debugger] Unify library:; notifications and move module debug name into ModuleDebugInfo

### DIFF
--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -825,17 +825,27 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
     reply.append("00:"_s, toNativeEndianHex(getStopPC(*state)), ';');
     reply.append("reason:"_s, stopInfo.reasonSuffix, ';');
 
-    // For new module load stops, append library:; to prompt LLDB to re-query qXfer:libraries:read,
-    // which causes LLDB to load debug info for the new module and resolve any pending breakpoints
-    // that target symbols in it. Also append a description so LLDB can display a human-readable
-    // stop reason in the UI.
-    if (state->isNewModuleLoad) {
-        RELEASE_ASSERT(state->isStoppedAtSystemCall());
+    // Append library:; to prompt LLDB to re-query qXfer:libraries:read when there are pending
+    // library changes: (1) new-module-load stop, (2) piggybacked on any natural stop when a module
+    // was loaded but no dedicated stop fired yet, (3) module removal via unregisterModule().
+    if (m_moduleManager.needsLibraryRequery()) {
         reply.append("library:;"_s);
-        reply.append("description:"_s);
-        for (UChar c : StringView("new wasm module loaded"_s).codeUnits())
-            reply.append(hex(static_cast<uint8_t>(c), 2, Lowercase));
-        reply.append(';');
+        // Include a human-readable description only for dedicated new-module-load stops.
+        if (state->isNewModuleLoad) {
+            RELEASE_ASSERT(state->isStoppedAtSystemCall());
+            reply.append("description:"_s);
+            StringBuilder description;
+            description.append("loaded new wasm module with ids: "_s);
+            auto ids = m_moduleManager.unnotifiedModuleIds();
+            for (size_t i = 0; i < ids.size(); ++i) {
+                if (i)
+                    description.append(", "_s);
+                description.append(ids[i]);
+            }
+            for (UChar c : StringView(description.toString()).codeUnits())
+                reply.append(hex(static_cast<uint8_t>(c), 2, Lowercase));
+            reply.append(';');
+        }
     }
 
     // For trap stops, include a hex-encoded description so LLDB can display the trap reason.

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp
@@ -31,8 +31,12 @@
 #include "Options.h"
 #include "WasmIPIntGenerator.h"
 #include "WasmModuleInformation.h"
+#include "WasmVirtualAddress.h"
 #include <wtf/DataLog.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/URL.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
 
 // Forward declaration to ensure proper linkage
 namespace JSC {
@@ -83,6 +87,41 @@ FunctionDebugInfo& ModuleDebugInfo::ensureFunctionDebugInfo(FunctionCodeIndex fu
     parseForDebugInfo(functionData, typeDefinition, moduleInfo, functionIndex, info);
     dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleDebugInfo] Debug info collection completed for function ", functionIndex, " with ", info.offsetToNextInstructions.size(), " instruction mappings and ", info.locals.size(), " locals");
     return info;
+}
+
+String ModuleDebugInfo::debugName() const
+{
+    if (m_cachedDebugName)
+        return *m_cachedDebugName;
+
+    StringBuilder result;
+
+    if (!sourceURL.isEmpty()) {
+        // LLDB normalizes "//" -> "/" in library names (FileSpec treats them as paths),
+        // so we strip the URL scheme and store only "host/path" to avoid mangling.
+        URL url { sourceURL };
+        if (url.isValid() && !url.host().isEmpty())
+            result.append(makeString(url.host(), url.path()));
+        else
+            result.append(sourceURL);
+    }
+
+    const auto& rawName = moduleInfo->nameSection->moduleName;
+    if (!rawName.isEmpty()) {
+        if (!result.isEmpty())
+            result.append(':');
+        result.append(rawName.span());
+    }
+
+    if (!result.isEmpty())
+        m_cachedDebugName = result.toString();
+    else {
+        // Fallback for modules with neither a name section nor a source URL.
+        m_cachedDebugName = makeString("0x"_s, VirtualAddress::createModule(id).hex(), ".wasm"_s);
+    }
+
+    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleDebugInfo][debugName] ", *m_cachedDebugName);
+    return *m_cachedDebugName;
 }
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h
@@ -31,6 +31,7 @@
 
 #include <JavaScriptCore/JSExportMacros.h>
 #include <cstdint>
+#include <optional>
 #include <wtf/DataLog.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
@@ -67,12 +68,18 @@ public:
     void takeSource(Vector<uint8_t>&& source) { this->source = WTF::move(source); }
     FunctionDebugInfo& ensureFunctionDebugInfo(FunctionCodeIndex);
 
+    // Lazily computed and cached; not thread-safe — must only be called from the debugger thread.
+    JS_EXPORT_PRIVATE String debugName() const;
+
     Ref<ModuleInformation> moduleInfo;
     uint32_t id { 0 };
     Vector<uint8_t> source;
     String sourceURL;
     using FunctionIndexToData = UncheckedKeyHashMap<size_t, FunctionDebugInfo, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>;
     FunctionIndexToData functionIndexToData;
+
+private:
+    mutable std::optional<String> m_cachedDebugName;
 };
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
@@ -43,8 +43,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/HexNumber.h>
 #include <wtf/IterationStatus.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/URL.h>
-#include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
@@ -71,6 +69,7 @@ void ModuleManager::unregisterModule(Module& module)
     uint32_t moduleId = module.debugId();
     m_moduleIdToModule.remove(moduleId);
     m_unnotifiedModuleIds.remove(moduleId);
+    m_hasPendingModuleRemovals = true;
     dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][unregisterModule] - unregistered module with debug ID: ", moduleId);
 }
 
@@ -97,10 +96,28 @@ bool ModuleManager::needsNewModuleNotification(JSWebAssemblyInstance* jsInstance
     return m_unnotifiedModuleIds.contains(moduleId);
 }
 
-void ModuleManager::markAllModulesAsNotified()
+bool ModuleManager::needsLibraryRequery() const
+{
+    Locker locker { m_lock };
+    return !m_unnotifiedModuleIds.isEmpty() || m_hasPendingModuleRemovals;
+}
+
+void ModuleManager::notifyLibraryRequeryComplete()
 {
     Locker locker { m_lock };
     m_unnotifiedModuleIds.clear();
+    m_hasPendingModuleRemovals = false;
+}
+
+Vector<uint32_t> ModuleManager::unnotifiedModuleIds() const
+{
+    Locker locker { m_lock };
+    Vector<uint32_t> result;
+    result.reserveInitialCapacity(m_unnotifiedModuleIds.size());
+    for (uint32_t id : m_unnotifiedModuleIds)
+        result.append(id);
+    std::sort(result.begin(), result.end());
+    return result;
 }
 
 Module* ModuleManager::module(uint32_t moduleId) const
@@ -150,46 +167,6 @@ JSWebAssemblyInstance* ModuleManager::jsInstance(uint32_t instanceId)
     return instance;
 }
 
-static String generateModuleName(VirtualAddress address, const RefPtr<Module>& module)
-{
-    // LLDB's `image list` already appends the load address in parentheses, so module
-    // names do not need an address suffix for uniqueness.
-    if (module) {
-        const auto& moduleInfo = module->moduleInformation();
-
-        StringBuilder result;
-
-        const String& sourceURL = moduleInfo.debugInfo->sourceURL;
-        if (!sourceURL.isEmpty()) {
-            // LLDB normalizes "//" -> "/" in library names (FileSpec treats them as paths),
-            // so we strip the URL scheme and store only "host/path" to avoid mangling.
-            URL url { sourceURL };
-            if (url.isValid() && !url.host().isEmpty())
-                result.append(makeString(url.host(), url.path()));
-            else
-                result.append(sourceURL);
-        }
-
-        const auto& rawName = moduleInfo.nameSection->moduleName;
-        if (!rawName.isEmpty()) {
-            if (!result.isEmpty())
-                result.append(':');
-            result.append(rawName.span());
-        }
-
-        if (!result.isEmpty()) {
-            String name = result.toString();
-            dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][generateModuleName] ", name);
-            return name;
-        }
-    }
-
-    // Fallback for modules with neither a name section nor a response URL.
-    String fallback = WTF::makeString("0x"_s, address.hex(), ".wasm"_s);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][generateModuleName] fallback: ", fallback);
-    return fallback;
-}
-
 String ModuleManager::generateLibrariesXML() const
 {
     Locker locker { m_lock };
@@ -197,26 +174,49 @@ String ModuleManager::generateLibrariesXML() const
     xml.append("<?xml version=\"1.0\"?>\n"_s);
     xml.append("<library-list>\n"_s);
 
+    auto appendXMLEscaped = [](StringBuilder& builder, const String& value) {
+        for (UChar c : StringView(value).codeUnits()) {
+            switch (c) {
+            case '&':
+                builder.append("&amp;"_s);
+                break;
+            case '<':
+                builder.append("&lt;"_s);
+                break;
+            case '>':
+                builder.append("&gt;"_s);
+                break;
+            case '"':
+                builder.append("&quot;"_s);
+                break;
+            default:
+                builder.append(c);
+                break;
+            }
+        }
+    };
+
     for (const auto& pair : m_moduleIdToModule) {
         uint32_t moduleId = pair.key;
         RefPtr module = pair.value;
         if (!module)
             continue;
 
-        const auto& source = module->moduleInformation().debugInfo->source;
-        if (source.isEmpty())
+        const auto& debugInfo = module->moduleInformation().debugInfo;
+        if (debugInfo->source.isEmpty())
             continue;
 
+        ASSERT(moduleId == debugInfo->id);
         VirtualAddress moduleBaseAddress = VirtualAddress::createModule(moduleId);
-        String moduleName = generateModuleName(moduleBaseAddress, module);
+        String moduleName = debugInfo->debugName();
         xml.append("  <library name=\""_s);
-        xml.append(moduleName);
+        appendXMLEscaped(xml, moduleName);
         xml.append("\">\n"_s);
         xml.append("    <section address=\"0x"_s);
         xml.append(moduleBaseAddress.hex());
         xml.append("\"/>\n"_s);
         xml.append("  </library>\n"_s);
-        dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][generateLibrariesXML] - added module '", moduleName, "' ID: ", moduleId, " at ", moduleBaseAddress, " size: 0x", hex(source.size(), Lowercase));
+        dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][generateLibrariesXML] - added module '", moduleName, "' ID: ", moduleId, " at ", moduleBaseAddress, " size: 0x", hex(debugInfo->source.size(), Lowercase));
     }
 
     xml.append("</library-list>\n"_s);

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h
@@ -61,13 +61,15 @@ public:
     Module* module(uint32_t moduleId) const;
 
     uint32_t registerInstance(JSWebAssemblyInstance*);
-    bool needsNewModuleNotification(JSWebAssemblyInstance*);
     JSWebAssemblyInstance* jsInstance(uint32_t instanceId);
     uint32_t nextInstanceId() const;
 
     String generateLibrariesXML() const;
 
-    void markAllModulesAsNotified();
+    bool needsNewModuleNotification(JSWebAssemblyInstance*);
+    bool needsLibraryRequery() const;
+    void notifyLibraryRequeryComplete();
+    Vector<uint32_t> unnotifiedModuleIds() const;
 
 private:
     using IdToModule = UncheckedKeyHashMap<uint32_t, Module*, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
@@ -81,7 +83,8 @@ private:
     mutable Lock m_lock;
     IdToModule m_moduleIdToModule WTF_GUARDED_BY_LOCK(m_lock);
     IdToInstance m_instanceIdToInstance WTF_GUARDED_BY_LOCK(m_lock);
-    ModuleIdSet m_unnotifiedModuleIds WTF_GUARDED_BY_LOCK(m_lock); // Module IDs not yet seen by LLDB; cleared by markAllModulesAsNotified() after each qXfer:libraries:read reply
+    ModuleIdSet m_unnotifiedModuleIds WTF_GUARDED_BY_LOCK(m_lock); // Module IDs not yet seen by LLDB; cleared by notifyLibraryRequeryComplete() after each qXfer:libraries:read reply
+    bool m_hasPendingModuleRemovals WTF_GUARDED_BY_LOCK(m_lock) { false }; // True when a module was unregistered but LLDB hasn't been notified yet
 
     uint32_t m_nextModuleId WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     uint32_t m_nextInstanceId WTF_GUARDED_BY_LOCK(m_lock) { 0 };

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -291,7 +291,7 @@ void QueryHandler::handleLibrariesRead(StringView packet)
         // Only mark modules notified and signal debugger-ready on the final chunk ('l' prefix).
         if (response[0] == 'l') {
             m_debugServer.m_isDebuggerReady.store(true, std::memory_order_release);
-            m_debugServer.moduleManager().markAllModulesAsNotified();
+            m_debugServer.moduleManager().notifyLibraryRequeryComplete();
         }
     } else {
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Failed to generate library list chunk");


### PR DESCRIPTION
#### de5a7d7024890fec84090b253b4ad14420725dc7
<pre>
[JSC][WASM][Debugger] Unify library:; notifications and move module debug name into ModuleDebugInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=312325">https://bugs.webkit.org/show_bug.cgi?id=312325</a>
<a href="https://rdar.apple.com/174785772">rdar://174785772</a>

Reviewed by Mark Lam.

Move generateModuleName() into ModuleDebugInfo::debugName() with lazy caching so
the name is computed once and reused across qXfer:libraries:read calls. XML-escape
the name in generateLibrariesXML() to fix potential injection for names with &amp;, &lt;,
&gt;, or &quot; (e.g. URLs with query strings or name sections with special characters).

Extend library:; stop reply coverage beyond dedicated new-module-load stops:
- needsLibraryRequery() returns true when there are unnotified modules or pending
  removals; any natural stop (interrupt/breakpoint/step) piggybacks the notification,
  avoiding a redundant dedicated stop if LLDB queries before instance creation.
- Module removal sets m_hasPendingModuleRemovals so the next stop of any kind
  prompts LLDB to update its library list.
- markAllModulesAsNotified() renamed to notifyLibraryRequeryComplete() and now
  also clears the removal flag.

Canonical link: <a href="https://commits.webkit.org/311291@main">https://commits.webkit.org/311291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f66c4308a60efa18e4a7426cb70fab861968704

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165267 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110526 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121166 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/110526 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101835 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22455 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20631 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13039 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148496 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167749 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17281 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11862 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129289 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129400 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35074 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140121 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87100 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24226 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16920 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188329 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29014 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92970 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48409 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28540 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28768 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28664 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->