### PR TITLE
Remove @objc from function declarations on @objc @implementation classes

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -409,7 +409,6 @@ extension WKBridgeUSDConfiguration {
         get { appRenderer.renderTargetDescriptor }
     }
 
-    @objc
     init(device: any MTLDevice, memoryOwner: task_id_token_t) {
         self.device = device
         do {
@@ -580,7 +579,6 @@ extension WKBridgeReceiver {
         )
     }
 
-    @objc
     func commandBuffer() -> (any MTLCommandBuffer)? {
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
@@ -880,21 +878,17 @@ extension WKBridgeReceiver {
         modelTransform = transform
     }
 
-    @objc
     func setFOV(_ fovY: Float) {
         appRenderer.setFOV(fovY)
     }
 
-    @objc
     func setBackgroundColor(_ color: simd_float3) {
         appRenderer.setBackgroundColor(color)
     }
 
-    @objc
     func setPlaying(_ play: Bool) {
     }
 
-    @objc
     func setEnvironmentMap(_ imageAsset: WKBridgeImageAsset) {
         do {
             guard
@@ -2027,12 +2021,10 @@ extension WKBridgeModelLoader {
         self.materialUpdatedCallback = materialUpdatedCallback
     }
 
-    @objc
     func loadModel(from url: Foundation.URL) {
         self.loader?.loadModel(from: url)
     }
 
-    @objc
     func loadModel(_ data: Foundation.Data) {
         self.loader?.loadModel(data: data)
     }
@@ -2042,17 +2034,14 @@ extension WKBridgeModelLoader {
         await self.loader?.update(deltaTime: deltaTime)
     }
 
-    @objc
     func setLoop(_ loop: Bool) {
         self.loader?.loop = loop
     }
 
-    @objc
     func requestCompleted(_ request: NSObject) {
         retainedRequests.remove(request)
     }
 
-    @objc
     func duration() -> Double {
         guard let loader else {
             return 0.0
@@ -2060,7 +2049,6 @@ extension WKBridgeModelLoader {
         return loader.duration()
     }
 
-    @objc
     func currentTime() -> Double {
         guard let loader else {
             return 0.0
@@ -2068,7 +2056,6 @@ extension WKBridgeModelLoader {
         return loader.currentTime()
     }
 
-    @objc
     func setCurrentTime(_ newTime: Double) {
         loader?.setCurrentTime(newTime)
     }
@@ -2677,7 +2664,6 @@ extension WKBridgeReceiver {
     ) throws {
     }
 
-    @objc
     func commandBuffer() -> (any MTLCommandBuffer)? {
         nil
     }
@@ -2702,19 +2688,15 @@ extension WKBridgeReceiver {
     func setTransform(_ transform: simd_float4x4) {
     }
 
-    @objc
     func setFOV(_ fovY: Float) {
     }
 
-    @objc
     func setBackgroundColor(_ color: simd_float3) {
     }
 
-    @objc
     func setPlaying(_ play: Bool) {
     }
 
-    @objc
     func setEnvironmentMap(_ imageAsset: WKBridgeImageAsset) {
     }
 }
@@ -2738,37 +2720,29 @@ extension WKBridgeModelLoader {
     ) {
     }
 
-    @objc
     func loadModel(from url: Foundation.URL) {
     }
 
-    @objc
     func loadModel(_ data: Foundation.Data) {
     }
 
-    @objc
     func update(_ deltaTime: Double) async {
     }
 
-    @objc
     func setLoop(_ loop: Bool) {
     }
 
-    @objc
     func requestCompleted(_ request: NSObject) {
     }
 
-    @objc
     func duration() -> Double {
         0.0
     }
 
-    @objc
     func currentTime() -> Double {
         0.0
     }
 
-    @objc
     func setCurrentTime(_ newTime: Double) {
     }
 }


### PR DESCRIPTION
#### 92bc0cf6a72540d5d682ef3f9e7330d97e2ea752
<pre>
Remove @objc from function declarations on @objc @implementation classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=312521">https://bugs.webkit.org/show_bug.cgi?id=312521</a>
<a href="https://rdar.apple.com/174961688">rdar://174961688</a>

Reviewed by Richard Robinson.

@objc is not needed on functions in @objc @implementation class extensions.

* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:

Canonical link: <a href="https://commits.webkit.org/311420@main">https://commits.webkit.org/311420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c24d43ddfcb554e11c08388f68d861da1331b2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165734 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121525 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb02db2b-4219-4d08-952a-b3f6b3b35b74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102193 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22817 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13506 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132498 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168219 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12378 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129641 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129748 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35146 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140526 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87576 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24580 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17330 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29482 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93497 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29005 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29235 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->