### PR TITLE
Popover test cases trigger nullptr dereference in WebKit

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8338,6 +8338,3 @@ imported/w3c/web-platform-tests/svg/text/reftests/textpath-side-005.svg [ ImageO
 
 webkit.org/b/312264 imported/w3c/web-platform-tests/css/cssom-view/interrupt-hidden-smooth-scroll.html [ Pass Failure ]
 
-webkit.org/b/312304 imported/w3c/web-platform-tests/html/semantics/popovers/popover-events.html [ Skip ] # crash
-webkit.org/b/312304 imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-blur-crash.html [ Skip ] # crash
-webkit.org/b/312304 imported/w3c/web-platform-tests/html/semantics/popovers/popover-remove-attribute-during-focusing-steps.html [ Skip ] # crash

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events-expected.txt
@@ -4,4 +4,5 @@ PASS The "beforetoggle" event (attribute) get properly dispatched for popovers
 PASS The "beforetoggle" event is cancelable for the "opening" transition
 PASS The "beforetoggle" event is not fired for element removal
 PASS The "toggle" event is coalesced
+FAIL The toggle event is still fired if the popover is removed during focus/blur assert_array_equals: lengths differ, expected array ["beforetoggle closed -> open", "button blur", "focusElement focus", "toggle closed -> open"] length 4, got ["beforetoggle closed -> open", "button blur", "focusElement focus"] length 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-remove-attribute-during-focusing-steps-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-remove-attribute-during-focusing-steps-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Remove popover attribute during the popover focusing steps assert_not_equals: toggle event should be dispatched got disallowed value undefined
+

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1137,7 +1137,8 @@ static void runPopoverFocusingSteps(HTMLElement& popover)
 
 void HTMLElement::queuePopoverToggleEventTask(ToggleState oldState, ToggleState newState, Element* source)
 {
-    popoverData()->ensureToggleEventTask(*this)->queue(oldState, newState, source);
+    if (auto* popoverData = this->popoverData())
+        popoverData->ensureToggleEventTask(*this)->queue(oldState, newState, source);
 }
 
 ExceptionOr<void> HTMLElement::showPopover(const ShowPopoverOptions& options)
@@ -1202,16 +1203,20 @@ ExceptionOr<void> HTMLElement::showPopoverInternal(HTMLElement* source)
 
     addToTopLayer();
 
-    popoverData()->setPreviouslyFocusedElement(nullptr);
+    if (auto* popoverData = this->popoverData())
+        popoverData->setPreviouslyFocusedElement(nullptr);
 
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::PopoverOpen, true);
-    popoverData()->setVisibilityState(PopoverVisibilityState::Showing);
+    if (auto* popoverData = this->popoverData())
+        popoverData->setVisibilityState(PopoverVisibilityState::Showing);
 
     runPopoverFocusingSteps(*this);
 
     if (shouldRestoreFocus) {
-        ASSERT(popoverState() == PopoverState::Auto);
-        popoverData()->setPreviouslyFocusedElement(previouslyFocusedElement.get());
+        if (auto* popoverData = this->popoverData()) {
+            ASSERT(popoverState() == PopoverState::Auto);
+            popoverData->setPreviouslyFocusedElement(previouslyFocusedElement.get());
+        }
     }
 
     queuePopoverToggleEventTask(ToggleState::Closed, ToggleState::Open, source);


### PR DESCRIPTION
#### 5d9589eb2f706fe1415b918607f0ab49c2a8ae39
<pre>
Popover test cases trigger nullptr dereference in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=312304">https://bugs.webkit.org/show_bug.cgi?id=312304</a>
<a href="https://rdar.apple.com/174767317">rdar://174767317</a>

Reviewed by Tim Nguyen.

The recent sync of WPT 311246@main exposed two nullptr dereferences that led to crashes
when running tests. This patch corrects those two issues, and updates expectations
to reflect the changes.

Tests: imported/w3c/web-platform-tests/html/semantics/popovers/popover-events.html
       imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-blur-crash.html
       imported/w3c/web-platform-tests/html/semantics/popovers/popover-remove-attribute-during-focusing-steps.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-remove-attribute-during-focusing-steps-expected.txt: Added.
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::queuePopoverToggleEventTask):
(WebCore::HTMLElement::showPopoverInternal):

Canonical link: <a href="https://commits.webkit.org/311343@main">https://commits.webkit.org/311343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74368d708fbaf72155e9c39a3858ef480d794d24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165509 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121359 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102027 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20838 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13281 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167992 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129473 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129583 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35106 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140332 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87348 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24411 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17136 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29255 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28780 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29010 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28906 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->