### PR TITLE
ImageCapture: queue takePhoto() and applyConstraints() to avoid concurrent capture session reconfiguration

### DIFF
--- a/LayoutTests/fast/mediastream/image-capture-take-photo-expected.txt
+++ b/LayoutTests/fast/mediastream/image-capture-take-photo-expected.txt
@@ -5,4 +5,6 @@ PASS The image returned by 'takePhoto()' should be at least as big as { photoSet
 PASS If 'takePhoto()' has to reconfigure capture track, 'mute' and 'unmute' should fire and track size should be restored
 PASS 'applyConstraints()' should not run until 'takePhoto()' has completed
 PASS All queued 'takePhoto()' and 'applyConstraints()' calls should resolve or reject
+PASS All 10 rapidly queued 'takePhoto()' calls should resolve
+PASS Interleaved 'takePhoto()' and 'applyConstraints()' calls should all resolve
 

--- a/LayoutTests/fast/mediastream/image-capture-take-photo.html
+++ b/LayoutTests/fast/mediastream/image-capture-take-photo.html
@@ -154,6 +154,45 @@
 
         }, `All queued 'takePhoto()' and 'applyConstraints()' calls should resolve or reject`);
 
+        promise_test(async (test) => {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 320 } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+            const [track] = stream.getVideoTracks();
+            const imageCapture = new ImageCapture(track);
+
+            const promises = [];
+            for (let i = 0; i < 10; i++)
+                promises.push(imageCapture.takePhoto());
+
+            const blobs = await Promise.all(promises);
+            assert_equals(blobs.length, 10, "all 10 takePhoto() calls resolved");
+            for (let i = 0; i < blobs.length; i++)
+                assert_true(blobs[i] instanceof Blob, `result ${i} is a Blob`);
+
+        }, `All 10 rapidly queued 'takePhoto()' calls should resolve`);
+
+        promise_test(async (test) => {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 320 } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+            const [track] = stream.getVideoTracks();
+            const imageCapture = new ImageCapture(track);
+
+            const photoPromises = [];
+            const constraintPromises = [];
+            for (let i = 0; i < 5; i++) {
+                photoPromises.push(imageCapture.takePhoto());
+                constraintPromises.push(track.applyConstraints({ width: i % 2 === 0 ? 320 : 640 }));
+            }
+
+            const blobs = await Promise.all(photoPromises);
+            await Promise.all(constraintPromises);
+
+            assert_equals(blobs.length, 5, "all 5 takePhoto() calls resolved");
+            for (let i = 0; i < blobs.length; i++)
+                assert_true(blobs[i] instanceof Blob, `photo ${i} is a Blob`);
+
+        }, `Interleaved 'takePhoto()' and 'applyConstraints()' calls should all resolve`);
+
     </script>
 </body>
 </html>

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
@@ -482,6 +482,48 @@ auto RealtimeVideoCaptureSource::takePhoto(PhotoSettings&& photoSettings) -> Ref
         photoSettings.imageWidth = sanitizedSize.width();
     }
 
+    auto producer = makeUniqueRef<TakePhotoNativePromise::Producer>();
+    auto promise = producer->promise();
+    m_pendingOperations.append(PendingOperation { PendingPhotoCapture { WTF::move(photoSettings), WTF::move(producer) } });
+
+    if (!m_captureInFlight)
+        dispatchNextOperation();
+
+    return promise;
+}
+
+void RealtimeVideoCaptureSource::applyConstraints(const MediaConstraints& constraints, ApplyConstraintsHandler&& handler)
+{
+    ASSERT(isMainThread());
+    if (!m_captureInFlight && m_pendingOperations.isEmpty()) {
+        RealtimeMediaSource::applyConstraints(constraints, WTF::move(handler));
+        return;
+    }
+    m_pendingOperations.append(PendingOperation { PendingConstraintApplication { constraints, WTF::move(handler) } });
+}
+
+void RealtimeVideoCaptureSource::dispatchNextOperation()
+{
+    ASSERT(isMainThread());
+    ASSERT(!m_captureInFlight);
+
+    // Drain synchronous constraint applications at the front of the queue.
+    while (!m_pendingOperations.isEmpty()) {
+        if (!WTF::holdsAlternative<PendingConstraintApplication>(m_pendingOperations.first()))
+            break;
+        auto pending = std::get<PendingConstraintApplication>(m_pendingOperations.takeFirst());
+        RealtimeMediaSource::applyConstraints(pending.constraints, WTF::move(pending.handler));
+    }
+
+    if (m_pendingOperations.isEmpty())
+        return;
+
+    // Front of queue is a photo capture — dispatch it asynchronously.
+    m_captureInFlight = true;
+    auto pending = std::get<PendingPhotoCapture>(m_pendingOperations.takeFirst());
+    auto photoSettings = WTF::move(pending.settings);
+    auto producer = WTF::move(pending.producer);
+
     std::optional<CaptureSizeFrameRateAndZoom> newPresetForPhoto;
     if (photoSettings.imageHeight || photoSettings.imageWidth) {
         newPresetForPhoto = bestSupportedSizeFrameRateAndZoomConsideringObservers({ photoSettings.imageWidth, photoSettings.imageHeight, { }, { } });
@@ -511,21 +553,38 @@ auto RealtimeVideoCaptureSource::takePhoto(PhotoSettings&& photoSettings) -> Ref
         setSizeFrameRateAndZoomForPhoto(WTF::move(*newPresetForPhoto));
     }
 
-    return takePhotoInternal(WTF::move(photoSettings))->whenSettled(RunLoop::mainSingleton(), [this, protectedThis = Ref { *this }, configurationToRestore = WTF::move(configurationToRestore)] (auto&& result) mutable {
+    takePhotoInternal(WTF::move(photoSettings))->whenSettled(RunLoop::mainSingleton(),
+        [this, protectedThis = Ref { *this }, producer = WTF::move(producer), configurationToRestore = WTF::move(configurationToRestore)] (auto&& result) mutable {
 
-        ASSERT(isMainThread());
+            ASSERT(isMainThread());
 
-        if (configurationToRestore) {
-            setSizeFrameRateAndZoomForPhoto(WTF::move(*configurationToRestore));
+            m_captureInFlight = false;
 
-            if (m_mutedForPhotoCapture) {
-                m_mutedForPhotoCapture = false;
-                setMuted(false);
+            if (configurationToRestore) {
+                setSizeFrameRateAndZoomForPhoto(WTF::move(*configurationToRestore));
+
+                if (m_mutedForPhotoCapture) {
+                    m_mutedForPhotoCapture = false;
+                    setMuted(false);
+                }
             }
-        }
 
-        return TakePhotoNativePromise::createAndSettle(WTF::move(result));
-    });
+            producer->settle(WTF::move(result));
+
+            if (!m_pendingOperations.isEmpty())
+                dispatchNextOperation();
+        });
+}
+
+void RealtimeVideoCaptureSource::didEnd()
+{
+    auto pending = WTF::move(m_pendingOperations);
+    for (auto& operation : pending) {
+        WTF::switchOn(operation,
+            [](PendingPhotoCapture& photo)               { photo.producer->reject("Track ended"_s); },
+            [](PendingConstraintApplication& constraint) { constraint.handler({ }); }
+        );
+    }
 }
 
 void RealtimeVideoCaptureSource::ensureIntrinsicSizeMaintainsAspectRatio()

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
@@ -31,6 +31,7 @@
 #include <WebCore/OrientationNotifier.h>
 #include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/VideoPreset.h>
+#include <wtf/Deque.h>
 #include <wtf/Lock.h>
 #include <wtf/RunLoop.h>
 
@@ -51,6 +52,8 @@ public:
     Vector<VideoPresetData> presetsData();
 
     void ensureIntrinsicSizeMaintainsAspectRatio();
+
+    using RealtimeMediaSource::applyConstraints;
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
@@ -101,6 +104,20 @@ private:
 
     void orientationChanged(IntDegrees) override;
 
+    struct PendingPhotoCapture {
+        PhotoSettings settings;
+        UniqueRef<TakePhotoNativePromise::Producer> producer;
+    };
+    struct PendingConstraintApplication {
+        MediaConstraints constraints;
+        ApplyConstraintsHandler handler;
+    };
+    using PendingOperation = Variant<PendingPhotoCapture, PendingConstraintApplication>;
+
+    void dispatchNextOperation();
+    void applyConstraints(const MediaConstraints&, ApplyConstraintsHandler&&) override;
+    void didEnd() override;
+
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const override { return "RealtimeVideoCaptureSource"_s; }
 #endif
@@ -110,6 +127,8 @@ private:
     Deque<double> m_observedFrameTimeStamps;
     double m_observedFrameRate { 0 };
     bool m_mutedForPhotoCapture { false };
+    Deque<PendingOperation> m_pendingOperations;
+    bool m_captureInFlight { false };
 };
 
 struct SizeFrameRateAndZoom {

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -266,14 +266,25 @@ const RealtimeMediaSourceCapabilities& MockRealtimeVideoSource::capabilities()
 
 auto MockRealtimeVideoSource::takePhotoInternal(PhotoSettings&&) -> Ref<TakePhotoNativePromise>
 {
+    if (m_isTakingPhoto)
+        return TakePhotoNativePromise::createAndReject("Already taking photo"_s);
+
     {
         Locker lock { m_imageBufferLock };
         invalidateDrawingState();
     }
 
+    m_isTakingPhoto = true;
     return invokeAsync(m_runLoop, [this, protectedThis = Ref { *this }] () mutable {
-        if (auto currentImage = generatePhoto())
+        auto currentImage = generatePhoto();
+        m_isTakingPhoto = false;
+
+        if (m_captureWasInterrupted.exchange(false))
+            return TakePhotoNativePromise::createAndReject("Capture interrupted by session reconfiguration"_s);
+
+        if (currentImage)
             return TakePhotoNativePromise::createAndResolve(std::make_pair(encodeData(WTF::move(currentImage), "image/png"_s, std::nullopt), "image/png"_s));
+
         return TakePhotoNativePromise::createAndReject("Failed to capture photo"_s);
     });
 }
@@ -809,6 +820,8 @@ void MockRealtimeVideoSource::triggerCameraConfigurationChange()
 void MockRealtimeVideoSource::startApplyingConstraints()
 {
     ASSERT(!m_beingConfigured);
+    if (m_isTakingPhoto)
+        m_captureWasInterrupted = true;
     m_beingConfigured = true;
 }
 

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -38,6 +38,7 @@
 #include <WebCore/MockMediaDevice.h>
 #include <WebCore/RealtimeMediaSourceFactory.h>
 #include <WebCore/RealtimeVideoCaptureSource.h>
+#include <atomic>
 #include <wtf/Lock.h>
 #include <wtf/RunLoop.h>
 
@@ -175,6 +176,8 @@ private:
     std::optional<PhotoSettings> m_photoSettings;
     bool m_beingConfigured { false };
     bool m_isUsingRotationAngleForHorizonLevelDisplayChanged { false };
+    bool m_isTakingPhoto { false };
+    std::atomic<bool> m_captureWasInterrupted { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 253f33f069cf75743106931a7b6a698a9bcede2f
<pre>
ImageCapture: queue takePhoto() and applyConstraints() to avoid concurrent capture session reconfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=312508">https://bugs.webkit.org/show_bug.cgi?id=312508</a>
<a href="https://rdar.apple.com/174950018">rdar://174950018</a>

Reviewed by Youenn Fablet.

`takePhoto()` reconfigures the MediaStreamTrack when the requested photo size requires
a different preset, and `applyConstraints()` reconfigures it whenever size, frame rate,
or zoom constraints change. If either fires while a takePhoto() capture is in-flight
on the Cocoa port, the concurrent reconfiguration causes AVFoundation to fail with
AVErrorUnknown (-11800).

Fix this by adding a pending operation queue to RealtimeVideoCaptureSource, so we can
serialize all calls to `applyConstraoints` and `takePhoto`.

MockRealtimeVideoSource tracks when a photo is being taken and rejects the pending
promise if a call to `takePhoto` or `applyConstraints` happens while a photo capture
is pending. This acts as a regression guard in case queue serialization in
RealtimeVideoCaptureSource is removed or broken.

No new test, fast/mediastream/image-capture-take-photo.html was updated for these changes.

* LayoutTests/fast/mediastream/image-capture-take-photo-expected.txt:
* LayoutTests/fast/mediastream/image-capture-take-photo.html:
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::RealtimeVideoCaptureSource::takePhoto):
(WebCore::RealtimeVideoCaptureSource::applyConstraints):
(WebCore::RealtimeVideoCaptureSource::dispatchNextOperation):
(WebCore::RealtimeVideoCaptureSource::didEnd):
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h:
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::takePhotoInternal):
(WebCore::MockRealtimeVideoSource::startApplyingConstraints):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:

Canonical link: <a href="https://commits.webkit.org/312196@main">https://commits.webkit.org/312196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6932312ba7467a8efe5e3beea119ddb3383fa3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113230 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123291 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86566 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103957 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24612 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23039 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15748 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170470 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16210 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131485 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131597 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35601 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142525 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90257 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19334 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31718 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97732 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31238 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31511 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->