### PR TITLE
[:has() perf] Replace MatchElement enum with a struct

### DIFF
--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1440,19 +1440,38 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
     if (checkingContext.disallowHasPseudoClass)
         return false;
 
-    auto matchElement = Style::computeHasPseudoClassMatchElement(hasSelector);
+    auto matchElement = Style::computeHasArgumentRelation(hasSelector);
+
+    enum class HasTraversalType : uint8_t { Children, Descendants, Siblings, SiblingDescendants };
+    auto traversalType = [&] {
+        switch (matchElement) {
+        case Style::MatchElement::HasRelation::Child:
+            return HasTraversalType::Children;
+        case Style::MatchElement::HasRelation::Descendant:
+            return HasTraversalType::Descendants;
+        case Style::MatchElement::HasRelation::DirectSibling:
+        case Style::MatchElement::HasRelation::IndirectSibling:
+            return HasTraversalType::Siblings;
+        case Style::MatchElement::HasRelation::SiblingChild:
+        case Style::MatchElement::HasRelation::SiblingDescendant:
+            return HasTraversalType::SiblingDescendants;
+        default:
+            ASSERT_NOT_REACHED();
+            return HasTraversalType::Descendants;
+        }
+    }();
 
     auto canMatch = [&] {
-        switch (matchElement) {
-        case Style::MatchElement::HasChild:
-        case Style::MatchElement::HasDescendant:
+        switch (traversalType) {
+        case HasTraversalType::Children:
+        case HasTraversalType::Descendants:
             return !!element.firstElementChild();
-        case Style::MatchElement::HasSibling:
-        case Style::MatchElement::HasSiblingDescendant:
+        case HasTraversalType::Siblings:
+        case HasTraversalType::SiblingDescendants:
             return !!element.nextElementSibling();
-        default:
-            return true;
-        };
+        }
+        ASSERT_NOT_REACHED();
+        return false;
     };
 
     // See if there are any elements that this :has() selector could match.
@@ -1483,7 +1502,16 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
     auto filterForElement = [&]() -> Style::HasSelectorFilter* {
         if (!checkingContext.selectorMatchingState)
             return nullptr;
-        auto type = Style::HasSelectorFilter::typeForMatchElement(matchElement);
+        auto type = [&]() -> std::optional<Style::HasSelectorFilter::Type> {
+            switch (traversalType) {
+            case HasTraversalType::Children:
+                return Style::HasSelectorFilter::Type::Children;
+            case HasTraversalType::Descendants:
+                return Style::HasSelectorFilter::Type::Descendants;
+            default:
+                return { };
+            }
+        }();
         if (!type)
             return nullptr;
         auto& filtersMap = checkingContext.selectorMatchingState->hasPseudoClassSelectorFilters;
@@ -1545,16 +1573,16 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
     };
 
     auto match = [&] {
-        switch (matchElement) {
-        // :has(> .child)
-        case Style::MatchElement::HasChild:
+        switch (traversalType) {
+        case HasTraversalType::Children:
+            // :has(> .child)
             for (CheckedRef child : childrenOfType<Element>(element)) {
                 if (checkRelative(child))
                     return true;
             }
             break;
-        // :has(.descendant)
-        case Style::MatchElement::HasDescendant: {
+        case HasTraversalType::Descendants: {
+            // :has(.descendant)
             if (cache) {
                 // See if we already know this descendant selector doesn't match in this subtree.
                 for (CheckedPtr ancestor = element.parentElement(); ancestor; ancestor = ancestor->parentElement()) {
@@ -1568,27 +1596,19 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
 
             break;
         }
-        // FIXME: Add a separate case for adjacent combinator.
-        // :has(+ .sibling)
-        // :has(~ .sibling)
-        case Style::MatchElement::HasSibling:
+        case HasTraversalType::Siblings:
+            // :has(~ .sibling)
             for (CheckedPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
                 if (checkRelative(*sibling))
                     return true;
             }
             break;
-        // FIXME: Add a separate case for adjacent combinator.
-        // :has(+ .sibling .descendant)
-        // :has(~ .sibling .descendant)
-        case Style::MatchElement::HasSiblingDescendant:
+        case HasTraversalType::SiblingDescendants:
+            // :has(~ .sibling .descendant)
             for (CheckedPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
                 if (checkDescendants(*sibling))
                     return true;
             }
-            break;
-
-        default:
-            ASSERT_NOT_REACHED();
             break;
         }
         return false;

--- a/Source/WebCore/style/AttributeChangeInvalidation.cpp
+++ b/Source/WebCore/style/AttributeChangeInvalidation.cpp
@@ -70,13 +70,13 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
     if (shouldInvalidateCurrent)
         m_element->invalidateStyle();
 
-    auto collect = [&](auto& ruleSets, std::optional<MatchElement> onlyMatchElement = { }) {
+    auto collect = [&](auto& ruleSets, std::optional<MatchElement::Relation> onlyRelation = { }) {
         auto* invalidationRuleSets = ruleSets.attributeInvalidationRuleSets(attributeNameForLookups);
         if (!invalidationRuleSets)
             return;
 
         for (auto& invalidationRuleSet : *invalidationRuleSets) {
-            if (onlyMatchElement && invalidationRuleSet.matchElement != onlyMatchElement)
+            if (onlyRelation && invalidationRuleSet.matchElement.relation != onlyRelation)
                 continue;
 
             for (auto& selector : invalidationRuleSet.invalidationSelectors) {
@@ -94,7 +94,7 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
     collect(m_element->styleResolver().ruleSets());
 
     if (RefPtr shadowRoot = m_element->shadowRoot())
-        collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Host);
+        collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Relation::Host);
 }
 
 void AttributeChangeInvalidation::invalidateStyleWithRuleSets()

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -62,23 +62,20 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
 
     bool isChild = changedElement.parentElement() == &parentElement();
 
-    auto canAffectElementsWithStyle = [&](MatchElement matchElement) {
-        switch (matchElement) {
-        case MatchElement::HasSibling:
-        case MatchElement::HasAnySibling:
-        case MatchElement::HasChild:
-        case MatchElement::HasChildAncestor:
-        case MatchElement::HasChildParent:
+    auto canAffectElementsWithStyle = [&](const InvalidationRuleSet& ruleSet) {
+        if (!ruleSet.matchElement.hasRelation)
+            return true;
+        switch (*ruleSet.matchElement.hasRelation) {
+        case MatchElement::HasRelation::Child:
+        case MatchElement::HasRelation::DirectSibling:
+        case MatchElement::HasRelation::IndirectSibling:
             return isChild;
-        case MatchElement::HasDescendant:
-        case MatchElement::HasSiblingDescendant:
-        case MatchElement::HasDescendantParent:
-        case MatchElement::HasNonSubject:
-        case MatchElement::HasScopeBreaking:
+        case MatchElement::HasRelation::Descendant:
+        case MatchElement::HasRelation::SiblingChild:
+        case MatchElement::HasRelation::SiblingDescendant:
             return true;
         default:
-            ASSERT_NOT_REACHED();
-            return false;
+            return true;
         }
     };
 
@@ -119,7 +116,7 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
         if (!invalidationRuleSets)
             return;
         for (auto& invalidationRuleSet : *invalidationRuleSets) {
-            if (!canAffectElementsWithStyle(invalidationRuleSet.matchElement))
+            if (!canAffectElementsWithStyle(invalidationRuleSet))
                 continue;
             if (!hasMatchingInvalidationSelector(invalidationRuleSet))
                 continue;
@@ -262,10 +259,10 @@ void ChildChangeInvalidation::invalidateForHasAfterMutation()
 
 static bool NODELETE needsDescendantTraversal(const RuleFeatureSet& features)
 {
-    return features.usesMatchElement(MatchElement::HasNonSubject)
-        || features.usesMatchElement(MatchElement::HasScopeBreaking)
-        || features.usesMatchElement(MatchElement::HasDescendant)
-        || features.usesMatchElement(MatchElement::HasSiblingDescendant);
+    // With the bundled MatchElement representation, any :has() with hasRelation=Descendant or SiblingDescendant
+    // needs descendant traversal. Since we don't have per-value tracking for hasRelation,
+    // use the usesHasPseudoClass flag as a conservative check.
+    return features.usesHasPseudoClass;
 };
 
 template<typename Function>

--- a/Source/WebCore/style/ClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/ClassChangeInvalidation.cpp
@@ -112,59 +112,51 @@ void ClassChangeInvalidation::computeInvalidation(const SpaceSplitString& oldCla
     if (shouldInvalidateCurrent)
         m_element->invalidateStyle();
 
-    auto invalidateBeforeAndAfterChange = [](MatchElement matchElement) {
-        switch (matchElement) {
-        case MatchElement::AnySibling:
-        case MatchElement::ParentAnySibling:
-        case MatchElement::AncestorAnySibling:
-        case MatchElement::HasAnySibling:
-        case MatchElement::HasNonSubject:
-        case MatchElement::HasScopeBreaking:
+    auto invalidateBeforeAndAfterChange = [](const InvalidationRuleSet& ruleSet) {
+        if (ruleSet.matchElement.hasRelation == MatchElement::HasRelation::ScopeBreaking)
             return true;
-        case MatchElement::Subject:
-        case MatchElement::Parent:
-        case MatchElement::Ancestor:
-        case MatchElement::DirectSibling:
-        case MatchElement::IndirectSibling:
-        case MatchElement::ParentSibling:
-        case MatchElement::AncestorSibling:
-        case MatchElement::HasChild:
-        case MatchElement::HasChildParent:
-        case MatchElement::HasChildAncestor:
-        case MatchElement::HasDescendantParent:
-        case MatchElement::HasDescendant:
-        case MatchElement::HasSibling:
-        case MatchElement::HasSiblingDescendant:
-        case MatchElement::Host:
-        case MatchElement::HostChild:
+        switch (ruleSet.matchElement.relation) {
+        case MatchElement::Relation::AnySibling:
+        case MatchElement::Relation::ParentAnySibling:
+        case MatchElement::Relation::AncestorAnySibling:
+            return true;
+        case MatchElement::Relation::Subject:
+        case MatchElement::Relation::Parent:
+        case MatchElement::Relation::Ancestor:
+        case MatchElement::Relation::DirectSibling:
+        case MatchElement::Relation::IndirectSibling:
+        case MatchElement::Relation::ParentSibling:
+        case MatchElement::Relation::AncestorSibling:
+        case MatchElement::Relation::Host:
+        case MatchElement::Relation::HostChild:
             return false;
         }
         ASSERT_NOT_REACHED();
         return false;
     };
 
-    auto invalidateBeforeChange = [&](ClassChangeType type, IsNegation isNegation, MatchElement matchElement) {
-        if (invalidateBeforeAndAfterChange(matchElement))
+    auto invalidateBeforeChange = [&](ClassChangeType type, IsNegation isNegation, const InvalidationRuleSet& ruleSet) {
+        if (invalidateBeforeAndAfterChange(ruleSet))
             return true;
         return type == ClassChangeType::Remove ? isNegation == IsNegation::No : isNegation == IsNegation::Yes;
     };
 
-    auto invalidateAfterChange = [&](ClassChangeType type, IsNegation isNegation, MatchElement matchElement) {
-        if (invalidateBeforeAndAfterChange(matchElement))
+    auto invalidateAfterChange = [&](ClassChangeType type, IsNegation isNegation, const InvalidationRuleSet& ruleSet) {
+        if (invalidateBeforeAndAfterChange(ruleSet))
             return true;
         return type == ClassChangeType::Add ? isNegation == IsNegation::No : isNegation == IsNegation::Yes;
     };
 
-    auto collect = [&](auto& ruleSets, std::optional<MatchElement> onlyMatchElement = { }) {
+    auto collect = [&](auto& ruleSets, std::optional<MatchElement::Relation> onlyRelation = { }) {
         for (auto& classChange : classChanges) {
             if (auto* invalidationRuleSets = ruleSets.classInvalidationRuleSets(classChange.className)) {
                 for (auto& invalidationRuleSet : *invalidationRuleSets) {
-                    if (onlyMatchElement && invalidationRuleSet.matchElement != onlyMatchElement)
+                    if (onlyRelation && invalidationRuleSet.matchElement.relation != onlyRelation)
                         continue;
 
-                    if (invalidateBeforeChange(classChange.type, invalidationRuleSet.isNegation, invalidationRuleSet.matchElement))
+                    if (invalidateBeforeChange(classChange.type, invalidationRuleSet.isNegation, invalidationRuleSet))
                         Invalidator::addToMatchElementRuleSets(m_beforeChangeRuleSets, invalidationRuleSet);
-                    if (invalidateAfterChange(classChange.type, invalidationRuleSet.isNegation, invalidationRuleSet.matchElement))
+                    if (invalidateAfterChange(classChange.type, invalidationRuleSet.isNegation, invalidationRuleSet))
                         Invalidator::addToMatchElementRuleSets(m_afterChangeRuleSets, invalidationRuleSet);
                 }
             }
@@ -174,7 +166,7 @@ void ClassChangeInvalidation::computeInvalidation(const SpaceSplitString& oldCla
     collect(m_element->styleResolver().ruleSets());
 
     if (RefPtr shadowRoot = m_element->shadowRoot())
-        collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Host);
+        collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Relation::Host);
 }
 
 void ClassChangeInvalidation::invalidateBeforeChange()

--- a/Source/WebCore/style/HasSelectorFilter.cpp
+++ b/Source/WebCore/style/HasSelectorFilter.cpp
@@ -54,18 +54,6 @@ HasSelectorFilter::HasSelectorFilter(const Element& element, Type type)
     }
 }
 
-auto HasSelectorFilter::typeForMatchElement(MatchElement matchElement) -> std::optional<Type>
-{
-    switch (matchElement) {
-    case MatchElement::HasChild:
-        return Type::Children;
-    case MatchElement::HasDescendant:
-        return Type::Descendants;
-    default:
-        return { };
-    }
-}
-
 auto HasSelectorFilter::makeKey(const CSSSelector& hasSelector) -> Key
 {
     SelectorFilter::CollectedSelectorHashes hashes;

--- a/Source/WebCore/style/HasSelectorFilter.h
+++ b/Source/WebCore/style/HasSelectorFilter.h
@@ -34,7 +34,7 @@ class Element;
 
 namespace Style {
 
-enum class MatchElement : uint8_t;
+struct MatchElement;
 
 class HasSelectorFilter {
     WTF_MAKE_TZONE_ALLOCATED(HasSelectorFilter);
@@ -43,7 +43,6 @@ public:
     HasSelectorFilter(const Element&, Type);
 
     Type type() const { return m_type; }
-    static std::optional<Type> NODELETE typeForMatchElement(MatchElement);
 
     using Key = unsigned;
     static Key makeKey(const CSSSelector& hasSelector);

--- a/Source/WebCore/style/IdChangeInvalidation.cpp
+++ b/Source/WebCore/style/IdChangeInvalidation.cpp
@@ -59,7 +59,7 @@ void IdChangeInvalidation::invalidateStyle(const AtomString& changedId)
 
     m_element->invalidateStyle();
 
-    auto collect = [&](auto& ruleSets, std::optional<MatchElement> onlyMatchElement = { }) {
+    auto collect = [&](auto& ruleSets, std::optional<MatchElement::Relation> onlyRelation = { }) {
         // This could be easily optimized for fine-grained descendant invalidation similar to ClassChangeInvalidation.
         // However using ids for dynamic styling is rare and this is probably not worth the memory cost of the required data structures.
         bool mayAffectDescendantStyle = ruleSets.features().idsMatchingAncestorsInRules.contains(changedId);
@@ -71,7 +71,7 @@ void IdChangeInvalidation::invalidateStyle(const AtomString& changedId)
         // Invalidation rulesets exist for :has() / :nth-child() / :nth-last-child.
         if (auto* invalidationRuleSets = ruleSets.idInvalidationRuleSets(changedId)) {
             for (auto& invalidationRuleSet : *invalidationRuleSets) {
-                if (onlyMatchElement && invalidationRuleSet.matchElement != onlyMatchElement)
+                if (onlyRelation && invalidationRuleSet.matchElement.relation != onlyRelation)
                     continue;
 
                 Invalidator::addToMatchElementRuleSets(m_matchElementRuleSets, invalidationRuleSet);
@@ -82,7 +82,7 @@ void IdChangeInvalidation::invalidateStyle(const AtomString& changedId)
     collect(m_element->styleResolver().ruleSets());
 
     if (RefPtr shadowRoot = m_element->shadowRoot())
-        collect(protect(shadowRoot->styleScope())->resolver().ruleSets(), MatchElement::Host);
+        collect(protect(shadowRoot->styleScope())->resolver().ruleSets(), MatchElement::Relation::Host);
 
 }
 

--- a/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
@@ -86,18 +86,18 @@ void PseudoClassChangeInvalidation::computeInvalidation(CSSSelector::PseudoClass
 
 void PseudoClassChangeInvalidation::collectRuleSets(const PseudoClassInvalidationKey& key, Value value, InvalidationScope invalidationScope)
 {
-    auto collect = [&](auto& ruleSets, std::optional<MatchElement> onlyMatchElement = { }) {
+    auto collect = [&](auto& ruleSets, std::optional<MatchElement::Relation> onlyRelation = { }) {
         auto* invalidationRuleSets = ruleSets.pseudoClassInvalidationRuleSets(key);
         if (!invalidationRuleSets)
             return;
 
         for (auto& invalidationRuleSet : *invalidationRuleSets) {
-            if (onlyMatchElement && invalidationRuleSet.matchElement != onlyMatchElement)
+            if (onlyRelation && invalidationRuleSet.matchElement.relation != onlyRelation)
                 continue;
 
             // For focus/hover we flip the whole ancestor chain. We only need to do deep invalidation traversal in the change root.
             auto shouldInvalidate = [&] {
-                bool invalidatesAllDescendants = invalidationRuleSet.matchElement == MatchElement::Ancestor && isUniversalInvalidation(key);
+                bool invalidatesAllDescendants = invalidationRuleSet.matchElement.relation == MatchElement::Relation::Ancestor && isUniversalInvalidation(key);
                 switch (invalidationScope) {
                 case InvalidationScope::All:
                     return true;
@@ -129,7 +129,7 @@ void PseudoClassChangeInvalidation::collectRuleSets(const PseudoClassInvalidatio
     collect(m_element.styleResolver().ruleSets());
 
     if (RefPtr shadowRoot = m_element.shadowRoot())
-        collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Host);
+        collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Relation::Host);
 }
 
 void PseudoClassChangeInvalidation::invalidateBeforeChange()

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -40,80 +40,39 @@
 namespace WebCore {
 namespace Style {
 
-static bool NODELETE isSiblingOrSubject(MatchElement matchElement)
+static bool NODELETE isSiblingOrSubject(MatchElement::Relation relation)
 {
-    switch (matchElement) {
-    case MatchElement::Subject:
-    case MatchElement::IndirectSibling:
-    case MatchElement::DirectSibling:
-    case MatchElement::AnySibling:
-    case MatchElement::HasSibling:
-    case MatchElement::HasAnySibling:
-    case MatchElement::Host:
-    case MatchElement::HostChild:
+    switch (relation) {
+    case MatchElement::Relation::Subject:
+    case MatchElement::Relation::IndirectSibling:
+    case MatchElement::Relation::DirectSibling:
+    case MatchElement::Relation::AnySibling:
+    case MatchElement::Relation::Host:
+    case MatchElement::Relation::HostChild:
         return true;
-    case MatchElement::Parent:
-    case MatchElement::Ancestor:
-    case MatchElement::ParentSibling:
-    case MatchElement::AncestorSibling:
-    case MatchElement::ParentAnySibling:
-    case MatchElement::AncestorAnySibling:
-    case MatchElement::HasChild:
-    case MatchElement::HasDescendant:
-    case MatchElement::HasSiblingDescendant:
-    case MatchElement::HasChildParent:
-    case MatchElement::HasChildAncestor:
-    case MatchElement::HasDescendantParent:
-    case MatchElement::HasNonSubject:
-    case MatchElement::HasScopeBreaking:
+    case MatchElement::Relation::Parent:
+    case MatchElement::Relation::Ancestor:
+    case MatchElement::Relation::ParentSibling:
+    case MatchElement::Relation::AncestorSibling:
+    case MatchElement::Relation::ParentAnySibling:
+    case MatchElement::Relation::AncestorAnySibling:
         return false;
     }
     ASSERT_NOT_REACHED();
     return false;
 }
 
-bool isHasPseudoClassMatchElement(MatchElement matchElement)
+static bool NODELETE isSiblingOrSubject(MatchElement::HasRelation relation)
 {
-    switch (matchElement) {
-    case MatchElement::HasChild:
-    case MatchElement::HasDescendant:
-    case MatchElement::HasSibling:
-    case MatchElement::HasSiblingDescendant:
-    case MatchElement::HasAnySibling:
-    case MatchElement::HasNonSubject:
-    case MatchElement::HasScopeBreaking:
+    switch (relation) {
+    case MatchElement::HasRelation::DirectSibling:
+    case MatchElement::HasRelation::IndirectSibling:
         return true;
-    default:
-        return false;
-    }
-}
-
-static bool NODELETE isScopeBreaking(MatchElement matchElement)
-{
-    switch (matchElement) {
-    case MatchElement::HasAnySibling:
-    case MatchElement::HasScopeBreaking:
-        return true;
-    case MatchElement::Subject:
-    case MatchElement::IndirectSibling:
-    case MatchElement::DirectSibling:
-    case MatchElement::AnySibling:
-    case MatchElement::HasSibling:
-    case MatchElement::Host:
-    case MatchElement::HostChild:
-    case MatchElement::Parent:
-    case MatchElement::Ancestor:
-    case MatchElement::ParentSibling:
-    case MatchElement::AncestorSibling:
-    case MatchElement::ParentAnySibling:
-    case MatchElement::AncestorAnySibling:
-    case MatchElement::HasChild:
-    case MatchElement::HasDescendant:
-    case MatchElement::HasSiblingDescendant:
-    case MatchElement::HasChildParent:
-    case MatchElement::HasChildAncestor:
-    case MatchElement::HasDescendantParent:
-    case MatchElement::HasNonSubject:
+    case MatchElement::HasRelation::Child:
+    case MatchElement::HasRelation::Descendant:
+    case MatchElement::HasRelation::SiblingChild:
+    case MatchElement::HasRelation::SiblingDescendant:
+    case MatchElement::HasRelation::ScopeBreaking:
         return false;
     }
     ASSERT_NOT_REACHED();
@@ -161,120 +120,84 @@ bool SelectorDeduplicationKey::operator==(const SelectorDeduplicationKey& other)
     return complexSelectorsEqual(*selector, *other.selector, ComplexSelectorsEqualMode::IgnoreNonElementBackedPseudoElements);
 }
 
-static MatchElement computeNextMatchElement(MatchElement matchElement, CSSSelector::Relation relation)
+static MatchElement::Relation computeNextRelation(MatchElement::Relation relation, CSSSelector::Relation selectorRelation)
 {
-    ASSERT(!isHasPseudoClassMatchElement(matchElement));
-
-    if (isSiblingOrSubject(matchElement)) {
-        switch (relation) {
+    if (isSiblingOrSubject(relation)) {
+        switch (selectorRelation) {
         case CSSSelector::Relation::Subselector:
-            return matchElement;
+            return relation;
         case CSSSelector::Relation::DescendantSpace:
-            return MatchElement::Ancestor;
+            return MatchElement::Relation::Ancestor;
         case CSSSelector::Relation::Child:
-            return MatchElement::Parent;
+            return MatchElement::Relation::Parent;
         case CSSSelector::Relation::IndirectAdjacent:
-            if (matchElement == MatchElement::AnySibling)
-                return MatchElement::AnySibling;
-            return MatchElement::IndirectSibling;
+            if (relation == MatchElement::Relation::AnySibling)
+                return MatchElement::Relation::AnySibling;
+            return MatchElement::Relation::IndirectSibling;
         case CSSSelector::Relation::DirectAdjacent:
-            if (matchElement == MatchElement::AnySibling)
-                return MatchElement::AnySibling;
-            return matchElement == MatchElement::Subject ? MatchElement::DirectSibling : MatchElement::IndirectSibling;
+            if (relation == MatchElement::Relation::AnySibling)
+                return MatchElement::Relation::AnySibling;
+            return relation == MatchElement::Relation::Subject ? MatchElement::Relation::DirectSibling : MatchElement::Relation::IndirectSibling;
         case CSSSelector::Relation::ShadowDescendant:
         case CSSSelector::Relation::ShadowPartDescendant:
-            return MatchElement::Host;
+            return MatchElement::Relation::Host;
         case CSSSelector::Relation::ShadowSlotted:
-            return MatchElement::HostChild;
+            return MatchElement::Relation::HostChild;
         };
     }
-    switch (relation) {
+    switch (selectorRelation) {
     case CSSSelector::Relation::Subselector:
-        return matchElement;
+        return relation;
     case CSSSelector::Relation::DescendantSpace:
     case CSSSelector::Relation::Child:
-        return MatchElement::Ancestor;
+        return MatchElement::Relation::Ancestor;
     case CSSSelector::Relation::IndirectAdjacent:
     case CSSSelector::Relation::DirectAdjacent:
-        return matchElement == MatchElement::Parent ? MatchElement::ParentSibling : MatchElement::AncestorSibling;
+        return relation == MatchElement::Relation::Parent ? MatchElement::Relation::ParentSibling : MatchElement::Relation::AncestorSibling;
     case CSSSelector::Relation::ShadowDescendant:
     case CSSSelector::Relation::ShadowPartDescendant:
-        return MatchElement::Host;
+        return MatchElement::Relation::Host;
     case CSSSelector::Relation::ShadowSlotted:
-        return MatchElement::HostChild;
+        return MatchElement::Relation::HostChild;
     };
     ASSERT_NOT_REACHED();
-    return matchElement;
+    return relation;
 };
 
-static MatchElement NODELETE computeNextHasPseudoClassMatchElement(MatchElement matchElement, CSSSelector::Relation relation, CanBreakScope canBreakScope)
+static MatchElement::HasRelation toHasRelation(MatchElement::Relation relation)
 {
-    ASSERT(isHasPseudoClassMatchElement(matchElement));
-
-    if (canBreakScope == CanBreakScope::No)
-        return matchElement;
-
-    // `:has(:is(foo bar))` can be affected by changes outside the :has scope.
-    if (relation == CSSSelector::Relation::DescendantSpace || relation == CSSSelector::Relation::Child) {
-        // However, for `:has(> :is(.x > .y))`, the child combinator (>) inside :is() is still scoped to the direct child's tree.
-        // The parent in the relationship must be the direct child itself, which is within the :has(>) scope.
-        // Only descendant combinators can reach outside this scope (to ancestors of the subject element).
-        if (matchElement == MatchElement::HasChild && relation == CSSSelector::Relation::Child)
-            return matchElement;
-
-        return MatchElement::HasScopeBreaking;
+    switch (relation) {
+    case MatchElement::Relation::Parent:
+        return MatchElement::HasRelation::Child;
+    case MatchElement::Relation::Ancestor:
+        return MatchElement::HasRelation::Descendant;
+    case MatchElement::Relation::DirectSibling:
+        return MatchElement::HasRelation::DirectSibling;
+    case MatchElement::Relation::IndirectSibling:
+    case MatchElement::Relation::AnySibling:
+        return MatchElement::HasRelation::IndirectSibling;
+    case MatchElement::Relation::ParentSibling:
+        return MatchElement::HasRelation::SiblingChild;
+    case MatchElement::Relation::AncestorSibling:
+    case MatchElement::Relation::ParentAnySibling:
+    case MatchElement::Relation::AncestorAnySibling:
+        return MatchElement::HasRelation::SiblingDescendant;
+    case MatchElement::Relation::Subject:
+    case MatchElement::Relation::Host:
+    case MatchElement::Relation::HostChild:
+        ASSERT_NOT_REACHED();
+        return MatchElement::HasRelation::Child;
     }
-
-    if (relation == CSSSelector::Relation::IndirectAdjacent || relation == CSSSelector::Relation::DirectAdjacent) {
-        // `:has(~ :is(.x ~ .y))` must look at previous siblings of the :scope scope too.
-        if (matchElement == MatchElement::HasSibling)
-            return MatchElement::HasAnySibling;
-
-        // `:has(~ :is(.x ~ .y)) .z` must be treated as scope breaking, rather than HasAnySibling like the previous case.
-        if (matchElement == MatchElement::HasNonSubject)
-            return MatchElement::HasScopeBreaking;
-    }
-
-    return matchElement;
+    ASSERT_NOT_REACHED();
+    return MatchElement::HasRelation::Child;
 }
 
-MatchElement computeHasPseudoClassMatchElement(const CSSSelector& hasSelector)
+MatchElement::HasRelation computeHasArgumentRelation(const CSSSelector& hasSelector)
 {
-    auto hasMatchElement = MatchElement::Subject;
+    auto relation = MatchElement::Relation::Subject;
     for (auto* simpleSelector = &hasSelector; simpleSelector->precedingInComplexSelector(); simpleSelector = simpleSelector->precedingInComplexSelector())
-        hasMatchElement = computeNextMatchElement(hasMatchElement, simpleSelector->relation());
-
-    switch (hasMatchElement) {
-    case MatchElement::Parent:
-    case MatchElement::Subject:
-        return MatchElement::HasChild;
-    case MatchElement::Ancestor:
-        return MatchElement::HasDescendant;
-    case MatchElement::IndirectSibling:
-    case MatchElement::DirectSibling:
-    case MatchElement::AnySibling:
-        return MatchElement::HasSibling;
-    case MatchElement::ParentSibling:
-    case MatchElement::AncestorSibling:
-    case MatchElement::ParentAnySibling:
-    case MatchElement::AncestorAnySibling:
-        return MatchElement::HasSiblingDescendant;
-    case MatchElement::HasChild:
-    case MatchElement::HasDescendant:
-    case MatchElement::HasSibling:
-    case MatchElement::HasSiblingDescendant:
-    case MatchElement::HasAnySibling:
-    case MatchElement::HasChildParent:
-    case MatchElement::HasChildAncestor:
-    case MatchElement::HasDescendantParent:
-    case MatchElement::HasNonSubject:
-    case MatchElement::HasScopeBreaking:
-    case MatchElement::Host:
-    case MatchElement::HostChild:
-        ASSERT_NOT_REACHED();
-        break;
-    }
-    return MatchElement::HasChild;
+        relation = computeNextRelation(relation, simpleSelector->relation());
+    return toHasRelation(relation);
 }
 
 static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, const CSSSelector& selector, const CSSSelector& childSelector)
@@ -283,46 +206,26 @@ static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, co
         auto type = selector.pseudoClass();
         // For :nth-child(n of .some-subselector) where an element change may affect other elements similar to sibling combinators.
         if (type == CSSSelector::PseudoClass::NthChild || type == CSSSelector::PseudoClass::NthLastChild) {
-            if (matchElement == MatchElement::Parent)
-                return MatchElement::ParentAnySibling;
-            if (matchElement == MatchElement::Ancestor)
-                return MatchElement::AncestorAnySibling;
-            return MatchElement::AnySibling;
+            if (matchElement.relation == MatchElement::Relation::Parent)
+                return { MatchElement::Relation::ParentAnySibling, matchElement.hasRelation };
+            if (matchElement.relation == MatchElement::Relation::Ancestor)
+                return { MatchElement::Relation::AncestorAnySibling, matchElement.hasRelation };
+            return { MatchElement::Relation::AnySibling, matchElement.hasRelation };
         }
 
         // Similarly for :host().
         if (type == CSSSelector::PseudoClass::Host)
-            return MatchElement::Host;
+            return { MatchElement::Relation::Host, matchElement.hasRelation };
 
         if (type == CSSSelector::PseudoClass::Has) {
-            auto hasSelectorMatchElement = computeHasPseudoClassMatchElement(childSelector);
-
-            if (hasSelectorMatchElement == MatchElement::HasChild) {
-                // :has(> .changed) > .subject
-                if (matchElement == MatchElement::Parent)
-                    return MatchElement::HasChildParent;
-                // :has(> .changed) .subject
-                if (matchElement == MatchElement::Ancestor)
-                    return MatchElement::HasChildAncestor;
-            }
-
-            if (hasSelectorMatchElement == MatchElement::HasDescendant) {
-                if (matchElement == MatchElement::Parent)
-                    return MatchElement::HasDescendantParent;
-            }
-
-
-            if (matchElement != MatchElement::Subject)
-                return MatchElement::HasNonSubject;
-
-            return hasSelectorMatchElement;
+            auto hasArgumentRelation = computeHasArgumentRelation(childSelector);
+            return { matchElement.relation, hasArgumentRelation };
         }
-
     }
     if (selector.match() == CSSSelector::Match::PseudoElement) {
         // Similarly for ::slotted().
         if (selector.pseudoElement() == CSSSelector::PseudoElement::Slotted)
-            return MatchElement::Host;
+            return { MatchElement::Relation::Host, matchElement.hasRelation };
     }
 
     return matchElement;
@@ -336,9 +239,9 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
         auto canBreakScope = allComponentsCanBreakScope;
         if (selector->match() == CSSSelector::Match::Id) {
             idsInRules.add(selector->value());
-            if (matchElement == MatchElement::Parent || matchElement == MatchElement::Ancestor)
+            if (matchElement.relation == MatchElement::Relation::Parent || matchElement.relation == MatchElement::Relation::Ancestor)
                 idsMatchingAncestorsInRules.add(selector->value());
-            else if (isHasPseudoClassMatchElement(matchElement) || matchElement == MatchElement::AnySibling || matchElement == MatchElement::Host || matchElement == MatchElement::HostChild)
+            else if (matchElement.hasRelation || matchElement.relation == MatchElement::Relation::AnySibling || matchElement.relation == MatchElement::Relation::Host || matchElement.relation == MatchElement::Relation::HostChild)
                 selectorFeatures.ids.append({ selector, matchElement, isNegation });
         } else if (selector->match() == CSSSelector::Match::Class)
             selectorFeatures.classes.append({ selector, matchElement, isNegation });
@@ -355,7 +258,7 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
                 selectorFeatures.pseudoClasses.append({ selector, matchElement, isNegation });
 
             // Check for the :has(:is(foo bar)) case. In this case `foo` can match elements outside the :has() scope.
-            if (isLogicalCombination && isHasPseudoClassMatchElement(matchElement))
+            if (isLogicalCombination && matchElement.hasRelation)
                 canBreakScope = CanBreakScope::Yes;
         }
 
@@ -365,11 +268,11 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
                 subSelectorIsNegation = isNegation == IsNegation::No ? IsNegation::Yes : IsNegation::No;
 
             for (auto& subSelector : *selectorList) {
-                auto subSelectorMatchElement = computeSubSelectorMatchElement(matchElement, *selector, subSelector);
-                auto pseudoClassDoesBreakScope = recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, subSelectorMatchElement, subSelectorIsNegation, canBreakScope);
+                auto subResult = computeSubSelectorMatchElement(matchElement, *selector, subSelector);
+                auto pseudoClassDoesBreakScope = recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, subResult, subSelectorIsNegation, canBreakScope);
 
                 if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Has)
-                    selectorFeatures.hasPseudoClasses.append({ &subSelector, subSelectorMatchElement, isNegation, pseudoClassDoesBreakScope });
+                    selectorFeatures.hasPseudoClasses.append({ &subSelector, subResult, isNegation, pseudoClassDoesBreakScope });
 
                 if (pseudoClassDoesBreakScope == DoesBreakScope::Yes)
                     doesBreakScope = DoesBreakScope::Yes;
@@ -379,14 +282,30 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
         if (!selector->precedingInComplexSelector())
             break;
 
-        matchElement = [&] {
-            if (isHasPseudoClassMatchElement(matchElement))
-                return computeNextHasPseudoClassMatchElement(matchElement, selector->relation(), allComponentsCanBreakScope);
-            return computeNextMatchElement(matchElement, selector->relation());
-        }();
+        auto relation = selector->relation();
+        matchElement.relation = computeNextRelation(matchElement.relation, relation);
 
-        if (isScopeBreaking(matchElement))
-            doesBreakScope = DoesBreakScope::Yes;
+        // Detect scope-breaking inside :has() arguments.
+        // When inside :has() and a logical combinator like :is() allows scope breaking,
+        // combinators can reach outside the :has() scope.
+        if (matchElement.hasRelation && *matchElement.hasRelation != MatchElement::HasRelation::ScopeBreaking && allComponentsCanBreakScope == CanBreakScope::Yes) {
+            if (relation == CSSSelector::Relation::DescendantSpace || relation == CSSSelector::Relation::Child) {
+                // For :has(> :is(.x > .y)), the child combinator inside :is() is still scoped to the direct child's tree.
+                // Only mark as scope-breaking if the has argument isn't a direct child, or the combinator is a descendant space.
+                if (matchElement.hasRelation != MatchElement::HasRelation::Child || relation != CSSSelector::Relation::Child) {
+                    matchElement.hasRelation = MatchElement::HasRelation::ScopeBreaking;
+                    doesBreakScope = DoesBreakScope::Yes;
+                }
+            }
+            if (relation == CSSSelector::Relation::IndirectAdjacent || relation == CSSSelector::Relation::DirectAdjacent) {
+                // :has(~ :is(.x ~ .y)) — sibling combinator inside :is() when :has() has sibling traversal.
+                // Widens to any-sibling search and is scope-breaking (elements outside :has() scope can be affected).
+                if (isSiblingOrSubject(*matchElement.hasRelation)) {
+                    matchElement.hasRelation = MatchElement::HasRelation::ScopeBreaking;
+                    doesBreakScope = DoesBreakScope::Yes;
+                }
+            }
+        }
 
         selector = selector->precedingInComplexSelector();
     };
@@ -462,8 +381,8 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
         auto collectSelectorList = [&] (const auto& selectorList) {
             if (!selectorList.isEmpty()) {
                 for (auto& subSelector : selectorList) {
-                    recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, MatchElement::Ancestor);
-                    recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, MatchElement::Subject);
+                    recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, { MatchElement::Relation::Ancestor, { } });
+                    recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, { MatchElement::Relation::Subject, { } });
                 }
             }
         };
@@ -493,10 +412,10 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
                 isNegation
             });
 
-            setUsesMatchElement(matchElement);
+            setUsesRelation(matchElement.relation);
 
             if constexpr (!std::is_same_v<std::nullptr_t, HostAffectingNames>) {
-                if (matchElement == MatchElement::Host)
+                if (matchElement.relation == MatchElement::Relation::Host)
                     hostAffectingNames->add(name);
             }
         }
@@ -518,9 +437,9 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
             CSSSelectorList::makeCopyingSimpleSelector(*selector)
         });
 
-        if (matchElement == MatchElement::Host)
+        if (matchElement.relation == MatchElement::Relation::Host)
             attributesAffectingHost.add(selector->attribute().localNameLowercase());
-        setUsesMatchElement(matchElement);
+        setUsesRelation(matchElement.relation);
     }
 
     for (auto& entry : selectorFeatures.pseudoClasses) {
@@ -535,11 +454,11 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
             isNegation
         });
 
-        if (matchElement == MatchElement::Host)
+        if (matchElement.relation == MatchElement::Relation::Host)
             pseudoClassesAffectingHost.add(selector->pseudoClass());
         pseudoClasses.add(selector->pseudoClass());
 
-        setUsesMatchElement(matchElement);
+        setUsesRelation(matchElement.relation);
     }
 
     for (auto& entry : selectorFeatures.hasPseudoClasses) {
@@ -559,7 +478,8 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
         if (doesBreakScope == DoesBreakScope::Yes)
             scopeBreakingHasPseudoClassRules.append({ ruleData });
 
-        setUsesMatchElement(matchElement);
+        setUsesRelation(matchElement.relation);
+        usesHasPseudoClass = true;
     }
 }
 
@@ -615,12 +535,13 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
     addMap(hasPseudoClassRules, other.hasPseudoClassRules);
     scopeBreakingHasPseudoClassRules.appendVector(other.scopeBreakingHasPseudoClassRules);
 
-    for (size_t i = 0; i < usedMatchElements.size(); ++i)
-        usedMatchElements[i] = usedMatchElements[i] || other.usedMatchElements[i];
+    for (size_t i = 0; i < usedRelations.size(); ++i)
+        usedRelations[i] = usedRelations[i] || other.usedRelations[i];
 
     usesFirstLineRules = usesFirstLineRules || other.usesFirstLineRules;
     usesFirstLetterRules = usesFirstLetterRules || other.usesFirstLetterRules;
     hasStartingStyleRules = hasStartingStyleRules || other.hasStartingStyleRules;
+    usesHasPseudoClass = usesHasPseudoClass || other.usesHasPseudoClass;
 }
 
 void RuleFeatureSet::registerSubstitutionAttribute(const AtomString& attributeName)

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -27,6 +27,7 @@
 #include <wtf/GenericHashKey.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/Markable.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -42,34 +43,42 @@ class RuleData;
 // MatchElement characterizes which elements a change in an element matched by a simple selector (as a part of a complex selector) may affect.
 // Style::Invalidator uses these classifications to traverse a minimal number of elements after a DOM mutation.
 // In the examples below the '.changed' simple selector will be classified with the given enum value.
-// FIXME: Has* values should be separated so we could better describe both the :has() argument and its position in the selector.
-enum class MatchElement : uint8_t {
-    Subject, // .changed
-    Parent, // .changed > .subject
-    Ancestor, // .changed .subject
-    DirectSibling, // .changed + .subject
-    IndirectSibling, // .changed ~ .subject
-    AnySibling, // :nth-last-child(even of .changed)
-    ParentSibling, // .changed ~ .a > .subject
-    AncestorSibling, // .changed ~ .a .subject
-    ParentAnySibling, // :nth-last-child(even of .changed) > .subject
-    AncestorAnySibling, // :nth-last-child(even of .changed) .subject
-    HasChild, // :has(> .changed)
-    HasDescendant, // :has(.changed)
-    HasSibling, // :has(~ .changed)
-    HasSiblingDescendant, // :has(~ .a .changed)
-    HasAnySibling, // :has(~ :is(.changed ~ .x))
-    HasChildParent, // :has(> .changed) > .subject
-    HasChildAncestor, // :has(> .changed) .subject
-    HasDescendantParent, // :has(.changed) > .subject
-    // FIXME: This is a catch-all for the rest of cases where :has() is in a non-subject position.
-    HasNonSubject, // :has(.changed) .subject
-    // FIXME: This is a catch-all for cases where :has() contains a scope breaking sub-selector.
-    HasScopeBreaking, // :has(:is(.changed .a))
-    Host, // :host(.changed) .subject
-    HostChild // ::slotted(.changed)
+// For :has() features, the matchElement field describes the position of :has() in the overall selector,
+// while hasRelation describes the changed element's relationship to the :has() scope element.
+struct MatchElement {
+    enum class Relation : uint8_t {
+        Subject, // .changed
+        Parent, // .changed > .subject
+        Ancestor, // .changed .subject
+        DirectSibling, // .changed + .subject
+        IndirectSibling, // .changed ~ .subject
+        AnySibling, // :nth-last-child(even of .changed)
+        ParentSibling, // .changed ~ .a > .subject
+        AncestorSibling, // .changed ~ .a .subject
+        ParentAnySibling, // :nth-last-child(even of .changed) > .subject
+        AncestorAnySibling, // :nth-last-child(even of .changed) .subject
+        Host, // :host(.changed) .subject
+        HostChild // ::slotted(.changed)
+    };
+
+    // Relationship of the :has() argument subject element to the :has() scope element.
+    enum class HasRelation : uint8_t {
+        Child, // :has(> .changed)
+        Descendant, // :has(.changed)
+        DirectSibling, // :has(+ .changed)
+        IndirectSibling, // :has(~ .changed)
+        SiblingChild, // :has(~ .a > .changed)
+        SiblingDescendant, // :has(~ .a .changed)
+        ScopeBreaking // :has(:is(.changed .a))
+    };
+
+    Relation relation;
+    Markable<HasRelation> hasRelation;
+
+    bool operator==(const MatchElement&) const = default;
+    unsigned hash() const { return pairIntHash(static_cast<unsigned>(relation), hasRelation ? static_cast<unsigned>(*hasRelation) : 255u); }
 };
-constexpr unsigned matchElementCount = static_cast<unsigned>(MatchElement::HostChild) + 1;
+constexpr unsigned matchRelationCount = static_cast<unsigned>(MatchElement::Relation::HostChild) + 1;
 
 enum class IsNegation : bool { No, Yes };
 enum class CanBreakScope : bool { No, Yes }; // Are we inside a logical combination pseudo-class like :is() or :not(), which if we were inside a :has(), could break out of its scope?
@@ -127,9 +136,8 @@ struct RuleFeatureSet {
     void collectFeatures(CollectionContext&, const RuleData&, const Vector<Ref<const StyleRuleScope>>& scopeRules = { });
     void registerSubstitutionAttribute(const AtomString&);
 
-    bool usesHasPseudoClass() const;
-    bool usesMatchElement(MatchElement matchElement) const { return usedMatchElements[std::to_underlying(matchElement)]; }
-    void setUsesMatchElement(MatchElement matchElement) { usedMatchElements[std::to_underlying(matchElement)] = true; }
+    bool usesRelation(MatchElement::Relation relation) const { return usedRelations[std::to_underlying(relation)]; }
+    void setUsesRelation(MatchElement::Relation relation) { usedRelations[std::to_underlying(relation)] = true; }
 
     HashSet<AtomString> idsInRules;
     HashSet<AtomString> idsMatchingAncestorsInRules;
@@ -149,11 +157,12 @@ struct RuleFeatureSet {
     HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClassesAffectingHost;
     HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClasses;
 
-    std::array<bool, matchElementCount> usedMatchElements { };
+    std::array<bool, matchRelationCount> usedRelations { };
 
     bool usesFirstLineRules { false };
     bool usesFirstLetterRules { false };
     bool hasStartingStyleRules { false };
+    bool usesHasPseudoClass { false };
 
 private:
     struct SelectorFeatures {
@@ -166,12 +175,11 @@ private:
         Vector<InvalidationFeature> pseudoClasses;
         Vector<HasInvalidationFeature> hasPseudoClasses;
     };
-    DoesBreakScope recursivelyCollectFeaturesFromSelector(SelectorFeatures&, const CSSSelector&, MatchElement = MatchElement::Subject, IsNegation = IsNegation::No, CanBreakScope = CanBreakScope::No);
+    DoesBreakScope recursivelyCollectFeaturesFromSelector(SelectorFeatures&, const CSSSelector&, MatchElement = { MatchElement::Relation::Subject, { } }, IsNegation = IsNegation::No, CanBreakScope = CanBreakScope::No);
     void NODELETE collectPseudoElementFeatures(const RuleData&);
 };
 
-bool NODELETE isHasPseudoClassMatchElement(MatchElement);
-MatchElement computeHasPseudoClassMatchElement(const CSSSelector&);
+MatchElement::HasRelation computeHasArgumentRelation(const CSSSelector&);
 
 enum class InvalidationKeyType : uint8_t { Universal = 1, Class, Id, Attribute, Tag };
 PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::PseudoClass, InvalidationKeyType, const AtomString& = starAtom());
@@ -181,17 +189,6 @@ bool NODELETE unlikelyToHaveSelectorForAttribute(const AtomString&);
 inline bool isUniversalInvalidation(const PseudoClassInvalidationKey& key)
 {
     return static_cast<InvalidationKeyType>(std::get<1>(key)) == InvalidationKeyType::Universal;
-}
-
-inline bool RuleFeatureSet::usesHasPseudoClass() const
-{
-    return usesMatchElement(MatchElement::HasChild)
-        || usesMatchElement(MatchElement::HasDescendant)
-        || usesMatchElement(MatchElement::HasSibling)
-        || usesMatchElement(MatchElement::HasSiblingDescendant)
-        || usesMatchElement(MatchElement::HasAnySibling)
-        || usesMatchElement(MatchElement::HasNonSubject)
-        || usesMatchElement(MatchElement::HasScopeBreaking);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -279,81 +279,145 @@ void Invalidator::invalidateStyle(Element& element)
 
 void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement matchElement)
 {
-    switch (matchElement) {
-    case MatchElement::Subject: {
-        // .changed
-        invalidateIfNeeded(element, nullptr);
-        break;
+    using Relation = MatchElement::Relation;
+    using HasRelation = MatchElement::HasRelation;
+
+    if (!matchElement.hasRelation) {
+        switch (matchElement.relation) {
+        case Relation::Subject:
+            // .changed
+            invalidateIfNeeded(element, nullptr);
+            break;
+        case Relation::Parent:
+            // .changed > .subject
+            for (Ref child : childrenOfType<Element>(element))
+                invalidateIfNeeded(child.get(), nullptr);
+            break;
+        case Relation::Ancestor: {
+            // .changed .subject
+            SelectorMatchingState selectorMatchingState;
+            invalidateStyleForDescendants(element, &selectorMatchingState);
+            break;
+        }
+        case Relation::DirectSibling:
+            // .changed + .subject
+            if (RefPtr sibling = element.nextElementSibling())
+                invalidateIfNeeded(*sibling, nullptr);
+            break;
+        case Relation::IndirectSibling:
+            // .changed ~ .subject
+            for (RefPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling())
+                invalidateIfNeeded(*sibling, nullptr);
+            break;
+        case Relation::AnySibling:
+            // :nth-last-child(even of .changed)
+            for (Ref parentChild : childrenOfType<Element>(*element.parentNode()))
+                invalidateIfNeeded(parentChild.get(), nullptr);
+            break;
+        case Relation::ParentSibling:
+            // .changed ~ .a > .subject
+            for (RefPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
+                for (Ref siblingChild : childrenOfType<Element>(*sibling))
+                    invalidateIfNeeded(siblingChild.get(), nullptr);
+            }
+            break;
+        case Relation::AncestorSibling: {
+            // .changed ~ .a .subject
+            SelectorMatchingState selectorMatchingState;
+            for (RefPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
+                selectorMatchingState.selectorFilter.popParentsUntil(element.parentElement());
+                invalidateStyleForDescendants(*sibling, &selectorMatchingState);
+            }
+            break;
+        }
+        case Relation::ParentAnySibling:
+            // :nth-last-child(even of .changed) > .subject
+            for (Ref sibling : childrenOfType<Element>(*element.parentNode())) {
+                for (Ref siblingChild : childrenOfType<Element>(sibling.get()))
+                    invalidateIfNeeded(siblingChild.get(), nullptr);
+            }
+            break;
+        case Relation::AncestorAnySibling: {
+            // :nth-last-child(even of .changed) .subject
+            SelectorMatchingState selectorMatchingState;
+            for (Ref sibling : childrenOfType<Element>(*element.parentNode())) {
+                selectorMatchingState.selectorFilter.popParentsUntil(element.parentElement());
+                invalidateStyleForDescendants(sibling.get(), &selectorMatchingState);
+            }
+            break;
+        }
+        case Relation::Host:
+            // :host(.changed) .subject
+            invalidateInShadowTreeIfNeeded(element);
+            break;
+        case Relation::HostChild:
+            // ::slotted(.changed)
+            if (RefPtr host = element.shadowHost()) {
+                for (Ref hostChild : childrenOfType<Element>(*host))
+                    invalidateIfNeeded(hostChild.get(), nullptr);
+            }
+            break;
+        }
+        return;
     }
-    case MatchElement::Parent: {
-        // .changed > .subject
-        auto children = childrenOfType<Element>(element);
-        for (Ref child : children)
-            invalidateIfNeeded(child.get(), nullptr);
-        break;
-    }
-    case MatchElement::Ancestor: {
-        // .changed .subject
+
+    auto hasRelation = *matchElement.hasRelation;
+
+    // HasScopeBreaking: :has(:is(.changed .a)) — invalidate entire document.
+    if (hasRelation == HasRelation::ScopeBreaking) {
         SelectorMatchingState selectorMatchingState;
-        invalidateStyleForDescendants(element, &selectorMatchingState);
-        break;
+        invalidateStyleForDescendants(*element.document().documentElement(), &selectorMatchingState);
+        return;
     }
-    case MatchElement::DirectSibling:
-        // .changed + .subject
-        if (RefPtr sibling = element.nextElementSibling())
-            invalidateIfNeeded(*sibling, nullptr);
-        break;
-    case MatchElement::IndirectSibling:
-        // .changed ~ .subject
-        for (RefPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling())
-            invalidateIfNeeded(*sibling, nullptr);
-        break;
-    case MatchElement::AnySibling:
-        // :nth-last-child(even of .changed)
-        for (Ref parentChild : childrenOfType<Element>(*element.parentNode()))
-            invalidateIfNeeded(parentChild.get(), nullptr);
-        break;
-    case MatchElement::ParentSibling:
-        // .changed ~ .a > .subject
-        for (RefPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
-            auto siblingChildren = childrenOfType<Element>(*sibling);
-            for (Ref siblingChild : siblingChildren)
-                invalidateIfNeeded(siblingChild.get(), nullptr);
+
+    // :has() in non-subject position.
+    if (matchElement.relation != Relation::Subject) {
+        if (matchElement.relation == Relation::Parent && hasRelation == HasRelation::Child) {
+            // :has(> .changed) > .subject
+            SelectorMatchingState selectorMatchingState;
+            if (RefPtr parent = element.parentElement())
+                selectorMatchingState.selectorFilter.pushParentInitializingIfNeeded(*parent);
+            for (Ref sibling : childrenOfType<Element>(*element.parentNode()))
+                invalidateIfNeeded(sibling.get(), &selectorMatchingState);
+            return;
         }
-        break;
-    case MatchElement::AncestorSibling: {
-        // .changed ~ .a .subject
+        if (matchElement.relation == Relation::Parent && hasRelation == HasRelation::Descendant) {
+            // :has(.changed) > .subject
+            Vector<Element*, 16> ancestors;
+            for (RefPtr parent = element.parentElement(); parent; parent = parent->parentElement())
+                ancestors.append(parent.get());
+
+            SelectorMatchingState selectorMatchingState;
+            selectorMatchingState.selectorFilter.parentStackReserveInitialCapacity(ancestors.size());
+            for (RefPtr ancestor : ancestors | std::views::reverse) {
+                selectorMatchingState.selectorFilter.pushParent(ancestor.get());
+                for (Ref ancestorChild : childrenOfType<Element>(*ancestor))
+                    invalidateIfNeeded(ancestorChild.get(), &selectorMatchingState);
+            }
+            return;
+        }
+        if (matchElement.relation == Relation::Ancestor && hasRelation == HasRelation::Child) {
+            // :has(> .changed) .subject
+            if (CheckedPtr parent = element.parentElement()) {
+                SelectorMatchingState selectorMatchingState;
+                invalidateStyleForDescendants(*parent, &selectorMatchingState);
+            }
+            return;
+        }
+        // FIXME: The remaining non-subject :has() cases could be made more precise with two-step invalidation.
         SelectorMatchingState selectorMatchingState;
-        for (RefPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
-            selectorMatchingState.selectorFilter.popParentsUntil(element.parentElement());
-            invalidateStyleForDescendants(*sibling, &selectorMatchingState);
-        }
-        break;
+        invalidateStyleForDescendants(*element.document().documentElement(), &selectorMatchingState);
+        return;
     }
-    case MatchElement::ParentAnySibling:
-        // :nth-last-child(even of .changed) > .subject
-        for (Ref sibling : childrenOfType<Element>(*element.parentNode())) {
-            auto siblingChildren = childrenOfType<Element>(sibling.get());
-            for (Ref siblingChild : siblingChildren)
-                invalidateIfNeeded(siblingChild.get(), nullptr);
-        }
-        break;
-    case MatchElement::AncestorAnySibling: {
-        // :nth-last-child(even of .changed) .subject
-        SelectorMatchingState selectorMatchingState;
-        for (Ref sibling : childrenOfType<Element>(*element.parentNode())) {
-            selectorMatchingState.selectorFilter.popParentsUntil(element.parentElement());
-            invalidateStyleForDescendants(sibling.get(), &selectorMatchingState);
-        }
-        break;
-    }
-    case MatchElement::HasChild: {
+
+    // :has() in subject position.
+    switch (hasRelation) {
+    case HasRelation::Child:
         // :has(> .changed)
         if (RefPtr parent = element.parentElement())
             invalidateIfNeeded(*parent, nullptr);
         break;
-    }
-    case MatchElement::HasDescendant: {
+    case HasRelation::Descendant: {
         // :has(.changed)
         Vector<Element*, 16> ancestors;
         for (RefPtr parent = element.parentElement(); parent; parent = parent->parentElement())
@@ -367,31 +431,23 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
         }
         break;
     }
-    case MatchElement::HasSibling:
-        // :has(~ .changed)
-        if (RefPtr sibling = element.previousElementSibling()) {
-            SelectorMatchingState selectorMatchingState;
-            if (RefPtr parent = element.parentElement())
-                selectorMatchingState.selectorFilter.pushParentInitializingIfNeeded(*parent);
-
-            for (; sibling; sibling = sibling->previousElementSibling())
-                invalidateIfNeeded(*sibling, &selectorMatchingState);
-        }
+    case HasRelation::DirectSibling:
+        // :has(+ .changed)
+        if (RefPtr sibling = element.previousElementSibling())
+            invalidateIfNeeded(*sibling, nullptr);
         break;
-
-    case MatchElement::HasChildParent:
-        // :has(> .changed) > .subject
-    case MatchElement::HasAnySibling: {
-        // :has(~ :is(.changed ~ .x))
+    case HasRelation::IndirectSibling: {
+        // :has(~ .changed)
         SelectorMatchingState selectorMatchingState;
         if (RefPtr parent = element.parentElement())
             selectorMatchingState.selectorFilter.pushParentInitializingIfNeeded(*parent);
-        for (Ref sibling : childrenOfType<Element>(*element.parentNode()))
-            invalidateIfNeeded(sibling.get(), &selectorMatchingState);
+        for (RefPtr sibling = element.previousElementSibling(); sibling; sibling = sibling->previousElementSibling())
+            invalidateIfNeeded(*sibling, &selectorMatchingState);
         break;
     }
-    case MatchElement::HasSiblingDescendant: {
-        // :has(~ .a .changed)
+    case HasRelation::SiblingChild:
+    case HasRelation::SiblingDescendant: {
+        // :has(~ .a .changed) or :has(~ .a > .changed)
         Vector<Element*, 16> elementAndAncestors;
         elementAndAncestors.append(&element);
         for (RefPtr parent = element.parentElement(); parent; parent = parent->parentElement())
@@ -402,52 +458,15 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
         for (RefPtr elementOrAncestor : elementAndAncestors | std::views::reverse) {
             for (RefPtr sibling = elementOrAncestor->previousElementSibling(); sibling; sibling = sibling->previousElementSibling())
                 invalidateIfNeeded(*sibling, &selectorMatchingState);
-
             selectorMatchingState.selectorFilter.pushParent(elementOrAncestor.get());
         }
         break;
     }
-    case MatchElement::HasDescendantParent: {
-        // :has(.changed) > .subject
-        Vector<Element*, 16> ancestors;
-        for (RefPtr parent = element.parentElement(); parent; parent = parent->parentElement())
-            ancestors.append(parent.get());
-
-        SelectorMatchingState selectorMatchingState;
-        selectorMatchingState.selectorFilter.parentStackReserveInitialCapacity(ancestors.size());
-        for (RefPtr ancestor : ancestors | std::views::reverse) {
-            selectorMatchingState.selectorFilter.pushParent(ancestor.get());
-            for (Ref ancestorChild : childrenOfType<Element>(*ancestor))
-                invalidateIfNeeded(ancestorChild.get(), &selectorMatchingState);
-        }
+    case HasRelation::ScopeBreaking:
+        ASSERT_NOT_REACHED();
         break;
-    }
-    case MatchElement::HasChildAncestor: {
-        // :has(> .changed) .subject
-        if (CheckedPtr parent = element.parentElement()) {
-            SelectorMatchingState selectorMatchingState;
-            invalidateStyleForDescendants(*parent, &selectorMatchingState);
-        }
-        break;
-    }
-    case MatchElement::HasNonSubject:
-        // :has(.changed) .subject
-    case MatchElement::HasScopeBreaking: {
-        // :has(:is(.changed .a))
-        SelectorMatchingState selectorMatchingState;
-        invalidateStyleForDescendants(*element.document().documentElement(), &selectorMatchingState);
-        break;
-    }
-    case MatchElement::Host:
-        // :host(.changed) .subject
-        invalidateInShadowTreeIfNeeded(element);
-        break;
-    case MatchElement::HostChild:
-        // ::slotted(.changed)
-        if (RefPtr host = element.shadowHost()) {
-            for (Ref hostChild : childrenOfType<Element>(*host))
-                invalidateIfNeeded(hostChild.get(), nullptr);
-        }
+    default:
+        ASSERT_NOT_REACHED();
         break;
     }
 }
@@ -530,7 +549,7 @@ void Invalidator::invalidateWithMatchElementRuleSets(Element& element, const Mat
 
     for (auto& matchElementAndRuleSet : matchElementRuleSets) {
         Invalidator invalidator(matchElementAndRuleSet.value);
-        invalidator.invalidateStyleWithMatchElement(element, matchElementAndRuleSet.key);
+        invalidator.invalidateStyleWithMatchElement(element, matchElementAndRuleSet.key.key());
     }
 }
 
@@ -538,7 +557,9 @@ void Invalidator::invalidateWithScopeBreakingHasPseudoClassRuleSet(Element& elem
 {
     SetForScope isInvalidating(element.styleResolver().ruleSets().isInvalidatingStyleWithRuleSets(), true);
     Invalidator invalidator(InvalidationRuleSetVector { { ruleSet } });
-    invalidator.invalidateStyleWithMatchElement(element, MatchElement::HasScopeBreaking);
+    // Scope-breaking :has() can be affected by changes anywhere, so invalidate all descendants from root.
+    SelectorMatchingState selectorMatchingState;
+    invalidator.invalidateStyleForDescendants(*element.document().documentElement(), &selectorMatchingState);
 }
 
 void Invalidator::invalidateAllStyle(Scope& scope)

--- a/Source/WebCore/style/StyleInvalidator.h
+++ b/Source/WebCore/style/StyleInvalidator.h
@@ -28,6 +28,7 @@
 #include "RuleFeature.h"
 #include "RuleSet.h"
 #include <wtf/Forward.h>
+#include <wtf/GenericHashKey.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore {
@@ -63,7 +64,7 @@ public:
 
     static void invalidateShadowParts(ShadowRoot&);
 
-    using MatchElementRuleSets = HashMap<MatchElement, InvalidationRuleSetVector, IntHash<MatchElement>, WTF::StrongEnumHashTraits<MatchElement>>;
+    using MatchElementRuleSets = HashMap<GenericHashKey<MatchElement>, InvalidationRuleSetVector>;
     static void addToMatchElementRuleSets(Invalidator::MatchElementRuleSets&, const InvalidationRuleSet&);
     static void addToMatchElementRuleSetsRespectingNegation(Invalidator::MatchElementRuleSets&, const InvalidationRuleSet&);
     static void invalidateWithMatchElementRuleSets(Element&, const MatchElementRuleSets&);

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -110,7 +110,7 @@ Resolver& Scope::resolver()
         else
             createDocumentResolver();
         
-        if (m_resolver->ruleSets().features().usesHasPseudoClass())
+        if (m_resolver->ruleSets().features().usesHasPseudoClass)
             m_usesHasPseudoClass = true;
     }
     return *m_resolver;
@@ -633,7 +633,7 @@ void Scope::updateActiveStyleSheets(UpdateType updateType)
             m_usesStyleBasedEditability = true;
     }
 
-    if (m_resolver && m_resolver->ruleSets().features().usesHasPseudoClass())
+    if (m_resolver && m_resolver->ruleSets().features().usesHasPseudoClass)
         m_usesHasPseudoClass = true;
 
     invalidateStyleAfterStyleSheetChange(styleSheetChange);

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -319,12 +319,12 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
             MatchElement matchElement;
             IsNegation isNegation;
         };
-        using BuilderKey = std::tuple<uint8_t, bool, bool>;
+        using BuilderKey = std::tuple<GenericHashKey<MatchElement>, bool>;
 
         HashMap<BuilderKey, Builder> builderMap;
 
         for (auto& feature : *features) {
-            auto key = BuilderKey { static_cast<uint8_t>(feature.matchElement), static_cast<bool>(feature.isNegation), true };
+            auto key = BuilderKey { feature.matchElement, static_cast<bool>(feature.isNegation) };
 
             auto& builder = builderMap.ensure(key, [&] {
                 return Builder {
@@ -422,7 +422,7 @@ SelectorsForStyleAttribute ScopeRuleSets::selectorsForStyleAttribute() const
         if (!ruleSets)
             return SelectorsForStyleAttribute::None;
         for (auto& ruleSet : *ruleSets) {
-            if (ruleSet.matchElement != MatchElement::Subject)
+            if (ruleSet.matchElement.relation != MatchElement::Relation::Subject)
                 return SelectorsForStyleAttribute::NonSubjectPosition;
         }
         return SelectorsForStyleAttribute::SubjectPositionOnly;


### PR DESCRIPTION
#### 0ef6313a07733f8c2b24b0f2e6b42f0fde114172
<pre>
[:has() perf] Replace MatchElement enum with a struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=312473">https://bugs.webkit.org/show_bug.cgi?id=312473</a>
<a href="https://rdar.apple.com/174922238">rdar://174922238</a>

Reviewed by Alan Baradlay.

Replace the current single enum value with a two-enum value struct.

struct MatchElement { Relation relation; Markable&lt;HasRelation&gt; hasRelation; }

This way we can describe both the position of :has() and the type of the selector within it in a natural manner.
This patch just does the mechanincal change, except for adding a simple optimization for the direct sibling
:has(+ .changed) case.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchHasPseudoClass const):
* Source/WebCore/style/AttributeChangeInvalidation.cpp:
(WebCore::Style::AttributeChangeInvalidation::invalidateStyle):
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
(WebCore::Style::needsDescendantTraversal):
* Source/WebCore/style/ClassChangeInvalidation.cpp:
(WebCore::Style::ClassChangeInvalidation::computeInvalidation):
* Source/WebCore/style/HasSelectorFilter.cpp:
(WebCore::Style::HasSelectorFilter::typeForMatchElement): Deleted.
* Source/WebCore/style/HasSelectorFilter.h:
(WebCore::Style::HasSelectorFilter::type const):
* Source/WebCore/style/IdChangeInvalidation.cpp:
(WebCore::Style::IdChangeInvalidation::invalidateStyle):
* Source/WebCore/style/PseudoClassChangeInvalidation.cpp:
(WebCore::Style::PseudoClassChangeInvalidation::collectRuleSets):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::isSiblingOrSubject):
(WebCore::Style::computeNextRelation):
(WebCore::Style::toHasRelation):
(WebCore::Style::computeHasArgumentRelation):
(WebCore::Style::computeSubSelectorMatchElement):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::collectFeatures):
(WebCore::Style::RuleFeatureSet::add):
(WebCore::Style::isHasPseudoClassMatchElement): Deleted.
(WebCore::Style::isScopeBreaking): Deleted.
(WebCore::Style::computeNextMatchElement): Deleted.
(WebCore::Style::computeNextHasPseudoClassMatchElement): Deleted.
(WebCore::Style::computeHasPseudoClassMatchElement): Deleted.
* Source/WebCore/style/RuleFeature.h:
(WebCore::Style::MatchElement::hash const):
(WebCore::Style::RuleFeatureSet::usesRelation const):
(WebCore::Style::RuleFeatureSet::setUsesRelation):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::usesMatchElement const): Deleted.
(WebCore::Style::RuleFeatureSet::setUsesMatchElement): Deleted.
(WebCore::Style::RuleFeatureSet::usesHasPseudoClass const): Deleted.
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):
(WebCore::Style::Invalidator::invalidateWithMatchElementRuleSets):
(WebCore::Style::Invalidator::invalidateWithScopeBreakingHasPseudoClassRuleSet):
* Source/WebCore/style/StyleInvalidator.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::resolver):
(WebCore::Style::Scope::updateActiveStyleSheets):
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ensureInvalidationRuleSets):
(WebCore::Style::ScopeRuleSets::selectorsForStyleAttribute const):

Canonical link: <a href="https://commits.webkit.org/311387@main">https://commits.webkit.org/311387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c65e4a67aa4749d651fb5197e762ebdde66ae263

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165655 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2eafa80c-7bb1-4326-9596-f20ece885a65) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121475 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102143 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22754 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20969 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13427 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168138 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129589 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129697 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35131 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140451 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24522 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17255 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29402 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93418 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28926 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->