### PR TITLE
[CMake] Resolve a bunch of warning output

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -7,6 +7,10 @@ enable_language(ASM)
 
 add_definitions(-DLIBYUV_DISABLE_SME)
 add_definitions(-DLIBYUV_DISABLE_SVE)
+add_definitions(-DWEBRTC_WEBKIT_BUILD=1)
+
+# Suppress all warnings for third-party libwebrtc code.
+add_compile_options(-w)
 
 if (NOT APPLE)
     find_package(LibEvent)
@@ -2273,7 +2277,6 @@ add_library(webrtc STATIC ${webrtc_SOURCES})
 target_compile_options(webrtc PRIVATE
     "$<$<COMPILE_LANGUAGE:CXX>:-std=c++2b>"
     "-UHAVE_CONFIG_H"
-    "-w"
 )
 
 set_target_properties(webrtc PROPERTIES CXX_VISIBILITY_PRESET hidden)
@@ -2321,7 +2324,6 @@ target_compile_definitions(webrtc PRIVATE
   WEBRTC_USE_H265=1
   RTC_ENABLE_H265
   DISABLE_RTC_AV1
-  WEBRTC_WEBKIT_BUILD=1
   WTF_USE_DYNAMIC_ANNOTATIONS=1
   _GNU_SOURCE
   HWAES
@@ -2420,10 +2422,6 @@ set(libsrtp_SOURCES
 )
 
 add_library(libsrtp OBJECT ${libsrtp_SOURCES})
-
-target_compile_options(libsrtp PRIVATE
-    "-w"
-)
 
 target_compile_definitions(libsrtp PRIVATE
     GCM
@@ -3247,4 +3245,3 @@ endif ()
 
 target_include_directories(vpx PRIVATE ${vpx_INCLUDE_DIRECTORIES})
 target_compile_options(vpx PRIVATE -Wno-cast-align -Wno-incompatible-pointer-types)
-target_compile_definitions(vpx PRIVATE WEBRTC_WEBKIT_BUILD=1)

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -303,17 +303,17 @@ endif ()
 add_link_options(-Wl,-dead_strip)
 add_link_options(-Wl,-dead_strip_dylibs)
 
-# Thin archives (ar crsT): store paths to .o files instead of copying contents.
-# Apple's ar supports T but OptionsCommon.cmake only auto-detects GNU ar.
 if (CMAKE_GENERATOR STREQUAL "Ninja")
-    set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> crsT <TARGET> <OBJECTS>")
-    set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> crsT <TARGET> <OBJECTS>")
-    set(CMAKE_CXX_ARCHIVE_APPEND "<CMAKE_AR> rsT <TARGET> <OBJECTS>")
-    set(CMAKE_C_ARCHIVE_APPEND "<CMAKE_AR> rsT <TARGET> <OBJECTS>")
-    # Thin archives can't be ranlib'd (they have no symbol table to update); make it a no-op.
+    set(CMAKE_CXX_ARCHIVE_CREATE "xcrun libtool -static -no_warning_for_no_symbols -o <TARGET> <OBJECTS>")
+    set(CMAKE_C_ARCHIVE_CREATE "xcrun libtool -static -no_warning_for_no_symbols -o <TARGET> <OBJECTS>")
+    set(CMAKE_CXX_ARCHIVE_APPEND "xcrun libtool -static -no_warning_for_no_symbols -o <TARGET> <TARGET> <OBJECTS>")
+    set(CMAKE_C_ARCHIVE_APPEND "xcrun libtool -static -no_warning_for_no_symbols -o <TARGET> <TARGET> <OBJECTS>")
     set(CMAKE_CXX_ARCHIVE_FINISH true)
     set(CMAKE_C_ARCHIVE_FINISH true)
 endif ()
+
+# Suppress "has no symbols" warnings from Swift's internal libtool invocation (e.g. PAL).
+set(CMAKE_STATIC_LINKER_FLAGS "-no_warning_for_no_symbols")
 
 # Apple Silicon handles more concurrent links than the default pool size.
 if (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" AND NOT DEFINED ENV{WEBKIT_NINJA_LINK_MAX})


### PR DESCRIPTION
#### 46005ca5a96a854adf0464ab6b484e53c2356908
<pre>
[CMake] Resolve a bunch of warning output
<a href="https://bugs.webkit.org/show_bug.cgi?id=312406">https://bugs.webkit.org/show_bug.cgi?id=312406</a>
<a href="https://rdar.apple.com/174862227">rdar://174862227</a>

Reviewed by Brandon Stewart.

Ignore warnings when building WebRTC because it&apos;s third party code we don&apos;t
control, and it has warnings.

Define WEBRTC_WEBKIT_BUILD because the Xcode build does.

Use libtool because it&apos;s the platform tool and we can suppress warnings for
empty .o files.

* Source/ThirdParty/libwebrtc/CMakeLists.txt:
* Source/cmake/OptionsMac.cmake:

Canonical link: <a href="https://commits.webkit.org/311335@main">https://commits.webkit.org/311335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/006d14fcae2b545a011bf87a558a143397d202bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30042 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/23225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165529 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/30178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30045 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159664 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/30178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102046 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/30178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13301 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/148756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/30178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168012 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/17541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/20175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129602 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/29567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/140349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23852 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/29567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/188667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29275 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/188667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->