### PR TITLE
[CMake] Avoid unnecessary Swift recompilation when only C++ sources change

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -834,9 +834,26 @@ set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WEBKIT_DIR}/Modules/Internal")
 WEBKIT_FRAMEWORK_DECLARE(WebKit)
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
-WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER(WebKit WebKit
-    "${WebKit_SWIFT_INTEROP_MODULE_PATH}"
-    "${WebKit_DERIVED_SOURCES_DIR}/WebKit-Swift-CPP.h")
+# When WebKitSwift exists (Apple ports with SWIFT_REQUIRED), set up the Swift
+# interop header generation on the separate static library.  Otherwise fall
+# back to the original behaviour for ports that compile Swift in-tree.
+if (TARGET WebKitSwift)
+    WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER(WebKitSwift WebKit
+        "${WebKit_SWIFT_INTEROP_MODULE_PATH}"
+        "${WebKit_DERIVED_SOURCES_DIR}/WebKit-Swift-CPP.h")
+    # The macro adds the generated-header include directory as PUBLIC on
+    # WebKitSwift; propagate it to WebKit so C++ sources can #include
+    # "WebKit-Swift-CPP.h".
+    target_include_directories(WebKit PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/include")
+    # Linking WebKitSwift causes CMake to promote WebKit's linker to Swift.
+    # Force CXX so that the framework links with c++ (fast) instead of swiftc,
+    # which would re-invoke the combined Swift compile+link rule.
+    set_target_properties(WebKit PROPERTIES LINKER_LANGUAGE CXX)
+else ()
+    WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER(WebKit WebKit
+        "${WebKit_SWIFT_INTEROP_MODULE_PATH}"
+        "${WebKit_DERIVED_SOURCES_DIR}/WebKit-Swift-CPP.h")
+endif ()
 
 if (PORT STREQUAL GTK OR PORT STREQUAL WPE)
     WEBKIT_ADD_TARGET_CXX_FLAGS(WebKit
@@ -1123,9 +1140,15 @@ list(APPEND WebKit_SOURCES
 )
 
 if (ENABLE_SWIFT_DEMO_URI_SCHEME)
-    list(APPEND WebKit_SOURCES
-        ${WEBKIT_DIR}/UIProcess/SwiftDemoLogo.swift
-    )
+    if (TARGET WebKitSwift)
+        target_sources(WebKitSwift PRIVATE
+            ${WEBKIT_DIR}/UIProcess/SwiftDemoLogo.swift
+        )
+    else ()
+        list(APPEND WebKit_SOURCES
+            ${WEBKIT_DIR}/UIProcess/SwiftDemoLogo.swift
+        )
+    endif ()
 endif ()
 
 list(APPEND WebKit_SOURCES ${WebKit_DERIVED_SOURCES})

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -88,12 +88,7 @@ list(APPEND WebKit_SOURCES
     UIProcess/Cocoa/WebInspectorPreferenceObserver.mm
 
     UIProcess/PDF/WKPDFHUDView.mm
-    ${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.swift
     UIProcess/PDF/WKPDFPageNumberIndicator.mm
-
-    ${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.swift
-
-    ${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKTextExtraction.swift
 
     WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm
 
@@ -269,38 +264,76 @@ file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap"
 ")
 set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WebKit_CMAKE_MODULEMAP_DIR}")
 
-# SPI .swiftinterface modules (SwiftUI_SPI, AVKit_SPI, etc.) live under
-# Platform/spi/. These paths mirror Xcode's SWIFT_INCLUDE_PATHS setting.
-set(WebKit_SWIFT_INCLUDE_DIRECTORIES
-    "${WEBKIT_DIR}/Platform/spi/Cocoa"
-    "${WEBKIT_DIR}/Platform/spi/Cocoa/Modules"
-    "${WEBKIT_DIR}/Platform/spi/ios"
-)
+# Build Swift sources in a separate STATIC library so that CMake generates an
+# independent Swift_STATIC_LIBRARY_LINKER rule. This prevents WebCore-only changes
+# from triggering a 37-second Swift recompilation: the WebKit framework link step
+# (CXX_SHARED_LIBRARY_LINKER) just relinks against the unchanged libWebKitSwift.a.
+if (SWIFT_REQUIRED)
+    add_library(WebKitSwift STATIC "${CMAKE_BINARY_DIR}/cmakeconfig.h")
+    target_sources(WebKitSwift PRIVATE
+        ${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.swift
+        ${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.swift
+        ${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKTextExtraction.swift
+    )
 
-# HAVE_MATERIAL_HOSTING is a PlatformHave.h preprocessor flag (macOS 16+),
-# not a CMake define. SWIFT_EXTRA_OPTIONS and SWIFT_INCLUDE_DIRECTORIES only
-# affect the typecheck custom command. Mirror everything to target_compile_options
-# so the actual Swift compilation sees the same flags.
-target_compile_options(WebKit PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MATERIAL_HOSTING>"
-    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa>"
-    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa/Modules>"
-    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/ios>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${WebKit_FRAMEWORK_HEADERS_DIR}>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${WTF_FRAMEWORK_HEADERS_DIR}>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${bmalloc_FRAMEWORK_HEADERS_DIR}>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${PAL_FRAMEWORK_HEADERS_DIR}>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${ICU_INCLUDE_DIRS}>"
-)
+    # HAVE_MATERIAL_HOSTING is a PlatformHave.h preprocessor flag (macOS 16+),
+    # not a CMake define. SWIFT_EXTRA_OPTIONS and SWIFT_INCLUDE_DIRECTORIES only
+    # affect the typecheck custom command. Mirror everything to target_compile_options
+    # so the actual Swift compilation sees the same flags.
+    target_compile_options(WebKitSwift PRIVATE
+        "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MATERIAL_HOSTING>"
+        "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa>"
+        "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa/Modules>"
+        "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/ios>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${WebKit_FRAMEWORK_HEADERS_DIR}>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${WTF_FRAMEWORK_HEADERS_DIR}>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${bmalloc_FRAMEWORK_HEADERS_DIR}>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${PAL_FRAMEWORK_HEADERS_DIR}>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${ICU_INCLUDE_DIRS}>"
+    )
 
-set(WebKit_SWIFT_EXTRA_OPTIONS
-    -DHAVE_MATERIAL_HOSTING
-    -Xcc -I${WebKit_FRAMEWORK_HEADERS_DIR}
-    -Xcc -I${WTF_FRAMEWORK_HEADERS_DIR}
-    -Xcc -I${bmalloc_FRAMEWORK_HEADERS_DIR}
-    -Xcc -I${PAL_FRAMEWORK_HEADERS_DIR}
-    -Xcc -I${ICU_INCLUDE_DIRS}
-)
+    set(WebKitSwift_SWIFT_INCLUDE_DIRECTORIES
+        "${WEBKIT_DIR}/Platform/spi/Cocoa"
+        "${WEBKIT_DIR}/Platform/spi/Cocoa/Modules"
+        "${WEBKIT_DIR}/Platform/spi/ios"
+    )
+
+    set(WebKitSwift_SWIFT_EXTRA_OPTIONS
+        -DHAVE_MATERIAL_HOSTING
+        -Xcc -I${WebKit_FRAMEWORK_HEADERS_DIR}
+        -Xcc -I${WTF_FRAMEWORK_HEADERS_DIR}
+        -Xcc -I${bmalloc_FRAMEWORK_HEADERS_DIR}
+        -Xcc -I${PAL_FRAMEWORK_HEADERS_DIR}
+        -Xcc -I${ICU_INCLUDE_DIRS}
+    )
+
+    # Ensure copy-headers targets run before Swift compilation so that the
+    # module map headers (WKWebView.h, etc.) are available.
+    add_dependencies(WebKitSwift WebKit_CopyHeaders)
+
+    # The Swift sources import ObjC headers via the module map. CMake's Swift
+    # rules have no depfile tracking, so ninja won't rebuild the Swift when
+    # those headers change. Work around this by generating a dummy .swift
+    # file that is touched whenever a module-map header changes — CMake
+    # includes .swift files as explicit inputs to the build rule, so the
+    # timestamp bump triggers a full Swift recompilation.
+    set(_swift_header_deps
+        "${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.h"
+        "${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.h"
+        "${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKTextExtractionInternal.h"
+    )
+    set(_swift_header_trigger "${CMAKE_CURRENT_BINARY_DIR}/WebKitSwiftHeaderDeps.swift")
+    file(WRITE ${_swift_header_trigger} "// Generated — forces Swift recompilation when module-map headers change.\n")
+    add_custom_command(
+        OUTPUT ${_swift_header_trigger}
+        DEPENDS ${_swift_header_deps}
+        COMMAND ${CMAKE_COMMAND} -E touch ${_swift_header_trigger}
+        COMMENT "Module-map header changed — marking Swift for recompilation"
+    )
+    target_sources(WebKitSwift PRIVATE ${_swift_header_trigger})
+
+    list(APPEND WebKit_PRIVATE_LIBRARIES WebKitSwift)
+endif ()
 
 # webpushd entry points are standalone daemon executables, not part of the
 # framework. WKMain.mm references them, so provide stubs that return error.


### PR DESCRIPTION
#### a74dd3c3cb7ed0867d1422ed1eeda95c3e6feb0d
<pre>
[CMake] Avoid unnecessary Swift recompilation when only C++ sources change
<a href="https://bugs.webkit.org/show_bug.cgi?id=312481">https://bugs.webkit.org/show_bug.cgi?id=312481</a>
<a href="https://rdar.apple.com/174930156">rdar://174930156</a>

Reviewed by NOBODY (OOPS!).

CMake&apos;s Ninja generator fuses Swift compilation and linking into a single
build rule (Swift_SHARED_LIBRARY_LINKER) for shared library targets. Because
WebCore.framework is an implicit dependency of this combined rule, touching
any WebCore .cpp file triggers a full recompilation of all Swift sources in
the WebKit target — a ~37-second penalty on every incremental build.

Fix this by extracting WebKit&apos;s Swift sources into a separate WebKitSwift
STATIC library, following the pattern PAL already uses. The static library
gets its own Swift_STATIC_LIBRARY_LINKER rule with no WebCore dependency,
while the WebKit framework switches to CXX_SHARED_LIBRARY_LINKER (forced
via LINKER_LANGUAGE CXX to prevent CMake&apos;s automatic Swift linker promotion).

Because CMake&apos;s Swift compilation rules lack depfile-based header tracking,
the module-map headers imported by Swift (WKPDFHUDView.h, etc.) are wired
up via a generated trigger .swift file whose timestamp is bumped by a custom
command whenever those headers change.

After the change, a WebCore-only incremental rebuild skips Swift entirely
(~37s → ~0.5s for the WebKit framework step), while changes to module-map
headers still correctly trigger Swift recompilation.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/PlatformMac.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a74dd3c3cb7ed0867d1422ed1eeda95c3e6feb0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165653 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110912 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d5f5944-9e03-4a85-8e61-acfd0f853af9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121472 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85306 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0aeff7f2-4f60-43c4-8821-41ff0907514b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102140 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22751 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20964 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13425 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132432 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168136 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12297 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129585 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129694 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140457 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87495 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24519 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17261 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93416 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28924 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->