### PR TITLE
[AutoFill Debugging] Click location argument should ignore obscured content insets

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interaction-with-content-inset-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interaction-with-content-inset-expected.txt
@@ -1,0 +1,10 @@
+Verifies that text extraction click interactions with a location automatically account for content insets, so that (0, 0) hits the top-left corner of the web content.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS clickError is ""
+PASS clickCount is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interaction-with-content-inset.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interaction-with-content-inset.html
@@ -1,0 +1,54 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true useFlexibleViewport=true obscuredInset.top=50 obscuredInset.left=50 ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        #target {
+            width: 50px;
+            height: 50px;
+            background-color: purple;
+        }
+    </style>
+</head>
+<body>
+    <div id="target"></div>
+    <div id="description"></div>
+    <div id="console"></div>
+    <script>
+    jsTestIsAsync = true;
+
+    description("Verifies that text extraction click interactions with a location automatically account for content insets, so that (0, 0) hits the top-left corner of the web content.");
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(50, 50, 50, 50);
+
+        target = document.getElementById("target");
+        clickCount = 0;
+
+        target.addEventListener("click", () => {
+            clickCount++;
+        });
+
+        if (!window.testRunner)
+            return;
+
+        clickError = await UIHelper.performTextExtractionInteraction("click", {
+            location: { x: 25, y: 25 }
+        });
+
+        shouldBeEqualToString("clickError", "");
+        shouldBe("clickCount", "1");
+
+        finishJSTest();
+    });
+    </script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -7202,10 +7202,12 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
     }
 
     if (wkInteraction.hasSetLocation) {
+        auto insets = self.obscuredContentInsets;
+        auto location = CGPointMake(wkInteraction.location.x + insets.left, wkInteraction.location.y + insets.top);
 #if PLATFORM(IOS_FAMILY)
-        interaction.locationInRootView = [self convertPoint:wkInteraction.location toView:_contentView.get()];
+        interaction.locationInRootView = [self convertPoint:location toView:_contentView.get()];
 #else
-        interaction.locationInRootView = wkInteraction.location;
+        interaction.locationInRootView = location;
 #endif
     }
     interaction.text = wkInteraction.text;


### PR DESCRIPTION
#### d0ae0830acb66baccb41a0b98f8b938ce63721d0
<pre>
[AutoFill Debugging] Click location argument should ignore obscured content insets
<a href="https://bugs.webkit.org/show_bug.cgi?id=312479">https://bugs.webkit.org/show_bug.cgi?id=312479</a>
<a href="https://rdar.apple.com/174928145">rdar://174928145</a>

Reviewed by Abrar Rahman Protyasha.

Passing in the origin as a click location should simulate a click over the top left corner in the
webpage (as opposed to the top left corner of the web view) when nonzero top or left obscured
content insets are set.

Test: fast/text-extraction/debug-text-extraction-interaction-with-content-inset.html

* LayoutTests/fast/text-extraction/debug-text-extraction-interaction-with-content-inset.html: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _convertToWebCoreInteraction:]):

Canonical link: <a href="https://commits.webkit.org/311396@main">https://commits.webkit.org/311396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66cb1075c137f2f193f844cb5ede169671b0f50e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165648 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121468 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102136 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22747 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20962 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13420 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168131 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12292 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129587 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129691 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35133 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140441 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87490 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24514 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17245 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29395 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93411 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28919 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29149 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->