### PR TITLE
Web Inspector: Assertion Failed: not reached"rendered" in WI.DOMTreeElement.badgeTypeForLayoutFlag()

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -91,7 +91,10 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             return WI.DOMTreeElement.BadgeType.SlotAssigned;
         case WI.DOMNode.LayoutFlag.SlotFilled:
             return WI.DOMTreeElement.BadgeType.SlotFilled;
+        case WI.DOMNode.LayoutFlag.Rendered:
+            return null;
         }
+
         console.assert(false, "not reached", layoutFlag);
     }
 
@@ -2112,7 +2115,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
     {
         console.assert(!this._elementForBadgeType.has(badgeType), badgeType);
 
-        if (!badgeType || !WI.settings.enabledDOMTreeBadgeTypes.value.includes(badgeType))
+        if (!WI.settings.enabledDOMTreeBadgeTypes.value.includes(badgeType))
             return;
 
         let text = "";
@@ -2193,8 +2196,11 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             badgeElement.remove();
         this._elementForBadgeType.clear();
 
-        for (let layoutFlag of this.representedObject.layoutFlags)
-            this._createBadge(WI.DOMTreeElement.badgeTypeForLayoutFlag(layoutFlag));
+        for (let layoutFlag of this.representedObject.layoutFlags) {
+            let badgeType = WI.DOMTreeElement.badgeTypeForLayoutFlag(layoutFlag);
+            if (badgeType)
+                this._createBadge(badgeType);
+        }
 
         if (!this._elementForBadgeType.size) {
             if (hadBadge) {


### PR DESCRIPTION
#### 5fd1ffa68fce4eeeae6c724ec26b957f5ca3eb57
<pre>
Web Inspector: Assertion Failed: not reached&quot;rendered&quot; in WI.DOMTreeElement.badgeTypeForLayoutFlag()
<a href="https://bugs.webkit.org/show_bug.cgi?id=312378">https://bugs.webkit.org/show_bug.cgi?id=312378</a>
<a href="https://rdar.apple.com/174834709">rdar://174834709</a>

Reviewed by Anne van Kesteren and Devin Rousso.

<a href="https://commits.webkit.org/310936@main">https://commits.webkit.org/310936@main</a> refactored `WI.DOMTreeElement` to consolidate creation of badges
per layout flag and added an assertion for an unknown badge type.

There is a layout flag, `WI.DOMNode.LayoutFlag.Rendered`, for which there is no badge.
This is used to dim not rendered DOM nodes in the DOM tree, for example `display: none` nodes.
The assertion is unintentionally tripped for most nodes in the DOM tree outline because they have this flag.

This patch guards for the `WI.DOMNode.LayoutFlag.Rendered` flag
and only creates a badge for supported layout flags.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.badgeTypeForLayoutFlag):
(WI.DOMTreeElement.prototype._createBadges):

Canonical link: <a href="https://commits.webkit.org/311359@main">https://commits.webkit.org/311359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c37ba3c14db6adc24cfb41cc670f8ccc80c0a3d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165609 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30125 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102107 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13381 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168092 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20239 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29724 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25006 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129662 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35114 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140413 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24490 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17217 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29356 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28880 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29006 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->