### PR TITLE
[AutoFill Debugging] Support `scroll` interaction with no scroll delta

### DIFF
--- a/LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page-expected.txt
+++ b/LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page-expected.txt
@@ -1,0 +1,20 @@
+Tests that scroll interactions with no delta scroll by one page and wrap around.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scrollVerticalError is ""
+PASS verticalScrollTopAfterFirstScroll is 200
+PASS scrollVerticalWrapError is ""
+PASS verticalScrollTopAfterWrap is 0
+PASS scrollHorizontalError is ""
+PASS horizontalScrollLeftAfterFirstScroll is 200
+PASS scrollHorizontalWrapError is ""
+PASS horizontalScrollLeftAfterWrap is 0
+PASS scrollPageError is ""
+PASS pageScrollTopAfterScroll is > 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Top of vertical scroller
+Start of horizontal scroller

--- a/LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page.html
+++ b/LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page.html
@@ -1,0 +1,129 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true AsyncOverflowScrollingEnabled=true CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        .vertical-scroller {
+            overflow: scroll;
+            scrollbar-width: none;
+            width: 200px;
+            height: 200px;
+            border: 1px solid tomato;
+        }
+
+        .horizontal-scroller {
+            overflow: scroll;
+            scrollbar-width: none;
+            width: 200px;
+            height: 200px;
+            white-space: nowrap;
+            border: 1px solid blue;
+        }
+
+        .tall {
+            height: 4000px;
+        }
+
+        .wide {
+            width: 4000px;
+            height: 50px;
+        }
+    </style>
+</head>
+<body>
+    <div class="vertical-scroller" aria-label="Vertical scroller">
+        <div class="tall">Top of vertical scroller</div>
+    </div>
+    <div class="horizontal-scroller" aria-label="Horizontal scroller">
+        <div class="wide">Start of horizontal scroller</div>
+    </div>
+    <script>
+    jsTestIsAsync = true;
+    description("Tests that scroll interactions with no delta scroll by one page and wrap around.");
+
+    addEventListener("load", async () => {
+        verticalScroller = document.querySelector(".vertical-scroller");
+        horizontalScroller = document.querySelector(".horizontal-scroller");
+
+        if (!window.testRunner)
+            return;
+
+        const debugText = await UIHelper.requestDebugText({
+            nodeIdentifierInclusion: "interactive",
+            includeAccessibilityAttributes: true,
+        });
+
+        scrollVerticalError = await UIHelper.performTextExtractionInteraction("scroll", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Vertical scroller"),
+        });
+
+        await UIHelper.ensureVisibleContentRectUpdate();
+        await UIHelper.ensurePresentationUpdate();
+
+        verticalScrollTopAfterFirstScroll = verticalScroller.scrollTop;
+
+        shouldBeEqualToString("scrollVerticalError", "");
+        shouldBe("verticalScrollTopAfterFirstScroll", "200");
+
+        verticalScroller.scrollTop = verticalScroller.scrollHeight;
+
+        scrollVerticalWrapError = await UIHelper.performTextExtractionInteraction("scroll", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Vertical scroller"),
+        });
+
+        await UIHelper.ensureVisibleContentRectUpdate();
+        await UIHelper.ensurePresentationUpdate();
+
+        verticalScrollTopAfterWrap = verticalScroller.scrollTop;
+
+        shouldBeEqualToString("scrollVerticalWrapError", "");
+        shouldBe("verticalScrollTopAfterWrap", "0");
+
+        scrollHorizontalError = await UIHelper.performTextExtractionInteraction("scroll", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Horizontal scroller"),
+        });
+
+        await UIHelper.ensureVisibleContentRectUpdate();
+        await UIHelper.ensurePresentationUpdate();
+
+        horizontalScrollLeftAfterFirstScroll = horizontalScroller.scrollLeft;
+
+        shouldBeEqualToString("scrollHorizontalError", "");
+        shouldBe("horizontalScrollLeftAfterFirstScroll", "200");
+
+        horizontalScroller.scrollLeft = horizontalScroller.scrollWidth;
+
+        scrollHorizontalWrapError = await UIHelper.performTextExtractionInteraction("scroll", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Horizontal scroller"),
+        });
+
+        await UIHelper.ensureVisibleContentRectUpdate();
+        await UIHelper.ensurePresentationUpdate();
+
+        horizontalScrollLeftAfterWrap = horizontalScroller.scrollLeft;
+
+        shouldBeEqualToString("scrollHorizontalWrapError", "");
+        shouldBe("horizontalScrollLeftAfterWrap", "0");
+
+        document.body.style.height = "4000px";
+        await UIHelper.ensurePresentationUpdate();
+
+        scrollPageError = await UIHelper.performTextExtractionInteraction("scroll", {});
+
+        await UIHelper.ensureVisibleContentRectUpdate();
+        await UIHelper.ensurePresentationUpdate();
+
+        pageScrollTopAfterScroll = document.scrollingElement.scrollTop;
+
+        shouldBeEqualToString("scrollPageError", "");
+        shouldBeGreaterThan("pageScrollTopAfterScroll", "0");
+
+        finishJSTest();
+    });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1924,6 +1924,41 @@ static void scrollBy(LocalFrame& frame, std::optional<NodeIdentifier>&& identifi
     completion(true, { });
 }
 
+static void scrollToNextPage(LocalFrame& frame, std::optional<NodeIdentifier>&& identifier, CompletionHandler<void(bool, String&&)>&& completion)
+{
+    RefPtr foundNode = resolveNodeWithBodyAsFallback(frame, identifier);
+    if (!foundNode)
+        return completion(false, invalidNodeIdentifierDescription(WTF::move(identifier)));
+
+    WeakPtr scroller = CheckedRef { frame.eventHandler() }->enclosingScrollableArea(foundNode.get());
+    if (!scroller)
+        return completion(false, "No scrollable area found"_s);
+
+    addBoxShadowIfNeeded(*foundNode, "#34c759"_s);
+
+    auto currentOffset = scroller->scrollOffset();
+    auto maxOffset = scroller->maximumScrollOffset();
+
+    bool scrollsHorizontally = maxOffset.x() > maxOffset.y();
+    bool isAtEnd = scrollsHorizontally ? currentOffset.x() >= maxOffset.x() : currentOffset.y() >= maxOffset.y();
+    bool isRTL = scroller->shouldPlaceVerticalScrollbarOnLeft();
+
+    if (isAtEnd) {
+        scroller->scrollToOffsetWithoutAnimation({ });
+        auto direction = scrollsHorizontally ? (isRTL ? "right"_s : "left"_s) : "up"_s;
+        auto distance = scrollsHorizontally ? roundToInt(currentOffset.x()) : roundToInt(currentOffset.y());
+        completion(true, makeString("Scrolled "_s, distance, "px "_s, direction, " (wrapped to start)"_s));
+    } else {
+        auto visibleSize = scroller->visibleSize();
+        auto delta = scrollsHorizontally ? FloatSize { static_cast<float>(visibleSize.width()), 0 } : FloatSize { 0, static_cast<float>(visibleSize.height()) };
+        scroller->scrollToOffsetWithoutAnimation(FloatPoint { currentOffset } + delta);
+        auto newOffset = scroller->scrollOffset();
+        auto direction = scrollsHorizontally ? (isRTL ? "left"_s : "right"_s) : "down"_s;
+        auto distance = scrollsHorizontally ? roundToInt(newOffset.x() - currentOffset.x()) : roundToInt(newOffset.y() - currentOffset.y());
+        completion(true, makeString("Scrolled "_s, distance, "px "_s, direction));
+    }
+}
+
 static void scrollToReveal(LocalFrame& frame, std::optional<NodeIdentifier>&& identifier, String&& searchText, CompletionHandler<void(bool, String&&)>&& completion)
 {
     RefPtr searchScope = resolveNodeWithBodyAsFallback(frame, identifier);
@@ -2103,7 +2138,7 @@ void handleInteraction(Interaction&& interaction, LocalFrame& frame, CompletionH
             return scrollToReveal(frame, WTF::move(interaction.nodeIdentifier), WTF::move(interaction.text), WTF::move(completion));
 
         if (interaction.scrollDelta.isZero())
-            return completion(false, "Scroll delta is zero"_s);
+            return scrollToNextPage(frame, WTF::move(interaction.nodeIdentifier), WTF::move(completion));
 
         return scrollBy(frame, WTF::move(interaction.nodeIdentifier), interaction.scrollDelta, WTF::move(completion));
     case Action::Hover: {
@@ -2398,8 +2433,12 @@ InteractionDescription interactionDescription(const Interaction& interaction, Lo
     }
 
     if (action == Action::Scroll && interaction.text.isEmpty()) {
-        auto delta = roundedIntSize(interaction.scrollDelta);
-        description.append(makeString(" by ("_s, delta.width(), ", "_s, delta.height(), ')'));
+        if (interaction.scrollDelta.isZero())
+            description.append(" to next page"_s);
+        else {
+            auto delta = roundedIntSize(interaction.scrollDelta);
+            description.append(makeString(" by ("_s, delta.width(), ", "_s, delta.height(), ')'));
+        }
     }
 
     auto appendElementString = [&]<typename... T>(T&&... args) {


### PR DESCRIPTION
#### e740706bbede428e25a36de7e559d524931b548d
<pre>
[AutoFill Debugging] Support `scroll` interaction with no scroll delta
<a href="https://bugs.webkit.org/show_bug.cgi?id=312327">https://bugs.webkit.org/show_bug.cgi?id=312327</a>
<a href="https://rdar.apple.com/174777888">rdar://174777888</a>

Reviewed by Abrar Rahman Protyasha.

Add support for invoking the `scroll` interaction action type with no arguments (or only a single
node argument representating a subscrollable container). If no delta or a zero delta is specified,
this should scroll page by page through the container until it hits the end, at which point it
should scroll all the way back up to the top (or left).

Test: fast/text-extraction/text-extraction-scroll-to-next-page.html

* LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page-expected.txt: Added.
* LayoutTests/fast/text-extraction/text-extraction-scroll-to-next-page.html: Added.
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::scrollToNextPage):
(WebCore::TextExtraction::handleInteraction):
(WebCore::TextExtraction::interactionDescription):

Canonical link: <a href="https://commits.webkit.org/311259@main">https://commits.webkit.org/311259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c09e26012764f67de527c0d32f206d7c4b335ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165259 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121157 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101826 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13031 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167741 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11854 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19944 "Found 1 new test failure: imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/form.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129279 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129390 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35050 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140125 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87092 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24214 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16924 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29006 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92962 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28532 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28760 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28656 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->