### PR TITLE
Speculation Rules: implement "moderate" eagerness

### DIFF
--- a/LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https-expected.txt
+++ b/LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Document rule with immediate eagerness prefetches immediately
 PASS Document rule with eager eagerness falls back to conservative
-PASS Document rule with moderate eagerness falls back to conservative
+PASS Document rule with moderate eagerness does not prefetch immediately
 PASS Document rule with conservative eagerness does not prefetch immediately
 PASS Document rule with eager eagerness prefetches on pointerdown
 PASS Document rule with moderate eagerness prefetches on pointerdown

--- a/LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https.html
+++ b/LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https.html
@@ -96,8 +96,8 @@ promise_test(async t => {
   t.add_cleanup(() => rules.remove());
 
   await new Promise(resolve => t.step_timeout(resolve, 2000));
-  assert_equals(await isUrlPrefetched(url), 0, 'moderate eagerness should fall back to conservative (no immediate prefetch)');
-}, 'Document rule with moderate eagerness falls back to conservative');
+  assert_equals(await isUrlPrefetched(url), 0, 'moderate eagerness should not prefetch immediately (hover-triggered)');
+}, 'Document rule with moderate eagerness does not prefetch immediately');
 
 promise_test(async t => {
   const url = getPrefetchUrl({ test: 'conservative' });

--- a/LayoutTests/http/wpt/prefetch/speculation-rules-moderate-hover.https-expected.txt
+++ b/LayoutTests/http/wpt/prefetch/speculation-rules-moderate-hover.https-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Moderate-only rules skip the upfront anchor scan
+PASS Moderate eagerness prefetches after hovering for 200ms
+PASS Short hover followed by pointerleave cancels moderate prefetch
+PASS Moderate eagerness prefetches immediately on pointerdown
+PASS Conservative eagerness does not prefetch on hover
+PASS Non-matching link is not prefetched on hover with moderate rules
+

--- a/LayoutTests/http/wpt/prefetch/speculation-rules-moderate-hover.https.html
+++ b/LayoutTests/http/wpt/prefetch/speculation-rules-moderate-hover.https.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SpeculationRulesPrefetchEnabled=true ] -->
+<meta charset="utf-8">
+<meta name="timeout" content="long">
+<title>Moderate eagerness prefetches on hover after 200ms delay</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<body>
+<script>
+
+setup(() => {
+  assert_implements(
+      'supports' in HTMLScriptElement,
+      'HTMLScriptElement.supports must be supported');
+  assert_implements(
+      HTMLScriptElement.supports('speculationrules'),
+      '<script type="speculationrules"> must be supported');
+});
+
+const PREFETCH_RESOURCE_URL = new URL('/speculation-rules/prefetch/resources/prefetch.py', location.href);
+
+function getPrefetchUrl(extra_params = {}) {
+  let params = new URLSearchParams({ uuid: token(), ...extra_params });
+  return new URL(`${PREFETCH_RESOURCE_URL}?${params}`);
+}
+
+async function isUrlPrefetched(url) {
+  let response = await fetch(url, { redirect: 'follow' });
+  return response.json();
+}
+
+async function waitForPrefetch(url, timeout = 5000) {
+  const start = performance.now();
+  while (performance.now() - start < timeout) {
+    if (await isUrlPrefetched(url) > 0)
+      return true;
+    await new Promise(r => setTimeout(r, 50));
+  }
+  return false;
+}
+
+async function flushNetworking() {
+  await fetch('/resources/blank.html');
+  await fetch('/resources/blank.html');
+}
+
+function insertSpeculationRules(body) {
+  let script = document.createElement('script');
+  script.type = 'speculationrules';
+  script.textContent = JSON.stringify(body);
+  document.head.appendChild(script);
+  return script;
+}
+
+function addLink(href, className, parent = document.body) {
+  const a = document.createElement('a');
+  a.href = href;
+  a.textContent = 'link';
+  if (className)
+    a.className = className;
+  parent.appendChild(a);
+  return a;
+}
+
+function triggerPointerEnter(element) {
+  const rect = element.getBoundingClientRect();
+  const x = rect.left + rect.width / 2;
+  const y = rect.top + rect.height / 2;
+
+  element.dispatchEvent(new PointerEvent('pointerenter', {
+    bubbles: false, cancelable: false, view: window,
+    clientX: x, clientY: y, pointerType: 'mouse'
+  }));
+}
+
+function triggerPointerLeave(element) {
+  const rect = element.getBoundingClientRect();
+  const x = rect.left + rect.width / 2;
+  const y = rect.top + rect.height / 2;
+
+  element.dispatchEvent(new PointerEvent('pointerleave', {
+    bubbles: false, cancelable: false, view: window,
+    clientX: x, clientY: y, pointerType: 'mouse'
+  }));
+}
+
+function triggerPointerDown(element) {
+  const rect = element.getBoundingClientRect();
+  const x = rect.left + rect.width / 2;
+  const y = rect.top + rect.height / 2;
+
+  element.dispatchEvent(new PointerEvent('pointerdown', {
+    bubbles: true, cancelable: true, view: window,
+    clientX: x, clientY: y, button: 0, pointerType: 'mouse'
+  }));
+  element.dispatchEvent(new MouseEvent('mousedown', {
+    bubbles: true, cancelable: true, view: window,
+    clientX: x, clientY: y, button: 0
+  }));
+}
+
+// Test: Moderate document rule with moderate-only rules stays lazy (no upfront scan).
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'moderate-lazy-scan' });
+
+  const link = addLink(url, 'mod-link');
+  link.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'moderate',
+      where: { selector_matches: '.mod-link' }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  // With moderate-only rules, the anchor scan is skipped (like conservative).
+  if (window.internals)
+    assert_equals(internals.anchorPrefetchEagerness(link), 'none', 'eagerness should be none (scan skipped for moderate-only rules)');
+}, 'Moderate-only rules skip the upfront anchor scan');
+
+// Test: Hover for 200ms triggers prefetch for moderate eagerness.
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'moderate-hover' });
+
+  const link = addLink(url, 'hover-link');
+  link.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'moderate',
+      where: { selector_matches: '.hover-link' }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  triggerPointerEnter(link);
+
+  // After hover, the lazy match should mark the anchor as moderate.
+  if (window.internals)
+    assert_equals(internals.anchorPrefetchEagerness(link), 'moderate', 'eagerness should be moderate after hover triggers lazy match');
+
+  // Should not be prefetched immediately on hover (200ms timer not yet fired).
+  await flushNetworking();
+  assert_equals(await isUrlPrefetched(url), 0, 'should not be prefetched immediately on hover');
+
+  // Wait for the 200ms timer to fire plus some margin.
+  await new Promise(resolve => t.step_timeout(resolve, 500));
+
+  assert_true(await waitForPrefetch(url), 'should be prefetched after hover timer fires');
+}, 'Moderate eagerness prefetches after hovering for 200ms');
+
+// Test: Short hover (< 200ms) followed by pointerleave does NOT trigger prefetch.
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'moderate-short-hover' });
+
+  const link = addLink(url, 'short-hover-link');
+  link.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'moderate',
+      where: { selector_matches: '.short-hover-link' }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  triggerPointerEnter(link);
+
+  // Leave before the 200ms timer fires.
+  await new Promise(resolve => t.step_timeout(resolve, 50));
+  triggerPointerLeave(link);
+
+  // Wait long enough for the timer to have fired if it wasn't cancelled.
+  await new Promise(resolve => t.step_timeout(resolve, 500));
+  await flushNetworking();
+
+  assert_equals(await isUrlPrefetched(url), 0, 'should not be prefetched after short hover + leave');
+}, 'Short hover followed by pointerleave cancels moderate prefetch');
+
+// Test: Pointerdown on moderate link triggers immediate prefetch (no 200ms wait).
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'moderate-pointerdown' });
+
+  const link = addLink(url, 'click-link');
+  link.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'moderate',
+      where: { selector_matches: '.click-link' }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  assert_equals(await isUrlPrefetched(url), 0, 'should not be prefetched before interaction');
+
+  triggerPointerDown(link);
+  assert_true(await waitForPrefetch(url), 'should be prefetched after pointerdown');
+}, 'Moderate eagerness prefetches immediately on pointerdown');
+
+// Test: Conservative rule does NOT trigger prefetch on hover.
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'conservative-no-hover' });
+
+  const link = addLink(url, 'conservative-link');
+  link.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'conservative',
+      where: { selector_matches: '.conservative-link' }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  triggerPointerEnter(link);
+
+  // Wait longer than the 200ms moderate timer.
+  await new Promise(resolve => t.step_timeout(resolve, 500));
+  await flushNetworking();
+
+  assert_equals(await isUrlPrefetched(url), 0, 'conservative link should not be prefetched on hover');
+}, 'Conservative eagerness does not prefetch on hover');
+
+// Test: Non-matching link does NOT trigger prefetch on hover.
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'no-match-hover' });
+
+  const link = addLink(url, 'no-match');
+  link.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'moderate',
+      where: { selector_matches: '.some-other-class' }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  triggerPointerEnter(link);
+
+  await new Promise(resolve => t.step_timeout(resolve, 500));
+  await flushNetworking();
+
+  assert_equals(await isUrlPrefetched(url), 0, 'non-matching link should not be prefetched on hover');
+}, 'Non-matching link is not prefetched on hover with moderate rules');
+
+</script>
+</body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4777,9 +4777,9 @@ void Document::processSpeculationRules()
     ASSERT(frame);
 
     // Only scan all anchors if there are rules requiring eager matching
-    // (Immediate/Eager/Moderate). Conservative rules are matched lazily
+    // (Immediate/Eager). Moderate and conservative rules are matched lazily
     // on user interaction in HTMLAnchorElement::defaultEventHandler().
-    if (speculationRules().hasNonConservativePrefetchRules()) {
+    if (speculationRules().hasImmediateOrEagerPrefetchRules()) {
         auto anchors = links();
         auto iterator = anchors->createIterator(this);
         for (RefPtr element = iterator.next(); element; element = iterator.next()) {

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -162,18 +162,46 @@ static void appendServerMapMousePosition(StringBuilder& url, Event& event)
     url.append('?', std::lround(absolutePosition.x()), ',', std::lround(absolutePosition.y()));
 }
 
+static bool isClickLikeEvent(Event& event)
+{
+    return event.type() == eventNames().keydownEvent || event.type() == eventNames().mousedownEvent || event.type() == eventNames().pointerdownEvent;
+}
+
 void HTMLAnchorElement::defaultEventHandler(Event& event)
 {
-    if (m_prefetchEagerness == PrefetchEagerness::Conservative && (event.type() == eventNames().keydownEvent || event.type() == eventNames().mousedownEvent || event.type() == eventNames().pointerdownEvent))
+    // Moderate eagerness (eagerly matched): hover starts a 200ms timer; pointerdown fires immediately.
+    if (m_prefetchEagerness == PrefetchEagerness::Moderate) {
+        if (event.type() == eventNames().pointerenterEvent)
+            startModerateHoverTimer();
+        else if (event.type() == eventNames().pointerleaveEvent)
+            cancelModerateHoverTimer();
+        else if (isClickLikeEvent(event)) {
+            cancelModerateHoverTimer();
+            protect(document())->prefetch(href(), m_speculationRulesTags, m_prefetchReferrerPolicy);
+        }
+    }
+    // Conservative eagerness (eagerly matched): prefetch on pointerdown/keydown.
+    else if (m_prefetchEagerness == PrefetchEagerness::Conservative && isClickLikeEvent(event))
         protect(document())->prefetch(href(), m_speculationRulesTags, m_prefetchReferrerPolicy);
-    else if (m_prefetchEagerness == PrefetchEagerness::None
-        && document().settings().speculationRulesPrefetchEnabled()
-        && (event.type() == eventNames().keydownEvent || event.type() == eventNames().mousedownEvent || event.type() == eventNames().pointerdownEvent)) {
-        // Lazy matching for conservative rules: evaluate at interaction time
-        // instead of scanning all links on every style recalculation.
-        if (auto prefetchRule = SpeculationRulesMatcher::hasMatchingRule(protect(document()), *this)) {
-            if (prefetchRule->eagerness != SpeculationRules::Eagerness::Immediate)
-                protect(document())->prefetch(href(), prefetchRule->tags, prefetchRule->referrerPolicy);
+    // Lazy path: no upfront scan matched this anchor. Evaluate rules at interaction time.
+    else if (m_prefetchEagerness == PrefetchEagerness::None && document().settings().speculationRulesPrefetchEnabled()) {
+        if (event.type() == eventNames().pointerenterEvent) {
+            // Lazy match on hover for moderate rules.
+            if (auto prefetchRule = SpeculationRulesMatcher::hasMatchingRule(protect(document()), *this)) {
+                if (prefetchRule->eagerness == SpeculationRules::Eagerness::Moderate) {
+                    setShouldBePrefetched(prefetchRule->eagerness, WTF::move(prefetchRule->tags), WTF::move(prefetchRule->referrerPolicy));
+                    startModerateHoverTimer();
+                }
+            }
+        } else if (event.type() == eventNames().pointerleaveEvent)
+            cancelModerateHoverTimer();
+        else if (isClickLikeEvent(event)) {
+            // Lazy match on click for conservative/moderate rules.
+            cancelModerateHoverTimer();
+            if (auto prefetchRule = SpeculationRulesMatcher::hasMatchingRule(protect(document()), *this)) {
+                if (prefetchRule->eagerness != SpeculationRules::Eagerness::Immediate)
+                    protect(document())->prefetch(href(), prefetchRule->tags, prefetchRule->referrerPolicy);
+            }
         }
     }
 
@@ -751,8 +779,18 @@ void HTMLAnchorElement::setFullURL(const URL& fullURL)
 void HTMLAnchorElement::setShouldBePrefetched(SpeculationRules::Eagerness eagerness, Vector<String>&& tags, std::optional<ReferrerPolicy>&& referrerPolicy)
 {
     // Map SpeculationRules::Eagerness to the anchor's PrefetchEagerness.
-    // Only Immediate triggers immediate prefetch; all others fall back to conservative behavior.
-    m_prefetchEagerness = eagerness == SpeculationRules::Eagerness::Immediate ? PrefetchEagerness::Immediate : PrefetchEagerness::Conservative;
+    switch (eagerness) {
+    case SpeculationRules::Eagerness::Immediate:
+        m_prefetchEagerness = PrefetchEagerness::Immediate;
+        break;
+    case SpeculationRules::Eagerness::Moderate:
+        m_prefetchEagerness = PrefetchEagerness::Moderate;
+        break;
+    case SpeculationRules::Eagerness::Eager:
+    case SpeculationRules::Eagerness::Conservative:
+        m_prefetchEagerness = PrefetchEagerness::Conservative;
+        break;
+    }
     m_speculationRulesTags = WTF::move(tags);
     m_prefetchReferrerPolicy = WTF::move(referrerPolicy);
     if (m_prefetchEagerness == PrefetchEagerness::Immediate)
@@ -766,6 +804,8 @@ String HTMLAnchorElement::prefetchEagernessForTesting() const
         return "none"_s;
     case PrefetchEagerness::Conservative:
         return "conservative"_s;
+    case PrefetchEagerness::Moderate:
+        return "moderate"_s;
     case PrefetchEagerness::Immediate:
         return "immediate"_s;
     }
@@ -776,8 +816,9 @@ void HTMLAnchorElement::checkForSpeculationRules()
 {
     if (!document().settings().speculationRulesPrefetchEnabled())
         return;
-    // For conservative-only rules, defer matching to interaction time.
-    if (!document().speculationRules().hasNonConservativePrefetchRules()) {
+    // For moderate/conservative-only rules, defer matching to interaction time.
+    if (!document().speculationRules().hasImmediateOrEagerPrefetchRules()) {
+        cancelModerateHoverTimer();
         m_prefetchEagerness = PrefetchEagerness::None;
         m_speculationRulesTags.clear();
         m_prefetchReferrerPolicy = std::nullopt;
@@ -786,10 +827,29 @@ void HTMLAnchorElement::checkForSpeculationRules()
     if (auto prefetchRule = SpeculationRulesMatcher::hasMatchingRule(protect(document()), *this))
         setShouldBePrefetched(prefetchRule->eagerness, WTF::move(prefetchRule->tags), WTF::move(prefetchRule->referrerPolicy));
     else {
+        cancelModerateHoverTimer();
         m_prefetchEagerness = PrefetchEagerness::None;
         m_speculationRulesTags.clear();
         m_prefetchReferrerPolicy = std::nullopt;
     }
+}
+
+void HTMLAnchorElement::startModerateHoverTimer()
+{
+    if (!m_moderateHoverTimer)
+        m_moderateHoverTimer = makeUnique<Timer>(*this, &HTMLAnchorElement::moderateHoverTimerFired);
+    m_moderateHoverTimer->startOneShot(200_ms);
+}
+
+void HTMLAnchorElement::cancelModerateHoverTimer()
+{
+    if (m_moderateHoverTimer)
+        m_moderateHoverTimer->stop();
+}
+
+void HTMLAnchorElement::moderateHoverTimerFired()
+{
+    protect(document())->prefetch(href(), m_speculationRulesTags, m_prefetchReferrerPolicy);
 }
 
 }

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -140,12 +140,18 @@ private:
     enum class PrefetchEagerness : uint8_t {
         None,
         Conservative,
+        Moderate,
         Immediate,
     };
+
+    void startModerateHoverTimer();
+    void cancelModerateHoverTimer();
+    void moderateHoverTimerFired();
 
     PrefetchEagerness m_prefetchEagerness { PrefetchEagerness::None };
     Vector<String> m_speculationRulesTags;
     std::optional<ReferrerPolicy> m_prefetchReferrerPolicy;
+    std::unique_ptr<Timer> m_moderateHoverTimer;
 
     bool m_hasRootEditableElementForSelectionOnMouseDown { false };
     bool m_wasShiftKeyDownOnMouseDown { false };

--- a/Source/WebCore/loader/SpeculationRules.cpp
+++ b/Source/WebCore/loader/SpeculationRules.cpp
@@ -384,11 +384,11 @@ bool SpeculationRules::parseSpeculationRules(Node& sourceNode, const StringView&
     return true;
 }
 
-bool SpeculationRules::hasNonConservativePrefetchRules() const
+bool SpeculationRules::hasImmediateOrEagerPrefetchRules() const
 {
     for (auto [node, rules] : m_prefetchRulesByNode) {
         for (const auto& rule : rules) {
-            if (rule.eagerness != Eagerness::Conservative)
+            if (rule.eagerness == Eagerness::Immediate || rule.eagerness == Eagerness::Eager)
                 return true;
         }
     }

--- a/Source/WebCore/loader/SpeculationRules.h
+++ b/Source/WebCore/loader/SpeculationRules.h
@@ -110,7 +110,7 @@ public:
 
     const WeakHashMap<Node, Vector<Rule>, WeakPtrImplWithEventTargetData>& prefetchRules() const LIFETIME_BOUND { return m_prefetchRulesByNode; }
 
-    bool NODELETE hasNonConservativePrefetchRules() const;
+    bool NODELETE hasImmediateOrEagerPrefetchRules() const;
 
 private:
     SpeculationRules() = default;


### PR DESCRIPTION
#### 1a140050d6fc18859b7acef1530c3d2768703aa7
<pre>
Speculation Rules: implement &quot;moderate&quot; eagerness
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

/* Do not review - early implementation prototype */

Test: http/wpt/prefetch/speculation-rules-moderate-hover.https.html

* LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https-expected.txt:
* LayoutTests/http/wpt/prefetch/speculation-rules-eagerness-fallback.https.html:
* LayoutTests/http/wpt/prefetch/speculation-rules-moderate-hover.https-expected.txt: Added.
* LayoutTests/http/wpt/prefetch/speculation-rules-moderate-hover.https.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processSpeculationRules):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::isClickLikeEvent):
(WebCore::HTMLAnchorElement::defaultEventHandler):
(WebCore::HTMLAnchorElement::setShouldBePrefetched):
(WebCore::HTMLAnchorElement::prefetchEagernessForTesting const):
(WebCore::HTMLAnchorElement::checkForSpeculationRules):
(WebCore::HTMLAnchorElement::startModerateHoverTimer):
(WebCore::HTMLAnchorElement::cancelModerateHoverTimer):
(WebCore::HTMLAnchorElement::moderateHoverTimerFired):
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/loader/SpeculationRules.cpp:
(WebCore::SpeculationRules::hasImmediateOrEagerPrefetchRules const):
(WebCore::SpeculationRules::hasNonConservativePrefetchRules const): Deleted.
* Source/WebCore/loader/SpeculationRules.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a140050d6fc18859b7acef1530c3d2768703aa7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156574 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110655 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121272 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85207 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22557 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20741 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13168 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132236 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167879 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12000 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129387 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129497 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87236 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24322 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17030 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29142 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93107 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28668 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->