### PR TITLE
Safari doesn't really fully dismiss the text selection in video player after closing the video

### DIFF
--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -555,6 +555,9 @@ void WebFullScreenManager::exitFullScreenForElement(WebCore::Element* element, C
 #if ENABLE(VIDEO)
     setMainVideoElement(nullptr);
 #endif
+#if ENABLE(IMAGE_ANALYSIS)
+    protect(m_page->playbackSessionManager())->cancelTextRecognition();
+#endif
 }
 
 void WebFullScreenManager::willEnterFullScreen(Element& element, CompletionHandler<void(ExceptionOr<void>)>&& willEnterFullscreenCallback, CompletionHandler<bool(bool)>&& didEnterFullscreenCallback, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
@@ -815,10 +818,8 @@ void WebFullScreenManager::handleEvent(WebCore::ScriptExecutionContext& context,
     if (&context != document.ptr() || !protect(document->fullscreen())->isFullscreen())
         return;
 
-    if (targetElement == m_element) {
+    if (targetElement == m_element)
         updateMainVideoElement();
-        return;
-    }
 
 #if ENABLE(IMAGE_ANALYSIS)
     if (targetElement == m_mainVideoElement.get()) {
@@ -846,8 +847,10 @@ void WebFullScreenManager::mainVideoElementTextRecognitionTimerFired()
     updateMainVideoElement();
 
     RefPtr mainVideoElement = m_mainVideoElement.get();
-    if (!mainVideoElement)
+    if (!mainVideoElement || !mainVideoElement->paused() || mainVideoElement->seeking()) {
+        endTextRecognitionForMainVideoIfNeeded();
         return;
+    }
 
     if (m_isPerformingTextRecognitionInMainVideo)
         m_page->cancelTextRecognitionForVideoInElementFullScreen();

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -144,6 +144,10 @@ public:
     WebCore::HTMLMediaElement* NODELETE mediaElementWithContextId(WebCore::HTMLMediaElementIdentifier) const;
     WebCore::HTMLMediaElement* NODELETE currentPlaybackControlsElement() const;
 
+#if ENABLE(IMAGE_ANALYSIS)
+    void cancelTextRecognition();
+#endif
+
 #if HAVE(PIP_SKIP_PREROLL)
     void actionHandlersChanged() final;
 #endif

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -420,6 +420,13 @@ void PlaybackSessionManager::rateChanged(WebCore::HTMLMediaElementIdentifier con
 #endif
 }
 
+#if ENABLE(IMAGE_ANALYSIS)
+void PlaybackSessionManager::cancelTextRecognition()
+{
+    m_textRecognitionRequest->cancel();
+}
+#endif
+
 void PlaybackSessionManager::seekableRangesChanged(WebCore::HTMLMediaElementIdentifier contextId, const WebCore::PlatformTimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
 {
     m_page->send(Messages::PlaybackSessionManagerProxy::SeekableRangesVectorChanged(processQualify(contextId), timeRanges, lastModifiedTime, liveUpdateInterval));

--- a/Source/WebKit/WebProcess/cocoa/TextRecognitionRequest.cpp
+++ b/Source/WebKit/WebProcess/cocoa/TextRecognitionRequest.cpp
@@ -71,7 +71,7 @@ void TextRecognitionRequest::requestTextRecognitionFor(HTMLMediaElementIdentifie
         if (!page)
             return;
         RefPtr element = dynamicDowncast<HTMLVideoElement>(manager->mediaElementWithContextId(identifier));
-        if (!element)
+        if (!element || !element->isInFullscreenOrPictureInPicture() || !element->paused() || element->seeking())
             return;
         page->beginTextRecognitionForVideoInElementFullScreen(*element);
     });

--- a/Tools/TestWebKitAPI/Resources/cocoa/element-fullscreen.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/element-fullscreen.html
@@ -79,5 +79,34 @@ function exitFullscreen()
     });
     return true;
 }
+
+function enterVideoFullscreen()
+{
+    if (document.webkitIsFullScreen)
+        return false;
+
+    performWithUserGestureIfPossible(() => {
+        video.webkitEnterFullscreen();
+        video.play();
+    });
+    return true;
+}
+
+function enterNativeVideoFullscreen()
+{
+    video.addEventListener("webkitbeginfullscreen", () => {
+        window.webkit.messageHandlers.testHandler.postMessage("enteredFullscreen");
+    }, { once: true });
+    video.webkitEnterFullscreen();
+    video.play();
+}
+
+function exitNativeVideoFullscreen()
+{
+    video.addEventListener("webkitendfullscreen", () => {
+        window.webkit.messageHandlers.testHandler.postMessage("exitedFullscreen");
+    }, { once: true });
+    video.webkitExitFullscreen();
+}
 </script>
 </html>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm
@@ -33,6 +33,7 @@
 #import "Helpers/Test.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKFullscreenDelegate.h>
 #import <pal/spi/cocoa/VisionKitCoreSPI.h>
@@ -85,6 +86,16 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     configuration.preferences.elementFullscreenEnabled = YES;
+    RetainPtr webView = adoptNS([[FullscreenVideoTextRecognitionWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
+    [webView synchronouslyLoadTestPageNamed:@"element-fullscreen"];
+    return webView;
+}
+
++ (RetainPtr<FullscreenVideoTextRecognitionWebView>)createForVideoFullscreen
+{
+    auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    configuration.preferences.elementFullscreenEnabled = YES;
+    [configuration.preferences _setVideoFullscreenRequiresElementFullscreen:YES];
     RetainPtr webView = adoptNS([[FullscreenVideoTextRecognitionWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"element-fullscreen"];
     return webView;
@@ -145,12 +156,33 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
     [self waitForNextPresentationUpdate];
 }
 
+- (void)enterVideoFullscreen
+{
+    _doneEnteringFullscreen = false;
+    [self evaluateJavaScript:@"enterVideoFullscreen()" completionHandler:nil];
+    TestWebKitAPI::Util::run(&_doneEnteringFullscreen);
+    [self waitForNextPresentationUpdate];
+}
+
 - (void)exitFullscreen
 {
     _doneExitingFullscreen = false;
     [self evaluateJavaScript:@"exitFullscreen()" completionHandler:nil];
     TestWebKitAPI::Util::run(&_doneExitingFullscreen);
     [self waitForNextPresentationUpdate];
+}
+
+- (void)dismissFullscreen
+{
+#if PLATFORM(IOS) || PLATFORM(VISION)
+    [self exitFullscreen];
+#else
+    _doneExitingFullscreen = false;
+    [self sendKey:@"\x1B" code:0x35 isDown:YES modifiers:0];
+    [self sendKey:@"\x1B" code:0x35 isDown:NO modifiers:0];
+    TestWebKitAPI::Util::run(&_doneExitingFullscreen);
+    [self waitForNextPresentationUpdate];
+#endif
 }
 
 - (void)didChangeValueForKey:(NSString *)key
@@ -219,6 +251,11 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
     return NO;
 }
 
+- (void)beginSeek:(double)time
+{
+    [self objectByEvaluatingJavaScript:[NSString stringWithFormat:@"video.currentTime = %f", time]];
+}
+
 - (void)waitForImageAnalysisToBegin
 {
     TestWebKitAPI::Util::waitForConditionWithLogging([&] {
@@ -237,13 +274,7 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
 
 namespace TestWebKitAPI {
 
-// FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved
-// FIXME: Re-enable this test in Sonoma once webkit.org/b/289025 is resolved.
-#if PLATFORM(IOS) || PLATFORM(VISION) || (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED > 140000 && __MAC_OS_X_VERSION_MIN_REQUIRED < 150000)
-TEST(FullscreenVideoTextRecognition, DISABLED_TogglePlaybackInElementFullscreen)
-#else
 TEST(FullscreenVideoTextRecognition, TogglePlaybackInElementFullscreen)
-#endif
 {
     auto webView = [FullscreenVideoTextRecognitionWebView create];
     [webView loadVideoSource:@"test.mp4"];
@@ -256,7 +287,7 @@ TEST(FullscreenVideoTextRecognition, TogglePlaybackInElementFullscreen)
     [webView waitForImageAnalysisToEnd];
 }
 
-// FIXME: re-enable for iOS when rdar://107476837 is resolved
+// FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved.
 #if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(FullscreenVideoTextRecognition, DISABLED_AddVideoAfterEnteringFullscreen)
 #else
@@ -275,10 +306,8 @@ TEST(FullscreenVideoTextRecognition, AddVideoAfterEnteringFullscreen)
     [webView waitForImageAnalysisToBegin];
 }
 
-// FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved
-// FIXME: Re-enable this test once webkit.org/b/248093 is resolved.
-// FIXME: Re-enable this test in Sonoma once webkit.org/b/289025 is resolved.
-#if PLATFORM(IOS) || PLATFORM(VISION) || !defined(NDEBUG) || (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED > 140000 && __MAC_OS_X_VERSION_MIN_REQUIRED < 150000)
+// FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved.
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(FullscreenVideoTextRecognition, DISABLED_DoNotAnalyzeVideoAfterExitingFullscreen)
 #else
 TEST(FullscreenVideoTextRecognition, DoNotAnalyzeVideoAfterExitingFullscreen)
@@ -304,6 +333,214 @@ TEST(FullscreenVideoTextRecognition, DoNotAnalyzeVideoAfterExitingFullscreen)
     });
     Util::run(&doneWaiting);
 }
+
+TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterExitingFullscreenViaEscape)
+{
+    auto webView = [FullscreenVideoTextRecognitionWebView create];
+    [webView loadVideoSource:@"test.mp4"];
+
+    [webView enterFullscreen];
+    [webView waitForVideoFrame];
+
+    // Exit fullscreen. Verify that no image analysis overlay is
+    // installed after fullscreen exit, even if playback state changes during
+    // the exit trigger TextRecognitionRequest::requestTextRecognitionFor.
+    [webView dismissFullscreen];
+
+    // Wait longer than the 250ms text recognition timer to ensure no overlay
+    // is installed after fullscreen exit.
+    bool doneWaiting = false;
+    RunLoop::mainSingleton().dispatchAfter(400_ms, [&] {
+        EXPECT_FALSE([webView hasActiveImageAnalysis]);
+        doneWaiting = true;
+    });
+    Util::run(&doneWaiting);
+}
+
+TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterSeekAndExitingFullscreenViaEscape)
+{
+    auto webView = [FullscreenVideoTextRecognitionWebView create];
+    [webView loadVideoSource:@"test.mp4"];
+
+    [webView enterFullscreen];
+    [webView waitForVideoFrame];
+    [webView pause];
+    [webView waitForImageAnalysisToBegin];
+    [webView beginSeek:0.5];
+
+    // Allow the seek to start before exiting fullscreen.
+    bool seekStarted = false;
+    RunLoop::mainSingleton().dispatchAfter(100_ms, [&] {
+        seekStarted = true;
+    });
+    Util::run(&seekStarted);
+
+    // Exit fullscreen while a seek is in progress. Verify that no
+    // image analysis overlay is installed after fullscreen exit.
+    [webView dismissFullscreen];
+
+    // Wait longer than the 250ms text recognition timer to ensure no overlay
+    // is installed after fullscreen exit.
+    bool doneWaiting = false;
+    RunLoop::mainSingleton().dispatchAfter(300_ms, [&] {
+        EXPECT_FALSE([webView hasActiveImageAnalysis]);
+        doneWaiting = true;
+    });
+    Util::run(&doneWaiting);
+}
+
+#if PLATFORM(MAC)
+
+TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterExitingVideoFullscreenViaEscape)
+{
+    auto webView = [FullscreenVideoTextRecognitionWebView createForVideoFullscreen];
+    [webView loadVideoSource:@"test.mp4"];
+
+    [webView enterVideoFullscreen];
+    [webView waitForVideoFrame];
+
+    // Exit fullscreen. Verify that no image analysis overlay is
+    // installed after fullscreen exit, even if playback state changes during
+    // the exit trigger TextRecognitionRequest::requestTextRecognitionFor.
+    [webView dismissFullscreen];
+
+    // Wait longer than the 250ms text recognition timer to ensure no overlay
+    // is installed after fullscreen exit.
+    bool doneWaiting = false;
+    RunLoop::mainSingleton().dispatchAfter(400_ms, [&] {
+        EXPECT_FALSE([webView hasActiveImageAnalysis]);
+        doneWaiting = true;
+    });
+    Util::run(&doneWaiting);
+}
+
+TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterSeekAndExitingVideoFullscreenViaEscape)
+{
+    auto webView = [FullscreenVideoTextRecognitionWebView createForVideoFullscreen];
+    [webView loadVideoSource:@"test.mp4"];
+
+    [webView enterVideoFullscreen];
+    [webView waitForVideoFrame];
+    [webView pause];
+    [webView waitForImageAnalysisToBegin];
+    [webView beginSeek:0.5];
+
+    // Allow the seek to start before exiting fullscreen.
+    bool seekStarted = false;
+    RunLoop::mainSingleton().dispatchAfter(100_ms, [&] {
+        seekStarted = true;
+    });
+    Util::run(&seekStarted);
+
+    // Exit fullscreen while a seek is in progress. Verify that no
+    // image analysis overlay is installed after fullscreen exit.
+    [webView dismissFullscreen];
+
+    // Wait longer than the 250ms text recognition timer to ensure no overlay
+    // is installed after fullscreen exit.
+    bool doneWaiting = false;
+    RunLoop::mainSingleton().dispatchAfter(300_ms, [&] {
+        EXPECT_FALSE([webView hasActiveImageAnalysis]);
+        doneWaiting = true;
+    });
+    Util::run(&doneWaiting);
+}
+
+#endif // PLATFORM(MAC)
+
+#if PLATFORM(IOS_FAMILY)
+
+TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterExitingNativeVideoFullscreen)
+{
+    auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    RetainPtr webView = adoptNS([[FullscreenVideoTextRecognitionWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
+    [webView synchronouslyLoadTestPageNamed:@"element-fullscreen"];
+    [webView objectByEvaluatingJavaScript:@"window.internals.setMockVideoPresentationModeEnabled(true)"];
+    [webView loadVideoSource:@"test.mp4"];
+
+    // Enter native video fullscreen via mock presentation mode.
+    __block bool enteredFullscreen = false;
+    [webView performAfterReceivingMessage:@"enteredFullscreen" action:^{ enteredFullscreen = true; }];
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"enterNativeVideoFullscreen()"];
+    Util::run(&enteredFullscreen);
+
+    // Wait for the fullscreen mode change to complete (DidEnterFullscreen IPC round-trip).
+    do {
+        if (![webView stringByEvaluatingJavaScript:@"window.internals.isChangingPresentationMode(document.querySelector('video'))"].boolValue)
+            break;
+        Util::runFor(100_ms);
+    } while (true);
+
+    [webView waitForVideoFrame];
+
+    // Exit native video fullscreen.
+    __block bool exitedFullscreen = false;
+    [webView performAfterReceivingMessage:@"exitedFullscreen" action:^{ exitedFullscreen = true; }];
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"exitNativeVideoFullscreen()"];
+    Util::run(&exitedFullscreen);
+    [webView waitForNextPresentationUpdate];
+
+    // Wait longer than the 250ms text recognition timer to ensure no overlay
+    // is installed after fullscreen exit.
+    bool doneWaiting = false;
+    RunLoop::mainSingleton().dispatchAfter(400_ms, [&] {
+        EXPECT_FALSE([webView hasActiveImageAnalysis]);
+        doneWaiting = true;
+    });
+    Util::run(&doneWaiting);
+}
+
+TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterSeekAndExitingNativeVideoFullscreen)
+{
+    auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    RetainPtr webView = adoptNS([[FullscreenVideoTextRecognitionWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
+    [webView synchronouslyLoadTestPageNamed:@"element-fullscreen"];
+    [webView objectByEvaluatingJavaScript:@"window.internals.setMockVideoPresentationModeEnabled(true)"];
+    [webView loadVideoSource:@"test.mp4"];
+
+    // Enter native video fullscreen via mock presentation mode.
+    __block bool enteredFullscreen = false;
+    [webView performAfterReceivingMessage:@"enteredFullscreen" action:^{ enteredFullscreen = true; }];
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"enterNativeVideoFullscreen()"];
+    Util::run(&enteredFullscreen);
+
+    // Wait for the fullscreen mode change to complete (DidEnterFullscreen IPC round-trip).
+    do {
+        if (![webView stringByEvaluatingJavaScript:@"window.internals.isChangingPresentationMode(document.querySelector('video'))"].boolValue)
+            break;
+        Util::runFor(100_ms);
+    } while (true);
+
+    [webView waitForVideoFrame];
+    [webView pause];
+    [webView waitForImageAnalysisToBegin];
+    [webView beginSeek:0.5];
+
+    // Allow the seek to start before exiting fullscreen.
+    bool seekStarted = false;
+    RunLoop::mainSingleton().dispatchAfter(100_ms, [&] {
+        seekStarted = true;
+    });
+    Util::run(&seekStarted);
+
+    // Exit native video fullscreen while a seek is in progress.
+    __block bool exitedFullscreen = false;
+    [webView performAfterReceivingMessage:@"exitedFullscreen" action:^{ exitedFullscreen = true; }];
+    [webView objectByEvaluatingJavaScriptWithUserGesture:@"exitNativeVideoFullscreen()"];
+    Util::run(&exitedFullscreen);
+    [webView waitForNextPresentationUpdate];
+
+    // Wait longer than the 250ms text recognition timer to ensure no overlay
+    // is installed after fullscreen exit.
+    bool doneWaiting = false;
+    RunLoop::mainSingleton().dispatchAfter(300_ms, [&] {
+        EXPECT_FALSE([webView hasActiveImageAnalysis]);
+        doneWaiting = true;
+    });
+    Util::run(&doneWaiting);
+}
+
+#endif // PLATFORM(IOS_FAMILY)
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### 6e15e1f73ee12ff54c3975e98860a893cb27fe25
<pre>
Safari doesn&apos;t really fully dismiss the text selection in video player after closing the video
<a href="https://bugs.webkit.org/show_bug.cgi?id=312462">https://bugs.webkit.org/show_bug.cgi?id=312462</a>
<a href="https://rdar.apple.com/173346436">rdar://173346436</a>

Reviewed by Youenn Fablet.

When a video is paused in fullscreen, WebKit starts text recognition after a
250ms debounce timer. Two independent code paths trigger this: WebFullScreenManager
(via DOM pause/seeking/playing events) and TextRecognitionRequest (via
PlaybackSessionManager rate/time change events). Both use separate 250ms timers
and both call WebPage::beginTextRecognitionForVideoInElementFullScreen, which
sends an IPC to the UIProcess to perform VisionKit image analysis and install
a VKCImageAnalysisOverlayView.

There were several issues causing the overlay to persist after fullscreen exit:

1. TextRecognitionRequest&apos;s timer callback did not re-validate element state.
Between scheduling the timer and it firing, the video could have exited
fullscreen, started playing, or begun seeking. The timer callback now
re-checks isInFullscreenOrPictureInPicture(), paused(), and seeking()
before proceeding.
2. WebFullScreenManager::mainVideoElementTextRecognitionTimerFired similarly
did not re-check whether the video was still paused and not seeking when
the timer fired. If conditions changed, it now calls endTextRecognitionForMainVideoIfNeeded()
to cancel any in-flight recognition.
3. WebFullScreenManager::handleEvent returned early when the event target was
the fullscreen element itself (targetElement == m_element), skipping the
text recognition handling block. This meant that when the video element
was directly the fullscreen element (video.webkitRequestFullscreen() rather
than a container), seeking/playing events never triggered cancellation of
in-flight text recognition via the WebFullScreenManager path.
4. WebFullScreenManager::exitFullScreenForElement only cancelled the
WebFullScreenManager&apos;s own text recognition timer via
setMainVideoElement(nullptr). It did not cancel TextRecognitionRequest&apos;s
independent timer. If TextRecognitionRequest&apos;s timer fired after the
WebFullScreenManager cancel but before the fullscreen exit completed, it
would send a new beginTextRecognitionForVideoInElementFullScreen IPC,
causing the overlay to be re-installed after it had been removed. The exit
path now also calls PlaybackSessionManager::cancelTextRecognition() to
cancel both paths.

New API tests verify that no image analysis overlay remains installed after
exiting fullscreen. Tests cover both element fullscreen (container as
fullscreen element) and video fullscreen (video as fullscreen element),
with and without an in-progress seek at the time of exit.

We also reenable three previously disabled tests now that the underlying race conditions
are fixed
  - TogglePlaybackInElementFullscreen
  - AddVideoAfterEnteringFullscreen
  - DoNotAnalyzeVideoAfterExitingFullscreen

- Source/WebKit/WebProcess/cocoa/TextRecognitionRequest.cpp:
(WebKit::TextRecognitionRequest::requestTextRecognitionFor): Re-check
element state in timer callback before beginning text recognition.
- Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::exitFullScreenForElement): Cancel
TextRecognitionRequest via PlaybackSessionManager on fullscreen exit.
(WebKit::WebFullScreenManager::handleEvent): Remove early return when
targetElement == m_element so text recognition events are handled when the
video is the fullscreen element.
(WebKit::WebFullScreenManager::mainVideoElementTextRecognitionTimerFired):
Re-check paused/seeking state; cancel if conditions changed.
- Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
- Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::cancelTextRecognition): Added.
- Tools/TestWebKitAPI/Resources/cocoa/element-fullscreen.html: Added
enterVideoFullscreen() function.
- Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm:
(FullscreenVideoTextRecognitionWebView enterVideoFullscreen): Added.
(-[FullscreenVideoTextRecognitionWebView enterVideoFullscreen]): Added.

Canonical link: <a href="https://commits.webkit.org/311561@main">https://commits.webkit.org/311561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3af0b5b0a8b4a4f9dee9bb8334052a10d4745092

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111446 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ccbc229f-f248-4319-a184-e586451206c9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121882 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85592 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d3233dc-396f-4fb2-a8eb-f915851fccdc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102550 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da45c248-941e-43ae-a9db-7b1344b5aa59) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23184 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21429 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13959 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168673 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12831 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130018 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35241 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30225 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88156 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24941 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17728 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93950 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29458 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29585 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->