### PR TITLE
[JSC] Add per-function dump filtering to greedy register allocator

### DIFF
--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -48,6 +48,7 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/TriState.h>
 #include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace JSC {
 
@@ -98,6 +99,9 @@ public:
 
     // Usually you use this via OriginDump, though it's cool to use it directly.
     void printOrigin(PrintStream& out, Origin origin) const;
+
+    void setName(String name) { m_name = WTF::move(name); }
+    const String& name() const { return m_name; }
 
     // This is a debugging hack. Sometimes while debugging B3 you need to break the abstraction
     // and get at the DFG Graph, or whatever data structure the frontend used to describe the
@@ -333,6 +337,7 @@ private:
     UniqueRef<AbstractHeapRepository> m_heaps;
     RefPtr<SharedTask<void(PrintStream&, Origin)>> m_originPrinter;
     const void* m_frontendData;
+    String m_name;
     PCToOriginMap m_pcToOriginMap;
     RefPtr<JSON::Array> m_ionGraphPasses;
     unsigned m_numEntrypoints { 1 };

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -766,6 +766,8 @@ public:
         m_stats[GP].numTmpsIn = m_code.numTmps(GP);
         m_stats[FP].numTmpsIn = m_code.numTmps(FP);
 
+        dataLogLnIf(verbose() || shouldDumpFunction(), "Greedy register allocator: function ", m_code.proc().name(), " input IR:\n", m_code);
+
         // FIXME: reconsider use of padIntereference, https://bugs.webkit.org/show_bug.cgi?id=288122
         padInterference(m_code);
         buildRegisterSets();
@@ -777,7 +779,7 @@ public:
         coalesceTmps<GP>();
         coalesceTmps<FP>();
 
-        dataLogLnIf(verbose(), "State before greedy register allocation:\n", *this);
+        dataLogLnIf(verbose() || shouldDumpFunction(), "Greedy register allocator: function ", m_code.proc().name(), " state before allocate registers:\n", *this, "IR:\n", m_code);
 
         allocateRegisters<GP>();
         allocateRegisters<FP>();
@@ -787,6 +789,8 @@ public:
         validateAssignments<GP>();
         validateAssignments<FP>();
 
+        dataLogLnIf(verbose() || shouldDumpFunction(), "Greedy register allocator: function ", m_code.proc().name(), " about to assign registers:\n", *this, "IR:\n", m_code);
+
         assignRegisters();
         fixSpillsAfterTerminals(m_code);
 
@@ -794,6 +798,16 @@ public:
         m_stats[FP].didSpill += m_didSpill[FP];
         m_stats[GP].numTmpsOut = m_code.numTmps(GP);
         m_stats[FP].numTmpsOut = m_code.numTmps(FP);
+
+        dataLogLnIf(verbose() || shouldDumpFunction(), "Greedy register allocator: function ", m_code.proc().name(), " output IR:\n", m_code);
+    }
+
+    bool shouldDumpFunction() const
+    {
+        const char* filter = Options::airGreedyRegAllocDumpFunction();
+        if (!filter)
+            return false;
+        return m_code.proc().name().find(String::fromLatin1(filter)) != notFound;
     }
 
     void dump(PrintStream& out) const
@@ -3077,7 +3091,6 @@ private:
     void assignRegisters()
     {
         CompilerTimingScope timingScope("Air"_s, "GreedyRegAlloc::assignRegisters"_s);
-        dataLogLnIf(verbose(), "Greedy register allocator about to assign registers:\n", *this, "IR:\n", m_code);
 
         for (BasicBlock* block : m_code) {
             for (Inst& inst : *block) {
@@ -3145,7 +3158,7 @@ private:
     BlockWorklist m_fastBlocks;
     UseCounts m_useCounts;
     TmpWidth m_tmpWidth;
-    std::array<AirAllocateRegistersStats, numBanks> m_stats = { GP, FP };
+    std::array<AirAllocateRegistersStats, numBanks> m_stats = { { { GP, m_code.proc().name() }, { FP, m_code.proc().name() } } };
     std::array<bool, numBanks> m_didSpill { };
     bool m_needsEmitSpillCode { false };
     bool m_hasUseDefLists { false };
@@ -3156,10 +3169,8 @@ private:
 void allocateRegistersByGreedy(Code& code)
 {
     PhaseScope phaseScope(code, "allocateRegistersByGreedy"_s);
-    dataLogIf(Greedy::verbose(), "Air before greedy register allocation:\n", code);
     Greedy::GreedyAllocator allocator(code);
     allocator.run();
-    dataLogIf(Greedy::verbose(), "Air after greedy register allocation:\n", code);
 }
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirPhaseStats.h
+++ b/Source/JavaScriptCore/b3/air/AirPhaseStats.h
@@ -33,6 +33,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>
 #include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/WTFString.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
@@ -45,6 +46,8 @@ namespace JSC { namespace B3 { namespace Air {
 public:                                                                 \
     forEachMacro(PHASE_STATS_MEMBER)                                    \
                                                                         \
+    void setLabel(const String& label) { m_label = label; }             \
+                                                                        \
     void dump(PrintStream& out) const {                                 \
         forEachMacro(PHASE_STATS_PRINT)                                 \
     }                                                                   \
@@ -53,8 +56,11 @@ public:                                                                 \
                                                                         \
     ~className() {                                                      \
         if (collectingStats())                                          \
-            dataLogLn(name(), " stats:", pointerDump(this));            \
+            dataLogLn(name(), " stats [", m_label, "]:", pointerDump(this)); \
     }                                                                   \
+                                                                        \
+private:                                                                \
+    String m_label;
 
 } } } // namespace JSC::B3::Air
 

--- a/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
+++ b/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
@@ -69,8 +69,8 @@ namespace JSC { namespace B3 { namespace Air {
 
 class AirAllocateRegistersStats {
 public:
-    AirAllocateRegistersStats(Bank bank)
-        : m_bank(bank) { }
+    AirAllocateRegistersStats(Bank bank, const String& label = { })
+        : m_bank(bank) { setLabel(label); }
 
     ASCIILiteral name() const
     {

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -70,6 +70,8 @@ State::State(Graph& graph)
 
     proc = makeUniqueWithoutFastMallocCheck<Procedure>(/* usesSIMD = */ false);
 
+    proc->setName(graph.m_codeBlock->inferredNameWithHash());
+
     if (graph.m_vm.shouldBuilderPCToCodeOriginMapping() || Options::useIRDump() || Options::useSourceCodeDump())
         proc->setNeedsPCToOriginMap();
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -507,6 +507,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, airForceBriggsAllocator, false, Normal, nullptr) \
     v(Bool, airForceIRCAllocator, false, Normal, nullptr) \
     v(Bool, airGreedyRegAllocVerbose, false, Normal, nullptr) \
+    v(OptionString, airGreedyRegAllocDumpFunction, nullptr, Normal, "dump greedy register allocator state and IR for functions matching this substring"_s) \
     v(Bool, airUseGreedyRegAlloc, true, Normal, nullptr) \
     v(Double, airGreedyRegAllocSplitMultiplier, 2.0, Normal, nullptr) \
     v(Bool, airGreedyRegAllocSpillsEverything, false, Normal, nullptr) \

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -6497,6 +6497,7 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
     compilationContext.procedure = makeUniqueWithoutFastMallocCheck<Procedure>(info.usesSIMD(functionIndex));
 
     Procedure& procedure = *compilationContext.procedure;
+    procedure.setName(callee.nameWithHash());
     if (shouldDumpIRFor(functionIndex + info.importFunctionCount()))
         procedure.setShouldDumpIR();
 


### PR DESCRIPTION
#### 86d3f77f318bb5d9edb248a70ee386d99c239efe
<pre>
[JSC] Add per-function dump filtering to greedy register allocator
<a href="https://bugs.webkit.org/show_bug.cgi?id=312400">https://bugs.webkit.org/show_bug.cgi?id=312400</a>
<a href="https://rdar.apple.com/174856004">rdar://174856004</a>

Reviewed by Yijia Huang.

The --airGreedyRegAllocVerbose option is useful for detailed debugging
but for large wasm modules, it produces too much output.

So for understanding transformations the register allocator is performing
on a particular function (especially for performance analysis), add
the --airGreedyRegAllocDumpFunction=filter option to dump greedy register
allocator state and IR for functions matching a substring filter.

Also, attach the function simple name + hash to the register allocator stats
output.

To accomplish this, store the simple name + hash into the B3::Procedure.
Also, consolidate IR dump points inside GreedyAllocator::run().

* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::setName):
(JSC::B3::Procedure::name const):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::run):
(JSC::B3::Air::Greedy::GreedyAllocator::shouldDumpFunction const):
(JSC::B3::Air::Greedy::GreedyAllocator::assignRegisters):
(JSC::B3::Air::allocateRegistersByGreedy):
* Source/JavaScriptCore/b3/air/AirPhaseStats.h:
* Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h:
(JSC::B3::Air::AirAllocateRegistersStats::AirAllocateRegistersStats):
* Source/JavaScriptCore/ftl/FTLState.cpp:
(JSC::FTL::State::State):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::parseAndCompileOMG):

Canonical link: <a href="https://commits.webkit.org/311592@main">https://commits.webkit.org/311592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9815d2424ebd6a2f7767cf0c06bf15ffdd7ab9f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156633 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110714 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121332 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85225 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102000 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3785c8fd-ae8e-4703-a92a-99c259d0bfcc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22607 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20800 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13228 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148683 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167939 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17468 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12059 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129442 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129552 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140286 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87295 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23941 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17089 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188594 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29202 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93166 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48441 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28727 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28957 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->