### PR TITLE
[JSC] Remove PL from IPInt

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -50,10 +50,11 @@
 # - MC: (Metadata Counter) IPInt's metadata pointer. This records the corresponding position in generated metadata.
 # - WI: (Wasm Instance) pointer to the current JSWebAssemblyInstance object. This is used for accessing
 #       function-specific data (callee-save).
-# - PL: (Pointer to Locals) pointer to the address of local 0 in the current function. This is used for accessing
-#       locals quickly.
 # - MB: (Memory Base) pointer to the current Wasm memory base address (callee-save).
 # - BC: (Bounds Check) the size of the current Wasm memory region, for bounds checking (callee-save).
+#
+# Locals are accessed at a constant offset from CFR:
+#   local[i] = CFR - IPIntLocalsBaseOffset - i * LocalSize
 #
 # Finally, we provide four "sc" (safe for call) registers which are guaranteed to not overlap with argument
 # registers (sc0, sc1, sc2, sc3)
@@ -67,8 +68,6 @@ const alignMInt = constexpr JSC::IPInt::alignMInt
 if ARM64 or ARM64E
     const PC = csr7
     const MC = csr6
-    const PL = t6
-    const notPL = t5 # Scratch register that is NOT PL
 
     # Wasm Pinned Registers
     const WI = csr0
@@ -82,8 +81,6 @@ if ARM64 or ARM64E
 elsif X86_64
     const PC = csr2
     const MC = csr1
-    const PL = t5
-    const notPL = t6 # Scratch register that is NOT PL
 
     # Wasm Pinned Registers
     const WI = csr0
@@ -97,7 +94,6 @@ elsif X86_64
 elsif RISCV64
     const PC = csr7
     const MC = csr6
-    const PL = csr10
 
     # Wasm Pinned Registers
     const WI = csr0
@@ -111,7 +107,6 @@ elsif RISCV64
 elsif ARMv7
     const PC = csr1
     const MC = t6
-    const PL = t7
 
     # Wasm Pinned Registers
     const WI = csr0
@@ -125,7 +120,6 @@ elsif ARMv7
 else
     const PC = invalidGPR
     const MC = invalidGPR
-    const PL = invalidGPR
 
     # Wasm Pinned Registers
     const WI = invalidGPR
@@ -172,6 +166,9 @@ const WasmToJSIPIntReturnPCSlot = constexpr Wasm::WasmToJSIPIntReturnPCSlot
 
 const IPIntCalleeSaveSpaceAsVirtualRegisters = constexpr Wasm::numberOfIPIntCalleeSaveRegisters + constexpr Wasm::numberOfIPIntInternalRegisters
 const IPIntCalleeSaveSpaceStackAligned = (IPIntCalleeSaveSpaceAsVirtualRegisters * SlotSize + StackAlignment - 1) & ~StackAlignmentMask
+
+# Offset from CFR to local[0]: local[i] = CFR - IPIntLocalsBaseOffset - i * LocalSize
+const IPIntLocalsBaseOffset = IPIntCalleeSaveSpaceStackAligned + LocalSize
 
 # Must match GPRInfo.h
 if X86_64
@@ -461,18 +458,14 @@ macro operationCall(fn)
     move wasmInstance, a0
     push PC, MC
     if ARM64 or ARM64E
-        push PL, ws0
-    elsif X86_64
-        push PL
-        # preserve 16 byte alignment.
-        subq MachineRegisterSize, sp
+        # Save ws0 with padding for 16-byte alignment (PC+MC=16, ws0+pad=16, total=32)
+        subp MachineRegisterSize * 2, sp
+        storep ws0, [sp]
     end
     fn()
     if ARM64 or ARM64E
-        pop ws0, PL
-    elsif X86_64
-        addq MachineRegisterSize, sp
-        pop PL
+        loadp [sp], ws0
+        addp MachineRegisterSize * 2, sp
     end
     pop MC, PC
 end
@@ -484,11 +477,8 @@ macro operationCallMayThrowImpl(fn, sizeOfExtraRegistersPreserved)
     move wasmInstance, a0
     push PC, MC
     if ARM64 or ARM64E
-        push PL, ws0
-    elsif X86_64
-        push PL
-        # preserve 16 byte alignment.
-        subq MachineRegisterSize, sp
+        # Save ws0 with padding for 16-byte alignment (PC+MC=16, ws0+ws0=16, total=32)
+        push ws0, ws0
     end
     fn()
     bpneq r1, (constexpr JSC::IPInt::SlowPathExceptionTag), .continuation
@@ -498,15 +488,15 @@ macro operationCallMayThrowImpl(fn, sizeOfExtraRegistersPreserved)
         move cfr, a1
         move sp, a2
         operationCall(macro() cCall3(_ipint_extern_handle_debugger_trap_if_needed) end)
+        addp sizeOfExtraRegistersPreserved + (4 * MachineRegisterSize), sp
+    elsif X86_64
+        addp sizeOfExtraRegistersPreserved + (2 * MachineRegisterSize), sp
     end
-    addp sizeOfExtraRegistersPreserved + (4 * MachineRegisterSize), sp
     jmp _wasm_throw_from_slow_path_trampoline
 .continuation:
     if ARM64 or ARM64E
-        pop ws0, PL
-    elsif X86_64
-        addq MachineRegisterSize, sp
-        pop PL
+        loadp [sp], ws0
+        addp MachineRegisterSize * 2, sp
     end
     pop MC, PC
 end
@@ -586,7 +576,7 @@ if JIT and not ARMv7
     move PC, a2
     # Add 1 to the index due to WTF::UncheckedKeyHashMap not supporting 0 as a key
     addq 1, a2
-    move PL, a3
+    move sp, a3
     operationCall(macro() cCall4(_ipint_extern_loop_osr) end)
     btpz r1, .recover
     restoreIPIntRegisters()
@@ -1279,9 +1269,9 @@ end
 
 macro handleDebuggerTrapIfNeeded()
     push PC, MC
-    push PL, ws0    # sp[0]=PL, sp[1]=ws0 (IPIntCallee*), sp[2]=PC, sp[3]=MC
+    push ws0, ws0   # sp[0]=ws0 (unused), sp[1]=ws0 (IPIntCallee*), sp[2]=PC, sp[3]=MC
     move cfr, a1
-    move sp, a2     # a2 = pointer to saved [PL, ws0, PC, MC]
+    move sp, a2     # a2 = pointer to saved [ws0, ws0, PC, MC]
     operationCall(macro() cCall3(_ipint_extern_handle_debugger_trap_if_needed) end)
     addp 4 * MachineRegisterSize, sp
 end
@@ -1330,7 +1320,7 @@ end)
 op(wasm_throw_from_fault_handler_trampoline_reg_instance, macro ()
     # enableWasmDebugger disables BBQ/OMG, so this trampoline is only
     # reached from IPInt when the debugger is active. The signal handler only patches
-    # the machine PC, so IPInt registers (PC, MC, PL, ws0, cfr) are still live.
+    # the machine PC, so IPInt registers (PC, MC, ws0, cfr) are still live.
     # Exception type comes from instance->m_exception; copy to CFR slot for handle_debugger_trap_if_needed.
     loadi JSWebAssemblyInstance::m_exception[wasmInstance], t0
     storei t0, ArgumentCountIncludingThis + PayloadOffset[cfr]
@@ -1385,7 +1375,6 @@ end
     operationCall(macro() cCall2(_ipint_extern_prepare_function_body) end)
     move r0, ws0
 
-    move sp, PL
     loadp Wasm::IPIntCallee::m_bytecode[ws0], PC
     loadp Wasm::IPIntCallee::m_metadata + VectorBufferOffset[ws0], MC
 
@@ -1434,18 +1423,9 @@ end
     loadp Wasm::IPIntCallee::m_metadata + VectorBufferOffset[ws0], t1
     addp t1, MC
 
-    # Recompute PL
-    if ARM64 or ARM64E
-        loadpairi Wasm::IPIntCallee::m_localSizeToAlloc[ws0], t0, t1
-    else
-        loadi Wasm::IPIntCallee::m_numRethrowSlotsToAlloc[ws0], t1
-        loadi Wasm::IPIntCallee::m_localSizeToAlloc[ws0], t0
-    end
-    addp t1, t0
-    mulp LocalSize, t0
-    addp IPIntCalleeSaveSpaceStackAligned, t0
-    subp cfr, t0, PL
-
+    # Recompute SP from catch metadata. [MC] contains localSizeToAlloc + stackValues.
+    # Add rethrowSlots to get the total frame size below callee-save space.
+    loadi Wasm::IPIntCallee::m_numRethrowSlotsToAlloc[ws0], t1
     loadi [MC], t0
     addp t1, t0
     mulp StackValueSize, t0
@@ -1468,8 +1448,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
 
     move cfr, a1
     move sp, a2
-    move PL, a3
-    operationCall(macro() cCall4(_ipint_extern_retrieve_and_clear_exception) end)
+    operationCall(macro() cCall3(_ipint_extern_retrieve_and_clear_exception) end)
 
     ipintReloadMemory()
     advanceMC(4)
@@ -1485,8 +1464,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
 
     move cfr, a1
     move 0, a2
-    move PL, a3
-    operationCall(macro() cCall4(_ipint_extern_retrieve_and_clear_exception) end)
+    operationCall(macro() cCall3(_ipint_extern_retrieve_and_clear_exception) end)
 
     ipintReloadMemory()
     advanceMC(4)
@@ -1504,8 +1482,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 
     move cfr, a1
     move sp, a2
-    move PL, a3
-    operationCall(macro() cCall4(_ipint_extern_retrieve_and_clear_exception) end)
+    operationCall(macro() cCall3(_ipint_extern_retrieve_and_clear_exception) end)
 
     ipintReloadMemory()
     advanceMC(4)
@@ -1523,8 +1500,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 
     move cfr, a1
     move sp, a2
-    move PL, a3
-    operationCall(macro() cCall4(_ipint_extern_retrieve_clear_and_push_exception_and_arguments) end)
+    operationCall(macro() cCall3(_ipint_extern_retrieve_clear_and_push_exception_and_arguments) end)
 
     ipintReloadMemory()
     advanceMC(4)
@@ -1542,8 +1518,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 
     move cfr, a1
     move 0, a2
-    move PL, a3
-    operationCall(macro() cCall4(_ipint_extern_retrieve_and_clear_exception) end)
+    operationCall(macro() cCall3(_ipint_extern_retrieve_and_clear_exception) end)
 
     ipintReloadMemory()
     advanceMC(4)
@@ -1561,8 +1536,7 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 
     move cfr, a1
     move sp, a2
-    move PL, a3
-    operationCall(macro() cCall4(_ipint_extern_retrieve_clear_and_push_exception) end)
+    operationCall(macro() cCall3(_ipint_extern_retrieve_clear_and_push_exception) end)
 
     ipintReloadMemory()
     advanceMC(4)

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -180,15 +180,21 @@ macro ipintEntry()
     end
     mulp LocalSize, argumINTEnd
     mulp LocalSize, argumINTTmp
-    subp argumINTEnd, sp
-    move sp, argumINTEnd
+    # Allocate locals first (closest to CFR)
     subp argumINTTmp, sp
     move sp, argumINTDsp
+    # Allocate rethrow slots below locals
+    subp argumINTEnd, sp
+    # argumINTEnd = boundary for zero-init loop. Handlers write [argumINTDst] then subp,
+    # so after localSizeToAlloc handlers, argumINTDst = argumINTDsp - LocalSize.
+    move argumINTDsp, argumINTEnd
+    subp LocalSize, argumINTEnd
     loadp Wasm::IPIntCallee::m_argumINTBytecode + VectorBufferOffset[ws0], MC
 
     push argumINTTmp, argumINTDst, argumINTSrc, argumINTEnd
 
-    move argumINTDsp, argumINTDst
+    # Start writing at local[0] = CFR - IPIntLocalsBaseOffset, going downward
+    leap -IPIntLocalsBaseOffset[cfr], argumINTDst
     leap FirstArgumentOffset[cfr], argumINTSrc
 
     validateOpcodeConfig(argumINTTmp)
@@ -210,7 +216,7 @@ end
 end
 
 macro argumINTInitializeDefaultLocals()
-    # zero out remaining locals
+    # zero out remaining locals (argumINTDst moves downward toward argumINTEnd)
     bpeq argumINTDst, argumINTEnd, .ipint_entry_finish_zero
     loadb [MC], argumINTTmp
     addp 1, MC
@@ -223,7 +229,7 @@ elsif X86_64
     storep argumINTTmp, [argumINTDst]
     storep 0, 8[argumINTDst]
 end
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
 end
 
 macro argumINTFinish()
@@ -356,9 +362,8 @@ ipintOp(_rethrow, macro()
     copyCalleeSavesToEntryFrameCalleeSavesBuffer(t0)
 
     move cfr, a1
-    move PL, a2
-    loadi IPInt::RethrowMetadata::tryDepth[MC], a3
-    operationCall(macro() cCall4(_ipint_extern_rethrow_exception) end)
+    loadi IPInt::RethrowMetadata::tryDepth[MC], a2
+    operationCall(macro() cCall3(_ipint_extern_rethrow_exception) end)
     jumpToException()
 end)
 
@@ -740,9 +745,10 @@ end)
     ###################################
 
 macro localGetPostDecode()
-    # Index into locals
+    # Index into locals: local[i] = CFR - IPIntLocalsBaseOffset - i * LocalSize
     mulq LocalSize, t0
-    loadv [PL, t0], v0
+    subp cfr, t0, t0
+    loadv -IPIntLocalsBaseOffset[t0], v0
     # Push to stack
     pushVec(v0)
     nextIPIntInstruction()
@@ -759,9 +765,10 @@ end)
 macro localSetPostDecode()
     # Pop from stack
     popVec(v0)
-    # Store to locals
+    # Store to locals: local[i] = CFR - IPIntLocalsBaseOffset - i * LocalSize
     mulq LocalSize, t0
-    storev v0, [PL, t0]
+    subp cfr, t0, t0
+    storev v0, -IPIntLocalsBaseOffset[t0]
     nextIPIntInstruction()
 end
 
@@ -776,9 +783,10 @@ end)
 macro localTeePostDecode()
     # Load from stack
     loadv [sp], v0
-    # Store to locals
+    # Store to locals: local[i] = CFR - IPIntLocalsBaseOffset - i * LocalSize
     mulq LocalSize, t0
-    storev v0, [PL, t0]
+    subp cfr, t0, t0
+    storev v0, -IPIntLocalsBaseOffset[t0]
     nextIPIntInstruction()
 end
 
@@ -10383,8 +10391,6 @@ macro weakCASExchangeQuad(mem, value, expected, scratch, scratch2)
 end
 
 ipintAtomicOp(_i32_atomic_rmw_cmpxchg, macro()
-    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
-    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
@@ -10396,8 +10402,6 @@ ipintAtomicOp(_i32_atomic_rmw_cmpxchg, macro()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_cmpxchg, macro()
-    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
-    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
@@ -10409,8 +10413,6 @@ ipintAtomicOp(_i64_atomic_rmw_cmpxchg, macro()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_cmpxchg_u, macro()
-    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
-    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
@@ -10422,8 +10424,6 @@ ipintAtomicOp(_i32_atomic_rmw8_cmpxchg_u, macro()
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_cmpxchg_u, macro()
-    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
-    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
@@ -10435,8 +10435,6 @@ ipintAtomicOp(_i32_atomic_rmw16_cmpxchg_u, macro()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_cmpxchg_u, macro()
-    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
-    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
@@ -10448,8 +10446,6 @@ ipintAtomicOp(_i64_atomic_rmw8_cmpxchg_u, macro()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_cmpxchg_u, macro()
-    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
-    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
@@ -10461,8 +10457,6 @@ ipintAtomicOp(_i64_atomic_rmw16_cmpxchg_u, macro()
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_cmpxchg_u, macro()
-    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
-    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
     popMemoryIndex(t0)
@@ -10533,7 +10527,7 @@ end
 
 .ipint_i32_load_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     loadi [t0], t1
     pushInt32(t1)
     move t4, PC
@@ -10541,7 +10535,7 @@ end
 
 .ipint_i64_load_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     loadq [t0], t1
     pushInt64(t1)
     move t4, PC
@@ -10549,7 +10543,7 @@ end
 
 .ipint_f32_load_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     loadf [t0], ft0
     pushFloat32(ft0)
     move t4, PC
@@ -10557,7 +10551,7 @@ end
 
 .ipint_f64_load_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     loadd [t0], ft0
     pushFloat64(ft0)
     move t4, PC
@@ -10565,7 +10559,7 @@ end
 
 .ipint_i32_load8s_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     loadbsi [t0], t1
     pushInt32(t1)
     move t4, PC
@@ -10573,7 +10567,7 @@ end
 
 .ipint_i32_load8u_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     loadb [t0], t1
     pushInt32(t1)
     move t4, PC
@@ -10581,7 +10575,7 @@ end
 
 .ipint_i32_load16s_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     loadhsi [t0], t1
     pushInt32(t1)
     move t4, PC
@@ -10589,7 +10583,7 @@ end
 
 .ipint_i32_load16u_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     loadh [t0], t1
     pushInt32(t1)
     move t4, PC
@@ -10597,7 +10591,7 @@ end
 
 .ipint_i64_load8s_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     loadbsq [t0], t1
     pushInt64(t1)
     move t4, PC
@@ -10605,7 +10599,7 @@ end
 
 .ipint_i64_load8u_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     loadb [t0], t1
     pushInt64(t1)
     move t4, PC
@@ -10613,7 +10607,7 @@ end
 
 .ipint_i64_load16s_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     loadhsq [t0], t1
     pushInt64(t1)
     move t4, PC
@@ -10621,7 +10615,7 @@ end
 
 .ipint_i64_load16u_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     loadh [t0], t1
     pushInt64(t1)
     move t4, PC
@@ -10629,7 +10623,7 @@ end
 
 .ipint_i64_load32s_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     loadi [t0], t1
     sxi2q t1, t1
     pushInt64(t1)
@@ -10638,7 +10632,7 @@ end
 
 .ipint_i64_load32u_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     loadi [t0], t1
     pushInt64(t1)
     move t4, PC
@@ -10646,63 +10640,63 @@ end
 
 .ipint_i32_store_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     storei t3, [t0]
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_store_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     storeq t3, [t0]
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_f32_store_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     storef ft0, [t0]
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_f64_store_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     stored ft0, [t0]
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_store8_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     storeb t3, [t0]
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_store16_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     storeh t3, [t0]
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_store8_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     storeb t3, [t0]
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_store16_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     storeh t3, [t0]
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_store32_mem_slow_path:
     leap 1[PC], t4
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     storei t3, [t0]
     move t4, PC
     nextIPIntInstruction()
@@ -10716,90 +10710,90 @@ end
 # After loadStoreMakePointerSlow, t4 points past the memarg.
 
 .simd_v128_load_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 16, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 16, t1, t2, t5, t6)
     loadv [t0], v0
     pushVec(v0)
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_load_8x8s_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     simdLoad8x8s()
     pushVec(v0)
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_load_8x8u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     simdLoad8x8u()
     pushVec(v0)
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_load_16x4s_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     simdLoad16x4s()
     pushVec(v0)
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_load_16x4u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     simdLoad16x4u()
     pushVec(v0)
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_load_32x2s_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     simdLoad32x2s()
     pushVec(v0)
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_load_32x2u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     simdLoad32x2u()
     pushVec(v0)
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_load8_splat_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     simdLoadSplat8()
     pushVec(v0)
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_load16_splat_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     simdLoadSplat16()
     pushVec(v0)
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_load32_splat_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     simdLoadSplat32()
     pushVec(v0)
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_load64_splat_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     simdLoadSplat64()
     pushVec(v0)
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_store_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 16, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 16, t1, t2, t5, t6)
     storev v0, [t0]
     move t4, PC
     nextIPIntInstruction()
 
 .simd_v128_load32_zero_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     loadi [t0], t0
     subp V128ISize, sp
     storei t0, [sp]
@@ -10809,7 +10803,7 @@ end
     nextIPIntInstruction()
 
 .simd_v128_load64_zero_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     loadq [t0], t0
     subp V128ISize, sp
     storeq t0, [sp]
@@ -10821,7 +10815,7 @@ end
 # t4 points past memarg after loadStoreMakePointerSlow. Lane index is at [t4].
 
 .simd_v128_load8_lane_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     loadb [t0], t0
     loadb [t4], t1
     andi ImmLaneIdx16Mask, t1
@@ -10831,7 +10825,7 @@ end
     nextIPIntInstruction()
 
 .simd_v128_load16_lane_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     loadh [t0], t0
     loadb [t4], t1
     andi ImmLaneIdx8Mask, t1
@@ -10841,7 +10835,7 @@ end
     nextIPIntInstruction()
 
 .simd_v128_load32_lane_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     loadi [t0], t0
     loadb [t4], t1
     andi ImmLaneIdx4Mask, t1
@@ -10851,7 +10845,7 @@ end
     nextIPIntInstruction()
 
 .simd_v128_load64_lane_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     loadq [t0], t0
     loadb [t4], t1
     andi ImmLaneIdx2Mask, t1
@@ -10864,7 +10858,7 @@ end
 # t4 points past memarg. Lane index is at [t4].
 
 .simd_v128_store8_lane_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     loadb [t4], t1
     andi ImmLaneIdx16Mask, t1
     pushVec(v0)
@@ -10875,7 +10869,7 @@ end
     nextIPIntInstruction()
 
 .simd_v128_store16_lane_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     loadb [t4], t1
     andi ImmLaneIdx8Mask, t1
     pushVec(v0)
@@ -10886,7 +10880,7 @@ end
     nextIPIntInstruction()
 
 .simd_v128_store32_lane_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     loadb [t4], t1
     andi ImmLaneIdx4Mask, t1
     pushVec(v0)
@@ -10897,7 +10891,7 @@ end
     nextIPIntInstruction()
 
 .simd_v128_store64_lane_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     loadb [t4], t1
     andi ImmLaneIdx2Mask, t1
     pushVec(v0)
@@ -10918,448 +10912,434 @@ end
 # After loadStoreMakePointerSlow, t4 points past the memarg.
 
 .ipint_i32_atomic_load_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI32AtomicLoad(t0, t2)
     pushInt32(t2)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_load_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     doI64AtomicLoad(t0, t2)
     pushInt64(t2)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_load8_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI32AtomicLoad8(t0, t2)
     pushInt32(t2)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_load16_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI32AtomicLoad16(t0, t2)
     pushInt32(t2)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_load8_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI64AtomicLoad8(t0, t2)
     pushInt64(t2)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_load16_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI64AtomicLoad16(t0, t2)
     pushInt64(t2)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_load32_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI64AtomicLoad32(t0, t2)
     pushInt64(t2)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_store_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI32AtomicStore(t0, t3, t2, t1)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_store_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     doI64AtomicStore(t0, t3, t2, t1)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_store8_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI32AtomicStore8(t0, t3, t2, t1)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_store16_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI32AtomicStore16(t0, t3, t2, t1)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_store8_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI64AtomicStore8(t0, t3, t2, t1)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_store16_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI64AtomicStore16(t0, t3, t2, t1)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_store32_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI64AtomicStore32(t0, t3, t2, t1)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw_add_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI32AtomicRmwAdd(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw_add_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     doI64AtomicRmwAdd(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw8_add_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI32AtomicRmwAdd8(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw16_add_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI32AtomicRmwAdd16(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw8_add_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI64AtomicRmwAdd8(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw16_add_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI64AtomicRmwAdd16(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw32_add_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI64AtomicRmwAdd32(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw_sub_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI32AtomicRmwSub(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw_sub_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     doI64AtomicRmwSub(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw8_sub_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI32AtomicRmwSub8(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw16_sub_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI32AtomicRmwSub16(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw8_sub_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI64AtomicRmwSub8(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw16_sub_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI64AtomicRmwSub16(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw32_sub_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI64AtomicRmwSub32(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw_and_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI32AtomicRmwAnd(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw_and_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     doI64AtomicRmwAnd(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw8_and_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI32AtomicRmwAnd8(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw16_and_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI32AtomicRmwAnd16(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw8_and_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI64AtomicRmwAnd8(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw16_and_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI64AtomicRmwAnd16(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw32_and_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI64AtomicRmwAnd32(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw_or_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI32AtomicRmwOr(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw_or_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     doI64AtomicRmwOr(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw8_or_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI32AtomicRmwOr8(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw16_or_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI32AtomicRmwOr16(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw8_or_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI64AtomicRmwOr8(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw16_or_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI64AtomicRmwOr16(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw32_or_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI64AtomicRmwOr32(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw_xor_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI32AtomicRmwXor(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw_xor_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     doI64AtomicRmwXor(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw8_xor_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI32AtomicRmwXor8(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw16_xor_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI32AtomicRmwXor16(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw8_xor_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI64AtomicRmwXor8(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw16_xor_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI64AtomicRmwXor16(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw32_xor_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI64AtomicRmwXor32(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw_xchg_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI32AtomicRmwXchg(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw_xchg_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     doI64AtomicRmwXchg(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw8_xchg_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI32AtomicRmwXchg8(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw16_xchg_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI32AtomicRmwXchg16(t0, t3, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw8_xchg_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI64AtomicRmwXchg8(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw16_xchg_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI64AtomicRmwXchg16(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw32_xchg_u_slow_path:
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI64AtomicRmwXchg32(t0, t3, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw_cmpxchg_slow_path:
-    push t3, t7
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
-    pop t7, t3
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI32AtomicCmpxchg(t0, t3, t7, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw_cmpxchg_slow_path:
-    push t3, t7
-    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
-    pop t7, t3
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, t5, t6)
     doI64AtomicCmpxchg(t0, t3, t7, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw8_cmpxchg_u_slow_path:
-    push t3, t7
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
-    pop t7, t3
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI32AtomicCmpxchg8(t0, t3, t7, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i32_atomic_rmw16_cmpxchg_u_slow_path:
-    push t3, t7
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
-    pop t7, t3
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI32AtomicCmpxchg16(t0, t3, t7, t2, t1)
     pushInt32(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw8_cmpxchg_u_slow_path:
-    push t3, t7
-    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
-    pop t7, t3
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, t5, t6)
     doI64AtomicCmpxchg8(t0, t3, t7, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw16_cmpxchg_u_slow_path:
-    push t3, t7
-    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
-    pop t7, t3
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, t5, t6)
     doI64AtomicCmpxchg16(t0, t3, t7, t2, t1)
     pushInt64(t0)
     move t4, PC
     nextIPIntInstruction()
 
 .ipint_i64_atomic_rmw32_cmpxchg_u_slow_path:
-    push t3, t7
-    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
-    pop t7, t3
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
     doI64AtomicCmpxchg32(t0, t3, t7, t2, t1)
     pushInt64(t0)
     move t4, PC
@@ -11476,8 +11456,6 @@ end
     # t3 is not used after this
     subp cfr, t3
     push t3, PC
-    # ditto for PL, t3 is okay to use as scratch
-    subp PL, cfr, t3
     push t3, wasmInstance
 
     # set up the call frame
@@ -11492,7 +11470,7 @@ end
     # reserved
     # reserved
     # (first_non_arg_addr - cfr), PC
-    # (PL - cfr), wasmInstance <- t2 = native argument stack (pushed by mINT)
+    # unused, wasmInstance <- t2 = native argument stack (pushed by mINT)
     # call frame
     # call frame
     # call frame
@@ -11995,7 +11973,7 @@ mintAlign(_end)
     # return result
     # return result     <- mintRetDst => new SP
     # (first_non_arg_addr - cfr), PC
-    # (PL - cfr), wasmInstance  <- sc3
+    # unused, wasmInstance  <- sc3
     # call frame
     # call frame
     # call frame
@@ -12015,7 +11993,6 @@ end
     loadp Callee[cfr], ws0
     unboxWasmCallee(ws0, ws1)
     storep ws0, UnboxedWasmCalleeStackSlot[cfr]
-    addp t3, cfr, PL
 
     # Restore memory
     ipintReloadMemory()
@@ -12302,18 +12279,18 @@ uintAlign(_ret)
 argumINTAlign(_a0)
 _argumINT_begin:
     storeq wa0, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_a1)
     storeq wa1, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_a2)
 if ARM64 or ARM64E or X86_64
     storeq wa2, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 else
     break
@@ -12323,7 +12300,7 @@ end
 argumINTAlign(_a3)
 if ARM64 or ARM64E or X86_64
     storeq wa3, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 else
     break
@@ -12332,7 +12309,7 @@ end
 argumINTAlign(_a4)
 if ARM64 or ARM64E or X86_64
     storeq wa4, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 else
     break
@@ -12341,7 +12318,7 @@ end
 argumINTAlign(_a5)
 if ARM64 or ARM64E or X86_64
     storeq wa5, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 else
     break
@@ -12350,7 +12327,7 @@ end
 argumINTAlign(_a6)
 if ARM64 or ARM64E
     storeq wa6, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 else
     break
@@ -12359,7 +12336,7 @@ end
 argumINTAlign(_a7)
 if ARM64 or ARM64E
     storeq wa7, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 else
     break
@@ -12367,49 +12344,49 @@ end
 
 argumINTAlign(_fa0)
     storev wfa0, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa1)
     storev wfa1, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa2)
     storev wfa2, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa3)
     storev wfa3, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa4)
     storev wfa4, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa5)
     storev wfa5, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa6)
     storev wfa6, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa7)
     storev wfa7, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_stack)
     loadq [argumINTSrc], csr0
     addp SlotSize, argumINTSrc
     storeq csr0, [argumINTDst]
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_stack_vector)
@@ -12418,7 +12395,7 @@ argumINTAlign(_stack_vector)
     loadq 8[argumINTSrc], csr0
     storeq csr0, 8[argumINTDst]
     addp 2 * SlotSize, argumINTSrc
-    addp LocalSize, argumINTDst
+    subp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_end)

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -62,6 +62,33 @@ namespace JSC { namespace IPInt {
         return encodeResult(first, second); \
     } while (false)
 
+static constexpr size_t ipintCalleeSaveSpaceStackAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>((Wasm::numberOfIPIntCalleeSaveRegisters + Wasm::numberOfIPIntInternalRegisters) * sizeof(Register));
+static constexpr size_t ipintLocalsBaseOffset = ipintCalleeSaveSpaceStackAligned + IPInt::LOCAL_SIZE;
+
+IPIntLocal* FrameAccess::localBase()
+{
+    // Points to local[0], matching assembly's CFR - IPIntLocalsBaseOffset.
+    return reinterpret_cast<IPIntLocal*>(reinterpret_cast<uint8_t*>(m_callFrame) - ipintLocalsBaseOffset);
+}
+
+IPIntLocal* FrameAccess::localSlot(unsigned index)
+{
+    return &localBase()[-static_cast<ptrdiff_t>(index)];
+}
+
+IPIntLocal* FrameAccess::rethrowSlot(unsigned index)
+{
+    return &localBase()[-static_cast<ptrdiff_t>(m_callee->localSizeToAlloc() + index)];
+}
+
+IPIntStackEntry* FrameAccess::stackEnd()
+{
+    // CFR - calleeSaveSpace - (localSizeToAlloc + rethrowSlots) * LocalSize
+    return reinterpret_cast<IPIntStackEntry*>(
+        reinterpret_cast<uint8_t*>(m_callFrame) - ipintCalleeSaveSpaceStackAligned
+        - (m_callee->localSizeToAlloc() + m_callee->rethrowSlots()) * IPInt::LOCAL_SIZE);
+}
+
 #define WASM_CALL_RETURN(targetInstance, callTarget) do { \
         static_assert(callTarget.getTag() == WasmEntryPtrTag); \
         callTarget.validate(); \
@@ -231,7 +258,7 @@ WASM_IPINT_EXTERN_CPP_DECL(prologue_osr, CallFrame* callFrame)
 }
 
 // This needs to be kept in sync with BBQJIT::makeStackMap.
-static ALWAYS_INLINE Wasm::Context::ScratchBufferEntry* buildEntryBufferForLoopOSR(Wasm::IPIntCallee* ipintCallee, Wasm::BBQCallee* bbqCallee, JSWebAssemblyInstance* instance, const Wasm::IPIntTierUpCounter::OSREntryData& osrEntryData, IPIntLocal* pl)
+static ALWAYS_INLINE Wasm::Context::ScratchBufferEntry* buildEntryBufferForLoopOSR(Wasm::IPIntCallee* ipintCallee, Wasm::BBQCallee* bbqCallee, JSWebAssemblyInstance* instance, const Wasm::IPIntTierUpCounter::OSREntryData& osrEntryData, CallFrame* callFrame, IPIntStackEntry* sp)
 {
     ASSERT(bbqCallee->compilationMode() == Wasm::CompilationMode::BBQMode);
     size_t osrEntryScratchBufferSize = bbqCallee->osrEntryScratchBufferSize();
@@ -242,8 +269,8 @@ static ALWAYS_INLINE Wasm::Context::ScratchBufferEntry* buildEntryBufferForLoopO
     if (!buffer)
         return nullptr;
     auto* currentEntry = buffer;
-    auto copyValueToBuffer = [&](const IPIntLocal& local) ALWAYS_INLINE_LAMBDA {
-        *std::bit_cast<v128_t*>(currentEntry++) = local.v128;
+    auto copyValueToBuffer = [&](const auto& entry) ALWAYS_INLINE_LAMBDA {
+        *std::bit_cast<v128_t*>(currentEntry++) = entry.v128;
     };
 
     // The loop index isn't really an IPIntLocal value, but it occupies the first slot of the OSR scratch buffer
@@ -252,13 +279,14 @@ static ALWAYS_INLINE Wasm::Context::ScratchBufferEntry* buildEntryBufferForLoopO
     loopIndexLocal.v128.u64x2[1] = 0;
     copyValueToBuffer(loopIndexLocal);
 
+    FrameAccess frame(callFrame, ipintCallee);
     for (uint32_t i = 0; i < ipintCallee->numLocals(); ++i)
-        copyValueToBuffer(pl[i]);
+        copyValueToBuffer(*frame.localSlot(i));
 
     if (ipintCallee->rethrowSlots()) {
         ASSERT(osrEntryData.tryDepth <= ipintCallee->rethrowSlots());
         for (uint32_t i = 0; i < osrEntryData.tryDepth; ++i)
-            copyValueToBuffer(pl[ipintCallee->localSizeToAlloc() + i]);
+            copyValueToBuffer(*frame.rethrowSlot(i));
     } else {
         // If there's no rethrow slots just 0 fill the buffer.
         IPIntLocal zeroValue = { };
@@ -267,15 +295,15 @@ static ALWAYS_INLINE Wasm::Context::ScratchBufferEntry* buildEntryBufferForLoopO
             copyValueToBuffer(zeroValue);
     }
 
-    for (uint32_t i = 0; i < osrEntryData.numberOfStackValues; ++i) {
-        pl -= 1;
-        copyValueToBuffer(*pl);
-    }
+    auto stackSlots = std::span { sp, sp + osrEntryData.numberOfStackValues };
+    for (auto& value : stackSlots | std::views::reverse)
+        copyValueToBuffer(value);
+
     return buffer;
 }
 
 
-WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint8_t* pc, IPIntLocal* pl)
+WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint8_t* pc, IPIntStackEntry* sp)
 {
     Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
     Wasm::IPIntTierUpCounter& tierUpCounter = callee->tierUpCounter();
@@ -307,13 +335,13 @@ WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint8_t* pc, IPIntLoc
     // The BBQ frame may use more stack than the IPInt frame. If there's not enough stack space,
     // skip OSR and continue executing in IPInt.
     if (bbqCallee->stackCheckSize() != Wasm::stackCheckNotNeeded) {
-        auto stackAtOSREntry = reinterpret_cast<uintptr_t>(pl - osrEntryData.numberOfStackValues);
+        auto stackAtOSREntry = reinterpret_cast<uintptr_t>(sp);
         auto candidateNewStackPointer = reinterpret_cast<void*>(stackAtOSREntry - bbqCallee->stackCheckSize());
         if (candidateNewStackPointer < instance->softStackLimit()) [[unlikely]]
             WASM_RETURN_TWO(nullptr, nullptr);
     }
 
-    auto* buffer = buildEntryBufferForLoopOSR(callee, bbqCallee, instance, osrEntryData, pl);
+    auto* buffer = buildEntryBufferForLoopOSR(callee, bbqCallee, instance, osrEntryData, callFrame, sp);
     if (!buffer)
         WASM_RETURN_TWO(nullptr, nullptr);
 
@@ -370,7 +398,7 @@ static void NODELETE copyExceptionPayloadToStack(const Wasm::FunctionSignature& 
     ASSERT(!payloadIndex);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(retrieve_and_clear_exception, CallFrame* callFrame, IPIntStackEntry* stackPointer, IPIntLocal* pl)
+WASM_IPINT_EXTERN_CPP_DECL(retrieve_and_clear_exception, CallFrame* callFrame, IPIntStackEntry* stackPointer)
 {
     VM& vm = instance->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -379,7 +407,8 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_and_clear_exception, CallFrame* callFrame, I
     Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
     if (callee->rethrowSlots()) {
         RELEASE_ASSERT(vm.targetTryDepthForThrow <= callee->rethrowSlots());
-        pl[callee->localSizeToAlloc() + vm.targetTryDepthForThrow - 1].i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
+        FrameAccess frame(callFrame, callee);
+        frame.rethrowSlot(vm.targetTryDepthForThrow - 1)->i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
     }
 
     if (stackPointer) {
@@ -397,7 +426,7 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_and_clear_exception, CallFrame* callFrame, I
     WASM_RETURN_TWO(nullptr, nullptr);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(retrieve_clear_and_push_exception, CallFrame* callFrame, IPIntStackEntry* stackPointer, IPIntLocal* pl)
+WASM_IPINT_EXTERN_CPP_DECL(retrieve_clear_and_push_exception, CallFrame* callFrame, IPIntStackEntry* stackPointer)
 {
     VM& vm = instance->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -406,7 +435,8 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_clear_and_push_exception, CallFrame* callFra
     Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
     if (callee->rethrowSlots()) {
         RELEASE_ASSERT(vm.targetTryDepthForThrow <= callee->rethrowSlots());
-        pl[callee->localSizeToAlloc() + vm.targetTryDepthForThrow - 1].i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
+        FrameAccess frame(callFrame, callee);
+        frame.rethrowSlot(vm.targetTryDepthForThrow - 1)->i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
     }
 
     Exception* exception = throwScope.exception();
@@ -420,7 +450,7 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_clear_and_push_exception, CallFrame* callFra
     WASM_RETURN_TWO(nullptr, nullptr);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(retrieve_clear_and_push_exception_and_arguments, CallFrame* callFrame, IPIntStackEntry* stackPointer, IPIntLocal* pl)
+WASM_IPINT_EXTERN_CPP_DECL(retrieve_clear_and_push_exception_and_arguments, CallFrame* callFrame, IPIntStackEntry* stackPointer)
 {
     VM& vm = instance->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -429,7 +459,8 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_clear_and_push_exception_and_arguments, Call
     Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
     if (callee->rethrowSlots()) {
         RELEASE_ASSERT(vm.targetTryDepthForThrow <= callee->rethrowSlots());
-        pl[callee->localSizeToAlloc() + vm.targetTryDepthForThrow - 1].i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
+        FrameAccess frame(callFrame, callee);
+        frame.rethrowSlot(vm.targetTryDepthForThrow - 1)->i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
     }
 
     Exception* exception = throwScope.exception();
@@ -474,7 +505,7 @@ WASM_IPINT_EXTERN_CPP_DECL(throw_exception, CallFrame* callFrame, IPIntStackEntr
     WASM_RETURN_TWO(vm.targetMachinePCForThrow, nullptr);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(rethrow_exception, CallFrame* callFrame, IPIntStackEntry* pl, unsigned tryDepth)
+WASM_IPINT_EXTERN_CPP_DECL(rethrow_exception, CallFrame* callFrame, unsigned tryDepth)
 {
     SlowPathFrameTracer tracer(instance->vm(), callFrame);
 
@@ -484,10 +515,11 @@ WASM_IPINT_EXTERN_CPP_DECL(rethrow_exception, CallFrame* callFrame, IPIntStackEn
 
     Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
     RELEASE_ASSERT(tryDepth <= callee->rethrowSlots());
+    FrameAccess frame(callFrame, callee);
 #if CPU(ADDRESS64)
-    JSWebAssemblyException* exception = std::bit_cast<JSWebAssemblyException*>(pl[callee->localSizeToAlloc() + tryDepth - 1].i64);
+    JSWebAssemblyException* exception = std::bit_cast<JSWebAssemblyException*>(frame.rethrowSlot(tryDepth - 1)->i64);
 #else
-    JSWebAssemblyException* exception = std::bit_cast<JSWebAssemblyException*>(pl[callee->localSizeToAlloc() + tryDepth - 1].i32);
+    JSWebAssemblyException* exception = std::bit_cast<JSWebAssemblyException*>(frame.rethrowSlot(tryDepth - 1)->i32);
 #endif
     RELEASE_ASSERT(exception);
     throwException(globalObject, throwScope, exception);
@@ -1312,7 +1344,7 @@ WASM_IPINT_EXTERN_CPP_DECL(check_stack_and_vm_traps, void* candidateNewStackPoin
 }
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
-static UNUSED_FUNCTION void displayWasmDebugState(JSWebAssemblyInstance* instance, Wasm::IPIntCallee* callee, IPIntStackEntry* sp, IPIntLocal* pl)
+static UNUSED_FUNCTION void displayWasmDebugState(JSWebAssemblyInstance* instance, Wasm::IPIntCallee* callee, CallFrame* callFrame, IPIntStackEntry* sp)
 {
     dataLogLn("=== WASM Debug State ===");
 
@@ -1321,12 +1353,14 @@ static UNUSED_FUNCTION void displayWasmDebugState(JSWebAssemblyInstance* instanc
     auto functionIndex = callee->functionIndex();
     const auto& moduleInfo = instance->module().moduleInformation();
     const Vector<Wasm::Type>& localTypes = moduleInfo.debugInfo->ensureFunctionDebugInfo(functionIndex).locals;
+    FrameAccess frame(callFrame, callee);
     for (uint32_t i = 0; i < numLocals; ++i)
-        logWasmLocalValue(i,  pl[i], localTypes[i]);
+        logWasmLocalValue(i, *frame.localSlot(i), localTypes[i]);
 
-    constexpr size_t STACK_ENTRY_SIZE = 16;
-    if (sp && pl && std::bit_cast<uintptr_t>(sp) <= std::bit_cast<uintptr_t>(pl)) {
-        size_t stackDepth = (reinterpret_cast<uint8_t*>(pl) - reinterpret_cast<uint8_t*>(sp)) / STACK_ENTRY_SIZE;
+    auto* stackEnd = frame.stackEnd();
+    if (sp && std::bit_cast<uintptr_t>(sp) <= std::bit_cast<uintptr_t>(stackEnd)) {
+        constexpr size_t STACK_ENTRY_SIZE = 16;
+        size_t stackDepth = (reinterpret_cast<uint8_t*>(stackEnd) - reinterpret_cast<uint8_t*>(sp)) / STACK_ENTRY_SIZE;
         dataLogLn("WASM Stack (", stackDepth, " entries - showing all type interpretations):");
 
         IPIntStackEntry* currentEntry = sp;
@@ -1352,13 +1386,12 @@ WASM_IPINT_EXTERN_CPP_DECL(handle_debugger_trap_if_needed, CallFrame* callFrame,
         if (debugServer.hasDebugger()) {
             uint8_t* pc = static_cast<uint8_t*>(sp[2].pointer());
             uint8_t* mc = static_cast<uint8_t*>(sp[3].pointer());
-            IPIntLocal* pl = static_cast<IPIntLocal*>(sp[0].pointer());
             auto* callee = static_cast<Wasm::IPIntCallee*>(sp[1].pointer());
             auto* stack = std::bit_cast<IPIntStackEntry*>(sp + 4);
             auto exceptionType = static_cast<Wasm::ExceptionType>(callFrame->argumentCountIncludingThis());
             if (Options::verboseWasmDebugger() && exceptionType == Wasm::ExceptionType::Unreachable)
-                displayWasmDebugState(instance, callee, stack, pl);
-            auto trapStatus = debugServer.execution().handleDebuggerTrapIfNeeded(callFrame, instance, callee, pc, mc, pl, stack, exceptionType);
+                displayWasmDebugState(instance, callee, callFrame, stack);
+            auto trapStatus = debugServer.execution().handleDebuggerTrapIfNeeded(callFrame, instance, callee, pc, mc, stack, exceptionType);
             shouldThrow = trapStatus == Wasm::DebuggerTrapStatus::NotResolvedByDebugger;
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -70,15 +70,15 @@ static constexpr uintptr_t SlowPathExceptionTag = JSValue::InvalidTag;
 
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prologue_osr, CallFrame* callFrame);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(loop_osr, CallFrame* callFrame, uint8_t* pc, IPIntLocal* pl);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(loop_osr, CallFrame* callFrame, uint8_t* pc, IPIntStackEntry* sp);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(epilogue_osr, CallFrame* callFrame);
 #endif
 
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_and_clear_exception, CallFrame*, IPIntStackEntry* stack, IPIntLocal* pl);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_clear_and_push_exception, CallFrame*, IPIntStackEntry* stack, IPIntLocal* pl);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_clear_and_push_exception_and_arguments, CallFrame*, IPIntStackEntry* stack, IPIntLocal* pl);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_and_clear_exception, CallFrame*, IPIntStackEntry* stack);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_clear_and_push_exception, CallFrame*, IPIntStackEntry* stack);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_clear_and_push_exception_and_arguments, CallFrame*, IPIntStackEntry* stack);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_exception, CallFrame*, IPIntStackEntry* arguments, unsigned exceptionIndex);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(rethrow_exception, CallFrame*, IPIntStackEntry* pl, unsigned tryDepth);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(rethrow_exception, CallFrame*, unsigned tryDepth);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_ref, CallFrame* callFrame, EncodedJSValue exnref);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(ref_func, unsigned index);
@@ -142,6 +142,29 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_notify, IPIntStackEntry*);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(check_stack_and_vm_traps, void* candidateNewStackPointer, Wasm::IPIntCallee*, CallFrame*);
 WASM_IPINT_EXTERN_CPP_DECL(handle_debugger_trap_if_needed, CallFrame*, Register*);
+
+
+class FrameAccess {
+public:
+    FrameAccess(CallFrame* callFrame, const Wasm::IPIntCallee* callee)
+        : m_callFrame(callFrame)
+        , m_callee(callee)
+    {
+    }
+
+    IPIntLocal* localSlot(unsigned);
+    IPIntLocal* rethrowSlot(unsigned);
+    // Past-the-end pointer for the expression stack area (= bottom of rethrow/locals area).
+    IPIntStackEntry* stackEnd();
+
+private:
+    // Returns pointer to local[0], matching assembly's CFR - IPIntLocalsBaseOffset.
+    // local[i] = localBase()[-i], rethrow[i] = localBase()[-(localSizeToAlloc + i)].
+    IPIntLocal* localBase();
+
+    CallFrame* m_callFrame;
+    SUPPRESS_UNCOUNTED_MEMBER const Wasm::IPIntCallee* m_callee;
+};
 
 } } // namespace JSC::IPInt
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
@@ -176,15 +176,6 @@ bool getWasmReturnPC(CallFrame* currentFrame, uint8_t*& returnPC, VirtualAddress
     return true;
 }
 
-// This is the C++ equivalent of the "# Recompute PL" block in InPlaceInterpreter.asm.
-IPInt::IPIntLocal* localsFromFrame(CallFrame* callFrame, const IPIntCallee* callee)
-{
-    // IPIntCalleeSaveSpaceStackAligned is defined in InPlaceInterpreter.asm.
-    static constexpr size_t ipintCalleeSaveSpaceStackAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>((Wasm::numberOfIPIntCalleeSaveRegisters + Wasm::numberOfIPIntInternalRegisters) * sizeof(Register));
-    size_t localsAndRethrowSize = (callee->localSizeToAlloc() + callee->rethrowSlots()) * IPInt::LOCAL_SIZE;
-    auto pl = reinterpret_cast<uintptr_t>(callFrame) - ipintCalleeSaveSpaceStackAligned - localsAndRethrowSize;
-    return reinterpret_cast<IPInt::IPIntLocal*>(pl);
-}
 
 // Walk the full CallFrame chain from a WASM breakpoint, collecting virtual addresses for
 // every WASM and JS frame. The result is consumed by qWasmCallStack to give LLDB a
@@ -347,12 +338,11 @@ StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFra
 {
 }
 
-StopData::StopData(VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
+StopData::StopData(VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
     : address(address)
     , originalBytecode(originalBytecode)
     , pc(pc)
     , mc(mc)
-    , locals(locals)
     , stack(stack)
     , callee(callee)
     , instance(instance)
@@ -360,8 +350,8 @@ StopData::StopData(VirtualAddress address, uint8_t originalBytecode, uint8_t* pc
 {
 }
 
-StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType type)
-    : StopData(VirtualAddress::toVirtual(instance, callee->functionIndex(), pc), 0, pc, mc, locals, stack, callee, instance, callFrame)
+StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType type)
+    : StopData(VirtualAddress::toVirtual(instance, callee->functionIndex(), pc), 0, pc, mc, stack, callee, instance, callFrame)
 {
     wasmTrapType = type;
 }
@@ -374,7 +364,6 @@ void StopData::dump(PrintStream& out) const
     out.print(", originalBytecode:", originalBytecode);
     out.print(", pc:", RawPointer(pc));
     out.print(", mc:", RawPointer(mc));
-    out.print(", locals:", RawPointer(locals));
     out.print(", stack:", RawPointer(stack));
     out.print(", callee:", RawPointer(callee.get()));
     out.print(", instance:", RawPointer(instance));

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -137,11 +137,11 @@ struct Breakpoint {
 struct StopData {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(StopData);
 
-    StopData(VirtualAddress, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
+    StopData(VirtualAddress, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry*, IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
 
     StopData(IPIntCallee*, JSWebAssemblyInstance*, CallFrame*); // Prologue: no pc/mc
 
-    StopData(IPIntCallee*, JSWebAssemblyInstance*, CallFrame*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, Wasm::ExceptionType); // Trap
+    StopData(IPIntCallee*, JSWebAssemblyInstance*, CallFrame*, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry*, Wasm::ExceptionType); // Trap
 
     ~StopData();
 
@@ -151,7 +151,6 @@ struct StopData {
     uint8_t originalBytecode { 0 };
     uint8_t* pc { nullptr };
     uint8_t* mc { nullptr };
-    IPInt::IPIntLocal* locals { nullptr };
     IPInt::IPIntStackEntry* stack { nullptr };
     RefPtr<IPIntCallee> callee;
     JSWebAssemblyInstance* instance { nullptr };
@@ -182,7 +181,7 @@ struct DebugState {
         stopData = makeUnique<StopData>(callee, instance, callFrame);
     }
 
-    void setBreakpointStopData(Breakpoint::Type type, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
+    void setBreakpointStopData(Breakpoint::Type type, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
     {
         switch (type) {
         case Breakpoint::Type::Step:
@@ -192,13 +191,13 @@ struct DebugState {
             stopReason = Reason::Breakpoint;
             break;
         }
-        stopData = makeUnique<StopData>(address, originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
+        stopData = makeUnique<StopData>(address, originalBytecode, pc, mc, stack, callee, instance, callFrame);
     }
 
-    void setTrapStopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType wasmTrapType)
+    void setTrapStopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType wasmTrapType)
     {
         stopReason = Reason::WasmTrap;
-        stopData = makeUnique<StopData>(callee, instance, callFrame, pc, mc, locals, stack, wasmTrapType);
+        stopData = makeUnique<StopData>(callee, instance, callFrame, pc, mc, stack, wasmTrapType);
     }
 
     // WHERE-based helpers — determined by stopData presence and pc:
@@ -297,7 +296,6 @@ struct FrameInfo {
 
 Vector<FrameInfo> collectCallStack(VirtualAddress stopAddress, CallFrame* startFrame, VM&, unsigned maxFrames = 100);
 
-IPInt::IPIntLocal* localsFromFrame(CallFrame*, const IPIntCallee*);
 
 inline StringView getErrorReply(ProtocolError error)
 {

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -134,13 +134,13 @@ void ExecutionHandler::stopTheWorld(VM& debuggee, StopTheWorldEvent event)
     VMManager::singleton().notifyVMStop(debuggee, event);
 }
 
-DebuggerTrapStatus ExecutionHandler::handleDebuggerTrapIfNeeded(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType exceptionType)
+DebuggerTrapStatus ExecutionHandler::handleDebuggerTrapIfNeeded(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType exceptionType)
 {
     VM& debuggee = instance->vm();
     if (exceptionType == Wasm::ExceptionType::Unreachable && hasBreakpoints()) {
         VirtualAddress address = VirtualAddress::toVirtual(instance, callee->functionIndex(), pc);
         if (auto* breakpoint = m_breakpointManager->findBreakpoint(address)) {
-            debuggee.debugState()->setBreakpointStopData(breakpoint->type, address, breakpoint->originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
+            debuggee.debugState()->setBreakpointStopData(breakpoint->type, address, breakpoint->originalBytecode, pc, mc, stack, callee, instance, callFrame);
             dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] Breakpoint at ", *breakpoint, " with ", *debuggee.debugState()->stopData);
             stopTheWorld(debuggee, StopTheWorldEvent::WasmProgramStop);
             return DebuggerTrapStatus::ResolvedByDebugger; // Don't throw; resume execution at this breakpoint
@@ -157,7 +157,7 @@ DebuggerTrapStatus ExecutionHandler::handleDebuggerTrapIfNeeded(CallFrame* callF
         debuggee.debugState()->stopReason = DebugState::Reason::WasmTrap;
         debuggee.debugState()->stopData->wasmTrapType = exceptionType;
     } else
-        debuggee.debugState()->setTrapStopData(callee, instance, callFrame, pc, mc, locals, stack, exceptionType);
+        debuggee.debugState()->setTrapStopData(callee, instance, callFrame, pc, mc, stack, exceptionType);
     dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] Wasm trap at ", *debuggee.debugState()->stopData);
     stopTheWorld(debuggee, StopTheWorldEvent::WasmProgramStop);
     return DebuggerTrapStatus::NotResolvedByDebugger; // Throw; trap was reported, now propagate it

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -78,7 +78,7 @@ public:
 
     ResumeMode stopCode(Locker<Lock>&, StopTheWorldEvent) WTF_REQUIRES_LOCK(m_lock);
 
-    DebuggerTrapStatus handleDebuggerTrapIfNeeded(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, Wasm::ExceptionType);
+    DebuggerTrapStatus handleDebuggerTrapIfNeeded(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry*, Wasm::ExceptionType);
 
     JS_EXPORT_PRIVATE void resume();
     JS_EXPORT_PRIVATE void step();

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -366,12 +366,12 @@ void QueryHandler::handleWasmLocal(StringView packet)
     }
 
     auto& stopData = *state->stopData;
-    IPInt::IPIntLocal* locals = nullptr;
+    CallFrame* localCallFrame = nullptr;
     RefPtr<IPIntCallee> localCallee;
     JSWebAssemblyInstance* instance = nullptr;
 
     if (!frameIndex) {
-        locals = stopData.locals;
+        localCallFrame = stopData.callFrame;
         localCallee = stopData.callee;
         instance = stopData.instance;
     } else {
@@ -381,7 +381,7 @@ void QueryHandler::handleWasmLocal(StringView packet)
             return;
         }
         const auto& frameInfo = frames[frameIndex];
-        locals = localsFromFrame(frameInfo.wasmCallFrame, frameInfo.wasmCallee.get());
+        localCallFrame = frameInfo.wasmCallFrame;
         localCallee = frameInfo.wasmCallee;
         instance = frameInfo.wasmCallFrame->wasmInstance();
     }
@@ -395,7 +395,8 @@ void QueryHandler::handleWasmLocal(StringView packet)
         return;
     }
 
-    IPInt::IPIntLocal& local = locals[localIndex];
+    IPInt::FrameAccess frame(localCallFrame, localCallee.get());
+    IPInt::IPIntLocal& local = *frame.localSlot(localIndex);
     Type localType = localTypes[localIndex];
     logWasmLocalValue(localIndex, local, localType);
 


### PR DESCRIPTION
#### f6f27b7f2bf68a14ceae0b77b08830deb705b9a7
<pre>
[JSC] Remove PL from IPInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=312339">https://bugs.webkit.org/show_bug.cgi?id=312339</a>
<a href="https://rdar.apple.com/174798744">rdar://174798744</a>

Reviewed by Yijia Huang and Dan Hecht.

IPInt is using a register for PL (pointer-to-locals) to accelerate
access to wasm locals. But this is not necessary if we carefully
organize locals layout since we can use cfr.
Now, we use the layout like this

    [  ...           ]
    [ return address ]
    [ previous cfr   ] &lt;- cfr
    [ callee save    ]
    [ callee save    ]
    [ callee save    ]
    [ callee save    ]
    [ local 0        ]
    [ local 1        ]
    [ local 2        ]
    [ ...            ]
    [ rethrow 0      ]
    [ rethrow 1      ]
    [ rethrow 2      ]
    [ ...            ]

Then cfr to local is always constant offset, so we can quickly access to
locals from cfr. Also this makes frame a bit cleaner as we no longer
have PL which is relying on CFR. So JSPI&apos;s save / restore do not need to
care about this register.

We introduce IPInt::FrameAccess to offer consistent access mechanism for
locals and rethrow slots.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::FrameAccess::localBase):
(JSC::IPInt::FrameAccess::localSlot):
(JSC::IPInt::FrameAccess::rethrowSlot):
(JSC::IPInt::FrameAccess::stackEnd):
(JSC::IPInt::buildEntryBufferForLoopOSR):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
(JSC::IPInt::displayWasmDebugState):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:
(JSC::IPInt::FrameAccess::FrameAccess):
* Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp:
(JSC::Wasm::StopData::StopData):
(JSC::Wasm::StopData::dump const):
(JSC::Wasm::localsFromFrame): Deleted.
* Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h:
(JSC::Wasm::DebugState::setBreakpointStopData):
(JSC::Wasm::DebugState::setTrapStopData):
* Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp:
(JSC::Wasm::ExecutionHandler::handleDebuggerTrapIfNeeded):
* Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h:
* Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp:
(JSC::Wasm::QueryHandler::handleWasmLocal):

Canonical link: <a href="https://commits.webkit.org/311377@main">https://commits.webkit.org/311377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2552055f94e27056e615a6e7fbf92a15869059b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110744 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121342 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85233 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23567 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140678 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102010 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22623 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20819 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13258 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148713 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167969 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17498 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12132 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20125 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129458 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129568 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140301 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87325 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23866 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17104 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188624 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93266 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48447 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28757 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28987 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28883 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->