### PR TITLE
Fix GC correctness bugs with NodeIterator, TreeWalker, and MutationRecord

### DIFF
--- a/LayoutTests/fast/dom/MutationObserver/mutation-record-child-list-disconnected-root-expected.txt
+++ b/LayoutTests/fast/dom/MutationObserver/mutation-record-child-list-disconnected-root-expected.txt
@@ -1,0 +1,11 @@
+This tests that MutationRecord keeps the disconnected roots of previousSibling and nextSibling alive.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS records[0].previousSibling.getRootNode().localName is "prev-root"
+PASS records[0].nextSibling.getRootNode().localName is "next-root"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/MutationObserver/mutation-record-child-list-disconnected-root.html
+++ b/LayoutTests/fast/dom/MutationObserver/mutation-record-child-list-disconnected-root.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script>
+
+description('This tests that MutationRecord keeps the disconnected roots of previousSibling and nextSibling alive.');
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+else
+    testFailed('This test requires GCController');
+
+let container = document.createElement('div');
+container.innerHTML = '<prev></prev><next></next>';
+
+const observer = new MutationObserver(() => { });
+observer.observe(container, {childList: true});
+
+// Insert a node between <prev> and <next>.
+// This creates a mutation record with previousSibling=<prev> and nextSibling=<next>.
+container.querySelector('prev').after(document.createElement('b'));
+
+// Take the records synchronously so that moving nodes below doesn't create
+// additional records whose removedNodes would keep the sibling trees alive.
+window.records = observer.takeRecords();
+observer.disconnect();
+
+// Move <prev> and <next> to separate disconnected trees so their opaque roots
+// differ from the target's.
+(function() {
+    let prevRoot = document.createElement('prev-root');
+    prevRoot.appendChild(container.querySelector('prev'));
+    let nextRoot = document.createElement('next-root');
+    nextRoot.appendChild(container.querySelector('next'));
+})();
+
+container = null;
+
+if (window.GCController)
+    GCController.collect();
+
+shouldBeEqualToString('records[0].previousSibling.getRootNode().localName', 'prev-root');
+shouldBeEqualToString('records[0].nextSibling.getRootNode().localName', 'next-root');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/node-iterator-disconnected-root-expected.txt
+++ b/LayoutTests/fast/dom/node-iterator-disconnected-root-expected.txt
@@ -1,0 +1,10 @@
+This tests holding onto a node via TreeWalker. WebKit should keep the root node alive.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS nodeIterator.referenceNode.getRootNode().localName is "div"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/node-iterator-disconnected-root.html
+++ b/LayoutTests/fast/dom/node-iterator-disconnected-root.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests holding onto a node via TreeWalker. WebKit should keep the root node alive.');
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+const nodeIterator = (function () {
+    let div = document.createElement('div');
+    let span = document.createElement('span');
+    div.appendChild(span);
+    return document.createNodeIterator(span);
+})();
+
+if (window.GCController)
+    GCController.collect();
+else
+    testFailed('This tests requires GCController');
+
+shouldBeEqualToString('nodeIterator.referenceNode.getRootNode().localName', 'div');
+
+</script></body>

--- a/LayoutTests/fast/dom/tree-walker-disconnected-root-expected.txt
+++ b/LayoutTests/fast/dom/tree-walker-disconnected-root-expected.txt
@@ -1,0 +1,10 @@
+This tests holding onto a node via TreeWalker. WebKit should keep the root node alive.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS treeWalker.currentNode.getRootNode().localName is "div"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/tree-walker-disconnected-root.html
+++ b/LayoutTests/fast/dom/tree-walker-disconnected-root.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests holding onto a node via TreeWalker. WebKit should keep the root node alive.');
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+let treeWalker = (function setup() {
+    let div = document.createElement('div');
+    let span = document.createElement('span');
+    div.appendChild(span);
+    return document.createTreeWalker(span);
+})();
+
+if (window.GCController)
+    GCController.collect();
+else
+    testFailed('This tests requires GCController');
+
+shouldBeEqualToString('treeWalker.currentNode.getRootNode().localName', 'div');
+
+</script></body>

--- a/Source/WebCore/bindings/js/JSNodeIteratorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeIteratorCustom.cpp
@@ -31,6 +31,7 @@ void JSNodeIterator::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (auto filter = wrapped().filter())
         addWebCoreOpaqueRoot(visitor, *filter);
+    addWebCoreOpaqueRoot(visitor, wrapped().root());
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSNodeIterator);

--- a/Source/WebCore/bindings/js/JSTreeWalkerCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTreeWalkerCustom.cpp
@@ -31,6 +31,7 @@ void JSTreeWalker::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (auto filter = wrapped().filter())
         addWebCoreOpaqueRoot(visitor, *filter);
+    addWebCoreOpaqueRoot(visitor, wrapped().root());
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSTreeWalker);

--- a/Source/WebCore/dom/MutationRecord.cpp
+++ b/Source/WebCore/dom/MutationRecord.cpp
@@ -76,6 +76,8 @@ private:
     void visitNodesInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
         addWebCoreOpaqueRoot(visitor, m_target.get());
+        addWebCoreOpaqueRoot(visitor, m_previousSibling.get());
+        addWebCoreOpaqueRoot(visitor, m_nextSibling.get());
         // We cannot ref m_addedNodes here as this function may get called from a GC thread.
         SUPPRESS_UNRETAINED_ARG visitNodeListInGCThread(visitor, m_addedNodes.get());
         // We cannot ref m_removedNodes here as this function may get called from a GC thread.


### PR DESCRIPTION
#### 561b0719d80db5f9e66400463c65a588c9c31208
<pre>
Fix GC correctness bugs with NodeIterator, TreeWalker, and MutationRecord
<a href="https://bugs.webkit.org/show_bug.cgi?id=312435">https://bugs.webkit.org/show_bug.cgi?id=312435</a>

Reviewed by Chris Dumez.

Fix the bugs that these classes weren&apos;t keeping JS wrappers of some of their Node properties alive
by adding them in visitAdditionalChildren.

Tests: fast/dom/MutationObserver/mutation-record-child-list-disconnected-root.html
       fast/dom/node-iterator-disconnected-root.html
       fast/dom/tree-walker-disconnected-root.html

* LayoutTests/fast/dom/MutationObserver/mutation-record-child-list-disconnected-root-expected.txt: Added.
* LayoutTests/fast/dom/MutationObserver/mutation-record-child-list-disconnected-root.html: Added.
* LayoutTests/fast/dom/node-iterator-disconnected-root-expected.txt: Added.
* LayoutTests/fast/dom/node-iterator-disconnected-root.html: Added.
* LayoutTests/fast/dom/tree-walker-disconnected-root-expected.txt: Added.
* LayoutTests/fast/dom/tree-walker-disconnected-root.html: Added.
* Source/WebCore/bindings/js/JSNodeIteratorCustom.cpp:
(WebCore::JSNodeIterator::visitAdditionalChildrenInGCThread):
* Source/WebCore/bindings/js/JSTreeWalkerCustom.cpp:
(WebCore::JSTreeWalker::visitAdditionalChildrenInGCThread):
* Source/WebCore/dom/MutationRecord.cpp:
(WebCore::ChildListRecord::visitNodesInGCThread):

Canonical link: <a href="https://commits.webkit.org/311355@main">https://commits.webkit.org/311355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5f04e30234fce3325a7e88522fa3bf65cb60e63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165560 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121407 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102075 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22675 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20885 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13332 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168043 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129520 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129629 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140372 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87399 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23860 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24446 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17176 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29307 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28831 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29061 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->