### PR TITLE
[Cocoa] Inifite scrolling video websites can cause window server jetsams

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1663,6 +1663,7 @@ html/InputTypeNames.cpp
 html/LabelsNodeList.cpp
 html/LazyLoadFrameObserver.cpp
 html/LazyLoadImageObserver.cpp
+html/LazyLoadVideoObserver.cpp
 html/LinkIconCollector.cpp
 html/LinkRelAttribute.cpp
 html/MediaController.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -443,6 +443,7 @@
 
 #if ENABLE(VIDEO)
 #include "CaptionUserPreferences.h"
+#include "LazyLoadVideoObserver.h"
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
@@ -11482,6 +11483,15 @@ LazyLoadModelObserver& Document::lazyLoadModelObserver()
     if (!m_lazyLoadModelObserver)
         m_lazyLoadModelObserver = makeUnique<LazyLoadModelObserver>();
     return *m_lazyLoadModelObserver;
+}
+#endif
+
+#if ENABLE(VIDEO)
+LazyLoadVideoObserver& Document::lazyLoadVideoObserver()
+{
+    if (!m_lazyLoadVideoObserver)
+        m_lazyLoadVideoObserver = makeUnique<LazyLoadVideoObserver>();
+    return *m_lazyLoadVideoObserver;
 }
 #endif
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -319,6 +319,10 @@ struct EventTrackingRegions;
 struct SystemPreviewInfo;
 #endif
 
+#if ENABLE(VIDEO)
+class LazyLoadVideoObserver;
+#endif
+
 #if ENABLE(WEB_RTC)
 class RTCPeerConnection;
 #endif
@@ -1977,6 +1981,9 @@ public:
 #if ENABLE(MODEL_ELEMENT)
     LazyLoadModelObserver& lazyLoadModelObserver();
 #endif
+#if ENABLE(VIDEO)
+    LazyLoadVideoObserver& lazyLoadVideoObserver();
+#endif
 
     ContentVisibilityDocumentState& contentVisibilityDocumentState();
 
@@ -2353,6 +2360,9 @@ private:
     std::unique_ptr<LazyLoadImageObserver> m_lazyLoadImageObserver;
 #if ENABLE(MODEL_ELEMENT)
     std::unique_ptr<LazyLoadModelObserver> m_lazyLoadModelObserver;
+#endif
+#if ENABLE(VIDEO)
+    std::unique_ptr<LazyLoadVideoObserver> m_lazyLoadVideoObserver;
 #endif
 
     std::unique_ptr<ContentVisibilityDocumentState> m_contentVisibilityDocumentState;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8246,7 +8246,7 @@ void HTMLMediaElement::createMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     player->setMuted(effectiveMuted());
     RefPtr page = document().page();
     player->setPageIsVisible(!m_elementIsHidden);
-    player->setVisibleInViewport(isVisibleInViewport());
+    player->setViewportVisibility(viewportVisibility());
     player->setInFullscreenOrPictureInPicture(isInFullscreenOrPictureInPicture());
 
     schedulePlaybackControlsManagerUpdate();
@@ -9682,7 +9682,7 @@ bool HTMLMediaElement::isVideoTooSmallForInlinePlayback()
 void HTMLMediaElement::isVisibleInViewportChanged()
 {
     if (RefPtr player = m_player)
-        player->setVisibleInViewport(isVisibleInViewport());
+        player->setViewportVisibility(viewportVisibility());
 
     queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [](auto& element) {
         if (element.isContextStopped())
@@ -9764,6 +9764,15 @@ bool HTMLMediaElement::isVisibleInViewport() const
 {
     auto renderer = this->renderer();
     return renderer && renderer->visibleInViewportState() == VisibleInViewportState::Yes;
+}
+
+WEBCORE_EXPORT auto HTMLMediaElement::viewportVisibility() const -> ViewportVisibility
+{
+    if (isVisibleInViewport())
+        return ViewportVisibility::VisibleInViewport;
+    if (isIntersectingViewport())
+        return ViewportVisibility::IntersectingViewport;
+    return ViewportVisibility::NotVisible;
 }
 
 void HTMLMediaElement::schedulePlaybackControlsManagerUpdate()
@@ -9992,7 +10001,7 @@ void HTMLMediaElement::updateMediaPlayer(IntSize presentationSize, bool shouldMa
     RefPtr player = m_player;
     player->setPresentationSize(presentationSize);
     visibilityStateChanged();
-    player->setVisibleInViewport(isVisibleInViewport());
+    player->setViewportVisibility(viewportVisibility());
 
     if (protect(document())->quirks().needsVideoShouldMaintainAspectRatioQuirk())
         shouldMaintainAspectRatio = true;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -608,6 +608,8 @@ public:
 
     void resetPlaybackSessionState();
     WEBCORE_EXPORT bool NODELETE isVisibleInViewport() const;
+    virtual bool isIntersectingViewport() const { return false; }
+    WEBCORE_EXPORT ViewportVisibility viewportVisibility() const;
     bool NODELETE hasEverNotifiedAboutPlaying() const;
     void setShouldDelayLoadEvent(bool);
 

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -42,6 +42,7 @@
 #include "ImageBuffer.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSVideoFrameRequestCallback.h"
+#include "LazyLoadVideoObserver.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "Logging.h"
@@ -99,7 +100,10 @@ inline HTMLVideoElement::HTMLVideoElement(const QualifiedName& tagName, Document
     m_defaultPosterURL = AtomString { document.settings().defaultVideoPosterURL() };
 }
 
-HTMLVideoElement::~HTMLVideoElement() = default;
+HTMLVideoElement::~HTMLVideoElement()
+{
+    LazyLoadVideoObserver::unobserve(*this, protect(document()));
+}
 
 Ref<HTMLVideoElement> HTMLVideoElement::create(const QualifiedName& tagName, Document& document, bool createdByParser)
 {
@@ -108,6 +112,8 @@ Ref<HTMLVideoElement> HTMLVideoElement::create(const QualifiedName& tagName, Doc
 #if ENABLE(PICTURE_IN_PICTURE_API)
     HTMLVideoElementPictureInPicture::providePictureInPictureTo(videoElement);
 #endif
+
+    LazyLoadVideoObserver::observe(videoElement);
 
     videoElement->suspendIfNeeded();
     return videoElement;
@@ -175,7 +181,7 @@ void HTMLVideoElement::computeAcceleratedRenderingStateAndUpdateMediaPlayer()
     bool isInFullScreen = false;
 #endif
     CheckedPtr renderer = this->renderer();
-    bool canBeAccelerated = player->supportsAcceleratedRendering() && (isInFullScreen || (renderer && protect(renderer->view())->compositor().hasAcceleratedCompositing()));
+    bool canBeAccelerated = player->supportsAcceleratedRendering() && (isInFullScreen || (m_isIntersectingViewport && renderer && protect(renderer->view())->compositor().hasAcceleratedCompositing()));
     if (canBeAccelerated == m_renderingCanBeAccelerated)
         return;
     m_renderingCanBeAccelerated = canBeAccelerated;
@@ -779,6 +785,17 @@ void HTMLVideoElement::stop()
         request->callback = nullptr;
 
     HTMLMediaElement::stop();
+}
+
+void HTMLVideoElement::viewportIntersectionChanged(bool isIntersecting)
+{
+    if (m_isIntersectingViewport == isIntersecting)
+        return;
+
+    m_isIntersectingViewport = isIntersecting;
+
+    isVisibleInViewportChanged();
+    computeAcceleratedRenderingStateAndUpdateMediaPlayer();
 }
 
 static void processVideoFrameMetadataTimestamps(VideoFrameMetadata& metadata, Performance& performance)

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -150,6 +150,9 @@ public:
     // ActiveDOMObject
     void stop() final;
 
+    bool isIntersectingViewport() const final { return m_isIntersectingViewport; }
+    void viewportIntersectionChanged(bool isIntersecting);
+
 private:
     HTMLVideoElement(const QualifiedName&, Document&, bool createdByParser);
 
@@ -213,6 +216,7 @@ private:
     Vector<UniqueRef<VideoFrameRequest>> m_videoFrameRequests;
     Vector<UniqueRef<VideoFrameRequest>> m_servicedVideoFrameRequests;
     unsigned m_nextVideoFrameRequestIndex { 0 };
+    bool m_isIntersectingViewport { false };
 
 #if USE(GSTREAMER)
     bool m_enableGStreamerHolePunching { false };

--- a/Source/WebCore/html/LazyLoadVideoObserver.cpp
+++ b/Source/WebCore/html/LazyLoadVideoObserver.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LazyLoadVideoObserver.h"
+
+#if ENABLE(VIDEO)
+
+#include "HTMLVideoElement.h"
+#include "IntersectionObserver.h"
+#include "IntersectionObserverCallback.h"
+#include "IntersectionObserverEntry.h"
+#include "LocalFrame.h"
+#include "NodeDocument.h"
+#include <limits>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LazyLoadVideoObserver);
+
+class LazyVideoLoadIntersectionObserverCallback final : public IntersectionObserverCallback {
+public:
+    static Ref<LazyVideoLoadIntersectionObserverCallback> create(Document& document)
+    {
+        return adoptRef(*new LazyVideoLoadIntersectionObserverCallback(document));
+    }
+
+private:
+    LazyVideoLoadIntersectionObserverCallback(Document& document)
+        : IntersectionObserverCallback(&document)
+    {
+    }
+
+    bool NODELETE hasCallback() const final { return true; }
+
+    CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
+    {
+        ASSERT(!entries.isEmpty());
+
+        for (auto& entry : entries) {
+            if (RefPtr element = dynamicDowncast<HTMLVideoElement>(entry->target()))
+                element->viewportIntersectionChanged(entry->isIntersecting());
+        }
+        return { };
+    }
+
+    CallbackResult<void> invokeRethrowingException(IntersectionObserver& thisObserver, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver& observer) final
+    {
+        return invoke(thisObserver, entries, observer);
+    }
+};
+
+LazyLoadVideoObserver::LazyLoadVideoObserver() = default;
+LazyLoadVideoObserver::~LazyLoadVideoObserver() = default;
+
+void LazyLoadVideoObserver::observe(HTMLVideoElement& element)
+{
+    auto& observer = protect(element.document())->lazyLoadVideoObserver();
+    RefPtr intersectionObserver = observer.intersectionObserver(protect(element.document()));
+    if (!intersectionObserver)
+        return;
+    intersectionObserver->observe(element);
+}
+
+void LazyLoadVideoObserver::unobserve(HTMLVideoElement& element, Document& document)
+{
+    if (auto& observer = document.lazyLoadVideoObserver().m_observer)
+        observer->unobserve(element);
+}
+
+IntersectionObserver* LazyLoadVideoObserver::intersectionObserver(Document& document)
+{
+    if (!m_observer) {
+        auto callback = LazyVideoLoadIntersectionObserverCallback::create(document);
+        static NeverDestroyed<const String> lazyLoadingScrollMarginFallback(MAKE_STATIC_STRING_IMPL("100%"));
+        IntersectionObserver::Init options { std::nullopt, { }, lazyLoadingScrollMarginFallback, { } };
+        auto observer = IntersectionObserver::create(document, WTF::move(callback), WTF::move(options));
+        if (observer.hasException())
+            return nullptr;
+        m_observer = observer.returnValue().ptr();
+    }
+    return m_observer.get();
+}
+
+bool LazyLoadVideoObserver::isObserved(HTMLVideoElement& element) const
+{
+    return m_observer && m_observer->isObserving(element);
+}
+
+}
+
+#endif

--- a/Source/WebCore/html/LazyLoadVideoObserver.h
+++ b/Source/WebCore/html/LazyLoadVideoObserver.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(VIDEO)
+
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class Document;
+class HTMLVideoElement;
+
+class LazyLoadVideoObserver {
+    WTF_MAKE_TZONE_ALLOCATED(LazyLoadVideoObserver);
+public:
+    LazyLoadVideoObserver();
+    ~LazyLoadVideoObserver();
+
+    static void observe(HTMLVideoElement&);
+    static void unobserve(HTMLVideoElement&, Document&);
+
+    bool isObserved(HTMLVideoElement&) const;
+
+private:
+    IntersectionObserver* intersectionObserver(Document&);
+
+    RefPtr<IntersectionObserver> m_observer;
+};
+
+#endif
+
+} // namespace

--- a/Source/WebCore/html/parser/HTMLParserOptions.cpp
+++ b/Source/WebCore/html/parser/HTMLParserOptions.cpp
@@ -27,6 +27,7 @@
 #include "HTMLParserOptions.h"
 
 #include "Document.h"
+#include "FrameDestructionObserverInlines.h"
 #include "LocalFrame.h"
 #include "ScriptController.h"
 #include "Settings.h"

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -675,8 +675,7 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
 
             if (m_pageIsVisible)
                 playerPrivate->setPageIsVisible(m_pageIsVisible);
-            if (m_visibleInViewport)
-                playerPrivate->setVisibleInViewport(m_visibleInViewport);
+            playerPrivate->setViewportVisibility(m_viewportVisibility);
             if (m_isGatheringVideoFrameMetadata)
                 playerPrivate->startVideoFrameMetadataGathering();
             if (m_processIdentity)
@@ -1197,13 +1196,13 @@ void MediaPlayer::setVisibleForCanvas(bool visible)
     protect(m_private)->setVisibleForCanvas(visible);
 }
 
-void MediaPlayer::setVisibleInViewport(bool visible)
+void MediaPlayer::setViewportVisibility(ViewportVisibility visibility)
 {
-    if (visible == m_visibleInViewport)
+    if (visibility == m_viewportVisibility)
         return;
 
-    m_visibleInViewport = visible;
-    protect(m_private)->setVisibleInViewport(visible);
+    m_viewportVisibility = visibility;
+    protect(m_private)->setViewportVisibility(visibility);
 }
 
 void MediaPlayer::setResourceOwner(const ProcessIdentity& processIdentity)
@@ -2219,6 +2218,20 @@ String convertEnumerationToString(MediaPlayer::BufferingPolicy enumerationValue)
     static_assert(static_cast<size_t>(MediaPlayer::BufferingPolicy::LimitReadAhead) == 1, "MediaPlayer::LimitReadAhead is not 1 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::BufferingPolicy::MakeResourcesPurgeable) == 2, "MediaPlayer::MakeResourcesPurgeable is not 2 as expected");
     static_assert(static_cast<size_t>(MediaPlayer::BufferingPolicy::PurgeResources) == 3, "MediaPlayer::PurgeResources is not 3 as expected");
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
+    return values[static_cast<size_t>(enumerationValue)];
+}
+
+String convertEnumerationToString(MediaPlayer::ViewportVisibility enumerationValue)
+{
+    static const std::array<NeverDestroyed<String>, 4> values {
+        MAKE_STATIC_STRING_IMPL("NotVisible"),
+        MAKE_STATIC_STRING_IMPL("IntersectingViewport"),
+        MAKE_STATIC_STRING_IMPL("VisibleInViewport"),
+    };
+    static_assert(!static_cast<size_t>(MediaPlayer::ViewportVisibility::NotVisible), "MediaPlayer::NotVisible is not 0 as expected");
+    static_assert(static_cast<size_t>(MediaPlayer::ViewportVisibility::IntersectingViewport) == 1, "MediaPlayer::IntersectingViewport is not 1 as expected");
+    static_assert(static_cast<size_t>(MediaPlayer::ViewportVisibility::VisibleInViewport) == 2, "MediaPlayer::VisibleInViewport is not 2 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -438,12 +438,13 @@ public:
 #endif
     void cancelLoad();
 
+    bool pageIsVisible() const { return m_pageIsVisible; }
     void setPageIsVisible(bool);
     void setVisibleForCanvas(bool);
     bool isVisibleForCanvas() const { return m_visibleForCanvas; }
 
-    void setVisibleInViewport(bool);
-    bool isVisibleInViewport() const { return m_visibleInViewport; }
+    void setViewportVisibility(ViewportVisibility);
+    ViewportVisibility viewportVisibility() const { return m_viewportVisibility; }
 
     void prepareToPlay();
     void play();
@@ -847,7 +848,6 @@ private:
     double m_volume { 1 };
     bool m_pageIsVisible { false };
     bool m_visibleForCanvas { false };
-    bool m_visibleInViewport { false };
     bool m_muted { false };
     bool m_preservesPitch { true };
     bool m_inPrivateBrowsingMode { false };
@@ -857,6 +857,7 @@ private:
     DynamicRangeMode m_preferredDynamicRangeMode;
     PlatformDynamicRangeLimit m_platformDynamicRangeLimit { PlatformDynamicRangeLimit::initialValueForVideos() };
     PitchCorrectionAlgorithm m_pitchCorrectionAlgorithm { PitchCorrectionAlgorithm::BestAllAround };
+    ViewportVisibility m_viewportVisibility { ViewportVisibility::NotVisible };
     RefPtr<PlatformMediaResourceLoader> m_mediaResourceLoader;
 
 #if ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -121,6 +121,12 @@ enum class MediaPlayerSoundStageSize : uint8_t {
     Large,
 };
 
+enum class MediaPlayerViewportVisibility : uint8_t {
+    NotVisible,
+    IntersectingViewport,
+    VisibleInViewport,
+};
+
 class MediaPlayerEnums {
 public:
     using NetworkState = MediaPlayerNetworkState;
@@ -135,6 +141,7 @@ public:
     using PitchCorrectionAlgorithm = MediaPlayerPitchCorrectionAlgorithm;
     using NeedsRenderingModeChanged = MediaPlayerNeedsRenderingModeChanged;
     using SoundStageSize = MediaPlayerSoundStageSize;
+    using ViewportVisibility = MediaPlayerViewportVisibility;
 
     enum {
         VideoFullscreenModeNone = 0,
@@ -152,6 +159,7 @@ String convertEnumerationToString(MediaPlayerEnums::NetworkState);
 String convertEnumerationToString(MediaPlayerEnums::Preload);
 String convertEnumerationToString(MediaPlayerEnums::SupportsType);
 String convertEnumerationToString(MediaPlayerEnums::BufferingPolicy);
+WEBCORE_EXPORT String convertEnumerationToString(MediaPlayerEnums::ViewportVisibility);
 
 enum class VideoRendererPreference : uint8_t {
     PrefersDecompressionSession = 1 << 0,
@@ -201,6 +209,14 @@ struct LogArgument<WebCore::MediaPlayerEnums::BufferingPolicy> {
     static String toString(const WebCore::MediaPlayerEnums::BufferingPolicy policy)
     {
         return convertEnumerationToString(policy);
+    }
+};
+
+template <>
+struct LogArgument<WebCore::MediaPlayerEnums::ViewportVisibility> {
+    static String toString(const WebCore::MediaPlayerEnums::ViewportVisibility visibility)
+    {
+        return convertEnumerationToString(visibility);
     }
 };
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -129,7 +129,9 @@ public:
 
     virtual void setPageIsVisible(bool) = 0;
     virtual void setVisibleForCanvas(bool visible) { setPageIsVisible(visible); }
-    virtual void setVisibleInViewport(bool) { }
+
+    using ViewportVisibility = MediaPlayer::ViewportVisibility;
+    virtual void setViewportVisibility(ViewportVisibility) { }
 
     virtual MediaTime duration() const { return MediaTime::zeroTime(); }
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -739,9 +739,9 @@ void AudioVideoRendererAVFObjC::setShouldMaintainAspectRatio(bool shouldMaintain
 
 void AudioVideoRendererAVFObjC::renderingCanBeAcceleratedChanged(bool isAccelerated)
 {
+    ALWAYS_LOG(LOGIDENTIFIER, isAccelerated);
     m_renderingCanBeAccelerated = isAccelerated;
-    if (isAccelerated)
-        updateDisplayLayerIfNeeded();
+    updateDisplayLayerIfNeeded();
 }
 
 void AudioVideoRendererAVFObjC::contentBoxRectChanged(const LayoutRect& newRect)

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -69,7 +69,7 @@ MediaPlayerPrivateAVFoundation::MediaPlayerPrivateAVFoundation(MediaPlayer& play
     , m_delayCharacteristicsChangedNotification(0)
     , m_mainThreadCallPending(false)
     , m_assetIsPlayable(false)
-    , m_visible(false)
+    , m_pageIsVisible(false)
     , m_loadingMetadata(false)
     , m_isAllowedToRender(false)
     , m_cachedHasAudio(false)
@@ -469,7 +469,7 @@ bool MediaPlayerPrivateAVFoundation::isReadyForVideoSetup() const
     // AVFoundation will not return true for firstVideoFrameAvailable until
     // an AVPlayerLayer has been added to the AVPlayerItem, so allow video setup
     // here if a video track to trigger allocation of a AVPlayerLayer.
-    return (m_isAllowedToRender || m_cachedHasVideo) && m_readyState >= MediaPlayer::ReadyState::HaveMetadata && m_visible;
+    return (m_isAllowedToRender || m_cachedHasVideo) && m_readyState >= MediaPlayer::ReadyState::HaveMetadata && m_pageIsVisible;
 }
 
 void MediaPlayerPrivateAVFoundation::prepareForRendering()
@@ -598,16 +598,25 @@ void MediaPlayerPrivateAVFoundation::updateStates()
 
 void MediaPlayerPrivateAVFoundation::setPageIsVisible(bool visible)
 {
-    if (m_visible == visible)
+    if (m_pageIsVisible == visible)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, visible);
 
-    m_visible = visible;
+    m_pageIsVisible = visible;
     if (visible)
         setUpVideoRendering();
 
-    platformSetVisible(visible);
+    platformPageIsVisibleChanged(visible);
+}
+
+void MediaPlayerPrivateAVFoundation::setViewportVisibility(ViewportVisibility visibility)
+{
+    if (m_viewportVisibility == visibility)
+        return;
+
+    m_viewportVisibility = visibility;
+    platformViewportVisibilityChanged(visibility);
 }
 
 void MediaPlayerPrivateAVFoundation::acceleratedRenderingStateChanged()

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -183,7 +183,10 @@ protected:
     FloatSize naturalSize() const override;
     bool hasVideo() const override { return m_cachedHasVideo; }
     bool hasAudio() const override { return m_cachedHasAudio; }
+    bool pageIsVisible() const { return m_pageIsVisible; }
     void setPageIsVisible(bool) final;
+    ViewportVisibility viewportVisibility() const { return m_viewportVisibility; }
+    void setViewportVisibility(ViewportVisibility) final;
     MediaTime duration() const override;
     MediaTime currentTime() const override = 0;
     void seekToTarget(const SeekTarget&) final;
@@ -246,7 +249,8 @@ protected:
     virtual AssetStatus assetStatus() const = 0;
     virtual long assetErrorCode() const = 0;
 
-    virtual void platformSetVisible(bool) = 0;
+    virtual void platformPageIsVisibleChanged(bool) = 0;
+    virtual void platformViewportVisibilityChanged(ViewportVisibility) = 0;
     virtual void platformPlay() = 0;
     virtual void platformPause() = 0;
     virtual bool platformPaused() const { return !rate(); }
@@ -292,7 +296,6 @@ protected:
     void setNetworkState(MediaPlayer::NetworkState);
     void setReadyState(MediaPlayer::ReadyState);
 
-    bool isVisible() const { return m_visible; }
     MediaRenderingMode currentRenderingMode() const;
     MediaRenderingMode preferredRenderingMode() const;
 
@@ -364,7 +367,7 @@ protected:
     int m_delayCharacteristicsChangedNotification;
     bool m_mainThreadCallPending;
     bool m_assetIsPlayable;
-    bool m_visible;
+    bool m_pageIsVisible { false };
     bool m_loadingMetadata;
     bool m_isAllowedToRender;
     bool m_cachedHasAudio;
@@ -376,6 +379,7 @@ protected:
     bool m_shouldMaintainAspectRatio;
     bool m_seeking;
     bool m_needsRenderingModeChanged { false };
+    ViewportVisibility m_viewportVisibility { ViewportVisibility::NotVisible };
 };
 
 String convertEnumerationToString(MediaPlayerPrivateAVFoundation::MediaRenderingMode);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -167,7 +167,9 @@ private:
     void synchronizeTextTrackState() final;
 
     bool timeIsProgressing() const final { return effectiveRate(); }
-    void platformSetVisible(bool) final;
+    void platformPageIsVisibleChanged(bool) final;
+    void platformViewportVisibilityChanged(ViewportVisibility) final;
+
     void platformPlay() final;
     void platformPause() final;
     bool platformPaused() const final;
@@ -405,6 +407,9 @@ private:
     void setParticipatesInAudioSession(bool);
 #endif
 
+    void updateLayerAttachment();
+    bool shouldAttachLayerToPlayer();
+
     RetainPtr<AVURLAsset> m_avAsset;
     RetainPtr<AVPlayer> m_avPlayer;
     RetainPtr<AVPlayerItem> m_avPlayerItem;
@@ -519,6 +524,7 @@ private:
     bool m_muted { false };
     bool m_preservesPitch { true };
     bool m_shouldObserveTimeControlStatus { false };
+    bool m_isinFullscreenOrPictureInPicture { false };
     mutable std::optional<bool> m_tracksArePlayable;
     bool m_automaticallyWaitsToMinimizeStalling { false };
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -648,7 +648,6 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer()
     ALWAYS_LOG(LOGIDENTIFIER);
 
     m_videoLayer = adoptNS([PAL::allocAVPlayerLayerInstance() init]);
-    [m_videoLayer setPlayer:m_avPlayer];
 
     [m_videoLayer setName:@"MediaPlayerPrivate AVPlayerLayer"];
     [m_videoLayer addObserver:m_objcObserver.get() forKeyPath:@"readyForDisplay" options:NSKeyValueObservingOptionNew context:(void *)MediaPlayerAVFoundationObservationContextAVPlayerLayer];
@@ -660,6 +659,8 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer()
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
     [m_videoLayer setPIPModeEnabled:(player->fullscreenMode() & MediaPlayer::VideoFullscreenModePictureInPicture)];
 #endif
+
+    updateLayerAttachment();
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     updateSpatialTrackingLabel();
@@ -1420,21 +1421,17 @@ void MediaPlayerPrivateAVFoundationObjC::didEnd(double now)
     MediaPlayerPrivateAVFoundation::didEnd(now);
 }
 
-void MediaPlayerPrivateAVFoundationObjC::platformSetVisible(bool isVisible)
+void MediaPlayerPrivateAVFoundationObjC::platformPageIsVisibleChanged(bool)
 {
-    assertIsMainThread();
-
 #if HAVE(SPATIAL_TRACKING_LABEL)
     updateSpatialTrackingLabel();
 #endif
+    updateLayerAttachment();
+}
 
-    if (!m_videoLayer)
-        return;
-
-    [CATransaction begin];
-    [CATransaction setDisableActions:YES];
-    [m_videoLayer setHidden:!isVisible];
-    [CATransaction commit];
+void MediaPlayerPrivateAVFoundationObjC::platformViewportVisibilityChanged(ViewportVisibility)
+{
+    updateLayerAttachment();
 }
 
 void MediaPlayerPrivateAVFoundationObjC::platformPlay()
@@ -4150,7 +4147,7 @@ void MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel()
         RetainPtr experience = createSpatialAudioExperienceWithOptions({
             .hasLayer = !!m_videoLayer,
             .hasTarget = !!m_videoTarget,
-            .isVisible = isVisible(),
+            .isVisible = pageIsVisible(),
             .soundStageSize = player->soundStageSize(),
             .sceneIdentifier = player->sceneIdentifier(),
 #if HAVE(SPATIAL_TRACKING_LABEL)
@@ -4173,7 +4170,7 @@ void MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel()
         return;
     }
 
-    if (m_videoLayer && isVisible()) {
+    if (m_videoLayer && pageIsVisible()) {
         // If the media player has a renderer, and that renderer belongs to a page that is visible,
         // then let AVPlayer manage setting the spatial tracking label in its AVPlayerLayer itself;
         ALWAYS_LOG(LOGIDENTIFIER, "No videoLayer, set STSLabel: nil");
@@ -4208,11 +4205,10 @@ void MediaPlayerPrivateAVFoundationObjC::setVideoTarget(const PlatformVideoTarge
         [m_avPlayer removeVideoTarget:m_videoTarget];
 
     m_videoTarget = videoTarget;
+    updateLayerAttachment();
 
     if (m_videoTarget)
         [m_avPlayer addVideoTarget:m_videoTarget];
-    else
-        [m_videoLayer setPlayer:m_avPlayer];
 #else
     UNUSED_PARAM(videoTarget);
 #endif
@@ -4223,14 +4219,19 @@ void MediaPlayerPrivateAVFoundationObjC::isInFullscreenOrPictureInPictureChanged
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     assertIsMainThread();
 
-    if (!m_videoTarget)
+    if (m_isInFullscreenOrPictureInPicture == isInFullscreenOrPictureInPicture)
         return;
-    if (isInFullscreenOrPictureInPicture)
-        [m_videoLayer setPlayer:nil];
-    else if (RetainPtr videoTarget = std::exchange(m_videoTarget, nullptr)) {
+
+    m_isInFullscreenOrPictureInPicture = isInFullscreenOrPictureInPicture;
+
+    updateLayerAttachment();
+
+    if (!m_videoTarget || isInFullscreenOrPictureInPicture)
+        return;
+
+    if (RetainPtr videoTarget = std::exchange(m_videoTarget, nullptr)) {
         INFO_LOG(LOGIDENTIFIER, "Clearing videoTarget");
         [m_avPlayer removeVideoTarget:videoTarget.get()];
-        [m_videoLayer setPlayer:m_avPlayer];
     }
 #else
     UNUSED_PARAM(isInFullscreenOrPictureInPicture);
@@ -4290,6 +4291,34 @@ void MediaPlayerPrivateAVFoundationObjC::setParticipatesInAudioSession(bool part
         [m_avPlayer setParticipatesInAudioSession:participatesInAudioSession completionHandler:nil];
 }
 #endif
+
+void MediaPlayerPrivateAVFoundationObjC::updateLayerAttachment()
+{
+    assertIsMainThread();
+    if (!m_videoLayer || !m_avPlayer)
+        return;
+
+    if (shouldAttachLayerToPlayer())
+        [m_videoLayer setPlayer:m_avPlayer.get()];
+    else
+        [m_videoLayer setPlayer:nil];
+}
+
+bool MediaPlayerPrivateAVFoundationObjC::shouldAttachLayerToPlayer()
+{
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    if (m_videoTarget && m_isInFullscreenOrPictureInPicture)
+        return false;
+#endif
+
+    if (!pageIsVisible())
+        return false;
+
+    if (viewportVisibility() == ViewportVisibility::NotVisible)
+        return false;
+
+    return true;
+}
 
 NSArray* assetMetadataKeyNames()
 {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -205,6 +205,8 @@ private:
     bool hasAudio() const override;
 
     void setPageIsVisible(bool) final;
+    void setViewportVisibility(ViewportVisibility) final;
+    void updateRendererVisibility();
 
     MediaTime duration() const override;
     MediaTime startTime() const override;
@@ -362,7 +364,8 @@ private:
     mutable bool m_loadingProgressed WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
     bool m_hasAvailableVideoFrame WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
     bool m_allRenderersHaveAvailableSamples WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
-    bool m_visible WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    bool m_pageIsVisible WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    ViewportVisibility m_viewportVisibility WTF_GUARDED_BY_CAPABILITY(mainThread) { ViewportVisibility::NotVisible };
     RetainPtr<CVOpenGLTextureRef> m_lastTexture WTF_GUARDED_BY_CAPABILITY(mainThread);
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     RefPtr<MediaPlaybackTarget> m_playbackTarget WTF_GUARDED_BY_CAPABILITY(mainThread);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -108,6 +108,8 @@ MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC(Media
     , m_rendererPrepareSeekRequest(NativePromiseRequest::create())
     , m_rendererFinishSeekRequest(NativePromiseRequest::create())
     , m_networkState(MediaPlayer::NetworkState::Empty)
+    , m_pageIsVisible { player.pageIsVisible() }
+    , m_viewportVisibility { player.viewportVisibility() }
     , m_logger(player.mediaPlayerLogger())
     , m_logIdentifier(player.mediaPlayerLogIdentifier())
 #if HAVE(SPATIAL_TRACKING_LABEL)
@@ -406,12 +408,31 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::hasAudio() const
 void MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible(bool visible)
 {
     assertIsMainThread();
-    if (m_visible == visible)
+    if (m_pageIsVisible == visible)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, visible);
-    m_visible = visible;
+    m_pageIsVisible = visible;
+    updateRendererVisibility();
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::setViewportVisibility(ViewportVisibility visibility)
+{
+    assertIsMainThread();
+    if (m_viewportVisibility == visibility)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, visibility);
+    m_viewportVisibility = visibility;
+    updateRendererVisibility();
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::updateRendererVisibility()
+{
+    assertIsMainThread();
+    bool visible = m_pageIsVisible && m_viewportVisibility != ViewportVisibility::NotVisible;
     m_renderer->setIsVisible(visible);
+    acceleratedRenderingStateChanged();
 }
 
 MediaTime MediaPlayerPrivateMediaSourceAVFObjC::duration() const
@@ -882,8 +903,16 @@ Ref<AudioVideoRenderer> MediaPlayerPrivateMediaSourceAVFObjC::audioVideoRenderer
 
 void MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged()
 {
+    assertIsMainThread();
+
     RefPtr player = m_player.get();
-    m_renderer->renderingCanBeAcceleratedChanged(player ? player->renderingCanBeAccelerated() : false);
+
+    // Don't create a layer if the player is not visible:
+    bool canBeAccelerated = m_pageIsVisible
+        && m_viewportVisibility != ViewportVisibility::NotVisible
+        && player
+        && player->renderingCanBeAccelerated();
+    m_renderer->renderingCanBeAcceleratedChanged(canBeAccelerated);
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::notifyActiveSourceBuffersChanged()

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -134,7 +134,7 @@ private:
 
     void setPageIsVisible(bool) final;
     void setVisibleForCanvas(bool) final;
-    void setVisibleInViewport(bool) final;
+    void setViewportVisibility(ViewportVisibility) final;
 
     MediaTime duration() const override;
     MediaTime currentTime() const override;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -713,9 +713,9 @@ void MediaPlayerPrivateMediaStreamAVFObjC::setVisibleForCanvas(bool)
 {
 }
 
-void MediaPlayerPrivateMediaStreamAVFObjC::setVisibleInViewport(bool isVisible)
+void MediaPlayerPrivateMediaStreamAVFObjC::setViewportVisibility(ViewportVisibility visibility)
 {
-    m_isVisibleInViewPort = isVisible;
+    m_isVisibleInViewPort = visibility == ViewportVisibility::VisibleInViewport;
 }
 
 MediaTime MediaPlayerPrivateMediaStreamAVFObjC::duration() const

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -148,7 +148,9 @@ VideoMediaSampleRenderer::~VideoMediaSampleRenderer()
 #if HAVE(AVSAMPLEBUFFERVIDEORENDERER)
 AVSampleBufferVideoRenderer *VideoMediaSampleRenderer::videoRendererFor(WebSampleBufferVideoRendering *renderer)
 {
-    ASSERT(renderer);
+    if (!renderer)
+        return nullptr;
+
     if (auto *displayLayer = dynamic_objc_cast<AVSampleBufferDisplayLayer>(renderer))
         return [displayLayer sampleBufferRenderer];
     return checked_objc_cast<AVSampleBufferVideoRenderer>(renderer);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -381,7 +381,7 @@ void MediaPlayerPrivateGStreamer::load(const String& urlString)
 
     ASSERT(m_pipeline);
     setPlaybinURL(url);
-    setVisibleInViewport(player->isVisibleInViewport());
+    setViewportVisibility(player->viewportVisibility());
 
     GST_DEBUG_OBJECT(pipeline(), "preload: %s", convertEnumerationToString(m_preload).utf8().data());
     if (m_preload == MediaPlayer::Preload::None && !isMediaSource()) {
@@ -4098,10 +4098,12 @@ void MediaPlayerPrivateGStreamer::flushCurrentBuffer()
 }
 #endif
 
-void MediaPlayerPrivateGStreamer::setVisibleInViewport(bool isVisible)
+void MediaPlayerPrivateGStreamer::setViewportVisibility(ViewportVisibility visibility)
 {
     if (isMediaStreamPlayer())
         return;
+
+    bool isVisible = visibility == ViewportVisibility::VisibleInViewport;
 
     // Some layout tests (webgl) expect playback of invisible videos to not be suspended, so allow
     // this using an environment variable, set from the webkitpy glib port sub-classes.

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -161,7 +161,7 @@ public:
     MediaPlayer::NetworkState networkState() const final;
     MediaPlayer::ReadyState readyState() const final;
     void setPageIsVisible(bool visible) final { m_pageIsVisible = visible; }
-    void setVisibleInViewport(bool isVisible) final;
+    void setViewportVisibility(ViewportVisibility) final;
     void setPresentationSize(const IntSize&) final;
     MediaTime duration() const override;
     MediaTime currentTime() const override;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5420,7 +5420,7 @@ bool Internals::elementIsBlockingDisplaySleep(const HTMLMediaElement& element) c
 bool Internals::isPlayerVisibleInViewport(const HTMLMediaElement& element) const
 {
     auto* player = element.player();
-    return player && player->isVisibleInViewport();
+    return player && player->viewportVisibility() == HTMLMediaElement::ViewportVisibility::VisibleInViewport;
 }
 
 bool Internals::isPlayerMuted(const HTMLMediaElement& element) const

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -341,6 +341,12 @@ void RemoteMediaPlayerProxy::setPageIsVisible(bool visible)
     protect(m_player)->setPageIsVisible(visible);
 }
 
+void RemoteMediaPlayerProxy::setViewportVisibility(ViewportVisibility visibility)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, visibility);
+    protect(m_player)->setViewportVisibility(visibility);
+}
+
 void RemoteMediaPlayerProxy::setShouldMaintainAspectRatio(bool maintainRatio)
 {
     protect(m_player)->setShouldMaintainAspectRatio(maintainRatio);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -179,6 +179,9 @@ public:
     void setPitchCorrectionAlgorithm(WebCore::MediaPlayer::PitchCorrectionAlgorithm);
 
     void setPageIsVisible(bool);
+
+    using ViewportVisibility = WebCore::MediaPlayer::ViewportVisibility;
+    void setViewportVisibility(ViewportVisibility);
     void setShouldMaintainAspectRatio(bool);
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     void setVideoFullscreenGravity(WebCore::MediaPlayerEnums::VideoGravity);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -55,6 +55,7 @@ messages -> RemoteMediaPlayerProxy {
 
     PrepareForRendering()
     SetPageIsVisible(bool visible)
+    SetViewportVisibility(enum:uint8_t WebCore::MediaPlayerViewportVisibility visibility)
     SetShouldMaintainAspectRatio(bool maintainAspectRatio)
     AcceleratedRenderingStateChanged(bool canBeAccelerated)
     SetShouldDisableSleep(bool disable)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1300,6 +1300,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::MediaPlayerPreload': ['<WebCore/MediaPlayerEnums.h>'],
         'WebCore::MediaPlayerSupportsType': ['<WebCore/MediaPlayerEnums.h>'],
         'WebCore::MediaPlayerVideoGravity': ['<WebCore/MediaPlayerEnums.h>'],
+        'WebCore::MediaPlayerViewportVisibility': ['<WebCore/MediaPlayerEnums.h>'],
         'WebCore::MediaEngineSupportParameters': ['<WebCore/MediaPlayer.h>'],
         'WebCore::MediaPlayerLoadOptions': ['<WebCore/MediaPlayer.h>'],
         'WebCore::MediaPlayerReadyState': ['<WebCore/MediaPlayerEnums.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4283,6 +4283,12 @@ enum class WebCore::MediaPlayerSoundStageSize : uint8_t {
     Large,
 };
 
+enum class WebCore::MediaPlayerViewportVisibility : uint8_t {
+    NotVisible,
+    IntersectingViewport,
+    VisibleInViewport,
+};
+
 class WebCore::GeolocationPositionData {
     double timestamp;
     double latitude;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -732,6 +732,17 @@ void MediaPlayerPrivateRemote::setPageIsVisible(bool visible)
     protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetPageIsVisible(visible), m_id);
 }
 
+void MediaPlayerPrivateRemote::setViewportVisibility(ViewportVisibility visibility)
+{
+    if (m_viewportVisibility == visibility)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, visibility);
+
+    m_viewportVisibility = visibility;
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetViewportVisibility(visibility), m_id);
+}
+
 void MediaPlayerPrivateRemote::setShouldMaintainAspectRatio(bool maintainRatio)
 {
     if (maintainRatio == m_shouldMaintainAspectRatio)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -315,6 +315,7 @@ private:
     bool hasAudio() const final;
 
     void setPageIsVisible(bool) final;
+    void setViewportVisibility(ViewportVisibility) final;
 
     MediaTime getStartDate() const final;
 
@@ -552,6 +553,7 @@ private:
     bool m_waitingForKey { false };
     std::optional<bool> m_shouldMaintainAspectRatio;
     std::optional<bool> m_pageIsVisible;
+    ViewportVisibility m_viewportVisibility { ViewportVisibility::NotVisible };
     RefPtr<RemoteVideoFrameProxy> m_videoFrameForCurrentTime;
 #if PLATFORM(COCOA)
     RefPtr<RemoteVideoFrameProxy> m_videoFrameGatheredWithVideoFrameMetadata;


### PR DESCRIPTION
#### 93297c8fc1f654c10a126c5b7a6aeeef295072ba
<pre>
[Cocoa] Inifite scrolling video websites can cause window server jetsams
<a href="https://rdar.apple.com/162452658">rdar://162452658</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312390">https://bugs.webkit.org/show_bug.cgi?id=312390</a>

Reviewed by Jean-Yves Avenard.

When infinitely scrolling on a website, a video element may become abandoned
very far away from the viewport. This element is still using memory resources
in the window server or compositor, even though it will be clipped out of the
resulting viewport. After enough scrolling, so many clipped video elements may
exist in the compositor as to cause that compositor to be killed by the system
for using too much memory.

To avoid this, install a viewport listener in HTMLMediaElement. In the future,
this listener could be use to implement a lazy load algorithm. But for now, it
just notifies the MediaPlayer that the media element is visible in the viewport,
close to or intersecting the viewport, or not visible.

Support this visibility enum by turning off the layer of MediaPlayerPrivateAVFoundationObjC
and MediaPlayerPrivateMediaSourceAVFObjC when the visibility drops to &quot;none&quot;, and
re-creating the layer when the visibility rises to &quot;intersecting&quot; or &quot;visible&quot;.
This behavior also occurs when switching tabs in a browser, when the page&apos;s own
visibility state drops to &quot;not visible&quot;.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::lazyLoadVideoObserver):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::isVisibleInViewportChanged):
(WebCore::HTMLMediaElement::viewportVisibility const):
(WebCore::HTMLMediaElement::updateMediaPlayer):
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::isIntersectingViewport const):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::~HTMLVideoElement):
(WebCore::HTMLVideoElement::create):
(WebCore::HTMLVideoElement::computeAcceleratedRenderingStateAndUpdateMediaPlayer):
(WebCore::HTMLVideoElement::viewportIntersectionChanged):
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/html/parser/HTMLParserOptions.cpp:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::loadWithNextMediaEngine):
(WebCore::MediaPlayer::setViewportVisibility):
(WebCore::convertEnumerationToString):
(WebCore::MediaPlayer::setVisibleInViewport): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerEnums.h:
(WTF::LogArgument&lt;WebCore::MediaPlayerEnums::ViewportVisibility&gt;::toString):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::setViewportVisibility):
(WebCore::MediaPlayerPrivateInterface::setVisibleInViewport): Deleted.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::renderingCanBeAcceleratedChanged):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::MediaPlayerPrivateAVFoundation):
(WebCore::MediaPlayerPrivateAVFoundation::isReadyForVideoSetup const):
(WebCore::MediaPlayerPrivateAVFoundation::setPageIsVisible):
(WebCore::MediaPlayerPrivateAVFoundation::setViewportVisibility):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
(WebCore::MediaPlayerPrivateAVFoundation::pageIsVisible const):
(WebCore::MediaPlayerPrivateAVFoundation::viewportVisibility const):
(WebCore::MediaPlayerPrivateAVFoundation::isVisible const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::platformPageIsVisibleChanged):
(WebCore::MediaPlayerPrivateAVFoundationObjC::platformViewportVisibilityChanged):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setVideoTarget):
(WebCore::MediaPlayerPrivateAVFoundationObjC::isInFullscreenOrPictureInPictureChanged):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateLayerAttachment):
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldAttachLayerToPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::platformSetVisible): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::WTF_GUARDED_BY_CAPABILITY):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setViewportVisibility):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateRendererVisibility):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setViewportVisibility):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setVisibleInViewport): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::setViewportVisibility):
(WebCore::MediaPlayerPrivateGStreamer::setVisibleInViewport): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isPlayerVisibleInViewport const):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::setViewportVisibility):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::setViewportVisibility):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/311380@main">https://commits.webkit.org/311380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6b2e26261918f85e8ff78fd0d9d91d4b7385b14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156723 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110804 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121394 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85263 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102062 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/156042 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22667 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20873 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13318 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132346 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168029 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12190 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129510 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129619 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35126 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140361 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87385 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24436 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17165 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93309 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28817 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29047 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28943 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->