### PR TITLE
Add an SPI in WKWebView which retrieves image metadata from image data

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2539,6 +2539,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ImageObserver.h
     platform/graphics/ImageOrientation.h
     platform/graphics/ImagePaintingOptions.h
+    platform/graphics/ImageResolution.h
     platform/graphics/ImageSource.h
     platform/graphics/ImageTypes.h
     platform/graphics/ImageUtilities.h

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -69,8 +69,10 @@ public:
     RefPtr<NativeImage> currentNativeImage() final { return m_source->currentNativeImage(); }
 
     // Image Metadata
+    String uti() const final { return m_source->uti(); }
     FloatSize size(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const final { return m_source->size(orientation); }
     FloatSize sourceSize(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const { return m_source->sourceSize(orientation); }
+    FloatSize density() const { return m_source->density(); }
     DestinationColorSpace colorSpace() final { return m_source->colorSpace(); }
     bool hasHDRContent() const final { return m_source->hasHDRContent(); }
     ImageOrientation orientation() const final { return m_source->orientation(); }
@@ -122,7 +124,6 @@ private:
 
     // Image Metadata
     bool hasDensityCorrectedSize() const final { return m_source->hasDensityCorrectedSize(); }
-    String uti() const final { return m_source->uti(); }
     String filenameExtension() const final { return m_source->filenameExtension(); }
     String accessibilityDescription() const final { return m_source->accessibilityDescription(); }
     std::optional<IntPoint> hotSpot() const final { return m_source->hotSpot(); }

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
@@ -138,6 +138,11 @@ IntSize BitmapImageDescriptor::sourceSize(ImageOrientation orientation) const
     return orientation.usesWidthAsHeight() ? size.transposedSize() : size;
 }
 
+FloatSize BitmapImageDescriptor::density() const
+{
+    return primaryImageFrameMetadata(m_density, CachedFlag::Density, &ImageFrame::density);
+}
+
 std::optional<IntSize> BitmapImageDescriptor::densityCorrectedSize() const
 {
     return primaryImageFrameMetadata(m_densityCorrectedSize, CachedFlag::DensityCorrectedSize, &ImageFrame::densityCorrectedSize, SubsamplingLevel::Default);

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
@@ -51,6 +51,7 @@ public:
     bool isSizeAvailable() const { return encodedDataStatus() >= EncodedDataStatus::SizeAvailable; }
     IntSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const;
     IntSize sourceSize(ImageOrientation = ImageOrientation::Orientation::FromImage) const;
+    FloatSize density() const;
     std::optional<IntSize> densityCorrectedSize() const;
     ImageOrientation orientation() const;
     unsigned primaryFrameIndex() const;
@@ -86,20 +87,21 @@ private:
     enum class CachedFlag : uint16_t {
         EncodedDataStatus           = 1 << 0,
         Size                        = 1 << 1,
-        DensityCorrectedSize        = 1 << 2,
-        Orientation                 = 1 << 3,
-        PrimaryFrameIndex           = 1 << 4,
-        FrameCount                  = 1 << 5,
-        RepetitionCount             = 1 << 6,
-        ColorSpace                  = 1 << 7,
-        SinglePixelSolidColor       = 1 << 8,
-        HasHDRGainMap               = 1 << 9,
+        Density                     = 1 << 2,
+        DensityCorrectedSize        = 1 << 3,
+        Orientation                 = 1 << 4,
+        PrimaryFrameIndex           = 1 << 5,
+        FrameCount                  = 1 << 6,
+        RepetitionCount             = 1 << 7,
+        ColorSpace                  = 1 << 8,
+        SinglePixelSolidColor       = 1 << 9,
+        HasHDRGainMap               = 1 << 10,
 
-        UTI                         = 1 << 10,
-        FilenameExtension           = 1 << 11,
-        AccessibilityDescription    = 1 << 12,
-        HotSpot                     = 1 << 13,
-        MaximumSubsamplingLevel     = 1 << 14,
+        UTI                         = 1 << 11,
+        FilenameExtension           = 1 << 12,
+        AccessibilityDescription    = 1 << 13,
+        HotSpot                     = 1 << 14,
+        MaximumSubsamplingLevel     = 1 << 15,
     };
 
     template<typename MetadataType>
@@ -115,6 +117,7 @@ private:
 
     mutable EncodedDataStatus m_encodedDataStatus { EncodedDataStatus::Unknown };
     mutable IntSize m_size;
+    mutable FloatSize m_density;
     mutable std::optional<IntSize> m_densityCorrectedSize;
     mutable ImageOrientation m_orientation;
     mutable size_t m_primaryFrameIndex { 0 };

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -159,6 +159,7 @@ private:
     EncodedDataStatus encodedDataStatus() const { return m_descriptor.encodedDataStatus(); }
     IntSize size(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const final { return m_descriptor.size(orientation); }
     IntSize sourceSize(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const final { return m_descriptor.sourceSize(orientation); }
+    FloatSize density() const final { return m_descriptor.density(); }
     std::optional<IntSize> densityCorrectedSize() const { return m_descriptor.densityCorrectedSize(); }
     bool hasDensityCorrectedSize() const final { return densityCorrectedSize().has_value(); }
     ImageOrientation orientation() const final { return m_descriptor.orientation(); }

--- a/Source/WebCore/platform/graphics/ImageDecoder.h
+++ b/Source/WebCore/platform/graphics/ImageDecoder.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/DecodingOptions.h>
 #include <WebCore/ImageOrientation.h>
+#include <WebCore/ImageResolution.h>
 #include <WebCore/ImageTypes.h>
 #include <WebCore/IntPoint.h>
 #include <WebCore/IntSize.h>
@@ -112,6 +113,7 @@ public:
 #endif
 
     virtual IntSize frameSizeAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default) const = 0;
+    virtual FloatSize frameDensityAtIndex(size_t) const { return { ImageResolution::DefaultResolution, ImageResolution::DefaultResolution }; }
     virtual bool frameIsCompleteAtIndex(size_t) const = 0;
     virtual ImageOrientation frameOrientationAtIndex(size_t) const { return ImageOrientation::Orientation::None; }
     virtual std::optional<IntSize> frameDensityCorrectedSizeAtIndex(size_t) const { return std::nullopt; }

--- a/Source/WebCore/platform/graphics/ImageFrame.h
+++ b/Source/WebCore/platform/graphics/ImageFrame.h
@@ -68,6 +68,9 @@ public:
 
     unsigned sizeInBytes() const { return (size().area() * sizeof(uint32_t)).value(); }
 
+    void setDensity(const FloatSize& density) { m_density = density; }
+    FloatSize density() const { return m_density; }
+
     void setDensityCorrectedSize(const IntSize& size) { m_densityCorrectedSize = size; }
     std::optional<IntSize> densityCorrectedSize() const { return m_densityCorrectedSize; }
 
@@ -144,6 +147,7 @@ private:
     DecodingStatus m_decodingStatus { DecodingStatus::Invalid };
 
     IntSize m_size;
+    FloatSize m_density;
     std::optional<IntSize> m_densityCorrectedSize;
 
     SubsamplingLevel m_subsamplingLevel { SubsamplingLevel::Default };

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/ImageFrame.h>
 #include <WebCore/ImageOrientation.h>
+#include <WebCore/ImageResolution.h>
 #include <WebCore/ImageTypes.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
@@ -81,6 +82,7 @@ public:
     // Image Metadata
     virtual IntSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const = 0;
     virtual IntSize sourceSize(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const { return size(orientation); }
+    virtual FloatSize density() const { return { ImageResolution::DefaultResolution, ImageResolution::DefaultResolution }; }
     virtual bool hasDensityCorrectedSize() const { return false; }
     virtual ImageOrientation orientation() const { return ImageOrientation::Orientation::None; }
     virtual unsigned primaryFrameIndex() const { return 0; }

--- a/Source/WebCore/platform/graphics/ImageUtilities.h
+++ b/Source/WebCore/platform/graphics/ImageUtilities.h
@@ -76,6 +76,7 @@ enum class ImageDecodingError : uint8_t {
 };
 WEBCORE_EXPORT String descriptionString(ImageDecodingError);
 WEBCORE_EXPORT Expected<std::pair<String, Vector<IntSize>>, ImageDecodingError> utiAndAvailableSizesFromImageData(std::span<const uint8_t>);
+WEBCORE_EXPORT Expected<Vector<std::pair<String, float>>, ImageDecodingError> imageMetadataFromImageData(std::span<const uint8_t>);
 WEBCORE_EXPORT void createBitmapsFromImageData(std::span<const uint8_t> data, std::span<const unsigned> lengths, CompletionHandler<void(Vector<Ref<ShareableBitmap>>&&)>&&);
 WEBCORE_EXPORT RefPtr<SharedBuffer> createIconDataFromBitmaps(Vector<Ref<ShareableBitmap>>&&);
 WEBCORE_EXPORT void decodeImageWithSize(std::span<const uint8_t> data, std::optional<FloatSize>, CompletionHandler<void(RefPtr<ShareableBitmap>&&)>&&);

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -30,10 +30,6 @@
 
 #include "FourCC.h"
 #include "ImageFrame.h"
-#include "ImageOrientation.h"
-#include "ImageResolution.h"
-#include "IntPoint.h"
-#include "IntSize.h"
 #include "Logging.h"
 #include "MIMETypeRegistry.h"
 #include "ProcessCapabilities.h"
@@ -241,18 +237,26 @@ static ImageOrientation orientationFromProperties(CFDictionaryRef imagePropertie
     return ImageOrientation::fromEXIFValue(exifValue);
 }
 
-static bool mayHaveDensityCorrectedSize(CFDictionaryRef imageProperties)
+static FloatSize frameDensityFromProperties(CFDictionaryRef imageProperties)
 {
     ASSERT(imageProperties);
     auto resolutionXProperty = (CFNumberRef)CFDictionaryGetValue(imageProperties, kCGImagePropertyDPIWidth);
     auto resolutionYProperty = (CFNumberRef)CFDictionaryGetValue(imageProperties, kCGImagePropertyDPIHeight);
     if (!resolutionXProperty || !resolutionYProperty)
-        return false;
+        return { ImageResolution::DefaultResolution, ImageResolution::DefaultResolution };
 
-    float resolutionX, resolutionY;
-    return CFNumberGetValue(resolutionXProperty, kCFNumberFloat32Type, &resolutionX)
-        && CFNumberGetValue(resolutionYProperty, kCFNumberFloat32Type, &resolutionY)
-        && (resolutionX != ImageResolution::DefaultResolution || resolutionY != ImageResolution::DefaultResolution);
+    float resolutionX = 0;
+    float resolutionY = 0;
+    CFNumberGetValue(resolutionXProperty, kCFNumberFloat32Type, &resolutionX);
+    CFNumberGetValue(resolutionYProperty, kCFNumberFloat32Type, &resolutionY);
+
+    return { resolutionX, resolutionY };
+}
+
+static bool mayHaveDensityCorrectedSize(CFDictionaryRef imageProperties)
+{
+    auto density = frameDensityFromProperties(imageProperties);
+    return density.width() != ImageResolution::DefaultResolution || density.height() != ImageResolution::DefaultResolution;
 }
 
 static std::optional<IntSize> densityCorrectedSizeFromProperties(CFDictionaryRef imageProperties)
@@ -517,6 +521,12 @@ IntSize ImageDecoderCG::frameSizeAtIndex(size_t index, SubsamplingLevel subsampl
     return frameSizeFromProperties(properties.get());
 }
 
+FloatSize ImageDecoderCG::frameDensityAtIndex(size_t index) const
+{
+    RetainPtr properties = adoptCF(CGImageSourceCopyPropertiesAtIndex(m_nativeDecoder.get(), index, imageSourceOptions().get()));
+    return frameDensityFromProperties(properties.get());
+}
+
 bool ImageDecoderCG::frameIsCompleteAtIndex(size_t index) const
 {
     ASSERT(frameCount());
@@ -603,6 +613,8 @@ bool ImageDecoderCG::fetchFrameMetaDataAtIndex(size_t index, SubsamplingLevel su
         frame.m_size = frame.nativeImage(options.shouldDecodeToHDR())->size();
     } else
         frame.m_size = frameSizeFromProperties(properties.get());
+
+    frame.m_density = frameDensityFromProperties(properties.get());
 
     if (!mayHaveDensityCorrectedSize(properties.get()))
         frame.m_densityCorrectedSize = std::nullopt;

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
@@ -62,6 +62,7 @@ public:
     std::optional<IntPoint> hotSpot() const final;
 
     IntSize frameSizeAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default) const final;
+    FloatSize frameDensityAtIndex(size_t) const final;
     bool frameIsCompleteAtIndex(size_t) const final;
     ImageOrientation frameOrientationAtIndex(size_t) const final;
     std::optional<IntSize> frameDensityCorrectedSizeAtIndex(size_t) const final;

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ImageUtilities.h"
 
+#include "BitmapImage.h"
 #include "FloatRect.h"
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
@@ -179,6 +180,34 @@ Expected<std::pair<String, Vector<IntSize>>, ImageDecodingError> utiAndAvailable
         sizes.append(imageDecoder->frameSizeAtIndex(index));
 
     return std::make_pair(WTF::move(uti), WTF::move(sizes));
+}
+
+Expected<Vector<std::pair<String, float>>, ImageDecodingError> imageMetadataFromImageData(std::span<const uint8_t> data)
+{
+    Ref buffer = SharedBuffer::create(data);
+    Ref bitmapImage = BitmapImage::create();
+    auto encodedDataStatus = bitmapImage->setData(buffer.get(), true);
+    if (encodedDataStatus == EncodedDataStatus::Error)
+        return makeUnexpected(ImageDecodingError::BadData);
+
+    auto uti = bitmapImage->uti();
+    if (!isSupportedImageType(uti))
+        return makeUnexpected(ImageDecodingError::UnsupportedType);
+
+    Vector<std::pair<String, float>> metadata;
+
+    auto size = bitmapImage->size();
+    metadata.append({ kCGImagePropertyPixelWidth, size.width() });
+    metadata.append({ kCGImagePropertyPixelHeight, size.height() });
+
+    auto density = bitmapImage->density();
+    metadata.append({ kCGImagePropertyDPIWidth, density.width() });
+    metadata.append({ kCGImagePropertyDPIHeight, density.height() });
+
+    auto frameCount = bitmapImage->frameCount();
+    metadata.append({ kCGImagePropertyImageCount, frameCount });
+
+    return WTF::move(metadata);
 }
 
 static RefPtr<NativeImage> tryCreateNativeImageFromBitmapImageData(std::span<const uint8_t> data, std::optional<FloatSize> preferredSize)

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -270,6 +270,7 @@
     [Legacy] StructureParam WebCore::CustomFontCreationData.fontFaceData
 
     [NotSentFromWebContent] MessageParam WebPage.GetInformationFromImageData imageData
+    [NotSentFromWebContent] MessageParam WebPage.GetImageMetadata imageData
     [NotSentFromWebContent] MessageParam WebPage.BindRemoteAccessibilityFrames dataToken
     [NotSentFromWebContent] MessageParamReply WebPageProxy.BindRemoteAccessibilityFrames token
     [NotSentFromWebContent] MessageParamReply WebPageProxy.LoadSynchronousURLSchemeTask data

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4952,6 +4952,24 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
     });
 }
 
+- (void)_getImageMetadata:(NSData *)imageData completionHandler:(void (^)(NSDictionary<NSString *, id> *metadata, NSError *error))completionHandler
+{
+    _page->getImageMetadata(makeVector(imageData), [completionHandler = makeBlockPtr(completionHandler)](auto result) mutable {
+        if (!result) {
+            RetainPtr error = adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey: WebCore::descriptionString(result.error()).createNSString().get() }]);
+            return completionHandler(nil, error.get());
+        }
+
+        auto metadata = result.value();
+        RetainPtr valueMap = adoptNS([[NSMutableDictionary alloc] initWithCapacity:metadata.size()]);
+
+        for (const auto& pair : metadata)
+            [valueMap setObject:@(pair.second) forKey:pair.first.createNSString().get()];
+
+        return completionHandler(valueMap.autorelease(), nil);
+    });
+}
+
 - (void)_createIconDataFromImageData:(NSData *)imageData withLengths:(NSArray<NSNumber *> *)lengths completionHandler:(void (^)(NSData *, NSError *))completionHandler
 {
     Vector<unsigned> targetLengths;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -204,6 +204,8 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 #endif
 - (void)_getInformationFromImageData:(NSData *)imageData completionHandler:(void (^)(NSString *typeIdentifier, NSArray<NSValue *> *availableSizes, NSError *error))completionHandler WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 
+- (void)_getImageMetadata:(NSData *)imageData completionHandler:(void (^)(NSDictionary<NSString *, id> *metadata, NSError *error))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 - (void)_createIconDataFromImageData:(NSData *)imageData withLengths:(NSArray<NSNumber *> *)lengths completionHandler:(void (^)(NSData *, NSError *))completionHandler WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 #if TARGET_OS_OSX
 - (void)_decodeImageData:(NSData *)imageData preferredSize:(NSValue *)preferredSize completionHandler:(void (^)(NSImage *, NSError *))completionHandler WK_API_AVAILABLE(macos(15.4));

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1864,6 +1864,16 @@ void WebPageProxy::getInformationFromImageData(Vector<uint8_t>&& data, Completio
     }, webPageIDInMainFrameProcess());
 }
 
+void WebPageProxy::getImageMetadata(Vector<uint8_t>&& data, CompletionHandler<void(Expected<Vector<std::pair<String, float>>, WebCore::ImageDecodingError>&&)>&& completionHandler)
+{
+    if (isClosed())
+        return completionHandler(makeUnexpected(WebCore::ImageDecodingError::Internal));
+
+    protect(ensureRunningProcess())->sendWithAsyncReply(Messages::WebPage::GetImageMetadata(WTF::move(data)), [preventProcessShutdownScope = protect(legacyMainFrameProcess())->shutdownPreventingScope(), completionHandler = WTF::move(completionHandler)] (auto result) mutable {
+        completionHandler(WTF::move(result));
+    }, webPageIDInMainFrameProcess());
+}
+
 void WebPageProxy::createIconDataFromImageData(Ref<WebCore::SharedBuffer>&& buffer, const Vector<unsigned>& lengths, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&& completionHandler)
 {
     if (isClosed())

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -980,6 +980,7 @@ public:
     void loadAndDecodeImage(WebCore::ResourceRequest&&, std::optional<WebCore::FloatSize>, size_t, CompletionHandler<void(Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError>&&)>&&);
 #if PLATFORM(COCOA)
     void getInformationFromImageData(Vector<uint8_t>&& data, CompletionHandler<void(Expected<std::pair<String, Vector<WebCore::IntSize>>, WebCore::ImageDecodingError>&&)>&&);
+    void getImageMetadata(Vector<uint8_t>&& data, CompletionHandler<void(Expected<Vector<std::pair<String, float>>, WebCore::ImageDecodingError>&&)>&&);
     void createIconDataFromImageData(Ref<WebCore::SharedBuffer>&&, const Vector<unsigned>&, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
     void decodeImageData(Ref<WebCore::SharedBuffer>&&, std::optional<WebCore::FloatSize>, CompletionHandler<void(RefPtr<WebCore::ShareableBitmap>&&)>&&);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2225,6 +2225,14 @@ void WebPage::getInformationFromImageData(const Vector<uint8_t>& data, Completio
     completionHandler(utiAndAvailableSizesFromImageData(data.span()));
 }
 
+void WebPage::getImageMetadata(const Vector<uint8_t>& data, CompletionHandler<void(Expected<Vector<std::pair<String, float>>, WebCore::ImageDecodingError>&&)>&& completionHandler)
+{
+    if (m_isClosed)
+        return completionHandler(makeUnexpected(ImageDecodingError::Internal));
+
+    completionHandler(imageMetadataFromImageData(data.span()));
+}
+
 void WebPage::insertTextPlaceholder(const IntSize& size, CompletionHandler<void(const std::optional<WebCore::ElementContext>&)>&& completionHandler)
 {
     // Inserting the placeholder may run JavaScript, which can do anything, including frame destruction.

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1760,6 +1760,7 @@ public:
     void loadAndDecodeImage(WebCore::ResourceRequest&&, std::optional<WebCore::FloatSize> sizeConstraint, uint64_t, CompletionHandler<void(Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError>&&)>&&);
 #if PLATFORM(COCOA)
     void getInformationFromImageData(const Vector<uint8_t>&, CompletionHandler<void(Expected<std::pair<String, Vector<WebCore::IntSize>>, WebCore::ImageDecodingError>&&)>&&);
+    void getImageMetadata(const Vector<uint8_t>&, CompletionHandler<void(Expected<Vector<std::pair<String, float>>, WebCore::ImageDecodingError>&&)>&&);
     void createBitmapsFromImageData(Ref<WebCore::SharedBuffer>&&, const Vector<unsigned>&, CompletionHandler<void(Vector<Ref<WebCore::ShareableBitmap>>&&)>&&);
     void decodeImageData(Ref<WebCore::SharedBuffer>&&, std::optional<WebCore::FloatSize>, CompletionHandler<void(RefPtr<WebCore::ShareableBitmap>&&)>&&);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -935,6 +935,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     LoadAndDecodeImage(WebCore::ResourceRequest request, std::optional<WebCore::FloatSize> sizeConstraint, uint64_t maximumBytesFromNetwork) -> (Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError> result)
 #if PLATFORM(COCOA)
     GetInformationFromImageData(Vector<uint8_t> imageData) -> (Expected<std::pair<String, Vector<WebCore::IntSize>>, WebCore::ImageDecodingError> result)
+    GetImageMetadata(Vector<uint8_t> imageData) -> (Expected<Vector<std::pair<String, float>>, WebCore::ImageDecodingError> result)
     CreateBitmapsFromImageData(Ref<WebCore::SharedBuffer> imageData, Vector<unsigned> lengths) -> ( Vector<Ref<WebCore::ShareableBitmap>> result);
     DecodeImageData(Ref<WebCore::SharedBuffer> imageData, std::optional<WebCore::FloatSize> preferredSize) -> (RefPtr<WebCore::ShareableBitmap> result)
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAndDecodeImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAndDecodeImage.mm
@@ -231,6 +231,59 @@ TEST(WebKit, GetInformationFromImageData)
     Util::run(&done);
 }
 
+TEST(WebKit, GetImageMetadata)
+{
+    RetainPtr webView = adoptNS([WKWebView new]);
+    done = false;
+    RetainPtr pngData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]];
+    [webView _getImageMetadata:pngData.get() completionHandler:^(NSDictionary *metadata, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_EQ(5, (int)[metadata count]);
+        EXPECT_EQ(215, [metadata[@"PixelWidth"] intValue]);
+        EXPECT_EQ(174, [metadata[@"PixelHeight"] intValue]);
+        EXPECT_EQ(72, [metadata[@"DPIWidth"] floatValue]);
+        EXPECT_EQ(72, [metadata[@"DPIHeight"] floatValue]);
+        EXPECT_EQ(1, [metadata[@"ImageCount"] intValue]);
+        done = true;
+    }];
+    Util::run(&done);
+
+    done = false;
+    RetainPtr gifData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"animated-red-green-blue-repeat-infinite" withExtension:@"gif"]];
+    [webView _getImageMetadata:gifData.get() completionHandler:^(NSDictionary *metadata, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_EQ(100, [metadata[@"PixelWidth"] intValue]);
+        EXPECT_EQ(100, [metadata[@"PixelHeight"] intValue]);
+        EXPECT_EQ(72, [metadata[@"DPIWidth"] floatValue]);
+        EXPECT_EQ(72, [metadata[@"DPIHeight"] floatValue]);
+        EXPECT_EQ(3, [metadata[@"ImageCount"] intValue]);
+        done = true;
+    }];
+    Util::run(&done);
+
+    done = false;
+    RetainPtr tiffData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-100px" withExtension:@"tiff"]];
+    [webView _getImageMetadata:tiffData.get() completionHandler:^(NSDictionary *metadata, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_EQ(100, [metadata[@"PixelWidth"] intValue]);
+        EXPECT_EQ(75, [metadata[@"PixelHeight"] intValue]);
+        EXPECT_EQ(72, [metadata[@"DPIWidth"] floatValue]);
+        EXPECT_EQ(72, [metadata[@"DPIHeight"] floatValue]);
+        EXPECT_EQ(1, [metadata[@"ImageCount"] intValue]);
+        done = true;
+    }];
+    Util::run(&done);
+
+    done = false;
+    RetainPtr svgData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"AllAhem" withExtension:@"svg"]];
+    [webView _getImageMetadata:svgData.get() completionHandler:^(NSDictionary *metadata, NSError *error) {
+        EXPECT_NOT_NULL(error);
+        EXPECT_EQ(0u, [metadata count]);
+        done = true;
+    }];
+    Util::run(&done);
+}
+
 TEST(WebKit, GetInformationFromImageDataAfterClosingWebView)
 {
     RetainPtr webView = adoptNS([WKWebView new]);


### PR DESCRIPTION
#### eb8ebc56f181195caa21aee5994540ccd8171643
<pre>
Add an SPI in WKWebView which retrieves image metadata from image data
<a href="https://bugs.webkit.org/show_bug.cgi?id=312425">https://bugs.webkit.org/show_bug.cgi?id=312425</a>
<a href="https://rdar.apple.com/173955537">rdar://173955537</a>

Reviewed by Tim Horton.

The SPI getImageMetadata will use the WebContent process to decode the image
data and retrieve the size, the density and the frame count of the image.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp:
(WebCore::BitmapImageDescriptor::density const):
* Source/WebCore/platform/graphics/BitmapImageDescriptor.h:
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/ImageDecoder.h:
(WebCore::ImageDecoder::frameDensityAtIndex const):
* Source/WebCore/platform/graphics/ImageFrame.h:
(WebCore::ImageFrame::setDensity):
(WebCore::ImageFrame::density const):
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::density const):
* Source/WebCore/platform/graphics/ImageUtilities.h:
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::frameDensityFromProperties):
(WebCore::mayHaveDensityCorrectedSize):
(WebCore::ImageDecoderCG::frameDensityAtIndex const):
(WebCore::ImageDecoderCG::fetchFrameMetaDataAtIndex const):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.h:
* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:
(WebCore::imageMetadataFromImageData):
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _getImageMetadata:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::getInformationFromImageData):
(WebKit::WebPageProxy::getImageMetadata):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getImageMetadata):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAndDecodeImage.mm:
(TestWebKitAPI::TEST(WebKit, GetImageMetadata)):

Canonical link: <a href="https://commits.webkit.org/311414@main">https://commits.webkit.org/311414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b41935f289c6d73b209e5210370ab940cebc2938

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165682 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110941 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121496 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85314 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102164 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/156178 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22775 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20993 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13454 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168167 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12326 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129611 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129719 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35142 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140486 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87524 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24547 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17290 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29430 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93445 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28953 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29183 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29079 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->