### PR TITLE
[JSC][JSPI] Scan PinballCompletion conservative roots via a GC marking constraint

### DIFF
--- a/JSTests/wasm/stress/jspi-gc-abandoned-suspensions.js
+++ b/JSTests/wasm/stress/jspi-gc-abandoned-suspensions.js
@@ -1,0 +1,55 @@
+//@ requireOptions("--useJSPI=1")
+
+import { instantiate } from "../wabt-wrapper.js"
+
+// When a suspending promise is abandoned without being resolved, the associated objects
+// should be garbage-collected even if there are reference cycles from conservative roots
+// on the evacuated stack back to the suspending promise.
+
+let wat = `
+(module
+  (import "env" "suspend" (func $suspend (param externref) (result i32)))
+  (func $entry (export "entry") (param $obj externref) (result i32)
+    local.get $obj
+    call $suspend
+  )
+)`;
+
+const count = 200;
+let weakRefs = [];
+
+{
+    const instance = await instantiate(wat, {
+        env: {
+            suspend: new WebAssembly.Suspending(function (obj) {
+                let promise = new Promise(() => {});
+                obj.promise = promise;
+                return promise;
+            })
+        }
+    });
+    const entry = WebAssembly.promising(instance.exports.entry);
+
+    for (let i = 0; i < count; i++) {
+        let obj = { index: i };
+        weakRefs.push(new WeakRef(obj));
+        entry(obj);
+        // Don't store the returned promise — abandon it immediately.
+    }
+}
+// instance, entry, obj, and all promises are now unreferenced.
+
+// Use setTimeout to cross a job boundary (required by the WeakRef spec
+// for targets to become clearable), then trigger a full GC.
+setTimeout(() => {
+    fullGC();
+
+    let collected = 0;
+    for (let weakRef of weakRefs) {
+        if (weakRef.deref() === undefined)
+            collected++;
+    }
+
+    if (collected == 0)
+        throw new Error("Expected at least some abandoned JSPI objects to be collected, but none were");
+}, 0);

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -4051,6 +4051,7 @@
 		23A3568F2E9790F40039C82A /* PinballCompletion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PinballCompletion.cpp; sourceTree = "<group>"; };
 		23A969692E95A903005A36F5 /* EvacuatedStack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EvacuatedStack.h; sourceTree = "<group>"; };
 		23A9696A2E95A903005A36F5 /* EvacuatedStack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EvacuatedStack.cpp; sourceTree = "<group>"; };
+		23CD2E2C2F908FC900119878 /* PinballHandlerContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PinballHandlerContext.cpp; sourceTree = "<group>"; };
 		23D7A3E02F3D0F4C00A27B88 /* JSPIContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSPIContext.h; sourceTree = "<group>"; };
 		23D7A3E12F3D0F4C00A27B88 /* JSPIContextInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSPIContextInlines.h; sourceTree = "<group>"; };
 		24FF4DFDAD3D4D97BE486930 /* JSCTimeZone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCTimeZone.h; sourceTree = "<group>"; };
@@ -9238,6 +9239,7 @@
 				37C738D11EDB5672003F2B0B /* ParseInt.h */,
 				23A3568F2E9790F40039C82A /* PinballCompletion.cpp */,
 				23A3568E2E9790F40039C82A /* PinballCompletion.h */,
+				23CD2E2C2F908FC900119878 /* PinballHandlerContext.cpp */,
 				8791D173F2EE43A7E6469029 /* PinballHandlerContext.h */,
 				CE20BD02237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.cpp */,
 				CE20BD01237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.h */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1030,6 +1030,7 @@ runtime/Options.cpp
 runtime/OrderedHashTable.cpp
 runtime/PageCount.cpp
 runtime/PinballCompletion.cpp
+runtime/PinballHandlerContext.cpp
 runtime/PredictionFileCreatingFuzzerAgent.cpp
 runtime/PrivateFieldPutKind.cpp
 runtime/ProfilerSupport.cpp

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -906,10 +906,7 @@ void Heap::gatherVMRoots(ConservativeRoots& roots)
         vm.scanSideState(roots);
     }
 #endif
-#if ENABLE(WEBASSEMBLY)
-    vm.gatherEvacuatedStackRoots(roots);
-#endif
-#if !(ENABLE(DFG_JIT) || ENABLE(WEBASSEMBLY))
+#if !ENABLE(DFG_JIT)
     UNUSED_PARAM(roots);
     UNUSED_VARIABLE(vm);
 #endif
@@ -3139,7 +3136,36 @@ void Heap::addCoreConstraints()
         })),
         ConstraintVolatility::GreyedByMarking,
         ConstraintParallelism::Parallel);
-    
+
+#if ENABLE(WEBASSEMBLY)
+    m_constraintSet->add(
+        "Pbc", "Pinball Completions",
+        MAKE_MARKING_CONSTRAINT_EXECUTOR_PAIR(([this] (auto& visitor) {
+            // FIXME: Unlike the "Cs" constraint which is skipped during verification
+            // because conservative roots are not stable, this skip is only here because
+            // ConservativeRoots::genericAddPointer asserts isMarking(), which doesn't
+            // hold during verification. This constraint could run always otherwise, but
+            // that would require rethinking the assumptions in ConservativeRoots.
+            if (m_isMarkingForGCVerifier)
+                return;
+            IsoSubspace* subspace = m_pinballCompletionSpace.get();
+            if (!subspace)
+                return;
+            ASSERT(worldIsStopped());
+            // FIXME: Add a second CellState for PinballCompletion so we can skip
+            // pinballs whose conservative roots have already been gathered this cycle.
+            ConservativeRoots conservativeRoots(*this);
+            subspace->forEachMarkedCell([&](HeapCell* cell, HeapCell::Kind) {
+                auto* pinball = uncheckedDowncast<PinballCompletion>(static_cast<JSCell*>(cell));
+                pinball->gatherConservativeRoots(conservativeRoots);
+            });
+            SetRootMarkReasonScope rootScope(visitor, RootMarkReason::PinballCompletionConservativeRoots);
+            visitor.append(conservativeRoots);
+        })),
+        ConstraintVolatility::GreyedByMarking,
+        ConstraintConcurrency::Sequential);
+#endif
+
 #if ENABLE(JIT)
     if (Options::useJIT()) {
         m_constraintSet->add(

--- a/Source/JavaScriptCore/runtime/PinballCompletion.cpp
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "ConservativeRoots.h"
 #include "EvacuatedStack.h"
 #include "Exception.h"
 #include "JSCellInlines.h"
@@ -52,12 +53,6 @@ PinballCompletion* PinballCompletion::create(VM& vm, Vector<std::unique_ptr<Evac
 {
     Structure* structure = vm.pinballCompletionStructure.get();
     auto* instance = new (NotNull, allocateCell<PinballCompletion>(vm)) PinballCompletion(vm, structure, WTF::move(slices), calleeSaves, resultPromise);
-    for (auto& slice : instance->m_slices)
-        vm.addEvacuatedStackSlice(slice.get());
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    vm.addEvacuatedCalleeSaves(std::span(instance->m_calleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     instance->finishCreation(vm);
     return instance;
 }
@@ -70,16 +65,6 @@ PinballCompletion::PinballCompletion(VM& vm, Structure* structure, Vector<std::u
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memcpySpan(std::span(m_calleeSaves), std::span(calleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-}
-
-PinballCompletion::~PinballCompletion()
-{
-    VM& vm = this->vm();
-    for (auto& slice : m_slices)
-        vm.removeEvacuatedStackSlice(slice.get());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    vm.removeEvacuatedCalleeSaves(std::span(m_calleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS));
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
@@ -96,6 +81,19 @@ void PinballCompletion::assimilate(PinballCompletion* other)
     m_slices = WTF::move(other->m_slices);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+void PinballCompletion::gatherConservativeRoots(ConservativeRoots& roots)
+{
+    for (auto& slice : m_slices) {
+        std::span<Register> slots = slice->slots();
+        roots.add(slots.data(), slots.data() + slots.size());
+    }
+    roots.add(m_calleeSaves, m_calleeSaves + NUMBER_OF_CALLEE_SAVES_REGISTERS);
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 template<typename Visitor>
 void PinballCompletion::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
@@ -104,8 +102,8 @@ void PinballCompletion::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(thisObject, visitor);
 
     visitor.append(thisObject->m_resultPromise);
-    // Evacuated stack slices are registered with the VM and are added to conservative roots,
-    // so no need to do anything about them here.
+    // Evacuated stack slices and callee saves are conservatively scanned by the "Pbc"
+    // constraint in Heap::addCoreConstraints() when this cell is marked.
 }
 
 DEFINE_VISIT_CHILDREN(PinballCompletion);
@@ -150,46 +148,18 @@ extern "C" void SYSV_ABI pinballHandlerImplantSlice(PinballHandlerContext*, Regi
 extern "C" UCPURegister SYSV_ABI pinballHandlerFulfillFunctionContinue(PinballHandlerContext*);
 extern "C" void SYSV_ABI pinballHandlerFinishReject(PinballHandlerContext*);
 
-static void pinballHandlerInitContext(JSGlobalObject* globalObject, CallFrame* callFrame, PinballHandlerContext* context)
-{
-    VM& vm = globalObject->vm();
-    JSFunctionWithFields* self = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
-
-    ASSERT(callFrame->argumentCount() == 1);
-    PinballCompletion* pinball = uncheckedDowncast<PinballCompletion>(self->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
-    ASSERT(pinball->hasSlices());
-#if ASSERT_ENABLED
-    context->magic = 0xBA11FEED;
-#endif
-    context->globalObject = globalObject;
-    context->vm = &vm;
-    context->handler = self;
-    new (&context->jspiContext) JSPIContext(JSPIContext::Purpose::Completing, vm, callFrame, pinball->resultPromise());
-    new (&context->slice) std::unique_ptr<EvacuatedStackSlice>(pinball->takeTopSlice()); // context is uninitialized, can't assign
-    context->sliceByteSize = context->slice->size() * sizeof(Register);
-    ASSERT(!(context->sliceByteSize % stackAlignmentBytes())); // asm code assumes alignment is not needed
-    context->evacuatedCalleeSaves = pinball->calleeSaves();
-#if ASSERT_ENABLED
-    zeroSpan(std::span(context->arguments));
-#endif
-}
-
 void pinballHandlerInitContextForFulfill(JSGlobalObject* globalObject, CallFrame* callFrame, PinballHandlerContext* context)
 {
-    pinballHandlerInitContext(globalObject, callFrame, context);
     ASSERT(callFrame->argumentCount() == 1);
+    new (context) PinballHandlerContext(globalObject, callFrame);
     context->arguments[0] = JSValue::encode(callFrame->argument(0));
 }
 
 void pinballHandlerInitContextForReject(JSGlobalObject* globalObject, CallFrame* callFrame, PinballHandlerContext* context)
 {
-#if ASSERT_ENABLED
-    JSFunctionWithFields* self = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
-    PinballCompletion* pinball = uncheckedDowncast<PinballCompletion>(self->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
-    ASSERT(pinball->slices().size() == 1); // exceptions are only supported with slab slicing, expecting 1 slice
-#endif
-
-    pinballHandlerInitContext(globalObject, callFrame, context);
+    ASSERT(callFrame->argumentCount() == 1);
+    new (context) PinballHandlerContext(globalObject, callFrame);
+    ASSERT(context->pinball->slices().size() == 1); // exceptions are only supported with slab slicing, expecting 1 slice
     JSValue reason = callFrame->argument(0);
 
     context->zombieFrameCallee = globalObject->zombieFrameCallee();
@@ -198,22 +168,14 @@ void pinballHandlerInitContextForReject(JSGlobalObject* globalObject, CallFrame*
 
 void pinballHandlerImplantSlice(PinballHandlerContext* context, Register *base, CallFrame* sentinelFrame, CallerFrameAndPC* returnFrame)
 {
-    ASSERT(context->magic == 0xBA11FEED);
-    VM& vm = context->globalObject->vm();
-    PinballCompletion* pinball = uncheckedDowncast<PinballCompletion>(context->handler->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
+    ASSERT(context->magic == PinballHandlerContext::expectedMagic);
 
-    auto* slice = context->slice.get();
+    auto slice = context->pinball->takeTopSlice();
     CallFrame* bottommostImplantedFrame = slice->implant(base, sentinelFrame);
     returnFrame->callerFrame = bottommostImplantedFrame;
-    auto* originalDiscriminator = saltedDiscriminator(reinterpret_cast<const void*>(slice));
+    auto* originalDiscriminator = saltedDiscriminator(reinterpret_cast<const void*>(slice.get()));
     auto* newDiscriminator = reinterpret_cast<const void*>(returnFrame + 1);
     returnFrame->returnPC = relocateReturnPC(const_cast<void*>(slice->entryPC()), originalDiscriminator, newDiscriminator);
-
-    vm.removeEvacuatedStackSlice(slice); // the slice data is now scanned as part of the stack
-    context->slice.reset();
-    // At this point callee saves have been loaded into the registers and it is safe for the VM to forget them.
-    // We end up doing it multiple times, which is okay. Repeat removals do nothing.
-    vm.removeEvacuatedCalleeSaves(std::span(pinball->calleeSaves(), NUMBER_OF_CALLEE_SAVES_REGISTERS));
 }
 
 // After the execution of a slice returns, determine how to proceed.
@@ -223,13 +185,12 @@ void pinballHandlerImplantSlice(PinballHandlerContext* context, Register *base, 
 // false means execution completed, the result promise has been resolved, and the driver should exit.
 UCPURegister pinballHandlerFulfillFunctionContinue(PinballHandlerContext* context)
 {
-    ASSERT(context->magic == 0xBA11FEED);
-    ASSERT(!context->slice);
+    ASSERT(context->magic == PinballHandlerContext::expectedMagic);
 
     VM& vm = *context->vm;
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSPIContext& jspiContext = context->jspiContext;
-    PinballCompletion* pinball = uncheckedDowncast<PinballCompletion>(context->handler->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
+    PinballCompletion* pinball = context->pinball;
 
     if (jspiContext.completion) {
         // Computation was suspended again; the remainder of this completion should be added to the new one.
@@ -242,8 +203,7 @@ UCPURegister pinballHandlerFulfillFunctionContinue(PinballHandlerContext* contex
 
     if (pinball->hasSlices()) {
         RELEASE_ASSERT(!scope.exception()); // multi-slice completion is not yet prepared to handle exceptions; we should never encounter one at this point
-        context->slice = pinball->takeTopSlice();
-        context->sliceByteSize = context->slice->size() * sizeof(Register);
+        context->sliceByteSize = pinball->topSlice()->size() * sizeof(Register);
         return 1;
     }
 
@@ -265,13 +225,12 @@ UCPURegister pinballHandlerFulfillFunctionContinue(PinballHandlerContext* contex
 
 void pinballHandlerFinishReject(PinballHandlerContext* context)
 {
-    ASSERT(context->magic == 0xBA11FEED);
-    ASSERT(!context->slice);
+    ASSERT(context->magic == PinballHandlerContext::expectedMagic);
 
     VM& vm = *context->vm;
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSPIContext& jspiContext = context->jspiContext;
-    PinballCompletion* pinball = uncheckedDowncast<PinballCompletion>(context->handler->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
+    PinballCompletion* pinball = context->pinball;
     ASSERT(!pinball->hasSlices());
 
     if (jspiContext.completion) {

--- a/Source/JavaScriptCore/runtime/PinballCompletion.h
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.h
@@ -34,6 +34,8 @@
 
 namespace JSC {
 
+class ConservativeRoots;
+
 // Orchestrates incremental slice-by-slice return for JSPI to pass the result of a
 // resolved promise through a series of synchronous code frames, with the value produced
 // by that code ultimately used to resolve another promise. "Pinball" because instead of
@@ -61,18 +63,20 @@ public:
 
     Vector<std::unique_ptr<EvacuatedStackSlice>>& slices() LIFETIME_BOUND { return m_slices; }
     std::unique_ptr<EvacuatedStackSlice> takeTopSlice() { return m_slices.takeLast(); }
+    EvacuatedStackSlice* topSlice() { return m_slices.last().get(); }
     bool hasSlices() const { return !m_slices.isEmpty(); }
 
     CPURegister* calleeSaves() { return m_calleeSaves; }
 
     void assimilate(PinballCompletion*);
+    void gatherConservativeRoots(ConservativeRoots&);
 
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
 
 private:
     PinballCompletion(VM&, Structure*, Vector<std::unique_ptr<EvacuatedStackSlice>>&& slices, CPURegister* calleeSaves, JSPromise* resultPromise);
-    ~PinballCompletion();
+    ~PinballCompletion() = default;
 
     Vector<std::unique_ptr<EvacuatedStackSlice>> m_slices;
     CPURegister m_calleeSaves[NUMBER_OF_CALLEE_SAVES_REGISTERS];

--- a/Source/JavaScriptCore/runtime/PinballHandlerContext.cpp
+++ b/Source/JavaScriptCore/runtime/PinballHandlerContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021, 2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,48 +23,38 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "PinballHandlerContext.h"
 
-#include <wtf/Forward.h>
+#if ENABLE(WEBASSEMBLY)
+
+#include "CallFrame.h"
+#include "JSCellInlines.h"
+#include "JSFunctionWithFields.h"
+#include "JSPIContextInlines.h"
+#include "PinballCompletion.h"
+#include "StackAlignment.h"
+
+#include <wtf/StdLibExtras.h>
 
 namespace JSC {
 
-#define FOR_EACH_ROOT_MARK_REASON(v) \
-    v(None) \
-    v(ConservativeScan) \
-    v(ExecutableToCodeBlockEdges) \
-    v(ExternalRememberedSet) \
-    v(StrongReferences) \
-    v(ProtectedValues) \
-    v(MarkListSet) \
-    v(VMExceptions) \
-    v(StrongHandles) \
-    v(Debugger) \
-    v(JITStubRoutines) \
-    v(WeakMapSpace) \
-    v(WeakSets) \
-    v(Output) \
-    v(JITWorkList) \
-    v(CodeBlocks) \
-    v(DOMGCOutput) \
-    v(PinballCompletionConservativeRoots)
-
-#define DECLARE_ROOT_MARK_REASON(reason) reason,
-
-enum class RootMarkReason : uint8_t {
-    FOR_EACH_ROOT_MARK_REASON(DECLARE_ROOT_MARK_REASON)
-};
-
-#undef DECLARE_ROOT_MARK_REASON
-
-ASCIILiteral rootMarkReasonDescription(RootMarkReason);
+PinballHandlerContext::PinballHandlerContext(JSGlobalObject* globalObject, CallFrame* callFrame)
+    : globalObject(globalObject)
+    , vm(&globalObject->vm())
+    , handler(uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee()))
+    , pinball(uncheckedDowncast<PinballCompletion>(handler->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion)))
+    , sliceByteSize(pinball->topSlice()->size() * sizeof(Register))
+    , jspiContext(JSPIContext::Purpose::Completing, *vm, callFrame, pinball->resultPromise())
+    , evacuatedCalleeSaves(pinball->calleeSaves())
+{
+    ASSERT(pinball->hasSlices());
+    ASSERT(!(sliceByteSize % stackAlignmentBytes()));
+#if ASSERT_ENABLED
+    zeroSpan(std::span(arguments));
+#endif
+}
 
 } // namespace JSC
 
-namespace WTF {
-
-class PrintStream;
-
-void printInternal(PrintStream&, JSC::RootMarkReason);
-
-} // namespace WTF
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/PinballHandlerContext.h
+++ b/Source/JavaScriptCore/runtime/PinballHandlerContext.h
@@ -31,32 +31,33 @@
 #include <JavaScriptCore/GPRInfo.h>
 #include <JavaScriptCore/JSPIContext.h>
 
-#include <memory>
-
 namespace JSC {
 
-class EvacuatedStackSlice;
 class Exception;
+class PinballCompletion;
+class CallFrame;
 class JSCallee;
 class JSFunctionWithFields;
 class JSGlobalObject;
-class Register;
 
 // Allocated on the stack by assembly entry points of fulfill and reject handlers of a suspension promise.
 // Holds all state shared by assembly and C++ code implementing the fulfillment or rejection.
 
 struct PinballHandlerContext final {
-    WTF_FORBID_HEAP_ALLOCATION;
+    WTF_FORBID_HEAP_ALLOCATION_ALLOWING_PLACEMENT_NEW;
 public:
+    PinballHandlerContext(JSGlobalObject*, CallFrame*);
+
     static constexpr size_t NumberOfWasmArgumentRegisters = GPRInfo::numberOfArgumentRegisters + FPRInfo::numberOfArgumentRegisters;
 
 #if ASSERT_ENABLED
-    size_t magic;
+    static constexpr size_t expectedMagic = 0xBA11FEED;
+    size_t magic { expectedMagic };
 #endif
     JSGlobalObject* globalObject;
     VM* vm;
     JSFunctionWithFields* handler;
-    std::unique_ptr<EvacuatedStackSlice> slice;
+    PinballCompletion* pinball;
     size_t sliceByteSize;
     JSPIContext jspiContext;
     // Callee saves to restore before entering the evacuated code (points into the PinballCompletion held by the handler).

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
@@ -280,4 +280,44 @@ String TemporalPlainYearMonth::monthCode() const
     return ISO8601::monthCode(m_plainYearMonth.month());
 }
 
+// https://tc39.es/proposal-temporal/#sec-temporal-adddurationtoyearmonth
+template<AddOrSubtract op>
+ISO8601::PlainYearMonth TemporalPlainYearMonth::addDurationToYearMonth(JSGlobalObject* globalObject, ISO8601::PlainYearMonth yearMonth, ISO8601::Duration duration, TemporalOverflow overflow)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if constexpr (op == AddOrSubtract::Subtract)
+        duration = -duration;
+    auto sign = TemporalDuration::sign(duration);
+    auto year = yearMonth.year();
+    auto month = yearMonth.month();
+    auto constexpr day = 1;
+    auto intermediateDate = ISO8601::PlainDate(year, month, day);
+    if (!ISO8601::isDateTimeWithinLimits(year, month, day, 0, 0, 0, 0, 0, 0)) [[unlikely]] {
+        throwRangeError(globalObject, scope, "date out of range in add or subtract"_s);
+        return { };
+    }
+    ISO8601::PlainDate date;
+    if (sign < 0) {
+        auto oneMonthDuration = ISO8601::Duration { 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 };
+        auto nextMonth = TemporalCalendar::isoDateAdd(globalObject,
+            intermediateDate, oneMonthDuration, TemporalOverflow::Constrain);
+        RETURN_IF_EXCEPTION(scope, { });
+        int32_t y = nextMonth.year();
+        uint8_t m = nextMonth.month();
+        uint8_t d = nextMonth.day() - 1;
+        date = TemporalCalendar::balanceISODate(globalObject, y, m, d);
+    } else
+        date = intermediateDate;
+    auto durationToAdd = TemporalDuration::toDateDurationRecordWithoutTime(globalObject, duration);
+    RETURN_IF_EXCEPTION(scope, { });
+    auto addedDate = TemporalCalendar::isoDateAdd(globalObject, date, durationToAdd, overflow);
+    RETURN_IF_EXCEPTION(scope, { });
+    return ISO8601::PlainYearMonth(addedDate.year(), addedDate.month());
+}
+
+template ISO8601::PlainYearMonth TemporalPlainYearMonth::addDurationToYearMonth<AddOrSubtract::Add>(JSGlobalObject*, ISO8601::PlainYearMonth, ISO8601::Duration, TemporalOverflow);
+template ISO8601::PlainYearMonth TemporalPlainYearMonth::addDurationToYearMonth<AddOrSubtract::Subtract>(JSGlobalObject*, ISO8601::PlainYearMonth, ISO8601::Duration, TemporalOverflow);
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
@@ -86,41 +86,4 @@ private:
     LazyProperty<TemporalPlainYearMonth, TemporalCalendar> m_calendar;
 };
 
-// https://tc39.es/proposal-temporal/#sec-temporal-adddurationtoyearmonth
-template<AddOrSubtract op>
-ISO8601::PlainYearMonth TemporalPlainYearMonth::addDurationToYearMonth(JSGlobalObject* globalObject, ISO8601::PlainYearMonth yearMonth, ISO8601::Duration duration, TemporalOverflow overflow)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if constexpr (op == AddOrSubtract::Subtract)
-        duration = -duration;
-    auto sign = TemporalDuration::sign(duration);
-    auto year = yearMonth.year();
-    auto month = yearMonth.month();
-    auto constexpr day = 1;
-    auto intermediateDate = ISO8601::PlainDate(year, month, day);
-    if (!ISO8601::isDateTimeWithinLimits(year, month, day, 0, 0, 0, 0, 0, 0)) [[unlikely]] {
-        throwRangeError(globalObject, scope, "date out of range in add or subtract"_s);
-        return { };
-    }
-    ISO8601::PlainDate date;
-    if (sign < 0) {
-        auto oneMonthDuration = ISO8601::Duration { 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 };
-        auto nextMonth = TemporalCalendar::isoDateAdd(globalObject,
-            intermediateDate, oneMonthDuration, TemporalOverflow::Constrain);
-        RETURN_IF_EXCEPTION(scope, { });
-        int32_t y = nextMonth.year();
-        uint8_t m = nextMonth.month();
-        uint8_t d = nextMonth.day() - 1;
-        date = TemporalCalendar::balanceISODate(globalObject, y, m, d);
-    } else
-        date = intermediateDate;
-    auto durationToAdd = TemporalDuration::toDateDurationRecordWithoutTime(globalObject, duration);
-    RETURN_IF_EXCEPTION(scope, { });
-    auto addedDate = TemporalCalendar::isoDateAdd(globalObject, date, durationToAdd, overflow);
-    RETURN_IF_EXCEPTION(scope, { });
-    return ISO8601::PlainYearMonth(addedDate.year(), addedDate.month());
-}
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -49,7 +49,6 @@
 #include "Disassembler.h"
 #include "DoublePredictionFuzzerAgent.h"
 #include "ErrorInstance.h"
-#include "EvacuatedStack.h"
 #include "EvalCodeBlockInlines.h"
 #include "EvalExecutableInlines.h"
 #include "Exception.h"
@@ -1205,21 +1204,6 @@ void VM::scanSideState(ConservativeRoots& roots) const
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif // ENABLE(DFG_JIT)
 
-#if ENABLE(WEBASSEMBLY)
-
-void VM::gatherEvacuatedStackRoots(ConservativeRoots& roots)
-{
-    ASSERT(heap.worldIsStopped());
-    for (auto* slice : m_evacuatedStackSlices) {
-        std::span<Register> slots = slice->slots();
-        roots.add(slots.data(), slots.data() + slots.size());
-    }
-    for (const auto& span : m_evacuatedCalleeSaves)
-        roots.add(span.data(), span.data() + span.size());
-}
-
-#endif // ENABLE(WEBASSEMBLY)
-
 void VM::pushCheckpointOSRSideState(std::unique_ptr<CheckpointOSRExitSideState>&& payload)
 {
     ASSERT(currentThreadIsHoldingAPILock());
@@ -1572,32 +1556,6 @@ bool VM::isScratchBuffer(void* ptr)
             return true;
     }
     return false;
-}
-
-void VM::addEvacuatedStackSlice(EvacuatedStackSlice* slice)
-{
-    ASSERT(currentThreadIsHoldingAPILock());
-    m_evacuatedStackSlices.append(slice);
-}
-
-void VM::removeEvacuatedStackSlice(EvacuatedStackSlice* slice)
-{
-    ASSERT(currentThreadIsHoldingAPILock());
-    m_evacuatedStackSlices.removeAll(slice);
-}
-
-void VM::addEvacuatedCalleeSaves(std::span<CPURegister> span)
-{
-    ASSERT(currentThreadIsHoldingAPILock());
-    m_evacuatedCalleeSaves.constructAndAppend(span);
-}
-
-void VM::removeEvacuatedCalleeSaves(std::span<CPURegister> span)
-{
-    ASSERT(currentThreadIsHoldingAPILock());
-    m_evacuatedCalleeSaves.removeAllMatching([&](const std::span<CPURegister>& existing) {
-        return existing.data() == span.data() && existing.size() == span.size();
-    });
 }
 
 Ref<Waiter> VM::syncWaiter()

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -112,7 +112,6 @@ class CompactTDZEnvironmentMap;
 class ConservativeRoots;
 class ControlFlowProfiler;
 class CrossTaskToken;
-class EvacuatedStackSlice;
 class Exception;
 class ExceptionScope;
 class FuzzerAgent;
@@ -952,11 +951,6 @@ public:
     void clearScratchBuffers();
     bool isScratchBuffer(void*);
 
-    void addEvacuatedStackSlice(EvacuatedStackSlice*);
-    void removeEvacuatedStackSlice(EvacuatedStackSlice*);
-    void addEvacuatedCalleeSaves(std::span<CPURegister>);
-    void removeEvacuatedCalleeSaves(std::span<CPURegister>);
-
     EncodedJSValue* exceptionFuzzingBuffer(size_t size)
     {
         ASSERT(Options::useExceptionFuzz());
@@ -966,7 +960,6 @@ public:
     }
 
     void gatherScratchBufferRoots(ConservativeRoots&);
-    void gatherEvacuatedStackRoots(ConservativeRoots&);
 
     static constexpr unsigned expectedMaxActiveSideStateCount = 4;
     void pushCheckpointOSRSideState(std::unique_ptr<CheckpointOSRExitSideState>&&);
@@ -1297,8 +1290,6 @@ private:
     Lock m_scratchBufferLock;
     Vector<ScratchBuffer*> m_scratchBuffers;
     size_t m_sizeOfLastScratchBuffer { 0 };
-    Vector<EvacuatedStackSlice*> m_evacuatedStackSlices;
-    Vector<std::span<CPURegister>> m_evacuatedCalleeSaves;
     Vector<std::unique_ptr<CheckpointOSRExitSideState>, expectedMaxActiveSideStateCount> m_checkpointSideState;
     InlineWatchpointSet m_primitiveGigacageEnabled { IsWatched };
     FunctionHasExecutedCache m_functionHasExecutedCache;


### PR DESCRIPTION
#### 4c00d7bcee9551888f474a7f1b1841312a71cc38
<pre>
[JSC][JSPI] Scan PinballCompletion conservative roots via a GC marking constraint
<a href="https://bugs.webkit.org/show_bug.cgi?id=307564">https://bugs.webkit.org/show_bug.cgi?id=307564</a>
<a href="https://rdar.apple.com/170156450">rdar://170156450</a>

Reviewed by Keith Miller.

In the existing JSPI implementation, evacuated Wasm stack slices and callee saves are
registered with the VM and scanned as conservative roots. This creates a potential memory
leak. Here is the reference structure:

    Promise --&gt; PinballCompletion --&gt; EvacuatedStacks, Callee Saves --&gt; ...
                                                ^
                                                |
                                               VM

The Promise is the promise that caused JSPI suspension, and it owns (transitively via
resolution handlers) the PinballCompletion with the suspended computation. Normally, when
the promise is fulfilled or rejected, PinballCompletion unregisters the evacuated stacks
and callee saves it owns, and all these objects become garbage-collectable. Also, if the
promise is forgotten without being resolved and becomes unmarked together with
PinballCompletion, PinballCompletion destructor unregisters the evacuated stacks and
callee saves, so everything is collected. However, if there happens to be a reference
chain starting in evacuated stacks or callee saves and leading back to the promise, this
transitive strong reference from the VM conservative roots will keep the promise and all
the other objects involved alive forever.

This patch prevents such a scenario. It stops treating evacuated stacks and callee saves
as VM conservative roots. Instead, a new GC constraint is introduced for PinballCompletion
objects, to scan the evacuated stacks and callee saves owned by a completion for
conservative roots only when the completion itself is marked.

This change requires some care in the implantation of evacuated stack slices. In the
original implementation the top slice is removed from a PinballCompletion and stored in
PinballHandlerContext by pinballHandlerInitContext(). Control would then return to
assembly code which would prepare the stack space for the slice and then call
pinballHandlerImplantSlice() to copy the slice data onto the stack. This creates a time
window when a stack slice has been taken out of its owner PinballCompletion, but its
contents have not yet been copied onto the stack. If GC were to run in this window, the
slice would not be scanned for conservative roots. This is not an immediate problem
because currently we do nothing in that time window that could start a GC, but it is a
fragility in case the code is changed in the future.

To avoid this fragility, we change the logic so that instead of storing the slice to
implant in PinballHandlerContext, we store the pinball object itself, and the slice is
only taken out of a PinballCompletion immediately before being implanted. We also refactor
the initialization code to make it an initializer of the PinballHandlerContext struct
instead of a static helper function.

Unified sources fixes
---------------------

The change in unified sources order with this patch, combined with the revision of JSC
header includes by <a href="https://bugs.webkit.org/show_bug.cgi?id=312585">https://bugs.webkit.org/show_bug.cgi?id=312585</a> caused build breakage.
The patch includes these additional changes unrelated to its core logic to fix the
breakage:

- TemporalPlainYearMonth.h / .cpp: Moved the addDurationToYearMonth template definition
  from the header into the .cpp file and added explicit template instantiations for
  AddOrSubtract::Add and AddOrSubtract::Subtract. The header only had a forward
  declaration of JSGlobalObject, so the globalObject-&gt;vm() call on line 91 failed with an
  incomplete type error.

- WeakMapImplInlines.h: Added #include &quot;Symbol.h&quot;. The canBeHeldWeakly function calls
  asSymbol() which is declared in Symbol.h, but the header only had a forward declaration
  of Symbol via the include chain.

- PinballHandlerContext.cpp: Added #include &quot;StackAlignment.h&quot;. The constructor asserts
  !(sliceByteSize % stackAlignmentBytes()), but stackAlignmentBytes() is declared in
  StackAlignment.h which wasn&apos;t included directly.

Testing
-------

- Added `jspi-gc-abandoned-suspensions.js` to reproduce the memory leak scenario described
  above.

- Refactoring changes are covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/312253@main">https://commits.webkit.org/312253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b3a3cada0950955e548056369e04cb9839a5d8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168125 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6608f394-b52c-4c4a-b580-3a8bf86477d6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123427 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1e0d2ff-d336-402e-86d1-9294dd067b39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143094 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104094 "Found 2 new API test failures: TestWebCore:Color.RGBToHSL_Blue, TestWebCore:CookieJar.ShouldNotIncludeSecureCookiesForNonLocalHostnames (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e150883-80b5-426b-9256-e001e6b1216f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23170 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15897 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151345 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170619 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20128 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16653 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22500 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131638 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131750 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35640 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90481 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26416 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19476 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191578 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31867 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98312 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49230 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31387 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31660 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31542 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->