### PR TITLE
REGRESSION(309060@main): Gradient rendering performance regressed by not caching stop in device colorspace.

### DIFF
--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/Color.h>
 #include <WebCore/ColorInterpolationMethod.h>
+#include <WebCore/DestinationColorSpace.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/GradientColorStops.h>
 #include <WebCore/GraphicsTypes.h>
@@ -116,7 +117,7 @@ public:
 
 #if USE(CG)
     void paint(GraphicsContext&);
-    void paint(CGContextRef);
+    void paint(CGContextRef, std::optional<DestinationColorSpace> = { });
 #endif
 
 #if USE(SKIA)

--- a/Source/WebCore/platform/graphics/cg/GradientCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientCG.cpp
@@ -31,10 +31,27 @@
 
 #include "GradientRendererCG.h"
 #include "GraphicsContextCG.h"
+#include "PredefinedColorSpace.h"
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {
+
+static std::optional<DestinationColorSpace> nonLinearDestinationColorSpace(const DestinationColorSpace& colorSpace)
+{
+    auto predefined = toPredefinedColorSpace(colorSpace);
+    if (!predefined)
+        return colorSpace;
+    switch (*predefined) {
+    case PredefinedColorSpace::SRGBLinear:
+#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
+    case PredefinedColorSpace::DisplayP3Linear:
+#endif
+        return std::nullopt;
+    default:
+        return colorSpace;
+    }
+}
 
 void Gradient::stopsChanged()
 {
@@ -49,13 +66,13 @@ void Gradient::fill(GraphicsContext& context, const FloatRect& rect)
 
 void Gradient::paint(GraphicsContext& context)
 {
-    paint(context.platformContext());
+    paint(context.platformContext(), nonLinearDestinationColorSpace(context.colorSpace()));
 }
 
-void Gradient::paint(CGContextRef platformContext)
+void Gradient::paint(CGContextRef platformContext, std::optional<DestinationColorSpace> colorSpace)
 {
-    if (!m_platformRenderer)
-        m_platformRenderer = GradientRendererCG { m_colorInterpolationMethod, m_stops.sorted() };
+    if (!m_platformRenderer || m_platformRenderer->colorSpace() != colorSpace)
+        m_platformRenderer = GradientRendererCG { m_colorInterpolationMethod, m_stops.sorted(), colorSpace };
 
     WTF::switchOn(m_data,
         [&] (const LinearData& data) {

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -26,8 +26,10 @@
 #include "config.h"
 #include "GradientRendererCG.h"
 
+#include "ColorConversion.h"
 #include "ColorHash.h"
 #include "ColorSpaceCG.h"
+#include "DestinationColorSpace.h"
 #include "GradientColorStops.h"
 #include "SampledGradientBuilder.h"
 #include <wtf/HashMap.h>
@@ -39,6 +41,7 @@ using namespace WebCore;
 struct SampledGradientCacheKey {
     ColorInterpolationMethod interpolationMethod;
     GradientColorStops::StopVector colorStops;
+    std::optional<DestinationColorSpace> destinationColorSpace;
 
     friend bool operator==(const SampledGradientCacheKey&, const SampledGradientCacheKey&) = default;
 };
@@ -52,7 +55,7 @@ bool TinyLRUCachePolicy<SampledGradientCacheKey, RetainPtr<CGGradientRef>>::isKe
 template<>
 RetainPtr<CGGradientRef> TinyLRUCachePolicy<SampledGradientCacheKey, RetainPtr<CGGradientRef>>::createValueForKey(const SampledGradientCacheKey& params)
 {
-    return WebCore::GradientRendererCG::createGradientBySampling(params.interpolationMethod, params.colorStops);
+    return WebCore::GradientRendererCG::createGradientBySampling(params.interpolationMethod, params.colorStops, params.destinationColorSpace);
 }
 
 } // namespace WTF
@@ -61,8 +64,9 @@ namespace WebCore {
 
 // MARK: - Constructor.
 
-GradientRendererCG::GradientRendererCG(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops)
-    : m_gradient { makeGradient(colorInterpolationMethod, stops) }
+GradientRendererCG::GradientRendererCG(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops, std::optional<DestinationColorSpace> colorSpace)
+    : m_colorSpace { WTF::move(colorSpace) }
+    , m_gradient { makeGradient(colorInterpolationMethod, stops) }
 {
 }
 
@@ -131,7 +135,16 @@ GradientRendererCG::Gradient GradientRendererCG::makeGradient(ColorInterpolation
     Vector<CGFloat, 4 * reservedStops> colorComponents;
     colorComponents.reserveInitialCapacity(numberOfStops * 4);
 
-    RetainPtr cgColorSpace = [&] {
+    RetainPtr cgColorSpace = [&] () -> CGColorSpaceRef {
+        if (m_colorSpace) {
+            for (const auto& stop : stops) {
+                auto components = stop.color.toResolvedColorComponentsInColorSpace(*m_colorSpace);
+                colorComponents.appendList({ components[0], components[1], components[2], components[3] });
+                locations.append(stop.offset);
+            }
+            return m_colorSpace->platformColorSpace();
+        }
+
         // FIXME: Now that we only ever use CGGradientCreateWithColorComponents, we should investigate
         // if there is any real benefit to using sRGB when all the stops are bounded vs just using
         // extended sRGB for all gradients.
@@ -188,24 +201,44 @@ GradientRendererCG::Gradient GradientRendererCG::makeGradientBySampling(ColorInt
 {
     auto colorStops = stops.sorted().stops();
     static NeverDestroyed<TinyLRUCache<WTF::SampledGradientCacheKey, RetainPtr<CGGradientRef>, 8>> cache;
-    RetainPtr gradient = cache.get().get({ colorInterpolationMethod, colorStops });
+    RetainPtr gradient = cache.get().get({ colorInterpolationMethod, colorStops, m_colorSpace });
     return Gradient { WTF::move(gradient) };
 }
 
-RetainPtr<CGGradientRef> GradientRendererCG::createGradientBySampling(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops::StopVector& stops)
+RetainPtr<CGGradientRef> GradientRendererCG::createGradientBySampling(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops::StopVector& stops, const std::optional<DestinationColorSpace>& destinationColorSpace)
 {
     using OutputSpaceColorType = std::conditional_t<HasCGColorSpaceMapping<ColorSpace::ExtendedSRGB>, ExtendedSRGBA<float>, SRGBA<float>>;
 
     auto sampled = sampleGradientStops<OutputSpaceColorType>(colorInterpolationMethod, stops);
 
-    auto cgColorSpace = cachedCGColorSpaceSingleton<ColorSpaceFor<OutputSpaceColorType>>();
-
     Vector<CGFloat> locations(sampled.locations.size());
     Vector<CGFloat> components(sampled.colorComponents.size());
     for (size_t i = 0; i < sampled.locations.size(); ++i)
         locations[i] = sampled.locations[i];
-    for (size_t i = 0; i < sampled.colorComponents.size(); ++i)
-        components[i] = sampled.colorComponents[i];
+
+    CGColorSpaceRef cgColorSpace;
+    if (destinationColorSpace) {
+        constexpr auto inputColorSpace = ColorSpaceFor<OutputSpaceColorType>;
+        auto numberOfStops = sampled.locations.size();
+        for (size_t i = 0; i < numberOfStops; ++i) {
+            ColorComponents<float, 4> input {
+                sampled.colorComponents[i * 4],
+                sampled.colorComponents[i * 4 + 1],
+                sampled.colorComponents[i * 4 + 2],
+                sampled.colorComponents[i * 4 + 3]
+            };
+            auto converted = convertAndResolveColorComponents(inputColorSpace, input, *destinationColorSpace);
+            components[i * 4] = converted[0];
+            components[i * 4 + 1] = converted[1];
+            components[i * 4 + 2] = converted[2];
+            components[i * 4 + 3] = converted[3];
+        }
+        cgColorSpace = destinationColorSpace->platformColorSpace();
+    } else {
+        for (size_t i = 0; i < sampled.colorComponents.size(); ++i)
+            components[i] = sampled.colorComponents[i];
+        cgColorSpace = cachedCGColorSpaceSingleton<ColorSpaceFor<OutputSpaceColorType>>();
+    }
 
     return adoptCF(CGGradientCreateWithColorComponentsAndOptions(cgColorSpace,
         components.span().data(), locations.span().data(), locations.size(), gradientOptionsDictionary(colorInterpolationMethod)));

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
@@ -27,6 +27,7 @@
 
 #include <CoreGraphics/CoreGraphics.h>
 #include <WebCore/ColorInterpolationMethod.h>
+#include <WebCore/DestinationColorSpace.h>
 #include <wtf/RetainPtr.h>
 
 namespace WebCore {
@@ -35,13 +36,15 @@ class GradientColorStops;
 
 class GradientRendererCG {
 public:
-    GradientRendererCG(ColorInterpolationMethod, const GradientColorStops&);
+    GradientRendererCG(ColorInterpolationMethod, const GradientColorStops&, std::optional<DestinationColorSpace> = { });
 
     void drawLinearGradient(CGContextRef, CGPoint startPoint, CGPoint endPoint, CGGradientDrawingOptions);
     void drawRadialGradient(CGContextRef, CGPoint startCenter, CGFloat startRadius, CGPoint endCenter, CGFloat endRadius, CGGradientDrawingOptions);
     void drawConicGradient(CGContextRef, CGPoint center, CGFloat angle);
 
-    static RetainPtr<CGGradientRef> createGradientBySampling(ColorInterpolationMethod, const GradientColorStops::StopVector&);
+    const std::optional<DestinationColorSpace>& colorSpace() const { return m_colorSpace; }
+
+    static RetainPtr<CGGradientRef> createGradientBySampling(ColorInterpolationMethod, const GradientColorStops::StopVector&, const std::optional<DestinationColorSpace>& = { });
 
 private:
     using Gradient = RetainPtr<CGGradientRef>;
@@ -49,6 +52,7 @@ private:
     Gradient makeGradient(ColorInterpolationMethod, const GradientColorStops&) const;
     Gradient makeGradientBySampling(ColorInterpolationMethod, const GradientColorStops&) const;
 
+    std::optional<DestinationColorSpace> m_colorSpace;
     Gradient m_gradient;
 };
 


### PR DESCRIPTION
#### f5492c8f3d5680fa6b458c496110962ed58c8ff7
<pre>
REGRESSION(309060@main): Gradient rendering performance regressed by not caching stop in device colorspace.
<a href="https://bugs.webkit.org/show_bug.cgi?id=312535">https://bugs.webkit.org/show_bug.cgi?id=312535</a>
&lt;<a href="https://rdar.apple.com/174044547">rdar://174044547</a>&gt;

Reviewed by Dan Glastonbury.

This change switched back to rendering gradients in sRGB instead of device
colourspace.

I think we can do this again, as long as the &apos;device&apos; (destination ImageBuffer)
colourspace isn&apos;t a linear one, and should be approximately equal to sRGB for
interpolation.

The regressing changeset added tests, so these should confirm this doesn&apos;t
reintroduce the bug.

* Source/WebCore/platform/graphics/Gradient.h:
* Source/WebCore/platform/graphics/cg/GradientCG.cpp:
(WebCore::nonLinearDestinationColorSpace):
(WebCore::Gradient::paint):
* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
(WTF::RetainPtr&lt;CGGradientRef&gt;&gt;::createValueForKey):
(WebCore::GradientRendererCG::GradientRendererCG):
(WebCore::GradientRendererCG::makeGradient const):
(WebCore::GradientRendererCG::makeGradientBySampling const):
(WebCore::GradientRendererCG::createGradientBySampling):
* Source/WebCore/platform/graphics/cg/GradientRendererCG.h:
(WebCore::GradientRendererCG::GradientRendererCG):
(WebCore::GradientRendererCG::colorSpace const):
(WebCore::GradientRendererCG::createGradientBySampling):

Canonical link: <a href="https://commits.webkit.org/311433@main">https://commits.webkit.org/311433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6cf873bac9b964c3844a685ffe920bf59bcd546

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165781 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121555 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102223 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22847 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21075 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13553 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168266 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12425 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129673 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129780 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35155 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140574 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87623 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24612 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17378 "Too many flaky failures: http/tests/media/clearkey/clear-key-hls-aes128.html, http/tests/misc/script-defer-after-slow-stylesheet.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/ping-to-prevalent-resource.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/report-blocked-data-uri.py, http/tests/security/mixedContent/redirect-http-to-https-iframe-in-main-frame.html, http/tests/site-isolation/frame-index.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29530 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93544 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29052 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29282 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29178 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->