### PR TITLE
Unregister service worker registration when failing to retrieve stored imported scripts

### DIFF
--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -619,10 +619,12 @@ std::optional<ServiceWorkerScripts> SWRegistrationDatabase::retrieveWorkerScript
 
     MemoryCompactRobinHoodHashMap<URL, ScriptBuffer> importedScripts;
     for (auto& scriptURL : importedScriptURLs) {
-        if (auto script = scriptStorage().retrieve(registrationKey, scriptURL))
-            importedScripts.add(scriptURL, WTF::move(script));
-        else
+        auto script = scriptStorage().retrieve(registrationKey, scriptURL);
+        if (!script) {
             RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::retrieveWorkerScripts failed to retrieve imported script from disk for service worker %" PRIu64, identifier.toUInt64());
+            return std::nullopt;
+        }
+        importedScripts.add(scriptURL, WTF::move(script));
     }
 
     return ServiceWorkerScripts { identifier, WTF::move(mainScript), WTF::move(importedScripts) };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -825,7 +825,7 @@ TEST(ServiceWorkers, UpdateCheckAfterRestoreFromDisk)
     done = false;
 }
 
-TEST(ServiceWorkers, CheckRegistrationWithoutScript)
+TEST(ServiceWorkers, CheckRegistrationWithoutMainScript)
 {
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
@@ -887,7 +887,96 @@ TEST(ServiceWorkers, CheckRegistrationWithoutScript)
     }
 
     // Create a new web view, restoring registration from disk with lazy script loading.
-    // Try launching the service worker, removal of script should trigger unregistration of the service worker.
+    // Try launching the service worker, removal of main script should trigger unregistration of the service worker.
+    configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"FAIL: No registrations found"]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
+
+    done = false;
+    webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadRequest:server.request("/scope/second.html"_s)];
+    TestWebKitAPI::Util::run(&done);
+
+    done = false;
+    [[WKWebsiteDataStore defaultDataStore] fetchDataRecordsOfTypes:websiteDataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
+        EXPECT_EQ(0U, dataRecords.count);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(ServiceWorkers, CheckRegistrationWithoutImportedScript)
+{
+    [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
+
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    RetainPtr<SWMessageHandlerForRestoreFromDiskTest> messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration was successful and service worker was activated"]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
+
+    TestWebKitAPI::HTTPServer server({
+        { "/scope/first.html"_s, { mainRegisteringWorkerInScopeBytes } },
+        { "/scope/second.html"_s, { mainUpdatingRestoredWorkerBytes } },
+        { "/scope/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, "importScripts('/scope/importedScript.js');"_s } },
+        { "/scope/importedScript.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+    });
+
+    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    // Register a service worker under /scope/ and wait for it to activate.
+    [webView loadRequest:server.request("/scope/first.html"_s)];
+    TestWebKitAPI::Util::run(&done);
+
+    // Flush registrations to disk and terminate the network process so that we will
+    // import registrations from disk (with lazy script loading) in a fresh network process.
+    [[WKWebsiteDataStore defaultDataStore] _storeServiceWorkerRegistrations:^{
+        done = true;
+    }];
+    done = false;
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    webView = nullptr;
+    configuration = nullptr;
+    messageHandler = nullptr;
+
+    // Verify there is a registration
+    RetainPtr websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeServiceWorkerRegistrations]]);
+    done = false;
+    [[WKWebsiteDataStore defaultDataStore] fetchDataRecordsOfTypes:websiteDataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
+        EXPECT_EQ(1U, dataRecords.count);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    [[WKWebsiteDataStore defaultDataStore] _terminateNetworkProcess];
+
+    // We remove the registration imported script stored on disk. We do this by finding the Scripts folders and removing files in that folder whose size matches the imported script size.
+    NSURL *path = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/Default/" stringByExpandingTildeInPath]];
+    NSDirectoryEnumerator *enumerator = [[NSFileManager defaultManager] enumeratorAtURL:path includingPropertiesForKeys:@[NSURLIsDirectoryKey] options:NSDirectoryEnumerationSkipsHiddenFiles errorHandler:nil];
+    for (NSURL *url in enumerator) {
+        NSNumber *isDirectory;
+        [url getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:nil];
+        if ([isDirectory boolValue] && [[url lastPathComponent] isEqualToString:@"Scripts"]) {
+            NSDirectoryEnumerator *fileEnumerator = [[NSFileManager defaultManager] enumeratorAtURL:url includingPropertiesForKeys:@[NSURLFileSizeKey] options:NSDirectoryEnumerationSkipsHiddenFiles errorHandler:nil];
+            for (NSURL *fileURL in fileEnumerator) {
+                NSNumber *fileSizeNumber;
+                if (![fileURL getResourceValue:&fileSizeNumber forKey:NSURLFileSizeKey error:NULL])
+                    continue;
+                if ([fileSizeNumber unsignedLongLongValue] == scriptBytes.length())
+                    [[NSFileManager defaultManager] removeItemAtURL:fileURL error:nil];
+            }
+        }
+    }
+
+    // Create a new web view, restoring registration from disk with lazy script loading.
+    // Try launching the service worker, removal of imported script should trigger unregistration of the service worker.
     configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"FAIL: No registrations found"]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];


### PR DESCRIPTION
#### 445265f9e1ad767be0e3b458e2a8a484c3df5660
<pre>
Unregister service worker registration when failing to retrieve stored imported scripts
<a href="https://rdar.apple.com/174833692">rdar://174833692</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312377">https://bugs.webkit.org/show_bug.cgi?id=312377</a>

Reviewed by Chris Dumez.

We fail reading scripts as soon as one imported script cannot be read from disk.
This triggers removal of the registration.
Covered by added unit test.

Canonical link: <a href="https://commits.webkit.org/311444@main">https://commits.webkit.org/311444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24d50ec4d3f55a1294b78b512480656f8e642b69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165636 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110895 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/855e9247-23bd-4597-abe4-cc16e2ab32b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121460 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85298 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102128 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88026faf-fc17-46a7-8cbf-4f0d08bdca20) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22742 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20952 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13408 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168119 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12280 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129574 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129683 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35161 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140439 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87478 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24510 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17243 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29383 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93399 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28907 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29137 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29033 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->