### PR TITLE
[JSC][WASM][Debugger] Fix library:; sent before debugger is ready and update stop description pattern in tests

### DIFF
--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -2038,7 +2038,7 @@ class DynamicModuleLoadTestCase(BaseTestCase):
 
         # Resume: stops for the module-load notification (library:; T-packet) when module 2 is
         # instantiated.  LLDB re-queries qXfer:libraries:read and loads module 2.
-        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "new wasm module loaded"])
+        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "loaded new wasm module with ids: 1"])
 
         # Set a breakpoint at the 'end' instruction of func_b in module 2 (virtual address
         # 0x4000000100000023).  Module 2 is now loaded, so the breakpoint resolves immediately.
@@ -2076,7 +2076,7 @@ class SwiftWasmDynamicModuleLoadTestCase(BaseTestCase):
         # Resume: stops at when Module B is loaded and the associated instance is created. This stop trigger
         # LLDB re-querying debug info and resolving the pending breakpoint for func_b, confirming that dynamic
         # module load triggers pending breakpoint resolution.
-        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "new wasm module loaded"])
+        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "loaded new wasm module with ids: 1"])
         self.send_lldb_command_or_raise("br list", patterns=["func_a", "func_b"])
 
         # Resume: stops at the func_b breakpoint (module B) on the first call, confirming that the pending breakpoint was resolved via debug info.

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -827,7 +827,9 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
     // Append library:; to prompt LLDB to re-query qXfer:libraries:read when there are pending
     // library changes: (1) new-module-load stop, (2) piggybacked on any natural stop when a module
     // was loaded but no dedicated stop fired yet, (3) module removal via unregisterModule().
-    if (m_moduleManager.needsLibraryRequery()) {
+    // Gated on isDebuggerReady() to avoid sending library:; in the ? reply before the initial
+    // qXfer:libraries:read handshake completes.
+    if (m_moduleManager.needsLibraryRequery() && m_debugServer.isDebuggerReady()) {
         reply.append("library:;"_s);
         // Include a human-readable description only for dedicated new-module-load stops.
         if (state->isNewModuleLoad) {


### PR DESCRIPTION
#### 0c340a7ddd0f875b645a214ccf6c4165929bf73f
<pre>
[JSC][WASM][Debugger] Fix library:; sent before debugger is ready and update stop description pattern in tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=312408">https://bugs.webkit.org/show_bug.cgi?id=312408</a>
<a href="https://rdar.apple.com/174862846">rdar://174862846</a>

Reviewed by Mark Lam.

This patch is a follow-up fix for [1].

Guard needsLibraryRequery() with isDebuggerReady() so library:; is not included in
the stop reply to LLDB&apos;s initial ? packet. Without the guard, modules registered
before LLDB attached would leave m_unnotifiedModuleIds non-empty, causing the ?
reply to carry library:; before the first qXfer:libraries:read had even been processed.
This would confuse LLDB during the initial connection handshakes.

Also update two test patterns to match the new stop description format introduced
in [1] (&quot;new wasm module loaded&quot; -&gt; &quot;loaded new wasm module with ids: 1&quot;).

[1] <a href="https://commits.webkit.org/311291@main">https://commits.webkit.org/311291@main</a>

Canonical link: <a href="https://commits.webkit.org/311389@main">https://commits.webkit.org/311389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d778c858a66ea32f92c676cd8ab831d73446415

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165494 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110752 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121348 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85237 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102016 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22632 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20826 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13266 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148721 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167977 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17506 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12150 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129464 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129574 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140309 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87333 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23872 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24400 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17112 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188632 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93263 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48450 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28765 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28995 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28891 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->