### PR TITLE
prepare-commit-msg: add unit test for git hook's get_bugs_string() to prevent future regressions (Follow-up)

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/prepare_commit_msg_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/prepare_commit_msg_unittest.py
@@ -34,6 +34,7 @@ import os
 import shutil
 import subprocess
 import sys
+import unittest
 
 from unittest.mock import MagicMock, patch
 
@@ -41,10 +42,12 @@ from webkitbugspy import mocks as bugspy_mocks
 from webkitcorepy import testing
 
 
-_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
-_SCRIPTS_DIR = _TEST_DIR[:_TEST_DIR.rindex(os.sep + os.path.join('Tools', 'Scripts') + os.sep)] + os.sep + os.path.join('Tools', 'Scripts')
-_HOOKS_DIR = os.path.join(_SCRIPTS_DIR, 'hooks')
-_HOOK_TEMPLATE = os.path.join(_HOOKS_DIR, 'prepare-commit-msg')
+_TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+_SCRIPTS_SUFFIX = os.sep + os.path.join('Tools', 'Scripts') + os.sep
+_SCRIPTS_IDX = _TEST_DIR.rfind(_SCRIPTS_SUFFIX)
+_SCRIPTS_DIR = _TEST_DIR[:_SCRIPTS_IDX] + os.sep + os.path.join('Tools', 'Scripts') if _SCRIPTS_IDX >= 0 else None
+_HOOKS_DIR = os.path.join(_SCRIPTS_DIR, 'hooks') if _SCRIPTS_DIR else None
+_HOOK_TEMPLATE = os.path.join(_HOOKS_DIR, 'prepare-commit-msg') if _HOOKS_DIR else None
 
 
 def _render_hook_template():
@@ -67,6 +70,7 @@ def _render_hook_template():
         )
 
 
+@unittest.skipUnless(_HOOK_TEMPLATE and os.path.isfile(_HOOK_TEMPLATE), 'prepare-commit-msg hook template not found')
 class TestGetBugsString(testing.PathTestCase):
     """Regression tests for prepare-commit-msg get_bugs_string().
 


### PR DESCRIPTION
#### 2625dd9448f9e504e33396b0c2ddc2d72b686044
<pre>
prepare-commit-msg: add unit test for git hook&apos;s get_bugs_string() to prevent future regressions (Follow-up)
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=312300">https://bugs.webkit.org/show_bug.cgi?id=312300</a>&gt;
&lt;<a href="https://rdar.apple.com/174765471">rdar://174765471</a>&gt;

Reviewed by David Kilzer.

Handle running tests outside of the WebKit repository.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/prepare_commit_msg_unittest.py:

Canonical link: <a href="https://commits.webkit.org/311315@main">https://commits.webkit.org/311315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a517cd8b8937f65e990c66dee87bc8167eece40f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165452 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158500 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121316 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159587 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101984 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/155948 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13224 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167935 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20100 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/156027 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29567 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24870 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129542 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140277 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23847 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24366 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17080 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29198 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28723 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28953 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28848 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->