### PR TITLE
After spending some time on a page, web content hangs forcing page reload - cnn.com, yahoo.com

### DIFF
--- a/LayoutTests/fast/js-promise/js-promise-self-perpetuating-inside-detached-iframe-expected.txt
+++ b/LayoutTests/fast/js-promise/js-promise-self-perpetuating-inside-detached-iframe-expected.txt
@@ -1,0 +1,10 @@
+Tests that a self-perpetuating promise chain whose chain function is defined inside a detached iframe is terminated.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Main thread remained responsive after removing iframe whose script defined a self-perpetuating promise chain
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/js-promise/js-promise-self-perpetuating-inside-detached-iframe.html
+++ b/LayoutTests/fast/js-promise/js-promise-self-perpetuating-inside-detached-iframe.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<script src="../../resources/js-test.js"></script>
+<body></body>
+<script>
+description("Tests that a self-perpetuating promise chain whose chain function is defined inside a detached iframe is terminated.");
+jsTestIsAsync = true;
+
+var frame = document.createElement('iframe');
+document.body.appendChild(frame);
+
+frame.contentWindow.eval(`
+    function chain() {
+        Promise.resolve().then(chain);
+    }
+    chain();
+`);
+
+frame.remove();
+
+var deadlineTimer = setTimeout(() => {
+    testFailed("Test exceeded 5 second deadline - microtask chain inside detached iframe was not terminated");
+    finishJSTest();
+}, 5000);
+
+setTimeout(() => {
+    clearTimeout(deadlineTimer);
+    testPassed("Main thread remained responsive after removing iframe whose script defined a self-perpetuating promise chain");
+    finishJSTest();
+}, 100);
+</script>

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -3646,6 +3646,25 @@ void JSGlobalObject::queueMicrotaskToEventLoop(JSC::JSGlobalObject& globalObject
     globalObject.queueMicrotask(globalObject.vm(), WTF::move(task));
 }
 
+static bool incumbentRealmIs(VM& vm, JSGlobalObject* target)
+{
+    bool result = false;
+    StackVisitor::visit(vm.topCallFrame, vm, [&](StackVisitor& visitor) {
+        if (visitor->isNativeCalleeFrame())
+            return IterationStatus::Continue;
+        if (auto* codeBlock = visitor->codeBlock()) {
+            if (auto* functionExecutable = dynamicDowncast<FunctionExecutable>(codeBlock->ownerExecutable()); functionExecutable && functionExecutable->isBuiltinFunction())
+                return IterationStatus::Continue;
+            if (codeBlock->globalObject() == target) {
+                result = true;
+                return IterationStatus::Done;
+            }
+        }
+        return IterationStatus::Continue;
+    });
+    return result;
+}
+
 void JSGlobalObject::queueMicrotask(VM& vm, QueuedTask&& task)
 {
     ([&] ALWAYS_INLINE_LAMBDA {
@@ -3661,6 +3680,10 @@ void JSGlobalObject::queueMicrotask(VM& vm, QueuedTask&& task)
             return;
         }
     }());
+    if (!m_associatedContextIsFullyActive) [[unlikely]] {
+        if (microtaskQueue().isPerformingMicrotaskCheckpoint() && incumbentRealmIs(vm, this)) [[unlikely]]
+            return;
+    }
     microtaskQueue().enqueue(WTF::move(task));
 }
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -233,6 +233,7 @@ private:
     VM* const m_vm;
     Debugger* m_debugger { nullptr };
     QueuedTaskResult m_microtaskRunnability { QueuedTaskResult::Executed };
+    bool m_associatedContextIsFullyActive { true };
     Ref<MicrotaskQueue> m_microtaskQueue;
 
 // Our hashtable code-generator tries to access these properties, so we make them public.
@@ -1248,6 +1249,8 @@ public:
 
     QueuedTaskResult microtaskRunnability() const { return m_microtaskRunnability; }
     void setMicrotaskRunnability(QueuedTaskResult runnability) { m_microtaskRunnability = runnability; }
+
+    void setAssociatedContextIsFullyActive(bool value) { m_associatedContextIsFullyActive = value; }
 
     MicrotaskQueue& microtaskQueue() const;
     JS_EXPORT_PRIVATE void setMicrotaskQueue(Ref<MicrotaskQueue>&&);

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.h
@@ -245,6 +245,8 @@ public:
     bool isScheduledToRun() const { return m_isScheduledToRun; }
     void setIsScheduledToRun(bool value) { m_isScheduledToRun = value; }
 
+    bool isPerformingMicrotaskCheckpoint() const { return m_isPerformingMicrotaskCheckpoint; }
+
 protected:
     JS_EXPORT_PRIVATE MicrotaskQueue(VM&);
     virtual void scheduleToRunIfNeeded()
@@ -252,6 +254,7 @@ protected:
         setIsScheduledToRun(true);
     }
     bool m_isScheduledToRun { false };
+    bool m_isPerformingMicrotaskCheckpoint { false };
 
 private:
     JS_EXPORT_PRIVATE std::pair<JSGlobalObject*, bool> drainWithUseCallOnEachMicrotask(JSGlobalObject* currentGlobalObject, VM&, TopExceptionScope&);

--- a/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
@@ -31,6 +31,7 @@
 #include <JavaScriptCore/MicrotaskQueue.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/VMEntryScopeInlines.h>
+#include <wtf/SetForScope.h>
 
 namespace JSC {
 
@@ -75,6 +76,7 @@ inline void MicrotaskQueue::enqueue(QueuedTask&& task)
 template<bool useCallOnEachMicrotask>
 inline void MicrotaskQueue::performMicrotaskCheckpoint(VM& vm, NOESCAPE const Invocable<void(JSGlobalObject*, JSGlobalObject*)> auto& globalObjectSwitchCallback)
 {
+    SetForScope inCheckpoint(m_isPerformingMicrotaskCheckpoint, true);
     auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     if (vm.executionForbidden()) [[unlikely]]
         clear();

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -126,6 +126,7 @@
 #include "UserScript.h"
 #include "UserTypingGestureIndicator.h"
 #include "VisibleUnits.h"
+#include "WindowProxy.h"
 #include "markup.h"
 #include "runtime_root.h"
 #include <JavaScriptCore/APICast.h>
@@ -1333,6 +1334,11 @@ void LocalFrame::frameWasDisconnectedFromOwner() const
 {
     if (!m_doc)
         return;
+
+    for (auto& jsWindowProxy : windowProxy().jsWindowProxiesAsVector()) {
+        if (auto* jsDOMWindow = dynamicDowncast<JSDOMWindowBase>(jsWindowProxy->window()))
+            jsDOMWindow->setAssociatedContextIsFullyActive(false);
+    }
 
     protect(document())->willBeRemovedFromFrame();
 }


### PR DESCRIPTION
#### f55db8dff653899cde7cb96a7b5cc205b1d65c62
<pre>
After spending some time on a page, web content hangs forcing page reload - cnn.com, yahoo.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=312438">https://bugs.webkit.org/show_bug.cgi?id=312438</a>
<a href="https://rdar.apple.com/174443020">rdar://174443020</a>

Reviewed by Yusuke Suzuki.

This is a speculative fix for an issue with hanging on cnn.com. Due to
the nature of the issue, it is hard to explicitly confirm that this
completely resolves the problem. The cause seems to be that ad frames
on navigated-away-from documents have DOMTimer tasks that fire in a
window where the document is no longer fully active but its
EventLoopTaskGroup has not yet been marked as ReadyToStop. These timer
callbacks trigger self-perpetuating microtask chains that cause the
microtask drain to hang indefinitely.

JSGlobalObject::queueMicrotask was not checking whether the queueing
realm&apos;s associated document is still fully active, allowing detached
realms to keep enqueueing microtasks indefinitely. This change adds that
check, dropping a microtask when the realm&apos;s document is no longer fully
active and the active script&apos;s realm is detached. The walk skips
engine-internal frames so thatvmachinery delivering microtasks across
realms is not misidentified. LocalFrame::frameWasDisconnectedFromOwner
marks each per-world JSDOMWindow wrapper as no longer fully active
when the frame detaches.

Test: fast/js-promise/js-promise-self-perpetuating-inside-detached-iframe.html

* LayoutTests/fast/js-promise/js-promise-self-perpetuating-inside-detached-iframe-expected.txt: Added.
* LayoutTests/fast/js-promise/js-promise-self-perpetuating-inside-detached-iframe.html: Added.
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::incumbentRealmIs):
(JSC::JSGlobalObject::queueMicrotask):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::setAssociatedContextIsFullyActive):
* Source/JavaScriptCore/runtime/MicrotaskQueue.h:
(JSC::MicrotaskQueue::isPerformingMicrotaskCheckpoint const):
* Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h:
(JSC::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::frameWasDisconnectedFromOwner const):

Canonical link: <a href="https://commits.webkit.org/312205@main">https://commits.webkit.org/312205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f64e33e4d67df7abb33cd2dcf030516e4c9244bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123176 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86491 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24504 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22900 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15565 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151014 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170286 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19797 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16028 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131369 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131481 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35606 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90075 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19197 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191246 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31536 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97550 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49158 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31056 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31211 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->