### PR TITLE
Removing/outdent a line from ordered list causes the following list to start with an incorrect number

### DIFF
--- a/LayoutTests/editing/execCommand/break-out-of-list-resets-start-number-expected.txt
+++ b/LayoutTests/editing/execCommand/break-out-of-list-resets-start-number-expected.txt
@@ -1,0 +1,36 @@
+This tests that pressing Enter twice to break out of a list resets the start attribute to 1 on the second half of the split list.
+
+Before:
+| "\n"
+| <ol>
+|   start="11"
+|   <li>
+|     "eleven"
+|   <li>
+|     id="target"
+|     "twelve"
+|   <li>
+|     "thirteen"
+|   <li>
+|     "fourteen"
+| "\n"
+
+After:
+| "\n"
+| <ol>
+|   start="11"
+|   <li>
+|     "eleven"
+|   <li>
+|     id="target"
+|     "twelve"
+| <div>
+|   <#selection-caret>
+|   <br>
+| <ol>
+|   start="1"
+|   <li>
+|     "thirteen"
+|   <li>
+|     "fourteen"
+| "\n"

--- a/LayoutTests/editing/execCommand/break-out-of-list-resets-start-number.html
+++ b/LayoutTests/editing/execCommand/break-out-of-list-resets-start-number.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+<div id="test" contenteditable>
+<ol start="11"><li>eleven</li><li id="target">twelve</li><li>thirteen</li><li>fourteen</li></ol>
+</div>
+<script>
+Markup.description('This tests that pressing Enter twice to break out of a list resets the start attribute to 1 on the second half of the split list.');
+
+Markup.dump('test', 'Before');
+
+var target = document.getElementById('target');
+var selection = window.getSelection();
+var range = document.createRange();
+range.selectNodeContents(target);
+range.collapse(false);
+selection.removeAllRanges();
+selection.addRange(range);
+
+document.execCommand('InsertParagraph', false, '');
+document.execCommand('InsertParagraph', false, '');
+
+Markup.dump('test', 'After');
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/execCommand/outdent-list-resets-start-number-expected.txt
+++ b/LayoutTests/editing/execCommand/outdent-list-resets-start-number-expected.txt
@@ -1,0 +1,32 @@
+This tests that outdenting a middle list item resets the start attribute to 1 on the second half of the split list.
+
+Before:
+| "\n"
+| <ol>
+|   start="11"
+|   <li>
+|     "eleven"
+|   <li>
+|     id="target"
+|     "twelve"
+|   <li>
+|     "thirteen"
+|   <li>
+|     "fourteen"
+| "\n"
+
+After:
+| "\n"
+| <ol>
+|   start="11"
+|   <li>
+|     "eleven"
+| "<#selection-caret>twelve"
+| <br>
+| <ol>
+|   start="1"
+|   <li>
+|     "thirteen"
+|   <li>
+|     "fourteen"
+| "\n"

--- a/LayoutTests/editing/execCommand/outdent-list-resets-start-number.html
+++ b/LayoutTests/editing/execCommand/outdent-list-resets-start-number.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+<div id="test" contenteditable>
+<ol start="11"><li>eleven</li><li id="target">twelve</li><li>thirteen</li><li>fourteen</li></ol>
+</div>
+<script>
+Markup.description('This tests that outdenting a middle list item resets the start attribute to 1 on the second half of the split list.');
+
+Markup.dump('test', 'Before');
+
+var target = document.getElementById('target');
+var selection = window.getSelection();
+var range = document.createRange();
+range.selectNodeContents(target);
+range.collapse(true);
+selection.removeAllRanges();
+selection.addRange(range);
+
+document.execCommand('Outdent', false, '');
+
+Markup.dump('test', 'After');
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -716,6 +716,13 @@ void CompositeEditCommand::splitElement(Element& element, Node& atChild)
     applyCommandToComposite(SplitElementCommand::create(element, atChild));
 }
 
+void CompositeEditCommand::splitListElement(Element& listNode, Node& listChild)
+{
+    splitElement(listNode, *splitTreeToNode(listChild, listNode));
+    if (listNode.hasTagName(olTag) && listNode.hasAttribute(startAttr))
+        setNodeAttribute(listNode, startAttr, AtomString::number(1));
+}
+
 void CompositeEditCommand::mergeIdenticalElements(Element& first, Element& second)
 {
     Ref<Element> protectedFirst = first;
@@ -1649,7 +1656,7 @@ bool CompositeEditCommand::breakOutOfEmptyListItem()
     if ((nextListNode && isListItem(*nextListNode)) || isListHTMLElement(nextListNode.get())) {
         // If emptyListItem follows another list item or nested list, split the list node.
         if (previousListNode && (isListItem(*previousListNode) || isListHTMLElement(previousListNode.get())))
-            splitElement(downcast<Element>(*listNode), *emptyListItem);
+            splitListElement(downcast<Element>(*listNode), *emptyListItem);
 
         // If emptyListItem is followed by other list item or nested list, then insert newBlock before the list node.
         // Because we have splitted the element, emptyListItem is the first element in the list node.

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -191,6 +191,7 @@ protected:
     Position positionOutsideTabSpan(const Position&);
     void setNodeAttribute(Element&, const QualifiedName& attribute, const AtomString& value);
     void splitElement(Element&, Node& atChild);
+    void splitListElement(Element&, Node& atChild);
     void splitTextNode(Text&, unsigned offset);
     void splitTextNodeContainingElement(Text&, unsigned offset);
     void wrapContentsInDummySpan(Element&);

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -350,14 +350,14 @@ void InsertListCommand::unlistifyParagraph(const VisiblePosition& originalStart,
     }
 
     if (nextListChild && previousListChild) {
-        // We want to pull listChildNode out of listNode, and place it before nextListChild 
+        // We want to pull listChildNode out of listNode, and place it before nextListChild
         // and after previousListChild, so we split listNode and insert it between the two lists.  
         // But to split listNode, we must first split ancestors of listChildNode between it and listNode,
         // if any exist.
         // FIXME: We appear to split at nextListChild as opposed to listChildNode so that when we remove
         // listChildNode below in moveParagraphs, previousListChild will be removed along with it if it is 
         // unrendered. But we ought to remove nextListChild too, if it is unrendered.
-        splitElement(listNode, *splitTreeToNode(*nextListChild, listNode));
+        splitListElement(listNode, *nextListChild);
         insertNodeBefore(WTF::move(nodeToInsert), listNode);
     } else if (nextListChild || listChildNode->parentNode() != &listNode) {
         // Just because listChildNode has no previousListChild doesn't mean there isn't any content
@@ -365,7 +365,7 @@ void InsertListCommand::unlistifyParagraph(const VisiblePosition& originalStart,
         // between it and listNode. So, we split up to listNode before inserting the placeholder
         // where we're about to move listChildNode to.
         if (RefPtr listChildNodeParentNode { listChildNode->parentNode() }; listChildNodeParentNode && listChildNodeParentNode != &listNode)
-            splitElement(listNode, *splitTreeToNode(*listChildNode, listNode).get());
+            splitListElement(listNode, *listChildNode);
         insertNodeBefore(WTF::move(nodeToInsert), listNode);
     } else
         insertNodeAfter(WTF::move(nodeToInsert), listNode);


### PR DESCRIPTION
#### 4216f6e6461a64bfde017ae0bcf193f7af1bbef0
<pre>
Removing/outdent a line from ordered list causes the following list to start with an incorrect number
<a href="https://bugs.webkit.org/show_bug.cgi?id=312522">https://bugs.webkit.org/show_bug.cgi?id=312522</a>
<a href="https://rdar.apple.com/173537449">rdar://173537449</a>

Reviewed by Aditya Keerthi.

In unlistifyParagraph, there isn&apos;t a procedure to set the
starting list number after splitting. So, when it calls
splitElement() to split the list, this calls
Element::cloneElementWithoutChildren which clones all attributes,
including the start attribute.

For example, if the original list started with 11 and the list
is split in the middle, both lists now start with 11. The
expectation is when splitting the list, the second list starts
from 1.

Thus, make a function that splits the list and sets the second starting
list number to be 1 if a start attribute was originally provided. Otherwise,
don&apos;t do anything. Now, outdenting, removing list formatting, and entering to
create new lines should all have the following list start with 1.

Additionally, add layout tests for the cases to confirm the correct
starting list numbers. For outdenting and remove list formatting, both
go down the same code path so there is only one test.

* LayoutTests/editing/execCommand/break-out-of-list-resets-start-number-expected.txt: Added.
* LayoutTests/editing/execCommand/break-out-of-list-resets-start-number.html: Added.
* LayoutTests/editing/execCommand/outdent-list-resets-start-number-expected.txt: Added.
* LayoutTests/editing/execCommand/outdent-list-resets-start-number.html: Added.
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::splitListElement):
(WebCore::CompositeEditCommand::moveParagraphs):
* Source/WebCore/editing/CompositeEditCommand.h:
* Source/WebCore/editing/InsertListCommand.cpp:
(WebCore::InsertListCommand::unlistifyParagraph):

Canonical link: <a href="https://commits.webkit.org/311696@main">https://commits.webkit.org/311696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a385044041de34d77a27bfd8f31a208a2e5b99b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111590 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c4e849c-1bfc-48af-98a6-a2df67ea93d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121965 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85672 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1854d233-a104-4b7e-a13d-0ac18ae9522d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102634 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a2fa99a-8186-4919-a40c-7014a4a372bc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23306 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21557 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14103 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168820 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13154 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20878 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130122 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130233 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141052 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88369 "Hash a3850440 for PR 62938 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23985 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25064 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17857 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30080 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94322 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29602 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29832 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29729 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->