### PR TITLE
[Swift in WebKit] Integrate Swift Testing into run-api-tests (part 4)

### DIFF
--- a/Tools/TestRunnerShared/cocoa/ClassMethodSwizzler.h
+++ b/Tools/TestRunnerShared/cocoa/ClassMethodSwizzler.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <objc/runtime.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
@@ -39,3 +41,5 @@ public:
     Method m_method;
     IMP m_originalImplementation;
 };
+
+#endif // __cplusplus

--- a/Tools/TestRunnerShared/cocoa/InstanceMethodSwizzler.h
+++ b/Tools/TestRunnerShared/cocoa/InstanceMethodSwizzler.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <objc/runtime.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
@@ -56,3 +58,5 @@ private:
     SEL m_originalSelector;
     IMP m_originalImplementation;
 };
+
+#endif // __cplusplus

--- a/Tools/TestRunnerShared/cocoa/PoseAsClass.h
+++ b/Tools/TestRunnerShared/cocoa/PoseAsClass.h
@@ -25,4 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 void poseAsClass(const char* imposter, const char* original);
+
+#endif

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -23,6 +23,8 @@
   * THE POSSIBILITY OF SUCH DAMAGE.
   */
 
+#import <wtf/Platform.h>
+
 #if PLATFORM(IOS_FAMILY)
 
 #import <UIKit/UIKit.h>

--- a/Tools/TestWebKitAPI/Helpers/CoroutineUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/CoroutineUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #import <wtf/CoroutineUtilities.h>
 
 namespace TestWebKitAPI {
@@ -41,3 +43,5 @@ struct ConnectionTask {
 };
 
 }
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/Counters.h
+++ b/Tools/TestWebKitAPI/Helpers/Counters.h
@@ -27,6 +27,8 @@
 #ifndef Counters_h
 #define Counters_h
 
+#ifdef __cplusplus
+
 #include <wtf/FastMalloc.h>
 
 struct CopyMoveCounter {
@@ -99,4 +101,6 @@ struct DeleterCounter {
 #endif
 #endif
 
-#endif // Counters_h
+#endif // __cplusplus
+
+#endif

--- a/Tools/TestWebKitAPI/Helpers/DeprecatedGlobalValues.h
+++ b/Tools/TestWebKitAPI/Helpers/DeprecatedGlobalValues.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #if PLATFORM(COCOA)
 #include <wtf/Deque.h>
 #include <wtf/RetainPtr.h>
@@ -65,3 +67,5 @@ extern RetainPtr<NSMutableArray> receivedMessages;
 extern Deque<RetainPtr<WKScriptMessage>> scriptMessages;
 WKScriptMessage *getNextMessage();
 #endif
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if !PLATFORM(COCOA) || !__has_feature(modules)
+
 #include "Helpers/Test.h"
 #include <WebCore/Color.h>
 #include <WebCore/FloatPoint.h>
@@ -43,3 +47,5 @@ namespace TestWebKitAPI {
 ::testing::AssertionResult imagePixelIs(WebCore::Color expected, WebCore::NativeImage&, WebCore::FloatPoint);
 
 }
+
+#endif // !PLATFORM(COCOA) || !__has_feature(modules)

--- a/Tools/TestWebKitAPI/Helpers/JavaScriptTest.h
+++ b/Tools/TestWebKitAPI/Helpers/JavaScriptTest.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if !PLATFORM(COCOA) || !__has_feature(modules)
+
 #if PLATFORM(COCOA)
 OBJC_CLASS WebView;
 OBJC_CLASS WKWebView;
@@ -48,3 +52,5 @@ namespace TestWebKitAPI {
 #endif
 
 } // namespace TestWebKitAPI
+
+#endif // !PLATFORM(COCOA) || !__has_feature(modules)

--- a/Tools/TestWebKitAPI/Helpers/PlatformUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/PlatformUtilities.h
@@ -28,6 +28,8 @@
 #ifndef PlatformUtilities_h
 #define PlatformUtilities_h
 
+#ifdef __cplusplus
+
 #include <WebKit/WKNativeEvent.h>
 #include <WebKit/WKRetainPtr.h>
 
@@ -96,6 +98,8 @@ WKRetainPtr<WKStringRef> toWK(const char* utf8String);
 
 #endif // WK_HAVE_C_SPI
 
+#if !PLATFORM(COCOA) || !__has_feature(modules)
+
 template<typename T, typename U>
 static inline ::testing::AssertionResult assertWKStringEqual(const char* expected_expression, const char* actual_expression, T expected, U actual)
 {
@@ -104,6 +108,8 @@ static inline ::testing::AssertionResult assertWKStringEqual(const char* expecte
 
 #define EXPECT_WK_STREQ(expected, actual) \
     EXPECT_PRED_FORMAT2(TestWebKitAPI::Util::assertWKStringEqual, expected, actual)
+
+#endif // !PLATFORM(COCOA) || !__has_feature(modules)
 
 #if PLATFORM(MAC)
 using PlatformImage = NSImage;
@@ -120,5 +126,7 @@ extern RetainPtr<CGImageRef> convertToCGImage(PlatformImage *);
 
 } // namespace Util
 } // namespace TestWebKitAPI
+
+#endif // __cplusplus
 
 #endif // PlatformUtilities_h

--- a/Tools/TestWebKitAPI/Helpers/PlatformWebView.h
+++ b/Tools/TestWebKitAPI/Helpers/PlatformWebView.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 
@@ -60,6 +62,7 @@ typedef WKViewRef PlatformWKView;
 typedef void* PlatformWindow;
 #endif
 typedef uint32_t WKEventModifiers;
+typedef int32_t WKEventMouseButton;
 
 namespace TestWebKitAPI {
 
@@ -97,3 +100,5 @@ private:
 };
 
 } // namespace TestWebKitAPI
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/SoftLinkShim.h
+++ b/Tools/TestWebKitAPI/Helpers/SoftLinkShim.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 namespace TestWebKitAPI {
 
 template<typename R, typename... Args>
@@ -59,6 +61,6 @@ private:
     Pointer m_originalFunctorValue;
 };
 
-
-
 }
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/Test.h
+++ b/Tools/TestWebKitAPI/Helpers/Test.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if !PLATFORM(COCOA) || !__has_feature(modules)
+
 #include <type_traits>
 #include <wtf/ASCIICType.h>
 #include <wtf/text/WTFString.h>
@@ -94,3 +98,5 @@ inline std::ostream& operator<<(std::ostream& os, const ASCIILiteral& string)
 }
 
 }
+
+#endif // !PLATFORM(COCOA) || !__has_feature(modules)

--- a/Tools/TestWebKitAPI/Helpers/TestNotificationProvider.h
+++ b/Tools/TestWebKitAPI/Helpers/TestNotificationProvider.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <WebKit/WKNotificationManager.h>
 #include <WebKit/WKNotificationProvider.h>
 #include <WebKit/WKRetainPtr.h>
@@ -66,3 +68,5 @@ private:
 };
 
 }
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/TestWebKitAPIPrefix.h
+++ b/Tools/TestWebKitAPI/Helpers/TestWebKitAPIPrefix.h
@@ -25,6 +25,8 @@
 
 #include <wtf/Platform.h>
 
+#ifdef __cplusplus
+
 #if defined(__APPLE__) && __APPLE__
 #ifdef __OBJC__
 #if PLATFORM(IOS_FAMILY)
@@ -60,3 +62,5 @@
 #if USE(OS_LOG)
 #include <os/log.h>
 #endif
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/Utilities.h
+++ b/Tools/TestWebKitAPI/Helpers/Utilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include "Helpers/WTFTestUtilities.h"
 
 #include <wtf/Seconds.h>
@@ -58,3 +60,5 @@ bool waitFor(Callable&& c, size_t maxTries = 100)
 }
 
 } // namespace TestWebKitAPI::Util
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/WTFTestUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/WTFTestUtilities.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
@@ -47,3 +49,5 @@ String utf16String(const char16_t (&url)[length])
 }
 
 }
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/WebCoreTestUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/WebCoreTestUtilities.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if !PLATFORM(COCOA) || !__has_feature(modules)
+
 #include "Helpers/Test.h"
 #include <WebCore/Color.h>
 #include <WebCore/FloatRect.h>
@@ -114,3 +118,5 @@ inline std::ostream& operator<<(std::ostream& os, const WebCore::FloatSegment& v
 }
 
 }
+
+#endif // !PLATFORM(COCOA) || !__has_feature(modules)

--- a/Tools/TestWebKitAPI/Helpers/cocoa/CGImagePixelReader.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/CGImagePixelReader.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <CoreGraphics/CoreGraphics.h>
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
@@ -58,3 +60,5 @@ private:
 };
 
 } // namespace TestWebKitAPI
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/DaemonTestUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/DaemonTestUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)
 
 #import <wtf/RetainPtr.h>
@@ -47,3 +49,4 @@ void registerPlistWithLaunchD(NSDictionary<NSString *, id> *plist, NSURL *tempDi
 
 #endif // PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)
 
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/DebugUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/DebugUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #if PLATFORM(COCOA)
 
 #include "Helpers/Utilities.h"
@@ -54,3 +56,5 @@ do { \
 } while (0)
 
 #endif // PLATFORM(COCOA)
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/DecomposedAttributedText.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/DecomposedAttributedText.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #import <wtf/ObjectIdentifier.h>
 #import <wtf/Variant.h>
 #import <wtf/Vector.h>
@@ -171,4 +173,4 @@ bool operator==(const DecomposedAttributedText::UnorderedList&, const Decomposed
 
 bool operator==(const DecomposedAttributedText&, const DecomposedAttributedText&);
 
-
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/DragAndDropSimulator.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/DragAndDropSimulator.h
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef __cplusplus
+
 #if ENABLE(DRAG_SUPPORT)
 
 #import "Helpers/cocoa/TestWKWebView.h"
@@ -176,3 +178,5 @@ typedef NSDictionary<NSNumber *, NSValue *> *ProgressToCGPointValueMap;
 #endif
 
 #endif // ENABLE(DRAG_SUPPORT)
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/EditingTestHarness.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/EditingTestHarness.h
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef __cplusplus
+
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <WebKit/WKUIDelegatePrivate.h>
 
@@ -63,3 +65,5 @@
 - (BOOL)latestEditorStateContains:(NSDictionary<NSString *, id> *)entries;
 
 @end
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/FindInPageUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/FindInPageUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <WebKit/_WKFindDelegate.h>
 #include <wtf/BlockPtr.h>
 #include <wtf/RetainPtr.h>
@@ -56,3 +58,5 @@ void testPerformTextSearchWithQueryStringInWebView(WKWebView *, NSString *query,
 RetainPtr<NSOrderedSet<UITextRange *>> textRangesForQueryString(WKWebView *, NSString *query);
 
 #endif
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #import "Helpers/cocoa/NetworkConnection.h"
 #import <wtf/CompletionHandler.h>
 #import <wtf/Forward.h>
@@ -202,3 +204,5 @@ RetainPtr<SecCertificateRef> testCertificate();
 RetainPtr<SecIdentityRef> testIdentity();
 RetainPtr<SecIdentityRef> testIdentity2();
 void verifyCertificateAndPublicKey(SecTrustRef);
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/HostWindowManager.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HostWindowManager.h
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef __cplusplus
+
 #import "Helpers/PlatformUtilities.h"
 #import <gtest/gtest.h>
 #import <wtf/RetainPtr.h>
@@ -46,3 +48,5 @@ private:
 };
 
 } // namespace TestWebKitAPI
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/ImageAnalysisTestingUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/ImageAnalysisTestingUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #if HAVE(VK_IMAGE_ANALYSIS)
 
 #import "InstanceMethodSwizzler.h"
@@ -61,3 +63,5 @@ private:
 } // namespace TestWebKitAPI
 
 #endif // HAVE(VK_IMAGE_ANALYSIS)
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/NetworkConnection.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/NetworkConnection.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #import "Helpers/CoroutineUtilities.h"
 #import <Network/Network.h>
 #import <wtf/CompletionHandler.h>
@@ -154,3 +156,5 @@ private:
 };
 
 } // namespace TestWebKitAPI
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/PDFTestHelpers.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/PDFTestHelpers.h
@@ -25,20 +25,28 @@
 
 #pragma once
 
+#ifdef __cplusplus
 #import <wtf/RetainPtr.h>
+#endif
 
-OBJC_CLASS NSData;
-OBJC_CLASS WKWebViewConfiguration;
-OBJC_CLASS _WKFrameHandle;
+@class NSData;
+@class WKWebViewConfiguration;
+@class _WKFrameHandle;
 
-OBJC_PROTOCOL(WKUIDelegate);
+@protocol WKUIDelegate;
 
 @interface PDFPrintUIDelegate : NSObject <WKUIDelegate>
 
+#if PLATFORM(MAC)
 - (NSSize)waitForPageSize;
+#else
+- (CGSize)waitForPageSize;
+#endif
 - (_WKFrameHandle *)lastPrintedFrame;
 
 @end
+
+#ifdef __cplusplus
 
 namespace TestWebKitAPI {
 
@@ -55,3 +63,5 @@ RetainPtr<WKWebViewConfiguration> configurationForWebViewTestingUnifiedPDF(bool 
 RetainPtr<NSData> testPDFData();
 
 }
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/PasteboardUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/PasteboardUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <wtf/RetainPtr.h>
 OBJC_CLASS TestWKWebView;
 
@@ -34,3 +36,5 @@ NSString *readURLFromPasteboard();
 NSString *readTitleFromPasteboard();
 
 void clearPasteboard();
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/SafeBrowsingTestUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/SafeBrowsingTestUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #import <Foundation/Foundation.h>
 #import <wtf/Seconds.h>
 
@@ -43,3 +45,5 @@
 @interface DelayedLookupContext : NSObject
 @property (nonatomic, class) Seconds delayDuration;
 @end
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #if USE(APPKIT)
 OBJC_CLASS NSImage;
 using CocoaImage = NSImage;
@@ -42,3 +44,5 @@ CocoaColor *toSRGBColor(CocoaColor *);
 bool compareColors(CocoaColor *, CocoaColor *, float tolerance = 0.01);
 
 } // namespace TestWebKitAPI::Util
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestContextMenuDriver.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestContextMenuDriver.h
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef __cplusplus
+
 #if USE(UICONTEXTMENU)
 
 #import <wtf/WeakObjCPtr.h>
@@ -49,3 +51,5 @@
 @end
 
 #endif // USE(UICONTEXTMENU)
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestDownloadDelegate.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestDownloadDelegate.h
@@ -26,6 +26,8 @@
 #import <WebKit/WKDownloadDelegate.h>
 #import <WebKit/WebKit.h>
 
+#ifdef __cplusplus
+
 enum class DownloadCallback : uint8_t {
     WillRedirect,
     AuthenticationChallenge,
@@ -42,6 +44,8 @@ enum class DownloadCallback : uint8_t {
     NavigationAction,
     NavigationResponse,
 };
+
+#endif // __cplusplus
 
 @interface TestDownloadDelegate : NSObject<WKDownloadDelegate, WKNavigationDelegate>
 
@@ -61,6 +65,8 @@ enum class DownloadCallback : uint8_t {
 #endif
 
 - (void)waitForDownloadDidFinish;
+#ifdef __cplusplus
 - (Vector<DownloadCallback>)takeCallbackRecord;
+#endif
 
 @end

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
@@ -38,6 +38,7 @@
 @class _WKProcessPoolConfiguration;
 
 #if PLATFORM(IOS_FAMILY)
+#import "UIKitSPIForTesting.h"
 #import "WKBrowserEngineDefinitions.h"
 @class _WKActivatedElementInfo;
 @class _WKTextInputContext;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/UISideCompositingScope.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/UISideCompositingScope.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <Foundation/Foundation.h>
 #include <objc/runtime.h>
 #include <wtf/Forward.h>
@@ -51,3 +53,5 @@ private:
 };
 
 } // namespace TestWebKitAPI
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "Helpers/cocoa/TestCocoa.h"
@@ -174,3 +176,5 @@ void loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources, WKWebE
 } // namespace TestWebKitAPI::Util
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebTransportServer.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebTransportServer.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #if PLATFORM(COCOA)
 
 #import "Helpers/CoroutineUtilities.h"
@@ -50,3 +52,5 @@ private:
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(COCOA)
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/ios/IOSMouseEventTestHarness.h
+++ b/Tools/TestWebKitAPI/Helpers/ios/IOSMouseEventTestHarness.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
 
 #import "InstanceMethodSwizzler.h"
@@ -83,3 +85,4 @@ private:
 
 #endif
 
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/ios/TestWKWebViewController.h
+++ b/Tools/TestWebKitAPI/Helpers/ios/TestWKWebViewController.h
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
+#ifdef __cplusplus
+
 #import "Helpers/cocoa/TestWKWebView.h"
 
 #if PLATFORM(IOS_FAMILY)
@@ -43,3 +47,5 @@
 @end
 
 #endif // PLATFORM(IOS_FAMILY)
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/ios/UserInterfaceSwizzler.h
+++ b/Tools/TestWebKitAPI/Helpers/ios/UserInterfaceSwizzler.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #if PLATFORM(IOS_FAMILY)
 
 #import "InstanceMethodSwizzler.h"
@@ -56,3 +58,5 @@ using IPhoneUserInterfaceSwizzler = UserInterfaceSwizzler<UIUserInterfaceIdiomPh
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(IOS_FAMILY)
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/mac/SyntheticBackingScaleFactorWindow.h
+++ b/Tools/TestWebKitAPI/Helpers/mac/SyntheticBackingScaleFactorWindow.h
@@ -23,8 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if PLATFORM(MAC)
+
 @interface SyntheticBackingScaleFactorWindow : NSWindow {
     CGFloat _backingScaleFactor;
 }
 - (void)setBackingScaleFactor:(CGFloat)scaleFactor;
 @end
+
+#endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Helpers/mac/VirtualGamepad.h
+++ b/Tools/TestWebKitAPI/Helpers/mac/VirtualGamepad.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #include <wtf/FastMalloc.h>
@@ -123,3 +125,5 @@ private:
 } // namespace TestWebKitAPI
 
 #endif // USE(APPLE_INTERNAL_SDK)
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/mac/WKWebViewForTestingImmediateActions.h
+++ b/Tools/TestWebKitAPI/Helpers/mac/WKWebViewForTestingImmediateActions.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #if PLATFORM(MAC)
 
 #import "Helpers/cocoa/TestWKWebView.h"
@@ -50,3 +52,5 @@ using ImmediateActionHitTestResult = std::pair<RetainPtr<_WKHitTestResult>, _WKI
 @end
 
 #endif
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/mac/WebKitAgnosticTest.h
+++ b/Tools/TestWebKitAPI/Helpers/mac/WebKitAgnosticTest.h
@@ -26,6 +26,8 @@
 #ifndef WebKitAgnosticTest_h
 #define WebKitAgnosticTest_h
 
+#ifdef __cplusplus
+
 #include "Helpers/PlatformUtilities.h"
 
 namespace TestWebKitAPI {
@@ -68,5 +70,7 @@ private:
 };
 
 } // namespace TestWebKitAPI
+
+#endif // __cplusplus
 
 #endif // WebKitAgnosticTest_h


### PR DESCRIPTION
#### 27861fea3b5ef3aecaaf6826438006cbebd73638
<pre>
[Swift in WebKit] Integrate Swift Testing into run-api-tests (part 4)
<a href="https://bugs.webkit.org/show_bug.cgi?id=312352">https://bugs.webkit.org/show_bug.cgi?id=312352</a>
<a href="https://rdar.apple.com/174808897">rdar://174808897</a>

Reviewed by Abrar Rahman Protyasha.

Add a few missing includes and compile guards.

* Tools/TestRunnerShared/cocoa/ClassMethodSwizzler.h:
* Tools/TestRunnerShared/cocoa/InstanceMethodSwizzler.h:
* Tools/TestRunnerShared/cocoa/PoseAsClass.h:
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Helpers/CoroutineUtilities.h:
* Tools/TestWebKitAPI/Helpers/Counters.h:
* Tools/TestWebKitAPI/Helpers/DeprecatedGlobalValues.h:
* Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.h:
* Tools/TestWebKitAPI/Helpers/JavaScriptTest.h:
* Tools/TestWebKitAPI/Helpers/PlatformUtilities.h:
* Tools/TestWebKitAPI/Helpers/PlatformWebView.h:
* Tools/TestWebKitAPI/Helpers/SoftLinkShim.h:
* Tools/TestWebKitAPI/Helpers/Test.h:
* Tools/TestWebKitAPI/Helpers/TestNotificationProvider.h:
* Tools/TestWebKitAPI/Helpers/TestWebKitAPIPrefix.h:
* Tools/TestWebKitAPI/Helpers/Utilities.h:
* Tools/TestWebKitAPI/Helpers/WTFTestUtilities.h:
* Tools/TestWebKitAPI/Helpers/WebCoreTestUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/CGImagePixelReader.h:
* Tools/TestWebKitAPI/Helpers/cocoa/DaemonTestUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/DebugUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/DecomposedAttributedText.h:
* Tools/TestWebKitAPI/Helpers/cocoa/DragAndDropSimulator.h:
* Tools/TestWebKitAPI/Helpers/cocoa/EditingTestHarness.h:
* Tools/TestWebKitAPI/Helpers/cocoa/FindInPageUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.h:
* Tools/TestWebKitAPI/Helpers/cocoa/HostWindowManager.h:
* Tools/TestWebKitAPI/Helpers/cocoa/ImageAnalysisTestingUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/NetworkConnection.h:
* Tools/TestWebKitAPI/Helpers/cocoa/PDFTestHelpers.h:
* Tools/TestWebKitAPI/Helpers/cocoa/PasteboardUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/SafeBrowsingTestUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestContextMenuDriver.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestDownloadDelegate.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/Helpers/cocoa/UISideCompositingScope.h:
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/WebTransportServer.h:
* Tools/TestWebKitAPI/Helpers/ios/IOSMouseEventTestHarness.h:
* Tools/TestWebKitAPI/Helpers/ios/TestWKWebViewController.h:
* Tools/TestWebKitAPI/Helpers/ios/UserInterfaceSwizzler.h:
* Tools/TestWebKitAPI/Helpers/mac/SyntheticBackingScaleFactorWindow.h:
* Tools/TestWebKitAPI/Helpers/mac/VirtualGamepad.h:
* Tools/TestWebKitAPI/Helpers/mac/WKWebViewForTestingImmediateActions.h:
* Tools/TestWebKitAPI/Helpers/mac/WebKitAgnosticTest.h:

Canonical link: <a href="https://commits.webkit.org/311323@main">https://commits.webkit.org/311323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31c989b907830f0c53bd1129e5aacfb36e5be15f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165454 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121317 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101985 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20793 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13226 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167937 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129433 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129543 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35092 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29492 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140288 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87293 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24368 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17091 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29200 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28725 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28955 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28850 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->