### PR TITLE
[CMake] Add TestIPC and TestWGSL targets

### DIFF
--- a/Source/WebGPU/WGSL/CMakeLists.txt
+++ b/Source/WebGPU/WGSL/CMakeLists.txt
@@ -71,7 +71,6 @@ set(wgslc_SOURCES
     WGSL.cpp
     WGSLEnums.cpp
     WGSLShaderModule.cpp
-    wgslc.cpp
 
     AST/ASTBinaryExpression.cpp
     AST/ASTBuilder.cpp
@@ -206,6 +205,23 @@ set(wgslc_PRIVATE_INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}/Metal)
 set(wgslc_DEPENDENCIES wgsl-types)
 
+# WGSLCore static library -- shared between wgslc and TestWGSL.
+add_library(WGSLCore STATIC ${wgslc_SOURCES})
+target_include_directories(WGSLCore PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}/../../..
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/AST
+    ${CMAKE_CURRENT_SOURCE_DIR}/Metal)
+target_link_libraries(WGSLCore PUBLIC WebKit::WTF WebKit::bmalloc)
+add_dependencies(WGSLCore wgsl-types)
+
+if (DEVELOPER_MODE_CXX_FLAGS)
+    target_compile_options(WGSLCore PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
+endif ()
+
+# wgslc executable
+list(APPEND wgslc_SOURCES wgslc.cpp)
 WEBKIT_EXECUTABLE_DECLARE(wgslc)
 WEBKIT_EXECUTABLE(wgslc)
 

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -457,6 +457,89 @@ if (ENABLE_WEBKIT)
     endif ()
 
     WEBKIT_EXECUTABLE_DECLARE(TestWebKit)
+
+    if (APPLE)
+        # TestIPC definitions
+        set(TestIPC_SOURCES
+            Helpers/Utilities.cpp
+
+            Runner/TestsController.cpp
+
+            Tests/IPC/ArgumentCoderTests.cpp
+            Tests/IPC/ConnectionTests.cpp
+            Tests/IPC/EventTests.cpp
+            Tests/IPC/IPCTestUtilities.cpp
+            Tests/IPC/MessageLogEndToEndTests.cpp
+            Tests/IPC/MessageLogTests.cpp
+            Tests/IPC/MessageSenderTests.cpp
+            Tests/IPC/StreamConnectionBufferTests.cpp
+            Tests/IPC/StreamConnectionEncoderTests.cpp
+            Tests/IPC/StreamConnectionTests.cpp
+            Tests/IPC/StreamConnectionWorkQueueTests.cpp
+            Tests/IPC/ThreadSafeObjectHeapTests.cpp
+            Tests/IPC/TransferStringTests.cpp
+        )
+
+        set(TestIPC_PRIVATE_INCLUDE_DIRECTORIES
+            ${CMAKE_BINARY_DIR}
+            ${JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS_DIR}
+            ${PAL_FRAMEWORK_HEADERS_DIR}
+            ${TESTWEBKITAPI_DIR}
+            ${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}
+            ${WebKit_FRAMEWORK_HEADERS_DIR}
+            ${WEBKIT_DIR}/Platform
+            ${WEBKIT_DIR}/Platform/IPC
+            ${WEBKIT_DIR}/Shared
+            ${WEBKIT_DIR}/Shared/API/c
+            ${WebKit_DERIVED_SOURCES_DIR}
+            ${WebKit_DERIVED_SOURCES_DIR}/IPC
+        )
+
+        set(TestIPC_LIBRARIES
+            WebKit::gtest
+        )
+
+        set(TestIPC_FRAMEWORKS
+            WebKit
+        )
+
+        WEBKIT_EXECUTABLE_DECLARE(TestIPC)
+        target_compile_definitions(TestIPC PRIVATE BUILDING_TEST_IPC GTEST_API_=)
+    endif ()
+endif ()
+
+# TestWGSL definitions
+if (APPLE AND ENABLE_WEBGPU)
+    set(TestWGSL_SOURCES
+        Runner/TestsController.cpp
+
+        Tests/WGSL/ASTStringDumperTests.cpp
+        Tests/WGSL/ConstLiteralTests.cpp
+        Tests/WGSL/LexerTests.cpp
+        Tests/WGSL/MetalGenerationTests.cpp
+        Tests/WGSL/ParserTests.cpp
+        Tests/WGSL/TestWGSLAPI.cpp
+    )
+
+    set(TestWGSL_PRIVATE_INCLUDE_DIRECTORIES
+        ${CMAKE_BINARY_DIR}
+        ${TESTWEBKITAPI_DIR}
+        ${JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS_DIR}
+    )
+
+    set(TestWGSL_LIBRARIES
+        WGSLCore
+        WebKit::gtest
+    )
+
+    set(TestWGSL_FRAMEWORKS
+        JavaScriptCore
+        WTF
+        bmalloc
+    )
+
+    WEBKIT_EXECUTABLE_DECLARE(TestWGSL)
+    target_compile_definitions(TestWGSL PRIVATE BUILDING_TEST_WGSL GTEST_API_=)
 endif ()
 
 # Include platform specific files
@@ -483,4 +566,12 @@ endif ()
 # TestWebKit target
 if (ENABLE_WEBKIT)
     WEBKIT_TEST(TestWebKit)
+    if (APPLE)
+        WEBKIT_TEST(TestIPC)
+    endif ()
+endif ()
+
+# TestWGSL target
+if (APPLE AND ENABLE_WEBGPU)
+    WEBKIT_TEST(TestWGSL)
 endif ()

--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -61,6 +61,7 @@ list(APPEND TestWebKit_PRIVATE_INCLUDE_DIRECTORIES
     ${bmalloc_FRAMEWORK_HEADERS_DIR}
     ${WebKit_FRAMEWORK_HEADERS_DIR}
     ${WebKitLegacy_FRAMEWORK_HEADERS_DIR}
+    ${WEBKITLEGACY_DIR}
 )
 
 list(APPEND TestWebKit_LIBRARIES
@@ -74,6 +75,55 @@ WEBKIT_ADD_TARGET_CXX_FLAGS(TestWebKit -Wno-deprecated-declarations)
 
 # run-api-tests expects the binary to be named TestWebKitAPI.
 set_target_properties(TestWebKit PROPERTIES OUTPUT_NAME TestWebKitAPI)
+
+# TestIPC
+list(APPEND TestIPC_SOURCES
+    ${_test_main_SOURCES}
+    Helpers/cocoa/UtilitiesCocoa.mm
+
+    Tests/IPC/IPCSerialization.mm
+    Tests/IPC/TransferStringObjCTests.mm
+)
+
+list(APPEND TestIPC_PRIVATE_INCLUDE_DIRECTORIES
+    ${WTF_FRAMEWORK_HEADERS_DIR}
+    ${bmalloc_FRAMEWORK_HEADERS_DIR}
+    ${WEBKIT_DIR}/Platform/cocoa
+    ${WEBKIT_DIR}/Platform/IPC/darwin
+    ${WEBKIT_DIR}/Platform/IPC/cocoa
+    ${WEBKIT_DIR}/Shared/Cocoa
+    ${WEBKIT_DIR}/Shared/cf
+)
+
+list(APPEND TestIPC_LIBRARIES
+    ${CARBON_LIBRARY}
+    "-framework CoreServices"
+    "-framework CoreVideo"
+    "-framework IOSurface"
+    "-framework UniformTypeIdentifiers"
+    WTF
+)
+
+WEBKIT_ADD_TARGET_CXX_FLAGS(TestIPC -Wno-deprecated-declarations)
+
+# TestWGSL
+if (ENABLE_WEBGPU)
+    list(APPEND TestWGSL_SOURCES
+        ${_test_main_SOURCES}
+        Tests/WGSL/MetalCompilationTests.mm
+        Tests/WGSL/TypeCheckingTests.mm
+    )
+
+    list(APPEND TestWGSL_PRIVATE_INCLUDE_DIRECTORIES
+        ${WTF_FRAMEWORK_HEADERS_DIR}
+        ${bmalloc_FRAMEWORK_HEADERS_DIR}
+    )
+
+    list(APPEND TestWGSL_LIBRARIES
+        ${CARBON_LIBRARY}
+        "-framework Metal"
+    )
+endif ()
 
 # Common framework header directories needed by config.h (<wtf/Platform.h>, <WebKit/WebKit2_C.h>, etc.)
 set(_testapi_framework_headers
@@ -138,7 +188,7 @@ WEBKIT_COPY_FILES(TestWebKitAPIResources
     FLATTENED
 )
 # Ensure all test targets depend on the resources bundle.
-foreach (_test_target TestWTF TestJavaScriptCore TestWebCore TestWebKitLegacy TestWebKit)
+foreach (_test_target TestWTF TestJavaScriptCore TestWebCore TestWebKitLegacy TestWebKit TestIPC TestWGSL)
     if (TARGET ${_test_target})
         add_dependencies(${_test_target} TestWebKitAPIResources)
     endif ()

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -36,7 +36,7 @@
 #import "CoreIPCPlistDictionary.h"
 #import "Encoder.h"
 #import "MessageSenderInlines.h"
-#import "test.h"
+#import "Helpers/Test.h"
 #import <CoreVideo/CoreVideo.h>
 #import <Foundation/NSValue.h>
 #import <Security/Security.h>

--- a/Tools/TestWebKitAPI/config.h
+++ b/Tools/TestWebKitAPI/config.h
@@ -42,11 +42,11 @@
 #if defined(BUILDING_WITH_CMAKE)
 
 // CMake path
-#if defined(BUILDING_TestJSC) || defined(BUILDING_TestJavaScriptCore)
+#if defined(BUILDING_TestJSC) || defined(BUILDING_TestJavaScriptCore) || defined(BUILDING_TEST_WGSL)
 #include <JavaScriptCore/JSExportMacros.h>
 #endif
 
-#if defined(BUILDING_TestWebCore)
+#if defined(BUILDING_TestWebCore) || defined(BUILDING_TEST_IPC)
 #include <JavaScriptCore/JSExportMacros.h>
 #include <WebCore/PlatformExportMacros.h>
 #include <pal/ExportMacros.h>
@@ -57,6 +57,10 @@
 #include <WebCore/PlatformExportMacros.h>
 #include <pal/ExportMacros.h>
 #include <WebKit/WebKit2_C.h>
+#endif
+
+#if defined(BUILDING_TestWebKit) && !defined(TestWebKitAPIInjectedBundle_EXPORTS) && PLATFORM(COCOA) && defined(__OBJC__)
+#import <WebKit/WebKit.h>
 #endif
 
 #else


### PR DESCRIPTION
#### 44574cea56a92d7e747868a92c2aa7b936a57d5e
<pre>
[CMake] Add TestIPC and TestWGSL targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=312441">https://bugs.webkit.org/show_bug.cgi?id=312441</a>
<a href="https://rdar.apple.com/174890671">rdar://174890671</a>

Reviewed by Pascoe and Mike Wyrzykowski.

run-api-tests expects TestIPC and TestWGSL binaries but the CMake build doesn&apos;t produce them. Add
both as standalone executables and introduce a WGSLCore static library to share sources between
wgslc and TestWGSL.

* Source/WebGPU/WGSL/CMakeLists.txt:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/PlatformMac.cmake:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
* Tools/TestWebKitAPI/config.h:

Canonical link: <a href="https://commits.webkit.org/311594@main">https://commits.webkit.org/311594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55501271b12499c7d6ef41cc7408c3787fa39534

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111476 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a8d5675-ae9c-442d-ad83-4713ee974b4c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121900 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85608 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc8aa780-60f6-42e6-b087-c527d4735230) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102568 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53a4faf6-c190-4f60-9f76-ab4dd4994d88) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23207 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21455 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13989 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168703 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12861 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20773 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130040 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130147 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140947 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88186 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23942 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24969 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17752 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29966 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93980 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29488 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29718 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29615 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->