### PR TITLE
[CMake] Fix FindApple.cmake framework resolution on macOS

### DIFF
--- a/Source/cmake/FindApple.cmake
+++ b/Source/cmake/FindApple.cmake
@@ -51,30 +51,59 @@ function(_FIND_APPLE_FRAMEWORK framework)
     set(OPTIONS "")
     set(oneValueArgs HEADER)
     set(multiValueArgs LIBRARY_NAMES)
-    cmake_parse_arguments(opt "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    cmake_parse_arguments(opt "${OPTIONS}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    # Find include directory and library
-    find_path(${framework}_INCLUDE_DIR NAMES ${opt_HEADER})
-    find_library(${framework}_LIBRARY NAMES ${opt_LIBRARY_NAMES})
+    if (APPLE)
+        # On macOS, find the framework by its canonical name. LIBRARY_NAMES
+        # and DEBUG_SUFFIX are Windows-specific alternatives; the framework
+        # name itself is what find_library needs. No INTERFACE_INCLUDE_DIRECTORIES
+        # is required -- the compiler resolves <Framework/Header.h> includes
+        # via the sysroot framework search path.
+        find_library(${framework}_LIBRARY NAMES ${framework})
 
-    if (${framework}_INCLUDE_DIR AND ${framework}_LIBRARY)
-        add_library(Apple::${framework} UNKNOWN IMPORTED)
-        set_target_properties(Apple::${framework} PROPERTIES
-            INTERFACE_INCLUDE_DIRECTORIES "${${framework}_INCLUDE_DIR}"
-            IMPORTED_LOCATION "${${framework}_LIBRARY}"
-        )
-        set(${framework}_FOUND ON PARENT_SCOPE)
-        if (Apple_FIND_REQUIRED_${framework})
-            set(Apple_LIBS_FOUND ${Apple_LIBS_FOUND} "${framework} (required): ${${framework}_LIBRARY}" PARENT_SCOPE)
+        if (${framework}_LIBRARY)
+            add_library(Apple::${framework} UNKNOWN IMPORTED)
+            set_target_properties(Apple::${framework} PROPERTIES
+                IMPORTED_LOCATION "${${framework}_LIBRARY}"
+            )
+            set(${framework}_FOUND ON PARENT_SCOPE)
+            if (Apple_FIND_REQUIRED_${framework})
+                set(Apple_LIBS_FOUND ${Apple_LIBS_FOUND} "${framework} (required): ${${framework}_LIBRARY}" PARENT_SCOPE)
+            else ()
+                set(Apple_LIBS_FOUND ${Apple_LIBS_FOUND} "${framework} (optional): ${${framework}_LIBRARY}" PARENT_SCOPE)
+            endif ()
         else ()
-            set(Apple_LIBS_FOUND ${Apple_LIBS_FOUND} "${framework} (optional): ${${framework}_LIBRARY}}" PARENT_SCOPE)
+            if (Apple_FIND_REQUIRED_${framework})
+                set(_Apple_REQUIRED_LIBS_FOUND NO PARENT_SCOPE)
+                set(Apple_LIBS_NOT_FOUND ${Apple_LIBS_NOT_FOUND} "${framework} (required)" PARENT_SCOPE)
+            else ()
+                set(Apple_LIBS_NOT_FOUND ${Apple_LIBS_NOT_FOUND} "${framework} (optional)" PARENT_SCOPE)
+            endif ()
         endif ()
     else ()
-        if (Apple_FIND_REQUIRED_${framework})
-            set(_Apple_REQUIRED_LIBS_FOUND NO PARENT_SCOPE)
-            set(Apple_LIBS_NOT_FOUND ${Apple_LIBS_NOT_FOUND} "${framework} (required)" PARENT_SCOPE)
+        # Non-Apple platforms (Windows): use HEADER + LIBRARY_NAMES for discovery.
+        find_path(${framework}_INCLUDE_DIR NAMES ${opt_HEADER})
+        find_library(${framework}_LIBRARY NAMES ${opt_LIBRARY_NAMES})
+
+        if (${framework}_INCLUDE_DIR AND ${framework}_LIBRARY)
+            add_library(Apple::${framework} UNKNOWN IMPORTED)
+            set_target_properties(Apple::${framework} PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${${framework}_INCLUDE_DIR}"
+                IMPORTED_LOCATION "${${framework}_LIBRARY}"
+            )
+            set(${framework}_FOUND ON PARENT_SCOPE)
+            if (Apple_FIND_REQUIRED_${framework})
+                set(Apple_LIBS_FOUND ${Apple_LIBS_FOUND} "${framework} (required): ${${framework}_LIBRARY}" PARENT_SCOPE)
+            else ()
+                set(Apple_LIBS_FOUND ${Apple_LIBS_FOUND} "${framework} (optional): ${${framework}_LIBRARY}" PARENT_SCOPE)
+            endif ()
         else ()
-            set(Apple_LIBS_NOT_FOUND ${Apple_LIBS_NOT_FOUND} "${framework} (optional)" PARENT_SCOPE)
+            if (Apple_FIND_REQUIRED_${framework})
+                set(_Apple_REQUIRED_LIBS_FOUND NO PARENT_SCOPE)
+                set(Apple_LIBS_NOT_FOUND ${Apple_LIBS_NOT_FOUND} "${framework} (required)" PARENT_SCOPE)
+            else ()
+                set(Apple_LIBS_NOT_FOUND ${Apple_LIBS_NOT_FOUND} "${framework} (optional)" PARENT_SCOPE)
+            endif ()
         endif ()
     endif ()
 
@@ -130,6 +159,13 @@ if ("CoreMedia" IN_LIST Apple_FIND_COMPONENTS)
     )
 endif ()
 
+if ("CoreServices" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(CoreServices
+        HEADER CoreServices/CoreServices.h
+        LIBRARY_NAMES CoreServices${DEBUG_SUFFIX}
+    )
+endif ()
+
 if ("CoreText" IN_LIST Apple_FIND_COMPONENTS)
     _FIND_APPLE_FRAMEWORK(CoreText
         HEADER CoreText/CoreText.h
@@ -141,6 +177,13 @@ if ("CoreVideo" IN_LIST Apple_FIND_COMPONENTS)
     _FIND_APPLE_FRAMEWORK(CoreVideo
         HEADER CoreVideo/CVBase.h
         LIBRARY_NAMES CoreVideo${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("ImageIO" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(ImageIO
+        HEADER ImageIO/ImageIO.h
+        LIBRARY_NAMES ImageIO${DEBUG_SUFFIX}
     )
 endif ()
 

--- a/Tools/ImageDiff/CoreGraphics.cmake
+++ b/Tools/ImageDiff/CoreGraphics.cmake
@@ -6,4 +6,5 @@ list(APPEND ImageDiff_LIBRARIES
     Apple::CoreFoundation
     Apple::CoreGraphics
     Apple::CoreText
+    Apple::ImageIO
 )

--- a/Tools/ImageDiff/PlatformMac.cmake
+++ b/Tools/ImageDiff/PlatformMac.cmake
@@ -1,15 +1,10 @@
-list(APPEND ImageDiff_SOURCES
-    cg/PlatformImageCG.cpp
-)
+find_package(Apple REQUIRED COMPONENTS CoreFoundation CoreGraphics CoreServices CoreText ImageIO)
 
-# FIXME: CoreGraphics.cmake's FindApple.cmake targets don't resolve native macOS framework
-# headers -- use -framework directly. https://bugs.webkit.org/show_bug.cgi?id=312069
+include(CoreGraphics.cmake)
+
+# CoreServices provides kUTTypePNG on macOS (guarded by __APPLE__ in PlatformImageCG.cpp).
 list(APPEND ImageDiff_LIBRARIES
-    "-framework CoreFoundation"
-    "-framework CoreGraphics"
-    "-framework CoreServices"  # kUTTypePNG
-    "-framework CoreText"
-    "-framework ImageIO"
+    Apple::CoreServices
 )
 
 # kUTTypePNG deprecated in 12.0; our deployment target is 26.2.


### PR DESCRIPTION
#### 0cada7ea29c82071f39911718c534cf81f76e1c9
<pre>
[CMake] Fix FindApple.cmake framework resolution on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=312069">https://bugs.webkit.org/show_bug.cgi?id=312069</a>
<a href="https://rdar.apple.com/174942090">rdar://174942090</a>

Reviewed by Geoffrey Garen.

FindApple.cmake was written for Windows-style Apple framework discovery
using find_path() + find_library(). On macOS, find_path() fails because
framework headers live inside .framework/Headers/ bundles and
Framework/Header.h does not resolve as a literal subdirectory path.
Since find_path() fails, Apple::* imported targets are never created.

Add an APPLE branch that uses find_library() with the framework&apos;s
canonical name (not the Windows-specific LIBRARY_NAMES) and creates
UNKNOWN IMPORTED targets with IMPORTED_LOCATION only. On macOS the
compiler resolves &lt;Framework/Header.h&gt; includes via the sysroot
framework search path, so INTERFACE_INCLUDE_DIRECTORIES is not needed.
The existing find_path()/find_library() logic moves into an else()
block for non-Apple platforms, preserving Windows behavior.

Add CoreServices and ImageIO as new FindApple components, and update
ImageDiff&apos;s PlatformMac.cmake to use find_package(Apple ...) with
CoreGraphics.cmake instead of raw -framework flags.

Also fix two pre-existing bugs: a ${options}/${OPTIONS} case mismatch
in cmake_parse_arguments, and a stray } in a status message string.

* Source/cmake/FindApple.cmake:
* Tools/ImageDiff/CoreGraphics.cmake:
* Tools/ImageDiff/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/311404@main">https://commits.webkit.org/311404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1c934f63cb726117887d57886b99014527b9834

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165689 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85d1ce7e-cd0a-4082-85ce-38ffe6c49ebb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30205 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/777732f0-15fa-49f0-8b0c-44f8bdf6f90d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102166 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ec9d6c7-3fcd-4dd0-b234-cd6d029a595d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13461 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148916 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132462 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168174 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17701 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129614 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129722 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35136 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140487 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/24550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17291 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188828 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29437 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/48489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->