### PR TITLE
Fix non-unified builds

### DIFF
--- a/Source/JavaScriptCore/runtime/ModuleGraphLoadingState.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleGraphLoadingState.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ModuleGraphLoadingState.h"
 
+#include "JSCellInlines.h"
 #include "JSPromise.h"
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/ModuleLoaderPayload.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleLoaderPayload.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ModuleLoaderPayload.h"
 
+#include "JSCellInlines.h"
 #include "JSPromise.h"
 
 namespace JSC {

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.h
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.h
@@ -41,6 +41,7 @@ class CallFrame;
 class JSGlobalObject;
 class JSModuleLoader;
 class JSModuleRecord;
+class JSPromise;
 class SourceOrigin;
 
 }

--- a/Source/WebCore/html/LazyLoadVideoObserver.h
+++ b/Source/WebCore/html/LazyLoadVideoObserver.h
@@ -27,12 +27,14 @@
 
 #if ENABLE(VIDEO)
 
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class Document;
 class HTMLVideoElement;
+class IntersectionObserver;
 
 class LazyLoadVideoObserver {
     WTF_MAKE_TZONE_ALLOCATED(LazyLoadVideoObserver);

--- a/Source/WebCore/inspector/agents/frame/FrameWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameWorkerAgent.cpp
@@ -27,6 +27,8 @@
 #include "FrameWorkerAgent.h"
 
 #include "Document.h"
+#include "DocumentPage.h"
+#include "FrameDestructionObserverInlines.h"
 #include "InstrumentingAgents.h"
 #include "LocalFrame.h"
 #include "Page.h"

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -34,6 +34,7 @@
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+LengthPercentageDefinitions.h"
 #include "CSSTokenizer.h"
+#include "DocumentQuirks.h"
 #include "DocumentSecurityOrigin.h"
 #include "DocumentView.h"
 #include "Element.h"

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -24,6 +24,7 @@
 #include "RenderTextFragment.h"
 
 #include "RenderBlock.h"
+#include "RenderInline.h"
 #include "RenderIterator.h"
 #include "RenderObjectInlines.h"
 #include "RenderMultiColumnFlow.h"

--- a/Source/WebCore/style/StyleSheetContentsCache.h
+++ b/Source/WebCore/style/StyleSheetContentsCache.h
@@ -40,7 +40,7 @@ class StyleSheetContentsCache {
 public:
     static StyleSheetContentsCache& NODELETE singleton();
 
-    using Key = std::pair<String, CSSParserContext>;
+    using Key = std::pair<WTF::String, CSSParserContext>;
 
     RefPtr<StyleSheetContents> get(const Key&);
     void add(Key&&, Ref<StyleSheetContents>);

--- a/Source/WebCore/style/values/images/kinds/StyleImageSet.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleImageSet.cpp
@@ -33,6 +33,7 @@
 #include "MIMETypeRegistry.h"
 #include "Page.h"
 #include "StyleInvalidImage.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -55,6 +55,7 @@
 #include <wtf/EnumTraits.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 


### PR DESCRIPTION
#### 892008ea276307ad7edb0380d74a03435f4c0664
<pre>
Fix non-unified builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=312506">https://bugs.webkit.org/show_bug.cgi?id=312506</a>

Reviewed by Claudio Saavedra.

Fix non-unified builds 04-16-2026

* Source/JavaScriptCore/runtime/ModuleGraphLoadingState.cpp:
* Source/JavaScriptCore/runtime/ModuleLoaderPayload.cpp:
* Source/WebCore/bindings/js/ScriptModuleLoader.h:
* Source/WebCore/html/LazyLoadVideoObserver.h:
* Source/WebCore/inspector/agents/frame/FrameWorkerAgent.cpp:
* Source/WebCore/page/IntersectionObserver.cpp:
* Source/WebCore/rendering/RenderTextFragment.cpp:
* Source/WebCore/style/StyleSheetContentsCache.h:
* Source/WebCore/style/values/images/kinds/StyleImageSet.cpp:
* Source/WebCore/workers/service/server/SWServer.cpp:

Canonical link: <a href="https://commits.webkit.org/311440@main">https://commits.webkit.org/311440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8be8c3d4a7d11af132293939004fc5af9b4a9f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121566 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102234 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22856 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21090 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13572 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149027 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168285 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17812 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12444 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129693 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129801 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35159 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140587 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87642 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24621 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17391 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188939 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29549 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93563 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48510 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29071 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->