### PR TITLE
REGRESSION(311175@main):  Deadlock in applyPendingChangesForAllIsolatedTrees when processing cross-frame objects

### DIFF
--- a/Source/WebCore/accessibility/AXTreeStore.cpp
+++ b/Source/WebCore/accessibility/AXTreeStore.cpp
@@ -38,17 +38,32 @@ WEBCORE_EXPORT void AXTreeStore<AXIsolatedTree>::applyPendingChangesForAllIsolat
 {
     AX_ASSERT(!isMainThread());
 
-    Locker locker { AXTreeStore<AXIsolatedTree>::s_storeLock };
-    auto& map = AXTreeStore<AXIsolatedTree>::isolatedTreeMap();
-    Vector<AXTreeID> treesToRemove;
-    for (const auto& axIDToTree : map) {
-        if (RefPtr tree = axIDToTree.value.get()) {
-            if (tree->applyPendingChangesOrTearDown() == DidTearDown::Yes)
-                treesToRemove.append(axIDToTree.key);
+    // Snapshot all live trees while holding the lock, then release it before
+    // calling applyPendingChangesOrTearDown. This is necessary because
+    // applyPendingChangesLocked can call attachPlatformWrapper ->
+    // crossFrameChildObject -> treeForFrameID, which needs to acquire
+    // s_storeLock. Holding s_storeLock across that call would self-deadlock.
+    Vector<std::pair<AXTreeID, Ref<AXIsolatedTree>>> trees;
+    {
+        Locker locker { AXTreeStore<AXIsolatedTree>::s_storeLock };
+        for (auto& entry : AXTreeStore<AXIsolatedTree>::isolatedTreeMap()) {
+            if (RefPtr tree = entry.value.get())
+                trees.append({ entry.key, tree.releaseNonNull() });
         }
     }
-    for (auto& treeID : treesToRemove)
-        map.remove(treeID);
+
+    Vector<AXTreeID> treesToRemove;
+    for (auto& [treeID, tree] : trees) {
+        if (tree->applyPendingChangesOrTearDown() == DidTearDown::Yes)
+            treesToRemove.append(treeID);
+    }
+
+    if (!treesToRemove.isEmpty()) {
+        Locker locker { AXTreeStore<AXIsolatedTree>::s_storeLock };
+        auto& map = AXTreeStore<AXIsolatedTree>::isolatedTreeMap();
+        for (auto& treeID : treesToRemove)
+            map.remove(treeID);
+    }
 
     AXIsolatedTree::clearAnyTreeNeedsTearDown();
 }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1137,12 +1137,6 @@ OptionSet<ActivityState> AXIsolatedTree::pageActivityState() const
     return m_pageActivityState;
 }
 
-OptionSet<ActivityState> AXIsolatedTree::lockedPageActivityState() const
-{
-    AX_ASSERT(s_storeLock.isLocked());
-    return m_pageActivityState;
-}
-
 AXCoreObject::AccessibilityChildrenVector AXIsolatedTree::sortedLiveRegions()
 {
     AX_ASSERT(!isMainThread());
@@ -1729,12 +1723,19 @@ AXTreePtr findAXTree(Function<bool(AXTreePtr)>&& match)
     }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    Locker locker { AXTreeStore<AXIsolatedTree>::s_storeLock };
-    for (auto it = AXTreeStore<AXIsolatedTree>::isolatedTreeMap().begin(); it != AXTreeStore<AXIsolatedTree>::isolatedTreeMap().end(); ++it) {
-        RefPtr tree = it->value.get();
-        if (!tree)
-            continue;
-
+    // Snapshot all live trees while holding the lock, then release it before
+    // calling the match callback. The callback can trigger applyPendingChanges
+    // (e.g. via focusedNodeID), which can call treeForFrameID via
+    // crossFrameChildObject, which needs to acquire s_storeLock.
+    Vector<RefPtr<AXIsolatedTree>> trees;
+    {
+        Locker locker { AXTreeStore<AXIsolatedTree>::s_storeLock };
+        for (auto& entry : AXTreeStore<AXIsolatedTree>::isolatedTreeMap()) {
+            if (RefPtr tree = entry.value.get())
+                trees.append(WTF::move(tree));
+        }
+    }
+    for (auto& tree : trees) {
         if (match(tree))
             return tree;
     }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -548,9 +548,7 @@ public:
     constexpr AXTreeID treeID() const { return m_id; }
     constexpr ProcessID processID() const { return m_processID; }
     void setPageActivityState(OptionSet<ActivityState>);
-    OptionSet<ActivityState> pageActivityState() const;
-    // Use only if the s_storeLock is already held like in findAXTree.
-    WEBCORE_EXPORT OptionSet<ActivityState> NODELETE lockedPageActivityState() const;
+    WEBCORE_EXPORT OptionSet<ActivityState> pageActivityState() const;
 
     AXTextMarkerRange selectedTextMarkerRange() { return m_selectedTextMarkerRange; }
     void setSelectedTextMarkerRange(AXTextMarkerRange&&);

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -257,7 +257,7 @@ id WebProcess::accessibilityFocusedUIElement()
 #else
                     if (typedTree) {
 #endif
-                        OptionSet<ActivityState> state = typedTree->lockedPageActivityState();
+                        OptionSet<ActivityState> state = typedTree->pageActivityState();
                         if (state.containsAll({ ActivityState::IsVisible, ActivityState::IsFocused, ActivityState::WindowIsActive }))
                             foundValidTree = true;
                         else if (state.containsAll({ ActivityState::IsVisible, ActivityState::WindowIsActive })) {


### PR DESCRIPTION
#### aba0338545e8a7dfc384721c03ea2a56433350c7
<pre>
REGRESSION(311175@main):  Deadlock in applyPendingChangesForAllIsolatedTrees when processing cross-frame objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=312538">https://bugs.webkit.org/show_bug.cgi?id=312538</a>
<a href="https://rdar.apple.com/174976942">rdar://174976942</a>

Reviewed by Joshua Hoffman.

applyPendingChangesForAllIsolatedTrees held s_storeLock for the entire
function, including while calling applyPendingChangesOrTearDown on each
tree. For LocalFrame objects, this eventually reaches attachPlatformWrapper
-&gt; crossFrameChildObject -&gt; treeForFrameID, which tries to re-acquire
s_storeLock. Since Lock is non-recursive, the AX thread self-deadlocks.

Fix by snapshotting all live trees while holding the lock, releasing it,
then processing each tree without holding s_storeLock. This is better
lock hygiene anyways -- holding the lock across applyPendingChanges is
bad because this function can take a relatively long time.

Apply the same fix for findAXTree, which can run arbitrary code that
could potentially take the lock while we hold it.

* Source/WebCore/accessibility/AXTreeStore.cpp:
(WebCore::AXTreeStore&lt;AXIsolatedTree&gt;::applyPendingChangesForAllIsolatedTrees):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::findAXTree):

Canonical link: <a href="https://commits.webkit.org/311461@main">https://commits.webkit.org/311461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c867ff0ed0c7f1d2b243326b2bbbebd16d54c2ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165810 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111069 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121575 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85366 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23815 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140969 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102243 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22869 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21101 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13582 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168295 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12454 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129702 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129810 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35174 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140591 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87652 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24632 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17395 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29559 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93573 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29081 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29311 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29207 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->