### PR TITLE
[Swift in WebKit] Swift Testing should support disabled tests

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -373,6 +373,8 @@ class _Worker(object):
                         status = Runner.STATUS_PASSED
                     elif '**FAIL**' in stdout_line:
                         status = Runner.STATUS_FAILED
+                    elif '**DISABLED**' in stdout_line:
+                        status = Runner.STATUS_DISABLED
                     else:
                         stdout_buffer += stdout_line
                         _log.error(stdout_line[:-1])

--- a/Tools/TestWebKitAPI/Runner/SwiftTestsController.swift
+++ b/Tools/TestWebKitAPI/Runner/SwiftTestsController.swift
@@ -54,7 +54,7 @@ actor SwiftTestsController: TestRunner {
     }
 
     nonisolated private func writeOutputIfNeeded(_ record: SwiftTestingABI.Record) {
-        guard case .event(let eventRecord) = record.kind, eventRecord.kind == .testEnded else {
+        guard case .event(let eventRecord) = record.kind else {
             return
         }
 
@@ -70,10 +70,8 @@ actor SwiftTestsController: TestRunner {
             return
         }
 
-        let passed = events.allSatisfy { $0.kind != .issueRecorded }
-        if passed {
-            print("**PASS** \(testID.canonicalizedRepresentation)")
-        } else {
+        switch eventRecord.kind {
+        case .testEnded where events.contains { $0.kind == .issueRecorded }:
             let failureDescriptions = events
                 .lazy
                 .filter { $0.kind == .issueRecorded }
@@ -84,6 +82,15 @@ actor SwiftTestsController: TestRunner {
                 .joined(separator: "\n")
 
             print("**FAIL** \(testID.canonicalizedRepresentation)\n\(failureDescriptions)")
+
+        case .testEnded:
+            print("**PASS** \(testID.canonicalizedRepresentation)")
+
+        case .testSkipped:
+            print("**DISABLED** \(testID.canonicalizedRepresentation)")
+
+        default:
+            break
         }
     }
 


### PR DESCRIPTION
#### 054004da4473047502dd0ba4491b5ac4a1b50318
<pre>
[Swift in WebKit] Swift Testing should support disabled tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=312429">https://bugs.webkit.org/show_bug.cgi?id=312429</a>
<a href="https://rdar.apple.com/174878908">rdar://174878908</a>

Reviewed by Aditya Keerthi.

Unlike GTest, Swift Testing reports disabled/skipped tests during the test run, so add logic
in the runner and the script to process and handle this information properly.

* Tools/Scripts/webkitpy/api_tests/runner.py:
(_Worker._run_single_test):
* Tools/TestWebKitAPI/Runner/SwiftTestsController.swift:
(writeOutputIfNeeded(_:)):

Canonical link: <a href="https://commits.webkit.org/311338@main">https://commits.webkit.org/311338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2b8f9c40cd5ef79de4aeab43899f3e1a6e8297c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165545 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30061 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121390 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159680 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102058 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/156041 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13317 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168028 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20177 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129613 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35101 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140351 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24430 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29291 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->