### PR TITLE
[Site Isolation] prefers-color-scheme doesn't see color-scheme from parent frames and above

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7479,7 +7479,6 @@ imported/w3c/web-platform-tests/dom/events/scrolling/wheel-event-transactions-ta
 imported/w3c/web-platform-tests/css/css-color/deprecated-sameas-002.html [ ImageOnlyFailure ]
 
 http/tests/site-isolation/touch-events [ Skip ]
-webkit.org/b/309611 http/tests/site-isolation/iframe-dark-mode.html [ ImageOnlyFailure ]
 http/tests/site-isolation/iframe-dark-mode-print.html [ ImageOnlyFailure ]
 
 # CSS syntax

--- a/LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme.html
+++ b/LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme.html
@@ -19,9 +19,11 @@
 <script>
   if (window.testRunner) {
     testRunner.waitUntilDone();
-    testRunner.setUseDarkAppearanceForTesting(true);
 
     ifr.addEventListener("load", () => {
+      // testRunner.setUseDarkAppearanceForTesting() only affects loaded frames,
+      // hence we set it after the frame is loaded.
+      testRunner.setUseDarkAppearanceForTesting(true);
       testRunner.notifyDone();
     })
   }

--- a/LayoutTests/http/tests/css/prefers-color-scheme-in-nested-iframes-follows-system-preference-expected.txt
+++ b/LayoutTests/http/tests/css/prefers-color-scheme-in-nested-iframes-follows-system-preference-expected.txt
@@ -1,0 +1,17 @@
+prefers-color-scheme in nested iframes follows system preference if none of the iframes explicitly specify color-scheme
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS caughtEvent.data is "rgb(255, 0, 0)"
+PASS caughtEvent.data is "rgb(255, 0, 0)"
+PASS caughtEvent.data is "rgb(255, 0, 0)"
+PASS caughtEvent.data is "rgb(255, 0, 0)"
+PASS caughtEvent.data is "rgb(0, 255, 0)"
+PASS caughtEvent.data is "rgb(0, 255, 0)"
+PASS caughtEvent.data is "rgb(0, 255, 0)"
+PASS caughtEvent.data is "rgb(0, 255, 0)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/css/prefers-color-scheme-in-nested-iframes-follows-system-preference.html
+++ b/LayoutTests/http/tests/css/prefers-color-scheme-in-nested-iframes-follows-system-preference.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+
+<!--
+  Each test case is a chain of nested iframes, controlled by the `origins` search
+  parameter (encoded as JSON array). `origins[i]` is the i'th nested iframe's src
+  origin ("main" or "alt")
+
+  Once the chain is set up, the leaf page (page at the end of the chain) sends back
+  the evaluation result of @media (prefers-color-scheme) to the test page at the top,
+  and the test page checks if the result is correct or not. None of the intermediate
+  iframes have `color-scheme` explicitly set, so prefers-color-scheme should resolve
+  to the system color scheme.
+-->
+
+<title>prefers-color-scheme in nested iframes follows system preference if none of the iframes explicitly specify color-scheme</title>
+
+<main id="main">
+</main>
+
+<template id="leafpage">
+  <style>
+    @media (prefers-color-scheme: dark) {
+      #target { background-color: #00ff00; }
+    }
+
+    @media (prefers-color-scheme: light) {
+      #target { background-color: #ff0000; }
+    }
+
+    #target {
+      width: 100px;
+      height: 100px;
+    }
+  </style>
+  <div id="target"></div>
+</template>
+
+<script>
+  const mainURL = new URL(location.pathname, "http://127.0.0.1:8000");
+  const altURL = new URL(location.pathname, "http://localhost:8000");
+
+  const params = new URLSearchParams(location.search);
+  const origins = JSON.parse(params.get("origins"));
+  const systemAppearance = JSON.parse(params.get("systemAppearance"));
+
+  const isTestPage = !origins;
+  const isLeafPage = origins && !origins.length;
+  const isIntermediatePage = !isTestPage && !isLeafPage;
+
+  function createNextIframe(origins, systemAppearance) {
+    const origin = origins.shift();
+    const childURL = origin == "alt" ? new URL(altURL): new URL(mainURL);
+    childURL.searchParams.append("origins", JSON.stringify(origins));
+    childURL.searchParams.append("systemAppearance", JSON.stringify(systemAppearance));
+
+    const iframe = document.createElement("iframe");
+    iframe.src = childURL.toString();
+
+    return iframe;
+  }
+
+  if (isLeafPage) {
+    main.appendChild(leafpage.content.cloneNode(true));
+
+    if (window.testRunner) {
+      // setUseDarkAppearanceForTesting affects loaded frames, but doesn't affect
+      // future frames, so we have to set this for every new test case.
+      testRunner.setUseDarkAppearanceForTesting(systemAppearance);
+    }
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const targetComputedBackgroundColor = getComputedStyle(target).backgroundColor;
+        window.top.postMessage(targetComputedBackgroundColor, "*");
+      });
+    });
+  } else if (isIntermediatePage) {
+    main.appendChild(createNextIframe(origins, systemAppearance));
+  } else if (isTestPage) {
+    async function nested_test(origins, systemAppearance, expectedColor) {
+      main.appendChild(createNextIframe(origins, systemAppearance));
+
+      caughtEvent = await new Promise((resolve) => window.addEventListener("message", resolve, { once: true }));
+      shouldBeEqualToString("caughtEvent.data", expectedColor);
+      main.replaceChildren();
+    }
+
+    async function run_tests(systemAppearance, expectedColor) {
+      // Tests run rather slowly (maybe because testRunner.setUseDarkAppearanceForTesting is slow),
+      // so only test limited cases here, to keep the test fast and avoid timing out.
+
+      await nested_test(["main", "main"], systemAppearance, expectedColor);
+      await nested_test(["main", "main", "alt"], systemAppearance, expectedColor);
+      await nested_test(["main", "alt", "main", "alt"], systemAppearance, expectedColor);
+      await nested_test(["alt", "main", "alt", "main"], systemAppearance, expectedColor);
+    }
+
+    async function load_js(src) {
+      const script = document.createElement("script");
+      script.src = src;
+      document.head.appendChild(script);
+
+      return new Promise((resolve) => script.addEventListener("load", resolve));
+    }
+
+    window.jsTestIsAsync = true;
+    if (window.testRunner)
+      testRunner.waitUntilDone();
+
+    (async () => {
+      // js-test-pre.js and js-test-post.js should not run in intermediate & leaf pages,
+      // so load it here using JS only in the test page.
+      await load_js("/js-test-resources/js-test-pre.js");
+
+      description("prefers-color-scheme in nested iframes follows system preference if none of the iframes explicitly specify color-scheme");
+
+      // Light system preferrence.
+      const expectedLightColor = "rgb(255, 0, 0)";
+      await run_tests(false, expectedLightColor);
+
+      // Dark system preferrence.
+      const expectedDarkColor = "rgb(0, 255, 0)";
+      await run_tests(true, expectedDarkColor);
+
+      finishJSTest();
+
+      await load_js("/js-test-resources/js-test-post.js");
+    })();
+  };
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-nested.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-nested.sub-expected.txt
@@ -1,0 +1,14 @@
+
+PASS prefers-color-scheme in nested iframes works
+PASS prefers-color-scheme in nested iframes works 1
+PASS prefers-color-scheme in nested iframes works 2
+PASS prefers-color-scheme in nested iframes works 3
+PASS prefers-color-scheme in nested iframes works 4
+PASS prefers-color-scheme in nested iframes works 5
+PASS prefers-color-scheme in nested iframes works 6
+PASS prefers-color-scheme in nested iframes works 7
+PASS prefers-color-scheme in nested iframes works 8
+PASS prefers-color-scheme in nested iframes works 9
+PASS prefers-color-scheme in nested iframes works 10
+PASS prefers-color-scheme in nested iframes works 11
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-nested.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-nested.sub.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+
+<!--
+  Each test case is a chain of nested iframes, some of which has color-scheme set
+  on the embedding element. This is controlled by `origins` and `colorSchemes`
+  search parameters (encoded as JSON arrays):
+  * `origins[i]` is the i'th nested iframe's src origin ("main" or "alt")
+  * `colorSchemes[i]` is the color scheme of the embedder element of the i'th
+    nested iframe ("dark", "light", or "" to not explicitly specify)
+  0'th iframe is in the test page.
+
+  Once the chain is set up, the leaf page (page at the end of the chain) sends back
+  the evaluation result of @media (prefers-color-scheme) to the test page at the top,
+  and the test page checks if the result is correct or not.
+-->
+
+<title>prefers-color-scheme in nested iframes works</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7493">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<main id="main">
+</main>
+
+<template id="leafpage">
+  <style>
+    @media (prefers-color-scheme: dark) {
+      #target { background-color: #00ff00; }
+    }
+
+    @media (prefers-color-scheme: light) {
+      #target { background-color: #ff0000; }
+    }
+
+    #target {
+      width: 100px;
+      height: 100px;
+    }
+  </style>
+  <div id="target"></div>
+</template>
+
+<script>
+  const mainURL = new URL(location.pathname, "http://{{hosts[][]}}:{{ports[http][0]}}");
+  const altURL = new URL(location.pathname, "http://{{hosts[alt][]}}:{{ports[http][0]}}");
+
+  const params = new URLSearchParams(location.search);
+  const origins = JSON.parse(params.get("origins"));
+  const colorSchemes = JSON.parse(params.get("colorSchemes"));
+
+  const isTestPage = !origins && !colorSchemes;
+  const isLeafPage = origins && !origins.length && colorSchemes && !colorSchemes.length;
+  const isIntermediatePage = !isTestPage && !isLeafPage;
+
+  function createNextIframe(origins, colorSchemes) {
+    const origin = origins.shift();
+    const colorScheme = colorSchemes.shift();
+
+    const iframe = document.createElement("iframe");
+    if (colorScheme)
+      iframe.style.colorScheme = colorScheme;
+
+    const childURL = origin == "alt" ? new URL(altURL): new URL(mainURL);
+    childURL.searchParams.append("origins", JSON.stringify(origins));
+    childURL.searchParams.append("colorSchemes", JSON.stringify(colorSchemes));
+    iframe.src = childURL.toString();
+
+    return iframe;
+  }
+
+  if (isLeafPage) {
+    main.appendChild(leafpage.content.cloneNode(true));
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const targetComputedBackgroundColor = getComputedStyle(target).backgroundColor;
+        window.top.postMessage(targetComputedBackgroundColor, "*");
+      });
+    });
+  } else if (isIntermediatePage) {
+    main.appendChild(createNextIframe(origins, colorSchemes));
+  } else if (isTestPage) {
+    function nested_test(origins, colorSchemes, expectedColor) {
+      promise_test(async (t) => {
+        main.appendChild(createNextIframe(origins, colorSchemes));
+
+        const actualColor = (await new Promise((resolve) => window.addEventListener("message", resolve, { once: true }))).data;
+        assert_equals(actualColor, expectedColor);
+        main.replaceChildren();
+      });
+    }
+
+    const expectedLightColor = "rgb(255, 0, 0)";
+    const expectedDarkColor = "rgb(0, 255, 0)";
+
+    // 3 nested
+    nested_test(["main", "main"], ["dark", ""], expectedDarkColor);
+    nested_test(["main", "alt"], ["light", ""], expectedLightColor);
+    nested_test(["alt", "alt"], ["dark", ""], expectedDarkColor);
+
+    // 4 nested
+    nested_test(["main", "main", "alt"], ["light", "", "dark"], expectedDarkColor);
+    nested_test(["main", "alt", "main"], ["light", "dark", ""], expectedDarkColor);
+    nested_test(["alt", "main", "main"], ["light", "", ""], expectedLightColor);
+    nested_test(["main", "main", "main"], ["dark", "", ""], expectedDarkColor);
+
+    // 5 nested
+    nested_test(["main", "alt", "main", "alt"], ["light", "", "dark", ""], expectedDarkColor);
+    nested_test(["alt", "main", "alt", "main"], ["light", "dark", "", ""], expectedDarkColor);
+    nested_test(["alt", "main", "alt", "main"], ["", "dark", "", ""], expectedDarkColor);
+    nested_test(["alt", "main", "main", "alt"], ["light", "", "", ""], expectedLightColor);
+    nested_test(["main", "main", "main", "main"], ["dark", "", "", ""], expectedDarkColor);
+  };
+</script>

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -486,9 +486,6 @@ imported/w3c/web-platform-tests/svg/shapes/rect-01.svg [ ImageOnlyFailure ]
 svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift.html [ ImageOnlyFailure ]
 svg/compositing/transform-change-repainting-no-viewBox.html [ ImageOnlyFailure ]
 svg/custom/svg-image-dark-mode-initial.html [ ImageOnlyFailure ]
-webkit.org/b/311812 http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme.html [ ImageOnlyFailure ]
-webkit.org/b/311812 imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub.html [ ImageOnlyFailure ]
-webkit.org/b/311812 imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub.html [ ImageOnlyFailure ]
 
 ####################################
 # Tests with missing expectations #

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -798,20 +798,32 @@ static const IdentifierSchema& overflowInlineFeatureSchema()
 }
 
 #if ENABLE(DARK_MODE_CSS)
-static bool frameUsesDarkAppearanceForPrefersColorScheme(const Frame& frame)
+static bool frameOwnerElementAncestorsUseDarkAppearance(const Frame& frame)
 {
-    if (RefPtr parent = frame.parent()) {
+    {
+        RefPtr<const Frame> child = &frame;
+        RefPtr<const Frame> parent = child->parent();
+
         // From CSS Media Queries Level 5: if the frame is a subframe, its preferred color scheme
         // is the color scheme of its owner element:
         // > the preferred color scheme must reflect the value of the used color scheme on the
         // > embedding node in the embedding document.
-        // FIXME (webkit.org/b/309611): this should recurse up to the main frame.
-        if (RefPtr ownerRenderer = frame.ownerRenderer()) {
-            if (ownerRenderer->style().hasExplicitlySetColorScheme())
-                return protect(parent->virtualView())->ownerElementOfChildFrameUsesDarkAppearance(frame);
+
+        // Iterate up the chain of owner elements to find the first one with explicitly set color scheme.
+        while (parent) {
+            ASSERT(child);
+
+            auto ownerElementAppearance = protect(parent->virtualView())->appearanceOfOwnerElementOfChildFrame(*child);
+
+            if (ownerElementAppearance.contains(FrameOwnerElementAppearance::ExplicitlySet))
+                return ownerElementAppearance.contains(FrameOwnerElementAppearance::IsDark);
+
+            child = parent;
+            parent = child->parent();
         }
     }
 
+    // If none of the ancestor owner elements specify color scheme, fallback to the system appearance.
     return protect(frame.page())->useDarkAppearance();
 }
 
@@ -822,7 +834,7 @@ static const IdentifierSchema& prefersColorSchemeFeatureSchema()
         FixedVector { CSSValueLight, CSSValueDark },
         MediaQueryDynamicDependency::Appearance,
         [](auto& context) {
-            bool useDarkAppearance = frameUsesDarkAppearanceForPrefersColorScheme(*context.document->frame());
+            bool useDarkAppearance = frameOwnerElementAncestorsUseDarkAppearance(*context.document->frame());
 
             return MatchingIdentifiers { useDarkAppearance ? CSSValueDark : CSSValueLight };
         }

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -359,7 +359,7 @@ void Frame::updateFrameTreeSyncData(const FrameTreeSyncSerializationData& data)
             auto oldFrameInfo = oldMap.getOptional(child->frameID());
             auto newFrameInfo = newMap.getOptional(child->frameID());
 
-            if (!oldFrameInfo || !newFrameInfo || oldFrameInfo->useDarkAppearance != newFrameInfo->useDarkAppearance) {
+            if (!oldFrameInfo || !newFrameInfo || oldFrameInfo->ownerElementAppearance.contains(FrameOwnerElementAppearance::IsDark) != newFrameInfo->ownerElementAppearance.contains(FrameOwnerElementAppearance::IsDark)) {
                 RefPtr localChildView = localChild->view();
 
                 localChildView->invalidateForBaseBackgroundOrColorSchemeChange();

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 class Frame;
 class RenderElement;
+enum class FrameOwnerElementAppearance : uint8_t;
 enum class RenderAsTextFlag : uint16_t;
 
 class FrameView : public ScrollView {
@@ -125,11 +126,11 @@ public:
     // direct child of this frame.
     virtual std::optional<LayoutRect> visibleRectOfChild(const Frame&) const = 0;
 
-    // Whether the child frame's owner element (which is in this frame) uses dark
-    // appearance or not. Note that this is _different_ from the child frame's
+    // Returns the appearance info of the child frame's owner element (which is
+    // in this frame). Note that this is _different_ from the child frame's
     // document's appearance, and they can be different (e.g the owner element
     // uses dark appearance, but the child frame's document is light).
-    virtual bool ownerElementOfChildFrameUsesDarkAppearance(const Frame&) const = 0;
+    virtual OptionSet<FrameOwnerElementAppearance> appearanceOfOwnerElementOfChildFrame(const Frame&) const = 0;
 
 private:
     ScrollableArea* enclosingScrollableArea() const final;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2156,17 +2156,26 @@ std::optional<LayoutRect> LocalFrameView::visibleRectOfChild(const Frame& child)
     return rects.transform([] (const auto& repaintRects) { return repaintRects.clippedOverflowRect; });
 }
 
-bool LocalFrameView::ownerElementOfChildFrameUsesDarkAppearance(const Frame& child) const
+OptionSet<FrameOwnerElementAppearance> LocalFrameView::appearanceOfOwnerElementOfChildFrame(const Frame& child) const
 {
     RefPtr childOwnerRenderer = child.ownerRenderer();
     if (!childOwnerRenderer)
-        return false;
+        return { };
 
     // Ensure |child| is a child of this frame.
     ASSERT(child.tree().parent()->frameID() == m_frame->frameID());
     ASSERT(childOwnerRenderer->frame().frameID() == m_frame->frameID());
 
-    return childOwnerRenderer->useDarkAppearance();
+    OptionSet<FrameOwnerElementAppearance> result;
+    if (childOwnerRenderer->useDarkAppearance())
+        result |= FrameOwnerElementAppearance::IsDark;
+#if ENABLE(DARK_MODE_CSS)
+    // FIXME: does <meta name="color-scheme"> counts as explicitly set too?
+    if (childOwnerRenderer->style().hasExplicitlySetColorScheme())
+        result |= FrameOwnerElementAppearance::ExplicitlySet;
+#endif
+
+    return result;
 }
 
 LayoutRect LocalFrameView::rectForFixedPositionLayout() const

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -324,7 +324,7 @@ public:
     LayoutRect layoutViewportRectIncludingObscuredInsets() const;
 
     std::optional<LayoutRect> visibleRectOfChild(const Frame&) const final;
-    bool ownerElementOfChildFrameUsesDarkAppearance(const Frame&) const final;
+    OptionSet<FrameOwnerElementAppearance> appearanceOfOwnerElementOfChildFrame(const Frame&) const final;
     
     static LayoutRect visibleDocumentRect(const FloatRect& visibleContentRect, float headerHeight, float footerHeight, const FloatSize& totalContentsSize, float pageScaleFactor);
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2201,9 +2201,13 @@ void Page::syncLocalFrameInfoToRemote()
             for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
                 auto visibleRect = frameView->visibleRectOfChild(*child.get());
                 float usedZoom = frame.usedZoomForChild(*child);
-                bool useDarkAppearance = frameView->ownerElementOfChildFrameUsesDarkAppearance(*child);
+                auto frameOwnerElementAppearance = frameView->appearanceOfOwnerElementOfChildFrame(*child);
 
-                childrenFrameLayoutInfo.add(child->frameID(), RemoteFrameLayoutInfo { .visibleRectInParent = visibleRect, .usedZoom = usedZoom, .useDarkAppearance = useDarkAppearance });
+                childrenFrameLayoutInfo.add(child->frameID(), RemoteFrameLayoutInfo {
+                    .visibleRectInParent = visibleRect,
+                    .usedZoom = usedZoom,
+                    .ownerElementAppearance = frameOwnerElementAppearance
+                });
             }
 
             frame.loader().client().broadcastChildrenFrameLayoutInfoToOtherProcesses(childrenFrameLayoutInfo);

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.h
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.h
@@ -29,10 +29,18 @@
 
 namespace WebCore {
 
-// Collection of layout info regarding a (potentially remote) frame.
+enum class FrameOwnerElementAppearance : uint8_t {
+    // Whether the used color scheme of the frame embedder is dark or not.
+    // This could either come from `color-scheme` CSS property or system preference.
+    IsDark = 1 << 0,
+
+    // Whether the color scheme is explicitly set using `color-scheme` CSS property or not.
+    ExplicitlySet = 1 << 1
+};
+
+// Collection of style/layout info regarding a (potentially remote) frame.
 // This is synchronized from LocalFrame in one process to RemoteFrames
-// in other processes using FrameTreeSyncData. Currently, it is used by
-// Intersection Observer to compute the intersection rectangle from any processes.
+// in other processes using FrameTreeSyncData.
 struct RemoteFrameLayoutInfo {
     // Rectangle of the visible portion of the frame in its parent frame,
     // in the coordinate space of the document of the parent frame.
@@ -41,8 +49,7 @@ struct RemoteFrameLayoutInfo {
     // RenderStyle::usedZoom of the owner renderer of the frame.
     float usedZoom;
 
-    // useDarkAppearance of the owner renderer of the frame.
-    bool useDarkAppearance;
+    OptionSet<FrameOwnerElementAppearance> ownerElementAppearance;
 };
 
 };

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -79,12 +79,12 @@ std::optional<LayoutRect> RemoteFrameView::visibleRectOfChild(const Frame& child
     });
 }
 
-bool RemoteFrameView::ownerElementOfChildFrameUsesDarkAppearance(const Frame& child) const
+OptionSet<FrameOwnerElementAppearance> RemoteFrameView::appearanceOfOwnerElementOfChildFrame(const Frame& child) const
 {
-    auto maybeInfo = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.getOptional(child.frameID());
-    return maybeInfo.transform([] (auto& info) {
-        return info.useDarkAppearance;
-    }).value_or(false);
+    if (auto info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.getOptional(child.frameID()))
+        return info->ownerElementAppearance;
+
+    return { };
 }
 
 // FIXME: Implement all the stubs below.

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -52,7 +52,7 @@ public:
     // RemoteFrameViews on the receiving end will set using this method to avoid repeating the sync.
     WEBCORE_EXPORT void setFrameRectWithoutSync(const IntRect&);
 
-    bool ownerElementOfChildFrameUsesDarkAppearance(const Frame&) const final;
+    OptionSet<FrameOwnerElementAppearance> appearanceOfOwnerElementOfChildFrame(const Frame&) const final;
 
 private:
     WEBCORE_EXPORT RemoteFrameView(RemoteFrame&);

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -743,7 +743,8 @@ bool RenderView::shouldPaintBaseBackground() const
             // iframes should fill with a base color if the used color scheme of the
             // element and the used color scheme of the embedded document’s root
             // element do not match.
-            if (frameView->useDarkAppearance() != parentFrameView->ownerElementOfChildFrameUsesDarkAppearance(frameView->frame()))
+            bool useDarkAppearance = parentFrameView->appearanceOfOwnerElementOfChildFrame(frameView->frame()).contains(FrameOwnerElementAppearance::IsDark);
+            if (frameView->useDarkAppearance() != useDarkAppearance)
                 return !frameView->isTransparent();
         }
     }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2196,10 +2196,15 @@ class WebCore::LayoutRect {
     WebCore::LayoutSize m_size;
 };
 
+[OptionSet] enum class WebCore::FrameOwnerElementAppearance : uint8_t {
+    IsDark,
+    ExplicitlySet
+};
+
 struct WebCore::RemoteFrameLayoutInfo {
     std::optional<WebCore::LayoutRect> visibleRectInParent;
     float usedZoom;
-    bool useDarkAppearance;
+    OptionSet<WebCore::FrameOwnerElementAppearance> ownerElementAppearance;
 };
 
 header: <WebCore/VP9Utilities.h>


### PR DESCRIPTION
#### 9e45d72ed9ea3871ccc4d9a4d9ae93d7a5debe38
<pre>
[Site Isolation] prefers-color-scheme doesn&apos;t see color-scheme from parent frames and above
<a href="https://rdar.apple.com/172229372">rdar://172229372</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309611">https://bugs.webkit.org/show_bug.cgi?id=309611</a>

Reviewed by Simon Fraser.

310465@main makes prefers-color-scheme follow the color scheme of the embedding element,
if the document is embedded in an iframe. 310874@main adds a behavior to use the system
appearance if the parent iframe doesn&apos;t explicitly set a color-scheme. This uses
ownerRenderer() to peek at the embedding element&apos;s style, and thus won&apos;t work with Site
Isolation. This patch makes it work with Site Isolation by using RemoteFrameLayoutInfo to
broadcast the info whether the embedding element&apos;s color scheme is explicitly set or not.
This involves extending RemoteFrameLayoutInfo::ownerElementAppearance (renamed from
useDarkAppearance) to store this info.

Additionally, this patch changes the logic of prefers-color-scheme to consider ancestor
embedding elements if the immediate embedding element doesn&apos;t have an explicitly
set color-scheme, in the case of nested iframes. The preferred color scheme is taken
from the nearest ancestor embedding element with an explicitly set color-scheme.
If none exists, it falls back to the system appearance.

Tests: http/tests/css/prefers-color-scheme-in-nested-iframes-follows-system-preference.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-nested.sub.html

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme.html:
* LayoutTests/http/tests/css/prefers-color-scheme-in-nested-iframes-follows-system-preference-expected.txt: Added.
* LayoutTests/http/tests/css/prefers-color-scheme-in-nested-iframes-follows-system-preference.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-nested.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-nested.sub.html: Added.
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::frameOwnerElementAncestorsUseDarkAppearance):
(WebCore::MQ::Features::prefersColorSchemeFeatureSchema):
(WebCore::MQ::Features::frameUsesDarkAppearanceForPrefersColorScheme):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::updateFrameTreeSyncData):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::appearanceOfOwnerElementOfChildFrame const):
(WebCore::LocalFrameView::ownerElementOfChildFrameUsesDarkAppearance const): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
* Source/WebCore/page/RemoteFrameLayoutInfo.h:
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::appearanceOfOwnerElementOfChildFrame const):
(WebCore::RemoteFrameView::ownerElementOfChildFrameUsesDarkAppearance const): Deleted.
* Source/WebCore/page/RemoteFrameView.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::shouldPaintBaseBackground const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/312212@main">https://commits.webkit.org/312212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82c17ab5a7bde6eb129e4047ebb77aa50d518367

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113123 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d57327d0-a6b3-4fb7-9a1f-e267997d91c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123215 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86520 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e6ee4b1-cf6e-49b4-bc95-61a3483ef269) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103882 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2947d368-45c4-4435-9c4c-3b660317e63b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24554 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22961 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15641 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170361 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16103 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131405 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27030 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131517 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35611 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142450 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90150 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19259 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31611 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97625 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31131 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31404 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31286 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->