### PR TITLE
Only use match-affecting find options as cache keys in the CachedMatchFinder

### DIFF
--- a/Source/WebCore/editing/CachedMatchFinder.cpp
+++ b/Source/WebCore/editing/CachedMatchFinder.cpp
@@ -38,6 +38,12 @@
 
 namespace WebCore {
 
+static inline FindOptions matchAffectingOptions(FindOptions options)
+{
+    static constexpr OptionSet matchAffectingFlags { FindOption::CaseInsensitive, FindOption::AtWordStarts, FindOption::TreatMedialCapitalAsWordStart, FindOption::AtWordEnds, FindOption::DoNotTraverseFlatTree };
+    return options & matchAffectingFlags;
+}
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CachedMatchFinder);
 
 CachedMatchFinder::CachedMatchFinder(Document& document)
@@ -233,7 +239,7 @@ Vector<SimpleRange> CachedMatchFinder::findMatches(const std::optional<SimpleRan
     m_countCache = results.size();
     m_searchResultCacheKeys.targetString = target;
     m_searchResultCacheKeys.limit = limit;
-    m_searchResultCacheKeys.options = options;
+    m_searchResultCacheKeys.options = matchAffectingOptions(options);
     return results;
 }
 
@@ -257,7 +263,7 @@ unsigned CachedMatchFinder::countMatches(const std::optional<SimpleRange>& searc
     m_countCache = count;
     m_searchResultCacheKeys.targetString = target;
     m_searchResultCacheKeys.limit = limit;
-    m_searchResultCacheKeys.options = options;
+    m_searchResultCacheKeys.options = matchAffectingOptions(options);
     return count;
 }
 
@@ -403,7 +409,7 @@ bool CachedMatchFinder::isSearchResultCacheValid(const String& target, FindOptio
     return m_searchResultCacheKeys.targetString
         && target == *m_searchResultCacheKeys.targetString
         && m_searchResultCacheKeys.limit == limit
-        && m_searchResultCacheKeys.options == options;
+        && m_searchResultCacheKeys.options == matchAffectingOptions(options);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 76f35ddd2dcfe307bccb1079556a915af28c98c5
<pre>
Only use match-affecting find options as cache keys in the CachedMatchFinder
<a href="https://rdar.apple.com/174963348">rdar://174963348</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312523">https://bugs.webkit.org/show_bug.cgi?id=312523</a>

Reviewed by Ryosuke Niwa.

All the find options are used as a cache key in the CachedMatchFinder even
though only some affect the matches.

To fix this issue, I filter the options down to only the ones that affect
matches.

* Source/WebCore/editing/CachedMatchFinder.cpp:
(WebCore::matchAffectingOptions):
(WebCore::CachedMatchFinder::findMatches):
(WebCore::CachedMatchFinder::countMatches):
(WebCore::CachedMatchFinder::isSearchResultCacheValid const):

Canonical link: <a href="https://commits.webkit.org/311462@main">https://commits.webkit.org/311462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be7152dad3b14b35d9d0834cb9e68c393f3b3a7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110994 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121526 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85338 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102194 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22807 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21040 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13507 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168220 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12379 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129643 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129750 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35176 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140533 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87577 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17337 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29483 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93498 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29006 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29236 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29132 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->