### PR TITLE
[soup] http/tests/security/redirect-BLOCKED-to-localURL.html fails

### DIFF
--- a/LayoutTests/http/tests/security/redirect-BLOCKED-to-localURL-expected.txt
+++ b/LayoutTests/http/tests/security/redirect-BLOCKED-to-localURL-expected.txt
@@ -1,3 +1,2 @@
-CONSOLE MESSAGE: Not allowed to load local resource: file-redirect-target.html
 
 This attempts to open a redirect link to a file URL, which should be blocked.

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2199,8 +2199,6 @@ webkit.org/b/201270 [ Debug ] http/tests/security/navigate-when-restoring-cached
 webkit.org/b/201270 [ Release ] http/tests/security/showModalDialog-sync-cross-origin-page-load2.html [ Timeout ]
 webkit.org/b/201270 [ Debug ] http/tests/security/showModalDialog-sync-cross-origin-page-load2.html [ Crash ]
 
-webkit.org/b/263720 http/tests/security/redirect-BLOCKED-to-localURL.html [ Crash ]
-
 webkit.org/b/164539 http/tests/security/module-crossorigin-error-event-information.html [ Failure Pass ]
 
 # WebKitTestRunner needs a more-complete implementation of eventSender

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -5085,7 +5085,6 @@ http/tests/navigation/success200-subframeload.html [ Failure ]
 http/tests/navigation/timerredirect-subframeload.html [ Failure ]
 http/tests/security/drag-drop-same-unique-origin.html [ Failure ]
 http/tests/security/no-referrer.html [ Failure ]
-http/tests/security/redirect-BLOCKED-to-localURL.html [ Failure ]
 http/tests/security/setDomainRelaxationForbiddenForURLScheme.html [ Failure ]
 http/tests/uri/css-href.py [ Failure ]
 

--- a/LayoutTests/platform/mac/http/tests/security/redirect-BLOCKED-to-localURL-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/security/redirect-BLOCKED-to-localURL-expected.txt
@@ -1,2 +1,0 @@
-
-This attempts to open a redirect link to a file URL, which should be blocked.

--- a/LayoutTests/platform/win/http/tests/security/redirect-BLOCKED-to-localURL-expected.txt
+++ b/LayoutTests/platform/win/http/tests/security/redirect-BLOCKED-to-localURL-expected.txt
@@ -1,2 +1,0 @@
-
-This attempts to open a redirect link to a file URL, which should be blocked.

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -381,14 +381,45 @@ void NetworkDataTaskSoup::sendRequestCallback(SoupSession* soupSession, GAsyncRe
         task->didSendRequest(WTF::move(inputStream));
 }
 
+enum class ShouldStartHTTPRedirection {
+    No,
+    Yes,
+    Blocked
+};
+
+static ShouldStartHTTPRedirection shouldStartHTTPRedirection(const WebCore::ResourceResponse& response)
+{
+    auto status = response.httpStatusCode();
+    if (!SOUP_STATUS_IS_REDIRECTION(status))
+        return ShouldStartHTTPRedirection::No;
+
+    // Some 3xx status codes aren't actually redirects.
+    if (status == 300 || status == 304 || status == 305 || status == 306)
+        return ShouldStartHTTPRedirection::No;
+
+    auto location = response.httpHeaderField(HTTPHeaderName::Location);
+    if (location.isEmpty())
+        return ShouldStartHTTPRedirection::No;
+    if (location.startsWith("file:"_s))
+        return ShouldStartHTTPRedirection::Blocked;
+
+    return ShouldStartHTTPRedirection::Yes;
+}
+
 void NetworkDataTaskSoup::didSendRequest(GRefPtr<GInputStream>&& inputStream)
 {
     m_response = ResourceResponse(m_soupMessage.get(), m_sniffedContentType);
 
-    if (shouldStartHTTPRedirection()) {
+    switch (shouldStartHTTPRedirection(m_response)) {
+    case ShouldStartHTTPRedirection::Yes:
         m_inputStream = WTF::move(inputStream);
         skipInputStreamForRedirection();
         return;
+    case ShouldStartHTTPRedirection::Blocked:
+        didFail(blockedError(m_currentRequest));
+        return;
+    case ShouldStartHTTPRedirection::No:
+        break;
     }
 
     if (m_response.isMultipart())
@@ -741,25 +772,6 @@ static bool shouldRedirectAsGET(SoupMessage* message, bool crossOrigin)
         return true;
 
     return false;
-}
-
-bool NetworkDataTaskSoup::shouldStartHTTPRedirection()
-{
-    ASSERT(m_soupMessage);
-    ASSERT(!m_response.isNull());
-
-    auto status = m_response.httpStatusCode();
-    if (!SOUP_STATUS_IS_REDIRECTION(status))
-        return false;
-
-    // Some 3xx status codes aren't actually redirects.
-    if (status == 300 || status == 304 || status == 305 || status == 306)
-        return false;
-
-    if (m_response.httpHeaderField(HTTPHeaderName::Location).isEmpty())
-        return false;
-
-    return true;
 }
 
 void NetworkDataTaskSoup::continueHTTPRedirection()

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
@@ -98,7 +98,6 @@ private:
     static void skipInputStreamForRedirectionCallback(GInputStream*, GAsyncResult*, NetworkDataTaskSoup*);
     void skipInputStreamForRedirection();
     void didFinishSkipInputStreamForRedirection();
-    bool shouldStartHTTPRedirection();
     void continueHTTPRedirection();
 
     static void readCallback(GInputStream*, GAsyncResult*, NetworkDataTaskSoup*);


### PR DESCRIPTION
#### fcd1bae996082932d9856e728a09a9934e152d53
<pre>
[soup] http/tests/security/redirect-BLOCKED-to-localURL.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=263720">https://bugs.webkit.org/show_bug.cgi?id=263720</a>

Reviewed by Claudio Saavedra.

This test case sends a response of HTTP redirect to a local file. And, the
redirection should be blocked.

In GTK and WPE ports, the redirection was blocked by
DocumentLoader::willSendRequest, and DidFailProvisionalLoadForFrame message was
sent to WebPageProxy. The message contained a ResourceError with a file URL.
WebPageProxy determined it&apos;s a invalid message due to the file URL, and
disconnected the connection to web process.

In Mac port, the HTTP redirect was blocked earlier in the network process in
this case. Do the same for libsoup backend.

The common expected.txt file for the test case was added for Chromium port.
Unified mac and win platform specific expected.txt files into the common
expected.txt file.

* LayoutTests/http/tests/security/redirect-BLOCKED-to-localURL-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/http/tests/security/redirect-BLOCKED-to-localURL-expected.txt: Removed.
* LayoutTests/platform/win/http/tests/security/redirect-BLOCKED-to-localURL-expected.txt: Removed.
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::shouldStartHTTPRedirection):
(WebKit::NetworkDataTaskSoup::didSendRequest):
(WebKit::NetworkDataTaskSoup::shouldStartHTTPRedirection):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h:

Canonical link: <a href="https://commits.webkit.org/311441@main">https://commits.webkit.org/311441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b99779c9e6dfcb7e9eec72f28ba894f3afe14896

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30359 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/23550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165846 "Failed to checkout and rebase branch from PR 62951") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30362 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/165846 "Failed to checkout and rebase branch from PR 62951") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159981 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/165846 "Failed to checkout and rebase branch from PR 62951") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13618 "Failed to checkout and rebase branch from PR 62951") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168331 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12490 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/20453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29961 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/129839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29884 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/140627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23897 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/24667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29595 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93609 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29117 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->