### PR TITLE
Need a short description (OOPS!).

### DIFF
--- a/Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift
@@ -34,7 +34,7 @@ private enum UnsafeErrors: Error {
 
 extension Data {
     fileprivate static func temporaryDataFromSpan(spanNoCopy: PAL.Crypto.SpanConstUInt8) -> Data {
-        guard unsafe spanNoCopy.empty() else {
+        guard spanNoCopy.empty() else {
             return unsafe Data(
                 bytesNoCopy: UnsafeMutablePointer(mutating: spanNoCopy.__dataUnsafe()),
                 count: spanNoCopy.size(),
@@ -49,7 +49,7 @@ extension Data {
 
 extension CryptoKit.HashFunction {
     mutating func update(data: PAL.Crypto.SpanConstUInt8) {
-        if unsafe data.empty() {
+        if data.empty() {
             self.update(data: Data())
         } else {
             unsafe self.update(
@@ -69,7 +69,7 @@ extension AES.GCM {
         iv: PAL.Crypto.SpanConstUInt8,
         ad: PAL.Crypto.SpanConstUInt8
     ) throws -> AES.GCM.SealedBox {
-        guard unsafe ad.size() > 0 else {
+        guard ad.size() > 0 else {
             return try unsafe AES.GCM.seal(
                 Data.temporaryDataFromSpan(spanNoCopy: message),
                 using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)),
@@ -105,7 +105,7 @@ extension AES.KeyWrap {
 
 extension P256.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -114,7 +114,7 @@ extension P256.Signing.ECDSASignature {
 
 extension P384.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -123,7 +123,7 @@ extension P384.Signing.ECDSASignature {
 
 extension P521.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -132,14 +132,14 @@ extension P521.Signing.ECDSASignature {
 
 extension P256.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe spanCompressed.empty() {
+        if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(
@@ -150,14 +150,14 @@ extension P256.Signing.PublicKey {
 
 extension P384.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe spanCompressed.empty() {
+        if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(
@@ -168,14 +168,14 @@ extension P384.Signing.PublicKey {
 
 extension P521.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe spanCompressed.empty() {
+        if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(
@@ -186,7 +186,7 @@ extension P521.Signing.PublicKey {
 
 extension P256.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -195,7 +195,7 @@ extension P256.Signing.PrivateKey {
 
 extension P384.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -204,7 +204,7 @@ extension P384.Signing.PrivateKey {
 
 extension P521.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -213,14 +213,14 @@ extension P521.Signing.PrivateKey {
 
 extension Curve25519.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func signature(span: PAL.Crypto.SpanConstUInt8) throws -> PAL.Crypto.VectorUInt8 {
-        if unsafe span.empty() {
+        if span.empty() {
             return try self.signature(for: Data()).copyToVectorUInt8()
         }
         return try unsafe self.signature(for: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -230,14 +230,14 @@ extension Curve25519.Signing.PrivateKey {
 
 extension Curve25519.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func isValidSignature(signature: PAL.Crypto.SpanConstUInt8, data: PAL.Crypto.SpanConstUInt8) -> Bool {
-        if unsafe (signature.empty() || data.empty()) {
+        if signature.empty() || data.empty() {
             return false
         }
 
@@ -250,14 +250,14 @@ extension Curve25519.Signing.PublicKey {
 
 extension Curve25519.KeyAgreement.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func sharedSecretFromKeyAgreement(pubSpan: PAL.Crypto.SpanConstUInt8) throws -> PAL.Crypto.VectorUInt8 {
-        if unsafe pubSpan.empty() {
+        if pubSpan.empty() {
             throw UnsafeErrors.emptySpan
         }
         let pub = try unsafe Curve25519.KeyAgreement.PublicKey(
@@ -269,7 +269,7 @@ extension Curve25519.KeyAgreement.PrivateKey {
 
 extension Curve25519.KeyAgreement.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))

--- a/Source/WebCore/PAL/pal/crypto/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/crypto/CryptoKitShim.swift
@@ -46,7 +46,7 @@ public final class AesGcm {
     ) -> PAL.Crypto.CryptoOperationReturnValue {
         var returnValue = PAL.Crypto.CryptoOperationReturnValue()
         do {
-            if unsafe iv.size() == 0 {
+            if iv.size() == 0 {
                 returnValue.errorCode = .InvalidArgument
                 return returnValue
             }
@@ -529,7 +529,7 @@ public final class EdKey {
     ) -> PAL.Crypto.CryptoOperationReturnValue {
         var returnValue = PAL.Crypto.CryptoOperationReturnValue()
         do {
-            if unsafe privateKey.size() != 32 {
+            if privateKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
@@ -558,7 +558,7 @@ public final class EdKey {
     ) -> PAL.Crypto.CryptoOperationReturnValue {
         var returnValue = PAL.Crypto.CryptoOperationReturnValue()
         do {
-            if unsafe privateKey.size() != 32 {
+            if privateKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
@@ -587,7 +587,7 @@ public final class EdKey {
         publicKey: PAL.Crypto.SpanConstUInt8
     ) -> Bool {
         do {
-            if unsafe (privateKey.size() != 32 || publicKey.size() != 32) {
+            if privateKey.size() != 32 || publicKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
@@ -612,7 +612,7 @@ public final class EdKey {
         publicKey: PAL.Crypto.SpanConstUInt8
     ) -> Bool {
         do {
-            if unsafe (privateKey.size() != 32 || publicKey.size() != 32) {
+            if privateKey.size() != 32 || publicKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {


### PR DESCRIPTION
#### ee4322170446d90075e2c7627ac28ae632727233
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift:
(Data.temporaryDataFromSpan(_:)):
(CryptoKit.update(_:)):
(Curve25519.signature(_:)):
(Curve25519.isValidSignature(_:data:)):
(Curve25519.sharedSecretFromKeyAgreement(_:)):
* Source/WebCore/PAL/pal/crypto/CryptoKitShim.swift:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee4322170446d90075e2c7627ac28ae632727233

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156716 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30052 "Hash ee432217 for PR 62862 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23235 "Hash ee432217 for PR 62862 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165539 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158587 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/30188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30055 "Hash ee432217 for PR 62862 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159674 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/30188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/23235 "Hash ee432217 for PR 62862 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102052 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/30188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/30055 "Hash ee432217 for PR 62862 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13311 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/30188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/23235 "Hash ee432217 for PR 62862 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168022 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/23235 "Hash ee432217 for PR 62862 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129499 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/30055 "Hash ee432217 for PR 62862 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129608 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/29577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/23235 "Hash ee432217 for PR 62862 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/29577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/23235 "Hash ee432217 for PR 62862 does not build (failure)") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/29285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->