### PR TITLE
Fix the iOS build

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestContextMenuDriver.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestContextMenuDriver.h
@@ -29,10 +29,23 @@
 
 #import <wtf/WeakObjCPtr.h>
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <UIKit/_UIClickInteractionDriving.h>
+#import <UIKit/UIEvent_Private.h>
+#else
+
+typedef NS_ENUM(NSUInteger, _UIInputPrecision) {
+    _UIInputPrecisionUnknown,
+    _UIInputPrecisionLow,
+    _UIInputPrecisionHigh,
+};
+
 @protocol _UIClickInteractionDriverDelegate;
 @protocol _UIClickInteractionDriving <NSObject>
 @property (nonatomic, weak) id<_UIClickInteractionDriverDelegate> delegate;
 @end
+
+#endif
 
 @interface TestContextMenuDriver : NSObject <_UIClickInteractionDriving> {
     WeakObjCPtr<id<_UIClickInteractionDriverDelegate>> _delegate;
@@ -42,6 +55,13 @@
     NSTimeInterval _touchDuration;
     BOOL _cancelsTouchesInView;
 }
+
+@property (nonatomic, class, readonly) BOOL requiresForceCapability;
+@property (nonatomic, readonly) BOOL hasExceededAllowableMovement;
+@property (nonatomic, readonly) BOOL isCurrentlyAcceleratedByForce;
+@property (nonatomic, readonly) BOOL clicksUpAutomaticallyAfterTimeout;
+@property (nonatomic, readonly) CGFloat maximumEffectProgress;
+@property (nonatomic, readonly) _UIInputPrecision inputPrecision;
 
 - (void)begin:(void(^)(BOOL))completionHandler;
 - (void)clickDown;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestContextMenuDriver.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestContextMenuDriver.mm
@@ -92,6 +92,36 @@
 {
 }
 
++ (BOOL)requiresForceCapability
+{
+    return NO;
+}
+
+- (BOOL)hasExceededAllowableMovement
+{
+    return NO;
+}
+
+- (BOOL)isCurrentlyAcceleratedByForce
+{
+    return NO;
+}
+
+- (BOOL)clicksUpAutomaticallyAfterTimeout
+{
+    return NO;
+}
+
+- (CGFloat)maximumEffectProgress
+{
+    return 0;
+}
+
+- (_UIInputPrecision)inputPrecision
+{
+    return _UIInputPrecisionUnknown;
+}
+
 - (void)begin:(void(^)(BOOL))completionHandler
 {
     auto completionBlock = makeBlockPtr(completionHandler);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm
@@ -85,9 +85,9 @@ using CocoaPasteboard = UIPasteboard;
 #endif
 
 @interface AttachmentUpdateObserver : NSObject <WKUIDelegatePrivate>
-@property (nonatomic, readonly) NSArray *inserted;
-@property (nonatomic, readonly) NSArray *removed;
-@property (nonatomic, readonly) NSArray *dataInvalidated;
+@property (nonatomic, readonly) NSArray<_WKAttachment *> *inserted;
+@property (nonatomic, readonly) NSArray<_WKAttachment *> *removed;
+@property (nonatomic, readonly) NSArray<_WKAttachment *> *dataInvalidated;
 @end
 
 @implementation AttachmentUpdateObserver {
@@ -1525,7 +1525,7 @@ TEST(WKAttachmentTests, ChangeFileWrapperForPastedImage)
     [webView paste:nil];
     [webView waitForImageElementSizeToBecome:CGSizeMake(215, 174)];
 
-    auto attachment = retainPtr(observer.observer().inserted.firstObject);
+    RetainPtr<_WKAttachment> attachment = retainPtr(observer.observer().inserted.firstObject);
     auto originalImageData = retainPtr([attachment info].fileWrapper);
     EXPECT_WK_STREQ([attachment uniqueIdentifier], [webView stringByEvaluatingJavaScript:@"HTMLAttachmentElement.getAttachmentIdentifier(document.querySelector('img'))"]);
 


### PR DESCRIPTION
#### 8eb2d4b83279cb396c2d2ffe10b66d4681498ca5
<pre>
Fix the iOS build
<a href="https://bugs.webkit.org/show_bug.cgi?id=312450">https://bugs.webkit.org/show_bug.cgi?id=312450</a>
<a href="https://rdar.apple.com/174897450">rdar://174897450</a>

Unreviewed build fix

* Tools/TestWebKitAPI/Helpers/cocoa/TestContextMenuDriver.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestContextMenuDriver.mm:
(+[TestContextMenuDriver requiresForceCapability]):
(-[TestContextMenuDriver hasExceededAllowableMovement]):
(-[TestContextMenuDriver isCurrentlyAcceleratedByForce]):
(-[TestContextMenuDriver clicksUpAutomaticallyAfterTimeout]):
(-[TestContextMenuDriver maximumEffectProgress]):
(-[TestContextMenuDriver inputPrecision]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm:
(TestWebKitAPI::TEST(WKAttachmentTests, ChangeFileWrapperForPastedImage)):

Canonical link: <a href="https://commits.webkit.org/311351@main">https://commits.webkit.org/311351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eef6c781545bca2068f27b4ad6e19d0342323d78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156761 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30097 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/23280 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165584 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30100 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23642 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13356 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168067 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/20220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29699 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/129646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29622 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/140394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23858 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24469 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29331 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93347 "Build is in progress. Recent messages:") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28855 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29085 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->