### PR TITLE
Revert 311354@main now that the Safer CPP bot no longer builds TestWebKitAPI

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.h
@@ -27,6 +27,8 @@
 
 #include <wtf/Platform.h>
 
+#if !PLATFORM(COCOA) || !__has_feature(modules)
+
 #include "Helpers/Test.h"
 #include <WebCore/Color.h>
 #include <WebCore/FloatPoint.h>
@@ -45,3 +47,5 @@ namespace TestWebKitAPI {
 ::testing::AssertionResult imagePixelIs(WebCore::Color expected, WebCore::NativeImage&, WebCore::FloatPoint);
 
 }
+
+#endif // !PLATFORM(COCOA) || !__has_feature(modules)

--- a/Tools/TestWebKitAPI/Helpers/JavaScriptTest.h
+++ b/Tools/TestWebKitAPI/Helpers/JavaScriptTest.h
@@ -27,6 +27,8 @@
 
 #include <wtf/Platform.h>
 
+#if !PLATFORM(COCOA) || !__has_feature(modules)
+
 #if PLATFORM(COCOA)
 OBJC_CLASS WebView;
 OBJC_CLASS WKWebView;
@@ -50,3 +52,5 @@ namespace TestWebKitAPI {
 #endif
 
 } // namespace TestWebKitAPI
+
+#endif // !PLATFORM(COCOA) || !__has_feature(modules)

--- a/Tools/TestWebKitAPI/Helpers/PlatformUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/PlatformUtilities.h
@@ -98,6 +98,8 @@ WKRetainPtr<WKStringRef> toWK(const char* utf8String);
 
 #endif // WK_HAVE_C_SPI
 
+#if !PLATFORM(COCOA) || !__has_feature(modules)
+
 template<typename T, typename U>
 static inline ::testing::AssertionResult assertWKStringEqual(const char* expected_expression, const char* actual_expression, T expected, U actual)
 {
@@ -106,6 +108,8 @@ static inline ::testing::AssertionResult assertWKStringEqual(const char* expecte
 
 #define EXPECT_WK_STREQ(expected, actual) \
     EXPECT_PRED_FORMAT2(TestWebKitAPI::Util::assertWKStringEqual, expected, actual)
+
+#endif // !PLATFORM(COCOA) || !__has_feature(modules)
 
 #if PLATFORM(MAC)
 using PlatformImage = NSImage;

--- a/Tools/TestWebKitAPI/Helpers/Test.h
+++ b/Tools/TestWebKitAPI/Helpers/Test.h
@@ -27,6 +27,8 @@
 
 #include <wtf/Platform.h>
 
+#if !PLATFORM(COCOA) || !__has_feature(modules)
+
 #include <type_traits>
 #include <wtf/ASCIICType.h>
 #include <wtf/text/WTFString.h>
@@ -96,3 +98,5 @@ inline std::ostream& operator<<(std::ostream& os, const ASCIILiteral& string)
 }
 
 }
+
+#endif // !PLATFORM(COCOA) || !__has_feature(modules)

--- a/Tools/TestWebKitAPI/Helpers/WebCoreTestUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/WebCoreTestUtilities.h
@@ -27,6 +27,8 @@
 
 #include <wtf/Platform.h>
 
+#if !PLATFORM(COCOA) || !__has_feature(modules)
+
 #include "Helpers/Test.h"
 #include <WebCore/Color.h>
 #include <WebCore/FloatRect.h>
@@ -116,3 +118,5 @@ inline std::ostream& operator<<(std::ostream& os, const WebCore::FloatSegment& v
 }
 
 }
+
+#endif // !PLATFORM(COCOA) || !__has_feature(modules)


### PR DESCRIPTION
#### 6edc6dbf9e61ee79e0f34e8c5f2a898b63dcece0
<pre>
Revert 311354@main now that the Safer CPP bot no longer builds TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=312539">https://bugs.webkit.org/show_bug.cgi?id=312539</a>
<a href="https://rdar.apple.com/174977047">rdar://174977047</a>

Unreviewed revert of 311354@main

* Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.h:
* Tools/TestWebKitAPI/Helpers/JavaScriptTest.h:
* Tools/TestWebKitAPI/Helpers/PlatformUtilities.h:
* Tools/TestWebKitAPI/Helpers/Test.h:
* Tools/TestWebKitAPI/Helpers/WebCoreTestUtilities.h:

Canonical link: <a href="https://commits.webkit.org/311417@main">https://commits.webkit.org/311417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4129c388ce14845f526296335405dbfb3ab848d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30301 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/23492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/165788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30304 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/165788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159923 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/165788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/13560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168273 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/20397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/129786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/29826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/140571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23888 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/29826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/29537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/29059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->