### PR TITLE
[Site Isolation] Validation message bubble is positioned incorrectly in cross-origin iframes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/validation-message-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/validation-message-iframe.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { margin: 0; padding: 0; }
+#input {
+    position: absolute;
+    left: 50px;
+    top: 30px;
+    width: 200px;
+    height: 30px;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0;
+}
+#submit {
+    position: absolute;
+    left: 50px;
+    top: 80px;
+}
+</style>
+</head>
+<body>
+<form id="form">
+    <input id="input" type="text" required>
+    <input id="submit" type="submit" value="Submit">
+</form>
+<script>
+window.addEventListener("message", (event) => {
+    if (event.data === "submit") {
+        document.getElementById("submit").click();
+        requestAnimationFrame(() => parent.postMessage("submitted", "*"));
+    }
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/validation-message-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/validation-message-cross-origin-iframe-expected.txt
@@ -1,0 +1,14 @@
+Test that validation bubble anchor rect is in main-frame coordinates for cross-origin iframes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS bubbleMessage is "Fill out this field"
+PASS anchorX is 150
+PASS anchorY is 130
+PASS anchorWidth is 200
+PASS anchorHeight is 30
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/validation-message-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/validation-message-cross-origin-iframe.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<style>
+body { margin: 0; padding: 0; }
+#frame {
+    position: absolute;
+    left: 100px;
+    top: 100px;
+    width: 300px;
+    height: 200px;
+    border: none;
+}
+</style>
+<script>
+function getValidationBubble()
+{
+    return new Promise((resolve) => {
+        requestAnimationFrame(() => {
+            setTimeout(() => {
+                testRunner.runUIScript(`(function() {
+                    return JSON.stringify(uiController.contentsOfUserInterfaceItem('validationBubble'));
+                })();`, function(result) {
+                    resolve(JSON.parse(result).validationBubble);
+                });
+            }, 0);
+        });
+    });
+}
+</script>
+</head>
+<body>
+<script>
+description("Test that validation bubble anchor rect is in main-frame coordinates for cross-origin iframes.");
+jsTestIsAsync = true;
+
+async function runTest() {
+    const iframe = document.getElementById("frame");
+
+    await new Promise((resolve) => {
+        window.addEventListener("message", (event) => {
+            if (event.data === "submitted")
+                resolve();
+        }, { once: true });
+        iframe.contentWindow.postMessage("submit", "*");
+    });
+
+    const bubble = await getValidationBubble();
+
+    window.bubbleMessage = bubble.message;
+    shouldBeEqualToString("bubbleMessage", "Fill out this field");
+
+    // The iframe is positioned at (100, 100). Inside the iframe, the input is
+    // at (50, 30) with size 200x30. After conversion to main-frame coordinates
+    // the anchor rect should be (150, 130, 200, 30).
+    window.anchorX = bubble.anchorRect.x;
+    window.anchorY = bubble.anchorRect.y;
+    window.anchorWidth = bubble.anchorRect.width;
+    window.anchorHeight = bubble.anchorRect.height;
+    shouldBe("anchorX", "150");
+    shouldBe("anchorY", "130");
+    shouldBe("anchorWidth", "200");
+    shouldBe("anchorHeight", "30");
+
+    finishJSTest();
+}
+</script>
+<iframe id="frame" src="http://localhost:8000/site-isolation/resources/validation-message-iframe.html" onload="runTest()"></iframe>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -748,7 +748,7 @@ public:
 
     void scrollbarWidthChanged(ScrollbarWidth) override;
 
-    std::optional<FrameIdentifier> NODELETE rootFrameID() const final;
+    WEBCORE_EXPORT std::optional<FrameIdentifier> NODELETE rootFrameID() const final;
 
     IntSize totalScrollbarSpace() const final;
     int scrollbarGutterWidth(bool isHorizontalWritingMode = true) const;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16114,6 +16114,24 @@ void WebPageProxy::hideValidationMessage()
 #endif
 }
 
+#if PLATFORM(COCOA) || PLATFORM(GTK)
+void WebPageProxy::showValidationMessage(const IntRect& anchorClientRect, String&& message, std::optional<WebCore::FrameIdentifier>&& rootFrameID)
+{
+    RefPtr pageClient = this->pageClient();
+    if (!pageClient)
+        return;
+
+    m_validationBubble = pageClient->createValidationBubble(WTF::move(message), { protect(preferences())->minimumFontSize() });
+
+    convertRectToMainFrameCoordinates(anchorClientRect, rootFrameID, [weakThis = WeakPtr { *this }](std::optional<FloatRect> convertedRect) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !convertedRect)
+            return;
+        protectedThis->showValidationMessageWithMainFrameRect(IntRect(*convertedRect));
+    });
+}
+#endif
+
 // FIXME: Consolidate with dismissContentRelativeChildWindows
 void WebPageProxy::closeOverlayedViews()
 {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2165,9 +2165,10 @@ public:
     void logScrollingEvent(uint32_t eventType, MonotonicTime, uint64_t);
 
     // Form validation messages.
-    void showValidationMessage(const WebCore::IntRect& anchorClientRect, String&& message);
+    void showValidationMessage(const WebCore::IntRect& anchorClientRect, String&& message, std::optional<WebCore::FrameIdentifier>&& rootFrameID);
     void hideValidationMessage();
 #if PLATFORM(COCOA) || PLATFORM(GTK)
+    void showValidationMessageWithMainFrameRect(const WebCore::IntRect& mainFrameAnchorRect);
     WebCore::ValidationBubble* validationBubble() const { return m_validationBubble.get(); } // For testing.
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -65,7 +65,7 @@ messages -> WebPageProxy {
     SetAccessibilityMode(enum:uint8_t WebCore::AccessibilityMode mode)
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)
-    ShowValidationMessage(WebCore::IntRect anchorRect, String message)
+    ShowValidationMessage(WebCore::IntRect anchorRect, String message, std::optional<WebCore::FrameIdentifier> rootFrameID)
     HideValidationMessage()
 #endif
 

--- a/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
@@ -91,14 +91,10 @@ void WebPageProxy::showEmojiPicker(const WebCore::IntRect& caretRect, Completion
     webkitWebViewBaseShowEmojiChooser(WEBKIT_WEB_VIEW_BASE(viewWidget()), caretRect, WTF::move(completionHandler));
 }
 
-void WebPageProxy::showValidationMessage(const WebCore::IntRect& anchorClientRect, String&& message)
+void WebPageProxy::showValidationMessageWithMainFrameRect(const WebCore::IntRect& mainFrameAnchorRect)
 {
-    RefPtr pageClient = this->pageClient();
-    if (!pageClient)
-        return;
-
-    m_validationBubble = pageClient->createValidationBubble(WTF::move(message), { m_preferences->minimumFontSize() });
-    m_validationBubble->showRelativeTo(anchorClientRect);
+    if (RefPtr bubble = m_validationBubble)
+        bubble->showRelativeTo(mainFrameAnchorRect);
 }
 
 void WebPageProxy::sendMessageToWebViewWithReply(UserMessage&& message, CompletionHandler<void(UserMessage&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1232,26 +1232,27 @@ void WebPageProxy::dispatchDidUpdateEditorState()
     m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement = false;
 }
 
-void WebPageProxy::showValidationMessage(const IntRect& anchorClientRect, String&& message)
+void WebPageProxy::showValidationMessageWithMainFrameRect(const IntRect& mainFrameAnchorRect)
 {
+    RefPtr bubble = m_validationBubble;
+    if (!bubble)
+        return;
+
     RefPtr pageClient = this->pageClient();
     if (!pageClient)
         return;
 
-    m_validationBubble = pageClient->createValidationBubble(WTF::move(message), { protect(m_preferences)->minimumFontSize() });
-    Ref validationBubble = *m_validationBubble;
-
-    validationBubble->setShouldSuppressPresentation(pageClient->shouldSuppressFormValidationBubble());
+    bubble->setShouldSuppressPresentation(pageClient->shouldSuppressFormValidationBubble());
 
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.
-    validationBubble->setAnchorRect(anchorClientRect, protect(uiClient().presentingViewController()));
+    bubble->setAnchorRect(mainFrameAnchorRect, protect(uiClient().presentingViewController()));
 
     // If we are currently doing a scrolling / zoom animation, then we'll delay showing the validation
     // bubble until the animation is over.
     if (!m_isScrollingOrZooming)
-        validationBubble->show();
+        bubble->show();
 }
 
 void WebPageProxy::setIsScrollingOrZooming(bool isScrollingOrZooming)

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -779,14 +779,10 @@ void WebPageProxy::rootViewToWindow(const WebCore::IntRect& viewRect, WebCore::I
     windowRect = pageClient ? pageClient->rootViewToWindow(viewRect) : WebCore::IntRect { };
 }
 
-void WebPageProxy::showValidationMessage(const IntRect& anchorClientRect, String&& message)
+void WebPageProxy::showValidationMessageWithMainFrameRect(const IntRect& mainFrameAnchorRect)
 {
-    RefPtr pageClient = this->pageClient();
-    if (!pageClient)
-        return;
-
-    m_validationBubble = pageClient->createValidationBubble(WTF::move(message), { protect(preferences())->minimumFontSize() });
-    protect(m_validationBubble)->showRelativeTo(anchorClientRect);
+    if (RefPtr bubble = m_validationBubble)
+        bubble->showRelativeTo(mainFrameAnchorRect);
 }
 
 RetainPtr<NSView> WebPageProxy::inspectorAttachmentView()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp
@@ -29,8 +29,10 @@
 #include "MessageSenderInlines.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
+#include <WebCore/DocumentView.h>
 #include <WebCore/Element.h>
 #include <WebCore/LocalFrame.h>
+#include <WebCore/LocalFrameView.h>
 #include <WebCore/NodeDocument.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -66,7 +68,12 @@ void WebValidationMessageClient::showValidationMessage(const Element& anchor, St
 
     m_currentAnchor = anchor;
     m_currentAnchorRect = anchor.boundingBoxInRootViewCoordinates();
-    Ref { *m_page }->send(Messages::WebPageProxy::ShowValidationMessage(m_currentAnchorRect, WTF::move(message)));
+
+    std::optional<FrameIdentifier> rootFrameID;
+    if (RefPtr view = anchor.document().view())
+        rootFrameID = view->rootFrameID();
+
+    Ref { *m_page }->send(Messages::WebPageProxy::ShowValidationMessage(m_currentAnchorRect, WTF::move(message), rootFrameID));
 }
 
 void WebValidationMessageClient::hideValidationMessage(const Element& anchor)


### PR DESCRIPTION
#### 4221343a3e61e96082cef53d6bfd5b33003d3287
<pre>
[Site Isolation] Validation message bubble is positioned incorrectly in cross-origin iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=312399">https://bugs.webkit.org/show_bug.cgi?id=312399</a>
<a href="https://rdar.apple.com/174855372">rdar://174855372</a>

Reviewed by Aditya Keerthi.

Add rootFrameID to the ShowValidationMessage IPC message and call
convertRectToMainFrameCoordinates() on the UIProcess side before displaying
the validation bubble. This converts the anchor rect from subframe coordinates
to main-frame coordinates when the element is inside a cross-origin iframe.

Updated the Mac, iOS, and GTK handlers to use the async coordinate conversion
pattern already established by the color picker, datalist, and datetime picker
fixes.

Test: http/tests/site-isolation/validation-message-cross-origin-iframe.html

* LayoutTests/http/tests/site-isolation/resources/validation-message-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/validation-message-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/validation-message-cross-origin-iframe.html: Added.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showValidationMessage):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp:
(WebKit::WebPageProxy::showValidationMessageWithMainFrameRect):
(WebKit::WebPageProxy::showValidationMessage):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::showValidationMessageWithMainFrameRect):
(WebKit::WebPageProxy::showValidationMessage):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::showValidationMessageWithMainFrameRect):
(WebKit::WebPageProxy::showValidationMessage):
* Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp:
(WebKit::WebValidationMessageClient::showValidationMessage):

Canonical link: <a href="https://commits.webkit.org/313326@main">https://commits.webkit.org/313326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b18fa60f442f0a31d1fe964ea0a3b311bbf7fc81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36251 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/29441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119221 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b83644fc-813b-4677-b0e4-2d1fd8e95f15) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126346 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7034e578-96d0-454d-891d-21de9e6868a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106923 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0eccdce5-00d0-493d-ba32-c93c1c5c2fea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27740 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26272 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19413 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174217 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21709 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134656 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134651 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36326 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145785 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98324 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29189 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22621 "Exiting early after 60 failures. 62990 tests run. 60 failures") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35419 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103379 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34920 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35165 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35068 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->