### PR TITLE
Fix the SaferCPP build

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.h
@@ -27,8 +27,6 @@
 
 #include <wtf/Platform.h>
 
-#if !PLATFORM(COCOA) || !__has_feature(modules)
-
 #include "Helpers/Test.h"
 #include <WebCore/Color.h>
 #include <WebCore/FloatPoint.h>
@@ -47,5 +45,3 @@ namespace TestWebKitAPI {
 ::testing::AssertionResult imagePixelIs(WebCore::Color expected, WebCore::NativeImage&, WebCore::FloatPoint);
 
 }
-
-#endif // !PLATFORM(COCOA) || !__has_feature(modules)

--- a/Tools/TestWebKitAPI/Helpers/JavaScriptTest.h
+++ b/Tools/TestWebKitAPI/Helpers/JavaScriptTest.h
@@ -27,8 +27,6 @@
 
 #include <wtf/Platform.h>
 
-#if !PLATFORM(COCOA) || !__has_feature(modules)
-
 #if PLATFORM(COCOA)
 OBJC_CLASS WebView;
 OBJC_CLASS WKWebView;
@@ -52,5 +50,3 @@ namespace TestWebKitAPI {
 #endif
 
 } // namespace TestWebKitAPI
-
-#endif // !PLATFORM(COCOA) || !__has_feature(modules)

--- a/Tools/TestWebKitAPI/Helpers/PlatformUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/PlatformUtilities.h
@@ -98,8 +98,6 @@ WKRetainPtr<WKStringRef> toWK(const char* utf8String);
 
 #endif // WK_HAVE_C_SPI
 
-#if !PLATFORM(COCOA) || !__has_feature(modules)
-
 template<typename T, typename U>
 static inline ::testing::AssertionResult assertWKStringEqual(const char* expected_expression, const char* actual_expression, T expected, U actual)
 {
@@ -108,8 +106,6 @@ static inline ::testing::AssertionResult assertWKStringEqual(const char* expecte
 
 #define EXPECT_WK_STREQ(expected, actual) \
     EXPECT_PRED_FORMAT2(TestWebKitAPI::Util::assertWKStringEqual, expected, actual)
-
-#endif // !PLATFORM(COCOA) || !__has_feature(modules)
 
 #if PLATFORM(MAC)
 using PlatformImage = NSImage;

--- a/Tools/TestWebKitAPI/Helpers/Test.h
+++ b/Tools/TestWebKitAPI/Helpers/Test.h
@@ -27,8 +27,6 @@
 
 #include <wtf/Platform.h>
 
-#if !PLATFORM(COCOA) || !__has_feature(modules)
-
 #include <type_traits>
 #include <wtf/ASCIICType.h>
 #include <wtf/text/WTFString.h>
@@ -98,5 +96,3 @@ inline std::ostream& operator<<(std::ostream& os, const ASCIILiteral& string)
 }
 
 }
-
-#endif // !PLATFORM(COCOA) || !__has_feature(modules)

--- a/Tools/TestWebKitAPI/Helpers/WebCoreTestUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/WebCoreTestUtilities.h
@@ -27,8 +27,6 @@
 
 #include <wtf/Platform.h>
 
-#if !PLATFORM(COCOA) || !__has_feature(modules)
-
 #include "Helpers/Test.h"
 #include <WebCore/Color.h>
 #include <WebCore/FloatRect.h>
@@ -118,5 +116,3 @@ inline std::ostream& operator<<(std::ostream& os, const WebCore::FloatSegment& v
 }
 
 }
-
-#endif // !PLATFORM(COCOA) || !__has_feature(modules)


### PR DESCRIPTION
#### 3ac856a4b4a3bdb261e0d4c239e12d5919bcd266
<pre>
Fix the SaferCPP build
<a href="https://bugs.webkit.org/show_bug.cgi?id=312455">https://bugs.webkit.org/show_bug.cgi?id=312455</a>
<a href="https://rdar.apple.com/174902279">rdar://174902279</a>

Unreviewed build fix

* Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.h:
* Tools/TestWebKitAPI/Helpers/JavaScriptTest.h:
* Tools/TestWebKitAPI/Helpers/PlatformUtilities.h:
* Tools/TestWebKitAPI/Helpers/Test.h:
* Tools/TestWebKitAPI/Helpers/WebCoreTestUtilities.h:

Canonical link: <a href="https://commits.webkit.org/311354@main">https://commits.webkit.org/311354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7169455c92c9861b8f05152e26dd071f4b7e2bd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30103 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/23286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165590 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30106 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121427 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159725 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102095 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13362 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168073 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/20226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129652 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29628 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/140400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87429 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23859 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24474 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29337 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28861 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29091 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28987 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->