### PR TITLE
[WPE] Implement a fallback popup menu

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1591,6 +1591,7 @@ html/DirectoryFileListCreator.cpp
 html/EmailInputType.cpp
 html/EnterKeyHint.cpp
 html/FTPDirectoryDocument.cpp
+html/FallbackPopupMenu.cpp
 html/FileInputType.cpp
 html/FormAssociatedCustomElement.cpp
 html/FormAssociatedElement.cpp

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -286,6 +286,21 @@
             "status": "non-standard",
             "user-agent-part": true
         },
+        "-internal-fallback-popup-menu": {
+            "user-agent-part": true
+        },
+        "-internal-fallback-popup-menu-group-label": {
+            "user-agent-part": true
+        },
+        "-internal-fallback-popup-menu-item": {
+            "user-agent-part": true
+        },
+        "-internal-fallback-popup-menu-item-selected": {
+            "user-agent-part": true
+        },
+        "-internal-fallback-popup-menu-separator": {
+            "user-agent-part": true
+        },
         "-webkit-color-swatch-wrapper": {
             "status": "non-standard",
             "user-agent-part": true

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1187,6 +1187,55 @@ select optgroup legend {
     min-block-size: 1lh;
 }
 
+select::-internal-fallback-popup-menu {
+    min-width: 200px;
+    background-color: Canvas;
+    color: CanvasText;
+    border: 1px solid color-mix(in srgb, CanvasText 25%, transparent);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px color-mix(in srgb, CanvasText 15%, transparent);
+    padding-block: 4px;
+    overflow: auto;
+    max-height: 50vh;
+    box-sizing: border-box;
+    z-index: 2147483647;
+}
+
+select::-internal-fallback-popup-menu-item,
+select::-internal-fallback-popup-menu-item-selected {
+    padding-block: 4px;
+    padding-inline: 12px;
+    cursor: default;
+    border-radius: 4px;
+    margin-inline: 4px;
+}
+
+select::-internal-fallback-popup-menu-item-selected {
+    background-color: color-mix(in srgb, Highlight 25%, Canvas);
+    font-weight: bold;
+}
+
+select::-internal-fallback-popup-menu-item:hover,
+select::-internal-fallback-popup-menu-item-selected:hover {
+    /* Items can have custom colors set but we want to always overrule them. */
+    background-color: Highlight !important;
+    color: HighlightText !important;
+}
+
+select::-internal-fallback-popup-menu-group-label {
+    padding-block: 4px;
+    padding-inline: 12px;
+    font-weight: bold;
+    color: color-mix(in srgb, CanvasText 60%, transparent);
+}
+
+select::-internal-fallback-popup-menu-separator {
+    border: none;
+    border-top: 1px solid color-mix(in srgb, CanvasText 20%, transparent);
+    margin-block: 4px;
+    margin-inline: 8px;
+}
+
 output {
     display: inline;
 }

--- a/Source/WebCore/html/FallbackPopupMenu.cpp
+++ b/Source/WebCore/html/FallbackPopupMenu.cpp
@@ -1,0 +1,386 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "FallbackPopupMenu.h"
+
+#include "AbortSignal.h"
+#include "CSSMarkup.h"
+#include "CSSPropertyNames.h"
+#include "CSSUnits.h"
+#include "CSSValueKeywords.h"
+#include "ColorSerialization.h"
+#include "DocumentView.h"
+#include "Event.h"
+#include "EventListener.h"
+#include "EventNames.h"
+#include "FontCascade.h"
+#include "HTMLDivElement.h"
+#include "HTMLNames.h"
+#include "HTMLSelectElement.h"
+#include "KeyboardEvent.h"
+#include "LocalDOMWindow.h"
+#include "MouseEvent.h"
+#include "Node.h"
+#include "PopupMenuStyle.h"
+#include "ScriptDisallowedScope.h"
+#include "ShadowRoot.h"
+#include "Text.h"
+#include "UserAgentParts.h"
+#include <wtf/CheckedRef.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/text/StringBuilder.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FallbackPopupMenu);
+
+class FallbackPopupMenuItemEventListener final : public EventListener {
+public:
+    static Ref<FallbackPopupMenuItemEventListener> create(FallbackPopupMenu& menu, int listIndex)
+    {
+        return adoptRef(*new FallbackPopupMenuItemEventListener(menu, listIndex));
+    }
+
+    void handleEvent(ScriptExecutionContext&, Event& event) final
+    {
+        if (event.type() == eventNames().mouseupEvent) {
+            if (RefPtr menu = m_menu.get())
+                menu->itemClicked(m_listIndex);
+        }
+    }
+
+private:
+    FallbackPopupMenuItemEventListener(FallbackPopupMenu& menu, int listIndex)
+        : EventListener(CPPEventListenerType)
+        , m_menu(menu)
+        , m_listIndex(listIndex)
+    {
+    }
+
+    WeakPtr<FallbackPopupMenu> m_menu;
+    int m_listIndex;
+};
+
+static void applyFontCascade(HTMLElement& element, const FontCascade& font)
+{
+    element.setInlineStyleProperty(CSSPropertyFontSize, font.size(), CSSUnitType::CSS_PX);
+    element.setInlineStyleProperty(CSSPropertyFontWeight, static_cast<double>(font.weight()), CSSUnitType::CSS_NUMBER);
+    if (font.fontStyleSlope())
+        element.setInlineStyleProperty(CSSPropertyFontStyle, CSSValueItalic);
+
+    StringBuilder families;
+    for (unsigned i = 0; i < font.familyCount(); ++i) {
+        if (i)
+            families.append(", "_s);
+        families.append(serializeFontFamily(font.familyAt(i).name));
+    }
+    if (!families.isEmpty())
+        element.setInlineStyleProperty(CSSPropertyFontFamily, families.toString());
+}
+
+static void applyItemStyle(HTMLElement& item, const PopupMenuStyle& style)
+{
+    if (auto& foreground = style.foregroundColor(); foreground.isValid())
+        item.setInlineStyleProperty(CSSPropertyColor, serializationForCSS(foreground));
+
+    if (style.backgroundColorType() == PopupMenuStyle::CustomBackgroundColor) {
+        if (auto& background = style.backgroundColor(); background.isValid())
+            item.setInlineStyleProperty(CSSPropertyBackgroundColor, serializationForCSS(background));
+    }
+
+    if (auto& language = style.language(); !language.isEmpty())
+        item.setAttributeWithoutSynchronization(HTMLNames::langAttr, AtomString { language });
+
+    if (CheckedRef font = style.font())
+        applyFontCascade(item, font);
+
+    item.setInlineStyleProperty(CSSPropertyDirection, style.textDirection() == TextDirection::RTL ? CSSValueRtl : CSSValueLtr);
+    if (style.hasTextDirectionOverride())
+        item.setInlineStyleProperty(CSSPropertyUnicodeBidi, CSSValueBidiOverride);
+}
+
+static void applyMenuStyle(HTMLElement& container, const PopupMenuStyle& style)
+{
+    if (auto& foreground = style.foregroundColor(); foreground.isValid())
+        container.setInlineStyleProperty(CSSPropertyColor, serializationForCSS(foreground));
+
+    if (auto& background = style.backgroundColor(); background.isValid())
+        container.setInlineStyleProperty(CSSPropertyBackgroundColor, serializationForCSS(background));
+
+    if (CheckedRef font = style.font())
+        applyFontCascade(container, font);
+
+    container.setInlineStyleProperty(CSSPropertyDirection, style.textDirection() == TextDirection::RTL ? CSSValueRtl : CSSValueLtr);
+    if (style.hasTextDirectionOverride())
+        container.setInlineStyleProperty(CSSPropertyUnicodeBidi, CSSValueBidiOverride);
+}
+
+class FallbackPopupMenuDismissListener final : public EventListener {
+public:
+    static Ref<FallbackPopupMenuDismissListener> create(FallbackPopupMenu& menu)
+    {
+        return adoptRef(*new FallbackPopupMenuDismissListener(menu));
+    }
+
+    void handleEvent(ScriptExecutionContext&, Event& event) final
+    {
+        RefPtr menu = m_menu.get();
+        if (!menu)
+            return;
+        if (event.type() == eventNames().scrollEvent || event.type() == eventNames().resizeEvent) {
+            menu->hide();
+            return;
+        }
+        if (event.type() == eventNames().keydownEvent) {
+            if (auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(event)) {
+                auto& key = keyboardEvent->key();
+                if (key == "Enter"_s || key == "Escape"_s) {
+                    menu->hide();
+                    event.setDefaultHandled();
+                }
+            }
+            return;
+        }
+        RefPtr target = dynamicDowncast<Node>(event.target());
+        if (!target)
+            return;
+        menu->maybeClose(*target, event);
+    }
+
+private:
+    explicit FallbackPopupMenuDismissListener(FallbackPopupMenu& menu)
+        : EventListener(CPPEventListenerType)
+        , m_menu(menu)
+    {
+    }
+
+    WeakPtr<FallbackPopupMenu> m_menu;
+};
+
+FallbackPopupMenu::FallbackPopupMenu(HTMLSelectElement& element)
+    : m_element(element)
+    , m_updateTimer(RunLoop::mainSingleton(), "FallbackPopupMenu update timer"_s, this, &FallbackPopupMenu::updateFromElementTimerFired)
+{
+}
+
+FallbackPopupMenu::~FallbackPopupMenu()
+{
+    deletePopupTree();
+}
+
+void FallbackPopupMenu::show(const IntRect& rect, LocalFrameView& frameView, int)
+{
+    if (m_container)
+        return;
+    buildPopupTree(rect, frameView);
+}
+
+void FallbackPopupMenu::hide()
+{
+    deletePopupTree();
+    if (RefPtr element = m_element.get()) {
+        element->setActive(false);
+        element->popupDidHide();
+    }
+}
+
+void FallbackPopupMenu::updateFromElement()
+{
+    if (!m_container)
+        return;
+    RefPtr element = m_element.get();
+    if (!element || !element->renderer())
+        return;
+    if (element->document().inStyleRecalc()) {
+        m_updateTimer.startOneShot(0_s);
+        return;
+    }
+    RefPtr view = element->document().view();
+    if (!view)
+        return;
+    deletePopupTree();
+    if (CheckedPtr renderer = element->renderer())
+        buildPopupTree(renderer->absoluteBoundingBoxRect(), *view);
+}
+
+void FallbackPopupMenu::updateFromElementTimerFired()
+{
+    updateFromElement();
+}
+
+void FallbackPopupMenu::disconnectClient()
+{
+    deletePopupTree();
+    m_element = nullptr;
+}
+
+void FallbackPopupMenu::itemClicked(int listIndex)
+{
+    RefPtr element = m_element.get();
+    if (!element || element->itemIsLabel(listIndex))
+        return;
+    Ref protectedElement = *element;
+    element->valueChanged(listIndex);
+    hide();
+}
+
+void FallbackPopupMenu::maybeClose(Node& target, Event& event)
+{
+    if (RefPtr element = m_element.get()) {
+        if (element.get() == &target || element->contains(&target)) {
+            // Shadow DOM retargets clicks on popup items so they appear with target == SELECT at the document level.
+            // Use coordinates to distinguish when a popup item click lands outside the SELECT's bounding rect.
+            event.setDefaultHandled();
+            auto* mouseEvent = dynamicDowncast<MouseEvent>(event);
+            CheckedPtr renderer = element->renderer();
+            if (mouseEvent && renderer) {
+                IntPoint clickPos(mouseEvent->pageX(), mouseEvent->pageY());
+                if (!renderer->absoluteBoundingBoxRect().contains(clickPos))
+                    return; // Don't hide.
+            }
+        }
+    }
+    hide();
+}
+
+void FallbackPopupMenu::buildPopupTree(const IntRect& elementRect, LocalFrameView& frameView)
+{
+    RefPtr element = m_element.get();
+    if (!element)
+        return;
+
+    auto scrollX = frameView.scrollX();
+    auto scrollY = frameView.scrollY();
+    auto viewportHeight = frameView.visibleContentRect().height();
+
+    Ref shadowRoot = element->ensureUserAgentShadowRoot();
+
+    ScriptDisallowedScope::InMainThread scriptDisallowedScope;
+    ScriptDisallowedScope::EventAllowedScope allowedScope(shadowRoot);
+
+    Ref document = element->document();
+
+    Ref container = HTMLDivElement::create(document.get());
+    shadowRoot->appendChild(container);
+    container->setUserAgentPart(UserAgentParts::internalFallbackPopupMenu());
+    applyMenuStyle(container, element->menuStyle());
+    container->setInlineStyleProperty(CSSPropertyPosition, CSSValueFixed);
+    container->setInlineStyleProperty(CSSPropertyLeft, elementRect.x() - scrollX, CSSUnitType::CSS_PX);
+    container->setInlineStyleProperty(CSSPropertyWidth, elementRect.width(), CSSUnitType::CSS_PX);
+
+    if (viewportHeight) {
+        // There are some heuristics here to try and position the popup in a pleasing way.
+        // Unlike a native popup we cannot grow past the viewport.
+        // Our goal is to prefer showing the popup below the element when possible.
+        // Once there is not enough space we flip it to show above the element.
+        // No matter what the maximum size is half of the viewport.
+        auto halfViewport = viewportHeight / 2;
+        auto elementTop = elementRect.y() - scrollY;
+        auto elementBottom = elementRect.maxY() - scrollY;
+        auto spaceBelow = std::max(0, viewportHeight - elementBottom);
+        auto spaceAbove = std::max(0, elementTop);
+        static constexpr int minSpaceBelow = 96;
+        static constexpr int popupPadding = 12; // It doesn't look nice to touch the edges of the viewport.
+        if (spaceBelow < minSpaceBelow) {
+            container->setInlineStyleProperty(CSSPropertyBottom, viewportHeight - elementTop, CSSUnitType::CSS_PX);
+            container->setInlineStyleProperty(CSSPropertyMaxHeight, std::min(spaceAbove - popupPadding, halfViewport), CSSUnitType::CSS_PX);
+        } else {
+            container->setInlineStyleProperty(CSSPropertyTop, elementBottom, CSSUnitType::CSS_PX);
+            container->setInlineStyleProperty(CSSPropertyMaxHeight, std::min(spaceBelow - popupPadding, halfViewport), CSSUnitType::CSS_PX);
+        }
+    } else
+        container->setInlineStyleProperty(CSSPropertyTop, elementRect.maxY() - scrollY, CSSUnitType::CSS_PX);
+
+    int size = element->listSize();
+    for (int i = 0; i < size; ++i) {
+        if (element->itemIsSeparator(i)) {
+            Ref item = HTMLDivElement::create(document.get());
+            container->appendChild(item);
+            item->setUserAgentPart(UserAgentParts::internalFallbackPopupMenuSeparator());
+            continue;
+        }
+
+        auto style = element->itemStyle(i);
+        if (style.isDisplayNone() || !style.isVisible())
+            continue;
+
+        Ref item = HTMLDivElement::create(document.get());
+        container->appendChild(item);
+
+        if (element->itemIsLabel(i))
+            item->setUserAgentPart(UserAgentParts::internalFallbackPopupMenuGroupLabel());
+        else {
+            bool selected = element->itemIsSelected(i);
+            item->setUserAgentPart(selected ? UserAgentParts::internalFallbackPopupMenuItemSelected() : UserAgentParts::internalFallbackPopupMenuItem());
+            Ref itemListener = FallbackPopupMenuItemEventListener::create(*this, i);
+            item->addEventListener(eventNames().mouseupEvent, WTF::move(itemListener));
+        }
+
+        if (auto accessibilityText = element->itemAccessibilityText(i); !accessibilityText.isEmpty())
+            item->setAttributeWithoutSynchronization(HTMLNames::aria_labelAttr, AtomString { accessibilityText });
+
+        if (auto toolTip = element->itemToolTip(i); !toolTip.isEmpty())
+            item->setAttributeWithoutSynchronization(HTMLNames::titleAttr, AtomString { toolTip });
+
+        applyItemStyle(item, style);
+
+        item->appendChild(Text::create(document.get(), element->itemText(i)));
+    }
+    m_container = WTF::move(container);
+
+    Ref dismissListener = FallbackPopupMenuDismissListener::create(*this);
+    AddEventListenerOptions captureOptions;
+    captureOptions.capture = true;
+    document->addEventListener(eventNames().mousedownEvent, dismissListener, captureOptions);
+    document->addEventListener(eventNames().keydownEvent, dismissListener, captureOptions);
+    document->addEventListener(eventNames().scrollEvent, dismissListener, captureOptions);
+    if (RefPtr window = document->window())
+        window->addEventListener(eventNames().resizeEvent, dismissListener, captureOptions);
+    m_dismissListener = WTF::move(dismissListener);
+}
+
+void FallbackPopupMenu::deletePopupTree()
+{
+    if (m_dismissListener) {
+        Ref dismissListener = m_dismissListener.releaseNonNull();
+        if (RefPtr element = m_element.get()) {
+            Ref document = element->document();
+            EventListenerOptions captureOptions;
+            captureOptions.capture = true;
+            document->removeEventListener(eventNames().mousedownEvent, dismissListener, captureOptions);
+            document->removeEventListener(eventNames().keydownEvent, dismissListener, captureOptions);
+            document->removeEventListener(eventNames().scrollEvent, dismissListener, captureOptions);
+            if (RefPtr window = element->document().window())
+                window->removeEventListener(eventNames().resizeEvent, dismissListener, captureOptions);
+        }
+    }
+
+    if (m_container) {
+        Ref container = m_container.releaseNonNull();
+        if (RefPtr element = m_element.get()) {
+            if (RefPtr shadowRoot = element->userAgentShadowRoot()) {
+                ScriptDisallowedScope::EventAllowedScope allowedScope(*shadowRoot);
+                shadowRoot->removeChild(container);
+            }
+        }
+    }
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/FallbackPopupMenu.h
+++ b/Source/WebCore/html/FallbackPopupMenu.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "PopupMenu.h"
+#include <wtf/Noncopyable.h>
+#include <wtf/RefPtr.h>
+#include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class Event;
+class EventListener;
+class HTMLElement;
+class HTMLSelectElement;
+class IntRect;
+class LocalFrameView;
+class Node;
+class WeakPtrImplWithEventTargetData;
+
+class FallbackPopupMenu : public PopupMenu, public CanMakeWeakPtr<FallbackPopupMenu> {
+    WTF_MAKE_TZONE_ALLOCATED(FallbackPopupMenu);
+    WTF_MAKE_NONCOPYABLE(FallbackPopupMenu);
+public:
+    static Ref<FallbackPopupMenu> create(HTMLSelectElement& element) { return adoptRef(*new FallbackPopupMenu(element)); }
+    ~FallbackPopupMenu();
+
+    void show(const IntRect&, LocalFrameView&, int selectedIndex) override;
+    void hide() override;
+    void updateFromElement() override;
+    void disconnectClient() override;
+
+    void itemClicked(int listIndex);
+    void maybeClose(Node&, Event&);
+
+private:
+    explicit FallbackPopupMenu(HTMLSelectElement&);
+
+    void buildPopupTree(const IntRect& elementBounds, LocalFrameView&);
+    void deletePopupTree();
+
+    void updateFromElementTimerFired();
+
+    WeakPtr<HTMLSelectElement, WeakPtrImplWithEventTargetData> m_element;
+    RefPtr<HTMLElement> m_container;
+    RefPtr<EventListener> m_dismissListener;
+    RunLoop::Timer m_updateTimer;
+};
+
+} // namespace WebCore
+

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -44,6 +44,7 @@
 #include "EventHandler.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "FallbackPopupMenu.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FormController.h"
 #include "GenericCachedHTMLCollection.h"
@@ -2549,6 +2550,30 @@ void HTMLSelectElement::popupDidHide()
     setPopupIsVisible(false);
 #endif
 }
+
+#if PLATFORM(WPE)
+void HTMLSelectElement::showFallbackPopupMenu()
+{
+    CheckedPtr renderer = this->renderer();
+    if (!renderer)
+        return;
+
+    RefPtr frame = document().frame();
+    if (!frame)
+        return;
+
+    RefPtr frameView = frame->view();
+    if (!frameView)
+        return;
+
+    m_popup = FallbackPopupMenu::create(*this);
+
+    FloatPoint absTopLeft = renderer->localToAbsolute(FloatPoint(), MapCoordinatesMode::UseTransforms);
+    IntRect absBounds = renderer->absoluteBoundingBoxRectIgnoringTransforms();
+    absBounds.setLocation(roundedIntPoint(absTopLeft));
+    protect(m_popup)->show(absBounds, *frameView, optionToListIndex(selectedIndex()));
+}
+#endif
 
 bool HTMLSelectElement::itemIsSeparator(unsigned listIndex) const
 {

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -143,6 +143,9 @@ public:
     PopupMenuStyle menuStyle() const override;
     int listSize() const override;
     void popupDidHide() override;
+#if PLATFORM(WPE)
+    void showFallbackPopupMenu() override;
+#endif
     bool itemIsSeparator(unsigned listIndex) const override;
     bool itemIsLabel(unsigned listIndex) const override;
     bool itemIsSelected(unsigned listIndex) const override;

--- a/Source/WebCore/html/LazyLoadVideoObserver.h
+++ b/Source/WebCore/html/LazyLoadVideoObserver.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "IntersectionObserver.h"
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/platform/PopupMenuClient.h
+++ b/Source/WebCore/platform/PopupMenuClient.h
@@ -49,6 +49,9 @@ public:
     virtual PopupMenuStyle menuStyle() const = 0;
     virtual int listSize() const = 0;
     virtual void popupDidHide() = 0;
+#if PLATFORM(WPE)
+    virtual void showFallbackPopupMenu() { };
+#endif
     virtual bool itemIsSeparator(unsigned listIndex) const = 0;
     virtual bool itemIsLabel(unsigned listIndex) const = 0;
     virtual bool itemIsSelected(unsigned listIndex) const = 0;

--- a/Source/WebKit/UIProcess/API/wpe/WebKitPopupMenu.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitPopupMenu.cpp
@@ -51,7 +51,11 @@ void WebKitPopupMenu::showPopupMenu(const IntRect& rect, TextDirection direction
     if (menu) {
         m_menu = WTF::move(menu);
         g_signal_connect_swapped(m_menu.get(), "close", G_CALLBACK(menuCloseCallback), this);
+        return;
     }
+
+    if (CheckedPtr checkedClient = client())
+        checkedClient->failedToShowPopupMenu();
 }
 
 void WebKitPopupMenu::hidePopupMenu()

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11874,7 +11874,7 @@ void WebPageProxy::postMessageToInjectedBundle(const String& messageName, API::O
     send(Messages::WebPage::PostInjectedBundleMessage(messageName, UserData(protect(legacyMainFrameProcess())->transformObjectsToHandles(messageBody).get())));
 }
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || PLATFORM(WPE)
 void WebPageProxy::Internals::failedToShowPopupMenu()
 {
     protect(page)->send(Messages::WebPage::FailedToShowPopupMenu());

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -424,7 +424,7 @@ public:
 #if !PLATFORM(COCOA)
     void setTextFromItemForPopupMenu(WebPopupMenuProxy*, int32_t index) final;
 #endif
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || PLATFORM(WPE)
     void failedToShowPopupMenu() final;
 #endif
 

--- a/Source/WebKit/UIProcess/WebPopupMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebPopupMenuProxy.h
@@ -57,7 +57,7 @@ public:
 #if !PLATFORM(COCOA)
     virtual void setTextFromItemForPopupMenu(WebPopupMenuProxy*, int32_t index) = 0;
 #endif
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || PLATFORM(WPE)
     virtual void failedToShowPopupMenu() = 0;
 #endif
 };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1117,6 +1117,8 @@ bool WebChromeClient::shouldNotifyOnFormChanges()
 RefPtr<PopupMenu> WebChromeClient::createPopupMenu(PopupMenuClient& client) const
 {
     RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
     return WebPopupMenu::create(page.get(), &client);
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
@@ -50,7 +50,7 @@ public:
 #if !PLATFORM(COCOA)
     void setTextForIndex(int newIndex);
 #endif
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || PLATFORM(WPE)
     WebCore::PopupMenuClient* client() const { return m_popupClient.get(); }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6474,13 +6474,20 @@ void WebPage::setTextForActivePopupMenu(int32_t index)
 }
 #endif
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || PLATFORM(WPE)
 void WebPage::failedToShowPopupMenu()
 {
     if (!m_activePopupMenu)
         return;
 
-    m_activePopupMenu->client()->popupDidHide();
+    auto activePopupMenu = std::exchange(m_activePopupMenu, nullptr);
+    if (auto* popupClient = activePopupMenu->client()) {
+#if PLATFORM(WPE)
+        popupClient->showFallbackPopupMenu();
+#else
+        popupClient->popupDidHide();
+#endif
+    }
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2524,7 +2524,7 @@ private:
     void setTextForActivePopupMenu(int32_t index);
 #endif
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || PLATFORM(WPE)
     void failedToShowPopupMenu();
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -434,7 +434,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #if !PLATFORM(COCOA)
     SetTextForActivePopupMenu(int32_t index)
 #endif
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || PLATFORM(WPE)
     FailedToShowPopupMenu()
 #endif
 


### PR DESCRIPTION
#### 5ccb692f3e65ac32d6d6b83796dd8c9ca0bf1e1b
<pre>
[WPE] Implement a fallback popup menu
<a href="https://bugs.webkit.org/show_bug.cgi?id=310383">https://bugs.webkit.org/show_bug.cgi?id=310383</a>

Reviewed by Carlos Garcia Campos.

When using WPE, depending on the backend, it may not have the capability
of creating a popup menu. In this case we fallback to WebKit rendering
its own.

The fallback popup supports all of the styling WebKit supports.
It tries to mimic a native OS popup in behavior where possible.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/html.css:
(select::-internal-fallback-popup-menu):
(select::-internal-fallback-popup-menu-item,):
(select::-internal-fallback-popup-menu-item-selected):
(select::-internal-fallback-popup-menu-item:hover,):
(select::-internal-fallback-popup-menu-group-label):
(select::-internal-fallback-popup-menu-separator):
* Source/WebCore/html/FallbackPopupMenu.cpp: Added.
(WebCore::applyFontCascade):
(WebCore::applyItemStyle):
(WebCore::applyMenuStyle):
(WebCore::FallbackPopupMenu::FallbackPopupMenu):
(WebCore::FallbackPopupMenu::~FallbackPopupMenu):
(WebCore::FallbackPopupMenu::show):
(WebCore::FallbackPopupMenu::hide):
(WebCore::FallbackPopupMenu::updateFromElement):
(WebCore::FallbackPopupMenu::updateFromElementTimerFired):
(WebCore::FallbackPopupMenu::disconnectClient):
(WebCore::FallbackPopupMenu::itemClicked):
(WebCore::FallbackPopupMenu::maybeClose):
(WebCore::FallbackPopupMenu::buildPopupTree):
(WebCore::FallbackPopupMenu::deletePopupTree):
* Source/WebCore/html/FallbackPopupMenu.h: Added.
(WebCore::FallbackPopupMenu::create):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/html/LazyLoadVideoObserver.h:
* Source/WebCore/platform/PopupMenuClient.h:
(WebCore::PopupMenuClient::showFallbackPopupMenu):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
* Source/WebKit/UIProcess/API/wpe/WebKitPopupMenu.cpp:
(WebKit::WebKitPopupMenu::showPopupMenu):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/WebPopupMenuProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createPopupMenu const):
* Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::failedToShowPopupMenu):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/315096@main">https://commits.webkit.org/315096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3ea29c744804f1f8da72fb358eaa9e0e7bd0ffd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177195 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125593 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130635 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32070 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30774 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25897 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179795 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29146 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32547 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139047 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138930 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37452 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42157 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105436 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34213 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27245 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40661 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113913 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40058 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5346 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40309 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->