### PR TITLE
[iOS] MediaDeviceRoute::loadURL is called multiple times during loading by MediaPlayerPrivateWirelessPlayback

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
@@ -46,6 +46,8 @@ public:
     virtual String deviceName() const = 0;
     virtual bool supportsRemoteVideoPlayback() const = 0;
 
+    virtual bool operator==(const MediaPlaybackTarget& other) const { return this == &other; }
+
 protected:
     MediaPlaybackTarget(Type type)
         : m_type { type }

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
@@ -31,6 +31,7 @@
 #include "MediaDeviceRoute.h"
 #include "MediaDeviceRouteController.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/TypeCasts.h>
 #include <wtf/UUID.h>
 
 namespace WebCore {
@@ -71,6 +72,16 @@ String MediaPlaybackTargetWirelessPlayback::deviceName() const
     if (RefPtr route = m_route)
         return m_route->deviceName();
     return { };
+}
+
+bool MediaPlaybackTargetWirelessPlayback::operator==(const MediaPlaybackTarget& other) const
+{
+    RefPtr otherWirelessPlaybackTarget = dynamicDowncast<MediaPlaybackTargetWirelessPlayback>(other);
+    if (!otherWirelessPlaybackTarget)
+        return false;
+
+    std::optional identifier = this->identifier();
+    return identifier && identifier == otherWirelessPlaybackTarget->identifier();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
@@ -55,6 +55,7 @@ private:
     String deviceName() const final;
     bool hasActiveRoute() const final { return m_hasActiveRoute; }
     bool supportsRemoteVideoPlayback() const final { return hasActiveRoute(); }
+    bool operator==(const MediaPlaybackTarget&) const final;
 
     RefPtr<MediaDeviceRoute> m_route;
     bool m_hasActiveRoute;

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -149,7 +149,7 @@ bool MediaPlayerPrivateWirelessPlayback::isCurrentPlaybackTargetWireless() const
 
 void MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&& playbackTarget)
 {
-    if (playbackTarget.ptr() == m_playbackTarget.get())
+    if (m_playbackTarget && *m_playbackTarget == playbackTarget.get())
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, playbackTarget->type());


### PR DESCRIPTION
#### cd1fe08a65fa708ada170c25c607ea43a324139b
<pre>
[iOS] MediaDeviceRoute::loadURL is called multiple times during loading by MediaPlayerPrivateWirelessPlayback
<a href="https://bugs.webkit.org/show_bug.cgi?id=312442">https://bugs.webkit.org/show_bug.cgi?id=312442</a>
<a href="https://rdar.apple.com/174891787">rdar://174891787</a>

Reviewed by Jer Noble.

MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget may be called more than once with
MediaPlaybackTargets that have different addresses but share a common MediaDeviceRoute. When this
happens, we don&apos;t want to ask the MediaDeviceRoute to load a URL again (since we already asked it
to the first time). Addressed this by returning early in
MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget when both the old and new
MediaPlaybackTargets are MediaPlaybackTargetWirelessPlaybacks and have equal identifiers.

Tested manually. It&apos;s currently not possible to test this exact case in a layout test since in that
configuration MediaPlayerPrivateWirelessPlayback is instantiated in the WebContent process where
there is always exactly one MediaPlaybackTargetWirelessPlayback for a given MediaDeviceRoute.

* Source/WebCore/platform/graphics/MediaPlaybackTarget.h:
(WebCore::MediaPlaybackTarget::operator== const):
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp:
(WebCore::MediaPlaybackTargetWirelessPlayback::operator== const):
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget):

Canonical link: <a href="https://commits.webkit.org/311501@main">https://commits.webkit.org/311501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e254a4d0326dc92b61a4a02cce817badd3c2efe3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165984 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159032 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/30633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30500 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160119 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/30633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/30633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13756 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/30633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168469 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20567 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25325 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/129951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35201 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140741 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/29733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/29255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->