### PR TITLE
Optimize isInteger slightly

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -2438,6 +2438,17 @@ public:
 
     void print(Printer::PrintRecordList*);
 
+    // Checks if src is an integer (whole number), storing the boolean result in
+    // dest. Returns false for NaN and Infinity since src - trunc(src) produces
+    // NaN for those values.
+    void isDoubleInteger(FPRegisterID src, FPRegisterID scratch1, FPRegisterID scratch2, RegisterID dest)
+    {
+        truncDouble(src, scratch1);
+        subDouble(src, scratch1, scratch1);
+        move64ToDouble(TrustedImm64(0), scratch2);
+        compareDouble(DoubleEqualAndOrdered, scratch1, scratch2, dest);
+    }
+
     template<PtrTag tag>
     void nearCallThunk(CodeLocationLabel<tag> label)
     {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -17846,11 +17846,6 @@ void SpeculativeJIT::compileNumberIsSafeInteger(Node* node)
             compareDouble(DoubleEqualAndOrdered, argumentFPR, tempFPR, isValidGPR);
         }
 
-        // check if the value is finite
-        subDouble(argumentFPR, argumentFPR, tempFPR);
-        compareDouble(DoubleEqualAndOrdered, tempFPR, tempFPR, scratchGPR);
-        and32(scratchGPR, isValidGPR);
-
         // check if the value is in the range
         absDouble(argumentFPR, tempFPR);
         move64ToDouble(TrustedImm64(std::bit_cast<uint64_t>(maxSafeInteger())), limitFPR);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5293,15 +5293,7 @@ void SpeculativeJIT::compile(Node* node)
 
         // We're a double here.
         unboxDouble(valueRegs.gpr(), resultGPR, tempFPR1);
-        urshift64(TrustedImm32(52), resultGPR);
-        and32(TrustedImm32(0x7ff), resultGPR);
-        auto notNanNorInfinity = branch32(NotEqual, TrustedImm32(0x7ff), resultGPR);
-        move(TrustedImm32(JSValue::ValueFalse), resultGPR);
-        done.append(jump());
-
-        notNanNorInfinity.link(this);
-        roundTowardZeroDouble(tempFPR1, tempFPR2);
-        compareDouble(DoubleEqualAndOrdered, tempFPR1, tempFPR2, resultGPR);
+        isDoubleInteger(tempFPR1, tempFPR2, tempFPR1, resultGPR);
         or32(TrustedImm32(JSValue::ValueFalse), resultGPR);
         done.append(jump());
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -14888,7 +14888,6 @@ IGNORE_CLANG_WARNINGS_END
     {
         LBasicBlock notInt32 = m_out.newBlock();
         LBasicBlock doubleCase = m_out.newBlock();
-        LBasicBlock doubleNotNanOrInf = m_out.newBlock();
         LBasicBlock continuation = m_out.newBlock();
 
         LValue input = lowJSValue(m_node->child1());
@@ -14902,32 +14901,18 @@ IGNORE_CLANG_WARNINGS_END
         m_out.branch(
             isNotNumber(input, provenType(m_node->child1())), unsure(continuation), unsure(doubleCase));
 
-        m_out.appendTo(doubleCase, doubleNotNanOrInf);
-        LValue doubleAsInt;
-        LValue asDouble = unboxDouble(input, &doubleAsInt);
-        LValue expBits = m_out.bitAnd(m_out.lShr(doubleAsInt, m_out.constInt32(52)), m_out.constInt64(0x7ff));
-        m_out.branch(
-            m_out.equal(expBits, m_out.constInt64(0x7ff)),
-            unsure(continuation), unsure(doubleNotNanOrInf));
-
-        m_out.appendTo(doubleNotNanOrInf, continuation);
-        PatchpointValue* patchpoint = m_out.patchpoint(Int32);
-        patchpoint->appendSomeRegister(asDouble);
-        patchpoint->numFPScratchRegisters = 1;
-        patchpoint->effects = Effects::none();
-        patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
-            JIT_COMMENT(jit, "NumberIsInteger");
-            GPRReg result = params[0].gpr();
-            FPRReg input = params[1].fpr();
-            FPRReg temp = params.fpScratch(0);
-            jit.roundTowardZeroDouble(input, temp);
-            jit.compareDouble(MacroAssembler::DoubleEqualAndOrdered, input, temp, result);
-        });
-        ValueFromBlock patchpointResult = m_out.anchor(patchpoint);
+        // Use value - trunc(value) == 0.0 which rejects NaN and Infinity
+        // without an explicit check since NaN - NaN and Inf - Inf both
+        // produce NaN.
+        m_out.appendTo(doubleCase, continuation);
+        LValue asDouble = unboxDouble(input);
+        LValue diff = m_out.doubleSub(asDouble, m_out.doubleTrunc(asDouble));
+        LValue isInt = m_out.doubleEqual(diff, m_out.constDouble(0.0));
+        ValueFromBlock doubleResult = m_out.anchor(isInt);
         m_out.jump(continuation);
 
         m_out.appendTo(continuation, lastNext);
-        setBoolean(m_out.phi(Int32, trueResult, falseResult, patchpointResult));
+        setBoolean(m_out.phi(Int32, trueResult, falseResult, doubleResult));
     }
 
     void compileGlobalIsNaN()
@@ -15065,10 +15050,6 @@ IGNORE_CLANG_WARNINGS_END
         case DoubleRepUse: {
             LValue argument = lowDouble(m_node->child1());
 
-            // check if the value is finite
-            LValue diff = m_out.doubleSub(argument, argument);
-            LValue isFinite = m_out.doubleEqual(diff, diff);
-
             // check if the value is an integer
             LValue isInteger = m_out.doubleEqual(argument, m_out.doubleTrunc(argument));
 
@@ -15076,8 +15057,7 @@ IGNORE_CLANG_WARNINGS_END
             LValue limit = m_out.constDouble(maxSafeInteger());
             LValue isInRange = m_out.doubleLessThanOrEqual(m_out.doubleAbs(argument), limit);
 
-            LValue isValid = m_out.bitAnd(isFinite, isInteger);
-            LValue result = m_out.bitAnd(isValid, isInRange);
+            LValue result = m_out.bitAnd(isInteger, isInRange);
 
             setBoolean(result);
             break;

--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -58,14 +58,16 @@ consteval uint64_t maxSafeIntegerAsUInt64()
     return 9007199254740991ULL;
 }
 
+// Use value - trunc(value) == 0.0 which rejects NaN and Infinity without
+// an explicit check since NaN - NaN and Inf - Inf both produce NaN.
 inline bool isInteger(double value)
 {
-    return std::isfinite(value) && std::trunc(value) == value;
+    return value - std::trunc(value) == 0.0;
 }
 
 inline bool isInteger(float value)
 {
-    return std::isfinite(value) && std::trunc(value) == value;
+    return value - std::truncf(value) == 0.0f;
 }
 
 inline bool isSafeInteger(double value)


### PR DESCRIPTION
#### d8899cf1ce9c50fe3816ec94c1b4456ab7b5f8a3
<pre>
Optimize isInteger slightly
<a href="https://bugs.webkit.org/show_bug.cgi?id=312485">https://bugs.webkit.org/show_bug.cgi?id=312485</a>
<a href="https://rdar.apple.com/174932570">rdar://174932570</a>

Reviewed by Yusuke Suzuki.

Use value - trunc(value) == 0.0 for isInteger, which rejects NaN and
Infinity without an explicit isFinite check since NaN - NaN and
Inf - Inf both produce NaN.

Add MacroAssembler::isDoubleInteger helper and use it in the DFG
NumberIsInteger path, removing the manual exponent-bit extraction
branch. Simplify the FTL NumberIsInteger path similarly using B3 IR.

Remove redundant isFinite checks from DFG and FTL NumberIsSafeInteger,
since the range check against maxSafeInteger already rejects Infinity.

On ARM64 the difference in codegen is roughly:

isIntegerOld(double):
        frintz  d1, d0
        fmov    x8, d0
        mov     w9, #2047
        ubfx    x8, x8, #52, #11
        fcmp    d1, d0
        ccmp    x8, x9, #2, eq
        cset    w0, lo
        ret

isIntegerNew(double):
        frintz  d1, d0
        fsub    d0, d0, d1
        fcmp    d0, #0.0
        cset    w0, eq
        ret

No new tests, no behavior change. Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/311413@main">https://commits.webkit.org/311413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68b5db226aa4c3928a1fce9cf6d800b8129e0a85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165691 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121499 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9c526a2-d904-4454-a947-9a4dcd7b90c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102167 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ac06337-895d-464a-96a7-948a37758982) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22777 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21000 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13463 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148918 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168176 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17703 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129616 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129724 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140490 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87533 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23886 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24552 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17294 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188830 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29439 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93454 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48490 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28962 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29192 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29088 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->