### PR TITLE
Use protect() instead of Ref { } in model element code

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelObjectHeap.cpp
@@ -47,7 +47,7 @@ ModelObjectHeap::~ModelObjectHeap() = default;
 void ModelObjectHeap::addObject(WebModelIdentifier identifier, RemoteMesh& mesh)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    auto result = m_objects.add(identifier, Object { IPC::ScopedActiveMessageReceiveQueue<RemoteMesh> { Ref { mesh } } });
+    auto result = m_objects.add(identifier, Object { IPC::ScopedActiveMessageReceiveQueue<RemoteMesh> { protect(mesh) } });
     ASSERT_UNUSED(result, result.isNewEntry);
 #else
     UNUSED_PARAM(identifier);

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
@@ -51,7 +51,7 @@ RemoteMesh::RemoteMesh(GPUConnectionToWebProcess& gpuConnectionToWebProcess, Rem
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)
 {
-    Ref { m_streamConnection }->startReceivingMessages(*this, Messages::RemoteMesh::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteMesh::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteMesh::~RemoteMesh() = default;
@@ -66,7 +66,7 @@ RefPtr<IPC::Connection> RemoteMesh::connection() const
 
 void RemoteMesh::stopListeningForIPC()
 {
-    Ref { m_streamConnection }->stopReceivingMessages(Messages::RemoteMesh::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteMesh::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteMesh::destruct()

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -735,7 +735,7 @@ void ModelProcessModelPlayerProxy::load(WebCore::Model& model, WebCore::LayoutSi
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::load size=%zu id=%" PRIu64, this, model.data()->size(), m_id.toUInt64());
     sizeDidChange(layoutSize);
 
-    WKREEngine::singleton().runWithSharedScene([this, protectedThis = Ref { *this }, model = Ref { model }] (RESceneRef scene) {
+    WKREEngine::singleton().runWithSharedScene([this, protectedThis = protect(*this), model = protect(model)] (RESceneRef scene) {
         m_scene = scene;
         if ([getWKRKEntityClassSingleton() isLoadFromDataAvailable])
             m_loader = RKUSDModelLoadScheduler::singleton().scheduleModelLoad(model.get(), m_attributionTaskID, m_debugEntityMemoryLimit ? *m_debugEntityMemoryLimit : defaultEntityMemoryLimit, *this);

--- a/Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp
@@ -89,7 +89,7 @@ void ModelProcessConnection::invalidate()
 void ModelProcessConnection::didClose(IPC::Connection&)
 {
     RELEASE_LOG(Process, "%p - ModelProcessConnection::didClose", this);
-    auto protector = Ref { *this };
+    Ref protector { *this };
     WebProcess::singleton().modelProcessConnectionClosed(*this);
 
     m_clients.forEach([this] (auto& client) {

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -144,7 +144,7 @@ WebModelPlayer::~WebModelPlayer() = default;
 
 void WebModelPlayer::ensureOnMainThreadWithProtectedThis(Function<void(Ref<WebModelPlayer>)>&& task)
 {
-    ensureOnMainThread([protectedThis = Ref { *this }, task = WTF::move(task)]() mutable {
+    ensureOnMainThread([protectedThis = protect(*this), task = WTF::move(task)]() mutable {
         task(protectedThis);
     });
 }
@@ -297,14 +297,14 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
         .swizzle = { }
     };
 
-    m_currentModel = static_cast<RemoteGPUProxy&>(gpu->backing()).createModelBacking(m_currentPixelSize.width(), m_currentPixelSize.height(), diffuseTexture, specularTexture, [protectedThis = Ref { *this }] (Vector<MachSendRight>&& surfaceHandles) {
+    m_currentModel = static_cast<RemoteGPUProxy&>(gpu->backing()).createModelBacking(m_currentPixelSize.width(), m_currentPixelSize.height(), diffuseTexture, specularTexture, [protectedThis = protect(*this)] (Vector<MachSendRight>&& surfaceHandles) {
         if (surfaceHandles.size())
             protectedThis->m_displayBuffers = WTF::move(surfaceHandles);
     });
     m_currentModel->setViewportSize(cssSize.width().toFloat(), cssSize.height().toFloat());
 
     m_modelLoader = adoptNS([allocWKBridgeModelLoaderInstance() init]);
-    Ref protectedThis = Ref { *this };
+    Ref protectedThis { *this };
     [m_modelLoader setCallbacksWithModelUpdatedCallback:^(NSArray<WKBridgeUpdateMesh *> *updateRequest) {
         ensureOnMainThreadWithProtectedThis([updateRequest] (Ref<WebModelPlayer> protectedThis) {
             RefPtr model = protectedThis->m_currentModel;
@@ -397,7 +397,7 @@ void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
 
     m_currentPixelSize = newPixelSize;
 
-    currentModel->sizeDidChange(newPixelSize.width(), newPixelSize.height(), [protectedThis = Ref { *this }](Vector<MachSendRight>&& newBuffers) {
+    currentModel->sizeDidChange(newPixelSize.width(), newPixelSize.height(), [protectedThis = protect(*this)](Vector<MachSendRight>&& newBuffers) {
         if (newBuffers.isEmpty())
             return;
 
@@ -616,7 +616,7 @@ void WebModelPlayer::scheduleUpdateIfNeeded()
         return;
 
     m_isUpdateScheduled = true;
-    document->eventLoop().queueTask(WebCore::TaskSource::ModelElement, [protectedThis = Ref { *this }] {
+    document->eventLoop().queueTask(WebCore::TaskSource::ModelElement, [protectedThis = protect(*this)] {
         protectedThis->m_isUpdateScheduled = false;
         protectedThis->update();
     });
@@ -674,7 +674,7 @@ bool WebModelPlayer::render()
     if (++m_renderTextureIndex >= m_displayBuffers.size())
         m_renderTextureIndex = 0;
 
-    currentModel->render(textureIndex, [protectedThis = Ref { *this }, textureIndex] (bool result) mutable {
+    currentModel->render(textureIndex, [protectedThis = protect(*this), textureIndex] (bool result) mutable {
         protectedThis->ensureOnMainThreadWithProtectedThis([result, textureIndex] (Ref<WebModelPlayer> protectedThis) {
             protectedThis->m_isUpdating = false;
             if (!result)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1595,10 +1595,10 @@ ModelProcessConnection& WebProcess::ensureModelProcessConnection()
 
     // If we've lost our connection to the model process (e.g. it crashed) try to re-establish it.
     if (!m_modelProcessConnection) {
-        m_modelProcessConnection = ModelProcessConnection::create(Ref { *parentProcessConnection() });
+        m_modelProcessConnection = ModelProcessConnection::create(protect(*parentProcessConnection()));
 
         for (auto& page : m_pageMap.values())
-            page->modelProcessConnectionDidBecomeAvailable(Ref { *m_modelProcessConnection });
+            page->modelProcessConnectionDidBecomeAvailable(protect(*m_modelProcessConnection));
     }
 
     return *m_modelProcessConnection;


### PR DESCRIPTION
#### 3412884cd531949b080784fb820424f917138e94
<pre>
Use protect() instead of Ref { } in model element code
<a href="https://bugs.webkit.org/show_bug.cgi?id=312424">https://bugs.webkit.org/show_bug.cgi?id=312424</a>
<a href="https://rdar.apple.com/174873729">rdar://174873729</a>

Reviewed by Ryosuke Niwa.

Mechanical migration from Ref { expr } to protect(expr) across all model
element code, aligning with the codebase-wide transition away from
brace-initialized smart pointer temporaries.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebKit/GPUProcess/graphics/Model/ModelObjectHeap.cpp:
(WebKit::ModelObjectHeap::addObject):
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp:
(WebKit::RemoteMesh::RemoteMesh):
(WebKit::RemoteMesh::stopListeningForIPC):
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::load):
* Source/WebKit/WebProcess/Model/ModelProcessConnection.cpp:
(WebKit::ModelProcessConnection::didClose):
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::ensureOnMainThreadWithProtectedThis):
(WebKit::WebModelPlayer::createNewModel):
(WebKit::WebModelPlayer::sizeDidChange):
(WebKit::WebModelPlayer::scheduleUpdateDisplay):
(WebKit::WebModelPlayer::render):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureModelProcessConnection):

Canonical link: <a href="https://commits.webkit.org/311361@main">https://commits.webkit.org/311361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/970d215a6e13948a8d30e34837ffdfccf90fbaed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110778 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121370 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85248 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102038 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22644 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20851 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13292 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132323 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168003 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12164 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20163 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129486 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129595 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35117 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140338 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87359 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24414 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17142 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29266 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93283 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28791 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29021 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28917 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->