### PR TITLE
Web Inspector: Elements: Editing an attribute value that contains double quotes results in a malformed value

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -1453,8 +1453,10 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         let attrNameElement = attrSpanElement.createChild("span", "html-attribute-name");
         attrNameElement.textContent = name;
         let attrValueElement = null;
+
+        let quote = value.includes('"') ? "'" : "\"";
         if (hasText)
-            attrSpanElement.append("=\u200B\"");
+            attrSpanElement.append("=\u200B", quote);
 
         if (name === "src" || /\bhref\b/.test(name)) {
             let baseURL = node.frame ? node.frame.url : null;
@@ -1511,7 +1513,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         }
 
         if (hasText)
-            attrSpanElement.append("\"");
+            attrSpanElement.append(quote);
 
         this._createModifiedAnimation(name, value, hasText ? attrValueElement : attrNameElement);
 


### PR DESCRIPTION
#### c7b3ebaa936a6c3cb28974d1f8b2f64c2c99d5ad
<pre>
Web Inspector: Elements: Editing an attribute value that contains double quotes results in a malformed value
<a href="https://bugs.webkit.org/show_bug.cgi?id=312465">https://bugs.webkit.org/show_bug.cgi?id=312465</a>
<a href="https://rdar.apple.com/149523483">rdar://149523483</a>

Reviewed by Devin Rousso.

Attributes in the Elements DOM tree outline are rendered by wrapping the value in double quotes
(`WI.DOMTreeElement.prototype._buildAttributeDOM()`).

Entering editing mode turns the `&lt;span`&gt; element containing the represented attribute
into a `contenteditable=plaintext` element. (`WI.startEditing()`).

When committing the changed value, the `textContent` of this editable element
is sent to the backend as a text string (`target.DOMAgent.setAttributesAsText()`)
which interpolates the string into a dummy element to parse the result and update the node.
(`InspectorDOMAgent::setAttributesAsText()`). This is done to handle cases where
the committed value contains additional attributes, not just a single changed attribute.

If the changed attribute value contains double quotes, these conflict with the double quotes used to wrap the value in the DOM tree outline.
Web Inspector does not use the same type of quotes as in the original HTML markup.

For example, markup like `style=&apos;filter: url(&quot;#glow&quot;)&apos;`, is rendered and offered for editing
as `style=&quot;filter: url(&quot;#glow&quot;)&quot;` and committed as `style=\&quot;filter: url(\&quot;#glow\&quot;)\&quot;`.

The interpolation on the backend results in a malformed string
that causes the HTML parser to break the value at double quote limits.

This patch changes the type of quotes used in Web Inspector DOM tree outline to represent
the attribute if the attribute value already contains double quotes.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype._buildAttributeDOM):

Canonical link: <a href="https://commits.webkit.org/311717@main">https://commits.webkit.org/311717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09f3009052211841ca06ebddee1453e25824addf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157046 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165869 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111128 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121622 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85398 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102290 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b6e9c71-9eb5-4f51-be8a-c789032755b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22919 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21150 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13641 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168354 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12513 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129749 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129857 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35332 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140648 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87724 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24681 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17452 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29618 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93632 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29140 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29267 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->