### PR TITLE
Fix leaks from Security APIs by using adoptCF() for CFErrorRef out parameters

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -373,10 +373,16 @@ static RetainPtr<CFDataRef> transformTrustToData(SecTrustRef trust)
 {
     if (CFGetTypeID(trust) != SecTrustGetTypeID())
         [NSException raise:NSInvalidArgumentException format:@"Error encoding invalid SecTrustRef"];
-    CFErrorRef error = nullptr;
-    auto data = adoptCF(SecTrustSerialize(trust, &error));
+    RetainPtr<CFDataRef> data;
+    RetainPtr<CFErrorRef> error;
+    {
+        // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
+        CFErrorRef rawError = NULL;
+        data = adoptCF(SecTrustSerialize(trust, &rawError));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT error = adoptCF(rawError);
+    }
     if (error)
-        [NSException raise:NSInvalidArgumentException format:@"Error serializing SecTrustRef: %@", error];
+        [NSException raise:NSInvalidArgumentException format:@"Error serializing SecTrustRef: %@", error.get()];
     return data;
 }
 
@@ -426,10 +432,16 @@ static RetainPtr<SecTrustRef> transformDataToTrust(NSData *data)
 {
     if (CFGetTypeID(data) != CFDataGetTypeID())
         [NSException raise:NSInvalidUnarchiveOperationException format:@"Invalid SecTrustRef data %@", NSStringFromClass([data class])];
-    CFErrorRef error = nullptr;
-    auto trust = adoptCF(SecTrustDeserialize((CFDataRef)data, &error));
+    RetainPtr<SecTrustRef> trust;
+    RetainPtr<CFErrorRef> error;
+    {
+        // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
+        CFErrorRef rawError = NULL;
+        trust = adoptCF(SecTrustDeserialize((CFDataRef)data, &rawError));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT error = adoptCF(rawError);
+    }
     if (error || !trust)
-        [NSException raise:NSInvalidUnarchiveOperationException format:@"Invalid SecTrustRef %@", error];
+        [NSException raise:NSInvalidUnarchiveOperationException format:@"Invalid SecTrustRef %@", error.get()];
     return trust;
 }
 

--- a/Source/WebKit/Shared/cf/CoreIPCSecTrust.mm
+++ b/Source/WebKit/Shared/cf/CoreIPCSecTrust.mm
@@ -255,12 +255,17 @@ static String optionalArrayOfDataHelper(std::optional<Vector<CoreIPCData>>& toSe
 
 CoreIPCSecTrust::CoreIPCSecTrust(SecTrustRef trust)
 {
-    CFErrorRef error = nullptr;
-
     if (!trust)
         return;
 
-    RetainPtr cfDictionary = adoptCF(dynamic_cf_cast<CFDictionaryRef>(SecTrustCopyPropertyListRepresentation(trust, &error)));
+    RetainPtr<CFDictionaryRef> cfDictionary;
+    RetainPtr<CFErrorRef> error;
+    {
+        // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
+        CFErrorRef rawError = NULL;
+        cfDictionary = adoptCF(dynamic_cf_cast<CFDictionaryRef>(SecTrustCopyPropertyListRepresentation(trust, &rawError)));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT error = adoptCF(rawError);
+    }
     if (!cfDictionary || error)
         return;
     RetainPtr dict = bridge_cast(cfDictionary.get());
@@ -892,8 +897,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [dict setObject:exceptions.get() forKey:@"exceptions"];
     }
 
-    CFErrorRef error = nullptr;
-    RetainPtr trust = adoptCF(SecTrustCreateFromPropertyListRepresentation(dict.get(), &error));
+    RetainPtr<SecTrustRef> trust;
+    RetainPtr<CFErrorRef> error;
+    {
+        // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
+        CFErrorRef rawError = NULL;
+        trust = adoptCF(SecTrustCreateFromPropertyListRepresentation(dict.get(), &rawError));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT error = adoptCF(rawError);
+    }
     if (error) {
         RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust error creating trust object");
         return { nullptr };

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
@@ -55,12 +55,15 @@ RetainPtr<SecKeyRef> createPrivateKey()
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrKeySizeInBits: @256,
     };
-    CFErrorRef errorRef = nullptr;
-    auto key = adoptCF(SecKeyCreateRandomKey(
-        (__bridge CFDictionaryRef)options,
-        &errorRef
-    ));
-    if (errorRef)
+    RetainPtr<SecKeyRef> key;
+    RetainPtr<CFErrorRef> error;
+    {
+        // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
+        CFErrorRef rawError = NULL;
+        key = adoptCF(SecKeyCreateRandomKey(bridge_cast(options), &rawError));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT error = adoptCF(rawError);
+    }
+    if (error)
         return nullptr;
     return key;
 }
@@ -117,13 +120,16 @@ RetainPtr<SecKeyRef> privateKeyFromBase64(const String& base64PrivateKey)
         (id)kSecAttrKeySizeInBits: @256,
     };
     RetainPtr<NSData> privateKey = adoptNS([[NSData alloc] initWithBase64EncodedString:base64PrivateKey.createNSString().get() options:0]);
-    CFErrorRef errorRef = nullptr;
-    auto key = adoptCF(SecKeyCreateWithData(
-        bridge_cast(privateKey.get()),
-        bridge_cast(options),
-        &errorRef
-    ));
-    ASSERT(!errorRef);
+    RetainPtr<SecKeyRef> key;
+    RetainPtr<CFErrorRef> error;
+    {
+        // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
+        CFErrorRef rawError = NULL;
+        key = adoptCF(SecKeyCreateWithData(bridge_cast(privateKey.get()), bridge_cast(options), &rawError));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT error = adoptCF(rawError);
+    }
+    if (error)
+        return nullptr;
     return key;
 }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -183,19 +183,29 @@ static bool secTrustRefsEqual(SecTrustRef trust1, SecTrustRef trust2)
 {
     // SecTrust doesn't compare equal after round-tripping through SecTrustSerialize/SecTrustDeserialize <rdar://122051396>
     // Therefore, we compare all the attributes we can access to verify equality.
-    CFErrorRef error = NULL;
     bool equal;
 #if HAVE(WK_SECURE_CODING_SECTRUST)
-    CFPropertyListRef trust1Plist = SecTrustCopyPropertyListRepresentation(trust1, &error);
-    EXPECT_FALSE(error);
-    CFPropertyListRef trust2Plist = SecTrustCopyPropertyListRepresentation(trust2, &error);
-    EXPECT_FALSE(error);
-    EXPECT_TRUE(CFGetTypeID(trust1Plist) == CFDictionaryGetTypeID());
-    EXPECT_TRUE(CFGetTypeID(trust2Plist) == CFDictionaryGetTypeID());
-    equal = CFEqual(trust1Plist, trust2Plist);
+    RetainPtr<CFPropertyListRef> trust1Plist;
+    RetainPtr<CFErrorRef> plistError;
+    {
+        // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
+        CFErrorRef rawError = NULL;
+        trust1Plist = adoptCF(SecTrustCopyPropertyListRepresentation(trust1, &rawError));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT plistError = adoptCF(rawError);
+    }
+    EXPECT_FALSE(plistError);
+    plistError = NULL;
+    RetainPtr<CFPropertyListRef> trust2Plist;
+    {
+        CFErrorRef rawError = NULL;
+        trust2Plist = adoptCF(SecTrustCopyPropertyListRepresentation(trust2, &rawError));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT plistError = adoptCF(rawError);
+    }
+    EXPECT_FALSE(plistError);
+    EXPECT_TRUE(CFGetTypeID(trust1Plist.get()) == CFDictionaryGetTypeID());
+    EXPECT_TRUE(CFGetTypeID(trust2Plist.get()) == CFDictionaryGetTypeID());
+    equal = CFEqual(trust1Plist.get(), trust2Plist.get());
     EXPECT_TRUE(equal);
-    CFRelease(trust1Plist);
-    CFRelease(trust2Plist);
 #endif
 
     SecKeyRef pk1 = SecTrustCopyPublicKey(trust1);
@@ -214,34 +224,42 @@ static bool secTrustRefsEqual(SecTrustRef trust1, SecTrustRef trust2)
     if (!equal)
         return false;
 
-    CFDataRef ex1 = SecTrustCopyExceptions(trust1);
-    CFDataRef ex2 = SecTrustCopyExceptions(trust2);
+    RetainPtr<CFDataRef> ex1 = adoptCF(SecTrustCopyExceptions(trust1));
+    RetainPtr<CFDataRef> ex2 = adoptCF(SecTrustCopyExceptions(trust2));
     EXPECT_TRUE(ex1);
     EXPECT_TRUE(ex2);
-    equal = CFEqual(ex1, ex2);
+    equal = CFEqual(ex1.get(), ex2.get());
 
     CFPropertyListFormat format;
-    CFPropertyListRef ex1plist = CFPropertyListCreateWithData(
-        kCFAllocatorDefault,
-        ex1,
-        kCFPropertyListImmutable,
-        &format,
-        &error
-    );
+    RetainPtr<CFErrorRef> error;
+    RetainPtr<CFPropertyListRef> ex1plist;
+    {
+        CFErrorRef rawError = NULL;
+        ex1plist = adoptCF(CFPropertyListCreateWithData(
+            kCFAllocatorDefault,
+            ex1.get(),
+            kCFPropertyListImmutable,
+            &format,
+            &rawError
+        ));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT error = adoptCF(rawError);
+    }
     EXPECT_FALSE(error);
-    CFPropertyListRef ex2plist = CFPropertyListCreateWithData(
-        kCFAllocatorDefault,
-        ex2,
-        kCFPropertyListImmutable,
-        &format,
-        &error
-    );
+    error = NULL;
+    RetainPtr<CFPropertyListRef> ex2plist;
+    {
+        CFErrorRef rawError = NULL;
+        ex2plist = adoptCF(CFPropertyListCreateWithData(
+            kCFAllocatorDefault,
+            ex2.get(),
+            kCFPropertyListImmutable,
+            &format,
+            &rawError
+        ));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT error = adoptCF(rawError);
+    }
     EXPECT_FALSE(error);
-    equal = CFEqual(ex1plist, ex2plist);
-    CFRelease(ex1);
-    CFRelease(ex2);
-    CFRelease(ex1plist);
-    CFRelease(ex2plist);
+    equal = CFEqual(ex1plist.get(), ex2plist.get());
     EXPECT_TRUE(equal);
     if (!equal)
         return false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Challenge.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Challenge.mm
@@ -44,6 +44,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/cf/VectorCF.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/Base64.h>
 
@@ -64,9 +65,15 @@ static RetainPtr<SecIdentityRef> createTestIdentity(const Vector<uint8_t>& priva
         (id)kSecAttrKeySizeInBits: @4096,
     };
     const NSUInteger pemEncodedPrivateKeyHeaderLength = 26;
-    CFErrorRef error = nullptr;
-    RetainPtr privateKey = adoptCF(SecKeyCreateWithData((__bridge CFDataRef)[derEncodedPrivateKey subdataWithRange:NSMakeRange(pemEncodedPrivateKeyHeaderLength, [derEncodedPrivateKey length] - pemEncodedPrivateKeyHeaderLength)], (__bridge CFDictionaryRef)options, &error));
-    EXPECT_NULL(error);
+    RetainPtr<SecKeyRef> privateKey;
+    RetainPtr<CFErrorRef> keyError;
+    {
+        // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
+        CFErrorRef rawError = NULL;
+        privateKey = adoptCF(SecKeyCreateWithData(bridge_cast([derEncodedPrivateKey subdataWithRange:NSMakeRange(pemEncodedPrivateKeyHeaderLength, [derEncodedPrivateKey length] - pemEncodedPrivateKeyHeaderLength)]), bridge_cast(options), &rawError));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT keyError = adoptCF(rawError);
+    }
+    EXPECT_NULL(keyError);
     EXPECT_NOT_NULL(privateKey.get());
 
     RetainPtr testCertificate = adoptCF(SecCertificateCreateWithData(nullptr, toCFData(certificateBytes.span()).get()));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm
@@ -42,6 +42,7 @@
 #import <WebKit/_WKInternalDebugFeature.h>
 #import <pal/spi/cocoa/NetworkSPI.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringBuilder.h>
@@ -783,9 +784,15 @@ TEST(WebTransport, ServerCertificateHashes)
             (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
             (id)kSecAttrKeySizeInBits: @256,
         };
-        CFErrorRef error = nullptr;
-        RetainPtr privateKey = adoptCF(SecKeyCreateRandomKey((__bridge CFDictionaryRef)options, &error));
-        EXPECT_NULL(error);
+        RetainPtr<SecKeyRef> privateKey;
+        RetainPtr<CFErrorRef> keyError;
+        {
+            // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
+            CFErrorRef rawError = NULL;
+            privateKey = adoptCF(SecKeyCreateRandomKey(bridge_cast(options), &rawError));
+            SUPPRESS_RETAINPTR_CTOR_ADOPT keyError = adoptCF(rawError);
+        }
+        EXPECT_NULL(keyError);
 
         NSArray *subject = @[];
         NSDictionary *parameters = @{

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
@@ -60,6 +60,7 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/WeakRandomNumber.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/MakeString.h>
 
@@ -363,13 +364,19 @@ bool addKeyToKeychain(const String& privateKeyBase64, const String& rpId, const 
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrKeySizeInBits: @256,
     };
-    CFErrorRef errorRef = nullptr;
-    RetainPtr key = adoptCF(SecKeyCreateWithData(
-        (__bridge CFDataRef)adoptNS([[NSData alloc] initWithBase64EncodedString:privateKeyBase64.createNSString().get() options:NSDataBase64DecodingIgnoreUnknownCharacters]).get(),
-        (__bridge CFDictionaryRef)options,
-        &errorRef
-    ));
-    if (errorRef)
+    RetainPtr<SecKeyRef> key;
+    RetainPtr<CFErrorRef> keyError;
+    {
+        // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
+        CFErrorRef rawError = NULL;
+        key = adoptCF(SecKeyCreateWithData(
+            bridge_cast(adoptNS([[NSData alloc] initWithBase64EncodedString:privateKeyBase64.createNSString().get() options:NSDataBase64DecodingIgnoreUnknownCharacters]).get()),
+            bridge_cast(options),
+            &rawError
+        ));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT keyError = adoptCF(rawError);
+    }
+    if (keyError)
         return false;
 
     RetainPtr credentialID = adoptNS([[NSData alloc] initWithBase64EncodedString:@"SMSXHngF7hEOsElA73C3RY+8bR4=" options:0]);

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -65,6 +65,7 @@
 #import <wtf/MainThread.h>
 #import <wtf/RunLoop.h>
 #import <wtf/UniqueRef.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/MakeString.h>
@@ -636,13 +637,19 @@ void TestController::addTestKeyToKeychain(const String& privateKeyBase64, const 
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrKeySizeInBits: @256
     };
-    CFErrorRef errorRef = nullptr;
-    auto key = adoptCF(SecKeyCreateWithData(
-        (__bridge CFDataRef)adoptNS([[NSData alloc] initWithBase64EncodedString:privateKeyBase64.createNSString().get() options:NSDataBase64DecodingIgnoreUnknownCharacters]).get(),
-        (__bridge CFDictionaryRef)options,
-        &errorRef
-    ));
-    ASSERT(!errorRef);
+    RetainPtr<SecKeyRef> key;
+    RetainPtr<CFErrorRef> keyError;
+    {
+        // FIXME: The Security framework API is missing the `CF_RETURNS_RETAINED` annotation (rdar://161546781).
+        CFErrorRef rawError = NULL;
+        key = adoptCF(SecKeyCreateWithData(
+            bridge_cast(adoptNS([[NSData alloc] initWithBase64EncodedString:privateKeyBase64.createNSString().get() options:NSDataBase64DecodingIgnoreUnknownCharacters]).get()),
+            bridge_cast(options),
+            &rawError
+        ));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT keyError = adoptCF(rawError);
+    }
+    ASSERT(!keyError);
 
     NSDictionary* addQuery = @{
         (id)kSecValueRef: (id)key.get(),


### PR DESCRIPTION
#### 12b5e059d376502dcaf63f1e3643106910a84db9
<pre>
Fix leaks from Security APIs by using adoptCF() for CFErrorRef out parameters
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=312411">https://bugs.webkit.org/show_bug.cgi?id=312411</a>&gt;
&lt;<a href="https://rdar.apple.com/174864243">rdar://174864243</a>&gt;

Reviewed by Chris Dumez.

Several Security framework APIs return +1 retained `CFErrorRef`
objects through their out parameters, but are missing the
`CF_RETURNS_RETAINED` annotation.

Adopt each raw `CFErrorRef` into a `RetainPtr` using a scoped
block to limit the raw pointer&apos;s lifetime, preventing accidental
use after `adoptCF()` takes ownership.  Also adopt other CF
objects returned by Copy/Create APIs with `RetainPtr` to
eliminate manual `CFRelease()` calls.

Test using `run-webkit-tests --leaks`.

* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(WebKit::transformTrustToData):
(WebKit::transformDataToTrust):
* Source/WebKit/Shared/cf/CoreIPCSecTrust.mm:
(WebKit::CoreIPCSecTrust::CoreIPCSecTrust):
(WebKit::CoreIPCSecTrust::createSecTrust const):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm:
(WebKit::createPrivateKey):
(WebKit::privateKeyFromBase64):

* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(secTrustRefsEqual):
- Adopt `SecTrustCopyExceptions()` and
  `CFPropertyListCreateWithData()` return values with
  `RetainPtr` to fix leaks.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Challenge.mm:
(createTestIdentity):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm:
(addKeyToKeychain):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::addTestKeyToKeychain):

Canonical link: <a href="https://commits.webkit.org/311454@main">https://commits.webkit.org/311454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cf568637b8e0d365c56010cf14e4ca71d7c0b76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110791 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121381 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85255 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102049 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22648 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20861 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13305 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168016 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12177 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129496 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129605 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140345 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87372 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23899 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24425 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17149 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29279 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93296 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28804 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28930 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->