### PR TITLE
YouTube controls do not appear when hovering the cursor over the video

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -530,6 +530,8 @@ public:
     bool ignoresNonWheelEvents() const { return m_ignoresNonWheelEvents; }
     void setIgnoresMouseMoveEvents(bool ignoresMouseMoveEvents) { m_ignoresMouseMoveEvents = ignoresMouseMoveEvents; }
     bool ignoresMouseMoveEvents() const { return m_ignoresMouseMoveEvents; }
+    bool webViewIsTopmostAtEventLocation(NSEvent *);
+    bool shouldSupressMouseMoveEvent(NSEvent *);
     void setIgnoresAllEvents(bool);
     bool ignoresAllEvents() const { return m_ignoresAllEvents; }
     void NODELETE setIgnoresMouseDraggedEvents(bool);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6318,9 +6318,23 @@ bool WebViewImpl::hasFlagsChangedEventMonitor()
     return m_flagsChangedEventMonitor;
 }
 
+bool WebViewImpl::webViewIsTopmostAtEventLocation(NSEvent *event)
+{
+    RetainPtr view = m_view.get();
+    NSView *hitView = [[view window].contentView hitTest:[[view window].contentView convertPoint:event.locationInWindow fromView:nil]];
+    return [hitView isDescendantOf:view.get()];
+}
+
+bool WebViewImpl::shouldSupressMouseMoveEvent(NSEvent *event)
+{
+    if (m_ignoresMouseMoveEvents && !webViewIsTopmostAtEventLocation(event))
+        return true;
+    return false;
+}
+
 void WebViewImpl::mouseEntered(NSEvent *event)
 {
-    if (m_ignoresMouseMoveEvents)
+    if (shouldSupressMouseMoveEvent(event))
         return;
 
     if (event.trackingArea == m_flagsChangedEventMonitorTrackingArea.get()) {
@@ -6333,7 +6347,7 @@ void WebViewImpl::mouseEntered(NSEvent *event)
 
 void WebViewImpl::mouseExited(NSEvent *event)
 {
-    if (m_ignoresMouseMoveEvents)
+    if (shouldSupressMouseMoveEvent(event))
         return;
 
     if (event.trackingArea == m_flagsChangedEventMonitorTrackingArea.get()) {
@@ -6396,7 +6410,10 @@ void WebViewImpl::mouseDraggedInternal(NSEvent *event, WebMouseEventInputSource 
 
 void WebViewImpl::mouseMoved(NSEvent *event)
 {
-    if (m_ignoresNonWheelEvents || m_ignoresMouseMoveEvents)
+    if (m_ignoresNonWheelEvents)
+        return;
+
+    if (shouldSupressMouseMoveEvent(event))
         return;
 
     for (auto& hud : _pdfHUDViews.values())

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MouseEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MouseEventTests.mm
@@ -447,6 +447,28 @@ TEST(MouseEventTests, AutoscrollOnMouseDragBelowWindow)
     EXPECT_GT(scrollY, 0);
 }
 
+TEST(MouseEventTests, IgnoresMouseMoveEvents)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView synchronouslyLoadTestPageNamed:@"mouse-move-listener"];
+    [webView _setIgnoresMouseMoveEvents:YES];
+
+    RetainPtr obscuringView = adoptNS([[NSView alloc] initWithFrame:NSMakeRect(200, 0, 200, 400)]);
+    [[webView superview] addSubview:obscuringView.get() positioned:NSWindowAbove relativeTo:webView.get()];
+
+    [webView mouseEnterAtPoint:NSMakePoint(100, 200)];
+    [webView mouseMoveToPoint:NSMakePoint(100, 200) withFlags:0];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"didMoveMouse()"] boolValue]);
+
+    [webView objectByEvaluatingJavaScript:@"mouseMoved = false"];
+
+    [webView mouseEnterAtPoint:NSMakePoint(300, 200)];
+    [webView mouseMoveToPoint:NSMakePoint(300, 200) withFlags:0];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"didMoveMouse()"] boolValue]);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 641be80bc2ae085229be7e767119fb055bce8435
<pre>
YouTube controls do not appear when hovering the cursor over the video
<a href="https://rdar.apple.com/169315862">rdar://169315862</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312541">https://bugs.webkit.org/show_bug.cgi?id=312541</a>

Reviewed by NOBODY (OOPS!).

Currently, to avoid mouse events leaking through from Safari&apos;s reader
overlay to the web view, the web view has data member m_ignoresMouseMoveEvents
that Safari sets to true when presenting the reader overlay or the tab group
sidebar overlay. When m_ignoresMouseMoveEvents is true, webkit ignores mousemove,
mouseenter, and mouseexit.

This logic does not work with the tab group overlay however because unlike reader, it
does not cover the entire web view, but rather just a small portion of it.
As a result, if the tab group side bar is open, webkit ignores all mouse events even
if the mouse is not over the sidebar.

To fix this, add a function to WebViewImpl called shouldSupressMouseMoveEvent that returns
true only if m_ignoresMouseMoveEvents is true and if a hit test returns a view that isn&apos;t
the web view or one of its descendents. Safari&apos;s reader and sidebar overlays are siblings of the
web view, so if the mouse is on top of an overlay, shouldSupressMouseMoveEvent will return true.
If the mouse is not on top of an overlay, and is instead directly on top of the web view, it
will return false and webkit will not ignore the mouse event.

Added API test MouseEventTests.IgnoresMouseMoveEvents

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::webViewIsTopmostAtEventLocation):
(WebKit::WebViewImpl::shouldSupressMouseMoveEvent):
(WebKit::WebViewImpl::mouseEntered):
(WebKit::WebViewImpl::mouseExited):
(WebKit::WebViewImpl::mouseMoved):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MouseEventTests.mm:
(TestWebKitAPI::TEST(MouseEventTests, IgnoresMouseMoveEvents)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/641be80bc2ae085229be7e767119fb055bce8435

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166354 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111612 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d0e0e9e-dec5-40b5-9046-99887d2322af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159401 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121978 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85679 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bf7e87a-2480-4fd4-85bc-b8b0d569994a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141450 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102647 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1dd6f962-91b8-4a5d-adbf-dfecc1e4f96f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23311 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21572 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14125 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168843 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130135 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25650 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130246 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88389 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25075 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17877 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30102 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94369 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29854 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29751 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->