### PR TITLE
[Site Isolation] Expose ValidationBubble anchorRect in testing API

### DIFF
--- a/Source/WebCore/platform/ValidationBubble.h
+++ b/Source/WebCore/platform/ValidationBubble.h
@@ -73,6 +73,7 @@ public:
 
     const String& message() const LIFETIME_BOUND { return m_message; }
     double fontSize() const { return m_fontSize; }
+    const IntRect& anchorRect() const { return m_anchorRect; }
 
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT void setAnchorRect(const IntRect& anchorRect, UIViewController* presentingViewController = nullptr);
@@ -96,6 +97,7 @@ protected:
 #endif
     String m_message;
     double m_fontSize { 0 };
+    IntRect m_anchorRect;
 #if PLATFORM(MAC)
     RetainPtr<NSPopover> m_popover;
 #elif PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
+++ b/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
@@ -225,6 +225,8 @@ static UIViewController *fallbackViewController(UIView *view)
 
 void ValidationBubble::setAnchorRect(const IntRect& anchorRect, UIViewController *presentingViewController)
 {
+    m_anchorRect = anchorRect;
+
     RetainPtr view = m_view.get();
     if (!presentingViewController)
         presentingViewController = fallbackViewController(view.get());

--- a/Source/WebCore/platform/mac/ValidationBubbleMac.mm
+++ b/Source/WebCore/platform/mac/ValidationBubbleMac.mm
@@ -86,6 +86,8 @@ ValidationBubble::~ValidationBubble()
 
 void ValidationBubble::showRelativeTo(const IntRect& anchorRect)
 {
+    m_anchorRect = anchorRect;
+
     // Passing an unparented view to [m_popover showRelativeToRect:ofView:preferredEdge:] crashes.
     RetainPtr view = m_view.get();
     if (![view window])

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -285,7 +285,17 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         RefPtr validationBubble = _page->validationBubble();
         String message = validationBubble ? validationBubble->message() : emptyString();
         double fontSize = validationBubble ? validationBubble->fontSize() : 0;
-        return @{ userInterfaceItem: @{ @"message": message.createNSString().get(), @"fontSize": @(fontSize) } };
+        auto anchorRect = validationBubble ? validationBubble->anchorRect() : WebCore::IntRect();
+        return @{ userInterfaceItem: @{
+            @"message": message.createNSString().get(),
+            @"fontSize": @(fontSize),
+            @"anchorRect": @{
+                @"x": @(anchorRect.x()),
+                @"y": @(anchorRect.y()),
+                @"width": @(anchorRect.width()),
+                @"height": @(anchorRect.height())
+            }
+        } };
     }
 
     if (RetainPtr contents = _page->contentsOfUserInterfaceItem(userInterfaceItem))


### PR DESCRIPTION
#### ba8d91ff545df44326fd34d4beb81dbcf2614f33
<pre>
[Site Isolation] Expose ValidationBubble anchorRect in testing API
<a href="https://bugs.webkit.org/show_bug.cgi?id=312398">https://bugs.webkit.org/show_bug.cgi?id=312398</a>
<a href="https://rdar.apple.com/174855001">rdar://174855001</a>

Reviewed by Aditya Keerthi.

Store the anchor rect passed to ValidationBubble::showRelativeTo() (macOS) and
ValidationBubble::setAnchorRect() (iOS), and return it from
_contentsOfUserInterfaceItem:@&quot;validationBubble&quot; for use in layout tests.

No new tests, as no change in functionality. Simply plumbing values through
for a followup patch to use.

* Source/WebCore/platform/ValidationBubble.h:
(WebCore::ValidationBubble::anchorRect const):
* Source/WebCore/platform/ios/ValidationBubbleIOS.mm:
(WebCore::ValidationBubble::setAnchorRect):
* Source/WebCore/platform/mac/ValidationBubbleMac.mm:
(WebCore::ValidationBubble::showRelativeTo):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _contentsOfUserInterfaceItem:]):

Canonical link: <a href="https://commits.webkit.org/311331@main">https://commits.webkit.org/311331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe4891f64e40d81b767eca8bf2ea11d33e85aaba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165453 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29969 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121318 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140655 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101986 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20794 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13225 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167936 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12056 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129434 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129544 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35097 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87292 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24369 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17081 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29199 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93163 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28724 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28954 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28849 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->