### PR TITLE
[JSC] Rewriting module loader follow-ups

### DIFF
--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
@@ -475,7 +475,7 @@ void CyclicModuleRecord::executeAsync(JSGlobalObject* globalObject)
     // 2. Assert: module.[[HasTLA]] is true.
     ASSERT(hasTLA());
     // 3. Let capability be ! NewPromiseCapability(%Promise%).
-    JSPromise* promise = JSPromise::create(vm, globalObject->internalPromiseStructure());
+    JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
     // 4. Let fulfilledClosure be a new Abstract Closure with no parameters that captures module and performs the following steps when called:
     //     4.a. Perform AsyncModuleExecutionFulfilled(module).
     //     4.b. Return NormalCompletion(undefined).
@@ -632,7 +632,11 @@ void CyclicModuleRecord::asyncExecutionFulfilled(JSGlobalObject* globalObject)
         } else if (m->hasTLA()) {
             // 12.b.i. Perform ExecuteAsyncModule(m).
             m->executeAsync(globalObject);
-            RETURN_IF_EXCEPTION(scope, void());
+            if (Exception* exception = scope.exception()) {
+                JSValue error = exception->value();
+                TRY_CLEAR_EXCEPTION(scope, void());
+                m->asyncExecutionRejected(globalObject, error);
+            }
         // 12.c. Else,
         } else {
             // 12.c.i. Let result be m.ExecuteModule().

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -896,9 +896,14 @@ static void moduleRegistryModuleSettled(JSGlobalObject* globalObject, VM& vm, st
     auto* modulePromise = jsCast<JSPromise*>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
-        auto* module = jsCast<AbstractModuleRecord*>(arguments[1]);
-        entry->fetchComplete(globalObject, module);
-        modulePromise->resolve(globalObject, vm, module);
+        auto* moduleRecord = jsDynamicCast<AbstractModuleRecord*>(arguments[1]);
+        if (!moduleRecord) {
+            // Promise.prototype.then was tampered with
+            modulePromise->resolve(globalObject, vm, arguments[1]);
+            return;
+        }
+        entry->fetchComplete(globalObject, moduleRecord);
+        modulePromise->resolve(globalObject, vm, moduleRecord);
     } else {
         JSValue errorValue = arguments[1];
         entry->evaluationError(globalObject, errorValue);


### PR DESCRIPTION
#### 26caa22a57171f79550c037a499c18d78df1d6af
<pre>
[JSC] Rewriting module loader follow-ups
<a href="https://bugs.webkit.org/show_bug.cgi?id=312349">https://bugs.webkit.org/show_bug.cgi?id=312349</a>

Reviewed by Yusuke Suzuki.

Three small follow-ups to 311236@main:

- asyncExecutionFulfilled step 12.b.i: recover from a synchronous exception
  out of ExecuteAsyncModule via AsyncModuleExecutionRejected, mirroring 12.c.
- executeAsync: use promiseStructure() for the capability promise, matching
  the spec and the rest of the rewritten loader.
- moduleRegistryModuleSettled: use jsDynamicCast and forward the raw value
  on mismatch, mirroring moduleLoadStep&apos;s tampered-then handling.

* Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp:
(JSC::CyclicModuleRecord::executeAsync):
(JSC::CyclicModuleRecord::asyncExecutionFulfilled):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::moduleRegistryModuleSettled):

Canonical link: <a href="https://commits.webkit.org/311271@main">https://commits.webkit.org/311271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d839b415b2cd6898c9360cfe7e1e71798d5a7da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165337 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121226 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23447 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101894 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13109 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148566 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167819 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17351 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11932 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129347 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129458 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140183 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87177 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24279 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16982 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/188477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29084 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93040 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/188477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28610 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->