### PR TITLE
[iOS release] webanimations/transform-animation-with-delay-yields-accelerated-animation.html is a flaky text failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8450,8 +8450,6 @@ http/tests/site-isolation/remote-frame-loaded-while-hidden.html [ Pass ImageOnly
 # from fast/ tests that are flaky: adding timeout 
 webkit.org/b/304027 fast/block/basic/001.html [ Pass Failure Timeout ]
 
-webkit.org/b/310557 [ Release ] webanimations/transform-animation-with-delay-yields-accelerated-animation.html [ Pass Failure ]
-
 webkit.org/b/303650 fast/lists/marker-before-empty-inline.html [ ImageOnlyFailure ]
 
 webkit.org/b/304298 accessibility/text-stitching-inside-links.html [ Failure ]

--- a/LayoutTests/webanimations/transform-animation-with-delay-yields-accelerated-animation-expected.txt
+++ b/LayoutTests/webanimations/transform-animation-with-delay-yields-accelerated-animation-expected.txt
@@ -1,3 +1,3 @@
 
-PASS A transform animation with a delay should run accelerated.
+PASS A transform animation with a delay should run accelerated once the delay has elapsed.
 

--- a/LayoutTests/webanimations/transform-animation-with-delay-yields-accelerated-animation.html
+++ b/LayoutTests/webanimations/transform-animation-with-delay-yields-accelerated-animation.html
@@ -2,34 +2,41 @@
 <body>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
+<script src="threaded-animations/threaded-animations-utils.js"></script>
 <style>
 
-    #target {
-        position: absolute;
-        left: 0;
-        top: 0;
-        width: 100px;
-        height: 100px;
-        background-color: black;
-    }
+@keyframes slide {
+    to { transform: translateX(600px) }
+}
+
+#target {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+.animated {
+    animation: slide 1000s 30ms;
+}
 
 </style>
 <div id="target"></div>
 <script>
 
 promise_test(async t => {
-    // Start an accelerated "transform" animation with a tiny delay.
-    const animation = document.getElementById("target").animate({ transform: "translateX(600px)" }, { duration: 1000 * 1000, delay: 1 });
+    // Start an accelerated "transform" animation with a delay longer than a single animation frame.
+    const target = document.getElementById("target");
+    target.classList.add("animated");
 
-    // Wait two frames for the accelerated animation to be committed.
-    await animation.ready;
-    await new Promise(requestAnimationFrame);
-    await new Promise(requestAnimationFrame);
-    // And another one since the delay means it will take another frame until the animation enters its active phase.
-    await new Promise(requestAnimationFrame);
+    // Wait for it to enter its active phase, at which point the "animationstart" event will trigger.
+    await new Promise(resolve => target.addEventListener("animationstart", resolve));
 
+    await threadedAnimationsCommit();
     assert_equals(internals.acceleratedAnimationsForElement(target).length, 1, "There should be an accelerated animation.");
-}, "A transform animation with a delay should run accelerated.");
+}, "A transform animation with a delay should run accelerated once the delay has elapsed.");
 
 </script>
 </body>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2111,6 +2111,13 @@ void KeyframeEffect::animationDidTick()
     invalidate();
     updateAcceleratedActions();
 
+#if ENABLE(THREADED_ANIMATIONS)
+    if (canHaveAcceleratedRepresentation() && isAboutToRunAccelerated()) {
+        if (getBasicTiming().phase == AnimationEffectPhase::Active)
+            updateAcceleratedAnimationIfNecessary();
+    }
+#endif
+
     if (RefPtr viewTimeline = activeViewTimeline())
         computeMissingKeyframeOffsets(m_parsedKeyframes, viewTimeline.get(), animation());
 }


### PR DESCRIPTION
#### 0cdf02fa9f6a2d81b95fed24625763706a10d000
<pre>
[iOS release] webanimations/transform-animation-with-delay-yields-accelerated-animation.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=310557">https://bugs.webkit.org/show_bug.cgi?id=310557</a>
<a href="https://rdar.apple.com/173171273">rdar://173171273</a>

Reviewed by Simon Fraser.

While we create threaded animations upon animation creation, any animation that is not in its &quot;active&quot; phase [0]
will not yield an accelerated animation because we only want to have actively-interpolating animations in the remote
layer tree. As such, an animation with a delay would not get a threaded animation representation. The reason the
test that was designed to check on this did not catch this regression reliably is because it used a 1ms delay that
could have elapsed by the time the asynchronous call to `AcceleratedEffectStackUpdater::update()`, hence the flakiness.

We update the test to use a delay that is longer than an animation frame is expected to be which made the test fail
reliably prior to this patch. And to fix the issue we add code in `KeyframeEffect::animationDidTick()` to schedule
a threaded animation update if the effect is not currently running accelerated but is in its &quot;active&quot; phase. This is
similar to what the legacy accelerated animation code would do within `KeyframeEffect::updateAcceleratedActions()`
also called within `KeyframeEffect::animationDidTick()`.

[0] <a href="https://drafts.csswg.org/web-animations-1/#animation-effect-active-phase">https://drafts.csswg.org/web-animations-1/#animation-effect-active-phase</a>

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/webanimations/transform-animation-with-delay-yields-accelerated-animation-expected.txt:
* LayoutTests/webanimations/transform-animation-with-delay-yields-accelerated-animation.html:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animationDidTick):

Canonical link: <a href="https://commits.webkit.org/311313@main">https://commits.webkit.org/311313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf27b2a35f756957c00a1e930288fd2846995899

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110653 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121270 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101937 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22562 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20738 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13166 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167877 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11998 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129385 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129495 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140227 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87234 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23845 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24317 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17029 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29140 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93105 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28666 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28791 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->