### PR TITLE
[JSC] Update the description of CallFrame::argumentCountIncludingThis for Wasm callees

### DIFF
--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -124,50 +124,53 @@ using JSInstruction = BaseInstruction<JSOpcodeTraits>;
     //  See details below the diagram.
     //
     //
-    //   |          ......            |   |
-    //   +----------------------------+   |
-    //   |           argN             |   v  lower addresses
-    //   +----------------------------+
-    //   |           ...              |
-    //   +----------------------------+
-    //   |           arg1             |
-    //   +----------------------------+
-    //   |           arg0             |
-    //   +----------------------------+
-    //   |          this(+)           |
-    //   +----------------------------+
-    //   | argumentCountIncludingThis |
-    //   +----------------------------+
-    //   |          callee            |
-    //   +----------------------------+
-    //   |       codeBlock(+)         |
-    //   +----------------------------+
-    //   |       returnAddress        |
-    //   +----------------------------+
-    //   |        callerFrame         |  <- callee's cfr is pointing at this address
-    //   +----------------------------+
-    //   |          local0            |
-    //   +----------------------------+
-    //   |          local1            |
-    //   +----------------------------+
-    //   |           ...              |
-    //   +----------------------------+
-    //   |          localN            |
-    //   +----------------------------+
-    //   |          ......            |
+    //   |            ......              |   |
+    //   +--------------------------------+   |
+    //   |             argN               |   v  lower addresses
+    //   +--------------------------------+
+    //   |             ...                |
+    //   +--------------------------------+
+    //   |             arg1               |
+    //   +--------------------------------+
+    //   |             arg0               |
+    //   +--------------------------------+
+    //   |            this(+)             |
+    //   +--------------------------------+
+    //   | argumentCountIncludingThis(+)  |
+    //   +--------------------------------+
+    //   |            callee              |
+    //   +--------------------------------+
+    //   |         codeBlock(+)           |
+    //   +--------------------------------+
+    //   |         returnAddress          |
+    //   +--------------------------------+
+    //   |          callerFrame           |  <- callee's cfr is pointing at this address
+    //   +--------------------------------+
+    //   |            local0              |
+    //   +--------------------------------+
+    //   |            local1              |
+    //   +--------------------------------+
+    //   |             ...                |
+    //   +--------------------------------+
+    //   |            localN              |
+    //   +--------------------------------+
+    //   |            ......              |
     //
     //
     //  Overloaded slots:
     //
     //    - 'this': when executing Wasm code, the slot contains the value of $sp relative to $fp, saved before the call.
     //      Saving the value allows moving the $sp freely in tail calls.
+    //    - 'argumentCountIncludingThis': when executing Wasm code, the tag half (upper 32 bits)
+    //      of this slot stores the call site index, used to look up exception handlers.
+    //      The payload half (lower 32 bits) is unused in Wasm-to-Wasm calls, but stores
+    //      the actual argument count when calling from Wasm into JS.
     //    - 'codeBlock': when executing Wasm code, the slot contains a pointer to the Wasm instance.
     //      A special case is calling a module import whose functionCallLinkInfo.targetInstance is
     //      null, which is the case when the imported function is a JS function.
     //      In that case, 'codeBlock' points at the functionCallLinkInfo object.
-    //
-    // Further, in Wasm execution not all slots shown above are used, and not all exist.
-    // Argument slots beyond 'this' typically do not exist and 'argumentCountIncludingThis' value is not meaningful.
+    //    - 'arg0': for Wasm multi-value returns, this is the first stack result
+    //      (i.e. the first return value that doesn't fit in a register).
 
     enum class CallFrameSlot {
         codeBlock = CallerFrameAndPC::sizeInRegisters,


### PR DESCRIPTION
#### d5d2f1973d40d5a7fdd430efafbd08386e1ea194
<pre>
[JSC] Update the description of CallFrame::argumentCountIncludingThis for Wasm callees
<a href="https://bugs.webkit.org/show_bug.cgi?id=312388">https://bugs.webkit.org/show_bug.cgi?id=312388</a>
<a href="https://rdar.apple.com/174847751">rdar://174847751</a>

Reviewed by Keith Miller.

The comment describing CallFrame layout says that the value argumentCountIncludingThis
slot is not meaningful in Wasm code. That is incorrect. Update the comment to describe
how it stores the call site index in the upper 32 bits. Also add a note about the
use of the arg0 slot for multi-value return in Wasm.

Doc-only change, no new tests.

* Source/JavaScriptCore/interpreter/CallFrame.h:

Canonical link: <a href="https://commits.webkit.org/311327@main">https://commits.webkit.org/311327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2993f8c6aa51af3836e7993d83d7829cc552ee2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165502 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30018 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159637 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13274 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/148729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167985 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/17514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20148 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129585 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35091 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29540 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140323 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/24403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/188640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29248 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/188640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->