### PR TITLE
Use usearch_previous when possible in CachedMatchFinder

### DIFF
--- a/Source/WebCore/editing/CachedMatchFinder.cpp
+++ b/Source/WebCore/editing/CachedMatchFinder.cpp
@@ -69,8 +69,6 @@ void CachedMatchFinder::performSearch(StringView buffer, unsigned startOffset, c
 
     bool backwards = options.contains(FindOption::Backwards);
 
-    icuSearcher.setOffset(backwards ? 0 : startOffset);
-
     Vector<char16_t> scratchBuffer;
 
     auto isMatch = [&](int matchStart, size_t matchLength) -> bool {
@@ -84,6 +82,20 @@ void CachedMatchFinder::performSearch(StringView buffer, unsigned startOffset, c
     };
 
     if (backwards) {
+#if !PLATFORM(PLAYSTATION)
+        icuSearcher.setOffset(startOffset);
+        while (true) {
+            std::optional<size_t> matchStartCandidate = icuSearcher.previous();
+            if (!matchStartCandidate)
+                break;
+            size_t matchLength = static_cast<size_t>(icuSearcher.matchedLength());
+            if (!isMatch(*matchStartCandidate, matchLength))
+                continue;
+            if (callback(*matchStartCandidate, *matchStartCandidate + matchLength) == SearchShouldContinue::No)
+                break;
+        }
+#else
+        icuSearcher.setOffset(0);
         Vector<std::pair<size_t, size_t>> matches;
         while (true) {
             std::optional<size_t> matchStartCandidate = icuSearcher.next();
@@ -98,7 +110,9 @@ void CachedMatchFinder::performSearch(StringView buffer, unsigned startOffset, c
             if (callback(start, end) == SearchShouldContinue::No)
                 break;
         }
+#endif
     } else {
+        icuSearcher.setOffset(startOffset);
         while (true) {
             std::optional<size_t> matchStartCandidate = icuSearcher.next();
             if (!matchStartCandidate)

--- a/Source/WebCore/editing/ICUSearcher.cpp
+++ b/Source/WebCore/editing/ICUSearcher.cpp
@@ -163,6 +163,18 @@ std::optional<size_t> ICUSearcher::next()
     return static_cast<size_t>(result);
 }
 
+#if !PLATFORM(PLAYSTATION)
+std::optional<size_t> ICUSearcher::previous()
+{
+    UErrorCode status = U_ZERO_ERROR;
+    SUPPRESS_FORWARD_DECL_ARG int32_t result = usearch_previous(searcher(), &status);
+    ASSERT(U_SUCCESS(status));
+    if (result == USEARCH_DONE)
+        return std::nullopt;
+    return static_cast<size_t>(result);
+}
+#endif
+
 size_t ICUSearcher::matchedLength()
 {
     SUPPRESS_FORWARD_DECL_ARG int32_t result = usearch_getMatchedLength(searcher());

--- a/Source/WebCore/editing/ICUSearcher.h
+++ b/Source/WebCore/editing/ICUSearcher.h
@@ -40,6 +40,9 @@ public:
     void setText(std::span<const char16_t>);
     void setOffset(size_t);
     std::optional<size_t> next();
+#if !PLATFORM(PLAYSTATION)
+    std::optional<size_t> previous();
+#endif
     size_t matchedLength();
 private:
     UStringSearch* searcher();


### PR DESCRIPTION
#### 90a08da7d817e461150866f662643f913bb0b90f
<pre>
Use usearch_previous when possible in CachedMatchFinder
<a href="https://bugs.webkit.org/show_bug.cgi?id=312333">https://bugs.webkit.org/show_bug.cgi?id=312333</a>
<a href="https://rdar.apple.com/174789271">rdar://174789271</a>

Reviewed by Ryosuke Niwa.

Currently, when searching backwards during find in page, we
collect all the matches forwards, and iterate over that collection
backwards looking for a valid match. We do this because we don&apos;t have
access to usearch_previous on PlayStation.

This patch adds support for usearch_previous on other platforms, so
we don&apos;t have to take a performance hit in the common case.

* Source/WebCore/editing/CachedMatchFinder.cpp:
(WebCore::CachedMatchFinder::performSearch):
* Source/WebCore/editing/ICUSearcher.cpp:
(WebCore::ICUSearcher::previous):
* Source/WebCore/editing/ICUSearcher.h:

Canonical link: <a href="https://commits.webkit.org/311299@main">https://commits.webkit.org/311299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e06dbca1c756d3633b74963a986caf231007d874

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110534 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121171 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85170 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101840 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22459 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20634 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13047 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167757 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11870 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129295 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29390 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24703 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129406 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35076 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140124 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87108 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24228 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16923 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29022 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92978 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28548 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28777 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28672 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->