### PR TITLE
Root element background-position ignores margin when painting on viewport

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-collapse-020-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-collapse-020-expected.xht
@@ -1,0 +1,31 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+ <head>
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+
+  <style type="text/css"><![CDATA[
+  body {margin: 40px 0px;}
+
+  div
+  {
+  background-color: green;
+  height: 20px;
+  width: 100px;
+  }
+  ]]></style>
+
+ </head>
+
+ <body>
+
+  <div></div>
+
+  <p>Test passes if there is <strong>no red</strong>.</p>
+
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-collapse-020.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-collapse-020.xht
@@ -1,0 +1,41 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Margin collapsing with the root element</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-08-15 -->
+        <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#collapsing-margins" />
+		<link rel="match" href="margin-collapse-020-ref.xht" />
+
+        <meta name="flags" content="ahem image" />
+        <meta name="assert" content="For HTML pages the html element does not collapse its margins with other elements." />
+        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+        <style type="text/css">
+            html
+            {
+                background: url('support/margin-collapse-020.png') 0 -1em no-repeat;
+                font: 20px/1em Ahem;
+                margin-top: 1em;
+            }
+            body
+            {
+                margin: 0;
+            }
+            div
+            {
+                background: green;
+                margin-top: 1em;
+                height: 1em;
+                width: 5em;
+            }
+            p
+            {
+                font: 12pt serif;
+            }
+        </style>
+    </head>
+    <body>
+        <div></div>
+        <p>Test passes if there is <strong>no red</strong>.</p>
+    </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-margin-root-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-margin-root-002.html
@@ -4,6 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#root-background">
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#the-background-attachment">
 <link rel="match" href="background-attachment-margin-root-002-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=50400" />
 <style>
   html {
     background: linear-gradient(rgba(0,255,0,0.5), rgba(0,0,255,0.5)), linear-gradient(rgba(0,0,0,1), rgba(0,0,0,1));

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -652,6 +652,9 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
                 LayoutRect extendedBackgroundRect = view.frameView().extendedBackgroundRectForPainting();
                 left += (renderer.marginLeft() - extendedBackgroundRect.x());
                 top += (renderer.marginTop() - extendedBackgroundRect.y());
+            } else {
+                left += renderer.marginLeft();
+                top += renderer.marginTop();
             }
         } else {
             positioningAreaSize = borderBoxRect.size() - LayoutSize(left + right, top + bottom);


### PR DESCRIPTION
#### 2c903ee0e3bec351c27c06dfd62686703071cad7
<pre>
Root element background-position ignores margin when painting on viewport
<a href="https://bugs.webkit.org/show_bug.cgi?id=312451">https://bugs.webkit.org/show_bug.cgi?id=312451</a>
<a href="https://rdar.apple.com/174897505">rdar://174897505</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The background positioning area for the root element should be offset
from the viewport origin by the element&apos;s margins, but the margin was
only factored in when hasExtendedBackgroundRectForPainting() was true.
In the normal path, left/top only contained border widths, so
background-position was computed as if the positioning area started at
the viewport top rather than at margin-top below it.

* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::calculateFillLayerImageGeometryImpl):
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-collapse-020-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/margin-padding-clear/margin-collapse-020.xht: Added.

&gt; Pixel Tolerance / Fuzziness (No difference in rendering):
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-margin-root-002.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c903ee0e3bec351c27c06dfd62686703071cad7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111054 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121561 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85359 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102229 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22853 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21088 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13567 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168280 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12439 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20408 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-margin-root-002.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129687 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29910 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25166 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-margin-root-002.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129795 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29833 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140582 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87637 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24624 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17386 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-margin-root-002.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93558 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29066 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29296 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29192 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->