### PR TITLE
RemoteImageBufferGraphicsContext::drawImageBuffer continually reallocate buffers.

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferGraphicsContext.cpp
@@ -68,13 +68,18 @@ void RemoteImageBufferGraphicsContext::drawImageBuffer(RenderingResourceIdentifi
     MESSAGE_CHECK(sourceImage);
     bool selfCopy = false;
     if (sourceImage == m_imageBuffer.ptr() && sourceImage->renderingMode() == RenderingMode::Accelerated) {
-        sourceImage = sourceImage->clone();
-        sourceImage->flushDrawingContext();
-        selfCopy = true;
+        RefPtr selfCopySourceImage = m_renderingBackend->createImageBufferForSelfCopy(sourceImage);
+        if (selfCopySourceImage) {
+            selfCopySourceImage->context().drawImageBuffer(m_imageBuffer, FloatPoint { }, { CompositeOperator::Copy });
+            sourceImage = selfCopySourceImage;
+            selfCopy = true;
+        }
     }
     context().drawImageBuffer(*sourceImage, destinationRect, srcRect, options);
-    if (selfCopy)
-        m_imageBuffer->flushDrawingContext();
+    if (selfCopy) {
+        m_imageBuffer->submitDrawingCommands();
+        m_renderingBackend->returnImageBufferForSelfCopy(WTF::move(sourceImage));
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -164,6 +164,10 @@ void RemoteRenderingBackend::workQueueUninitialize()
     // Make sure we destroy the ResourceCache on the WorkQueue since it gets populated on the WorkQueue.
     m_remoteResourceCache.releaseAllResources();
 
+    if (m_imageBufferForSelfCopyTimer)
+        m_imageBufferForSelfCopyTimer->stop();
+    m_imageBufferForSelfCopyTimer = nullptr;
+
     Ref streamConnection = m_streamConnection;
     streamConnection->stopReceivingMessages(Messages::RemoteRenderingBackend::messageReceiverName(), m_renderingBackendIdentifier.toUInt64());
     streamConnection->invalidate();
@@ -318,6 +322,41 @@ void RemoteRenderingBackend::createImageBuffer(const FloatSize& logicalSize, Ren
     }
     auto result = m_remoteImageBuffers.add(identifier, RemoteImageBuffer::create(imageBuffer.releaseNonNull(), identifier, contextIdentifier, *this));
     MESSAGE_CHECK(result.isNewEntry, "Duplicate ImageBuffers");
+}
+
+RefPtr<ImageBuffer> RemoteRenderingBackend::createImageBufferForSelfCopy(ImageBuffer* source)
+{
+    assertIsCurrent(workQueue());
+    RefPtr imageBuffer = std::exchange(m_imageBufferForSelfCopy, nullptr);
+    if (m_imageBufferForSelfCopyTimer)
+        m_imageBufferForSelfCopyTimer->stop();
+
+    if (imageBuffer
+        && imageBuffer->logicalSize().width() >= source->logicalSize().width()
+        && imageBuffer->logicalSize().height() >= source->logicalSize().height()
+        && imageBuffer->renderingMode() == source->renderingMode()
+        && imageBuffer->renderingPurpose() == source->renderingPurpose()
+        && imageBuffer->resolutionScale() == source->resolutionScale()
+        && imageBuffer->colorSpace() == source->colorSpace()
+        && imageBuffer->pixelFormat() == source->pixelFormat())
+        return imageBuffer;
+
+    return allocateImageBuffer(source->logicalSize(), source->renderingMode(), source->renderingPurpose(), source->resolutionScale(), source->colorSpace(), { source->pixelFormat() }, { });
+}
+
+void RemoteRenderingBackend::returnImageBufferForSelfCopy(RefPtr<ImageBuffer>&& buffer)
+{
+    assertIsCurrent(workQueue());
+    m_imageBufferForSelfCopy = WTF::move(buffer);
+    if (!m_imageBufferForSelfCopyTimer)
+        m_imageBufferForSelfCopyTimer = makeUnique<Timer>(*this, &RemoteRenderingBackend::cleanupImageBufferForSelfCopy);
+    m_imageBufferForSelfCopyTimer->startOneShot(200_ms);
+}
+
+void RemoteRenderingBackend::cleanupImageBufferForSelfCopy()
+{
+    assertIsCurrent(workQueue());
+    m_imageBufferForSelfCopy = nullptr;
 }
 
 void RemoteRenderingBackend::releaseImageBuffer(RenderingResourceIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -58,6 +58,7 @@
 #include <WebCore/PixelFormat.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/RenderingResourceIdentifier.h>
+#include <WebCore/Timer.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -135,6 +136,10 @@ public:
     RefPtr<WebCore::ImageBuffer> allocateImageBuffer(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferFormat, WebCore::ImageBufferCreationContext);
 
     RemoteRenderingBackendIdentifier identifier() { return m_renderingBackendIdentifier; }
+
+    RefPtr<WebCore::ImageBuffer> createImageBufferForSelfCopy(WebCore::ImageBuffer*);
+    void returnImageBufferForSelfCopy(RefPtr<WebCore::ImageBuffer>&&);
+
 private:
     friend class RemoteImageBufferSet;
     RemoteRenderingBackend(GPUConnectionToWebProcess&, RemoteRenderingBackendIdentifier, Ref<IPC::StreamServerConnection>&&);
@@ -203,6 +208,8 @@ private:
 
     void getImageBufferResourceLimitsForTesting(CompletionHandler<void(WebCore::ImageBufferResourceLimits)>&&);
 
+    void cleanupImageBufferForSelfCopy();
+
     const Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     const Ref<IPC::StreamServerConnection> m_streamConnection;
     const Ref<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
@@ -211,6 +218,9 @@ private:
     WebCore::ProcessIdentity m_resourceOwner;
     RemoteRenderingBackendIdentifier m_renderingBackendIdentifier;
     RefPtr<WebCore::SharedMemory> m_getPixelBufferSharedMemory;
+
+    RefPtr<WebCore::ImageBuffer> m_imageBufferForSelfCopy  WTF_GUARDED_BY_CAPABILITY(workQueue());
+    std::unique_ptr<WebCore::Timer> m_imageBufferForSelfCopyTimer  WTF_GUARDED_BY_CAPABILITY(workQueue());
 
     HashMap<WebCore::RenderingResourceIdentifier, IPC::ScopedActiveMessageReceiveQueue<RemoteImageBuffer>> m_remoteImageBuffers WTF_GUARDED_BY_CAPABILITY(workQueue());
 


### PR DESCRIPTION
#### 61c4954ff80af23a30432e39971e8774f4485169
<pre>
RemoteImageBufferGraphicsContext::drawImageBuffer continually reallocate buffers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=312532">https://bugs.webkit.org/show_bug.cgi?id=312532</a>
&lt;<a href="https://rdar.apple.com/174969976">rdar://174969976</a>&gt;

Reviewed by Dan Glastonbury.

RemoteImageBufferGraphicsContext::drawImageBuffer uses a temporary buffer when
it detects a self-copy.

If there are many of these, it pays the cost for allocating over and over.

We should cache a single buffer to be reused, and free it if isn&apos;t used for a
while.

* Source/WebKit/GPUProcess/graphics/RemoteImageBufferGraphicsContext.cpp:
(WebKit::RemoteImageBufferGraphicsContext::drawImageBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::workQueueUninitialize):
(WebKit::RemoteRenderingBackend::createImageBufferForSelfCopy):
(WebKit::RemoteRenderingBackend::returnImageBufferForSelfCopy):
(WebKit::RemoteRenderingBackend::cleanupImageBufferForSelfCopy):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:

Canonical link: <a href="https://commits.webkit.org/311500@main">https://commits.webkit.org/311500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba9a8b05ae88b83c25040b9875fd555f0021146b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165940 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab16e003-4313-4eb2-a145-aef081c02eac) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121677 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9691d706-ab9e-494b-a3a9-982bcddd51bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102345 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22983 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21216 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13712 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132663 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168425 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12584 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129805 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129913 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35203 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140708 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87799 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17512 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29689 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93703 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29211 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29441 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29338 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->