### PR TITLE
[Web Inspector] [Site Isolation] Add inspector test for Page.setScreenSizeOverride with cross-origin iframes under site isolation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/resources/screen-size-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resources/screen-size-frame.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+@media only screen and (max-device-width: 1000px) {
+    body {
+        color: red;
+    }
+}
+</style>
+<p>Cross-origin frame for screen size override test.</p>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-screen-size-override-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-screen-size-override-cross-origin-iframe-expected.txt
@@ -1,0 +1,27 @@
+Test that Page.setScreenSizeOverride propagates to cross-origin iframes under site isolation.
+
+
+== Running test suite: SiteIsolation.Page.SetScreenSizeOverrideCrossOriginIFrame
+-- Running test case: SiteIsolation.Page.SetScreenSizeOverride.DefaultScreenSize
+PASS: Added target should have Frame type.
+PASS: Main page should not match media query (black).
+PASS: Cross-origin iframe should not match media query (black).
+
+-- Running test case: SiteIsolation.Page.SetScreenSizeOverride.OverrideAndReload
+Overriding screen size to 1000x500...
+Reloading...
+PASS: Main page screen width should be 1000.
+PASS: Main page screen height should be 500.
+PASS: Main page should match media query (red).
+Re-adding cross-origin iframe...
+PASS: Cross-origin iframe screen width should be 1000.
+PASS: Cross-origin iframe screen height should be 500.
+PASS: Cross-origin iframe should match media query (red).
+
+-- Running test case: SiteIsolation.Page.SetScreenSizeOverride.RemoveOverrideAndReload
+Removing screen size override...
+Reloading...
+PASS: Main page should not match media query (black).
+Re-adding cross-origin iframe...
+PASS: Cross-origin iframe should not match media query (black).
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-screen-size-override-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-screen-size-override-cross-origin-iframe.html
@@ -1,0 +1,128 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<style>
+@media only screen and (max-device-width: 1000px) {
+    body {
+        color: red;
+    }
+}
+</style>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+let iframe;
+
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    iframe = document.createElement("iframe");
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/screen-size-frame.html`;
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    async function addIFrameAndGetTarget() {
+        let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+        InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+        let event = await targetAddedPromise;
+        return event.data.target;
+    }
+
+    async function getScreenSizeInTarget(target) {
+        // Wait for the iframe document to fully load before checking screen size.
+        // TargetAdded fires when the JS context is created, before DOM and CSS are ready.
+        await target.RuntimeAgent.evaluate.invoke({
+            expression: "new Promise(resolve => { if (document.readyState === 'complete') resolve(); else window.addEventListener('load', resolve); })",
+            objectGroup: "test",
+            awaitPromise: true,
+        });
+
+        let widthResponse = await target.RuntimeAgent.evaluate.invoke({expression: "window.screen.width", objectGroup: "test", returnByValue: true});
+        InspectorTest.assert(widthResponse.result.value !== undefined, "Should be able to evaluate screen.width in cross-origin target.");
+
+        let heightResponse = await target.RuntimeAgent.evaluate.invoke({expression: "window.screen.height", objectGroup: "test", returnByValue: true});
+        InspectorTest.assert(heightResponse.result.value !== undefined, "Should be able to evaluate screen.height in cross-origin target.");
+
+        return {width: widthResponse.result.value, height: heightResponse.result.value};
+    }
+
+    async function getComputedColorInTarget(target) {
+        let response = await target.RuntimeAgent.evaluate.invoke({expression: "window.getComputedStyle(document.body).getPropertyValue('color')", objectGroup: "test", returnByValue: true});
+        InspectorTest.assert(response.result.value, "Should be able to evaluate computed style in cross-origin target.");
+        return response.result.value;
+    }
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.SetScreenSizeOverrideCrossOriginIFrame");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.SetScreenSizeOverride.DefaultScreenSize",
+        description: "Both the main page and cross-origin iframe should have the default screen size.",
+        async test() {
+            let target = await addIFrameAndGetTarget();
+            InspectorTest.expectEqual(target.type, WI.TargetType.Frame, "Added target should have Frame type.");
+
+            let mainPageColor = await InspectorTest.evaluateInPage(`getComputedStyle(document.body).color`);
+            InspectorTest.expectEqual(mainPageColor, "rgb(0, 0, 0)", "Main page should not match media query (black).");
+
+            let iframeColor = await getComputedColorInTarget(target);
+            InspectorTest.expectEqual(iframeColor, "rgb(0, 0, 0)", "Cross-origin iframe should not match media query (black).");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.SetScreenSizeOverride.OverrideAndReload",
+        description: "Overriding screen size to 1000x500 and reloading should affect screen size in the cross-origin iframe.",
+        async test() {
+            InspectorTest.log("Overriding screen size to 1000x500...");
+            await PageAgent.setScreenSizeOverride(1000, 500);
+
+            InspectorTest.log("Reloading...");
+            await InspectorTest.reloadPage();
+            await InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad);
+
+            let mainPageScreenWidth = await InspectorTest.evaluateInPage(`window.screen.width`);
+            InspectorTest.expectEqual(mainPageScreenWidth, 1000, "Main page screen width should be 1000.");
+            let mainPageScreenHeight = await InspectorTest.evaluateInPage(`window.screen.height`);
+            InspectorTest.expectEqual(mainPageScreenHeight, 500, "Main page screen height should be 500.");
+
+            let mainPageColor = await InspectorTest.evaluateInPage(`getComputedStyle(document.body).color`);
+            InspectorTest.expectEqual(mainPageColor, "rgb(255, 0, 0)", "Main page should match media query (red).");
+
+            InspectorTest.log("Re-adding cross-origin iframe...");
+            let target = await addIFrameAndGetTarget();
+
+            let iframeScreenSize = await getScreenSizeInTarget(target);
+            InspectorTest.expectEqual(iframeScreenSize.width, 1000, "Cross-origin iframe screen width should be 1000.");
+            InspectorTest.expectEqual(iframeScreenSize.height, 500, "Cross-origin iframe screen height should be 500.");
+
+            let iframeColor = await getComputedColorInTarget(target);
+            InspectorTest.expectEqual(iframeColor, "rgb(255, 0, 0)", "Cross-origin iframe should match media query (red).");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.SetScreenSizeOverride.RemoveOverrideAndReload",
+        description: "Removing the screen size override and reloading should restore the default screen size in both frames.",
+        async test() {
+            InspectorTest.log("Removing screen size override...");
+            await PageAgent.setScreenSizeOverride();
+
+            InspectorTest.log("Reloading...");
+            await InspectorTest.reloadPage();
+            await InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad);
+
+            let mainPageColor = await InspectorTest.evaluateInPage(`getComputedStyle(document.body).color`);
+            InspectorTest.expectEqual(mainPageColor, "rgb(0, 0, 0)", "Main page should not match media query (black).");
+
+            InspectorTest.log("Re-adding cross-origin iframe...");
+            let target = await addIFrameAndGetTarget();
+
+            let iframeColor = await getComputedColorInTarget(target);
+            InspectorTest.expectEqual(iframeColor, "rgb(0, 0, 0)", "Cross-origin iframe should not match media query (black).");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that Page.setScreenSizeOverride propagates to cross-origin iframes under site isolation.</p>
+</body>

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -256,6 +256,7 @@ http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/page/override-setting-cross-origin-iframe.html [ Pass Failure ]
+http/tests/site-isolation/inspector/page/set-screen-size-override-cross-origin-iframe.html [ Pass Failure ]
 http/tests/ssl/applepay/page-cache-active-apple-pay-session.html [ Failure ]
 http/tests/ssl/applepay/page-cache-inactive-apple-pay-session.html [ Failure ]
 http/tests/ssl/media-stream/get-user-media-secure-connection.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2416,6 +2416,7 @@ http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe.html
 http/tests/site-isolation/inspector/runtime/execution-context-from-frame-target.html [ Failure ]
 http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html [ Failure ]
 http/tests/site-isolation/inspector/page/override-setting-cross-origin-iframe.html [ Pass Failure ]
+http/tests/site-isolation/inspector/page/set-screen-size-override-cross-origin-iframe.html [ Pass Failure ]
 
 webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubberbands.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 9f5d1a3ae228d21d38fc5f2bdbc327de7611a519
<pre>
[Web Inspector] [Site Isolation] Add inspector test for Page.setScreenSizeOverride with cross-origin iframes under site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=312393">https://bugs.webkit.org/show_bug.cgi?id=312393</a>
<a href="https://rdar.apple.com/174850907">rdar://174850907</a>

Reviewed by NOBODY (OOPS!).

Add a layout test that verifies Page.setScreenSizeOverride propagates to
cross-origin iframes when site isolation is enabled. The test overrides
the screen size to 1000x500 via Web Inspector, reloads, and confirms
that screen.width, screen.height, and a max-device-width media query
in a cross-origin iframe (running in a separate process) all reflect
the overridden values.

* LayoutTests/http/tests/site-isolation/inspector/page/resources/screen-size-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-screen-size-override-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-screen-size-override-cross-origin-iframe.html: Added.
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f5d1a3ae228d21d38fc5f2bdbc327de7611a519

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165439 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110697 "Failed to checkout and rebase branch from PR 62831") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121303 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/110697 "Failed to checkout and rebase branch from PR 62831") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140640 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101971 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22591 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20780 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13211 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167922 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129419 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129529 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140263 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87278 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24356 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17065 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29185 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28710 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28940 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->