### PR TITLE
[JSC] Suppress -Wunsafe-buffer-usage warnings

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp
@@ -56,6 +56,7 @@ InlineCacheHandler::InlineCacheHandler()
     disableThreadingChecks();
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 InlineCacheHandler::InlineCacheHandler(bool makesJSCalls, Ref<InlineCacheHandler>&& previous, Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&& watchpoint, CacheType cacheType)
     : m_callTarget(stubRoutine->code().code().template retagged<JITStubRoutinePtrTag>())
     , m_jumpTarget(CodePtr<NoPtrTag> { m_callTarget.retagged<NoPtrTag>().dataLocation<uint8_t*>() + prologueSizeInBytesDataIC }.template retagged<JITStubRoutinePtrTag>())
@@ -67,6 +68,7 @@ InlineCacheHandler::InlineCacheHandler(bool makesJSCalls, Ref<InlineCacheHandler
 {
     disableThreadingChecks();
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 InlineCacheHandlerWithJSCall::InlineCacheHandlerWithJSCall(Ref<InlineCacheHandler>&& previous, Ref<PolymorphicAccessJITStubRoutine>&& stubRoutine, std::unique_ptr<PropertyInlineCacheClearingWatchpoint>&& watchpoint, CacheType cacheType)
     : InlineCacheHandler(true, WTF::move(previous), WTF::move(stubRoutine), WTF::move(watchpoint), cacheType)
@@ -192,6 +194,7 @@ Ref<InlineCacheHandler> InlineCacheHandler::createNonHandlerSlowPath(CodePtr<JIT
     return result;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 Ref<InlineCacheHandler> InlineCacheHandler::createSlowPath(VM& vm, AccessType accessType)
 {
     auto result = adoptRef(*new InlineCacheHandler);
@@ -200,6 +203,7 @@ Ref<InlineCacheHandler> InlineCacheHandler::createSlowPath(VM& vm, AccessType ac
     result->m_jumpTarget = CodePtr<NoPtrTag> { codeRef.retaggedCode<NoPtrTag>().dataLocation<uint8_t*>() + prologueSizeInBytesDataIC }.template retagged<JITStubRoutinePtrTag>();
     return result;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 Ref<InlineCacheHandler> InlineCacheCompiler::generateSlowPathHandler(VM& vm, AccessType accessType)
 {

--- a/Source/JavaScriptCore/runtime/MarkedVector.cpp
+++ b/Source/JavaScriptCore/runtime/MarkedVector.cpp
@@ -166,21 +166,25 @@ auto MarkedVectorBase::expandCapacity(unsigned newCapacity) -> Status
         return Status::Overflowed;
 #if CPU(ADDRESS32)
     if (m_storageType != StorageType::JSValue) {
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         auto* newPointerBuffer = std::bit_cast<void**>(newBuffer);
         const auto* oldPointerBuffer = std::bit_cast<void**>(m_buffer);
         for (unsigned i = 0; i < m_size; ++i) {
             newPointerBuffer[i] = oldPointerBuffer[i];
             addMarkSet(oldPointerBuffer[i]);
         }
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     } else
 #endif
     {
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         auto* newJSValueBuffer = std::bit_cast<EncodedJSValue*>(newBuffer);
         const auto* oldJSValueBuffer = std::bit_cast<EncodedJSValue*>(m_buffer);
         for (unsigned i = 0; i < m_size; ++i) {
             newJSValueBuffer[i] = oldJSValueBuffer[i];
             addMarkSet(JSValue::decode(oldJSValueBuffer[i]));
         }
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     if (EncodedJSValue* base = mallocBase())


### PR DESCRIPTION
#### 92526e91925a340c038a992cc96046000db76905
<pre>
[JSC] Suppress -Wunsafe-buffer-usage warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=312509">https://bugs.webkit.org/show_bug.cgi?id=312509</a>

Reviewed by Yusuke Suzuki.

Wrap unsafe pointer arithmetic with WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN/END in
two JSC files that trigger -Werror,-Wunsafe-buffer-usage with clang

- InlineCacheHandler: m_jumpTarget computation offsets a CodePtr via
  dataLocation&lt;uint8_t*&gt;() + prologueSizeInBytesDataIC.
- MarkedVector: expandCapacity() uses raw pointer indexing to copy buffer
  contents during reallocation.

* Source/JavaScriptCore/bytecode/InlineCacheHandler.cpp:
* Source/JavaScriptCore/runtime/MarkedVector.cpp:
(JSC::MarkedVectorBase::expandCapacity):

Canonical link: <a href="https://commits.webkit.org/311560@main">https://commits.webkit.org/311560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12e2db216b5d8fc73b947166c02224df814a3584

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165704 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110963 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121510 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85325 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102178 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22790 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21014 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13476 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148931 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168189 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17716 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12348 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129625 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29819 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129732 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29742 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140504 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87546 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23932 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24559 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17308 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188843 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29452 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93467 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48496 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28975 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->