### PR TITLE
Make downcast / dynamicDowncast / uncheckedDowncast work with JSCell subclasses

### DIFF
--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSCell.h>
+#include <wtf/TypeCasts.h>
 
 namespace JSC {
 
@@ -191,48 +192,48 @@ namespace JSCastingHelpers {
 
 template<bool isFinal>
 struct FinalTypeDispatcher {
-    template<typename Target, typename From>
+    template<typename To, typename From>
     static inline bool inheritsGeneric(From* from)
     {
-        static_assert(!std::is_same<JSObject*, Target*>::value, "This ensures our overloads work");
-        static_assert(std::is_base_of<JSCell, Target>::value && std::is_base_of<JSCell, typename std::remove_pointer<From>::type>::value, "JS casting expects that the types you are casting to/from are subclasses of JSCell");
-        // Do not use inherits<Target>() since inherits<T> depends on this function.
-        return from->JSCell::inherits(Target::info());
+        static_assert(!std::same_as<JSObject*, To*>, "This ensures our overloads work");
+        static_assert(std::derived_from<To, JSCell> && std::derived_from<std::remove_pointer_t<From>, JSCell>, "JS casting expects that the types you are casting to/from are subclasses of JSCell");
+        // Do not use inherits<To>() since inherits<T> depends on this function.
+        return from->JSCell::inherits(To::info());
     }
 };
 
 template<>
 struct FinalTypeDispatcher</* isFinal */ true> {
-    template<typename Target, typename From>
+    template<typename To, typename From>
     static inline bool inheritsGeneric(From* from)
     {
-        static_assert(!std::is_same<JSObject*, Target*>::value, "This ensures our overloads work");
-        static_assert(std::is_base_of<JSCell, Target>::value && std::is_base_of<JSCell, typename std::remove_pointer<From>::type>::value, "JS casting expects that the types you are casting to/from are subclasses of JSCell");
-        static_assert(std::is_final<Target>::value, "Target is a final type");
-        bool canCast = from->JSCell::classInfo() == Target::info();
-        // Do not use inherits<Target>() since inherits<T> depends on this function.
-        ASSERT(canCast == from->JSCell::inheritsSlow(Target::info()));
+        static_assert(!std::same_as<JSObject*, To*>, "This ensures our overloads work");
+        static_assert(std::derived_from<To, JSCell> && std::derived_from<std::remove_pointer_t<From>, JSCell>, "JS casting expects that the types you are casting to/from are subclasses of JSCell");
+        static_assert(std::is_final<To>::value, "To is a final type");
+        bool canCast = from->JSCell::classInfo() == To::info();
+        // Do not use inherits<To>() since inherits<T> depends on this function.
+        ASSERT(canCast == from->JSCell::inheritsSlow(To::info()));
         return canCast;
     }
 };
 
-template<typename Target, typename From>
+template<typename To, typename From>
 inline bool inheritsJSTypeImpl(From* from, JSTypeRange range)
 {
-    static_assert(std::is_base_of<JSCell, Target>::value && std::is_base_of<JSCell, typename std::remove_pointer<From>::type>::value, "JS casting expects that the types you are casting to/from are subclasses of JSCell");
+    static_assert(std::derived_from<To, JSCell> && std::derived_from<std::remove_pointer_t<From>, JSCell>, "JS casting expects that the types you are casting to/from are subclasses of JSCell");
     bool canCast = range.contains(from->type());
-    // Do not use inherits<Target>() since inherits<T> depends on this function.
-    ASSERT(canCast == from->JSCell::inheritsSlow(Target::info()));
+    // Do not use inherits<To>() since inherits<T> depends on this function.
+    ASSERT(canCast == from->JSCell::inheritsSlow(To::info()));
     return canCast;
 }
 
 // C++ has bad syntax so we need to use this struct because C++ doesn't have a
 // way to say that we are overloading just the first type in a template list...
-template<typename Target>
+template<typename To>
 struct InheritsTraits {
     static constexpr std::optional<JSTypeRange> typeRange { std::nullopt };
     template<typename From>
-    static inline bool inherits(From* from) { return FinalTypeDispatcher<std::is_final<Target>::value>::template inheritsGeneric<Target>(from); }
+    static inline bool inherits(From* from) { return FinalTypeDispatcher<std::is_final<To>::value>::template inheritsGeneric<To>(from); }
 };
 
 #define DEFINE_TRAITS_FOR_JS_TYPE_OVERLOAD(className, firstJSType, lastJSType) \
@@ -248,10 +249,10 @@ FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD(DEFINE_TRAITS_FOR_JS_TYPE_OVERLOAD)
 #undef DEFINE_TRAITS_FOR_JS_TYPE_OVERLOAD
 
 
-template<typename Target, typename From>
+template<typename To, typename From>
 bool inherits(From* from)
 {
-    using Dispatcher = InheritsTraits<Target>;
+    using Dispatcher = InheritsTraits<To>;
     return Dispatcher::template inherits<>(from);
 }
 
@@ -282,4 +283,144 @@ To jsSecureCast(From from)
     return result;
 }
 
+} // namespace JSC
+
+// Concept that identifies JSCell subclasses without requiring complete types.
+// Uses T::info() as a marker instead of std::derived_from (which is UB with incomplete types).
+template<typename T>
+concept IsJSCellType = requires { T::info(); };
+
+// TypeCastTraits specializations for JSCell subclasses.
+// This allows using is<>(), dynamicDowncast<>(), downcast<>(), and uncheckedDowncast<>() with JS types.
+
+// Per-type specializations preserve the optimized JSType range checking.
+#define JSC_SPECIALIZE_TYPE_CAST_TRAITS(className, firstJSType, lastJSType) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::className) \
+    static bool isType(const JSC::JSCell& cell) \
+    { \
+        return JSC::JSCastingHelpers::InheritsTraits<JSC::className>::inherits(&cell); \
+    } \
+SPECIALIZE_TYPE_TRAITS_END()
+
+FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD(JSC_SPECIALIZE_TYPE_CAST_TRAITS)
+#undef JSC_SPECIALIZE_TYPE_CAST_TRAITS
+
+// Generic fallback for JSCell subclasses not in the overload list (e.g. WebCore binding types).
+// Uses IsJSCellType concept which is SFINAE-friendly with incomplete types.
+namespace WTF {
+template<typename To, typename From>
+    requires (IsJSCellType<std::remove_const_t<To>> && IsJSCellType<std::remove_const_t<From>>)
+struct TypeCastTraits<To, From, false> {
+    static bool isOfType(From& source)
+    {
+        return JSC::JSCastingHelpers::InheritsTraits<std::remove_const_t<To>>::inherits(&source);
+    }
+};
+
+template<typename To, typename From>
+    requires (IsJSCellType<To> && IsJSCellType<From>)
+inline match_constness_t<From, To>& uncheckedDowncast(From& source)
+{
+    static_assert(!std::same_as<From, To>, "Unnecessary cast to same type");
+    static_assert(std::derived_from<To, From>, "Should be a downcast");
+#if (ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)) && CPU(X86_64)
+    if (!is<To>(source)) [[unlikely]]
+        JSC::reportZappedCellAndCrash(&source);
+#else
+    ASSERT_WITH_SECURITY_IMPLICATION(is<To>(source));
+#endif
+    SUPPRESS_MEMORY_UNSAFE_CAST return static_cast<match_constness_t<From, To>&>(source);
 }
+
+template<typename To, typename From>
+    requires (IsJSCellType<To> && IsJSCellType<From>)
+inline match_constness_t<From, To>* uncheckedDowncast(From* source)
+{
+    static_assert(!std::same_as<From, To>, "Unnecessary cast to same type");
+    static_assert(std::derived_from<To, From>, "Should be a downcast");
+#if (ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)) && CPU(X86_64)
+    if (source && !is<To>(*source)) [[unlikely]]
+        JSC::reportZappedCellAndCrash(source);
+#else
+    ASSERT_WITH_SECURITY_IMPLICATION(!source || is<To>(*source));
+#endif
+    SUPPRESS_MEMORY_UNSAFE_CAST return static_cast<match_constness_t<From, To>*>(source);
+}
+
+// JSValue overloads for dynamicDowncast, downcast, and uncheckedDowncast.
+// Uses explicit JSC::JSValue& parameter type which is more specialized than the
+// deduced From& in WTF's overloads, so these win in partial ordering.
+
+template<typename To>
+    requires IsJSCellType<To>
+inline To* dynamicDowncast(JSC::JSValue& value)
+{
+    if (!value.isCell()) [[unlikely]]
+        return nullptr;
+    return dynamicDowncast<To>(value.asCell());
+}
+
+template<typename To>
+    requires IsJSCellType<To>
+inline To* dynamicDowncast(const JSC::JSValue& value)
+{
+    if (!value.isCell()) [[unlikely]]
+        return nullptr;
+    return dynamicDowncast<To>(value.asCell());
+}
+
+template<typename To>
+    requires IsJSCellType<To>
+inline To* downcast(JSC::JSValue& value)
+{
+    RELEASE_ASSERT(value.isCell());
+    return downcast<To>(value.asCell());
+}
+
+template<typename To>
+    requires IsJSCellType<To>
+inline To* downcast(const JSC::JSValue& value)
+{
+    RELEASE_ASSERT(value.isCell());
+    return downcast<To>(value.asCell());
+}
+
+template<typename To>
+    requires IsJSCellType<To>
+inline To* uncheckedDowncast(JSC::JSValue& value)
+{
+#if (ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)) && CPU(X86_64)
+    ASSERT_WITH_SECURITY_IMPLICATION(value.isCell());
+    JSC::JSCell* cell = value.asCell();
+    if (!is<To>(*cell)) [[unlikely]]
+        JSC::reportZappedCellAndCrash(cell);
+    SUPPRESS_MEMORY_UNSAFE_CAST return static_cast<To*>(cell);
+#else
+    ASSERT_WITH_SECURITY_IMPLICATION(value.isCell() && is<To>(*value.asCell()));
+    SUPPRESS_MEMORY_UNSAFE_CAST return static_cast<To*>(value.asCell());
+#endif
+}
+
+template<typename To>
+    requires IsJSCellType<To>
+inline To* uncheckedDowncast(const JSC::JSValue& value)
+{
+#if (ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)) && CPU(X86_64)
+    ASSERT_WITH_SECURITY_IMPLICATION(value.isCell());
+    JSC::JSCell* cell = value.asCell();
+    if (!is<To>(*cell)) [[unlikely]]
+        JSC::reportZappedCellAndCrash(cell);
+    SUPPRESS_MEMORY_UNSAFE_CAST return static_cast<To*>(cell);
+#else
+    ASSERT_WITH_SECURITY_IMPLICATION(value.isCell() && is<To>(*value.asCell()));
+    SUPPRESS_MEMORY_UNSAFE_CAST return static_cast<To*>(value.asCell());
+#endif
+}
+
+} // namespace WTF
+
+// Re-export the JSValue overloads so unqualified lookup finds them.
+// The using declarations in TypeCasts.h only see overloads declared before that point.
+using WTF::dynamicDowncast;
+using WTF::downcast;
+using WTF::uncheckedDowncast;

--- a/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
+++ b/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
@@ -218,7 +218,7 @@ static RefPtr<IDBKey> createIDBKeyFromValue(JSGlobalObject& lexicalGlobalObject,
 
     if (value.isObject()) {
         JSObject* object = asObject(value);
-        if (auto* array = jsDynamicCast<JSArray*>(object)) {
+        if (auto* array = dynamicDowncast<JSArray>(*object)) {
             size_t length = array->length();
 
             if (stack.contains(array))
@@ -245,10 +245,10 @@ static RefPtr<IDBKey> createIDBKeyFromValue(JSGlobalObject& lexicalGlobalObject,
             return IDBKey::createArray(WTF::move(subkeys));
         }
 
-        if (auto* arrayBuffer = jsDynamicCast<JSArrayBuffer*>(value))
+        if (auto* arrayBuffer = dynamicDowncast<JSArrayBuffer>(value))
             return IDBKey::createBinary(*arrayBuffer);
 
-        if (auto* arrayBufferView = jsDynamicCast<JSArrayBufferView*>(value))
+        if (auto* arrayBufferView = dynamicDowncast<JSArrayBufferView>(value))
             return IDBKey::createBinary(*arrayBufferView);
     }
     return nullptr;

--- a/Source/WebCore/bindings/js/JSDOMConvertXPathNSResolver.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertXPathNSResolver.h
@@ -53,9 +53,9 @@ template<> struct Converter<IDLInterface<XPathNSResolver>> : DefaultConverter<ID
 
         auto object = asObject(value);
         if (object->inherits<JSXPathNSResolver>())
-            return { JSC::jsCast<JSXPathNSResolver*>(object)->wrapped() };
+            return { uncheckedDowncast<JSXPathNSResolver>(*object).wrapped() };
 
-        return { JSCustomXPathNSResolver::create(object, JSC::jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)) };
+        return { JSCustomXPathNSResolver::create(object, uncheckedDowncast<JSDOMGlobalObject>(&lexicalGlobalObject)) };
     }
 };
 

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -394,7 +394,7 @@ inline JSC::JSValue callPromiseFunction(JSC::JSGlobalObject& lexicalGlobalObject
     JSC::VM& vm = JSC::getVM(&lexicalGlobalObject);
     auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    auto& globalObject = *JSC::jsSecureCast<JSDOMGlobalObject*>(&lexicalGlobalObject);
+    auto& globalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject);
     auto* promise = JSC::JSPromise::create(vm, globalObject.promiseStructure());
     ASSERT(promise);
 

--- a/Source/WebCore/bindings/js/JSEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSEventListener.cpp
@@ -296,7 +296,7 @@ String JSEventListener::functionName() const
     auto& vm = m_isolatedWorld->vm();
     JSC::JSLockHolder lock(vm);
 
-    auto* handlerFunction = JSC::jsDynamicCast<JSC::JSFunction*>(m_jsFunction.get());
+    auto* handlerFunction = dynamicDowncast<JSC::JSFunction>(m_jsFunction.get());
     if (!handlerFunction)
         return { };
 

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -357,7 +357,7 @@ void ScriptController::initScriptForWindowProxy(JSWindowProxy& windowProxy)
 static Identifier jsValueToModuleKey(JSGlobalObject* lexicalGlobalObject, JSValue value)
 {
     if (value.isSymbol())
-        return Identifier::fromUid(jsCast<Symbol*>(value)->privateName());
+        return Identifier::fromUid(uncheckedDowncast<Symbol>(value)->privateName());
     ASSERT(value.isString());
     return asString(value)->toIdentifier(lexicalGlobalObject);
 }


### PR DESCRIPTION
#### 195397957f976f8920ba3310698dc69dc6b0c12a
<pre>
Make downcast / dynamicDowncast / uncheckedDowncast work with JSCell subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=312444">https://bugs.webkit.org/show_bug.cgi?id=312444</a>

Reviewed by Yusuke Suzuki.

Add TypeCastTraits specializations to JSCast.h so that the WTF casting
functions (uncheckedDowncast, downcast, dynamicDowncast) work with JS
types, enabling a future transition away from jsCast / jsSecureCast /
jsDynamicCast.

  - Per-type TypeCastTraits specializations generated via
    FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD macro, preserving optimized
    JSType range checking.
  - Generic constrained TypeCastTraits fallback for JSCell subclasses not
    in the macro list (e.g. WebCore binding types like JSDOMGlobalObject).
  - JSCell-specific uncheckedDowncast overloads that preserve
    reportZappedCellAndCrash behavior on x86_64.
  - JSValue overloads for all three casting functions.
  - Adopt the new casting functions in a handful of WebCore sites to
    prove they work end-to-end.

* Source/JavaScriptCore/runtime/JSCast.h:
(WTF::uncheckedDowncast):
(dynamicDowncast):
(downcast):
(uncheckedDowncast):
* Source/WebCore/bindings/js/IDBBindingUtilities.cpp:
(WebCore::createIDBKeyFromValue):
* Source/WebCore/bindings/js/JSDOMConvertXPathNSResolver.h:
(WebCore::Converter&lt;IDLInterface&lt;XPathNSResolver&gt;&gt;::convert):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::callPromiseFunction):
* Source/WebCore/bindings/js/JSEventListener.cpp:
(WebCore::JSEventListener::functionName const):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::jsValueToModuleKey):

Canonical link: <a href="https://commits.webkit.org/311418@main">https://commits.webkit.org/311418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5f8b8ba8dc6e5d50b7ada6eec158f6f3a837001

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156962 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30298 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/23489 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165785 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30301 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159920 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/13557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/149012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168270 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/17797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12429 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/20404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/129796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35145 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29823 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/140578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/24618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/188924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29534 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93548 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/188924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/29056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->