### PR TITLE
gdb: Fix UTF-16 pretty printer

### DIFF
--- a/Tools/gdb/webkit.py
+++ b/Tools/gdb/webkit.py
@@ -57,7 +57,7 @@ def guess_string_length(ptr):
 
 
 def ustring_to_string(ptr, length=None):
-    """Convert a pointer to UTF-16 data into a Python string encoded with utf-8.
+    """Convert a pointer to UTF-16 data into a Python string.
 
     ptr and length are both gdb.Value objects.
     If length is unspecified, will guess at the length."""
@@ -67,12 +67,12 @@ def ustring_to_string(ptr, length=None):
     else:
         length = int(length)
     char_vals = [int((ptr + i).dereference()) for i in range(length)]
-    string = struct.pack('H' * length, *char_vals).decode('utf-16', 'replace').encode('utf-8')
+    string = struct.pack('H' * length, *char_vals).decode('utf-16', 'replace')
     return string + error_message
 
 
 def lstring_to_string(ptr, length=None):
-    """Convert a pointer to Latin1Character* data into a Python (non-Unicode) string.
+    """Convert a pointer to Latin1Character* data into a Python string.
 
     ptr and length are both gdb.Value objects.
     If length is unspecified, will guess at the length."""


### PR DESCRIPTION
#### 3fb078257aab04823b4452ed0ad2d1b38e38269a
<pre>
gdb: Fix UTF-16 pretty printer
<a href="https://bugs.webkit.org/show_bug.cgi?id=312395">https://bugs.webkit.org/show_bug.cgi?id=312395</a>

Reviewed by Adrian Perez de Castro.

ustring_to_string() (the function used for printing UTF-16 strings) was
wrongfully re-encoding a text string back into bytes, causing an error
later when concatenated with another text string.

This patch also removes comments about Unicode vs non-Unicode strings in
both ustring_to_string and lstring_to_string because they do not
represent how strings work in Python 3: both functions must return
regular strings.

* Tools/gdb/webkit.py:
(ustring_to_string): remove incorrect .encode(&apos;utf-8&apos;), update doc
comment.
(lstring_to_string): update doc comment.

Canonical link: <a href="https://commits.webkit.org/311364@main">https://commits.webkit.org/311364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1644a05ff8bffc312e3bc24df451ac634ddaa12d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165440 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110698 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121304 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85221 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101972 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22592 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20783 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13212 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167923 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20091 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129420 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129530 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35119 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29478 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140268 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87279 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24357 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17071 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29186 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28941 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->