### PR TITLE
innerText getter: apply ::first-line text-transform

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -73,8 +73,8 @@ PASS Soft breaks ignored, text-transform applied ("<div style='width:1px; word-b
 PASS <br> returned as newline, following space collapsed ("<div style='width:1px; word-break:break-word'>Hello<br> Kitty</div>")
 PASS <br> returned as newline, preceding space collapsed ("<div style='width:1px; word-break:break-word'>Hello <br>Kitty</div>")
 PASS <br> returned as newline, adjacent spaces collapsed across element boundaries ("<div style='width:1px; word-break:break-word'><x>Hello </x> <br> <x> Kitty</x></div>")
-FAIL ::first-line styles applied ("<div class='first-line-uppercase'>abc") assert_equals: innerText expected "ABC" but got "abc"
-FAIL ::first-line styles applied ("<div class='first-line-uppercase' style='width:0'>abc def") assert_equals: innerText expected "ABC def" but got "abc def"
+PASS ::first-line styles applied ("<div class='first-line-uppercase'>abc")
+PASS ::first-line styles applied ("<div class='first-line-uppercase' style='width:0'>abc def")
 PASS ::first-letter styles applied ("<div class='first-letter-uppercase' style='width:0'>abc def")
 PASS ::first-letter float ignored ("<div class='first-letter-float' style='width:0'>abc def")
 PASS &nbsp; preserved ("<div>&nbsp;")

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1270,13 +1270,26 @@ void TextIterator::emitText(Text& textNode, RenderText& renderer, int textStartO
     ASSERT(textEndOffset >= 0);
     ASSERT(textStartOffset <= textEndOffset);
 
-    bool shouldIgnoreFullSizeKana = m_behaviors.contains(TextIteratorBehavior::IgnoresFullSizeKana) && renderer.style().textTransform().contains(Style::TextTransformValue::FullSizeKana);
+    bool shouldEmitOriginalText = m_behaviors.contains(TextIteratorBehavior::EmitsOriginalText)
+        || (m_behaviors.contains(TextIteratorBehavior::IgnoresFullSizeKana) && renderer.style().textTransform().contains(Style::TextTransformValue::FullSizeKana));
 
     // FIXME: This probably yields the wrong offsets when text-transform: lowercase turns a single character into two characters.
-    String string = m_behaviors.contains(TextIteratorBehavior::EmitsOriginalText) || shouldIgnoreFullSizeKana ? renderer.originalText()
-        : (m_behaviors.contains(TextIteratorBehavior::EmitsTextsWithoutTranscoding) ? renderer.textWithoutConvertingBackslashToYenSymbol() : renderer.text());
+    String string = [&]() -> String {
+        if (shouldEmitOriginalText)
+            return renderer.originalText();
+        // If this text is on the first line and ::first-line has a different text-transform
+        // than the base style, apply text-transform using the first-line style.
+        if (m_textRun && !m_textRun->lineIndex()) {
+            CheckedRef firstLineStyle = renderer.firstLineStyle();
+            if (firstLineStyle->textTransform() != renderer.style().textTransform())
+                return applyTextTransform(firstLineStyle, renderer.originalText());
+        }
+        if (m_behaviors.contains(TextIteratorBehavior::EmitsTextsWithoutTranscoding))
+            return renderer.textWithoutConvertingBackslashToYenSymbol();
+        return renderer.text();
+    }();
 
-    ASSERT(m_behaviors.contains(TextIteratorBehavior::EmitsOriginalText) || string.length() >= static_cast<unsigned>(textEndOffset));
+    ASSERT(shouldEmitOriginalText || string.length() >= static_cast<unsigned>(textEndOffset));
 
     textEndOffset = std::min(string.length(), static_cast<unsigned>(textEndOffset));
 


### PR DESCRIPTION
#### eb01ddc81f42db30b637d1bd67ac072189c6775b
<pre>
innerText getter: apply ::first-line text-transform
<a href="https://bugs.webkit.org/show_bug.cgi?id=312366">https://bugs.webkit.org/show_bug.cgi?id=312366</a>

Reviewed by Darin Adler.

TextIterator::emitText() uses renderer.text() which has text-transform
applied from the base style only. Unlike ::first-letter which creates a
separate RenderTextFragment with its own style, ::first-line only
overrides styles for layout/painting without creating a distinct
renderer. As a result, innerText ignored ::first-line text-transform.

Fix this by checking whether the current text run is on the first line
and, if so, whether the ::first-line style has a different text-transform
than the base style. When it does, re-apply text-transform using the
first-line style on the original text.

No new tests, rebaselined existing WPT test. Firefox and Chrome were
already passing these subtests so we&apos;re aligning behavior with them.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::emitText):

Canonical link: <a href="https://commits.webkit.org/311436@main">https://commits.webkit.org/311436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7723914ca3c4164c35d6bafd1189db41a7c2fed4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165743 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111002 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121529 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85343 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102197 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be38782c-b692-4344-9e63-6a7156f0760a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22811 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21043 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13515 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168228 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12387 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129647 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129754 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35156 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140527 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87585 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17331 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29491 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93506 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29014 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29244 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->