### PR TITLE
[JSC] Add a bit more module loader tests for "then" tampering

### DIFF
--- a/JSTests/stress/module-loader-object-prototype-then-no-promise-tamper.js
+++ b/JSTests/stress/module-loader-object-prototype-then-no-promise-tamper.js
@@ -1,3 +1,5 @@
+//@ runDefault
+
 // Test that module loading works correctly when Object.prototype.then is set
 // to a callable function. Module records have null prototype and JSSourceCode
 // is a JSCell (not JSObject), so Object.prototype.then should not interfere
@@ -14,10 +16,13 @@ Object.prototype.then = function (resolve, reject) {
 
 import("./resources/module-loader-promise-then-tampered-target.js").then(
     function (ns) {
-        if (ns.value !== 42)
-            throw new Error("Expected ns.value to be 42, got " + ns.value);
+        if (ns.value !== 42) {
+            print("Expected ns.value to be 42, got " + ns.value);
+            $vm.abort();
+        }
     },
     function (e) {
-        throw new Error("Module loading should not have failed: " + e);
+        print("Module loading should not have failed: " + e);
+        $vm.abort();
     }
 );

--- a/JSTests/stress/module-loader-promise-then-reassigned-same-value.js
+++ b/JSTests/stress/module-loader-promise-then-reassigned-same-value.js
@@ -1,3 +1,5 @@
+//@ runDefault
+
 // Test that module loading works correctly when Promise.prototype.then is
 // replaced with the same value (invalidating the watchpoint but not changing
 // behavior). The module should load successfully.
@@ -8,12 +10,17 @@ Promise.prototype.then = originalThen;
 originalThen.call(
     import("./resources/module-loader-promise-then-tampered-target.js"),
     function (ns) {
-        if (ns.value !== 42)
-            throw new Error("Expected ns.value to be 42, got " + ns.value);
-        if (ns.dep !== "from dependency")
-            throw new Error("Expected ns.dep to be 'from dependency', got " + ns.dep);
+        if (ns.value !== 42) {
+            print("Expected ns.value to be 42, got " + ns.value);
+            $vm.abort();
+        }
+        if (ns.dep !== "from dependency") {
+            print("Expected ns.dep to be 'from dependency', got " + ns.dep);
+            $vm.abort();
+        }
     },
     function (e) {
-        throw new Error("Module loading should not have failed: " + e);
+        print("Module loading should not have failed: " + e);
+        $vm.abort();
     }
 );

--- a/JSTests/stress/module-loader-promise-then-tampered-no-deps.js
+++ b/JSTests/stress/module-loader-promise-then-tampered-no-deps.js
@@ -1,3 +1,5 @@
+//@ runDefault
+
 // Test that module loading works for a module with NO dependencies even when
 // Promise.prototype.then is completely replaced. The initial module goes
 // through loadModule's first overload which chains on the already-fulfilled

--- a/JSTests/stress/module-loader-promise-then-tampered.js
+++ b/JSTests/stress/module-loader-promise-then-tampered.js
@@ -18,12 +18,17 @@ Promise.prototype.then = function (onFulfilled, onRejected) {
 originalThen.call(
     import("./resources/module-loader-promise-then-tampered-target.js"),
     function (ns) {
-        if (ns.value !== 42)
-            throw new Error("Expected ns.value to be 42, got " + ns.value);
-        if (ns.dep !== "from dependency")
-            throw new Error("Expected ns.dep to be 'from dependency', got " + ns.dep);
+        if (ns.value !== 42) {
+            print("Expected ns.value to be 42, got " + ns.value);
+            $vm.abort();
+        }
+        if (ns.dep !== "from dependency") {
+            print("Expected ns.dep to be 'from dependency', got " + ns.dep);
+            $vm.abort();
+        }
     },
     function (e) {
-        throw new Error("Module loading should not have failed: " + e);
+        print("Module loading should not have failed: " + e);
+        $vm.abort();
     }
 );

--- a/JSTests/stress/module-loader-security-deep-chain-tampered.js
+++ b/JSTests/stress/module-loader-security-deep-chain-tampered.js
@@ -1,0 +1,68 @@
+//@ runDefault
+
+// Test that a deep import chain (A -> B -> C) works correctly when
+// Promise.prototype.then is tampered. Each dependency goes through the full
+// fetch -> parse -> ModuleRegistryFetchSettled -> ModuleRegistryModuleSettled
+// pipeline, passing JSSourceCode* and AbstractModuleRecord* through internal
+// promises at each step. This test verifies none of them leak.
+
+function fail(msg) { print("FAIL: " + msg); $vm.abort(); }
+
+var originalThen = Promise.prototype.then;
+
+function isInternalType(desc) {
+    if (/ModuleRecord(?!.*NamespaceObject)/.test(desc))
+        return true;
+    var types = ["JSSourceCode", "ModuleRegistryEntry", "ModuleLoadingContext",
+                 "ModuleGraphLoadingState", "ModuleLoaderPayload"];
+    for (var i = 0; i < types.length; i++) {
+        if (desc.indexOf(types[i]) !== -1)
+            return true;
+    }
+    return false;
+}
+
+var leakedValues = [];
+
+Promise.prototype.then = function (onFulfilled, onRejected) {
+    var desc = describe(this);
+    if (isInternalType(desc))
+        leakedValues.push("then-this: " + desc);
+
+    var wrappedFulfilled = onFulfilled ? function (val) {
+        if (val !== null && val !== undefined) {
+            var valDesc = describe(val);
+            if (isInternalType(valDesc))
+                leakedValues.push("fulfilled-arg: " + valDesc);
+        }
+        return onFulfilled(val);
+    } : onFulfilled;
+
+    var wrappedRejected = onRejected ? function (err) {
+        if (err !== null && err !== undefined) {
+            var errDesc = describe(err);
+            if (isInternalType(errDesc))
+                leakedValues.push("rejected-arg: " + errDesc);
+        }
+        return onRejected(err);
+    } : onRejected;
+
+    return originalThen.call(this, wrappedFulfilled, wrappedRejected);
+};
+
+originalThen.call(
+    import("./resources/module-loader-security-deep-a.js"),
+    function (ns) {
+        if (ns.a !== "a")
+            fail("Expected ns.a to be 'a', got " + ns.a);
+        if (ns.b !== "b")
+            fail("Expected ns.b to be 'b', got " + ns.b);
+        if (ns.c !== "c")
+            fail("Expected ns.c to be 'c', got " + ns.c);
+        if (leakedValues.length > 0)
+            fail("Internal objects leaked: " + leakedValues.join(", "));
+    },
+    function (e) {
+        fail("Module loading should not have failed: " + e);
+    }
+);

--- a/JSTests/stress/module-loader-security-defineproperty-then.js
+++ b/JSTests/stress/module-loader-security-defineproperty-then.js
@@ -1,0 +1,49 @@
+//@ runDefault
+
+// Test using Object.defineProperty with a getter on Promise.prototype.then
+// to detect ALL .then property lookups. This is more sophisticated than simple
+// assignment: it detects property lookups (not just calls). After the fix,
+// internal promises should NEVER have their .then looked up.
+
+function fail(msg) { print("FAIL: " + msg); $vm.abort(); }
+
+var originalThen = Promise.prototype.then;
+
+function isInternalType(desc) {
+    if (/ModuleRecord(?!.*NamespaceObject)/.test(desc))
+        return true;
+    var types = ["JSSourceCode", "ModuleRegistryEntry", "ModuleLoadingContext",
+                 "ModuleGraphLoadingState", "ModuleLoaderPayload"];
+    for (var i = 0; i < types.length; i++) {
+        if (desc.indexOf(types[i]) !== -1)
+            return true;
+    }
+    return false;
+}
+
+var leakedValues = [];
+
+Object.defineProperty(Promise.prototype, "then", {
+    get: function () {
+        var selfDesc = describe(this);
+        if (isInternalType(selfDesc))
+            leakedValues.push("then-getter-this: " + selfDesc);
+        return originalThen;
+    },
+    configurable: true
+});
+
+originalThen.call(
+    import("./resources/module-loader-promise-then-tampered-target.js"),
+    function (ns) {
+        if (ns.value !== 42)
+            fail("Expected ns.value to be 42, got " + ns.value);
+        if (ns.dep !== "from dependency")
+            fail("Expected ns.dep to be 'from dependency', got " + ns.dep);
+        if (leakedValues.length > 0)
+            fail("Internal object detected in .then getter: " + leakedValues.join(", "));
+    },
+    function (e) {
+        fail("Module loading should not have failed: " + e);
+    }
+);

--- a/JSTests/stress/module-loader-security-failure-tampered.js
+++ b/JSTests/stress/module-loader-security-failure-tampered.js
@@ -1,0 +1,66 @@
+//@ runDefault
+
+// Test that module loading failure (non-existent module) works correctly when
+// Promise.prototype.then is tampered. The rejection path goes through
+// rejectWithCaughtException on internal promises. This verifies:
+// 1. Error handling still works (rejection propagates)
+// 2. No internal objects leak in rejection values
+// 3. No crash
+
+function fail(msg) { print("FAIL: " + msg); $vm.abort(); }
+
+var originalThen = Promise.prototype.then;
+
+function isInternalType(desc) {
+    if (/ModuleRecord(?!.*NamespaceObject)/.test(desc))
+        return true;
+    var types = ["JSSourceCode", "ModuleRegistryEntry", "ModuleLoadingContext",
+                 "ModuleGraphLoadingState", "ModuleLoaderPayload"];
+    for (var i = 0; i < types.length; i++) {
+        if (desc.indexOf(types[i]) !== -1)
+            return true;
+    }
+    return false;
+}
+
+var leakedValues = [];
+
+Promise.prototype.then = function (onFulfilled, onRejected) {
+    var desc = describe(this);
+    if (isInternalType(desc))
+        leakedValues.push("then-this: " + desc);
+
+    var wrappedFulfilled = onFulfilled ? function (val) {
+        if (val !== null && val !== undefined) {
+            var valDesc = describe(val);
+            if (isInternalType(valDesc))
+                leakedValues.push("fulfilled-arg: " + valDesc);
+        }
+        return onFulfilled(val);
+    } : onFulfilled;
+
+    var wrappedRejected = onRejected ? function (err) {
+        if (err !== null && err !== undefined) {
+            var errDesc = describe(err);
+            if (isInternalType(errDesc))
+                leakedValues.push("rejected-arg: " + errDesc);
+        }
+        return onRejected(err);
+    } : onRejected;
+
+    return originalThen.call(this, wrappedFulfilled, wrappedRejected);
+};
+
+originalThen.call(
+    import("./resources/nonexistent-module-security-test-xyz.js"),
+    function (ns) {
+        fail("Import of non-existent module should not have succeeded");
+    },
+    function (e) {
+        // Rejection is expected. Verify the error is a proper Error object.
+        if (!(e instanceof Error))
+            fail("Expected rejection with Error, got: " + typeof e);
+        if (leakedValues.length > 0)
+            fail("Internal objects leaked in error path: " + leakedValues.join(", "));
+    }
+);

--- a/JSTests/stress/module-loader-security-proxy-then.js
+++ b/JSTests/stress/module-loader-security-proxy-then.js
@@ -1,0 +1,76 @@
+//@ runDefault
+
+// Test using a Proxy-wrapped function as Promise.prototype.then to create
+// the most thorough interception possible. The Proxy's apply trap logs all
+// invocations including this value and all arguments, then validates via
+// describe() that no internal objects appear.
+
+function fail(msg) { print("FAIL: " + msg); $vm.abort(); }
+
+var originalThen = Promise.prototype.then;
+
+function isInternalType(desc) {
+    if (/ModuleRecord(?!.*NamespaceObject)/.test(desc))
+        return true;
+    var types = ["JSSourceCode", "ModuleRegistryEntry", "ModuleLoadingContext",
+                 "ModuleGraphLoadingState", "ModuleLoaderPayload"];
+    for (var i = 0; i < types.length; i++) {
+        if (desc.indexOf(types[i]) !== -1)
+            return true;
+    }
+    return false;
+}
+
+var leakedValues = [];
+
+Promise.prototype.then = new Proxy(originalThen, {
+    apply: function (target, thisArg, args) {
+        var thisDesc = describe(thisArg);
+        if (isInternalType(thisDesc))
+            leakedValues.push("proxy-this: " + thisDesc);
+
+        for (var i = 0; i < args.length; i++) {
+            if (args[i] !== null && args[i] !== undefined && typeof args[i] !== "function") {
+                var argDesc = describe(args[i]);
+                if (isInternalType(argDesc))
+                    leakedValues.push("proxy-arg[" + i + "]: " + argDesc);
+            }
+        }
+
+        // Wrap onFulfilled to also check resolution values
+        var wrappedArgs = [];
+        for (var i = 0; i < args.length; i++) {
+            if (typeof args[i] === "function") {
+                wrappedArgs.push((function (fn) {
+                    return function (val) {
+                        if (val !== null && val !== undefined) {
+                            var valDesc = describe(val);
+                            if (isInternalType(valDesc))
+                                leakedValues.push("proxy-callback-arg: " + valDesc);
+                        }
+                        return fn(val);
+                    };
+                })(args[i]));
+            } else {
+                wrappedArgs.push(args[i]);
+            }
+        }
+
+        return Reflect.apply(target, thisArg, wrappedArgs);
+    }
+});
+
+originalThen.call(
+    import("./resources/module-loader-promise-then-tampered-target.js"),
+    function (ns) {
+        if (ns.value !== 42)
+            fail("Expected ns.value to be 42, got " + ns.value);
+        if (ns.dep !== "from dependency")
+            fail("Expected ns.dep to be 'from dependency', got " + ns.dep);
+        if (leakedValues.length > 0)
+            fail("Internal objects detected via Proxy: " + leakedValues.join(", "));
+    },
+    function (e) {
+        fail("Module loading should not have failed: " + e);
+    }
+);

--- a/JSTests/stress/module-loader-security-reimport-tampered.js
+++ b/JSTests/stress/module-loader-security-reimport-tampered.js
@@ -1,0 +1,80 @@
+//@ runDefault
+
+// Test that re-importing an already-loaded module works correctly when
+// Promise.prototype.then is tampered AFTER the first import. The second
+// import hits the module registry cache path (ModuleLoadingContext::Step::Cached)
+// which uses jsSecureCast and fulfill(). This verifies the cached path
+// doesn't leak internal objects.
+
+function fail(msg) { print("FAIL: " + msg); $vm.abort(); }
+
+var originalThen = Promise.prototype.then;
+
+function isInternalType(desc) {
+    if (/ModuleRecord(?!.*NamespaceObject)/.test(desc))
+        return true;
+    var types = ["JSSourceCode", "ModuleRegistryEntry", "ModuleLoadingContext",
+                 "ModuleGraphLoadingState", "ModuleLoaderPayload"];
+    for (var i = 0; i < types.length; i++) {
+        if (desc.indexOf(types[i]) !== -1)
+            return true;
+    }
+    return false;
+}
+
+// First import: clean, no tampering
+originalThen.call(
+    import("./resources/module-loader-promise-then-tampered-target.js"),
+    function (ns) {
+        if (ns.value !== 42)
+            fail("First import: Expected ns.value to be 42, got " + ns.value);
+
+        // Now tamper Promise.prototype.then
+        var leakedValues = [];
+
+        Promise.prototype.then = function (onFulfilled, onRejected) {
+            var desc = describe(this);
+            if (isInternalType(desc))
+                leakedValues.push("then-this: " + desc);
+
+            var wrappedFulfilled = onFulfilled ? function (val) {
+                if (val !== null && val !== undefined) {
+                    var valDesc = describe(val);
+                    if (isInternalType(valDesc))
+                        leakedValues.push("fulfilled-arg: " + valDesc);
+                }
+                return onFulfilled(val);
+            } : onFulfilled;
+
+            var wrappedRejected = onRejected ? function (err) {
+                if (err !== null && err !== undefined) {
+                    var errDesc = describe(err);
+                    if (isInternalType(errDesc))
+                        leakedValues.push("rejected-arg: " + errDesc);
+                }
+                return onRejected(err);
+            } : onRejected;
+
+            return originalThen.call(this, wrappedFulfilled, wrappedRejected);
+        };
+
+        // Second import: same module, but with tampered then
+        originalThen.call(
+            import("./resources/module-loader-promise-then-tampered-target.js"),
+            function (ns2) {
+                if (ns2.value !== 42)
+                    fail("Second import: Expected ns2.value to be 42, got " + ns2.value);
+                if (ns2.dep !== "from dependency")
+                    fail("Second import: Expected ns2.dep, got " + ns2.dep);
+                if (leakedValues.length > 0)
+                    fail("Internal objects leaked on re-import: " + leakedValues.join(", "));
+            },
+            function (e) {
+                fail("Second import should not have failed: " + e);
+            }
+        );
+    },
+    function (e) {
+        fail("First import should not have failed: " + e);
+    }
+);

--- a/JSTests/stress/module-loader-security-thenable-namespace-tampered.js
+++ b/JSTests/stress/module-loader-security-thenable-namespace-tampered.js
@@ -1,0 +1,63 @@
+//@ runDefault
+
+// Test that import() of a module exporting "then" works correctly even when
+// Promise.prototype.then is ALSO tampered. This exercises both:
+// 1. The internal pipeline (which should bypass the tampered then)
+// 2. The final user-visible resolve() in importModuleNamespace (spec-required)
+
+function fail(msg) { print("FAIL: " + msg); $vm.abort(); }
+
+var originalThen = Promise.prototype.then;
+
+function isInternalType(desc) {
+    if (/ModuleRecord(?!.*NamespaceObject)/.test(desc))
+        return true;
+    var types = ["JSSourceCode", "ModuleRegistryEntry", "ModuleLoadingContext",
+                 "ModuleGraphLoadingState", "ModuleLoaderPayload"];
+    for (var i = 0; i < types.length; i++) {
+        if (desc.indexOf(types[i]) !== -1)
+            return true;
+    }
+    return false;
+}
+
+var leakedValues = [];
+
+Promise.prototype.then = function (onFulfilled, onRejected) {
+    var desc = describe(this);
+    if (isInternalType(desc))
+        leakedValues.push("then-this: " + desc);
+
+    var wrappedFulfilled = onFulfilled ? function (val) {
+        if (val !== null && val !== undefined) {
+            var valDesc = describe(val);
+            if (isInternalType(valDesc))
+                leakedValues.push("fulfilled-arg: " + valDesc);
+        }
+        return onFulfilled(val);
+    } : onFulfilled;
+
+    var wrappedRejected = onRejected ? function (err) {
+        if (err !== null && err !== undefined) {
+            var errDesc = describe(err);
+            if (isInternalType(errDesc))
+                leakedValues.push("rejected-arg: " + errDesc);
+        }
+        return onRejected(err);
+    } : onRejected;
+
+    return originalThen.call(this, wrappedFulfilled, wrappedRejected);
+};
+
+originalThen.call(
+    import("./resources/module-loader-security-thenable-namespace-module.js"),
+    function (result) {
+        if (result.value !== 42)
+            fail("Expected result.value to be 42, got " + result.value);
+        if (leakedValues.length > 0)
+            fail("Internal objects leaked: " + leakedValues.join(", "));
+    },
+    function (e) {
+        fail("Module loading should not have failed: " + e);
+    }
+);

--- a/JSTests/stress/module-loader-security-thenable-namespace.js
+++ b/JSTests/stress/module-loader-security-thenable-namespace.js
@@ -1,0 +1,29 @@
+//@ runDefault
+
+// Test that import() of a module exporting "then" correctly uses thenable
+// unwrapping per spec (ContinueDynamicImport step 6.d.ii). The namespace
+// is a thenable and its "then" export should receive proper resolve/reject
+// functions, not internal objects.
+//
+// The validation of resolve/reject and this-value is done inside the
+// module's exported "then" function itself (see the helper module).
+
+function fail(msg) { print("FAIL: " + msg); $vm.abort(); }
+
+var originalThen = Promise.prototype.then;
+
+originalThen.call(
+    import("./resources/module-loader-security-thenable-namespace-module.js"),
+    function (result) {
+        // The "then" export calls resolve({value, isNamespaceResult}) to break
+        // the thenable cycle. With the isDefinitelyNonThenable fix, thenable
+        // unwrapping happens even when the watchpoint is valid.
+        if (result.value !== 42)
+            fail("Expected result.value to be 42, got " + result.value);
+        if (result.isNamespaceResult !== true)
+            fail("Expected isNamespaceResult to be true, got " + result.isNamespaceResult);
+    },
+    function (e) {
+        fail("Module loading should not have failed: " + e);
+    }
+);

--- a/JSTests/stress/module-loader-security-tla-tampered-then.js
+++ b/JSTests/stress/module-loader-security-tla-tampered-then.js
@@ -1,0 +1,64 @@
+//@ runDefault
+
+// Test that top-level await (TLA) modules work correctly when
+// Promise.prototype.then is tampered. The TLA path uses:
+//   asyncModuleExecutionResume -> capability->resolve() for await semantics
+//   asyncExecutionFulfilled -> capability->fulfill() for completion
+// This test verifies no internal objects leak through the TLA promise chain.
+
+function fail(msg) { print("FAIL: " + msg); $vm.abort(); }
+
+var originalThen = Promise.prototype.then;
+
+function isInternalType(desc) {
+    if (/ModuleRecord(?!.*NamespaceObject)/.test(desc))
+        return true;
+    var types = ["JSSourceCode", "ModuleRegistryEntry", "ModuleLoadingContext",
+                 "ModuleGraphLoadingState", "ModuleLoaderPayload"];
+    for (var i = 0; i < types.length; i++) {
+        if (desc.indexOf(types[i]) !== -1)
+            return true;
+    }
+    return false;
+}
+
+var leakedValues = [];
+
+Promise.prototype.then = function (onFulfilled, onRejected) {
+    var desc = describe(this);
+    if (isInternalType(desc))
+        leakedValues.push("then-this: " + desc);
+
+    var wrappedFulfilled = onFulfilled ? function (val) {
+        if (val !== null && val !== undefined) {
+            var valDesc = describe(val);
+            if (isInternalType(valDesc))
+                leakedValues.push("fulfilled-arg: " + valDesc);
+        }
+        return onFulfilled(val);
+    } : onFulfilled;
+
+    var wrappedRejected = onRejected ? function (err) {
+        if (err !== null && err !== undefined) {
+            var errDesc = describe(err);
+            if (isInternalType(errDesc))
+                leakedValues.push("rejected-arg: " + errDesc);
+        }
+        return onRejected(err);
+    } : onRejected;
+
+    return originalThen.call(this, wrappedFulfilled, wrappedRejected);
+};
+
+originalThen.call(
+    import("./resources/module-loader-security-tla-module.js"),
+    function (ns) {
+        if (ns.value !== 42)
+            fail("Expected ns.value to be 42, got " + ns.value);
+        if (leakedValues.length > 0)
+            fail("Internal objects leaked: " + leakedValues.join(", "));
+    },
+    function (e) {
+        fail("Module loading should not have failed: " + e);
+    }
+);

--- a/JSTests/stress/resources/module-loader-security-deep-a.js
+++ b/JSTests/stress/resources/module-loader-security-deep-a.js
@@ -1,0 +1,3 @@
+import { b, c } from "./module-loader-security-deep-b.js";
+export var a = "a";
+export { b, c };

--- a/JSTests/stress/resources/module-loader-security-deep-b.js
+++ b/JSTests/stress/resources/module-loader-security-deep-b.js
@@ -1,0 +1,3 @@
+import { c } from "./module-loader-security-deep-c.js";
+export var b = "b";
+export { c };

--- a/JSTests/stress/resources/module-loader-security-deep-c.js
+++ b/JSTests/stress/resources/module-loader-security-deep-c.js
@@ -1,0 +1,1 @@
+export var c = "c";

--- a/JSTests/stress/resources/module-loader-security-thenable-namespace-module.js
+++ b/JSTests/stress/resources/module-loader-security-thenable-namespace-module.js
@@ -1,0 +1,36 @@
+export var value = 42;
+
+// This "then" export makes the namespace object a thenable per spec.
+// When import() resolves with this namespace, the spec requires thenable
+// unwrapping (ContinueDynamicImport step 6.d.ii).
+export function then(resolve, reject) {
+    // Validate that we receive proper resolve/reject functions.
+    if (typeof resolve !== "function")
+        throw new Error("resolve is not a function: " + typeof resolve);
+    if (typeof reject !== "function")
+        throw new Error("reject is not a function: " + typeof reject);
+
+    // Validate that 'this' is the module namespace, not an internal object.
+    if (this.value !== 42)
+        throw new Error("'this' is not the namespace: value=" + this.value);
+
+    // Check that resolve/reject are not internal objects via describe().
+    var resolveDesc = describe(resolve);
+    var rejectDesc = describe(reject);
+    var internalTypes = ["JSSourceCode", "ModuleRegistryEntry", "ModuleLoadingContext",
+                         "ModuleGraphLoadingState", "ModuleLoaderPayload"];
+    for (var i = 0; i < internalTypes.length; i++) {
+        if (resolveDesc.indexOf(internalTypes[i]) !== -1)
+            throw new Error("resolve is internal object: " + resolveDesc);
+        if (rejectDesc.indexOf(internalTypes[i]) !== -1)
+            throw new Error("reject is internal object: " + rejectDesc);
+    }
+    if (/ModuleRecord(?!.*NamespaceObject)/.test(resolveDesc))
+        throw new Error("resolve is ModuleRecord: " + resolveDesc);
+    if (/ModuleRecord(?!.*NamespaceObject)/.test(rejectDesc))
+        throw new Error("reject is ModuleRecord: " + rejectDesc);
+
+    // Resolve with a non-thenable value to avoid infinite thenable unwrapping.
+    // (Calling resolve(this) would loop because this namespace IS a thenable.)
+    resolve({ value: this.value, isNamespaceResult: true });
+}

--- a/JSTests/stress/resources/module-loader-security-tla-module.js
+++ b/JSTests/stress/resources/module-loader-security-tla-module.js
@@ -1,0 +1,2 @@
+var x = await Promise.resolve(42);
+export var value = x;

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -322,6 +322,8 @@ bool isDefinitelyNonThenable(JSObject* object, JSGlobalObject* globalObject)
     while (structure) {
         if (structure->hasSpecialProperties())
             return false;
+        if (structure->typeInfo().getOwnPropertySlotIsImpureForPropertyAbsence())
+            return false;
         if (structure->typeInfo().overridesGetPrototype())
             return false;
         if (!structure->hasMonoProto())


### PR DESCRIPTION
#### b8a88485f970d507fe4c215a4bb9cac8131e98a1
<pre>
[JSC] Add a bit more module loader tests for &quot;then&quot; tampering
<a href="https://bugs.webkit.org/show_bug.cgi?id=312419">https://bugs.webkit.org/show_bug.cgi?id=312419</a>
<a href="https://rdar.apple.com/174871382">rdar://174871382</a>

Reviewed by Yijia Huang.

A bit adding more tests to ensure that tampered &quot;then&quot; does not affect
on the module loader. Also, fixing `isDefinitelyNonThenable` for
namespace object.

* JSTests/stress/module-loader-object-prototype-then-no-promise-tamper.js:
(import.string_appeared_here.then):
* JSTests/stress/module-loader-promise-then-reassigned-same-value.js:
* JSTests/stress/module-loader-promise-then-tampered-no-deps.js:
* JSTests/stress/module-loader-promise-then-tampered.js:
* JSTests/stress/module-loader-security-deep-chain-tampered.js: Added.
(fail):
(isInternalType):
(Promise.prototype.then):
* JSTests/stress/module-loader-security-defineproperty-then.js: Added.
(fail):
(isInternalType):
* JSTests/stress/module-loader-security-failure-tampered.js: Added.
(fail):
(isInternalType):
(Promise.prototype.then):
* JSTests/stress/module-loader-security-proxy-then.js: Added.
(fail):
(isInternalType):
(apply):
* JSTests/stress/module-loader-security-reimport-tampered.js: Added.
(fail):
(isInternalType):
(Promise.prototype.then):
* JSTests/stress/module-loader-security-thenable-namespace-tampered.js: Added.
(fail):
(isInternalType):
(Promise.prototype.then):
* JSTests/stress/module-loader-security-thenable-namespace.js: Added.
(fail):
* JSTests/stress/module-loader-security-tla-tampered-then.js: Added.
(fail):
(isInternalType):
(Promise.prototype.then):
* JSTests/stress/resources/module-loader-security-deep-a.js: Added.
* JSTests/stress/resources/module-loader-security-deep-b.js: Added.
* JSTests/stress/resources/module-loader-security-deep-c.js: Added.
* JSTests/stress/resources/module-loader-security-thenable-namespace-module.js: Added.
(export.then):
* JSTests/stress/resources/module-loader-security-tla-module.js: Added.
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::isDefinitelyNonThenable):

Canonical link: <a href="https://commits.webkit.org/311378@main">https://commits.webkit.org/311378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a11fdcd7c1d4764850befb9b5ba19d79bff3d774

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165524 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110782 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121371 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85250 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102039 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22664 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20855 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13296 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148751 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168007 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17536 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12168 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129490 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129599 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87363 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23867 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24416 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17148 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188662 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29270 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93287 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48456 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28795 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29025 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28921 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->