### PR TITLE
Replace raw pointer key with SingleThreadWeakRef in LegacyRenderSVGResourceGradient's m_gradientMap

### DIFF
--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -57,7 +57,7 @@ void LegacyRenderSVGResourceGradient::removeAllClientsFromCacheAndMarkForInvalid
 
 void LegacyRenderSVGResourceGradient::removeClientFromCache(RenderElement& client)
 {
-    m_gradientMap.remove(&client);
+    m_gradientMap.remove(client);
 }
 
 GradientData::Inputs LegacyRenderSVGResourceGradient::computeInputs(RenderElement& renderer, OptionSet<RenderSVGResourceMode> resourceMode)
@@ -93,7 +93,7 @@ GradientData* LegacyRenderSVGResourceGradient::gradientDataForRenderer(RenderEle
     if (inputs.objectBoundingBox && inputs.objectBoundingBox->isEmpty())
         return nullptr;
 
-    auto& gradientData = *m_gradientMap.ensure(&renderer, [&]() {
+    auto& gradientData = *m_gradientMap.ensure(renderer, [&]() {
         return makeUnique<GradientData>();
     }).iterator->value;
 
@@ -345,7 +345,7 @@ void LegacyRenderSVGResourceGradient::postApplyResource(RenderElement& renderer,
     if (!m_gradientApplier)
         return;
 
-    auto gradientData = m_gradientMap.find(&renderer);
+    auto gradientData = m_gradientMap.find(renderer);
     if (gradientData != m_gradientMap.end())
         m_gradientApplier->postApplyResource(renderer, context, *gradientData->value, gradientUnits(), gradientTransform(), resourceMode, path, shape);
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
@@ -100,7 +100,7 @@ private:
     virtual bool collectGradientAttributes() = 0;
     virtual Ref<Gradient> buildGradient(const RenderStyle&) const = 0;
 
-    HashMap<RenderObject*, std::unique_ptr<GradientData>> m_gradientMap;
+    HashMap<SingleThreadWeakRef<RenderElement>, std::unique_ptr<GradientData>> m_gradientMap;
 
     std::unique_ptr<GradientApplier> m_gradientApplier;
     bool m_shouldCollectGradientAttributes { true };


### PR DESCRIPTION
#### d49dd65c51687fe820e7ed479fa8fcfa2598dcec
<pre>
Replace raw pointer key with SingleThreadWeakRef in LegacyRenderSVGResourceGradient&apos;s m_gradientMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=312350">https://bugs.webkit.org/show_bug.cgi?id=312350</a>
<a href="https://rdar.apple.com/174808573">rdar://174808573</a>

Reviewed by Chris Dumez.

The patch extends work done in 273264@main which converted the other
resource caches (Filter, Masker, Pattern, Clipper) from raw RenderObject*
keys to SingleThreadWeakRef, now for Gradient.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp:
(WebCore::LegacyRenderSVGResourceGradient::removeClientFromCache):
(WebCore::LegacyRenderSVGResourceGradient::gradientDataForRenderer):
(WebCore::LegacyRenderSVGResourceGradient::postApplyResource):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h:

Canonical link: <a href="https://commits.webkit.org/311350@main">https://commits.webkit.org/311350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb2d2ebd3f205d7f4d2134f15eef49af1692b4eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165330 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110589 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121220 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85188 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101888 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22501 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20687 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13102 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167812 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11925 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129341 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129452 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35109 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140175 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87170 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24270 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16974 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93033 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28603 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28832 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28727 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->