### PR TITLE
[webkitcorepy] Support multiple pypi urls

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -20,6 +20,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import configparser
 import importlib.abc
 import importlib.machinery
 import json
@@ -47,6 +48,7 @@ from webkitcorepy.file_lock import FileLock
 from html.parser import HTMLParser
 from urllib.request import urlopen
 from urllib.error import URLError
+from urllib.parse import urlparse
 
 
 class SimplyPypiIndexPageParser(HTMLParser):
@@ -446,17 +448,35 @@ class Package(object):
                 AutoInstall.userspace_should_own(manifest)
 
 
+def _pypi_indices_from_file(file):
+    result = []
+    config = configparser.ConfigParser()
+    config.read_file(file)
+    for section in ('global', 'user'):
+        if not config.has_section(section):
+            continue
+        for key in ('index-url', 'extra-index-url'):
+            value = config.get(section, key, fallback=None)
+            if value:
+                for url in value.split('\n'):
+                    url = url.strip()
+                    if url:
+                        parsed = urlparse(url)
+                        if parsed.hostname:
+                            result.append(parsed.hostname)
+    return result
 
-def _default_pypi_index():
-    pypi_url = re.compile(r'\Aindex\S* = https?://(?P<host>\S+)/.*')
-    pip_config = '/Library/Application Support/pip/pip.conf'
-    if os.path.isfile(pip_config):
-        with open(pip_config, 'r') as config:
-            for line in config.readlines():
-                match = pypi_url.match(line.lstrip())
-                if match:
-                    return match.group('host')
-    return 'pypi.org'
+
+def _default_pypi_indices():
+    for path in ['~/Library/Application Support/pip/pip.conf', '/Library/Application Support/pip/pip.conf']:
+        path = os.path.expanduser(path)
+        if not os.path.isfile(path):
+            continue
+        with open(path, 'r') as f:
+            result = _pypi_indices_from_file(f)
+        if result:
+            return result
+    return ['pypi.org']
 
 
 class AutoInstall(importlib.abc.MetaPathFinder):
@@ -470,7 +490,8 @@ class AutoInstall(importlib.abc.MetaPathFinder):
     BASE_LIBRARIES = ['setuptools', 'wheel', 'six', 'pyparsing', 'packaging', 'tomli', 'setuptools_scm']
 
     directory = None
-    index = _default_pypi_index()
+    _indexes = _default_pypi_indices()
+    index = _indexes[-1]
     timeout = 30
     times_to_retry = 1
     version = Version(sys.version_info[0], sys.version_info[1], sys.version_info[2])
@@ -483,7 +504,7 @@ class AutoInstall(importlib.abc.MetaPathFinder):
     if not ca_cert_path or not os.path.isfile(ca_cert_path):
         ca_cert_path = os.path.join(os.path.dirname(__file__), 'cacert.pem')
 
-    _previous_index = None
+    _previous_index = _indexes[0] if len(_indexes) > 1 else None
     _previous_ca_cert_path = None
     _fatal_check = False
     _temporary_disable = 0

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py
@@ -20,13 +20,40 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import io
+import os
 import unittest
 from unittest.mock import patch
 from urllib.error import URLError
 
 from webkitcorepy import autoinstall, OutputCapture
-from webkitcorepy.autoinstall import AutoInstall, Package
+from webkitcorepy.autoinstall import AutoInstall, Package, _default_pypi_indices, _pypi_indices_from_file
 from webkitcorepy.version import Version
+
+
+class DefaultPyPIIndexTest(unittest.TestCase):
+    def test_no_config(self):
+        with patch('os.path.isfile', return_value=False):
+            self.assertEqual(_default_pypi_indices(), ['pypi.org'])
+
+    def test_primary_index_only(self):
+        config = io.StringIO('[global]\nindex-url = https://internal.example.com/\n')
+        self.assertEqual(_pypi_indices_from_file(config), ['internal.example.com'])
+
+    def test_extra_index_only(self):
+        config = io.StringIO('[global]\nextra-index-url = https://extra.example.com/\n')
+        self.assertEqual(_pypi_indices_from_file(config), ['extra.example.com'])
+
+    def test_primary_and_extra_index(self):
+        config = io.StringIO('[global]\nindex-url = https://primary.example.com/\nextra-index-url = https://extra.example.com/\n')
+        result = _pypi_indices_from_file(config)
+        self.assertEqual(result[0], 'primary.example.com')
+        self.assertEqual(result[-1], 'extra.example.com')
+
+    def test_multiple_extra_indexes(self):
+        config = io.StringIO('[global]\nindex-url = https://primary.example.com/\nextra-index-url =\n    https://extra1.example.com/\n    https://extra2.example.com/\n')
+        result = _pypi_indices_from_file(config)
+        self.assertEqual(result, ['primary.example.com', 'extra1.example.com', 'extra2.example.com'])
 
 
 class ArchiveTest(unittest.TestCase):


### PR DESCRIPTION
#### 2e2a6fc1699ac187fa049be86720ab2650070859
<pre>
[webkitcorepy] Support multiple pypi urls
<a href="https://bugs.webkit.org/show_bug.cgi?id=312490">https://bugs.webkit.org/show_bug.cgi?id=312490</a>
<a href="https://rdar.apple.com/174934749">rdar://174934749</a>

Reviewed by Sam Sneddon.

Support two pypi URL candidates using the existing fallback mechanisms.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(_pypi_indices_from_file): Parse pip.conf files and extract pip URLs.
(_default_pypi_indices): Return a prioritized list of pypi URLs.
(AutoInstall): Set both index and _previous_index based on _default_pypi_indecies.
(_default_pypi_index): Renamed _default_pypi_indecies.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/autoinstall_unittest.py:
(DefaultPyPIIndexTest.test_no_config):
(DefaultPyPIIndexTest.test_primary_index_only):
(DefaultPyPIIndexTest.test_extra_index_only):
(DefaultPyPIIndexTest.test_primary_and_extra_index):
(DefaultPyPIIndexTest.test_multiple_extra_indexes):

Canonical link: <a href="https://commits.webkit.org/311407@main">https://commits.webkit.org/311407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fed7c290b4e5e735818fb7cc85e51431f538d69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156904 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/30240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/23431 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/165727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158775 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/30376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30243 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/165727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159862 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/30376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/165727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/156224 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/30376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/13499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/30376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/168212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/20345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/168212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/156302 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/168212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/29765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/140519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23883 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/29765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/29475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->