### PR TITLE
Fix crash in FontSelectionAlgorithm when all font faces are penalized

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-last-resort-weight-selection-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-last-resort-weight-selection-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+
+<title>CSS Fonts reference: weight selection among last-resort oblique faces</title>
+
+<style>
+@font-face {
+  font-family: ref;
+  src: url("resources/markA.ttf");
+}
+
+div { font: 50px ref; }
+</style>
+
+<!-- Expected: full-size 50px 'A' from markA.ttf (Face 1, w400, no size-adjust selected) -->
+<div>A</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-last-resort-weight-selection-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-last-resort-weight-selection-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+
+<title>CSS Fonts reference: weight selection among last-resort oblique faces</title>
+
+<style>
+@font-face {
+  font-family: ref;
+  src: url("resources/markA.ttf");
+}
+
+div { font: 50px ref; }
+</style>
+
+<!-- Expected: full-size 50px 'A' from markA.ttf (Face 1, w400, no size-adjust selected) -->
+<div>A</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-last-resort-weight-selection.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-last-resort-weight-selection.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+
+<title>CSS Fonts: weight selection among last-resort oblique faces</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-style-matching">
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-synthesis-style">
+<meta name="assert" content="When italic is requested with font-synthesis-style:oblique-only and only oblique faces exist, the best weight match is selected among the penalized last-resort candidates">
+<link rel="match" href="oblique-last-resort-weight-selection-ref.html">
+
+<style>
+/*
+ * font-family 'test' has two oblique faces (both penalized as last resort when italic
+ * is requested with font-synthesis-style:oblique-only).
+ *
+ * Face 1 (declared first): oblique 14deg–30deg, weight 400
+ *   Good weight match for the request (w400). No size-adjust → full 50px glyphs.
+ *
+ * Face 2 (declared second): oblique 5deg–14deg, weight 700
+ *   Poor weight match. size-adjust:50% → 25px glyphs if erroneously selected.
+ *
+ * WebKit builds the capabilities vector in reverse declaration order, so Face 2
+ * is iterated first in FontSelectionAlgorithm. This makes the test deterministic:
+ *
+ *   With slope.minimum:
+ *     Face 2 yields value=5 (its slope minimum). Face 1's range [14,30] does not
+ *     contain 5, so Face 1 is eliminated. Only Face 2 (w700) survives; its 50%
+ *     size-adjust produces 25px glyphs. ← INCORRECT
+ *
+ *   With clamp(requestSlope, slope.minimum, slope.maximum):
+ *     Face 2 yields clamp(14,5,14)=14. Face 1 yields clamp(14,14,30)=14. Both
+ *     ranges contain 14, so both survive the slope filter. Weight matching then
+ *     selects Face 1 (w400 = requested weight) → full 50px glyphs. ← CORRECT
+ */
+@font-face {
+  font-family: test;
+  font-style: oblique 14deg 30deg;
+  font-weight: 400;
+  src: url("resources/markA.ttf");
+}
+@font-face {
+  font-family: test;
+  font-style: oblique 5deg 14deg;
+  font-weight: 700;
+  src: url("resources/markA.ttf");
+  size-adjust: 50%;
+}
+
+div { font: 50px test; }
+</style>
+
+<!--
+  Requesting italic + font-synthesis-style:oblique-only + font-weight:400.
+  Both oblique faces are penalized (penalizeObliqueFontSelection=true).
+  Among last-resort faces, CSS weight matching must select Face 1 (w400).
+  Correct result: full-size (50px) 'A' glyph from markA.ttf with no size-adjust.
+-->
+<div style="font-style: italic; font-synthesis-style: oblique-only; font-weight: 400">A</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-request-italic-only-family-no-crash-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-request-italic-only-family-no-crash-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Requesting oblique 75deg with an italic-only @font-face family does not crash
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-request-italic-only-family-no-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-request-italic-only-family-no-crash.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+
+<title>CSS Fonts: oblique request with italic-only family does not crash</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-style-matching">
+<meta name="assert" content="Requesting oblique when the font family has only an italic face must not crash; the italic face is used as a last resort">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+/* Only face in the family is italic (faceAxis=ital, slope=[14,14]).
+   An oblique request triggers the last-resort penalty path; the fix ensures
+   the italic face still survives the slope filter rather than all candidates
+   being eliminated and causing a crash in FontSelectionAlgorithm::bestValue. */
+@font-face {
+    font-family: "testFont";
+    src: url("resources/markA.ttf");
+    font-style: italic;
+}
+</style>
+
+<div id="target" style="font-family: testFont; font-style: oblique 75deg;">
+    This text triggers oblique selection against an italic-only font family.
+</div>
+
+<script>
+test(() => {
+    // Force style resolution and layout. If the font selection algorithm
+    // crashes, this line is never reached and the test fails with a crash.
+    assert_greater_than(document.getElementById("target").offsetHeight, 0,
+        "element rendered without crash");
+}, "Requesting oblique 75deg with an italic-only @font-face family does not crash");
+</script>

--- a/Source/WebCore/platform/graphics/FontSelectionAlgorithm.cpp
+++ b/Source/WebCore/platform/graphics/FontSelectionAlgorithm.cpp
@@ -78,11 +78,15 @@ auto FontSelectionAlgorithm::styleDistance(Capabilities capabilities) const -> D
     // We implement this by giving mismatched faces a distance penalty large enough to
     // always lose to any matching-category face, while still allowing last-resort use
     // when no better face exists.
-    if (m_request.slopeAxis == FontStyleAxis::slnt && capabilities.faceAxis == FontStyleAxis::ital)
-        return { FontSelectionValue::maximumValue(), requestSlope };
+    if (m_request.slopeAxis == FontStyleAxis::slnt && capabilities.faceAxis == FontStyleAxis::ital) {
+        auto clampedSlope = std::clamp(requestSlope, slope.minimum, slope.maximum);
+        return { FontSelectionValue::maximumValue(), clampedSlope };
+    }
 
-    if (m_request.penalizeObliqueFontSelection && capabilities.faceAxis == FontStyleAxis::slnt)
-        return { FontSelectionValue::maximumValue(), requestSlope };
+    if (m_request.penalizeObliqueFontSelection && capabilities.faceAxis == FontStyleAxis::slnt) {
+        auto clampedSlope = std::clamp(requestSlope, slope.minimum, slope.maximum);
+        return { FontSelectionValue::maximumValue(), clampedSlope };
+    }
 
     if (slope.includes(requestSlope))
         return { FontSelectionValue(), requestSlope };
@@ -163,6 +167,7 @@ FontSelectionValue FontSelectionAlgorithm::bestValue(std::span<const bool> elimi
         if (!smallestDistance || distanceResult.distance < smallestDistance.value().distance)
             smallestDistance = distanceResult;
     }
+    ASSERT(smallestDistance);
     return smallestDistance.value().value;
 }
 


### PR DESCRIPTION
#### 47b07ba22fd84835ba672ee3dce9d376f205ba70
<pre>
Fix crash in FontSelectionAlgorithm when all font faces are penalized
<a href="https://bugs.webkit.org/show_bug.cgi?id=312351">https://bugs.webkit.org/show_bug.cgi?id=312351</a>
<a href="https://rdar.apple.com/174644983">rdar://174644983</a>

Reviewed by Brent Fulgham and Vitor Roriz.

styleDistance&apos;s axis-mismatch penalty paths returned the requested slope value,
but filterCapability eliminates faces whose slope range doesn&apos;t include that
value. When all faces are penalized (e.g. only italic faces available for an
oblique request), every face gets eliminated, and the next pass crashes on an
empty set.

Fix by clamping the returned value to the face&apos;s own slope range in both penalty
paths. This preserves the maximum-distance penalty (so penalised faces always
lose to any unpenalised face) while ensuring the returned value satisfies the
invariant that every other branch in styleDistance() upholds: the value must lie
within capabilities.slope so filterCapability() retains the face as a last resort.

This patch includes a test that we don&apos;t crash under these conditions, as well as a
test that confirms we make the right font selection in cases where styleDistance
cannot find a proper match.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-last-resort-weight-selection-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-last-resort-weight-selection-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-last-resort-weight-selection.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-request-italic-only-family-no-crash-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-request-italic-only-family-no-crash.html: Added.
* Source/WebCore/platform/graphics/FontSelectionAlgorithm.cpp:
(WebCore::FontSelectionAlgorithm::styleDistance const):
(WebCore::FontSelectionAlgorithm::bestValue const):

Canonical link: <a href="https://commits.webkit.org/311341@main">https://commits.webkit.org/311341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c35bbbcb6da10fcb379f8c86d212ddcc941ef52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165512 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121363 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102031 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20841 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13284 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167995 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129476 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129586 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35105 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140326 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87351 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17129 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29258 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28783 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29013 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28909 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->