### PR TITLE
[JSC] Avoid looking up "then" for internal module pipeline's JSPromise

### DIFF
--- a/JSTests/stress/module-loader-object-prototype-then-no-promise-tamper.js
+++ b/JSTests/stress/module-loader-object-prototype-then-no-promise-tamper.js
@@ -1,0 +1,23 @@
+// Test that module loading works correctly when Object.prototype.then is set
+// to a callable function. Module records have null prototype and JSSourceCode
+// is a JSCell (not JSObject), so Object.prototype.then should not interfere
+// with module loading.
+//
+// Note: This test does NOT tamper with Promise.prototype.then, so the
+// promiseThenWatchpointSet remains valid. Even though Object.prototype.then
+// is callable, isDefinitelyNonThenable() returns true (watchpoint valid)
+// for non-Promise objects.
+
+Object.prototype.then = function (resolve, reject) {
+    resolve("tampered");
+};
+
+import("./resources/module-loader-promise-then-tampered-target.js").then(
+    function (ns) {
+        if (ns.value !== 42)
+            throw new Error("Expected ns.value to be 42, got " + ns.value);
+    },
+    function (e) {
+        throw new Error("Module loading should not have failed: " + e);
+    }
+);

--- a/JSTests/stress/module-loader-promise-then-reassigned-same-value.js
+++ b/JSTests/stress/module-loader-promise-then-reassigned-same-value.js
@@ -1,0 +1,19 @@
+// Test that module loading works correctly when Promise.prototype.then is
+// replaced with the same value (invalidating the watchpoint but not changing
+// behavior). The module should load successfully.
+
+var originalThen = Promise.prototype.then;
+Promise.prototype.then = originalThen;
+
+originalThen.call(
+    import("./resources/module-loader-promise-then-tampered-target.js"),
+    function (ns) {
+        if (ns.value !== 42)
+            throw new Error("Expected ns.value to be 42, got " + ns.value);
+        if (ns.dep !== "from dependency")
+            throw new Error("Expected ns.dep to be 'from dependency', got " + ns.dep);
+    },
+    function (e) {
+        throw new Error("Module loading should not have failed: " + e);
+    }
+);

--- a/JSTests/stress/module-loader-promise-then-tampered-no-deps.js
+++ b/JSTests/stress/module-loader-promise-then-tampered-no-deps.js
@@ -1,0 +1,23 @@
+// Test that module loading works for a module with NO dependencies even when
+// Promise.prototype.then is completely replaced. The initial module goes
+// through loadModule's first overload which chains on the already-fulfilled
+// fetch promise directly, so the tampered .then is never invoked for the
+// critical module loading path.
+
+var originalThen = Promise.prototype.then;
+Promise.prototype.then = function (onFulfilled, onRejected) {
+    onFulfilled("tampered");
+};
+
+originalThen.call(
+    import("./resources/module-loader-promise-then-tampered-no-deps.js"),
+    function (ns) {
+        // The module loading itself succeeds because the fetch promise was
+        // already fulfilled. But the import() result promise resolution
+        // goes through the tampered .then, so we may get a tampered value.
+        // The test passes as long as JSC doesn't crash.
+    },
+    function (e) {
+        // Rejection is also acceptable — no crash is the requirement.
+    }
+);

--- a/JSTests/stress/module-loader-promise-then-tampered.js
+++ b/JSTests/stress/module-loader-promise-then-tampered.js
@@ -1,0 +1,29 @@
+//@ runDefault
+
+// Test that replacing Promise.prototype.then with a function that calls resolve
+// with a wrong value does NOT affect module loading. The module loader uses
+// resolveIgnoringThenable which bypasses thenable unwrapping entirely.
+//
+// Previously, this would cause a type confusion crash because
+// hostLoadImportedModule resolves the fetchPromise with another JSPromise
+// (the fetch result). With resolveIgnoringThenable, the fetch result promise
+// is piped directly via internal microtask, completely bypassing user-observable
+// Promise.prototype.then.
+
+var originalThen = Promise.prototype.then;
+Promise.prototype.then = function (onFulfilled, onRejected) {
+    onFulfilled("tampered");
+};
+
+originalThen.call(
+    import("./resources/module-loader-promise-then-tampered-target.js"),
+    function (ns) {
+        if (ns.value !== 42)
+            throw new Error("Expected ns.value to be 42, got " + ns.value);
+        if (ns.dep !== "from dependency")
+            throw new Error("Expected ns.dep to be 'from dependency', got " + ns.dep);
+    },
+    function (e) {
+        throw new Error("Module loading should not have failed: " + e);
+    }
+);

--- a/JSTests/stress/resources/module-loader-promise-then-tampered-dep.js
+++ b/JSTests/stress/resources/module-loader-promise-then-tampered-dep.js
@@ -1,0 +1,1 @@
+export var dep = "from dependency";

--- a/JSTests/stress/resources/module-loader-promise-then-tampered-no-deps.js
+++ b/JSTests/stress/resources/module-loader-promise-then-tampered-no-deps.js
@@ -1,0 +1,8 @@
+// Test that module loading works correctly for a module with no dependencies
+// when Promise.prototype.then is tampered. The initial module load goes through
+// loadModule (first overload) which chains directly on the already-fulfilled
+// fetch promise via performPromiseThenWithInternalMicrotask. Since the fetch
+// promise is already fulfilled, the value is taken directly from the promise's
+// internal state, bypassing resolvePromise() entirely.
+
+export var value = 42;

--- a/JSTests/stress/resources/module-loader-promise-then-tampered-target.js
+++ b/JSTests/stress/resources/module-loader-promise-then-tampered-target.js
@@ -1,0 +1,3 @@
+import { dep } from "./module-loader-promise-then-tampered-dep.js";
+export var value = 42;
+export { dep };

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -32,7 +32,6 @@
 #include "JSGlobalObject.h"
 #include "JSLock.h"
 #include "JSModuleLoader.h"
-#include "JSNativeStdFunction.h"
 #include "JSPromise.h"
 #include "JSScriptFetchParameters.h"
 #include "JSWithScope.h"
@@ -239,13 +238,11 @@ JSPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, SourceCode&& sour
     JSPromise* promise = globalObject->moduleLoader()->loadModule(globalObject, globalObject, request, ModuleLoaderPayload::create(vm, graphLoadingState), scriptFetcher, true, false);
     RETURN_IF_EXCEPTION(scope, rejectPromise(scope, globalObject));
 
-    promise = jsCast<JSPromise*>(promise->then(globalObject, JSNativeStdFunction::create(vm, globalObject, 1, { }, [](JSGlobalObject* globalObject, CallFrame* callFrame) {
-        auto* module = jsCast<AbstractModuleRecord*>(callFrame->argument(0));
-        return JSValue::encode(JSC::identifierToJSValue(globalObject->vm(), module->moduleKey()));
-    }), jsUndefined()));
-    RETURN_IF_EXCEPTION(scope, rejectPromise(scope, globalObject));
+    JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
+    resultPromise->markAsHandled();
+    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadReturnModuleKey, resultPromise, jsUndefined());
 
-    return promise;
+    return resultPromise;
 }
 
 JSPromise* loadModule(JSGlobalObject* globalObject, const Identifier& moduleKey, JSValue parameters, JSValue scriptFetcher)

--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
@@ -427,7 +427,7 @@ JSPromise* CyclicModuleRecord::evaluate(JSGlobalObject* globalObject)
             ASSERT(module->asyncEvaluationOrder().isUnset() || module->asyncEvaluationOrder().isDone());
             // 10.c.ii. NOTE: module.[[AsyncEvaluationOrder]] is DONE if and only if module had already been evaluated and that evaluation was asynchronous.
             // 10.c.iii. Perform ! Call(capability.[[Resolve]], undefined, « undefined »).
-            capability->resolve(globalObject, vm, jsUndefined());
+            capability->fulfill(vm, globalObject, jsUndefined());
         }
         // 10.d. Assert: stack is empty.
         ASSERT(stack.isEmpty());
@@ -453,7 +453,7 @@ void CyclicModuleRecord::execute(JSGlobalObject* globalObject, JSPromise* capabi
                 JSModuleLoader::attachErrorInfo(globalObject, exception, wasmModule, wasmModule->moduleKey(), ScriptFetchParameters::WebAssembly, JSModuleLoader::ModuleFailure::Kind::Evaluation);
                 capability->rejectWithCaughtException(globalObject, scope);
             } else
-                capability->resolve(globalObject, vm, result);
+                capability->fulfill(vm, globalObject, result);
             return;
         }
         RELEASE_AND_RETURN(scope, void());
@@ -603,7 +603,7 @@ void CyclicModuleRecord::asyncExecutionFulfilled(JSGlobalObject* globalObject)
         // 7.a. Assert: module.[[CycleRoot]] and module are the same Module Record.
         ASSERT(cycleRoot() == this);
         // 7.b. Perform ! Call(module.[[TopLevelCapability]].[[Resolve]], undefined, « undefined »).
-        capability->resolve(globalObject, vm, jsUndefined());
+        capability->fulfill(vm, globalObject, jsUndefined());
     }
     // 8. Let execList be a new empty List.
     // (Note: it's safe to use a Vector instead of a MarkedArgumentsBuffer here because all the contents are accessed through WriteBarriers starting at `this`.)
@@ -658,7 +658,7 @@ void CyclicModuleRecord::asyncExecutionFulfilled(JSGlobalObject* globalObject)
                     // 12.c.iii.3.a. Assert: m.[[CycleRoot]] and m are the same Module Record.
                     ASSERT(m->cycleRoot() == m);
                     // 12.c.iii.3.b. Perform ! Call(m.[[TopLevelCapability]].[[Resolve]], undefined, « undefined »).
-                    capability->resolve(globalObject, vm, jsUndefined());
+                    capability->fulfill(vm, globalObject, jsUndefined());
                 }
             }
         }

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2204,7 +2204,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     if (Wasm::isSupported()) {
         m_webAssemblyModuleRecordStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                init.set(WebAssemblyModuleRecord::createStructure(init.vm, init.owner, init.owner->m_objectPrototype.get()));
+                init.set(WebAssemblyModuleRecord::createStructure(init.vm, init.owner, jsNull()));
             });
         m_webAssemblyFunctionStructure.initLater(
             [] (const Initializer<Structure>& init) {

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -816,8 +816,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncImportModule, (JSGlobalObject* globalObject, 
     RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
 
     scope.release();
-    promise->resolve(globalObject, vm, importPromise);
-    return JSValue::encode(promise);
+    return JSValue::encode(importPromise);
 }
 
 static bool NODELETE canPerformFastPropertyEnumerationForCopyDataProperties(Structure* structure)

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -866,12 +866,7 @@ static void moduleRegistryFetchSettled(JSGlobalObject* globalObject, VM& vm, Thr
     auto* modulePromise = jsCast<JSPromise*>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
-        auto* jsSourceCode = jsDynamicCast<JSSourceCode*>(arguments[1]);
-        if (!jsSourceCode) {
-            // Promise.prototype.then was tampered with
-            modulePromise->resolve(globalObject, vm, arguments[1]);
-            return;
-        }
+        auto* jsSourceCode = jsSecureCast<JSSourceCode*>(arguments[1]);
         JSPromise* makeModulePromise = JSModuleLoader::makeModule(globalObject, entry->key(), jsSourceCode);
         if (scope.exception()) {
             modulePromise->rejectWithCaughtException(globalObject, scope);
@@ -896,14 +891,9 @@ static void moduleRegistryModuleSettled(JSGlobalObject* globalObject, VM& vm, st
     auto* modulePromise = jsCast<JSPromise*>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
-        auto* moduleRecord = jsDynamicCast<AbstractModuleRecord*>(arguments[1]);
-        if (!moduleRecord) {
-            // Promise.prototype.then was tampered with
-            modulePromise->resolve(globalObject, vm, arguments[1]);
-            return;
-        }
+        auto* moduleRecord = jsSecureCast<AbstractModuleRecord*>(arguments[1]);
         entry->fetchComplete(globalObject, moduleRecord);
-        modulePromise->resolve(globalObject, vm, moduleRecord);
+        modulePromise->fulfill(vm, globalObject, moduleRecord);
     } else {
         JSValue errorValue = arguments[1];
         entry->evaluationError(globalObject, errorValue);
@@ -941,12 +931,7 @@ static void moduleLoadStep(JSGlobalObject* globalObject, VM& vm, ThrowScope& sco
     case ModuleLoadingContext::Step::Main: {
         // modulePromise settled: on fulfillment, call loadRequestedModules and chain next step
         if (status == JSPromise::Status::Fulfilled) {
-            auto* module = jsDynamicCast<AbstractModuleRecord*>(arguments[1]);
-            if (!module) {
-                // Promise.prototype.then was tampered with
-                loadPromise->resolve(globalObject, vm, arguments[1]);
-                return;
-            }
+            auto* module = jsSecureCast<AbstractModuleRecord*>(arguments[1]);
             context->module(vm, module);
             JSPromise* requestedPromise = globalObject->moduleLoader()->loadRequestedModules(globalObject, module, context->scriptFetcher());
             if (scope.exception()) {
@@ -973,11 +958,11 @@ static void moduleLoadStep(JSGlobalObject* globalObject, VM& vm, ThrowScope& sco
             auto* entry = context->entry();
             if (auto* cyclic = jsDynamicCast<CyclicModuleRecord*>(module); cyclic && cyclic->status() != CyclicModuleRecord::Status::Unlinked) {
                 ASSERT(cyclic->status() != CyclicModuleRecord::Status::Linking);
-                loadPromise->resolve(globalObject, vm, entry->record());
+                loadPromise->fulfill(vm, globalObject, entry->record());
             } else {
                 entry->record(vm, module);
                 entry->status(ModuleRegistryEntry::Status::Fetched);
-                loadPromise->resolve(globalObject, vm, entry->record());
+                loadPromise->fulfill(vm, globalObject, entry->record());
             }
         } else {
             // onRejected logic: store evaluation error on entry
@@ -991,18 +976,13 @@ static void moduleLoadStep(JSGlobalObject* globalObject, VM& vm, ThrowScope& sco
     case ModuleLoadingContext::Step::Cached: {
         // Cached loadPromise settled: on fulfillment, call finishLoading
         if (status == JSPromise::Status::Fulfilled) {
-            auto* module = jsDynamicCast<AbstractModuleRecord*>(arguments[1]);
-            if (!module) {
-                // Promise.prototype.then was tampered with
-                loadPromise->resolve(globalObject, vm, arguments[1]);
-                return;
-            }
+            auto* module = jsSecureCast<AbstractModuleRecord*>(arguments[1]);
             globalObject->moduleLoader()->finishLoadingImportedModule(globalObject, context->referrer(), context->moduleRequest(), context->payload(), module, context->scriptFetcher());
             if (scope.exception()) {
                 loadPromise->rejectWithCaughtException(globalObject, scope);
                 return;
             }
-            loadPromise->resolve(globalObject, vm, module);
+            loadPromise->fulfill(vm, globalObject, module);
         } else {
             auto* entry = context->entry();
             JSValue errorValue = arguments[1];
@@ -1026,11 +1006,7 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
     auto* intermediatePromise = jsCast<JSPromise*>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
-        auto* jsSourceCode = jsDynamicCast<JSSourceCode*>(arguments[1]);
-        if (!jsSourceCode) {
-            intermediatePromise->resolve(globalObject, vm, arguments[1]);
-            return;
-        }
+        auto* jsSourceCode = jsSecureCast<JSSourceCode*>(arguments[1]);
 
         const Identifier& specifier = context->moduleRequest().m_specifier;
         auto type = context->moduleRequest().type();
@@ -1043,6 +1019,7 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
         }
 
         JSPromise* statePromise = JSPromise::create(vm, globalObject->promiseStructure());
+        statePromise->markAsHandled();
         AbstractModuleRecord::ModuleRequest request { specifier, ScriptFetchParameters::create(type) };
         ModuleLoaderPayload* modulePayload;
         JSPromise* loadPromise;
@@ -1060,6 +1037,7 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
             }
             // Specifier transform: instead of creating a closure, use a microtask
             JSPromise* transformedStatePromise = JSPromise::create(vm, globalObject->promiseStructure());
+            transformedStatePromise->markAsHandled();
             statePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadSpecifierTransform, transformedStatePromise, context);
             statePromise = transformedStatePromise;
         }
@@ -1070,11 +1048,12 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
         }
 
         JSPromise* combinedPromise = JSPromise::create(vm, globalObject->promiseStructure());
+        combinedPromise->markAsHandled();
 
         loadPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadCombinedLoadSettled, combinedPromise, modulePayload);
         statePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadCombinedStateSettled, combinedPromise, modulePayload);
 
-        intermediatePromise->resolve(globalObject, vm, combinedPromise);
+        intermediatePromise->pipeFrom(vm, combinedPromise);
     } else {
         // onFetchRejected logic
         const Identifier& specifier = context->moduleRequest().m_specifier;
@@ -1106,7 +1085,7 @@ static void moduleLoadTopRejected(JSGlobalObject* globalObject, VM& vm, ThrowSco
     auto* resultPromise = jsCast<JSPromise*>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled)
-        resultPromise->resolve(globalObject, vm, arguments[1]);
+        resultPromise->fulfill(vm, globalObject, arguments[1]);
     else {
         const Identifier& specifier = context->moduleRequest().m_specifier;
         auto type = context->moduleRequest().type();
@@ -1144,7 +1123,7 @@ static void moduleLoadSpecifierTransform(JSGlobalObject* globalObject, VM& vm, T
     if (status == JSPromise::Status::Fulfilled) {
         auto* context = jsCast<ModuleLoadingContext*>(arguments[2]);
         scope.release();
-        transformedPromise->resolve(globalObject, vm, identifierToJSValue(vm, context->moduleRequest().m_specifier));
+        transformedPromise->fulfill(vm, globalObject, identifierToJSValue(vm, context->moduleRequest().m_specifier));
     } else
         transformedPromise->reject(vm, globalObject, arguments[1]);
 }
@@ -1163,7 +1142,7 @@ static void moduleLoadCombinedLoadSettled(JSGlobalObject* globalObject, VM& vm, 
         if (modulePayload->decrementRemaining() && combinedPromise->status() == JSPromise::Status::Pending) {
             JSValue fulfillmentValue = modulePayload->fulfillment();
             ASSERT(fulfillmentValue);
-            combinedPromise->resolve(globalObject, vm, fulfillmentValue);
+            combinedPromise->fulfill(vm, globalObject, fulfillmentValue);
         }
     } else {
         modulePayload->decrementRemaining();
@@ -1185,7 +1164,7 @@ static void moduleLoadCombinedStateSettled(JSGlobalObject* globalObject, VM& vm,
     if (status == JSPromise::Status::Fulfilled) {
         if (modulePayload->decrementRemaining()) {
             if (combinedPromise->status() == JSPromise::Status::Pending)
-                combinedPromise->resolve(globalObject, vm, arguments[1]);
+                combinedPromise->fulfill(vm, globalObject, arguments[1]);
         } else
             modulePayload->fulfillment(vm, arguments[1]);
     } else {
@@ -1205,11 +1184,7 @@ static void moduleLoadLinkEvaluateSettled(JSGlobalObject* globalObject, VM& vm, 
     auto* resultPromise = jsCast<JSPromise*>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
-        auto* record = jsDynamicCast<AbstractModuleRecord*>(arguments[1]);
-        if (!record) {
-            resultPromise->resolve(globalObject, vm, arguments[1]);
-            return;
-        }
+        auto* record = jsSecureCast<AbstractModuleRecord*>(arguments[1]);
         if (context->evaluate()) {
             record->link(globalObject, context->scriptFetcher());
             JSModuleLoader::attachErrorInfo(globalObject, scope, record, record->moduleKey(), record->moduleType(), JSModuleLoader::ModuleFailure::Kind::Instantiation);
@@ -1226,7 +1201,7 @@ static void moduleLoadLinkEvaluateSettled(JSGlobalObject* globalObject, VM& vm, 
             // Chain: when evaluation completes, resolve resultPromise with record
             evaluatePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadReturnRecord, resultPromise, record);
         } else
-            resultPromise->resolve(globalObject, vm, identifierToJSValue(vm, record->moduleKey()));
+            resultPromise->fulfill(vm, globalObject, identifierToJSValue(vm, record->moduleKey()));
     } else
         resultPromise->reject(vm, globalObject, arguments[1]);
 }
@@ -1241,7 +1216,7 @@ static void moduleLoadReturnRecord(JSGlobalObject* globalObject, VM& vm, ThrowSc
     auto status = static_cast<JSPromise::Status>(payload);
     scope.release();
     if (status == JSPromise::Status::Fulfilled)
-        resultPromise->resolve(globalObject, vm, arguments[2]);
+        resultPromise->fulfill(vm, globalObject, arguments[2]);
     else
         resultPromise->reject(vm, globalObject, arguments[1]);
 }
@@ -1315,30 +1290,33 @@ static void dynamicImportEvaluateSettled(JSGlobalObject* globalObject, VM& vm, T
             capabilityPromise->rejectWithCaughtException(globalObject, scope);
             return;
         }
-        capabilityPromise->resolve(globalObject, vm, moduleNamespace);
+        // ContinueDynamicImport https://tc39.es/ecma262/#sec-ContinueDynamicImport
+        // Step 10 resolves the promiseCapability with the namespace. However,
+        // capabilityPromise here is the internal statePromise from moduleLoadTopSettled,
+        // not the user-visible import() promise. The actual spec-required resolve()
+        // happens in importModuleNamespace. Use fulfill here to avoid unnecessary
+        // thenable unwrapping on internal pipeline.
+        capabilityPromise->fulfill(vm, globalObject, moduleNamespace);
     } else
         capabilityPromise->reject(vm, globalObject, arguments[1]);
 }
 
-static void importModuleNamespace(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
+static void importModuleNamespace(JSGlobalObject* globalObject, VM& vm, ThrowScope&, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
 {
     // requestImportModule: namespace getter
     // arguments[0] = resultPromise
-    // arguments[1] = resolution (AbstractModuleRecord*) or error
+    // arguments[1] = module namespace (from dynamic import pipeline) or error
     // arguments[2] = unused
     auto* resultPromise = jsCast<JSPromise*>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
-        auto* record = jsDynamicCast<AbstractModuleRecord*>(arguments[1]);
-        if (!record) {
-            resultPromise->resolve(globalObject, vm, arguments[1]);
-            return;
-        }
-        JSModuleNamespaceObject* moduleNamespace = record->getModuleNamespace(globalObject);
-        if (scope.exception()) {
-            resultPromise->rejectWithCaughtException(globalObject, scope);
-            return;
-        }
+        // The value is a JSModuleNamespaceObject forwarded from the internal
+        // pipeline (dynamicImportEvaluateSettled → combinedPromise → here).
+        // resultPromise is the user-visible import() promise. Must use resolve() per spec:
+        // ContinueDynamicImport https://tc39.es/ecma262/#sec-ContinueDynamicImport
+        // Step 6.d.ii: Call(promiseCapability.[[Resolve]], undefined, « namespace »).
+        // A module namespace that exports "then" is a thenable per spec.
+        auto* moduleNamespace = jsSecureCast<JSModuleNamespaceObject*>(arguments[1]);
         resultPromise->resolve(globalObject, vm, moduleNamespace);
     } else
         resultPromise->reject(vm, globalObject, arguments[1]);
@@ -1429,6 +1407,25 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
             promise->rejectPromise(vm, globalObject, resolution);
             break;
         }
+        }
+        return;
+    }
+
+    case InternalMicrotask::PromiseFulfillWithoutHandlerJob: {
+        auto* promise = jsCast<JSPromise*>(arguments[0]);
+        JSValue resolution = arguments[1];
+        switch (static_cast<JSPromise::Status>(payload)) {
+        case JSPromise::Status::Pending:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        case JSPromise::Status::Fulfilled:
+            scope.release();
+            promise->fulfillPromise(vm, globalObject, resolution);
+            break;
+        case JSPromise::Status::Rejected:
+            scope.release();
+            promise->rejectPromise(vm, globalObject, resolution);
+            break;
         }
         return;
     }
@@ -1682,6 +1679,21 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
 
     case InternalMicrotask::ModuleLoadReturnRecord: {
         moduleLoadReturnRecord(globalObject, vm, scope, arguments, payload);
+        return;
+    }
+
+    case InternalMicrotask::ModuleLoadReturnModuleKey: {
+        // loadAndEvaluateModule: extract module key from AbstractModuleRecord
+        // arguments[0] = resultPromise
+        // arguments[1] = resolution (AbstractModuleRecord*) or error
+        auto* resultPromise = jsCast<JSPromise*>(arguments[0]);
+        auto status = static_cast<JSPromise::Status>(payload);
+        scope.release();
+        if (status == JSPromise::Status::Fulfilled) {
+            auto* module = jsSecureCast<AbstractModuleRecord*>(arguments[1]);
+            resultPromise->fulfillPromise(vm, globalObject, identifierToJSValue(vm, module->moduleKey()));
+        } else
+            resultPromise->rejectPromise(vm, globalObject, arguments[1]);
         return;
     }
 

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -379,9 +379,11 @@ JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const Identi
     auto* context = ModuleLoadingContext::create(vm, request, scriptFetcher, evaluate, dynamic, useImportMap);
 
     JSPromise* intermediatePromise = JSPromise::create(vm, globalObject->promiseStructure());
+    intermediatePromise->markAsHandled();
     promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadTopSettled, intermediatePromise, context);
 
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
+    resultPromise->markAsHandled();
     intermediatePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadTopRejected, resultPromise, context);
 
     return resultPromise;
@@ -442,6 +444,7 @@ JSPromise* JSModuleLoader::requestImportModule(JSGlobalObject* globalObject, con
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
+    resultPromise->markAsHandled();
     promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ImportModuleNamespace, resultPromise, jsUndefined());
 
     return resultPromise;
@@ -660,6 +663,7 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
             } else {
                 auto* context = ModuleLoadingContext::create(vm, ModuleLoadingContext::Step::Cached, referrer, moduleRequest, payload, mapEntry, scriptFetcher);
                 JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
+                resultPromise->markAsHandled();
                 promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadStep, resultPromise, context);
                 promise = resultPromise;
             }
@@ -684,7 +688,7 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
         RETURN_IF_EXCEPTION(scope, nullptr);
 
         mapEntry->status(ModuleRegistryEntry::Status::Fetching);
-        mapEntry->ensureFetchPromise(globalObject)->resolve(globalObject, vm, promise);
+        mapEntry->ensureFetchPromise(globalObject)->pipeFrom(vm, promise);
     }
 
     JSPromise* modulePromise = mapEntry->ensureModulePromise(globalObject);
@@ -692,6 +696,7 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
 
     auto* context = ModuleLoadingContext::create(vm, ModuleLoadingContext::Step::Main, referrer, moduleRequest, payload, mapEntry, scriptFetcher);
     JSPromise* loadPromise = JSPromise::create(vm, globalObject->promiseStructure());
+    loadPromise->markAsHandled();
 
     modulePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadStep, loadPromise, context);
 
@@ -710,6 +715,7 @@ JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const Module
 
     auto* context = ModuleLoadingContext::create(vm, moduleRequest, scriptFetcher, evaluate, false, useImportMap);
     JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
+    resultPromise->markAsHandled();
 
     promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadLinkEvaluateSettled, resultPromise, context);
     resultPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadStoreError, jsUndefined(), context);
@@ -782,7 +788,7 @@ void JSModuleLoader::innerModuleLoading(JSGlobalObject* globalObject, ModuleGrap
                 loaded->status(CyclicModuleRecord::Status::Unlinked);
         });
         // 5.c. Perform ! Call(state.[[PromiseCapability]].[[Resolve]], undefined, « undefined »).
-        state->promise()->resolve(globalObject, vm, module);
+        state->promise()->fulfill(vm, globalObject, module);
     }
     // 6. Return UNUSED.
     scope.release();
@@ -908,6 +914,7 @@ JSPromise* JSModuleLoader::loadRequestedModules(JSGlobalObject* globalObject, Ab
     // 1. If hostDefined is not present, let hostDefined be empty.
     // 2. Let pc be ! NewPromiseCapability(%Promise%).
     JSPromise* pc = JSPromise::create(vm, globalObject->promiseStructure()); // This will eventually be resolved with an AbstractModuleRecord*.
+    pc->markAsHandled();
     // 3. Let state be the GraphLoadingState Record { [[IsLoading]]: true, [[PendingModulesCount]]: 1, [[Visited]]: « », [[PromiseCapability]]: pc, [[HostDefined]]: hostDefined }.
     auto state = ModuleGraphLoadingState::create(vm, pc, scriptFetcher);
     RETURN_IF_EXCEPTION(scope, nullptr);
@@ -1001,6 +1008,7 @@ JSPromise* JSModuleLoader::makeModule(JSGlobalObject* globalObject, const Identi
     const SourceCode& sourceCode = jsSourceCode->sourceCode();
 
     JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
+    promise->markAsHandled();
 
 #if ENABLE(WEBASSEMBLY)
     if (sourceCode.provider()->sourceType() == SourceProviderSourceType::WebAssembly)
@@ -1013,7 +1021,7 @@ JSPromise* JSModuleLoader::makeModule(JSGlobalObject* globalObject, const Identi
         attachErrorInfo(globalObject, scope, moduleRecord, moduleKey, ScriptFetchParameters::JSON, ModuleFailure::Kind::Evaluation);
         RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
         scope.release();
-        promise->resolve(globalObject, vm, moduleRecord);
+        promise->fulfill(vm, globalObject, moduleRecord);
         return promise;
     }
 
@@ -1041,7 +1049,7 @@ JSPromise* JSModuleLoader::makeModule(JSGlobalObject* globalObject, const Identi
         RELEASE_AND_RETURN(scope, promise);
     }
 
-    promise->resolve(globalObject, vm, result.value());
+    promise->fulfill(vm, globalObject, result.value());
     RELEASE_AND_RETURN(scope, promise);
 }
 

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -209,6 +209,17 @@ void JSPromise::fulfill(VM& vm, JSGlobalObject* globalObject, JSValue value)
     }
 }
 
+void JSPromise::pipeFrom(VM& vm, JSPromise* from)
+{
+    int32_t flags = this->flags();
+    if (flags & isFirstResolvingFunctionCalledFlag)
+        return;
+    internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(flags | isFirstResolvingFunctionCalledFlag)));
+
+    JSGlobalObject* globalObject = this->realm();
+    from->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseFulfillWithoutHandlerJob, this, jsUndefined());
+}
+
 void JSPromise::performPromiseThenExported(VM& vm, JSGlobalObject* globalObject, JSValue onFulfilled, JSValue onRejected, JSValue promiseOrCapability)
 {
     return performPromiseThen(vm, globalObject, onFulfilled, onRejected, promiseOrCapability);

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -97,7 +97,10 @@ public:
 
     JS_EXPORT_PRIVATE void resolve(JSGlobalObject*, VM&, JSValue);
     JS_EXPORT_PRIVATE void reject(VM&, JSGlobalObject*, JSValue);
-    void fulfill(VM&, JSGlobalObject*, JSValue);
+    JS_EXPORT_PRIVATE void fulfill(VM&, JSGlobalObject*, JSValue);
+    // Pipes its settlement to this promise via internal microtask. Otherwise directly
+    // fulfills. Never triggers user-observable behavior.
+    JS_EXPORT_PRIVATE void pipeFrom(VM&, JSPromise* from);
     JS_EXPORT_PRIVATE void rejectAsHandled(VM&, JSGlobalObject*, JSValue);
     JS_EXPORT_PRIVATE void reject(VM&, JSGlobalObject*, Exception*);
     JS_EXPORT_PRIVATE void rejectAsHandled(VM&, JSGlobalObject*, Exception*);

--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -40,6 +40,7 @@ enum class InternalMicrotask : uint8_t {
     PromiseResolveThenableJobWithInternalMicrotask,
 
     PromiseResolveWithoutHandlerJob,
+    PromiseFulfillWithoutHandlerJob,
 
     PromiseRaceResolveJob,
     PromiseAllResolveJob,
@@ -74,6 +75,7 @@ enum class InternalMicrotask : uint8_t {
     ModuleLoadCombinedStateSettled,
     ModuleLoadLinkEvaluateSettled,
     ModuleLoadReturnRecord,
+    ModuleLoadReturnModuleKey,
     ModuleLoadStoreError,
     DynamicImportLoadSettled,
     DynamicImportEvaluateSettled,

--- a/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
@@ -109,6 +109,7 @@ JSPromise* ModuleRegistryEntry::ensureFetchPromise(JSGlobalObject* globalObject)
     VM& vm = globalObject->vm();
 
     JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
+    promise->markAsHandled();
 
     if (m_fetchError)
         promise->reject(vm, globalObject, m_fetchError.get());
@@ -127,6 +128,7 @@ JSPromise* ModuleRegistryEntry::ensureModulePromise(JSGlobalObject* globalObject
     // Pre-create the module promise. It will be resolved/rejected by the
     // ModuleRegistryFetchSettled and ModuleRegistryModuleSettled microtask handlers.
     JSPromise* modulePromise = JSPromise::create(vm, globalObject->promiseStructure());
+    modulePromise->markAsHandled();
     m_modulePromise.set(vm, this, modulePromise);
 
     JSPromise* fetchPromise = ensureFetchPromise(globalObject);
@@ -240,7 +242,7 @@ void ModuleRegistryEntry::provideFetch(JSGlobalObject* globalObject, JSSourceCod
 
     scope.release();
     m_status = Status::Fetching;
-    m_fetchPromise->resolve(globalObject, vm, jsSourceCode);
+    m_fetchPromise->fulfill(vm, globalObject, jsSourceCode);
 }
 
 void ModuleRegistryEntry::fetchComplete(JSGlobalObject* globalObject, AbstractModuleRecord* record)

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -109,6 +109,9 @@ void DeferredPromise::callFunction(JSGlobalObject& lexicalGlobalObject, ResolveM
     case ResolveMode::RejectAsHandled:
         deferred()->rejectAsHandled(vm, &lexicalGlobalObject, resolution);
         break;
+    case ResolveMode::Fulfill:
+        deferred()->fulfill(vm, &lexicalGlobalObject, resolution);
+        break;
     }
 
     if (m_mode == Mode::ClearPromiseOnResolve)

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -185,6 +185,23 @@ public:
     }
 
     template<typename Callback>
+    void fulfillWithCallback(Callback callback)
+    {
+        if (shouldIgnoreRequestToFulfill())
+            return;
+
+        ASSERT(deferred());
+        ASSERT(globalObject());
+        auto* lexicalGlobalObject = globalObject();
+        auto& vm = lexicalGlobalObject->vm();
+        JSC::JSLockHolder locker(vm);
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        auto jsValue = callback(*globalObject());
+        DEFERRED_PROMISE_HANDLE_AND_RETURN_IF_EXCEPTION(scope, lexicalGlobalObject);
+        fulfillWithoutThenableCheck(*lexicalGlobalObject, jsValue);
+    }
+
+    template<typename Callback>
     void rejectWithCallback(const Callback& callback, RejectAsHandled rejectAsHandled = RejectAsHandled::No)
     {
         if (shouldIgnoreRequestToFulfill())
@@ -229,10 +246,11 @@ private:
 
     JSC::JSPromise* deferred() const { return guarded(); }
 
-    enum class ResolveMode { Resolve, Reject, RejectAsHandled };
+    enum class ResolveMode { Resolve, Reject, RejectAsHandled, Fulfill };
     WEBCORE_EXPORT void callFunction(JSC::JSGlobalObject&, ResolveMode, JSC::JSValue resolution);
 
     void resolve(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue resolution) { callFunction(lexicalGlobalObject, ResolveMode::Resolve, resolution); }
+    void fulfillWithoutThenableCheck(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue resolution) { callFunction(lexicalGlobalObject, ResolveMode::Fulfill, resolution); }
     void reject(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue resolution, RejectAsHandled rejectAsHandled)
     {
         callFunction(lexicalGlobalObject, rejectAsHandled == RejectAsHandled::Yes ? ResolveMode::RejectAsHandled : ResolveMode::Reject, resolution);

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -632,7 +632,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
     }
 
     protect(context->eventLoop())->queueTask(TaskSource::Networking, [promise = WTF::move(promise), sourceCode = WTF::move(sourceCode)] mutable {
-        promise->resolveWithCallback([&, sourceCode = WTF::move(sourceCode)](JSDOMGlobalObject& jsGlobalObject) mutable {
+        promise->fulfillWithCallback([&, sourceCode = WTF::move(sourceCode)](JSDOMGlobalObject& jsGlobalObject) mutable {
             return JSC::JSSourceCode::create(jsGlobalObject.vm(), WTF::move(sourceCode));
         });
     });


### PR DESCRIPTION
#### d92dec18da8e9098eb5c3f044dd28ae6dd3f7497
<pre>
[JSC] Avoid looking up &quot;then&quot; for internal module pipeline&apos;s JSPromise
<a href="https://bugs.webkit.org/show_bug.cgi?id=312368">https://bugs.webkit.org/show_bug.cgi?id=312368</a>
<a href="https://rdar.apple.com/174820983">rdar://174820983</a>

Reviewed by Keith Miller.

Let&apos;s not use `resolve` for internal module pipeline&apos;s JSPromise as it
needs to look up &quot;then&quot;. We need to make sure that they are not
observable as it happens to use JSPromise internally. Also, we make
things defensive by using jsSecureCast for module pipeline populated
values. We add JSPromise::pipeFrom which just connect an incoming JSPromise
to the resulted JSPromise without user-observable behavior.

Tests: JSTests/stress/module-loader-object-prototype-then-no-promise-tamper.js
       JSTests/stress/module-loader-promise-then-reassigned-same-value.js
       JSTests/stress/module-loader-promise-then-tampered-no-deps.js
       JSTests/stress/module-loader-promise-then-tampered.js

* JSTests/stress/module-loader-object-prototype-then-no-promise-tamper.js: Added.
(Object.prototype.then):
(import.string_appeared_here.then):
* JSTests/stress/module-loader-promise-then-reassigned-same-value.js: Added.
* JSTests/stress/module-loader-promise-then-tampered-no-deps.js: Added.
(Promise.prototype.then):
* JSTests/stress/module-loader-promise-then-tampered.js: Added.
(Promise.prototype.then):
* JSTests/stress/resources/module-loader-promise-then-tampered-dep.js: Added.
* JSTests/stress/resources/module-loader-promise-then-tampered-no-deps.js: Added.
* JSTests/stress/resources/module-loader-promise-then-tampered-target.js: Added.
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::loadAndEvaluateModule):
* Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp:
(JSC::CyclicModuleRecord::evaluate):
(JSC::CyclicModuleRecord::execute):
(JSC::CyclicModuleRecord::asyncExecutionFulfilled):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::moduleRegistryFetchSettled):
(JSC::moduleRegistryModuleSettled):
(JSC::moduleLoadStep):
(JSC::moduleLoadTopSettled):
(JSC::moduleLoadTopRejected):
(JSC::moduleLoadSpecifierTransform):
(JSC::moduleLoadCombinedLoadSettled):
(JSC::moduleLoadCombinedStateSettled):
(JSC::moduleLoadLinkEvaluateSettled):
(JSC::moduleLoadReturnRecord):
(JSC::dynamicImportEvaluateSettled):
(JSC::importModuleNamespace):
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::loadModule):
(JSC::JSModuleLoader::requestImportModule):
(JSC::JSModuleLoader::hostLoadImportedModule):
(JSC::JSModuleLoader::innerModuleLoading):
(JSC::JSModuleLoader::loadRequestedModules):
(JSC::JSModuleLoader::makeModule):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::pipeFrom):
* Source/JavaScriptCore/runtime/JSPromise.h:
* Source/JavaScriptCore/runtime/Microtask.h:
* Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp:
(JSC::ModuleRegistryEntry::ensureFetchPromise):
(JSC::ModuleRegistryEntry::ensureModulePromise):
(JSC::ModuleRegistryEntry::provideFetch):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::DeferredPromise::callFunction):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::DeferredPromise::fulfillWithCallback):
(WebCore::DeferredPromise::fulfillWithoutThenableCheck):
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::notifyFinished):

Canonical link: <a href="https://commits.webkit.org/311296@main">https://commits.webkit.org/311296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f95035821562b94f7b83fe2482a6abd87b3c1017

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165381 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121264 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101931 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20727 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13152 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148608 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167863 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17393 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11984 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129379 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129489 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87220 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23838 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24311 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17018 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188519 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29126 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93091 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48430 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28652 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28881 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28777 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->