### PR TITLE
[CMake, Mac] Use arm64e for internal SDK

### DIFF
--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -187,11 +187,19 @@ find_package(Threads REQUIRED)
 # SDK resolution
 # -----------------------------------------------------------------------------
 # Ask xcrun directly; CMake's default sysroot discovery can lag Xcode versions.
+# Prefer the internal SDK when available (mirrors Xcode/WKA: webkitdirs.pm:1041-1056).
 if (NOT CMAKE_OSX_SYSROOT)
-    execute_process(COMMAND xcrun --show-sdk-path
+    execute_process(COMMAND xcrun --sdk macosx.internal --show-sdk-path
         OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
         OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE _internal_sdk_result
         ERROR_QUIET)
+    if (NOT _internal_sdk_result EQUAL 0 OR NOT CMAKE_OSX_SYSROOT)
+        execute_process(COMMAND xcrun --show-sdk-path
+            OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET)
+    endif ()
 endif ()
 
 # Deployment target must match SDK version -- PlatformHave.h SPI guards depend on
@@ -206,6 +214,13 @@ if (_sdk_version)
         set(CMAKE_OSX_DEPLOYMENT_TARGET "${_sdk_major_minor}" CACHE STRING "Minimum macOS version" FORCE)
         message(WARNING "Deployment target auto-set to SDK version: ${CMAKE_OSX_DEPLOYMENT_TARGET} (SPI header guards require this)")
     endif ()
+endif ()
+
+if (NOT CMAKE_OSX_ARCHITECTURES
+        AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64"
+        AND CMAKE_OSX_SYSROOT MATCHES "\\.Internal\\.sdk$")
+    set(CMAKE_OSX_ARCHITECTURES "arm64e")
+    message(STATUS "arm64e enabled (internal SDK detected)")
 endif ()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
#### 2671da314419d2956d28d18f102fea3d3d4fe7c4
<pre>
[CMake, Mac] Use arm64e for internal SDK
<a href="https://rdar.apple.com/174922438">rdar://174922438</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312474">https://bugs.webkit.org/show_bug.cgi?id=312474</a>

Reviewed by NOBODY (OOPS!).

We should use arm64e on internal sdk to match Xcode.

* Source/cmake/OptionsMac.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2671da314419d2956d28d18f102fea3d3d4fe7c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110900 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121463 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85301 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102131 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22744 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20954 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13413 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148868 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132425 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168124 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17653 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129576 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129685 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140447 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87483 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24521 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17251 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188780 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29388 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48483 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28912 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29038 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->