### PR TITLE
[css-anchor-position-1] Change findAnchorsForAnchorPositionedElement and friends to take anchor-positioned elements as Styleable

### DIFF
--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1046,11 +1046,11 @@ std::optional<double> AnchorPositionEvaluator::evaluateSize(BuilderState& builde
     return { };
 }
 
-static const RenderElement* penultimateContainingBlockChainElement(const RenderElement& descendant, const RenderElement* ancestor)
+static const RenderElement* penultimateContainingBlockChainElement(const RenderElement& descendant, const RenderElement& ancestor)
 {
     auto* currentElement = &descendant;
     for (auto* nextElement = currentElement->container(); nextElement; nextElement = nextElement->container()) {
-        if (nextElement == ancestor)
+        if (nextElement == &ancestor)
             return currentElement;
         currentElement = nextElement;
     }
@@ -1063,7 +1063,7 @@ static const RenderElement* penultimateContainingBlockChainElement(const RenderE
 // returns nullptr.
 // (*): an anchor element can also establish an anchor scope containing itself. In this
 // case, the return value is itself.
-static CheckedPtr<const Element> anchorScopeForAnchorName(const RenderBoxModelObject& renderer, const ResolvedScopedName anchorName)
+static CheckedPtr<const Element> anchorScopeForAnchorName(const RenderElement& renderer, const ResolvedScopedName anchorName)
 {
     // Traverse up the composed tree through itself and each ancestor.
     CheckedPtr<const Element> anchorElement = renderer.element();
@@ -1091,7 +1091,7 @@ static CheckedPtr<const Element> anchorScopeForAnchorName(const RenderBoxModelOb
 }
 
 enum class TopLayerStatus : uint8_t { Same, Lower, Higher };
-static TopLayerStatus computeTopLayerStatus(const RenderBox& anchored, const RenderBoxModelObject& anchor)
+static TopLayerStatus computeTopLayerStatus(const RenderElement& anchored, const RenderElement& anchor)
 {
     // Two elements are in the same top layer if they have the same top layer root (including if both are none).
     // An element A is in a higher top layer than an element B if A has a top layer root, and either B has a top
@@ -1129,14 +1129,14 @@ static TopLayerStatus computeTopLayerStatus(const RenderBox& anchored, const Ren
 }
 
 // See: https://drafts.csswg.org/css-anchor-position-1/#acceptable-anchor-element
-static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer, Ref<const Element> anchorPositionedElement, const std::optional<ResolvedScopedName> anchorName = { })
+static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer, const Styleable& anchorPositioned, const std::optional<ResolvedScopedName> anchorName = { })
 {
     // "Possible anchor is either an element or a fully styleable tree-abiding pseudo-element."
     // This always have an associated Element (for ::before/::after it is PseudoElement).
     if (!anchorRenderer.element())
         return false;
 
-    CheckedPtr anchorPositionedRenderer = dynamicDowncast<RenderBox>(anchorPositionedElement->renderer());
+    CheckedPtr anchorPositionedRenderer = anchorPositioned.renderer();
     ASSERT(anchorPositionedRenderer);
 
     if (anchorName) {
@@ -1163,7 +1163,7 @@ static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer
         CheckedPtr containingBlock = anchorPositionedRenderer->container();
         ASSERT(containingBlock);
 
-        auto* penultimateElement = penultimateContainingBlockChainElement(anchorRenderer, containingBlock.get());
+        auto* penultimateElement = penultimateContainingBlockChainElement(anchorRenderer, *containingBlock);
         if (!penultimateElement)
             return false;
 
@@ -1179,17 +1179,17 @@ static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer
     return false;
 }
 
-static RefPtr<Element> findImplicitAnchor(const Element& anchorPositionedElement)
+static RefPtr<Element> findImplicitAnchor(const Styleable& anchorPositioned)
 {
     auto find = [&]() -> RefPtr<Element> {
         // "The implicit anchor element of a pseudo-element is its originating element, unless otherwise specified."
         // https://drafts.csswg.org/css-anchor-position-1/#implicit
-        if (auto pseudoElement = dynamicDowncast<PseudoElement>(anchorPositionedElement))
-            return pseudoElement->hostElement();
+        if (anchorPositioned.pseudoElementIdentifier)
+            return anchorPositioned.element;
 
         // https://html.spec.whatwg.org/multipage/popover.html#the-popover-attribute
         // 24. Set element's implicit anchor element to invoker.
-        if (auto popoverData = anchorPositionedElement.popoverData())
+        if (auto popoverData = anchorPositioned.element.popoverData())
             return popoverData->invoker();
 
         return nullptr;
@@ -1199,22 +1199,22 @@ static RefPtr<Element> findImplicitAnchor(const Element& anchorPositionedElement
         // "If [a spec] defines is an implicit anchor element for query el which is an acceptable anchor element for query el, return that element."
         // https://drafts.csswg.org/css-anchor-position-1/#target
         CheckedPtr anchor = dynamicDowncast<RenderBoxModelObject>(implicitAnchorElement->renderer());
-        if (anchor && isAcceptableAnchorElement(*anchor, anchorPositionedElement))
+        if (anchor && isAcceptableAnchorElement(*anchor, anchorPositioned))
             return implicitAnchorElement;
     }
 
     return nullptr;
 }
 
-static RefPtr<Element> findLastAcceptableAnchorWithName(ResolvedScopedName anchorName, const Element& anchorPositionedElement, const AnchorsForAnchorName& anchorsForAnchorName)
+static RefPtr<Element> findLastAcceptableAnchorWithName(ResolvedScopedName anchorName, const Styleable& anchorPositioned, const AnchorsForAnchorName& anchorsForAnchorName)
 {
     if (anchorName.name() == implicitAnchorElementName().name)
-        return findImplicitAnchor(anchorPositionedElement);
+        return findImplicitAnchor(anchorPositioned);
 
     const auto& anchors = anchorsForAnchorName.get(anchorName);
 
     for (auto& anchor : anchors | std::views::reverse) {
-        if (isAcceptableAnchorElement(anchor.get(), anchorPositionedElement, anchorName))
+        if (isAcceptableAnchorElement(anchor.get(), anchorPositioned, anchorName))
             return anchor->element();
     }
 
@@ -1258,12 +1258,12 @@ static AnchorsForAnchorName collectAnchorsForAnchorName(const Document& document
     return anchorsForAnchorName;
 }
 
-AnchorElements AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement(const Element& anchorPositionedElement, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName& anchorsForAnchorName)
+static AnchorElements findAnchorsForAnchorPositionedElement(const Styleable& anchorPositioned, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName& anchorsForAnchorName)
 {
     AnchorElements anchorElements;
 
     for (auto& anchorName : anchorNames) {
-        auto anchor = findLastAcceptableAnchorWithName(anchorName, anchorPositionedElement, anchorsForAnchorName);
+        auto anchor = findLastAcceptableAnchorWithName(anchorName, anchorPositioned, anchorsForAnchorName);
         anchorElements.add(anchorName, anchor);
     }
 
@@ -1278,23 +1278,18 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
     // FIXME: Make the code below oeprate on renderers (boxes) rather than elements.
     auto anchorsForAnchorName = collectAnchorsForAnchorName(document);
 
-    for (auto& [weakStyleable, state] : anchorPositionedStates) {
-        auto styleable = weakStyleable.styleable();
-        if (!styleable)
+    for (auto& [weakAnchorPositioned, state] : anchorPositionedStates) {
+        auto anchorPositioned = weakAnchorPositioned.styleable();
+        if (!anchorPositioned)
             continue;
 
-        CheckedPtr renderer = styleable->renderer();
+        CheckedPtr renderer = anchorPositioned->renderer();
 
         switch (state->stage) {
         case AnchorPositionResolutionStage::FindAnchors: {
             if (renderer) {
-                // FIXME: change the anchor finding pipeline to use Styleable instead.
-                RefPtr elementForFinding = &styleable->element;
-                if (styleable->pseudoElementIdentifier)
-                    elementForFinding = elementForFinding->pseudoElementIfExists(*styleable->pseudoElementIdentifier);
-
                 // FIXME: Remove the redundant anchorElements member. The mappings are available in anchorPositionedToAnchorMap.
-                state->anchorElements = findAnchorsForAnchorPositionedElement(*elementForFinding, state->anchorNames, anchorsForAnchorName);
+                state->anchorElements = findAnchorsForAnchorPositionedElement(*anchorPositioned, state->anchorNames, anchorsForAnchorName);
                 if (isLayoutTimeAnchorPositioned(renderer->style()))
                     renderer->setNeedsLayout();
 
@@ -1306,7 +1301,7 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
                         .name = anchorNameAndElement.key
                     });
                 }
-                document.styleScope().anchorPositionedToAnchorMap().set(*styleable, AnchorPositionedToAnchorEntry {
+                document.styleScope().anchorPositionedToAnchorMap().set(*anchorPositioned, AnchorPositionedToAnchorEntry {
                     .anchors = WTF::move(anchors)
                 });
             }

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -222,7 +222,6 @@ public:
 
 private:
     static CheckedPtr<RenderBoxModelObject> findAnchorForAnchorFunctionAndAttemptResolution(BuilderState&, std::optional<ScopedName> elementName);
-    static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName&);
     static RefPtr<const Element> anchorPositionedElementOrPseudoElement(BuilderState&);
     static void addAnchorFunctionScrollCompensatedAxis(RenderStyle&, const RenderBox& anchored, const RenderBoxModelObject& anchor, BoxAxis);
     static LayoutSize scrollOffsetFromAnchor(const RenderBoxModelObject& anchor, const RenderBox& anchored);


### PR DESCRIPTION
#### 646ee9045efce32c22709cc5f0be460075eab9cf
<pre>
[css-anchor-position-1] Change findAnchorsForAnchorPositionedElement and friends to take anchor-positioned elements as Styleable
<a href="https://rdar.apple.com/174867992">rdar://174867992</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312416">https://bugs.webkit.org/show_bug.cgi?id=312416</a>

Reviewed by Antti Koivisto.

Following 311053@main, make findAnchorsForAnchorPositionedElement and its friends
take Styleable instead of Element for anchor-positioned elements.

Functions using RenderBox/RenderBoxModelObject were also changed to take
RenderElement whenever possible, this helps reduce unnecessary downcast
when RenderElement is sufficient.

Refactoring change, tested by existing test suite.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::penultimateContainingBlockChainElement):
(WebCore::Style::anchorScopeForAnchorName):
(WebCore::Style::computeTopLayerStatus):
(WebCore::Style::isAcceptableAnchorElement):
(WebCore::Style::findImplicitAnchor):
(WebCore::Style::findLastAcceptableAnchorWithName):
(WebCore::Style::findAnchorsForAnchorPositionedElement):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
(WebCore::Style::AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement): Deleted.
    - Make this a static function in AnchorPositionEvaluator.cpp and
      not part of AnchorPositionEvaluator class.

* Source/WebCore/style/AnchorPositionEvaluator.h:

Canonical link: <a href="https://commits.webkit.org/311384@main">https://commits.webkit.org/311384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aff9bd9eb469b37c9947cc7da922e78ecebe2ba5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165544 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110802 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121393 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85261 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140736 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102061 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22659 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20871 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13316 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132338 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168027 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12188 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129507 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129616 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35128 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140359 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87383 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24435 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17163 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29290 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93307 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 40738 issues") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28815 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29045 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28941 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->