### PR TITLE
Enhanced <select>: make the tab key close the picker

### DIFF
--- a/LayoutTests/fast/forms/select/base/select-tab-closes-picker-expected.txt
+++ b/LayoutTests/fast/forms/select/base/select-tab-closes-picker-expected.txt
@@ -1,0 +1,29 @@
+Tests that Tab and Shift+Tab close a base-select picker and advance focus.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS select.matches(":open") is true
+PASS document.activeElement.id is "opt1"
+PASS select.matches(":open") is false
+PASS document.activeElement.id is "after"
+PASS select.value is "one"
+PASS select.matches(":open") is true
+PASS document.activeElement.id is "opt2"
+PASS select.matches(":open") is false
+PASS document.activeElement.id is "after"
+PASS select.value is "two"
+PASS select.matches(":open") is true
+PASS document.activeElement.id is "opt1"
+PASS select.matches(":open") is false
+PASS document.activeElement.id is "before"
+PASS select.value is "one"
+PASS document.activeElement.id is "opt1"
+PASS document.activeElement.id is "opt2"
+PASS select.matches(":open") is false
+PASS document.activeElement.id is "after"
+PASS select.value is "one"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/select/base/select-tab-closes-picker.html
+++ b/LayoutTests/fast/forms/select/base/select-tab-closes-picker.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+<style>
+select, ::picker(select) {
+  appearance: base-select;
+}
+</style>
+</head>
+<body>
+<input id="before" type="text">
+<select id="select">
+    <option id="opt1">one</option>
+    <option id="opt2">two</option>
+    <option id="opt3">three</option>
+</select>
+<input id="after" type="text">
+<script>
+description("Tests that Tab and Shift+Tab close a base-select picker and advance focus.");
+
+const select = document.getElementById("select");
+const before = document.getElementById("before");
+const after = document.getElementById("after");
+
+async function openPicker() {
+    await UIHelper.activateElement(select);
+    await UIHelper.animationFrame();
+}
+
+jsTestIsAsync = true;
+
+(async () => {
+
+    // Test: Tab closes the picker and moves focus to the next focusable element.
+    select.value = "one";
+    await openPicker();
+    shouldBeTrue('select.matches(":open")');
+    shouldBe('document.activeElement.id', '"opt1"');
+
+    await UIHelper.keyDown("\t");
+    await UIHelper.animationFrame();
+    shouldBeFalse('select.matches(":open")');
+    shouldBe('document.activeElement.id', '"after"');
+    shouldBe('select.value', '"one"');
+
+    // Test: Tab from a non-first option also closes and advances focus.
+    select.value = "two";
+    await openPicker();
+    shouldBeTrue('select.matches(":open")');
+    shouldBe('document.activeElement.id', '"opt2"');
+
+    await UIHelper.keyDown("\t");
+    await UIHelper.animationFrame();
+    shouldBeFalse('select.matches(":open")');
+    shouldBe('document.activeElement.id', '"after"');
+    shouldBe('select.value', '"two"');
+
+    // Test: Shift+Tab closes the picker and moves focus to the previous focusable element.
+    select.value = "one";
+    await openPicker();
+    shouldBeTrue('select.matches(":open")');
+    shouldBe('document.activeElement.id', '"opt1"');
+
+    await UIHelper.keyDown("\t", ["shiftKey"]);
+    await UIHelper.animationFrame();
+    shouldBeFalse('select.matches(":open")');
+    shouldBe('document.activeElement.id', '"before"');
+    shouldBe('select.value', '"one"');
+
+    // Test: Arrow down then Tab closes picker without committing the focused option.
+    select.value = "one";
+    await openPicker();
+    shouldBe('document.activeElement.id', '"opt1"');
+
+    await UIHelper.keyDown("downArrow");
+    shouldBe('document.activeElement.id', '"opt2"');
+
+    await UIHelper.keyDown("\t");
+    await UIHelper.animationFrame();
+    shouldBeFalse('select.matches(":open")');
+    shouldBe('document.activeElement.id', '"after"');
+    shouldBe('select.value', '"one"');
+
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional-expected.txt
@@ -4,10 +4,10 @@ PASS defaultbutton: When the listbox is closed, spacebar should open the listbox
 FAIL defaultbutton: When the listbox is closed, all arrow keys should open the listbox. assert_true: Arrow left should open the listbox. expected true got false
 PASS defaultbutton: When the listbox is closed, the enter key should not trigger form submission.
 FAIL defaultbutton: When the listbox is open, the enter key should commit the selected option. assert_equals: The first option should remain focused after pressing the right arrow key. expected Element node <option class="one">one</option> but got Element node <option class="two">two</option>
-FAIL defaultbutton: When the listbox is open, the tab key should close the listbox. assert_false: Tab should close the listbox. expected false got true
+PASS defaultbutton: When the listbox is open, the tab key should close the listbox.
 PASS custombutton: When the listbox is closed, spacebar should open the listbox.
 FAIL custombutton: When the listbox is closed, all arrow keys should open the listbox. assert_true: Arrow left should open the listbox. expected true got false
 PASS custombutton: When the listbox is closed, the enter key should not trigger form submission.
 FAIL custombutton: When the listbox is open, the enter key should commit the selected option. assert_equals: The first option should remain focused after pressing the right arrow key. expected Element node <option class="one">one</option> but got Element node <option class="two">two</option>
-FAIL custombutton: When the listbox is open, the tab key should close the listbox. assert_false: Tab should close the listbox. expected false got true
+PASS custombutton: When the listbox is open, the tab key should close the listbox.
 

--- a/LayoutTests/platform/ios/fast/forms/select/base/select-tab-closes-picker-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/select/base/select-tab-closes-picker-expected.txt
@@ -1,0 +1,30 @@
+Tests that Tab and Shift+Tab close a base-select picker and advance focus.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS select.matches(":open") is true
+PASS document.activeElement.id is "opt1"
+FAIL select.matches(":open") should be false. Was true.
+FAIL document.activeElement.id should be after. Was opt1.
+PASS select.value is "one"
+FAIL select.matches(":open") should be true. Was false.
+FAIL document.activeElement.id should be opt2. Was select.
+PASS select.matches(":open") is false
+FAIL document.activeElement.id should be after. Was select.
+PASS select.value is "two"
+PASS select.matches(":open") is true
+PASS document.activeElement.id is "opt1"
+FAIL select.matches(":open") should be false. Was true.
+FAIL document.activeElement.id should be before. Was opt1.
+PASS select.value is "one"
+FAIL document.activeElement.id should be opt1. Was select.
+FAIL document.activeElement.id should be opt2. Was select.
+PASS select.matches(":open") is false
+FAIL document.activeElement.id should be after. Was select.
+PASS select.value is "one"
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -305,6 +305,12 @@ void HTMLOptionElement::defaultEventHandler(Event& event)
 
         const String& keyIdentifier = keyboardEvent->keyIdentifier();
 
+        // [Shift+]Tab closes the picker; fall through to move focus.
+        if (keyIdentifier == "U+0009"_s) {
+            select->hidePickerPopoverElement();
+            return HTMLElement::defaultEventHandler(event);
+        }
+
         int currentIndex = select->optionToListIndex(index());
         int listIndex = select->computeNavigationIndex(keyIdentifier, currentIndex, select->pickerNavigationKeyIdentifiers());
         if (listIndex >= 0) {


### PR DESCRIPTION
#### 433445a769427b4dcabd78aa94f3aa6a114b44a1
<pre>
Enhanced &lt;select&gt;: make the tab key close the picker
<a href="https://bugs.webkit.org/show_bug.cgi?id=312452">https://bugs.webkit.org/show_bug.cgi?id=312452</a>

Reviewed by Aditya Keerthi.

It is not entirely clear what the Cocoa behavior should be (tracked by
<a href="https://rdar.apple.com/174468005">rdar://174468005</a>), so for now we make the tab key close the picker and
move focus as appropriate as that seems rather reasonable.

Test: fast/forms/select/base/select-tab-closes-picker.html
Canonical link: <a href="https://commits.webkit.org/311376@main">https://commits.webkit.org/311376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eae3745d1cd7a7b2431a26955e17409684ce344e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165626 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121451 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102119 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22734 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20942 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13398 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168109 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129569 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129678 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140429 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87468 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23865 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24502 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17233 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93389 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28897 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29127 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29023 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->