### PR TITLE
[WPE] Android build broken after 4ca156ae@main

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -268,9 +268,10 @@ private:
     class RenderTargetEGLImage final : public RenderTargetShareableBuffer {
     public:
         static std::unique_ptr<RenderTarget> create(AcceleratedSurface&, const WebCore::IntSize&, const BufferFormat&);
-        RenderTargetEGLImage(AcceleratedSurface&, const WebCore::IntSize&, EGLImage, WebCore::DMABufBufferAttributes&&, RendererBufferFormat::Usage);
 #if OS(ANDROID)
         RenderTargetEGLImage(AcceleratedSurface&, const WebCore::IntSize&, EGLImage, RefPtr<AHardwareBuffer>&&);
+#else
+        RenderTargetEGLImage(AcceleratedSurface&, const WebCore::IntSize&, EGLImage, WebCore::DMABufBufferAttributes&&, RendererBufferFormat::Usage);
 #endif
         ~RenderTargetEGLImage();
 


### PR DESCRIPTION
#### b6d89ee119656491a34cec4e0071bb51605c0bf8
<pre>
[WPE] Android build broken after 4ca156ae@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=312373">https://bugs.webkit.org/show_bug.cgi?id=312373</a>

Reviewed by Adrian Perez de Castro.

The refactoring of DMABuf code incorrectly exposed it to the android
build. We should properly guard the code that makes use of it.

No new tests as this is mainly a build fix.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:

Canonical link: <a href="https://commits.webkit.org/311284@main">https://commits.webkit.org/311284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1763aaf6b752825ca6dda0556745e502e5e2c869

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165382 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29898 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121261 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 10 flakes; Uploaded test results; Passed layout tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101928 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13153 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167864 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11985 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20038 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129376 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 12 flakes 4 failures; Uploaded test results; 2 flakes") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129486 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35066 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29419 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140215 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87221 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24306 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17017 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93092 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28653 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28882 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->