### PR TITLE
RTCInboundRtpStreamStats.trackIdentifier doesn't match MediaStreamTrack.id

### DIFF
--- a/LayoutTests/webrtc/video-stats.html
+++ b/LayoutTests/webrtc/video-stats.html
@@ -122,9 +122,11 @@ function testTimestampDifference(timeStampDifference, numberOfFrames)
 
 function checkInboundFramesNumberIncreased(secondConnection, statsSecondConnection, count)
 {
+    const remoteTrackIds = new Set(secondConnection.getReceivers().map(receiver => receiver.track.id));
     return getInboundRTPStats(secondConnection).then((stats) => {
         assert_true("framesDropped" in stats, "framesDropped");
         assert_true(!!stats.trackIdentifier, "trackIdentifier");
+        assert_true(remoteTrackIds.has(stats.trackIdentifier), "trackIdentifier matches track.id");
         assert_true(!!stats.kind, "kind");
         if (stats.framesDecoded > statsSecondConnection.framesDecoded) {
             if (testTimestampDifference(stats.timestamp - statsSecondConnection.timestamp, stats.framesDecoded - statsSecondConnection.framesDecoded))

--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.h
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.h
@@ -189,7 +189,7 @@ public:
         std::optional<uint32_t> fecSsrc;
 
 #if USE(LIBWEBRTC)
-        static InboundRtpStreamStats convert(const webrtc::RTCInboundRtpStreamStats&);
+        static InboundRtpStreamStats convert(const webrtc::RTCInboundRtpStreamStats&, const HashMap<String, String>&);
 #elif USE(GSTREAMER_WEBRTC)
         static InboundRtpStreamStats convert(const GstStructure*);
 #endif

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -317,8 +317,8 @@ webrtc::scoped_refptr<LibWebRTCStatsCollector> LibWebRTCMediaEndpoint::createSta
         if (protectedThis->isStopped())
             return;
 
-        ActiveDOMObject::queueTaskKeepingObjectAlive(protectedThis->m_peerConnectionBackend->connection(), TaskSource::Networking, [promise = WTF::move(promise), rtcReport](auto&) {
-            promise->resolve<IDLInterface<RTCStatsReport>>(LibWebRTCStatsCollector::createReport(rtcReport));
+        ActiveDOMObject::queueTaskKeepingObjectAlive(protectedThis->m_peerConnectionBackend->connection(), TaskSource::Networking, [promise = WTF::move(promise), rtcReport = WTF::move(rtcReport), trackIds = protectedThis->m_peerConnectionBackend->trackIds()](auto&) mutable {
+            promise->resolve<IDLInterface<RTCStatsReport>>(LibWebRTCStatsCollector::createReport(WTF::move(rtcReport), WTF::move(trackIds)));
         });
     });
 }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -286,7 +286,11 @@ Ref<RTCRtpReceiver> LibWebRTCPeerConnectionBackend::createReceiver(LibWebRTCRtpR
 {
     Ref document = downcast<Document>(*m_peerConnection->scriptExecutionContext());
 
-    Ref remoteTrackPrivate = MediaStreamTrackPrivate::create(document->logger(), WTF::move(backendAndSource.source), createVersion4UUIDString());
+    auto sourceId = backendAndSource.source->persistentID();
+    auto trackId = createVersion4UUIDString();
+    m_trackIds.add(WTF::move(sourceId), trackId);
+
+    Ref remoteTrackPrivate = MediaStreamTrackPrivate::create(document->logger(), WTF::move(backendAndSource.source), WTF::move(trackId));
     Ref remoteTrack = MediaStreamTrack::create(document.get(), WTF::move(remoteTrackPrivate));
 
     return RTCRtpReceiver::create(*this, WTF::move(remoteTrack), WTF::move(backendAndSource.backend));

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -97,6 +97,8 @@ private:
 
     void collectTransceivers(Vector<Ref<RTCRtpTransceiver>>&&) final;
 
+    const HashMap<String, String>& trackIds() const { return m_trackIds; }
+
 private:
     bool isLocalDescriptionSet() const final { return m_isLocalDescriptionSet; }
 
@@ -124,6 +126,7 @@ private:
     Vector<std::unique_ptr<webrtc::IceCandidate>> m_pendingCandidates;
     Vector<Ref<RTCRtpReceiver>> m_pendingReceivers;
 
+    HashMap<String, String> m_trackIds;
     Function<void(String&&)> m_rtcStatsLogCallback;
 };
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
@@ -86,11 +86,19 @@ RTCStatsReport::ReceivedRtpStreamStats RTCStatsReport::ReceivedRtpStreamStats::c
     };
 }
 
-RTCStatsReport::InboundRtpStreamStats RTCStatsReport::InboundRtpStreamStats::convert(const webrtc::RTCInboundRtpStreamStats& rtcStats)
+RTCStatsReport::InboundRtpStreamStats RTCStatsReport::InboundRtpStreamStats::convert(const webrtc::RTCInboundRtpStreamStats& rtcStats, const HashMap<String, String>& trackIds)
 {
+    String trackId;
+    if (rtcStats.track_identifier) {
+        auto rtcTrackId = fromStdString(*rtcStats.track_identifier);
+        ASSERT(!rtcTrackId.isEmpty());
+        trackId = trackIds.get(rtcTrackId);
+        ASSERT(!trackId.isEmpty());
+    }
+
     return InboundRtpStreamStats {
         ReceivedRtpStreamStats::convert(RTCStatsReport::Type::InboundRtp, rtcStats, rtcStats.packets_received ? std::optional { *rtcStats.packets_received } : std::nullopt),
-        rtcStats.track_identifier ? fromStdString(*rtcStats.track_identifier) : String(),
+        WTF::move(trackId),
         rtcStats.mid ? fromStdString(*rtcStats.mid) : String(),
         rtcStats.remote_id ? fromStdString(*rtcStats.remote_id) : String(),
         rtcStats.frames_decoded ? std::optional { *rtcStats.frames_decoded } : std::nullopt,
@@ -519,11 +527,21 @@ void addToStatsMap(DOMMapAdapter& report, const webrtc::RTCStats& rtcStats)
     report.set<IDLDOMString, IDLDictionary<T>>(WTF::move(statsId), WTF::move(stats));
 }
 
-static inline void initializeRTCStatsReportBackingMap(DOMMapAdapter& report, const webrtc::RTCStatsReport& rtcReport)
+
+template<typename T, typename PreciseType>
+void addToStatsMap(DOMMapAdapter& report, const webrtc::RTCStats& rtcStats, const HashMap<String, String>& trackIds)
+{
+    // This is a cast from a webrtc type, not much we can do to make it safe.
+    SUPPRESS_MEMORY_UNSAFE_CAST auto stats = T::convert(static_cast<const PreciseType&>(rtcStats), trackIds);
+    auto statsId = stats.id;
+    report.set<IDLDOMString, IDLDictionary<T>>(WTF::move(statsId), WTF::move(stats));
+}
+
+static inline void initializeRTCStatsReportBackingMap(DOMMapAdapter& report, const webrtc::RTCStatsReport& rtcReport, const HashMap<String, String>& trackIds)
 {
     for (const auto& rtcStats : rtcReport) {
         if (rtcStats.type() == webrtc::RTCInboundRtpStreamStats::kType)
-            addToStatsMap<RTCStatsReport::InboundRtpStreamStats, webrtc::RTCInboundRtpStreamStats>(report, rtcStats);
+            addToStatsMap<RTCStatsReport::InboundRtpStreamStats, webrtc::RTCInboundRtpStreamStats>(report, rtcStats, trackIds);
         else if (rtcStats.type() == webrtc::RTCOutboundRtpStreamStats::kType)
             addToStatsMap<RTCStatsReport::OutboundRtpStreamStats, webrtc::RTCOutboundRtpStreamStats>(report, rtcStats);
         else if (rtcStats.type() == webrtc::RTCDataChannelStats::kType)
@@ -555,16 +573,18 @@ static inline void initializeRTCStatsReportBackingMap(DOMMapAdapter& report, con
 
 void LibWebRTCStatsCollector::OnStatsDelivered(const webrtc::scoped_refptr<const webrtc::RTCStatsReport>& rtcReport)
 {
-    callOnMainThread([this, protectedThis = webrtc::scoped_refptr<LibWebRTCStatsCollector>(this), rtcReport]() {
-        m_callback(rtcReport);
+    callOnMainThread([protectedThis = webrtc::scoped_refptr<LibWebRTCStatsCollector>(this), rtcReport = webrtc::scoped_refptr { rtcReport }]() mutable {
+        protectedThis->m_callback(WTF::move(rtcReport));
     });
 }
 
-Ref<RTCStatsReport> LibWebRTCStatsCollector::createReport(const webrtc::scoped_refptr<const webrtc::RTCStatsReport>& rtcReport)
+Ref<RTCStatsReport> LibWebRTCStatsCollector::createReport(webrtc::scoped_refptr<const webrtc::RTCStatsReport>&& rtcReport, HashMap<String, String>&& trackIds)
 {
-    return RTCStatsReport::create([rtcReport](auto& mapAdapter) {
+    ASSERT(isMainThread());
+    return RTCStatsReport::create([rtcReport = WTF::move(rtcReport), trackIds = WTF::move(trackIds)](auto& mapAdapter) {
+        ASSERT(isMainThread());
         if (rtcReport)
-            initializeRTCStatsReportBackingMap(mapAdapter, *rtcReport);
+            initializeRTCStatsReportBackingMap(mapAdapter, *rtcReport, trackIds);
     });
 }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.h
@@ -46,14 +46,14 @@ namespace WebCore {
 class DOMMapAdapter;
 class RTCStatsReport;
 
-void initializeRTCStatsReportBackingMap(RTCStatsReport&);
+void initializeRTCStatsReportBackingMap(RTCStatsReport&, const HashMap<String, String>&);
 
 class LibWebRTCStatsCollector : public webrtc::RTCStatsCollectorCallback {
 public:
-    using CollectorCallback = CompletionHandler<void(const webrtc::scoped_refptr<const webrtc::RTCStatsReport>&)>;
+    using CollectorCallback = CompletionHandler<void(webrtc::scoped_refptr<const webrtc::RTCStatsReport>&&)>;
     static webrtc::scoped_refptr<LibWebRTCStatsCollector> create(CollectorCallback&& callback) { return webrtc::make_ref_counted<LibWebRTCStatsCollector>(WTF::move(callback)); }
 
-    static Ref<RTCStatsReport> createReport(const webrtc::scoped_refptr<const webrtc::RTCStatsReport>&);
+    static Ref<RTCStatsReport> createReport(webrtc::scoped_refptr<const webrtc::RTCStatsReport>&&, HashMap<String, String>&&);
 
     explicit LibWebRTCStatsCollector(CollectorCallback&&);
     ~LibWebRTCStatsCollector();


### PR DESCRIPTION
#### 5f7fdedf0823cf3542b2ca069cf6b3b1cf745fe6
<pre>
RTCInboundRtpStreamStats.trackIdentifier doesn&apos;t match MediaStreamTrack.id
<a href="https://bugs.webkit.org/show_bug.cgi?id=312471">https://bugs.webkit.org/show_bug.cgi?id=312471</a>
<a href="https://rdar.apple.com/174938984">rdar://174938984</a>

Reviewed by Eric Carlson.

Now that rtc remote track Ids are not matching MediaStreamTrack ids, we need to keep a map to convert rtc Ids to track Ids in the stats.
We store the map in LibWebRTCPeerConnectionBackend and provide it to LibWebRTCStatsCollector.

Covered by updated test.

Canonical link: <a href="https://commits.webkit.org/311455@main">https://commits.webkit.org/311455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b562d48fa28e4e6be71ebc7ce0402cebde351182

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165835 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111094 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121596 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102264 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bfdeef72-78a7-4c98-9d4a-4d6689bb1fff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22890 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21124 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13607 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168320 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12479 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129721 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35170 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140616 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87677 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24653 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17420 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93598 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29106 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29336 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29232 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->