### PR TITLE
[Site Isolation] Main frame onload event does not fire if iframe load is blocked

### DIFF
--- a/LayoutTests/http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https-expected.txt
+++ b/LayoutTests/http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: [blocked] The page at https://127.0.0.1:8443/security/mixedContent/mainframe-onload-after-iframe-block.https.html requested insecure content from http://127.0.0.1:8443/frame-b.html. This content was blocked and must be served over HTTPS.
+
+CONSOLE MESSAGE: Onload Triggered!
+

--- a/LayoutTests/http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https.html
+++ b/LayoutTests/http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+onload = function()
+{
+    console.log('Onload Triggered!');
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+</script>
+<iframe src="http://127.0.0.1:8443/frame-b.html" width="800" height="800"></iframe>
+</body>
+</html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2367,8 +2367,10 @@ void FrameLoader::clearProvisionalLoad()
 void FrameLoader::provisionalLoadFailedInAnotherProcess()
 {
     m_provisionalLoadHappeningInAnotherProcess = false;
+    m_isComplete = true;
+
     if (RefPtr localParent = dynamicDowncast<LocalFrame>(m_frame->tree().parent()))
-        localParent->loader().checkLoadComplete();
+        localParent->loader().checkCompleted();
 }
 
 void FrameLoader::commitProvisionalLoad()


### PR DESCRIPTION
#### 0e46277991b156ac338714ebe3dc3ad3808870f5
<pre>
[Site Isolation] Main frame onload event does not fire if iframe load is blocked
<a href="https://bugs.webkit.org/show_bug.cgi?id=312358">https://bugs.webkit.org/show_bug.cgi?id=312358</a>
<a href="https://rdar.apple.com/161348735">rdar://161348735</a>

Reviewed by Charlie Wolfe.

Once child frames have finished loading (or failed to load), the main frame&apos;s
onload event must fire. But with site isolation on, when the iframe load is
blocked by the mixed content checker, the main frame&apos;s onload event never fires.

With site isolation off, the way this works is:

1. Main frame begins loading but is blocked from completing by the iframe&apos;s load.
2. DocumentLoader::startLoadingMainResource() starts loading the iframe
3. MixedContentChecker::shouldBlockRequest() returns that we should block
4. DocumentLoader::cancelMainResourceLoad()
5. FrameLoader::checkCompleted() sets m_isComplete on the iframe and calls
6. FrameLoader::checkCompleted() on the parent frame (the main frame)
7. Document::implicitClose()
8. Document::dispatchWindowLoadEvent()
9. LocalDOMWindow::dispatchLoadEvent()

With site isolation on, when FrameLoader::checkCompleted() is called on the iframe,
we don&apos;t go any further because the m_isComplete flag is already set to true. This
is because this iframe&apos;s flag was never set to false by FrameLoader::started()
when the load began because this function isn&apos;t called on the LocalFrame iframe
that is created for loads that occur in another process. So we never call
FrameLoader::checkCompleted() on the main frame to tell it the load finished.

Since the load finished in another process, this process needs to send a message
to the main frame&apos;s web process and tell it the load finished. This already happens.
When the iframe&apos;s load gets blocked, the web process notifies the UI Process of this,
and it calls FrameLoader::provisionalLoadFailedInAnotherProcess() on the loader
associated with the same frame in the main frame&apos;s process. The issue is that this
function does not call checkCompleted() on the main frame so that it may fire its
onload event.

To fix this, we amend FrameLoader::provisionalLoadFailedInAnotherProcess() to call
FrameLoader::checkCompleted() on the parent (main) frame. This function will check
that all children are complete. So we must also set m_isComplete to true for this
iframe before calling checkCompleted() on the parent.

This is covered by a new layout test that passes with both site isolation on and off.

* LayoutTests/http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https-expected.txt: Added.
* LayoutTests/http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::provisionalLoadFailedInAnotherProcess):

Canonical link: <a href="https://commits.webkit.org/311314@main">https://commits.webkit.org/311314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48b7889711ce4c6b0c4ece1ab2908aa7e4a2703c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156655 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29991 "Failed to checkout and rebase branch from PR 62804") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/23174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165478 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158526 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/30127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29994 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159613 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/30127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/30127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/13250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/30127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167961 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/20127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/129560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/29516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/140303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23846 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/29516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29224 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->