### PR TITLE
[Swift] Add multi-platform macros to support downlevels

### DIFF
--- a/Source/WebKit/Scripts/generate-swift-availability-macros
+++ b/Source/WebKit/Scripts/generate-swift-availability-macros
@@ -1,4 +1,19 @@
-#!/bin/sh
+#!/bin/bash
+# Generates custom availability versions usable by Swift @available attributes,
+# based on build-time conditions. For example:
+#
+#     @available(anyAppleOSAndDownlevels 26.0, *)
+#     public func ...
+#
+# denotes a declaration that shipped on all OS releases that contain anyAppleOSAndDownlevels 26.0.
+# In comparison:
+#
+#     @available(TBA, *)
+#     public func ...
+#
+# denotes a declaration which has not yet shipped in a public OS release. In
+# internal builds, the TBA will be replaced with an actual version number in
+# the module's interface.
 
 for search_path in "${BUILT_PRODUCTS_DIR}" "${SDKROOT}"; do
     candidate="${search_path}${WK_LIBRARY_HEADERS_FOLDER_PATH}/WebKitAdditions/Scripts/postprocess-framework-headers-definitions"
@@ -33,6 +48,46 @@ else
     [[ -n ${IOS_VERSION} ]] || IOS_VERSION="9999"
 fi
 
-echo "-Xfrontend -define-availability -Xfrontend \"WK_IOS_TBA:iOS ${IOS_VERSION}\"" \
-    "-Xfrontend -define-availability -Xfrontend \"WK_MAC_TBA:macOS ${OSX_VERSION}\"" \
-    "-Xfrontend -define-availability -Xfrontend \"WK_XROS_TBA:visionOS ${XROS_VERSION}\"" | tee "${SCRIPT_OUTPUT_FILE_0}"
+# Platform version numbers are dynamic: either the release version OR the
+# active deployment target, whichever is lower. This supports building
+# downlevels, where clients can use API that did not officially ship in that
+# release's SDK.
+function macOS {
+    minVersion=$(printf '%s\n' $1 ${MACOSX_DEPLOYMENT_TARGET} | sort -V | head -1)
+    echo macOS ${minVersion}
+}
+
+function iOS {
+    minVersion=$(printf '%s\n' $1 ${IPHONEOS_DEPLOYMENT_TARGET} | sort -V | head -1)
+    echo iOS ${minVersion}
+}
+
+function visionOS {
+    minVersion=$(printf '%s\n' $1 ${XROS_DEPLOYMENT_TARGET} | sort -V | head -1)
+    echo visionOS ${minVersion}
+}
+
+releases="
+# Shipped releases which contribute Swift API.
+anyAppleOSAndDownlevels 14.0: $(macOS 10.16), $(iOS 14.0)
+anyAppleOSAndDownlevels 15.0: $(macOS 12.0), $(iOS 15.0)
+anyAppleOSAndDownlevels 17.0: $(macOS 14.0), $(iOS 17.0), $(visionOS 1.0)
+anyAppleOSAndDownlevels 18.4: $(macOS 15.4), $(iOS 18.4), $(visionOS 2.4)
+anyAppleOSAndDownlevels 26.0: $(macOS 26.0), $(iOS 26.0), $(visionOS 26.0)
+anyAppleOSAndDownlevels 26.4: $(macOS 26.4), $(iOS 26.4), $(visionOS 26.4)
+
+# Upcoming API, release version unspecified.
+TBA: macOS ${OSX_VERSION}, iOS ${IOS_VERSION}, visionOS ${XROS_VERSION}
+
+# Legacy platform-specific versions that work like WebKit's ObjC availability
+# versions.
+WK_IOS_TBA: iOS ${IOS_VERSION}
+WK_MAC_TBA: macOS ${OSX_VERSION}
+WK_XROS_TBA: visionOS ${XROS_VERSION}
+"
+
+# Turn the release table into compiler arguments.
+echo "${releases}" | while read line; do
+    [[ -n "${line}" && "${line}" != \#* ]] || continue
+    echo "-Xfrontend -define-availability -Xfrontend \"${line}\""
+done | tee "${SCRIPT_OUTPUT_FILE_0}"

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore+SwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore+SwiftOverlay.swift
@@ -28,7 +28,7 @@ extension WKWebsiteDataStore {
     ///
     /// Changing the proxy configurations might interrupt current networking operations in any WKWebView that use this WKWebsiteDataStore,
     /// so it is encouraged to finish setting the proxy configurations before starting any page loads.
-    @available(iOS 17.0, macOS 14.0, visionOS 1.0, *)
+    @available(anyAppleOSAndDownlevels 17.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public var proxyConfigurations: [ProxyConfiguration] {

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -31,7 +31,7 @@
 import WebKit_Private.WKWebExtensionPrivate
 #endif
 
-@available(iOS 14.0, macOS 10.16, *)
+@available(anyAppleOSAndDownlevels 14.0, *)
 extension WKPDFConfiguration {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -41,7 +41,7 @@ extension WKPDFConfiguration {
     }
 }
 
-@available(iOS 14.0, macOS 10.16, *)
+@available(anyAppleOSAndDownlevels 14.0, *)
 extension WKWebView {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -99,7 +99,7 @@ extension WKWebView {
     }
 }
 
-@available(iOS 15.0, macOS 12.0, *)
+@available(anyAppleOSAndDownlevels 15.0, *)
 extension WKWebView {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -136,7 +136,7 @@ extension WKWebView {
 }
 
 #if ENABLE_WK_WEB_EXTENSIONS
-@available(iOS 18.4, macOS 15.4, visionOS 2.4, *)
+@available(anyAppleOSAndDownlevels 18.4, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension WKWebExtension {
@@ -165,7 +165,7 @@ extension WKWebExtension {
     }
 }
 
-@available(iOS 18.4, macOS 15.4, visionOS 2.4, *)
+@available(anyAppleOSAndDownlevels 18.4, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension WKWebExtensionController {
@@ -188,7 +188,7 @@ extension WKWebExtensionController {
     }
 }
 
-@available(iOS 18.4, macOS 15.4, visionOS 2.4, *)
+@available(anyAppleOSAndDownlevels 18.4, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension WKWebExtensionContext {

--- a/Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift
+++ b/Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift
@@ -30,7 +30,7 @@ import WebKit_Internal
 ///
 /// Scheme names are case sensitive, must start with an ASCII letter, and may contain only ASCII letters,
 /// numbers, the “+” character, the “-” character, and the “.” character.
-@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+@available(anyAppleOSAndDownlevels 26.0, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 public struct URLScheme: Hashable, Sendable {
@@ -54,7 +54,7 @@ public struct URLScheme: Hashable, Sendable {
 }
 
 /// A value used as part of a sequence of results from a ``URLSchemeHandler``, which can either be a `Data` or a `URLResponse`.
-@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+@available(anyAppleOSAndDownlevels 26.0, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 public enum URLSchemeTaskResult: Sendable {
@@ -90,7 +90,7 @@ public enum URLSchemeTaskResult: Sendable {
 /// If WebKit determines that it no longer needs a resource that your handler is loading, it will cancel
 /// the Task responsible for the async sequence. Typically, this may happen when the user navigates to another
 /// page, but may happen for other reasons.
-@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+@available(anyAppleOSAndDownlevels 26.0, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 public protocol URLSchemeHandler {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift
@@ -95,7 +95,7 @@ extension WebPage {
     /// Because ``WebPage/backForwardList`` is an observable property, the states of these buttons
     /// are automatically updated.
     @MainActor
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct BackForwardList: Equatable, Sendable {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -28,7 +28,7 @@ import Foundation
 extension WebPage {
     /// A configuration type that specifies the preferences and behaviors of a webpage.
     @MainActor
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct Configuration {
@@ -178,7 +178,7 @@ extension WebPage {
 
 extension WebPage {
     /// A type that describes the authorization permissions policy for the device's sensors a web resource may access.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct DeviceSensorAuthorization {
@@ -210,7 +210,7 @@ extension WebPage {
 
 extension WebPage.Configuration {
     /// The behavior used when playing HTML video within a page.
-    @available(iOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @available(macOS, unavailable)

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
@@ -29,7 +29,7 @@ public import Foundation
 
 extension WebPage {
     /// The result of handling a JavaScript confirm invocation.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public enum JavaScriptConfirmResult: Hashable, Sendable {
@@ -41,7 +41,7 @@ extension WebPage {
     }
 
     /// The result of handling a JavaScript confirm invocation.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public enum JavaScriptPromptResult: Hashable, Sendable {
@@ -53,7 +53,7 @@ extension WebPage {
     }
 
     /// The result of handling a JavaScript open invocation.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public enum FileInputPromptResult: Hashable, Sendable {
@@ -74,7 +74,7 @@ extension WebPage {
     /// which will then be communicated back to JavaScript.
     ///
     /// When these methods are invoked, JavaScript is blocked until the async method returns.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public protocol DialogPresenting {
@@ -125,7 +125,7 @@ extension WebPage {
 
 // MARK: Default implementation
 
-@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+@available(anyAppleOSAndDownlevels 26.0, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension WebPage.DialogPresenting {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+FormInfo.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+FormInfo.swift
@@ -28,7 +28,7 @@ public import Foundation
 extension WebPage {
     /// A type that contains information about a form submission from a webpage.
     @MainActor
-    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct FormInfo {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
@@ -28,7 +28,7 @@ public import Foundation
 extension WebPage {
     /// A type that contains information about a frame on a webpage.
     @MainActor
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct FrameInfo {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift
@@ -28,7 +28,7 @@ public import Foundation
 extension WebPage {
     /// An object representing a website-provided immersive environment that is ready for presentation.
     @MainActor
-    @available(WK_XROS_TBA, *)
+    @available(TBA, *)
     @available(iOS, unavailable)
     @available(macOS, unavailable)
     @available(watchOS, unavailable)

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
@@ -27,7 +27,7 @@ import Foundation
 
 extension WebPage {
     /// A particular state that occurs during the progression of a navigation.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public enum NavigationEvent: Hashable, Sendable {
@@ -48,7 +48,7 @@ extension WebPage {
     }
 
     /// A specific error that caused a navigation to fail.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public enum NavigationError: Error {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
@@ -33,7 +33,7 @@ extension WebPage {
     /// A `NavigationAction` value is intended to be used to make policy decisions about whether to
     /// allow navigation within a web page via a `NavigationDeciding`.
     @MainActor
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct NavigationAction {
@@ -78,7 +78,7 @@ extension WebPage {
     /// A `NavigationResponse` value is intended to be used to make policy decisions about whether to
     /// allow navigation within a web page via a `NavigationDeciding`.
     @MainActor
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct NavigationResponse {
@@ -107,7 +107,7 @@ extension WebPage {
     /// Allows providing custom behavior to handle navigation changes and to coordinate these changes for the web page's main page.
     ///
     /// For example, you might use these methods to restrict navigation from specific links within your content.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public protocol NavigationDeciding {
@@ -149,7 +149,7 @@ extension WebPage {
         /// The form submission will not actually proceed until after this callback asynchronously resolves.
         ///
         /// - Parameter formInfo: The form values that will be submitted for this navigation
-        @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+        @available(TBA, *)
         @MainActor
         mutating func willSubmit(formInfo: WebPage.FormInfo) async
     }
@@ -157,7 +157,7 @@ extension WebPage {
 
 // MARK: Default implementation
 
-@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+@available(anyAppleOSAndDownlevels 26.0, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension WebPage.NavigationDeciding {
@@ -185,7 +185,7 @@ extension WebPage.NavigationDeciding {
     }
 
     /// By default, this method does nothing.
-    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(TBA, *)
     @MainActor
     public func willSubmit(formInfo: WebPage.FormInfo) async {
     }

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -31,7 +31,7 @@ extension WebPage {
     /// Create a `NavigationPreferences` value when you want to change the default rendering behavior of
     /// your web page. Typically, iOS devices render web content for a mobile experience, and Mac devices
     /// render content for a desktop experience.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct NavigationPreferences: Sendable {
@@ -64,7 +64,7 @@ extension WebPage {
         }
 
         /// Security restriction modes for WebView content.
-        @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+        @available(anyAppleOSAndDownlevels 26.4, *)
         @available(watchOS, unavailable)
         @available(tvOS, unavailable)
         public enum SecurityRestrictionMode: Sendable {
@@ -121,7 +121,7 @@ extension WebPage {
         /// This preference only applies to main frame navigations and will be ignored for subframe navigations. When set for a main frame, all subframe content and opened windows inherit the same security restrictions.
         /// When the system has chosen `SecurityRestrictionMode.lockdown` (e.g., in Lockdown Mode), attempts to set a less restrictive mode will fail silently.
         /// The default value is `SecurityRestrictionMode.none`.
-        @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+        @available(anyAppleOSAndDownlevels 26.4, *)
         @available(watchOS, unavailable)
         @available(tvOS, unavailable)
         public var securityRestrictionMode: SecurityRestrictionMode {
@@ -130,13 +130,13 @@ extension WebPage {
         }
 
         /// Used to make changes to the network request that will be used for this navigation's main resource load.
-        @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+        @available(TBA, *)
         @available(watchOS, unavailable)
         @available(tvOS, unavailable)
         public var alternateRequest: URLRequest? = nil
 
         /// Used to apply a custom `referer` header to all resource loads in the frame of this navigation.
-        @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+        @available(TBA, *)
         @available(watchOS, unavailable)
         @available(tvOS, unavailable)
         public var overrideReferrer: Swift.String? = nil
@@ -172,7 +172,7 @@ extension WebPage.NavigationPreferences.UpgradeToHTTPSPolicy {
     }
 }
 
-@available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+@available(anyAppleOSAndDownlevels 26.4, *)
 extension WebPage.NavigationPreferences.SecurityRestrictionMode {
     init(_ wrapped: WKSecurityRestrictionMode) {
         self =

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Transferable.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Transferable.swift
@@ -31,7 +31,7 @@ import WebKit_Private
 import WebKit_Private.WKSnapshotConfigurationPrivate
 import WebKit_Private.WKWebViewPrivate
 
-@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+@available(anyAppleOSAndDownlevels 26.0, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension WebPage: Transferable {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -91,7 +91,7 @@ import WebKit_Internal
 /// of PDF or image export, use ``WebPage/exported(as:)``.
 @MainActor
 @Observable
-@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+@available(anyAppleOSAndDownlevels 26.0, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 #if compiler(>=6.2.3)
@@ -104,7 +104,7 @@ final public class WebPage {
     /// by webpages to apply parts of a style sheet depending on the media properties specified.
     ///
     /// You can customize the media type of a ``WebPage`` by using the ``WebPage/mediaType`` property.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct CSSMediaType: Hashable, RawRepresentable, Sendable {
@@ -131,7 +131,7 @@ final public class WebPage {
     }
 
     /// The set of possible fullscreen states a webpage may be in.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public enum FullscreenState: Hashable, Sendable {

--- a/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
@@ -126,7 +126,7 @@ final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate {
         await navigationDecider.decideAuthenticationChallengeDisposition(for: challenge)
     }
 
-    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(TBA, *)
     func webView(
         _ webView: WKWebView,
         willSubmitForm formInfo: WKFormInfo

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -28,7 +28,7 @@ public import SwiftUI
 
 extension View {
     /// Determines whether horizontal swipe gestures trigger backward and forward page navigation.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public nonisolated func webViewBackForwardNavigationGestures(_ value: WebView.BackForwardNavigationGesturesBehavior) -> some View {
@@ -36,7 +36,7 @@ extension View {
     }
 
     /// Determines whether magnify gestures change the view’s magnification.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public nonisolated func webViewMagnificationGestures(_ value: WebView.MagnificationGesturesBehavior) -> some View {
@@ -44,7 +44,7 @@ extension View {
     }
 
     /// Determines whether pressing a link displays a preview of the destination for the link.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public nonisolated func webViewLinkPreviews(_ value: WebView.LinkPreviewBehavior) -> some View {
@@ -52,7 +52,7 @@ extension View {
     }
 
     /// Determines whether to allow people to select or otherwise interact with text.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public nonisolated func webViewTextSelection<S>(_ selectability: S) -> some View where S: TextSelectability {
@@ -60,7 +60,7 @@ extension View {
     }
 
     /// Determines whether a web view can display content full screen.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public nonisolated func webViewElementFullscreenBehavior(_ value: WebView.ElementFullscreenBehavior) -> some View {
@@ -71,7 +71,7 @@ extension View {
     ///
     /// - Parameter menu: A closure that produces the menu. The single parameter to the closure describes the type of webpage element that was acted upon.
     /// - Returns: A view that can display an item-based context menu.
-    @available(macOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(iOS, unavailable)
     @available(visionOS, unavailable)
     @available(watchOS, unavailable)
@@ -98,7 +98,7 @@ extension View {
     ///
     /// - Parameter visibility: The visibility to use for the background.
     /// - Returns: A view with the specified content background visibility.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public nonisolated func webViewContentBackground(_ visibility: Visibility) -> some View {
@@ -114,7 +114,7 @@ extension View {
     /// - Returns: A view that invokes the action when the relevant part of a web view's scroll geometry changes.
     ///
     /// - Note: The content size of web content may exceed the current size of the view's frame, however it will never be smaller than it.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public nonisolated func webViewOnScrollGeometryChange<T>(
@@ -137,7 +137,7 @@ extension View {
     /// Associates a binding to a scroll position with the web view.
     ///
     /// - Note: ``WebView`` does not support scrolling to a view with an identity. It only supports scrolling to a concrete offset, or to an edge.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public nonisolated func webViewScrollPosition(_ position: Binding<ScrollPosition>) -> some View {
@@ -150,7 +150,7 @@ extension View {
     ///   - behavior: Whether scrolling should be enabled or disabled for this input.
     ///   - input: The input for which to enable or disable scrolling.
     /// - Returns: A view with the configured scroll input behavior for web views.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public nonisolated func webViewScrollInputBehavior(_ behavior: ScrollInputBehavior, for input: ScrollInputKind) -> some View {
@@ -186,7 +186,7 @@ extension View {
     ///     the immersive environment. It receives the `WebPage.ImmersiveEnvironment` to dismiss.
     ///     This closure should return after the dismissal transition completes.
     /// - Returns: A modified view that manages immersive environment lifecycle.
-    @available(WK_XROS_TBA, *)
+    @available(TBA, *)
     @available(iOS, unavailable)
     @available(macOS, unavailable)
     @available(watchOS, unavailable)

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift
@@ -29,7 +29,7 @@ public import SwiftUI
 
 extension WebPage {
     /// The theme color that the system gets from the first valid meta tag in the webpage.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public var themeColor: Color? {

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebPageNavigationAction+SwiftUI.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebPageNavigationAction+SwiftUI.swift
@@ -29,7 +29,7 @@ public import SwiftUI
 
 extension WebPage.NavigationAction {
     /// The modifier keys that were pressed at the time of the navigation request.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public var modifierFlags: EventModifiers { EventModifiers(wrapped.modifierFlags) }

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -30,7 +30,7 @@ public import SwiftUI
 ///
 /// Connect a ``WebView`` with a ``WebPage`` to fully control the browsing experience, including essential functionality such as loading a URL.
 /// Any updates to the webpage propagate the information to the view.
-@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+@available(anyAppleOSAndDownlevels 26.0, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 public struct WebView: View {
@@ -98,7 +98,7 @@ public struct WebView: View {
 
 extension WebView {
     /// A type that defines the behavior of how horizontal swipe gestures trigger backward and forward page navigation.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct BackForwardNavigationGesturesBehavior: Sendable {
@@ -132,7 +132,7 @@ extension WebView {
     }
 
     /// The options for controlling the behavior for how magnification gestures interact with web views.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct MagnificationGesturesBehavior: Sendable {
@@ -166,7 +166,7 @@ extension WebView {
     }
 
     /// A type specifying the behavior for the presentation of link previews when pressing a link.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct LinkPreviewBehavior: Sendable {
@@ -200,7 +200,7 @@ extension WebView {
     }
 
     /// The behavior that determines whether a web view can display content full screen.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct ElementFullscreenBehavior: Sendable {
@@ -236,7 +236,7 @@ extension WebView {
     /// Contains information about an element the user activated in a webpage, which may be used to configure a context menu for that element.
     ///
     /// For links, the information contains the URL that is linked to.
-    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(anyAppleOSAndDownlevels 26.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct ActivatedElementInfo: Hashable, Sendable {

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift
@@ -33,7 +33,7 @@ import WebKit_Private
 /// `WebPage.ImmersiveEnvironment` received from the presentation callback to render
 /// that specific environment.
 @MainActor
-@available(WK_XROS_TBA, *)
+@available(TBA, *)
 @available(iOS, unavailable)
 @available(macOS, unavailable)
 @available(watchOS, unavailable)


### PR DESCRIPTION
#### 60ce8b311afabff47c7cce8de2fef8ab02fe42bd
<pre>
[Swift] Add multi-platform macros to support downlevels
<a href="https://bugs.webkit.org/show_bug.cgi?id=294412">https://bugs.webkit.org/show_bug.cgi?id=294412</a>
<a href="https://rdar.apple.com/153851259">rdar://153851259</a>

Reviewed by Richard Robinson.

The platform-specific way of annotating a Swift API `@available(macOS
X.Y, *)` does not work for downlevel builds. We write the OS version
that an API shipped in, but in downlevels, that API is still available,
because we are building a backported WebKit. Yet its declaration
indicates that it is unavailable, so clients cannot use it.

Unlike clang, Swift has no preprocessor, so we can&apos;t easily #undef
availability annotations like we do in Objective-C code.

Instead, switch Cocoa Swift APIs to using a custom availability
platform, whose name is based on the recently-added `anyAppleOS`
platform &lt;<a href="https://forums.swift.org/t/introducing-anyappleos/85728">https://forums.swift.org/t/introducing-anyappleos/85728</a>&gt;.

For example, instead of writing:

    @available(macOS 26.4, iOS 26.4, visionOS 26.4, *)

we now write:

    @availabile(anyAppleOSAndDownlevels 26.4, *)

Also, add a cross-platform &quot;TBA&quot; version to save typing. Instead of:

    @available(WK_MAC_TBA, WK_IOS_TBA, WK_XROS_TBA, *)

write:

    @available(TBA, *)

When an API doesn&apos;t ship on a particular platform, we continue to use
`unavailable` declarations to denote it. For example:

    @available(anyAppleOSAndDownlevels 26.4, *)
    @available(macOS, unavailable)
    @available(watchOS, unavailable)
    @available(tvOS, unavailable)
    public func ...

denotes an iOS and visionOS-only API.

* LayoutTests/TestExpectations:
* Source/WebKit/Scripts/generate-swift-availability-macros:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore+SwiftOverlay.swift:
* Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift:
* Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+FormInfo.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+Transferable.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
* Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift:
* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebPageNavigationAction+SwiftUI.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebView.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift:

Canonical link: <a href="https://commits.webkit.org/312640@main">https://commits.webkit.org/312640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8d9760574cdbeab562787675ed2383c61a88bd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169505 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b1b1479-94e6-4b76-84f0-ab1715c6f63e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124546 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/576713d9-d696-41a9-a150-78c2a8683525) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105146 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/202f7d0a-7489-4bf5-98db-26f8956def84) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/159922 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17225 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135540 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171984 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18859 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132812 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132827 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35894 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143827 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95537 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27425 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20642 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33244 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100464 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32743 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32987 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32891 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->