### PR TITLE
[GFC] Handle percentage and calc specified size suggestion.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -65,18 +65,13 @@ static bool NODELETE spansFlexMaxTrackSizingFunction(WTF::Range<size_t> spannedT
     return false;
 }
 
-static std::optional<LayoutUnit> inlineSpecifiedSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding)
+static std::optional<LayoutUnit> inlineSpecifiedSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, LayoutUnit containingBlockSize)
 {
     auto& preferredSize = gridItem.inlineAxisSizes().preferredSize;
-    return WTF::switchOn(preferredSize,
-        [&](const Style::PreferredSize::Fixed fixedSize) -> std::optional<LayoutUnit> {
-            return Style::evaluate<LayoutUnit>(fixedSize, gridItem.usedZoom()) + borderAndPadding;
-        },
-        [](const auto&) -> std::optional<LayoutUnit> {
-            ASSERT_NOT_IMPLEMENTED_YET();
-            return { };
-        }
-    );
+    if (preferredSize.isFixed() || preferredSize.isPercent() || preferredSize.isCalculated())
+        return Style::evaluate<LayoutUnit>(preferredSize, containingBlockSize, gridItem.usedZoom()) + borderAndPadding;
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
 }
 
 static std::optional<LayoutUnit> NODELETE inlineTransferredSizeSuggestion(const PlacedGridItem&)
@@ -91,17 +86,13 @@ static LayoutUnit inlineContentSizeSuggestion(const PlacedGridItem& gridItem, co
     return integrationUtils.minContentWidth(gridItem.layoutBox());
 }
 
-static std::optional<LayoutUnit> blockSpecifiedSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding)
+static std::optional<LayoutUnit> blockSpecifiedSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, LayoutUnit containingBlockSize)
 {
     auto& preferredSize = gridItem.blockAxisSizes().preferredSize;
-    return WTF::switchOn(preferredSize,
-        [&](const Style::PreferredSize::Fixed fixedSize) -> std::optional<LayoutUnit> {
-            return Style::evaluate<LayoutUnit>(fixedSize, gridItem.usedZoom()) + borderAndPadding;
-        },
-        [](const auto&) -> std::optional<LayoutUnit> {
-            ASSERT_NOT_IMPLEMENTED_YET();
-            return { };
-    });
+    if (preferredSize.isFixed() || preferredSize.isPercent() || preferredSize.isCalculated())
+        return Style::evaluate<LayoutUnit>(preferredSize, containingBlockSize, gridItem.usedZoom()) + borderAndPadding;
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
 }
 
 static std::optional<LayoutUnit> NODELETE blockTransferredSizeSuggestion(const PlacedGridItem&)
@@ -181,7 +172,7 @@ LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem& placedGridItem, Layou
 
 // https://drafts.csswg.org/css-grid-1/#min-size-auto
 static LayoutUnit automaticMinimumInlineSize(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, const TrackSizingFunctionsList& trackSizingFunctions,
-    const IntegrationUtils& integrationUtils)
+    LayoutUnit containingBlockSize, const IntegrationUtils& integrationUtils)
 {
     auto& inlineAxisSizes = gridItem.inlineAxisSizes();
     ASSERT(inlineAxisSizes.minimumSize.isAuto());
@@ -211,7 +202,7 @@ static LayoutUnit automaticMinimumInlineSize(const PlacedGridItem& gridItem, Lay
     // The content-based minimum size for a grid item in a given dimension is its
     auto contentBasedMinimumSize = [&] {
         // specified size suggestion if it exists
-        if (auto specifiedSizeSuggestion = inlineSpecifiedSizeSuggestion(gridItem, borderAndPadding))
+        if (auto specifiedSizeSuggestion = inlineSpecifiedSizeSuggestion(gridItem, borderAndPadding, containingBlockSize))
             return *specifiedSizeSuggestion;
 
         // otherwise its transferred size suggestion if that exists and the element is replaced
@@ -233,7 +224,7 @@ static LayoutUnit automaticMinimumInlineSize(const PlacedGridItem& gridItem, Lay
 
 // https://drafts.csswg.org/css-grid-1/#min-size-auto
 static LayoutUnit automaticMinimumBlockSize(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, const TrackSizingFunctionsList& trackSizingFunctions,
-    const IntegrationUtils& integrationUtils)
+    LayoutUnit containingBlockSize, const IntegrationUtils& integrationUtils)
 {
     auto& blockAxisSizes = gridItem.blockAxisSizes();
     ASSERT(blockAxisSizes.minimumSize.isAuto());
@@ -263,7 +254,7 @@ static LayoutUnit automaticMinimumBlockSize(const PlacedGridItem& gridItem, Layo
     // The content-based minimum size for a grid item in a given dimension is its
     auto contentBasedMinimumSize = [&] {
         // specified size suggestion if it exists
-        if (auto specifiedSizeSuggestion = blockSpecifiedSizeSuggestion(gridItem, borderAndPadding))
+        if (auto specifiedSizeSuggestion = blockSpecifiedSizeSuggestion(gridItem, borderAndPadding, containingBlockSize))
             return *specifiedSizeSuggestion;
 
         // otherwise its transferred size suggestion if that exists and the element is replaced
@@ -345,7 +336,7 @@ LayoutUnit usedInlineMinimumSize(const PlacedGridItem& gridItem, const TrackSizi
             return Style::evaluate<LayoutUnit>(calculated, columnsSize, gridItem.usedZoom()) + borderAndPadding;
         },
         [&](const CSS::Keyword::Auto&) -> LayoutUnit {
-            return automaticMinimumInlineSize(gridItem, borderAndPadding, trackSizingFunctions, integrationUtils);
+            return automaticMinimumInlineSize(gridItem, borderAndPadding, trackSizingFunctions, columnsSize, integrationUtils);
         },
         [](const auto&) -> LayoutUnit {
             ASSERT_NOT_IMPLEMENTED_YET();
@@ -368,7 +359,7 @@ LayoutUnit usedBlockMinimumSize(const PlacedGridItem& gridItem, const TrackSizin
             return Style::evaluate<LayoutUnit>(calculated, rowsSize, gridItem.usedZoom()) + borderAndPadding;
         },
         [&](const CSS::Keyword::Auto&) -> LayoutUnit {
-            return automaticMinimumBlockSize(gridItem, borderAndPadding, trackSizingFunctions, integrationUtils);
+            return automaticMinimumBlockSize(gridItem, borderAndPadding, trackSizingFunctions, rowsSize, integrationUtils);
         },
         [](const auto&) -> LayoutUnit {
             ASSERT_NOT_IMPLEMENTED_YET();


### PR DESCRIPTION
#### b76ea8760138439b638991c4bbe1ab384d3f68ba
<pre>
[GFC] Handle percentage and calc specified size suggestion.
<a href="https://bugs.webkit.org/show_bug.cgi?id=312409">https://bugs.webkit.org/show_bug.cgi?id=312409</a>
&lt;<a href="https://rdar.apple.com/174863227">rdar://174863227</a>&gt;

Reviewed by Sammy Gill.

Per <a href="https://drafts.csswg.org/css-grid-2/#specified-size-suggestion">https://drafts.csswg.org/css-grid-2/#specified-size-suggestion</a>:
&quot;If the item’s preferred size in the relevant axis is definite, then the
specified size suggestion is that size. It is otherwise undefined.&quot;&quot;

This PR updates GridLayoutUtils to handle inline and block specified
size suggestions for percentage and calc sizing. Previously percent
and calc preferred size would hit ASSERT_NOT_IMPLEMENTED_YET().

This PR also pipes sizes needed to resolve percent and calc values.

* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::inlineSpecifiedSizeSuggestion):
(WebCore::Layout::GridLayoutUtils::blockSpecifiedSizeSuggestion):
(WebCore::Layout::GridLayoutUtils::automaticMinimumInlineSize):
(WebCore::Layout::GridLayoutUtils::automaticMinimumBlockSize):
(WebCore::Layout::GridLayoutUtils::usedInlineMinimumSize):
(WebCore::Layout::GridLayoutUtils::usedBlockMinimumSize):

Canonical link: <a href="https://commits.webkit.org/311344@main">https://commits.webkit.org/311344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00311ed2c313379ebc20b6a549676a413d8c1e91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110743 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121341 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85232 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102009 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22622 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20818 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13257 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167968 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129456 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129566 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29523 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140299 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87324 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23854 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17102 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29231 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28756 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28986 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28882 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->