### PR TITLE
Use findDelegate in mac MiniBrowser

### DIFF
--- a/Tools/MiniBrowser/mac/SettingsController.h
+++ b/Tools/MiniBrowser/mac/SettingsController.h
@@ -73,6 +73,7 @@ typedef NS_ENUM(NSInteger, AttachmentElementEnabledState) {
 @property (nonatomic, readonly) BOOL allowUniversalAccessFromFileURLs;
 @property (nonatomic, readonly) BOOL siteSpecificQuirksModeEnabled;
 @property (nonatomic, readonly) BOOL tabFocusesLinksEnabled;
+@property (nonatomic, readonly) BOOL useFindDelegate;
 
 @property (nonatomic, readonly) NSString *defaultURL;
 @property (nonatomic, readonly) NSString *customUserAgent;

--- a/Tools/MiniBrowser/mac/SettingsController.m
+++ b/Tools/MiniBrowser/mac/SettingsController.m
@@ -82,6 +82,7 @@ static NSString * const UseRemoteLayerTreeDrawingAreaPreferenceKey = @"WebKit2Us
 
 static NSString * const PerWindowWebProcessesDisabledKey = @"PerWindowWebProcessesDisabled";
 static NSString * const NetworkCacheSpeculativeRevalidationDisabledKey = @"NetworkCacheSpeculativeRevalidationDisabled";
+static NSString * const UseFindDelegatePreferenceKey = @"UseFindDelegate";
 
 typedef NS_ENUM(NSInteger, DebugOverylayMenuItemTag) {
     NonFastScrollableRegionOverlayTag = 100,
@@ -115,6 +116,7 @@ typedef NS_ENUM(NSInteger, AttachmentElementEnabledMenuItemTag) {
         WebViewFillsWindowKey,
         ResourceLoadStatisticsEnabledPreferenceKey,
         AllowsContentJavascriptPreferenceKey,
+        UseFindDelegatePreferenceKey,
     ];
 
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
@@ -222,6 +224,7 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     addItem(@"Use GameController.framework on macOS (Restart required)", @selector(toggleUsesGameControllerFramework:));
     addItem(@"Disable network cache speculative revalidation", @selector(toggleNetworkCacheSpeculativeRevalidationDisabled:));
     addItem(@"Allow JavaScript from web content to run", @selector(toggleAllowsContentJavascript:));
+    addItem(@"Use Find Delegate", @selector(toggleUseFindDelegate:));
     indent = NO;
 
     NSMenu *debugOverlaysMenu = addSubmenu(@"Debug Overlays");
@@ -454,6 +457,8 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
         [menuItem setState:[self attachmentElementEnabled:menuItem] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleTabFocusesLinksEnabled:))
         [menuItem setState:[self tabFocusesLinksEnabled] ? NSControlStateValueOn : NSControlStateValueOff];
+    else if (action == @selector(toggleUseFindDelegate:))
+        [menuItem setState:[self useFindDelegate] ? NSControlStateValueOn : NSControlStateValueOff];
 
     WKPreferences *defaultPreferences = [[NSApplication sharedApplication] browserAppDelegate].defaultPreferences;
     if (menuItem.tag == ExperimentalFeatureTag) {
@@ -746,6 +751,16 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
 - (BOOL)tabFocusesLinksEnabled
 {
     return [[NSUserDefaults standardUserDefaults] boolForKey:TabFocusesLinksEnabledPreferenceKey];
+}
+
+- (void)toggleUseFindDelegate:(id)sender
+{
+    [self _toggleBooleanDefault:UseFindDelegatePreferenceKey];
+}
+
+- (BOOL)useFindDelegate
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:UseFindDelegatePreferenceKey];
 }
 
 - (void)togglePunchOutWhiteBackgroundsInDarkMode:(id)sender

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -46,6 +46,8 @@
 #import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/WebNSURLExtras.h>
 #import <WebKit/_WKArchiveConfiguration.h>
+#import <WebKit/_WKFindDelegate.h>
+#import <WebKit/_WKFindOptions.h>
 #import <WebKit/_WKIconLoadingDelegate.h>
 #import <WebKit/_WKInspector.h>
 #import <WebKit/_WKLinkIconParameters.h>
@@ -73,7 +75,26 @@ static const int testFooterBannerHeight = 58;
 
 @end
 
-@interface WK2BrowserWindowController () <NSTextFinderBarContainer, WKNavigationDelegate, WKUIDelegate, WKUIDelegatePrivate, _WKIconLoadingDelegate>
+@interface FindBarFieldEditor : NSTextView
+@end
+
+@implementation FindBarFieldEditor
+
+- (void)performTextFinderAction:(id)sender
+{
+    [self.window.windowController performTextFinderAction:sender];
+}
+
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem
+{
+    if (menuItem.action == @selector(performTextFinderAction:))
+        return YES;
+    return [super validateMenuItem:menuItem];
+}
+
+@end
+
+@interface WK2BrowserWindowController () <NSTextFinderBarContainer, _WKFindDelegate, NSSearchFieldDelegate, WKNavigationDelegate, WKUIDelegate, WKUIDelegatePrivate, _WKIconLoadingDelegate>
 @end
 
 @implementation WK2BrowserWindowController {
@@ -86,7 +107,15 @@ static const int testFooterBannerHeight = 58;
 
     MiniBrowserNSTextFinder *_textFinder;
     NSView *_textFindBarView;
+
+    NSView *_findBar;
+    NSSearchField *_findSearchField;
+    NSTextField *_findMatchCountLabel;
+    FindBarFieldEditor *_findBarFieldEditor;
+    id _findBarClickMonitor;
+
     BOOL _findBarVisible;
+    BOOL _usingFindDelegate;
 
     CATextLayer *_pointerLockBanner;
 }
@@ -133,23 +162,19 @@ static const int testFooterBannerHeight = 58;
 
     _webView._usePlatformFindUI = NO;
 
-    _textFinder = [[MiniBrowserNSTextFinder alloc] init];
-    _textFinder.incrementalSearchingEnabled = YES;
-    _textFinder.incrementalSearchingShouldDimContentView = NO;
-    _textFinder.client = _webView;
-    _textFinder.findBarContainer = self;
-    
-#if __has_feature(objc_arc)
-    __weak WKWebView *weakWebView = _webView;
-#else
-    WKWebView *weakWebView = _webView;
-#endif
-    _textFinder.hideInterfaceCallback = ^{
-        WKWebView *webView = weakWebView;
-        [webView _hideFindUI];
-    };
-
     _zoomTextOnly = NO;
+}
+
+- (id)windowWillReturnFieldEditor:(NSWindow *)sender toObject:(id)client
+{
+    if (client == _findSearchField) {
+        if (!_findBarFieldEditor) {
+            _findBarFieldEditor = [[FindBarFieldEditor alloc] init];
+            _findBarFieldEditor.fieldEditor = YES;
+        }
+        return _findBarFieldEditor;
+    }
+    return nil;
 }
 
 - (instancetype)initWithConfiguration:(WKWebViewConfiguration *)configuration
@@ -167,6 +192,11 @@ static const int testFooterBannerHeight = 58;
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    if (_findBarClickMonitor)
+        [NSEvent removeMonitor:_findBarClickMonitor];
+    _webView._findDelegate = nil;
+    _textFinder.client = nil;
+    _textFinder.findBarContainer = nil;
     [_webView removeObserver:self forKeyPath:@"title"];
     [_webView removeObserver:self forKeyPath:@"URL"];
     [_webView removeObserver:self forKeyPath:@"hasOnlySecureContent"];
@@ -1006,10 +1036,291 @@ static BOOL isJavaScriptURL(NSURL *url)
 
 #pragma mark Find in Page
 
+static const NSUInteger findMaxMatchCount = 1000;
+
+- (BOOL)_shouldUseFindDelegate
+{
+    SettingsController *settings = [[NSApplication sharedApplication] browserAppDelegate].settingsController;
+    return settings.useFindDelegate;
+}
+
+- (void)_ensureFindDelegateSetup
+{
+    if (_findBar)
+        return;
+    _webView._findDelegate = self;
+    [self _buildFindBar];
+}
+
+- (void)_ensureTextFinderSetup
+{
+    if (_textFinder)
+        return;
+    _textFinder = [[MiniBrowserNSTextFinder alloc] init];
+    _textFinder.incrementalSearchingEnabled = YES;
+    _textFinder.incrementalSearchingShouldDimContentView = NO;
+    _textFinder.client = _webView;
+    _textFinder.findBarContainer = self;
+    __weak WKWebView *weakWebView = _webView;
+    _textFinder.hideInterfaceCallback = ^{
+        [weakWebView _hideFindUI];
+    };
+}
+
+- (void)_buildFindBar
+{
+    NSVisualEffectView *bar = [[NSVisualEffectView alloc] init];
+    bar.translatesAutoresizingMaskIntoConstraints = NO;
+    bar.material = NSVisualEffectMaterialTitlebar;
+    bar.blendingMode = NSVisualEffectBlendingModeWithinWindow;
+    _findBar = bar;
+
+    _findSearchField = [[NSSearchField alloc] init];
+    _findSearchField.translatesAutoresizingMaskIntoConstraints = NO;
+    _findSearchField.placeholderString = @"Find in Page";
+    _findSearchField.delegate = self;
+    [_findBar addSubview:_findSearchField];
+
+    NSButton *prevButton = [NSButton buttonWithTitle:@"<" target:self action:@selector(_findPrevious:)];
+    prevButton.translatesAutoresizingMaskIntoConstraints = NO;
+    prevButton.bezelStyle = NSBezelStyleRounded;
+    [_findBar addSubview:prevButton];
+
+    NSButton *nextButton = [NSButton buttonWithTitle:@">" target:self action:@selector(_findNext:)];
+    nextButton.translatesAutoresizingMaskIntoConstraints = NO;
+    nextButton.bezelStyle = NSBezelStyleRounded;
+    [_findBar addSubview:nextButton];
+
+    NSButton *doneButton = [NSButton buttonWithTitle:@"Done" target:self action:@selector(_hideFindBar:)];
+    doneButton.translatesAutoresizingMaskIntoConstraints = NO;
+    doneButton.bezelStyle = NSBezelStyleRounded;
+    [_findBar addSubview:doneButton];
+
+    _findMatchCountLabel = [NSTextField labelWithString:@""];
+    _findMatchCountLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    _findMatchCountLabel.font = [NSFont systemFontOfSize:11];
+    _findMatchCountLabel.textColor = [NSColor secondaryLabelColor];
+    _findMatchCountLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+    [_findMatchCountLabel setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [_findBar addSubview:_findMatchCountLabel];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [_findSearchField.leadingAnchor constraintEqualToAnchor:_findBar.leadingAnchor constant:4],
+        [_findSearchField.centerYAnchor constraintEqualToAnchor:_findBar.centerYAnchor],
+        [prevButton.leadingAnchor constraintEqualToAnchor:_findSearchField.trailingAnchor constant:4],
+        [prevButton.centerYAnchor constraintEqualToAnchor:_findBar.centerYAnchor],
+        [prevButton.widthAnchor constraintEqualToConstant:30],
+        [nextButton.leadingAnchor constraintEqualToAnchor:prevButton.trailingAnchor constant:2],
+        [nextButton.centerYAnchor constraintEqualToAnchor:_findBar.centerYAnchor],
+        [nextButton.widthAnchor constraintEqualToConstant:30],
+        [doneButton.leadingAnchor constraintEqualToAnchor:nextButton.trailingAnchor constant:2],
+        [doneButton.centerYAnchor constraintEqualToAnchor:_findBar.centerYAnchor],
+        [_findMatchCountLabel.leadingAnchor constraintEqualToAnchor:doneButton.trailingAnchor constant:4],
+        [_findMatchCountLabel.centerYAnchor constraintEqualToAnchor:_findBar.centerYAnchor],
+        [_findMatchCountLabel.trailingAnchor constraintLessThanOrEqualToAnchor:_findBar.trailingAnchor constant:-4],
+    ]];
+}
+
+- (void)_showFindBar
+{
+    if (!_findBarVisible) {
+        _findBarVisible = YES;
+
+        [containerView addSubview:_findBar];
+        [NSLayoutConstraint activateConstraints:@[
+            [_findBar.topAnchor constraintEqualToAnchor:containerView.safeAreaLayoutGuide.topAnchor],
+            [_findBar.leadingAnchor constraintEqualToAnchor:containerView.leadingAnchor],
+            [_findBar.trailingAnchor constraintEqualToAnchor:containerView.trailingAnchor],
+            [_findBar.heightAnchor constraintEqualToConstant:30],
+        ]];
+
+        __weak WK2BrowserWindowController *weakSelf = self;
+        _findBarClickMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskLeftMouseDown handler:^NSEvent *(NSEvent *event) {
+            WK2BrowserWindowController *strongSelf = weakSelf;
+            if (!strongSelf)
+                return event;
+            NSPoint locationInBar = [strongSelf->_findBar convertPoint:event.locationInWindow fromView:nil];
+            if (![strongSelf->_findBar mouse:locationInBar inRect:strongSelf->_findBar.bounds])
+                [strongSelf _hideFindBarAndUI];
+            return event;
+        }];
+    }
+
+    [self.window makeFirstResponder:_findSearchField];
+    [_findSearchField selectText:nil];
+}
+
+- (void)_hideFindBarAndUI
+{
+    if (!_findBarVisible)
+        return;
+
+    _findBarVisible = NO;
+    [NSEvent removeMonitor:_findBarClickMonitor];
+    _findBarClickMonitor = nil;
+    [_findBar removeFromSuperview];
+    _findMatchCountLabel.stringValue = @"";
+    [_webView _hideFindUI];
+    [self.window makeFirstResponder:_webView];
+}
+
+- (void)_findStringInDirection:(BOOL)backward
+{
+    NSString *searchString = _findSearchField.stringValue;
+    if (!searchString.length)
+        return;
+
+    _WKFindOptions options = _WKFindOptionsCaseInsensitive | _WKFindOptionsWrapAround | _WKFindOptionsShowFindIndicator | _WKFindOptionsShowOverlay | _WKFindOptionsDetermineMatchIndex;
+    if (backward)
+        options |= _WKFindOptionsBackwards;
+
+    [_webView _findString:searchString options:options maxCount:findMaxMatchCount];
+    [_findSearchField selectText:nil];
+}
+
 - (IBAction)performTextFinderAction:(id)sender
 {
-    [_textFinder performAction:[sender tag]];
+    NSInteger tag = [sender tag];
+
+    if (tag == NSTextFinderActionShowFindInterface) {
+        BOOL shouldUseFindDelegate = [self _shouldUseFindDelegate];
+
+        if (_findBarVisible && shouldUseFindDelegate != _usingFindDelegate) {
+            if (_usingFindDelegate)
+                [self _hideFindBarAndUI];
+            else {
+                [_textFinder performAction:NSTextFinderActionHideFindInterface];
+                _findBarVisible = NO;
+                [_textFindBarView removeFromSuperview];
+                [_webView _hideFindUI];
+            }
+        }
+
+        _usingFindDelegate = shouldUseFindDelegate;
+
+        if (_usingFindDelegate) {
+            [self _ensureFindDelegateSetup];
+            [self _showFindBar];
+        } else {
+            [self _ensureTextFinderSetup];
+            [_textFinder performAction:NSTextFinderActionShowFindInterface];
+        }
+        return;
+    }
+
+    if (_usingFindDelegate) {
+        switch (tag) {
+        case NSTextFinderActionNextMatch:
+            [self _findStringInDirection:NO];
+            break;
+        case NSTextFinderActionPreviousMatch:
+            [self _findStringInDirection:YES];
+            break;
+        case NSTextFinderActionHideFindInterface:
+            [self _hideFindBarAndUI];
+            break;
+        default:
+            break;
+        }
+    } else {
+        [self _ensureTextFinderSetup];
+        [_textFinder performAction:tag];
+    }
 }
+
+- (void)_findNext:(id)sender
+{
+    [self _findStringInDirection:NO];
+}
+
+- (void)_findPrevious:(id)sender
+{
+    [self _findStringInDirection:YES];
+}
+
+- (void)_hideFindBar:(id)sender
+{
+    [self _hideFindBarAndUI];
+}
+
+- (void)cancelOperation:(id)sender
+{
+    if (_findBarVisible) {
+        if (_usingFindDelegate)
+            [self _hideFindBarAndUI];
+        else
+            [_textFinder performAction:NSTextFinderActionHideFindInterface];
+    }
+}
+
+- (BOOL)control:(NSControl *)control textView:(NSTextView *)textView doCommandBySelector:(SEL)commandSelector
+{
+    if (!_usingFindDelegate || control != _findSearchField)
+        return NO;
+
+    if (commandSelector == @selector(insertNewline:)) {
+        BOOL shiftDown = !!([NSEvent modifierFlags] & NSEventModifierFlagShift);
+        [self _findStringInDirection:shiftDown];
+        return YES;
+    }
+
+    if (commandSelector == @selector(cancelOperation:)) {
+        [self _hideFindBarAndUI];
+        return YES;
+    }
+
+    return NO;
+}
+
+#pragma mark NSSearchFieldDelegate
+
+- (void)controlTextDidChange:(NSNotification *)notification
+{
+    if (!_usingFindDelegate)
+        return;
+
+    NSString *searchString = _findSearchField.stringValue;
+    if (!searchString.length) {
+        _findMatchCountLabel.stringValue = @"";
+        [_webView _hideFindUI];
+        return;
+    }
+
+    [_webView _findString:searchString options:_WKFindOptionsCaseInsensitive | _WKFindOptionsWrapAround | _WKFindOptionsShowFindIndicator | _WKFindOptionsShowOverlay | _WKFindOptionsDetermineMatchIndex maxCount:findMaxMatchCount];
+}
+
+#pragma mark _WKFindDelegate
+
+- (void)_updateDisplayedMatchCount:(NSUInteger)matchCount matchIndex:(NSInteger)matchIndex
+{
+    if (!matchCount)
+        _findMatchCountLabel.stringValue = @"Not found";
+    else if (matchCount == 1)
+        _findMatchCountLabel.stringValue = @"1 match";
+    else if (matchCount > findMaxMatchCount)
+        _findMatchCountLabel.stringValue = [NSString stringWithFormat:@"More than %lu matches", (unsigned long)findMaxMatchCount];
+    else if (matchIndex != NSNotFound && matchIndex >= 0)
+        _findMatchCountLabel.stringValue = [NSString stringWithFormat:@"%lu of %lu", (unsigned long)(matchIndex % matchCount + 1), (unsigned long)matchCount];
+    else
+        _findMatchCountLabel.stringValue = [NSString stringWithFormat:@"%lu matches", (unsigned long)matchCount];
+}
+
+- (void)_webView:(WKWebView *)webView didCountMatches:(NSUInteger)matches forString:(NSString *)string
+{
+    [self _updateDisplayedMatchCount:matches matchIndex:NSNotFound];
+}
+
+- (void)_webView:(WKWebView *)webView didFindMatches:(NSUInteger)matches forString:(NSString *)string withMatchIndex:(NSInteger)matchIndex
+{
+    [self _updateDisplayedMatchCount:matches matchIndex:matchIndex];
+}
+
+- (void)_webView:(WKWebView *)webView didFailToFindString:(NSString *)string
+{
+    [self _updateDisplayedMatchCount:0 matchIndex:NSNotFound];
+}
+
+#pragma mark NSTextFinderBarContainer
 
 - (NSView *)findBarView
 {
@@ -1021,7 +1332,6 @@ static BOOL isJavaScriptURL(NSURL *url)
     _textFindBarView = findBarView;
     _textFindBarView.autoresizingMask = NSViewMaxYMargin | NSViewWidthSizable;
     _textFindBarView.frame = NSMakeRect(0, 0, containerView.bounds.size.width, _textFindBarView.frame.size.height);
-
     _findBarVisible = YES;
 }
 


### PR DESCRIPTION
#### 9835f97a12015b31a58358dfc1773e974ed6103d
<pre>
Use findDelegate in mac MiniBrowser
<a href="https://rdar.apple.com/174960802">rdar://174960802</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312518">https://bugs.webkit.org/show_bug.cgi?id=312518</a>

Reviewed by Megan Gardner.

Mac&apos;s MiniBrowser implementation does Find in Page differently
than Safari, which means that every time changes are made to the
find code on the WebKit side, Safari has to be built to manually
test the changes.

I have added an option to MiniBrowser&apos;s settings called &quot;Use Find Delegate.&quot;
This is on by default, and changes the find implementation to be similar to
Safari&apos;s. The workload is similar and the API calls are the same, so MiniBrowser
can be used to test Find in Page.

You can uncheck &quot;Use Find Delegate&quot; to use the old TextFinder implementation.

* Tools/MiniBrowser/mac/SettingsController.h:
* Tools/MiniBrowser/mac/SettingsController.m:
(-[SettingsController initWithMenu:]):
(-[SettingsController _populateMenu:]):
(-[SettingsController validateMenuItem:]):
(-[SettingsController toggleUseFindDelegate:]):
(-[SettingsController useFindDelegate]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[FindBarFieldEditor performTextFinderAction:]):
(-[FindBarFieldEditor validateMenuItem:]):
(-[WK2BrowserWindowController awakeFromNib]):
(-[WK2BrowserWindowController windowWillReturnFieldEditor:toObject:]):
(-[WK2BrowserWindowController dealloc]):
(-[WK2BrowserWindowController _shouldUseFindDelegate]):
(-[WK2BrowserWindowController _ensureFindDelegateSetup]):
(-[WK2BrowserWindowController _ensureTextFinderSetup]):
(-[WK2BrowserWindowController _buildFindBar]):
(-[WK2BrowserWindowController _showFindBar]):
(-[WK2BrowserWindowController _hideFindBarAndUI]):
(-[WK2BrowserWindowController _findStringInDirection:]):
(-[WK2BrowserWindowController performTextFinderAction:]):
(-[WK2BrowserWindowController _findNext:]):
(-[WK2BrowserWindowController _findPrevious:]):
(-[WK2BrowserWindowController _hideFindBar:]):
(-[WK2BrowserWindowController cancelOperation:]):
(-[WK2BrowserWindowController control:textView:doCommandBySelector:]):
(-[WK2BrowserWindowController controlTextDidChange:]):
(-[WK2BrowserWindowController _updateDisplayedMatchCount:matchIndex:]):
(-[WK2BrowserWindowController _webView:didCountMatches:forString:]):
(-[WK2BrowserWindowController _webView:didFindMatches:forString:withMatchIndex:]):
(-[WK2BrowserWindowController _webView:didFailToFindString:]):
(-[WK2BrowserWindowController setFindBarView:]):
* default.profraw: Added.

Canonical link: <a href="https://commits.webkit.org/311498@main">https://commits.webkit.org/311498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5547163da689a640069ce74b7550a1f0326af3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111180 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121665 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102333 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc01f1c7-1940-428a-83a5-9cef9c197ecc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22967 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21198 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13693 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132647 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168406 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129791 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129899 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35202 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87780 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24726 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17498 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29670 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29192 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29319 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->