### PR TITLE
Test Gardening: Correct new test to be a proper WPT "no crash" test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-request-italic-only-family-no-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-request-italic-only-family-no-crash.html
@@ -6,9 +6,6 @@
 <link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-style-matching">
 <meta name="assert" content="Requesting oblique when the font family has only an italic face must not crash; the italic face is used as a last resort">
 
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-
 <style>
 /* Only face in the family is italic (faceAxis=ital, slope=[14,14]).
    An oblique request triggers the last-resort penalty path; the fix ensures
@@ -21,15 +18,6 @@
 }
 </style>
 
-<div id="target" style="font-family: testFont; font-style: oblique 75deg;">
+<div style="font-family: testFont; font-style: oblique 75deg;">
     This text triggers oblique selection against an italic-only font family.
 </div>
-
-<script>
-test(() => {
-    // Force style resolution and layout. If the font selection algorithm
-    // crashes, this line is never reached and the test fails with a crash.
-    assert_greater_than(document.getElementById("target").offsetHeight, 0,
-        "element rendered without crash");
-}, "Requesting oblique 75deg with an italic-only @font-face family does not crash");
-</script>


### PR DESCRIPTION
#### 41ea740c0523cd0d5314ef9dcb4930c8aaf0d5b1
<pre>
Test Gardening: Correct new test to be a proper WPT &quot;no crash&quot; test
<a href="https://bugs.webkit.org/show_bug.cgi?id=312493">https://bugs.webkit.org/show_bug.cgi?id=312493</a>
<a href="https://rdar.apple.com/174935698">rdar://174935698</a>

Unreviewed test correction.

I added a new WPT test in Bug 312351 that was a conversion of an internal WebKit test.
However, I mistakenly used `test harness.js` in that test, which is not allowed in WPT
crash tests.

This patch corrects this oversight so that I can push the WPT upstream cleanly.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/oblique-request-italic-only-family-no-crash.html:

Canonical link: <a href="https://commits.webkit.org/311405@main">https://commits.webkit.org/311405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a4087045f381e2b20339db2c413167181d74ba2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165676 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46e0376a-61ff-408e-9e07-cd78366dd929) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121489 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102157 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22767 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20987 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13448 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168160 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129603 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129711 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35138 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140478 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87518 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24539 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17282 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29424 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28947 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29177 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29073 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->