### PR TITLE
[CMake] Make Mac CMake build work with PCH enabled

### DIFF
--- a/Source/WebCore/testing/js/WebCoreTestSupportPrefix.h
+++ b/Source/WebCore/testing/js/WebCoreTestSupportPrefix.h
@@ -99,11 +99,6 @@
 #endif // PLATFORM(IOS_FAMILY)
 #endif
 
-#ifdef __cplusplus
-#define new ("if you use new/delete make sure to include config.h at the top of the file"()) 
-#define delete ("if you use new/delete make sure to include config.h at the top of the file"()) 
-#endif
-
 /* When C++ exceptions are disabled, the C++ library defines |try| and |catch|
  * to allow C++ code that expects exceptions to build. These definitions
  * interfere with Objective-C++ uses of Objective-C exception handlers, which

--- a/Source/WebKitLegacy/PlatformMac.cmake
+++ b/Source/WebKitLegacy/PlatformMac.cmake
@@ -567,35 +567,28 @@ set(WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES
 
 target_precompile_headers(WebKitLegacy PRIVATE mac/WebKitPrefix.h)
 
-set(C99_FILES
-    mac/DefaultDelegates/WebDefaultEditingDelegate.m
-
-    mac/Misc/WebKitErrors.m
-    mac/Misc/WebKitStatistics.m
-    mac/Misc/WebNSControlExtras.m
-    mac/Misc/WebNSEventExtras.m
-    mac/Misc/WebNSPrintOperationExtras.m
-    mac/Misc/WebNSURLRequestExtras.m
-    mac/Misc/WebNSViewExtras.m
-    mac/Misc/WebNSWindowExtras.m
-
-    mac/WebView/WebFormDelegate.m
-)
-
 set(CPP_FILES
     Storage/StorageThread.cpp
 )
 
 foreach (_file ${WebKitLegacy_SOURCES})
-    list(FIND C99_FILES ${_file} _c99_index)
     list(FIND CPP_FILES ${_file} _cpp_index)
-    if (NOT ${_c99_index} EQUAL -1)
-        set_source_files_properties(${_file} PROPERTIES COMPILE_FLAGS -std=c99)
-    elseif (NOT ${_cpp_index} EQUAL -1)
+    if (NOT ${_cpp_index} EQUAL -1)
+        # Truly C++ (not Objective-C++): compile via the CXX rule with -std=c++2b.
         set_source_files_properties(${_file} PROPERTIES COMPILE_FLAGS -std=c++2b)
-    else ()
-        set_source_files_properties(${_file} PROPERTIES COMPILE_FLAGS "-ObjC++ -std=c++2b")
+    elseif (_file MATCHES "\\.cpp$")
+        # Most WebKitLegacy .cpp files transitively include Objective-C
+        # headers (e.g. WebView.h declares `@class`), so they must be compiled
+        # as Objective-C++. CMake assigns CXX to .cpp by extension; force the
+        # source language to OBJCXX so they go through the OBJCXX rule with
+        # the OBJCXX PCH and Objective-C semantics enabled. This replaces the
+        # previous "-ObjC++ -std=c++2b" COMPILE_FLAGS override, which conflicts
+        # with the proper OBJC/OBJCXX language pipeline now that those
+        # languages are enabled (see Source/cmake/OptionsMac.cmake).
+        set_source_files_properties(${_file} PROPERTIES LANGUAGE OBJCXX)
     endif ()
+    # .m / .mm sources need no override: CMake routes them through the OBJC /
+    # OBJCXX compile rules with the appropriate language semantics.
 endforeach ()
 
 foreach (_file ${WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES})

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -3,6 +3,14 @@
 set(WEBKIT_MAC_VERSION 615.1.1)
 set(MACOSX_FRAMEWORK_BUNDLE_VERSION 615.1.1+)
 
+# Enable Objective-C / Objective-C++ so .m/.mm sources use the OBJC/OBJCXX
+# compile rules. Without this CMake falls back to compiling .mm as CXX, which
+# causes target_precompile_headers() to generate only a CXX PCH (Objective-C
+# disabled) that is then -included into .mm sources where Objective-C is
+# enabled by file extension, producing:
+#   "Objective-C was disabled in precompiled file ... but is currently enabled"
+enable_language(OBJC OBJCXX)
+
 WEBKIT_OPTION_BEGIN()
 # Private options shared with other WebKit ports. Add options here only if
 # we need a value different from the default defined in WebKitFeatures.cmake.
@@ -296,6 +304,8 @@ if (CMAKE_CXX_COMPILER_LAUNCHER OR CMAKE_C_COMPILER_LAUNCHER)
     # -frecord-command-line embeds absolute paths; use CMAKE_*_FLAGS for all languages.
     string(APPEND CMAKE_C_FLAGS " -fno-record-command-line")
     string(APPEND CMAKE_CXX_FLAGS " -fno-record-command-line")
+    string(APPEND CMAKE_OBJC_FLAGS " -fno-record-command-line")
+    string(APPEND CMAKE_OBJCXX_FLAGS " -fno-record-command-line")
 endif ()
 
 # Dead-strip unused symbols and dylibs.

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -52,44 +52,74 @@ endfunction()
 
 # Prepends flags to CMAKE_C_FLAGS if supported by the C compiler. Almost all
 # flags should be prepended to allow the user to override them.
+#
+# Also mirrors the resulting flags into CMAKE_OBJC_FLAGS so that .m sources on
+# Apple ports get the same WebKit-curated flag set as their .c counterparts.
+# This is a no-op on ports where OBJC is not an enabled language.
 macro(WEBKIT_PREPEND_GLOBAL_C_FLAGS)
     WEBKIT_VAR_ADD_COMPILER_FLAGS(C PREPEND CMAKE_C_FLAGS ${ARGN})
+    WEBKIT_VAR_ADD_COMPILER_FLAGS(C PREPEND CMAKE_OBJC_FLAGS ${ARGN})
 endmacro()
 
 # Appends flags to CMAKE_C_FLAGS if supported by the C compiler. This macro
 # should be used sparingly. Only append flags if the user must not be allowed to
 # override them.
+#
+# See WEBKIT_PREPEND_GLOBAL_C_FLAGS for the OBJC mirroring rationale.
 macro(WEBKIT_APPEND_GLOBAL_C_FLAGS)
     WEBKIT_VAR_ADD_COMPILER_FLAGS(C APPEND CMAKE_C_FLAGS ${ARGN})
+    WEBKIT_VAR_ADD_COMPILER_FLAGS(C APPEND CMAKE_OBJC_FLAGS ${ARGN})
 endmacro()
 
 # Prepends flags to CMAKE_CXX_FLAGS if supported by the C++ compiler. Almost all
 # flags should be prepended to allow the user to override them.
+#
+# Also mirrors the resulting flags into CMAKE_OBJCXX_FLAGS so that .mm sources
+# on Apple ports get the same WebKit-curated flag set (warnings, -fno-rtti,
+# -fno-exceptions, etc.) as their .cpp counterparts. Without this mirroring,
+# .mm sources are compiled with default OBJCXX flags (notably *with* RTTI),
+# which produces undefined-symbol errors at link time when ObjC++ subclasses
+# reference RTTI-less C++ base classes' typeinfo. This is a no-op on ports
+# where OBJCXX is not an enabled language.
 macro(WEBKIT_PREPEND_GLOBAL_CXX_FLAGS)
     WEBKIT_VAR_ADD_COMPILER_FLAGS(CXX PREPEND CMAKE_CXX_FLAGS ${ARGN})
+    WEBKIT_VAR_ADD_COMPILER_FLAGS(CXX PREPEND CMAKE_OBJCXX_FLAGS ${ARGN})
 endmacro()
 
 # Appends flags to CMAKE_CXX_FLAGS if supported by the C++ compiler. This macro
 # should be used sparingly. Only append flags if the user must not be allowed to
 # override them.
+#
+# See WEBKIT_PREPEND_GLOBAL_CXX_FLAGS for the OBJCXX mirroring rationale.
 macro(WEBKIT_APPEND_GLOBAL_CXX_FLAGS)
     WEBKIT_VAR_ADD_COMPILER_FLAGS(CXX APPEND CMAKE_CXX_FLAGS ${ARGN})
+    WEBKIT_VAR_ADD_COMPILER_FLAGS(CXX APPEND CMAKE_OBJCXX_FLAGS ${ARGN})
 endmacro()
 
 # Prepends flags to CMAKE_C_FLAGS and CMAKE_CXX_FLAGS if supported by the C
 # or C++ compiler, respectively. Almost all flags should be prepended to allow
 # the user to override them.
+#
+# Also mirrors into CMAKE_OBJC_FLAGS / CMAKE_OBJCXX_FLAGS — see the per-language
+# macros above for rationale.
 macro(WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS)
     WEBKIT_VAR_ADD_COMPILER_FLAGS(C PREPEND CMAKE_C_FLAGS ${ARGN})
+    WEBKIT_VAR_ADD_COMPILER_FLAGS(C PREPEND CMAKE_OBJC_FLAGS ${ARGN})
     WEBKIT_VAR_ADD_COMPILER_FLAGS(CXX PREPEND CMAKE_CXX_FLAGS ${ARGN})
+    WEBKIT_VAR_ADD_COMPILER_FLAGS(CXX PREPEND CMAKE_OBJCXX_FLAGS ${ARGN})
 endmacro()
 
 # Appends flags to CMAKE_C_FLAGS and CMAKE_CXX_FLAGS if supported by the C or
 # C++ compiler, respectively. This macro should be used sparingly. Only append
 # flags if the user must not be allowed to override them.
+#
+# Also mirrors into CMAKE_OBJC_FLAGS / CMAKE_OBJCXX_FLAGS — see the per-language
+# macros above for rationale.
 macro(WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS)
     WEBKIT_VAR_ADD_COMPILER_FLAGS(C APPEND CMAKE_C_FLAGS ${ARGN})
+    WEBKIT_VAR_ADD_COMPILER_FLAGS(C APPEND CMAKE_OBJC_FLAGS ${ARGN})
     WEBKIT_VAR_ADD_COMPILER_FLAGS(CXX APPEND CMAKE_CXX_FLAGS ${ARGN})
+    WEBKIT_VAR_ADD_COMPILER_FLAGS(CXX APPEND CMAKE_OBJCXX_FLAGS ${ARGN})
 endmacro()
 
 # Appends flags to COMPILE_OPTIONS of _subject if supported by the C
@@ -304,6 +334,9 @@ endif ()
 if (LTO_MODE AND COMPILER_IS_CLANG AND NOT MSVC)
     set(CMAKE_C_FLAGS "-flto=${LTO_MODE} ${CMAKE_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "-flto=${LTO_MODE} ${CMAKE_CXX_FLAGS}")
+    # Mirror to OBJC/OBJCXX for Apple ports — see compiler-flag macro comments.
+    set(CMAKE_OBJC_FLAGS "-flto=${LTO_MODE} ${CMAKE_OBJC_FLAGS}")
+    set(CMAKE_OBJCXX_FLAGS "-flto=${LTO_MODE} ${CMAKE_OBJCXX_FLAGS}")
     set(CMAKE_EXE_LINKER_FLAGS "-flto=${LTO_MODE} ${CMAKE_EXE_LINKER_FLAGS}")
     set(CMAKE_SHARED_LINKER_FLAGS "-flto=${LTO_MODE} ${CMAKE_SHARED_LINKER_FLAGS}")
     set(CMAKE_MODULE_LINKER_FLAGS "-flto=${LTO_MODE} ${CMAKE_MODULE_LINKER_FLAGS}")
@@ -361,6 +394,10 @@ if (COMPILER_IS_GCC_OR_CLANG)
 
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZER_COMPILER_FLAGS}")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZER_COMPILER_FLAGS}")
+        # Apple ports also enable OBJC/OBJCXX so .m/.mm sources need the same flags.
+        # On ports where these languages are not enabled, setting these variables is harmless.
+        set(CMAKE_OBJC_FLAGS "${CMAKE_OBJC_FLAGS} ${SANITIZER_COMPILER_FLAGS}")
+        set(CMAKE_OBJCXX_FLAGS "${CMAKE_OBJCXX_FLAGS} ${SANITIZER_COMPILER_FLAGS}")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${SANITIZER_LINK_FLAGS}")
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${SANITIZER_LINK_FLAGS}")
         set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${SANITIZER_LINK_FLAGS}")


### PR DESCRIPTION
#### 3a6d77d38cd5983686e8b6cd7c265baa4943e032
<pre>
[CMake] Make Mac CMake build work with PCH enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=312517">https://bugs.webkit.org/show_bug.cgi?id=312517</a>
<a href="https://rdar.apple.com/174960208">rdar://174960208</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/311402@main">311402@main</a> turned on precompiled headers for all ports. On Mac that
exposed a stack of latent issues because OBJC/OBJCXX were never
actually enabled as project languages -- before PCH the gaps were
invisible because .m/.mm files quietly fell through the C/C++ compile
rules. Fix them so `cmake --build` on Mac links every C/C++/ObjC/ObjC++
framework: WTF, JavaScriptCore, WebGPU, WebCore, WebKitLegacy.

Four issues, four fixes:

1. CMake generated only a CXX precompiled header. When that PCH was
   force-included into a .mm source (which clang treats as ObjC++ by
   extension), the compiler errored &quot;Objective-C was disabled in
   precompiled file ... but is currently enabled&quot;.

   Fix in OptionsMac.cmake: enable_language(OBJC OBJCXX) so CMake
   recognises .m/.mm and generates per-language PCHs.

2. With OBJCXX now enabled, .mm files compile through the OBJCXX rule
   with bare-default flags -- no -fno-rtti, no warnings, no sanitizer
   instrumentation. .mm files built *with* RTTI emitted typeinfo
   references for C++ base classes that the .cpp side (built without
   RTTI) couldn&apos;t satisfy, breaking linking.

   Fix in WebKitCompilerFlags.cmake: the WEBKIT_*_GLOBAL_*_FLAGS
   macros now mirror writes into CMAKE_OBJC_FLAGS / CMAKE_OBJCXX_FLAGS
   alongside CMAKE_C_FLAGS / CMAKE_CXX_FLAGS. Same for the LTO and
   sanitizer direct-write blocks. No-op on ports where OBJC/OBJCXX
   isn&apos;t enabled.

3. WebCoreTestSupportPrefix.h&apos;s `#define new`/`#define delete` poison
   macros are vestigial: under PCH the prefix is auto-included in
   every TU, so they never catch a missing `#include &quot;config.h&quot;`,
   only legitimate libc++ uses of `= delete` (e.g. `&lt;__compare&gt;`).
   WebCorePrefix.h gets away with it by pre-including enough libc++
   to mask everything; keeping two parallel pre-include blocks in
   sync is whack-a-mole.

   Fix: delete the poison macros from WebCoreTestSupportPrefix.h.

4. WebKitLegacy/PlatformMac.cmake was applying `-ObjC++ -std=c++2b`
   to every source not in a small carve-out, plus `-std=c99` to
   listed .m files. That was the long-standing way to coerce
   .cpp files (which include @class headers like WebView.h) through
   the CXX rule as ObjC++. With OBJC/OBJCXX enabled, the override
   conflicts with the proper compile rules (&quot;-std=c++2b not allowed
   with Objective-C&quot;, and a C-standard PCH/TU mismatch).

   Fix: replace the flag overrides with the CMake-native equivalent
   -- set LANGUAGE = OBJCXX on the .cpp files that need ObjC++.
   .m files compile via the OBJC rule directly. Drop the dead
   C99_FILES list.

* Source/WebCore/testing/js/WebCoreTestSupportPrefix.h:
* Source/WebKitLegacy/PlatformMac.cmake:
* Source/cmake/OptionsMac.cmake:
* Source/cmake/WebKitCompilerFlags.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a6d77d38cd5983686e8b6cd7c265baa4943e032

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110996 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db41188c-9438-4746-bc74-33228c22a96a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121527 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85339 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102195 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22819 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21042 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13509 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148964 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168222 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17749 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12381 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129644 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129751 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140530 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87579 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24583 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17334 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188876 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29485 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93500 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48502 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29008 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29238 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29134 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->