### PR TITLE
Use const char* instead of CString in WPEDisplayQtQuick

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEDisplayQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEDisplayQtQuick.cpp
@@ -36,7 +36,6 @@
 #include <wpe/GRefPtrWPE.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
-#include <wtf/text/CString.h>
 
 #ifndef EGL_DRM_RENDER_NODE_FILE_EXT
 #define EGL_DRM_RENDER_NODE_FILE_EXT 0x3377
@@ -75,7 +74,7 @@ static gboolean wpeDisplayQtQuickConnect(WPEDisplay* display, GError** error)
         return FALSE;
     }
 
-    CString drmDevice;
+    const char* drmDevice = nullptr;
     const char* extensions = eglQueryDeviceStringEXT(eglDevice, EGL_EXTENSIONS);
     if (epoxy_extension_in_string(extensions, "EGL_EXT_device_drm"))
         drmDevice = eglQueryDeviceStringEXT(eglDevice, EGL_DRM_DEVICE_FILE_EXT);
@@ -84,7 +83,7 @@ static gboolean wpeDisplayQtQuickConnect(WPEDisplay* display, GError** error)
         return FALSE;
     }
 
-    CString drmRenderNode;
+    const char* drmRenderNode = nullptr;
     if (epoxy_extension_in_string(extensions, "EGL_EXT_device_drm_render_node"))
         drmRenderNode = eglQueryDeviceStringEXT(eglDevice, EGL_DRM_RENDER_NODE_FILE_EXT);
     else {
@@ -92,7 +91,7 @@ static gboolean wpeDisplayQtQuickConnect(WPEDisplay* display, GError** error)
         return FALSE;
     }
 
-    priv->drmDevice = adoptGRef(wpe_drm_device_new(drmDevice.data(), drmRenderNode.data()));
+    priv->drmDevice = adoptGRef(wpe_drm_device_new(drmDevice, drmRenderNode));
     return TRUE;
 }
 


### PR DESCRIPTION
#### ea9518d268c23404bfa537d2645f570219748f84
<pre>
Use const char* instead of CString in WPEDisplayQtQuick

<a href="https://bugs.webkit.org/show_bug.cgi?id=312154">https://bugs.webkit.org/show_bug.cgi?id=312154</a>

Reviewed by Claudio Saavedra.

Under some environments, CString::CString(const char *), which is
implemented in WTF, cannot be directly used in libraries that only
link to WebKit. Otherwise a linking-time missing symbol error will
occur.

eglQueryDeviceStringEXT returns pointers to static data, so
not taking an owned copy of the returned string should cause no
problem. The two variables are very soon passed to wpe_drm_device_new,
which then uses CString to copy and own the data.

Compile-time only change, no runtime tests needed.

* Source/WebKit/UIProcess/API/wpe/qt6/WPEDisplayQtQuick.cpp:
(wpeDisplayQtQuickConnect):

Canonical link: <a href="https://commits.webkit.org/311311@main">https://commits.webkit.org/311311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31f64bb64fbdbf2157f3d4143c9678a2632fb741

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165447 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29963 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121309 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23540 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101977 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13219 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167930 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12050 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129425 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129535 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140267 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23844 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24360 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17070 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29193 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93157 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->