### PR TITLE
[CMake] Add mac-asan preset and fix sanitizer link flags

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -133,6 +133,26 @@
             }
         },
         {
+            "name": "mac-asan",
+            "displayName": "macOS ASan (AddressSanitizer, RelWithDebInfo, ccache)",
+            "inherits": ["mac", "dev"],
+            "binaryDir": "WebKitBuild/cmake-mac/ASan",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": {
+                    "type": "STRING",
+                    "value": "RelWithDebInfo"
+                },
+                "ENABLE_SANITIZERS": {
+                    "type": "STRING",
+                    "value": "address"
+                },
+                "ENABLE_EXPERIMENTAL_FEATURES": {
+                    "type": "BOOL",
+                    "value": "OFF"
+                }
+            }
+        },
+        {
             "name": "wpe",
             "hidden": true,
             "generator": "Ninja",
@@ -191,6 +211,11 @@
             "name": "mac-dev-relwithdebinfo",
             "displayName": "macOS Development RelWithDebInfo",
             "configurePreset": "mac-dev-relwithdebinfo"
+        },
+        {
+            "name": "mac-asan",
+            "displayName": "macOS ASan",
+            "configurePreset": "mac-asan"
         },
         {
             "name": "gtk-release",

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -1031,7 +1031,7 @@ set(ObjCForwardingHeaders
     DOMXPathResult.h
 )
 
-set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "-compatibility_version 1 -current_version ${WEBKIT_MAC_VERSION}")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -compatibility_version 1 -current_version ${WEBKIT_MAC_VERSION}")
 target_link_options(WebKit PRIVATE -lsandbox -framework AuthKit)
 
 set(WebKit_OUTPUT_NAME WebKit)

--- a/Source/WebKitLegacy/PlatformMac.cmake
+++ b/Source/WebKitLegacy/PlatformMac.cmake
@@ -638,4 +638,4 @@ list(APPEND WebKitLegacy_SOURCES
 
 set(WebKitLegacy_OUTPUT_NAME WebKitLegacy)
 
-set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "-compatibility_version 1 -current_version ${WEBKIT_MAC_VERSION} -framework SecurityInterface")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -compatibility_version 1 -current_version ${WEBKIT_MAC_VERSION} -framework SecurityInterface")

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -298,6 +298,22 @@ if (CMAKE_CXX_COMPILER_LAUNCHER OR CMAKE_C_COMPILER_LAUNCHER)
     string(APPEND CMAKE_CXX_FLAGS " -fno-record-command-line")
 endif ()
 
+# Mac-specific sanitizer flags — mirror Configurations/Sanitizers.xcconfig.
+if (ENABLE_SANITIZERS)
+    # Prevents wtf/Compiler.h macros like ALWAYS_INLINE from interfering with
+    # sanitizer instrumentation in optimized builds.
+    add_compile_definitions(RELEASE_WITHOUT_OPTIMIZATIONS)
+
+    # Disable ASan's "fake stack" (use-after-return detection) — it breaks JSC
+    # garbage collection by keeping stack frames alive that the GC expects to be
+    # dead. See Sanitizers.xcconfig.
+    string(FIND "${ENABLE_SANITIZERS}" "address" _asan_pos)
+    if (NOT _asan_pos EQUAL -1)
+        add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-fsanitize-address-use-after-return=never>")
+        add_link_options("$<$<NOT:$<LINK_LANGUAGE:Swift>>:-fsanitize-address-use-after-return=never>")
+    endif ()
+endif ()
+
 # Dead-strip unused symbols and dylibs.
 add_link_options(-Wl,-dead_strip)
 add_link_options(-Wl,-dead_strip_dylibs)


### PR DESCRIPTION
#### 2dbae6f74c8d0390568b497fe56b47f738a2dc72
<pre>
[CMake] Add mac-asan preset and fix sanitizer link flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=312514">https://bugs.webkit.org/show_bug.cgi?id=312514</a>
<a href="https://rdar.apple.com/174956971">rdar://174956971</a>

Reviewed by Geoffrey Garen.

Add a mac-asan CMake preset for AddressSanitizer builds and fix two
pre-existing bugs that prevented ENABLE_SANITIZERS from working on the
Mac port.

The mac-asan preset uses RelWithDebInfo (optimized + debuggable), enables
ENABLE_SANITIZERS=address, and inherits dev settings (ccache,
compile_commands).

OptionsMac.cmake now mirrors Configurations/Sanitizers.xcconfig by adding
-fsanitize-address-use-after-return=never (disables ASan&apos;s fake stack
which breaks JSC garbage collection) and -DRELEASE_WITHOUT_OPTIMIZATIONS
(prevents ALWAYS_INLINE from defeating sanitizer instrumentation). Both
flags are gated to exclude Swift compilation and linking.

Fix unquoted CMAKE_SHARED_LINKER_FLAGS appends in WebKit and
WebKitLegacy PlatformMac.cmake. Without quotes, CMake treats the
expansion as a list, inserting a literal semicolon into the generated
Ninja link command, which the shell interprets as a command separator.
This was latent when CMAKE_SHARED_LINKER_FLAGS was empty but breaks any
build that populates it (e.g. ENABLE_SANITIZERS).

* CMakePresets.json:
* Source/WebKit/PlatformMac.cmake:
* Source/WebKitLegacy/PlatformMac.cmake:
* Source/cmake/OptionsMac.cmake:

Canonical link: <a href="https://commits.webkit.org/311472@main">https://commits.webkit.org/311472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/832168e7b4c55ec423161e8f80b2fb9b18007dd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165719 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110978 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3905e54e-4356-4dc5-ad68-6b6f6e5bc4e3) 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121517 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85333 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18305f42-bf00-442a-93f1-455b03873d64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102185 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78d04d5e-c961-4713-8fff-9352148a7e17) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22800 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21020 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13491 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148946 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168204 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17731 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12363 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129632 "Passed tests") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129739 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35182 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87561 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24571 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17320 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188858 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29467 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93482 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48499 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28990 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29220 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29116 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->