### PR TITLE
Improve EnhancedSecurityPolicies test output to be more informative of where the failure occurs

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
@@ -52,6 +52,7 @@
 #import <WebKit/_WKFrameTreeNode.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
+#import <source_location>
 #import <wtf/Assertions.h>
 #import <wtf/Function.h>
 #import <wtf/RetainPtr.h>
@@ -159,15 +160,17 @@ static RetainPtr<WKHTTPCookieStore> globalCookieStore;
 
 @end
 
-static void testAlertWithEnhancedSecurity(RetainPtr<TestUIDelegate> uiDelegate, String message, BOOL enhancedSecurityEnabled)
+static void testAlertWithEnhancedSecurity(RetainPtr<TestUIDelegate> uiDelegate, String message, BOOL enhancedSecurityEnabled, std::source_location location)
 {
     NSArray *result = [uiDelegate waitForAlertWithEnhancedSecurity];
 
     EXPECT_WK_STREQ(result[0], message);
-    EXPECT_EQ([result[1] boolValue], enhancedSecurityEnabled);
-
-    if ([result[1] boolValue] != enhancedSecurityEnabled)
-        NSLog(@"Enhanced Security state mismatch for alert: %s (expected: %s, actual: %s)", message.utf8().data() , enhancedSecurityEnabled ? "Enabled" : "Disabled", [result[1] boolValue] ? "Enabled" : "Disabled");
+    if ([result[1] boolValue] != enhancedSecurityEnabled) {
+        ADD_FAILURE_AT(location.file_name(), location.line())
+            << "Enhanced security mismatch for alert '" << message.utf8().data() << "'"
+            << " (expected: " << (enhancedSecurityEnabled ? "Enabled" : "Disabled")
+            << ", actual: " << ([result[1] boolValue] ? "Enabled" : "Disabled") << ")";
+    }
 }
 
 static RetainPtr<TestWKWebView> enhancedSecurityTestConfiguration(
@@ -216,7 +219,8 @@ enum class ExpectedEnhancedSecurity : bool { Disabled = false, Enabled = true };
 static void runActionAndCheckEnhancedSecurityAlerts(
     RetainPtr<TestWKWebView> webView,
     Function<void()>&& performAction,
-    std::initializer_list<std::pair<String, ExpectedEnhancedSecurity>> alerts)
+    std::initializer_list<std::pair<String, ExpectedEnhancedSecurity>> alerts,
+    std::source_location location = std::source_location::current())
 {
     RELEASE_ASSERT(!webView.get().UIDelegate);
 
@@ -236,7 +240,7 @@ static void runActionAndCheckEnhancedSecurityAlerts(
     performAction();
 
     for (auto& pair : alerts)
-        testAlertWithEnhancedSecurity(uiDelegate, pair.first, static_cast<bool>(pair.second));
+        testAlertWithEnhancedSecurity(uiDelegate, pair.first, static_cast<bool>(pair.second), location);
 
     [webView setUIDelegate:nil];
 }
@@ -244,11 +248,12 @@ static void runActionAndCheckEnhancedSecurityAlerts(
 static void loadRequestAndCheckEnhancedSecurityAlerts(
     RetainPtr<TestWKWebView> webView,
     NSString *url,
-    std::initializer_list<std::pair<String, ExpectedEnhancedSecurity>> alerts)
+    std::initializer_list<std::pair<String, ExpectedEnhancedSecurity>> alerts,
+    std::source_location location = std::source_location::current())
 {
     runActionAndCheckEnhancedSecurityAlerts(webView, [webView, url] {
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
-    }, alerts);
+    }, alerts, location);
 }
 
 #define TEST_WITHOUT_SITE_ISOLATION(test_name) \


### PR DESCRIPTION
#### 925dcb89b0d95adb1b427edef221573b6b839b23
<pre>
Improve EnhancedSecurityPolicies test output to be more informative of where the failure occurs
<a href="https://bugs.webkit.org/show_bug.cgi?id=312363">https://bugs.webkit.org/show_bug.cgi?id=312363</a>
<a href="https://rdar.apple.com/174816736">rdar://174816736</a>

Reviewed by Vitor Roriz.

Test failures from Enhanced Security state mismatches were failing to report useful
information about what the mismatch was, or pinpoint the original line location.

This patch improves the output by making use of C++20 std::source_location::current()
as a default argument, which gets evaluated at each call site. This allows propagating
our line location information with minimal other changes.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm:
(testAlertWithEnhancedSecurity):
(runActionAndCheckEnhancedSecurityAlerts):
(loadRequestAndCheckEnhancedSecurityAlerts):

Canonical link: <a href="https://commits.webkit.org/311317@main">https://commits.webkit.org/311317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a67964deaeaa5baa023cb84b8925b9ad0015377

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110612 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121239 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85197 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101907 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22528 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20708 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13125 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167835 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129359 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129468 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35086 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140196 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87193 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16998 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29100 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28626 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28855 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28851 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->