### PR TITLE
REGRESSION (309147@main): Table on a ESPNCricInfo page disappears and re-appears

### DIFF
--- a/LayoutTests/compositing/overflow/sticky-overlap-extent-in-overflow-expected.html
+++ b/LayoutTests/compositing/overflow/sticky-overlap-extent-in-overflow-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroller {
+            overflow: auto;
+            height: 300px;
+            margin-top: 400px;
+            position: relative;
+        }
+
+        .sticky {
+            position: relative;
+            height: 150px;
+            background: blue;
+            z-index: 1;
+        }
+
+        .box {
+            position: absolute;
+            width: 50px;
+            height: 50px;
+            background: orange;
+            z-index: 2;
+            top: 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="sticky"></div>
+        <div class="box"></div>
+        <div style="height: 400px"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/overflow/sticky-overlap-extent-in-overflow.html
+++ b/LayoutTests/compositing/overflow/sticky-overlap-extent-in-overflow.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroller {
+            overflow: auto;
+            height: 300px;
+            margin-top: 400px;
+            position: relative;
+        }
+
+        .sticky {
+            position: sticky;
+            height: 150px;
+            background: blue;
+            z-index: 1;
+        }
+
+        .box {
+            position: absolute;
+            width: 50px;
+            height: 50px;
+            background: orange;
+            z-index: 2;
+            top: 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="sticky"></div>
+        <div class="box"></div>
+        <div style="height: 400px"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2594,6 +2594,7 @@ void RenderLayerCompositor::computeExtent(const LayerOverlapMap& overlapMap, con
         auto constrainingRect = box.constrainingRectForStickyPosition();
         box.computeStickyPositionConstraints(constraints, constrainingRect);
         auto stickyBounds = LayoutRect(constraints.computeStickyExtent());
+        stickyBounds.move(extent.bounds.x() - LayoutUnit(constraints.stickyBoxRect().x()), extent.bounds.y() - LayoutUnit(constraints.stickyBoxRect().y()));
         scrollInflated.intersect(stickyBounds);
         extent.bounds = scrollInflated;
     } else if (renderer.isFixedPositioned() && renderer.container() == &m_renderView) {


### PR DESCRIPTION
#### 66afe029e18cbb44aacb57f95a3973e824aecafb
<pre>
REGRESSION (309147@main): Table on a ESPNCricInfo page disappears and re-appears
<a href="https://bugs.webkit.org/show_bug.cgi?id=312448">https://bugs.webkit.org/show_bug.cgi?id=312448</a>
<a href="https://rdar.apple.com/171179878">rdar://171179878</a>

Reviewed by Simon Fraser.

computeExtent() intersects the scroll inflated bounds (absolute coordinates) with
computeStickyExtent() (scroll ancestor relative coordinates). For viewport scrolled
sticky elements both spaces match, but inside an overflow container the mismatch
produces an empty intersection when content above positions the container below the
page origin. The overlap map then misses the sticky layer, so overlapping content
with higher z-index is never composited and paints behind the sticky layer.

Fix by converting computeStickyExtent() to absolute coordinates before intersecting.

Test: compositing/overflow/sticky-overlap-extent-in-overflow.html

* LayoutTests/compositing/overflow/sticky-overlap-extent-in-overflow-expected.html: Added.
* LayoutTests/compositing/overflow/sticky-overlap-extent-in-overflow.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeExtent const):

Canonical link: <a href="https://commits.webkit.org/311411@main">https://commits.webkit.org/311411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8b78a29ea1ccb0df4f53ed2abd40051f6a97b23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110860 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121434 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85289 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102102 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22711 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20922 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13373 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168084 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12245 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129549 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129658 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87443 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23885 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17210 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29348 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93364 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28872 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29102 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28998 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->