### PR TITLE
Event's target can get its JS wrapper GC'ed

### DIFF
--- a/LayoutTests/fast/events/event-disconnected-target-expected.txt
+++ b/LayoutTests/fast/events/event-disconnected-target-expected.txt
@@ -1,0 +1,10 @@
+This tests removing a event target from its ancestor. WebKit should keep the root node alive.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS savedEvent.target.getRootNode().localName is "span"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/event-disconnected-target.html
+++ b/LayoutTests/fast/events/event-disconnected-target.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="container"><span><b><i><em>target</em></i></b></span></div>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests removing a event target from its ancestor. WebKit should keep the root node alive.');
+
+jsTestIsAsync = true;
+
+const container = document.getElementById('container');
+container.remove();
+
+container.querySelector('i').addEventListener('dummy', () => {
+    container.replaceChildren();
+});
+
+let savedEvent = null;
+container.querySelector('b').addEventListener('dummy', (event) => {
+    savedEvent = event;
+});
+
+container.querySelector('em').dispatchEvent(new Event('dummy', {bubbles: true}));
+
+if (!window.GCController) {
+    testFailed('This test requires GCController.');
+    finishJSTest();
+} else {
+    requestAnimationFrame(() => {
+        GCController.collect();
+        requestAnimationFrame(() => {
+            shouldBeEqualToString('savedEvent.target.getRootNode().localName', 'span');
+            finishJSTest();
+        });
+    });
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -29,6 +29,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "DOMPromiseProxy.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "GPUAdapterInfo.h"
 #include "GPUBindGroup.h"
 #include "GPUBindGroupDescriptor.h"

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -32,6 +32,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "DocumentPage.h"
 #include "Editor.h"
+#include "EventTargetInlines.h"
 #include "EventTargetInterfaces.h"
 #include "FrameInlines.h"
 #include "JSBlob.h"

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -40,6 +40,7 @@
 #include "DocumentPage.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "JSDOMConvertBoolean.h"
 #include "JSMediaKeyStatusMap.h"
 #include "Logging.h"

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
@@ -35,6 +35,7 @@
 #include "Document.h"
 #include "DocumentPage.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "MediaRecorderErrorEvent.h"
 #include "MediaRecorderPrivate.h"
 #include "Page.h"

--- a/Source/WebCore/Modules/mediasource/DOMURLMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/DOMURLMediaSource.cpp
@@ -35,6 +35,7 @@
 
 #include "DOMURL.h"
 #include "Document.h"
+#include "EventTargetInlines.h"
 #include "MediaSource.h"
 #include <wtf/MainThread.h>
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -43,6 +43,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "Event.h"
+#include "EventTargetInlines.h"
 #include "EventNames.h"
 #include "ExceptionOr.h"
 #include "HTMLMediaElement.h"
@@ -1469,9 +1470,9 @@ size_t SourceBuffer::memoryCost() const
     return sizeof(SourceBuffer) + m_extraMemoryCost;
 }
 
-WebCoreOpaqueRoot SourceBuffer::opaqueRoot()
+WebCoreOpaqueRoot SourceBuffer::opaqueRoot() const
 {
-    return WebCoreOpaqueRoot { this };
+    return WebCoreOpaqueRoot { const_cast<SourceBuffer*>(this) };
 }
 
 void SourceBuffer::memoryPressure()

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -143,7 +143,7 @@ public:
     WTFLogChannel& NODELETE logChannel() const final;
 #endif
 
-    WebCoreOpaqueRoot NODELETE opaqueRoot();
+    WebCoreOpaqueRoot NODELETE opaqueRoot() const final;
 
     virtual bool isManaged() const { return false; }
     void memoryPressure();

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -28,6 +28,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 #include "ContextDestructionObserverInlines.h"
+#include "EventTargetInlines.h"
 #include "GraphicsContext.h"
 #include "HTMLCanvasElement.h"
 #include "VideoFrame.h"

--- a/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.cpp
@@ -34,6 +34,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 #include "Document.h"
+#include "EventTargetInlines.h"
 #include "LocalFrameInlines.h"
 #include "MediaDevices.h"
 #include "Navigator.h"

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_RTC)
 
 #include "ContextDestructionObserverInlines.h"
+#include "EventTargetInlines.h"
 #include "ExceptionOr.h"
 #include "RTCDTMFSenderBackend.h"
 #include "RTCDTMFToneChangeEvent.h"

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -31,6 +31,7 @@
 #include "Blob.h"
 #include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
+#include "EventTargetInlines.h"
 #include "ExceptionCode.h"
 #include "ExceptionOr.h"
 #include "Logging.h"

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
@@ -67,7 +67,7 @@ RemotePlayback::RemotePlayback(HTMLMediaElement& element)
 
 RemotePlayback::~RemotePlayback() = default;
 
-WebCoreOpaqueRoot RemotePlayback::opaqueRootConcurrently() const
+WebCoreOpaqueRoot RemotePlayback::opaqueRoot() const
 {
     // Cannot ref m_mediaElement here since this may get called on a GC thread.
     SUPPRESS_UNCOUNTED_ARG return root(m_mediaElement.get());

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -78,7 +78,7 @@ public:
 
     void NODELETE invalidate();
 
-    WebCoreOpaqueRoot opaqueRootConcurrently() const;
+    WebCoreOpaqueRoot opaqueRoot() const final;
     Node* NODELETE ownerNode() const;
 
 private:

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.idl
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.idl
@@ -36,7 +36,7 @@ enum RemotePlaybackState {
     EnabledBySetting=RemotePlaybackEnabled,
     Exposed=Window,
     GenerateIsReachable=ImplOwnerNodeRoot,
-    GenerateAddOpaqueRoot=opaqueRootConcurrently
+    GenerateAddOpaqueRoot,
 ] interface RemotePlayback : EventTarget {
     Promise<long> watchAvailability(RemotePlaybackAvailabilityCallback callback);
     Promise<undefined> cancelWatchAvailability(optional long id);

--- a/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
@@ -33,6 +33,7 @@
 #include "AudioParam.h"
 #include "AudioUtilities.h"
 #include "ConstantSourceOptions.h"
+#include "EventTargetInlines.h"
 #include "ExceptionOr.h"
 #include <algorithm>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRFilterNode.cpp
@@ -29,6 +29,7 @@
 #include "IIRFilterNode.h"
 
 #include "BaseAudioContext.h"
+#include "EventTargetInlines.h"
 #include "ExceptionCode.h"
 #include "ExceptionOr.h"
 #include "IIRFilter.h"

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.cpp
@@ -31,6 +31,7 @@
 #include "AudioNodeInput.h"
 #include "ContextDestructionObserverInlines.h"
 #include "Document.h"
+#include "EventTargetInlines.h"
 #include "MediaStream.h"
 #include "MediaStreamAudioSource.h"
 #include <wtf/Locker.h>

--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
@@ -29,6 +29,7 @@
 #include "WaveShaperDSPKernel.h"
 
 #include "AudioUtilities.h"
+#include "EventTargetInlines.h"
 #include "WaveShaperProcessor.h"
 #include <JavaScriptCore/Float32Array.h>
 #include <algorithm>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -31,6 +31,7 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
+#include "EventTargetInlines.h"
 #include "ExceptionOr.h"
 #include "JSDOMConvertDictionary.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -31,6 +31,7 @@
 #include "CSSStyleImageValue.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
+#include "EventTargetInlines.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLVideoElement.h"

--- a/Source/WebCore/Modules/webxr/WebXRBoundedReferenceSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRBoundedReferenceSpace.cpp
@@ -30,6 +30,7 @@
 
 #include "DOMPointReadOnly.h"
 #include "Document.h"
+#include "EventTargetInlines.h"
 #include "Exception.h"
 #include "ExceptionOr.h"
 #include "ScriptWrappableInlines.h"

--- a/Source/WebCore/Modules/webxr/WebXRJointSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRJointSpace.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR) && ENABLE(WEBXR_HANDS)
 
+#include "EventTargetInlines.h"
 #include "WebXRFrame.h"
 #include "WebXRHand.h"
 #include "WebXRRigidTransform.h"

--- a/Source/WebCore/Modules/webxr/WebXRLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRLayer.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBXR)
 
 #include "ContextDestructionObserverInlines.h"
+#include "EventTargetInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webxr/WebXRReferenceSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRReferenceSpace.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBXR)
 
 #include "Document.h"
+#include "EventTargetInlines.h"
 #include "ExceptionOr.h"
 #include "WebXRFrame.h"
 #include "WebXRRigidTransform.h"

--- a/Source/WebCore/Modules/webxr/WebXRSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.cpp
@@ -31,6 +31,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "DOMPointReadOnly.h"
 #include "Document.h"
+#include "EventTargetInlines.h"
 #include "WebXRRigidTransform.h"
 #include "WebXRSession.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -30,6 +30,7 @@
 #if ENABLE(WEBXR)
 
 #include "ContextDestructionObserverInlines.h"
+#include "EventTargetInlines.h"
 #include "ExceptionOr.h"
 #include "HTMLCanvasElement.h"
 #include "IntSize.h"

--- a/Source/WebCore/Modules/webxr/XRCompositionLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRCompositionLayer.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "EventTargetInlines.h"
 #include "WebGLOpaqueTexture.h"
 #include "WebXRSession.h"
 #include "XRLayerBacking.h"

--- a/Source/WebCore/Modules/webxr/XRCylinderLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRCylinderLayer.cpp
@@ -24,9 +24,10 @@
  */
 
 #include "config.h"
+#include "XRCylinderLayer.h"
 
 #if ENABLE(WEBXR_LAYERS)
-#include "XRCylinderLayer.h"
+#include "EventTargetInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webxr/XRQuadLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRQuadLayer.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "EventTargetInlines.h"
 #include "Logging.h"
 #include "WebXRRigidTransform.h"
 #include "WebXRSession.h"

--- a/Source/WebCore/bindings/js/JSEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSEventCustom.cpp
@@ -30,7 +30,9 @@
 #include "JSEvent.h"
 
 #include "JSDOMWrapperCache.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/SlotVisitorInlines.h>
 
 namespace WebCore {
 
@@ -38,5 +40,13 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
 {
     return wrap(lexicalGlobalObject, globalObject, event);
 }
+
+template<typename Visitor>
+void JSEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
+{
+    wrapped().visitInGCThread(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSEvent);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -31,10 +31,12 @@
 #include "EventTargetInlines.h"
 #include "InspectorInstrumentation.h"
 #include "JSDOMGlobalObject.h"
+#include "JSNodeCustomInlines.h"
 #include "LocalDOMWindow.h"
 #include "Performance.h"
 #include "ScriptWrappableInlines.h"
 #include "UserGestureIndicator.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include "WorkerGlobalScope.h"
 #include <wtf/HexNumber.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -136,7 +138,10 @@ void Event::setTarget(RefPtr<EventTarget>&& target)
     if (m_target == target)
         return;
 
-    m_target = WTF::move(target);
+    {
+        Locker targetLocker { m_targetLock };
+        m_target = WTF::move(target);
+    }
     if (m_target)
         receivedTarget();
 }
@@ -205,6 +210,16 @@ void Event::resetAfterDispatch()
 
     InspectorInstrumentation::eventDidResetAfterDispatch(*this);
 }
+
+template<typename Visitor>
+void Event::visitInGCThread(Visitor& visitor)
+{
+    Locker targetLocker { m_targetLock };
+    addWebCoreOpaqueRoot(visitor, dynamicDowncast<Node>(m_target.get()));
+}
+
+template void Event::visitInGCThread(JSC::AbstractSlotVisitor&);
+template void Event::visitInGCThread(JSC::SlotVisitor&);
 
 String Event::debugDescription() const
 {

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -28,6 +28,7 @@
 #include <WebCore/EventInterfaces.h>
 #include <WebCore/EventOptions.h>
 #include <WebCore/ScriptWrappable.h>
+#include <wtf/Lock.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TypeCasts.h>
@@ -149,6 +150,8 @@ public:
 
     bool isTrustedForBindings() const { return m_isTrusted || m_isTrustedForBindingsOnly; }
 
+    template<typename Visitor> void visitInGCThread(Visitor&);
+
 protected:
     explicit Event(enum EventInterfaceType, IsTrusted = IsTrusted::No);
     Event(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed = IsComposed::No);
@@ -188,7 +191,7 @@ private:
 
     unsigned m_eventInterface : 7 { 0 };
 
-    // 8-bits left.
+    Lock m_targetLock;
 
     AtomString m_type;
 

--- a/Source/WebCore/dom/Event.idl
+++ b/Source/WebCore/dom/Event.idl
@@ -26,6 +26,7 @@ typedef double DOMHighResTimeStamp;
     ExportToWrappedFunction,
     Exposed=*,
     JSCustomHeader,
+    JSCustomMarkFunction,
 ] interface Event {
     constructor([AtomString] DOMString type, optional EventInit eventInitDict = {});
 

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -83,6 +83,13 @@ EventTarget::~EventTarget()
         eventTargetData->clear();
 }
 
+#if PLATFORM(WIN)
+WebCoreOpaqueRoot EventTarget::opaqueRoot() const
+{
+    return WebCoreOpaqueRoot { const_cast<EventTarget*>(this) };
+}
+#endif
+
 bool EventTarget::isPaymentRequest() const
 {
     return false;

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -57,6 +57,7 @@ enum class EventTargetInterfaceType : uint8_t;
 class DOMWrapperWorld;
 class EventTarget;
 class JSEventListener;
+class WebCoreOpaqueRoot;
 template<typename> class ExceptionOr;
 
 struct EventTargetData {
@@ -95,6 +96,12 @@ public:
 
     virtual enum EventTargetInterfaceType NODELETE eventTargetInterface() const = 0;
     virtual ScriptExecutionContext* scriptExecutionContext() const = 0;
+
+#if PLATFORM(WIN)
+    virtual WebCoreOpaqueRoot NODELETE opaqueRoot() const;
+#else
+    virtual inline WebCoreOpaqueRoot NODELETE opaqueRoot() const; // Defined in EventTargetInlines.h.
+#endif
 
     virtual bool NODELETE isPaymentRequest() const;
 

--- a/Source/WebCore/dom/EventTargetInlines.h
+++ b/Source/WebCore/dom/EventTargetInlines.h
@@ -33,6 +33,7 @@
 
 #include <WebCore/EventTarget.h>
 #include <WebCore/Node.h>
+#include <WebCore/WebCoreOpaqueRoot.h>
 
 namespace WebCore {
 
@@ -53,6 +54,13 @@ inline void EventTarget::deref()
     else
         derefEventTarget();
 }
+
+#if !PLATFORM(WIN)
+inline WebCoreOpaqueRoot EventTarget::opaqueRoot() const
+{
+    return WebCoreOpaqueRoot { const_cast<EventTarget*>(this) };
+}
+#endif
 
 inline bool EventTarget::hasEventListeners() const
 {

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1485,6 +1485,18 @@ Node& Node::shadowIncludingRoot() const
     return root;
 }
 
+#if PLATFORM(WIN)
+SUPPRESS_NODELETE WebCoreOpaqueRoot Node::opaqueRoot() const
+{
+    if (isConnected()) {
+        Locker locker { TreeScope::treeScopeMutationLock() };
+        return WebCoreOpaqueRoot { &treeScope().documentScope() };
+    }
+    // FIXME: Possible race?
+    return traverseToOpaqueRoot();
+}
+#endif
+
 Node& Node::getRootNode(const GetRootNodeOptions& options) const
 {
     return options.composed ? shadowIncludingRoot() : rootNode();

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -318,7 +318,12 @@ public:
     };
     Node& NODELETE getRootNode(const GetRootNodeOptions&) const;
 
-    inline WebCoreOpaqueRoot opaqueRoot() const;
+#if PLATFORM(WIN)
+    WebCoreOpaqueRoot opaqueRoot() const final;
+#else
+    inline WebCoreOpaqueRoot opaqueRoot() const final;
+#endif
+
     WebCoreOpaqueRoot NODELETE traverseToOpaqueRoot() const;
 
     template<typename T, typename Task> static void queueTaskKeepingNodeAlive(T&, TaskSource, Task&&);

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -51,7 +51,8 @@ inline ContainerNode* Node::parentOrShadowHostNode() const
     return parentNode();
 }
 
-inline WebCoreOpaqueRoot Node::opaqueRoot() const
+#if !PLATFORM(WIN)
+SUPPRESS_NODELETE inline WebCoreOpaqueRoot Node::opaqueRoot() const
 {
     if (isConnected()) {
         Locker locker { TreeScope::treeScopeMutationLock() };
@@ -60,6 +61,7 @@ inline WebCoreOpaqueRoot Node::opaqueRoot() const
     // FIXME: Possible race?
     return traverseToOpaqueRoot();
 }
+#endif
 
 inline Document* Node::ownerDocument() const
 {

--- a/Source/WebCore/dom/XMLDocument.cpp
+++ b/Source/WebCore/dom/XMLDocument.cpp
@@ -39,5 +39,7 @@ Ref<XMLDocument> XMLDocument::createXHTML(LocalFrame* frame, const Settings& set
     return document;
 }
 
+XMLDocument::~XMLDocument() = default;
+
 } // namespace WebCore
 

--- a/Source/WebCore/dom/XMLDocument.h
+++ b/Source/WebCore/dom/XMLDocument.h
@@ -41,6 +41,8 @@ public:
         return document;
     }
 
+    ~XMLDocument();
+
     WEBCORE_EXPORT static Ref<XMLDocument> createXHTML(LocalFrame*, const Settings&, const URL&);
 
 protected:

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -37,6 +37,7 @@
 #include "BlobPart.h"
 #include "BlobURL.h"
 #include "ContextDestructionObserverInlines.h"
+#include "EventTargetInlines.h"
 #include "File.h"
 #include "JSDOMConvertBufferSource.h"
 #include "JSDOMConvertStrings.h"

--- a/Source/WebCore/html/HTMLAudioElement.cpp
+++ b/Source/WebCore/html/HTMLAudioElement.cpp
@@ -60,6 +60,8 @@ Ref<HTMLAudioElement> HTMLAudioElement::createForLegacyFactoryFunction(Document&
     return element;
 }
 
+HTMLAudioElement::~HTMLAudioElement() = default;
+
 }
 
 #endif

--- a/Source/WebCore/html/HTMLAudioElement.h
+++ b/Source/WebCore/html/HTMLAudioElement.h
@@ -41,6 +41,8 @@ public:
     static Ref<HTMLAudioElement> create(const QualifiedName&, Document&, bool);
     static Ref<HTMLAudioElement> createForLegacyFactoryFunction(Document&, const AtomString& src);
 
+    ~HTMLAudioElement();
+
 private:
     HTMLAudioElement(const QualifiedName&, Document&, bool);
 

--- a/Source/WebCore/html/HTMLBDIElement.cpp
+++ b/Source/WebCore/html/HTMLBDIElement.cpp
@@ -38,6 +38,8 @@ Ref<HTMLBDIElement> HTMLBDIElement::create(const QualifiedName& name, Document& 
     return adoptRef(*new HTMLBDIElement(name, document));
 }
 
+HTMLBDIElement::~HTMLBDIElement() = default;
+
 HTMLBDIElement::HTMLBDIElement(const QualifiedName& name, Document& document)
     : HTMLElement(name, document)
 {

--- a/Source/WebCore/html/HTMLBDIElement.h
+++ b/Source/WebCore/html/HTMLBDIElement.h
@@ -30,6 +30,8 @@ class HTMLBDIElement final : public HTMLElement {
 public:
     static Ref<HTMLBDIElement> create(const QualifiedName&, Document&);
 
+    ~HTMLBDIElement();
+
 private:
     HTMLBDIElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/html/HTMLDListElement.cpp
+++ b/Source/WebCore/html/HTMLDListElement.cpp
@@ -43,4 +43,6 @@ Ref<HTMLDListElement> HTMLDListElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new HTMLDListElement(tagName, document));
 }
 
+HTMLDListElement::~HTMLDListElement() = default;
+
 }

--- a/Source/WebCore/html/HTMLDListElement.h
+++ b/Source/WebCore/html/HTMLDListElement.h
@@ -32,6 +32,8 @@ class HTMLDListElement final : public HTMLElement {
 public:
     static Ref<HTMLDListElement> create(const QualifiedName&, Document&);
 
+    ~HTMLDListElement();
+
 private:
     HTMLDListElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/html/HTMLDataElement.cpp
+++ b/Source/WebCore/html/HTMLDataElement.cpp
@@ -46,4 +46,6 @@ inline HTMLDataElement::HTMLDataElement(const QualifiedName& tagName, Document& 
     ASSERT(hasTagName(dataTag));
 }
 
+HTMLDataElement::~HTMLDataElement() = default;
+
 } // namespace WebCore.

--- a/Source/WebCore/html/HTMLDataElement.h
+++ b/Source/WebCore/html/HTMLDataElement.h
@@ -35,6 +35,8 @@ class HTMLDataElement final : public HTMLElement {
 public:
     static Ref<HTMLDataElement> create(const QualifiedName&, Document&);
 
+    ~HTMLDataElement();
+
 private:
     HTMLDataElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/html/HTMLDirectoryElement.cpp
+++ b/Source/WebCore/html/HTMLDirectoryElement.cpp
@@ -43,4 +43,6 @@ Ref<HTMLDirectoryElement> HTMLDirectoryElement::create(const QualifiedName& tagN
     return adoptRef(*new HTMLDirectoryElement(tagName, document));
 }
 
+HTMLDirectoryElement::~HTMLDirectoryElement() = default;
+
 }

--- a/Source/WebCore/html/HTMLDirectoryElement.h
+++ b/Source/WebCore/html/HTMLDirectoryElement.h
@@ -32,6 +32,8 @@ class HTMLDirectoryElement final : public HTMLElement {
 public:
     static Ref<HTMLDirectoryElement> create(const QualifiedName& tagName, Document&);
 
+    ~HTMLDirectoryElement();
+
 private:
     HTMLDirectoryElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/html/HTMLHeadElement.cpp
+++ b/Source/WebCore/html/HTMLHeadElement.cpp
@@ -50,4 +50,6 @@ Ref<HTMLHeadElement> HTMLHeadElement::create(const QualifiedName& tagName, Docum
     return adoptRef(*new HTMLHeadElement(tagName, document));
 }
 
+HTMLHeadElement::~HTMLHeadElement() = default;
+
 }

--- a/Source/WebCore/html/HTMLHeadElement.h
+++ b/Source/WebCore/html/HTMLHeadElement.h
@@ -34,6 +34,8 @@ public:
     static Ref<HTMLHeadElement> create(Document&);
     static Ref<HTMLHeadElement> create(const QualifiedName&, Document&);
 
+    ~HTMLHeadElement();
+
 private:
     HTMLHeadElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/html/HTMLHeadingElement.cpp
+++ b/Source/WebCore/html/HTMLHeadingElement.cpp
@@ -40,6 +40,8 @@ Ref<HTMLHeadingElement> HTMLHeadingElement::create(const QualifiedName& tagName,
     return adoptRef(*new HTMLHeadingElement(tagName, document));
 }
 
+HTMLHeadingElement::~HTMLHeadingElement() = default;
+
 unsigned HTMLHeadingElement::level() const
 {
     auto& tag = tagQName();

--- a/Source/WebCore/html/HTMLHeadingElement.h
+++ b/Source/WebCore/html/HTMLHeadingElement.h
@@ -32,6 +32,8 @@ class HTMLHeadingElement final : public HTMLElement {
 public:
     static Ref<HTMLHeadingElement> create(const QualifiedName&, Document&);
 
+    ~HTMLHeadingElement();
+
     unsigned NODELETE level() const;
 
 private:

--- a/Source/WebCore/html/HTMLHtmlElement.cpp
+++ b/Source/WebCore/html/HTMLHtmlElement.cpp
@@ -57,4 +57,6 @@ Ref<HTMLHtmlElement> HTMLHtmlElement::create(const QualifiedName& tagName, Docum
     return adoptRef(*new HTMLHtmlElement(tagName, document));
 }
 
+HTMLHtmlElement::~HTMLHtmlElement() = default;
+
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLHtmlElement.h
+++ b/Source/WebCore/html/HTMLHtmlElement.h
@@ -34,6 +34,8 @@ public:
     WEBCORE_EXPORT static Ref<HTMLHtmlElement> create(Document&);
     static Ref<HTMLHtmlElement> create(const QualifiedName&, Document&);
 
+    ~HTMLHtmlElement();
+
 private:
     HTMLHtmlElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/html/HTMLMenuElement.cpp
+++ b/Source/WebCore/html/HTMLMenuElement.cpp
@@ -45,4 +45,6 @@ Ref<HTMLMenuElement> HTMLMenuElement::create(const QualifiedName& tagName, Docum
     return adoptRef(*new HTMLMenuElement(tagName, document));
 }
 
+HTMLMenuElement::~HTMLMenuElement() = default;
+
 }

--- a/Source/WebCore/html/HTMLMenuElement.h
+++ b/Source/WebCore/html/HTMLMenuElement.h
@@ -32,6 +32,8 @@ class HTMLMenuElement final : public HTMLElement {
 public:
     static Ref<HTMLMenuElement> create(const QualifiedName&, Document&);
 
+    ~HTMLMenuElement();
+
 private:
     HTMLMenuElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/html/HTMLParamElement.cpp
+++ b/Source/WebCore/html/HTMLParamElement.cpp
@@ -43,4 +43,6 @@ Ref<HTMLParamElement> HTMLParamElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new HTMLParamElement(tagName, document));
 }
 
+HTMLParamElement::~HTMLParamElement() = default;
+
 }

--- a/Source/WebCore/html/HTMLParamElement.h
+++ b/Source/WebCore/html/HTMLParamElement.h
@@ -32,6 +32,8 @@ class HTMLParamElement final : public HTMLElement {
 public:
     static Ref<HTMLParamElement> create(const QualifiedName&, Document&);
 
+    ~HTMLParamElement();
+
 private:
     HTMLParamElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/html/HTMLSelectElementWin.cpp
+++ b/Source/WebCore/html/HTMLSelectElementWin.cpp
@@ -29,6 +29,8 @@
 #if OS(WINDOWS)
 
 #include "Element.h"
+#include "EventTargetInlines.h"
+#include "NodeInlines.h"
 #include "KeyboardEvent.h"
 
 namespace WebCore {

--- a/Source/WebCore/html/HTMLSpanElement.cpp
+++ b/Source/WebCore/html/HTMLSpanElement.cpp
@@ -51,4 +51,6 @@ Ref<HTMLSpanElement> HTMLSpanElement::create(const QualifiedName& tagName, Docum
     return adoptRef(*new HTMLSpanElement(tagName, document));
 }
 
+HTMLSpanElement::~HTMLSpanElement() = default;
+
 }

--- a/Source/WebCore/html/HTMLSpanElement.h
+++ b/Source/WebCore/html/HTMLSpanElement.h
@@ -36,6 +36,8 @@ public:
     static Ref<HTMLSpanElement> create(Document&);
     static Ref<HTMLSpanElement> create(const QualifiedName&, Document&);
 
+    ~HTMLSpanElement();
+
 private:
     HTMLSpanElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/html/HTMLTableRowElement.cpp
+++ b/Source/WebCore/html/HTMLTableRowElement.cpp
@@ -61,6 +61,8 @@ Ref<HTMLTableRowElement> HTMLTableRowElement::create(const QualifiedName& tagNam
     return adoptRef(*new HTMLTableRowElement(tagName, document));
 }
 
+HTMLTableRowElement::~HTMLTableRowElement() = default;
+
 static inline RefPtr<HTMLTableElement> NODELETE findTable(const HTMLTableRowElement& row)
 {
     auto* parent = row.parentNode();

--- a/Source/WebCore/html/HTMLTableRowElement.h
+++ b/Source/WebCore/html/HTMLTableRowElement.h
@@ -37,6 +37,8 @@ public:
     static Ref<HTMLTableRowElement> create(Document&);
     static Ref<HTMLTableRowElement> create(const QualifiedName&, Document&);
 
+    ~HTMLTableRowElement();
+
     WEBCORE_EXPORT int rowIndex() const;
     void setRowIndex(int);
 

--- a/Source/WebCore/html/HTMLTimeElement.cpp
+++ b/Source/WebCore/html/HTMLTimeElement.cpp
@@ -46,4 +46,6 @@ inline HTMLTimeElement::HTMLTimeElement(const QualifiedName& tagName, Document& 
     ASSERT(hasTagName(timeTag));
 }
 
+HTMLTimeElement::~HTMLTimeElement() = default;
+
 } // namespace WebCore.

--- a/Source/WebCore/html/HTMLTimeElement.h
+++ b/Source/WebCore/html/HTMLTimeElement.h
@@ -35,6 +35,8 @@ class HTMLTimeElement final : public HTMLElement {
 public:
     static Ref<HTMLTimeElement> create(const QualifiedName&, Document&);
 
+    ~HTMLTimeElement();
+
 private:
     HTMLTimeElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/html/HTMLUnknownElement.cpp
+++ b/Source/WebCore/html/HTMLUnknownElement.cpp
@@ -32,5 +32,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLUnknownElement);
 
+HTMLUnknownElement::~HTMLUnknownElement() = default;
+
 } // namespace WebCore
 

--- a/Source/WebCore/html/HTMLUnknownElement.h
+++ b/Source/WebCore/html/HTMLUnknownElement.h
@@ -42,6 +42,8 @@ public:
         return adoptRef(*new HTMLUnknownElement(tagName, document));
     }
 
+    ~HTMLUnknownElement();
+
 private:
     HTMLUnknownElement(const QualifiedName& tagName, Document& document)
         : HTMLElement(tagName, document, TypeFlag::IsUnknownElement)

--- a/Source/WebCore/html/track/InbandDataTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandDataTextTrack.cpp
@@ -31,6 +31,7 @@
 
 #include "DataCue.h"
 #include "Document.h"
+#include "EventTargetInlines.h"
 #include "ExceptionOr.h"
 #include "InbandTextTrackPrivate.h"
 #include "TextTrackList.h"

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -54,6 +54,7 @@ public:
     void ref() const override { TrackBase::ref(); }
     void deref() const override { TrackBase::deref(); }
     USING_CAN_MAKE_WEAKPTR(EventTarget);
+    WebCoreOpaqueRoot opaqueRoot() const final { return TrackBase::opaqueRoot(); }
 
     void didMoveToNewDocument(Document& newDocument) final;
 

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -80,6 +80,8 @@ TextTrackCueBox::TextTrackCueBox(Document& document, TextTrackCue& cue)
 {
 }
 
+TextTrackCueBox::~TextTrackCueBox() = default;
+
 void TextTrackCueBox::initialize()
 {
     setUserAgentPart(UserAgentParts::webkitMediaTextTrackDisplay());

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -59,7 +59,7 @@ protected:
     void initialize();
 
     TextTrackCueBox(Document&, TextTrackCue&);
-    ~TextTrackCueBox() { }
+    ~TextTrackCueBox();
 
 private:
 

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -119,12 +119,12 @@ TrackListBase* TrackBase::trackList() const
     return m_trackList.get();
 }
 
-WebCoreOpaqueRoot TrackBase::opaqueRoot()
+WebCoreOpaqueRoot TrackBase::opaqueRoot() const
 {
     // Runs on GC thread.
     if (SUPPRESS_UNCOUNTED_LOCAL auto* trackList = this->trackList())
         return trackList->opaqueRoot();
-    return WebCoreOpaqueRoot { this };
+    return WebCoreOpaqueRoot { const_cast<TrackBase*>(this) };
 }
 
 // See: https://tools.ietf.org/html/bcp47#section-2.1

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -78,7 +78,7 @@ public:
     void setTrackList(TrackListBase&);
     void clearTrackList();
     TrackListBase* NODELETE trackList() const;
-    WebCoreOpaqueRoot opaqueRoot();
+    WebCoreOpaqueRoot NODELETE opaqueRoot() const;
 
     virtual bool enabled() const = 0;
 

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -58,12 +58,12 @@ void TrackListBase::didMoveToNewDocument(Document& newDocument)
         track->didMoveToNewDocument(newDocument);
 }
 
-WebCoreOpaqueRoot TrackListBase::opaqueRoot()
+WebCoreOpaqueRoot TrackListBase::opaqueRoot() const
 {
     // Cannot ref the observer as this gets called on a GC thread.
     SUPPRESS_UNCOUNTED_LOCAL if (auto* rootObserver = m_opaqueRootObserver.get())
         return (*rootObserver)();
-    return WebCoreOpaqueRoot { this };
+    return WebCoreOpaqueRoot { const_cast<TrackListBase*>(this) };
 }
 
 unsigned TrackListBase::length() const

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -60,10 +60,9 @@ public:
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const override = 0;
     ScriptExecutionContext* scriptExecutionContext() const final;
+    WebCoreOpaqueRoot NODELETE opaqueRoot() const final;
 
     void didMoveToNewDocument(Document&);
-
-    WebCoreOpaqueRoot opaqueRoot();
 
     using OpaqueRootObserver = WTF::Observer<WebCoreOpaqueRoot()>;
     void setOpaqueRootObserver(const OpaqueRootObserver& observer) { m_opaqueRootObserver = observer; };

--- a/Source/WebCore/loader/SinkDocument.cpp
+++ b/Source/WebCore/loader/SinkDocument.cpp
@@ -27,6 +27,7 @@
 #include "SinkDocument.h"
 
 #include "LocalFrame.h"
+#include "NodeInlines.h"
 #include "RawDataDocumentParser.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/mathml/MathMLUnknownElement.cpp
+++ b/Source/WebCore/mathml/MathMLUnknownElement.cpp
@@ -28,11 +28,14 @@
 
 #if ENABLE(MATHML)
 
+#include "NodeInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MathMLUnknownElement);
+
+MathMLUnknownElement::~MathMLUnknownElement() = default;
 
 } // namespace WebCore
 

--- a/Source/WebCore/mathml/MathMLUnknownElement.h
+++ b/Source/WebCore/mathml/MathMLUnknownElement.h
@@ -40,6 +40,8 @@ public:
         return adoptRef(*new MathMLUnknownElement(tagName, document));
     }
 
+    ~MathMLUnknownElement();
+
 private:
     MathMLUnknownElement(const QualifiedName& tagName, Document& document)
         : MathMLRowElement(tagName, document, TypeFlag::IsUnknownElement)

--- a/Source/WebCore/page/Crypto.cpp
+++ b/Source/WebCore/page/Crypto.cpp
@@ -32,6 +32,7 @@
 #include "Crypto.h"
 
 #include "Document.h"
+#include "EventTargetInlines.h"
 #include "ExceptionOr.h"
 #include "SubtleCrypto.h"
 #include <JavaScriptCore/ArrayBufferView.h>

--- a/Source/WebCore/page/UserContentProvider.cpp
+++ b/Source/WebCore/page/UserContentProvider.cpp
@@ -30,6 +30,7 @@
 #include "ChromeClient.h"
 #include "Document.h"
 #include "DocumentLoader.h"
+#include "EventTargetInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "LocalFrame.h"

--- a/Source/WebCore/svg/SVGDocument.cpp
+++ b/Source/WebCore/svg/SVGDocument.cpp
@@ -36,6 +36,8 @@ SVGDocument::SVGDocument(LocalFrame* frame, const Settings& settings, const URL&
 {
 }
 
+SVGDocument::~SVGDocument() = default;
+
 bool SVGDocument::zoomAndPanEnabled() const
 {
     RefPtr element = DocumentSVG::rootElement(*this);

--- a/Source/WebCore/svg/SVGDocument.h
+++ b/Source/WebCore/svg/SVGDocument.h
@@ -33,6 +33,8 @@ class SVGDocument final : public XMLDocument {
 public:
     static Ref<SVGDocument> create(LocalFrame*, const Settings&, const URL&);
 
+    ~SVGDocument();
+
     bool zoomAndPanEnabled() const;
     void startPan(const FloatPoint& start);
     void updatePan(const FloatPoint& position) const;

--- a/Source/WebCore/testing/EventTargetForTesting.cpp
+++ b/Source/WebCore/testing/EventTargetForTesting.cpp
@@ -28,6 +28,7 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "CustomEvent.h"
+#include "EventTargetInlines.h"
 #include "MessageForTesting.h"
 #include "MessageTargetForTesting.h"
 #include <JavaScriptCore/HeapInlines.h>


### PR DESCRIPTION
#### 05f145f9a116c459b4d5df49f1832309a5bc5a27
<pre>
Event&apos;s target can get its JS wrapper GC&apos;ed
<a href="https://bugs.webkit.org/show_bug.cgi?id=312491">https://bugs.webkit.org/show_bug.cgi?id=312491</a>

Reviewed by Geoffrey Garen.

Add the opaque root of Event target when visiting Event to avoid
premature collection of JS wrappers of the event target.

To do this, we introduce a virtual EventTarget::opaqueRoot() const which
each event target overrides to provide the opaque root.

Test: fast/events/event-disconnected-target.html

* LayoutTests/fast/events/event-disconnected-target-expected.txt: Added.
* LayoutTests/fast/events/event-disconnected-target.html: Added.
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp:
* Source/WebCore/Modules/mediasource/DOMURLMediaSource.cpp:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::opaqueRoot const):
(WebCore::SourceBuffer::opaqueRoot): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
* Source/WebCore/Modules/mediastream/NavigatorMediaDevices.cpp:
* Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp:
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp:
(WebCore::RemotePlayback::opaqueRoot const):
(WebCore::RemotePlayback::opaqueRootConcurrently const): Deleted.
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.idl:
* Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp:
* Source/WebCore/Modules/webaudio/IIRFilterNode.cpp:
* Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.cpp:
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
* Source/WebCore/Modules/webxr/WebXRBoundedReferenceSpace.cpp:
* Source/WebCore/Modules/webxr/WebXRJointSpace.cpp:
* Source/WebCore/Modules/webxr/WebXRLayer.cpp:
* Source/WebCore/Modules/webxr/WebXRReferenceSpace.cpp:
* Source/WebCore/Modules/webxr/WebXRSpace.cpp:
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
* Source/WebCore/Modules/webxr/XRCompositionLayer.cpp:
* Source/WebCore/Modules/webxr/XRCylinderLayer.cpp:
* Source/WebCore/Modules/webxr/XRQuadLayer.cpp:
* Source/WebCore/bindings/js/JSEventCustom.cpp:
(WebCore::JSEvent::visitAdditionalChildrenInGCThread):
* Source/WebCore/dom/Event.cpp:
(WebCore::Event::setTarget):
(WebCore::Event::visitInGCThread):
* Source/WebCore/dom/Event.h:
* Source/WebCore/dom/Event.idl:
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::opaqueRoot const):
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/EventTargetInlines.h:
(WebCore::EventTarget::opaqueRoot const):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::opaqueRoot const):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::opaqueRoot const):
* Source/WebCore/dom/XMLDocument.cpp:
* Source/WebCore/dom/XMLDocument.h:
* Source/WebCore/fileapi/Blob.cpp:
* Source/WebCore/html/HTMLAudioElement.cpp:
* Source/WebCore/html/HTMLAudioElement.h:
* Source/WebCore/html/HTMLBDIElement.cpp:
* Source/WebCore/html/HTMLBDIElement.h:
* Source/WebCore/html/HTMLDListElement.cpp:
* Source/WebCore/html/HTMLDListElement.h:
* Source/WebCore/html/HTMLDataElement.cpp:
* Source/WebCore/html/HTMLDataElement.h:
* Source/WebCore/html/HTMLDirectoryElement.cpp:
* Source/WebCore/html/HTMLDirectoryElement.h:
* Source/WebCore/html/HTMLHeadElement.cpp:
* Source/WebCore/html/HTMLHeadElement.h:
* Source/WebCore/html/HTMLHeadingElement.cpp:
* Source/WebCore/html/HTMLHeadingElement.h:
* Source/WebCore/html/HTMLHtmlElement.cpp:
* Source/WebCore/html/HTMLHtmlElement.h:
* Source/WebCore/html/HTMLMenuElement.cpp:
* Source/WebCore/html/HTMLMenuElement.h:
* Source/WebCore/html/HTMLParamElement.cpp:
* Source/WebCore/html/HTMLParamElement.h:
* Source/WebCore/html/HTMLSelectElementWin.cpp:
* Source/WebCore/html/HTMLSpanElement.cpp:
* Source/WebCore/html/HTMLSpanElement.h:
* Source/WebCore/html/HTMLTableRowElement.cpp:
* Source/WebCore/html/HTMLTableRowElement.h:
* Source/WebCore/html/HTMLTimeElement.cpp:
* Source/WebCore/html/HTMLTimeElement.h:
* Source/WebCore/html/HTMLUnknownElement.cpp:
* Source/WebCore/html/HTMLUnknownElement.h:
* Source/WebCore/html/track/InbandDataTextTrack.cpp:
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.cpp:
* Source/WebCore/html/track/TextTrackCue.h:
(WebCore::TextTrackCueBox::~TextTrackCueBox): Deleted.
* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::TrackBase::opaqueRoot const):
(WebCore::TrackBase::opaqueRoot): Deleted.
* Source/WebCore/html/track/TrackBase.h:
* Source/WebCore/html/track/TrackListBase.cpp:
(WebCore::TrackListBase::opaqueRoot const):
(WebCore::TrackListBase::opaqueRoot): Deleted.
* Source/WebCore/html/track/TrackListBase.h:
* Source/WebCore/loader/SinkDocument.cpp:
* Source/WebCore/mathml/MathMLUnknownElement.cpp:
* Source/WebCore/mathml/MathMLUnknownElement.h:
* Source/WebCore/page/Crypto.cpp:
* Source/WebCore/page/UserContentProvider.cpp:
* Source/WebCore/svg/SVGDocument.cpp:
* Source/WebCore/svg/SVGDocument.h:
* Source/WebCore/testing/EventTargetForTesting.cpp:

Canonical link: <a href="https://commits.webkit.org/312017@main">https://commits.webkit.org/312017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86c9a875ab5d3cc0c817d964ade4087099f065db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112754 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c605b60-99c0-4d74-b1a8-af8f75a1581f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32084 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122916 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86249 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3340b084-f085-475b-9c77-9dd63408d6c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103585 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e7f055d-6e81-409c-bde1-ea921d6fee97) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24230 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22632 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15271 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169991 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15734 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131103 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131217 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142113 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89647 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24125 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25910 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18921 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31242 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97256 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30762 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31035 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30916 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->