### PR TITLE
[css-contain] Support contain:style for quotes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5688,13 +5688,6 @@ imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visib
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/quote-scoping-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/quote-scoping-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/quote-scoping-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/quote-scoping-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/quote-scoping-invalidation-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/quote-scoping-invalidation-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/quote-scoping-invalidation-004.html [ ImageOnlyFailure ]
 
 # Flaky css-contain test
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/animation-display-lock.html [ Failure Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-style-dynamic-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-style-dynamic-001-expected.txt
@@ -1,6 +1,6 @@
 
 PASS contain: none
-FAIL contain: style assert_equals: open-quote expected true but got false
+PASS contain: style
 FAIL switching contain from none to style assert_equals: increment-counter expected true but got false
 FAIL switching contain from style to none assert_equals: increment-counter expected false but got true
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1100,7 +1100,12 @@ void RenderElement::styleDidChange(Style::Difference diff, const RenderStyle* ol
 
     if (!m_parent)
         return;
-    
+
+    // When style containment changes, quote depth scoping boundaries change,
+    // so all quotes need to be recalculated.
+    if (oldStyle && oldStyle->usedContain().contains(Style::ContainValue::Style) != m_style.usedContain().contains(Style::ContainValue::Style))
+        view().setHasQuotesNeedingUpdate(true);
+
     if (diff == Style::DifferenceResult::Layout || diff == Style::DifferenceResult::Overflow) {
         RenderCounter::rendererStyleChanged(*this, oldStyle, m_style);
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -36,6 +36,7 @@
 #include "RenderCounter.h"
 #include "RenderDescendantIterator.h"
 #include "RenderElementInlines.h"
+#include "RenderElementStyleInlines.h"
 #include "RenderImage.h"
 #include "RenderQuote.h"
 #include "RenderStyle+GettersInlines.h"
@@ -62,7 +63,29 @@ void RenderTreeUpdater::GeneratedContent::updateRemainingQuotes()
         return;
     updateQuotesUpTo(nullptr);
     m_previousUpdatedQuote = nullptr;
+    m_quoteScopeStack.clear();
     m_updater.renderView().setHasQuotesNeedingUpdate(false);
+}
+
+static RenderElement* findQuoteScopeRoot(const RenderObject& renderer)
+{
+    for (auto* ancestor = renderer.parent(); ancestor; ancestor = ancestor->parent()) {
+        if (ancestor->shouldApplyStyleContainment())
+            return ancestor;
+    }
+    return nullptr;
+}
+
+RenderElement* RenderTreeUpdater::GeneratedContent::popExitedQuoteScopes(const RenderQuote& quote)
+{
+    auto* scopeRoot = findQuoteScopeRoot(quote);
+    auto isCurrentScopeAncestorOfQuote = [&] {
+        auto* topScope = m_quoteScopeStack.last().scopeRoot.get();
+        return topScope == scopeRoot || (topScope && quote.isDescendantOf(topScope));
+    };
+    while (m_quoteScopeStack.size() > 1 && !isCurrentScopeAncestorOfQuote())
+        m_quoteScopeStack.removeLast();
+    return scopeRoot;
 }
 
 void RenderTreeUpdater::GeneratedContent::updateQuotesUpTo(RenderQuote* lastQuote)
@@ -70,10 +93,21 @@ void RenderTreeUpdater::GeneratedContent::updateQuotesUpTo(RenderQuote* lastQuot
     auto quoteRenderers = descendantsOfType<RenderQuote>(m_updater.renderView());
     auto it = m_previousUpdatedQuote ? ++quoteRenderers.at(*m_previousUpdatedQuote) : quoteRenderers.begin();
     auto end = quoteRenderers.end();
+
+    if (m_quoteScopeStack.isEmpty())
+        m_quoteScopeStack.append({ nullptr, m_previousUpdatedQuote.get() });
+
     for (; it != end; ++it) {
         auto& quote = *it;
-        // Quote character depends on quote depth so we chain the updates.
-        quote.updateRenderer(m_updater.m_builder, m_previousUpdatedQuote.get());
+        auto* scopeRoot = popExitedQuoteScopes(quote);
+
+        bool hasEnteredNewContainmentScope = scopeRoot != m_quoteScopeStack.last().scopeRoot.get();
+        if (hasEnteredNewContainmentScope)
+            m_quoteScopeStack.append({ scopeRoot, m_quoteScopeStack.last().lastQuote.get() });
+
+        quote.updateRenderer(m_updater.m_builder, m_quoteScopeStack.last().lastQuote.get());
+        m_quoteScopeStack.last().lastQuote = quote;
+
         m_previousUpdatedQuote = quote;
         if (&quote == lastQuote)
             return;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 class Element;
+class RenderElement;
 class RenderQuote;
 
 class RenderTreeUpdater::GeneratedContent {
@@ -53,11 +54,18 @@ public:
 
 private:
     void updateQuotesUpTo(RenderQuote*);
+    RenderElement* popExitedQuoteScopes(const RenderQuote&);
 
     bool needsPseudoElement(const RenderStyle*);
 
+    struct QuoteScopeEntry {
+        SingleThreadWeakPtr<RenderElement> scopeRoot;
+        SingleThreadWeakPtr<RenderQuote> lastQuote;
+    };
+
     RenderTreeUpdater& m_updater;
     SingleThreadWeakPtr<RenderQuote> m_previousUpdatedQuote;
+    Vector<QuoteScopeEntry, 4> m_quoteScopeStack;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### fecb6a8fbcc7d3a1278988ab0d8824e5b941c80a
<pre>
[css-contain] Support contain:style for quotes
<a href="https://bugs.webkit.org/show_bug.cgi?id=232083">https://bugs.webkit.org/show_bug.cgi?id=232083</a>
<a href="https://rdar.apple.com/84758186">rdar://84758186</a>

Reviewed by Antti Koivisto.

WebKit does not honor the CSS Containment spec requirement that
contain:style creates a scoping boundary for quote depth. Quotes inside
a style-contained element inherit the current depth from the outer scope,
but depth changes inside do not propagate back out.

Add a scope stack to updateQuotesUpTo() that tracks contain:style
boundaries during quote processing. When entering a new containment
scope, the stack inherits the parent scope&apos;s last quote so inner quotes
start at the correct depth. When leaving a scope, the parent scope&apos;s
state is restored so outer quotes are unaffected by inner depth changes.

Also trigger quote recalculation when contain:style changes dynamically
on any element, since this alters scope boundaries for existing quotes.

Tests: imported/w3c/web-platform-tests/css/css-contain/quote-scoping-001.html
       imported/w3c/web-platform-tests/css/css-contain/quote-scoping-002.html
       imported/w3c/web-platform-tests/css/css-contain/quote-scoping-003.html
       imported/w3c/web-platform-tests/css/css-contain/quote-scoping-004.html
       imported/w3c/web-platform-tests/css/css-contain/quote-scoping-invalidation-001.html
       imported/w3c/web-platform-tests/css/css-contain/quote-scoping-invalidation-003.html
       imported/w3c/web-platform-tests/css/css-contain/quote-scoping-invalidation-004.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-style-dynamic-001-expected.txt:
  Document the new PASS condition.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleDidChange): Set hasQuotesNeedingUpdate when style containment
changes on an element.
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateRemainingQuotes): Clear scope stack
after full pass.
(WebCore::findQuoteScopeRoot): Added. Walks ancestors to find the nearest contain:style boundary.
(WebCore::RenderTreeUpdater::GeneratedContent::popExitedQuoteScopes): Added. Unwinds
the scope stack when a quote is no longer inside the top scope.
(WebCore::RenderTreeUpdater::GeneratedContent::updateQuotesUpTo):Use scope stack to pass
the correct previous quote per containment scope instead of flat document order.
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h:

Canonical link: <a href="https://commits.webkit.org/311785@main">https://commits.webkit.org/311785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59db9e931c60999b218247d2854b0ff865ee3c81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111058 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121564 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85360 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7eda7a9e-7105-47ab-8ca2-4355e58ad230) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102232 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0afd9785-b04c-4d0f-8e98-9af771ab37ef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22864 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21089 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13571 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168284 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129690 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129798 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35383 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140581 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87641 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24620 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17385 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29548 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93562 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29070 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29300 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29196 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->