### PR TITLE
[GTK][WPE] Skia Compositor: use SkCanvas::clipShader for image masks instead of intermediate surface

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -70,6 +70,7 @@ void SkiaCompositingLayer::invalidate()
 {
     m_backingStore = nullptr;
     m_animatedBackingStoreClient = nullptr;
+    m_maskImage = nullptr;
     m_imageBackingStore = nullptr;
     m_contentsBuffer = nullptr;
 
@@ -142,6 +143,7 @@ void SkiaCompositingLayer::setUseBackingStore(bool useBackingStore, CoordinatedA
     if (!useBackingStore) {
         m_backingStore = nullptr;
         m_animatedBackingStoreClient = nullptr;
+        m_maskImage = nullptr;
         return;
     }
 
@@ -160,6 +162,10 @@ void SkiaCompositingLayer::updateBackingStore(CoordinatedBackingStoreProxy::Upda
         m_backingStore->removeTile(tileID);
     for (const auto& tileUpdate : update.tilesToUpdate())
         m_backingStore->updateTile(tileUpdate.tileID, tileUpdate.dirtyRect, tileUpdate.tileRect, tileUpdate.buffer.copyRef(), { });
+
+    if (m_maskImage && !update.isEmpty())
+        m_maskImage = nullptr;
+
     m_backingStore->processPendingUpdates();
 }
 
@@ -510,8 +516,6 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
     paint.setStyle(SkPaint::kFill_Style);
     paint.setAntiAlias(true);
     paint.setAlphaf(context.opacity);
-    if (context.isMask)
-        paint.setBlendMode(SkBlendMode::kDstIn);
     if (context.colorFilter)
         paint.setColorFilter(context.colorFilter);
 
@@ -723,6 +727,38 @@ IntRect SkiaCompositingLayer::clipBounds(const SkCanvas& canvas, const PaintCont
     return clip;
 }
 
+sk_sp<SkImage> SkiaCompositingLayer::maskImage()
+{
+    if (m_maskImage)
+        return m_maskImage;
+
+    if (!m_backingStore)
+        return nullptr;
+
+    // Paint the mask at the same scale the tiles were painted.
+    auto scale = m_backingStore->scale();
+    auto rect = effectiveLayerRect();
+    rect.scale(scale);
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    auto imageInfo = SkImageInfo::Make(rect.width(), rect.height(), kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, nullptr);
+    if (!surface)
+        return nullptr;
+
+    auto* surfaceCanvas = surface->getCanvas();
+    if (!surfaceCanvas)
+        return nullptr;
+
+    surfaceCanvas->clear(SK_ColorTRANSPARENT);
+    SkPaint paint;
+    surfaceCanvas->scale(scale, scale);
+    m_backingStore->paintToCanvas(*surfaceCanvas, paint);
+    grContext->flushAndSubmit(surface.get(), GrSyncCpu::kNo);
+    m_maskImage = surface->makeImageSnapshot();
+    return m_maskImage;
+}
+
 void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintContext& context, const IntRect& contentsRect, SkPaint* paint, PaintFunction&& paintFunction)
 {
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
@@ -746,35 +782,41 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
 
 void SkiaCompositingLayer::paintSelfAndChildrenWithFilterAndMask(SkCanvas& canvas, PaintContext& context)
 {
-    auto mask = m_mask;
-    const bool shouldClipPath = mask && !mask->m_clipPath.isEmpty();
-    SkAutoCanvasRestore autoRestore(&canvas, shouldClipPath);
-    if (shouldClipPath) {
-        canvas.clipPath(mask->m_clipPath.makeTransform(SkM44(mask->m_transforms.combined).asM33()), true);
-        mask = nullptr;
+    const bool shouldClipPath = m_mask && !m_mask->m_clipPath.isEmpty();
+    sk_sp<SkImage> maskImage = m_mask && !shouldClipPath ? m_mask->maskImage() : nullptr;
+    SkAutoCanvasRestore autoRestore(&canvas, shouldClipPath || maskImage);
+    if (shouldClipPath || maskImage) {
+        TransformationMatrix transform(context.accumulatedReplicaTransform);
+        transform.multiply(m_mask->m_transforms.combined);
+        if (maskImage)
+            transform = transform.scale(1 / m_mask->m_backingStore->scale());
+        auto matrix = SkM44(transform).asM33();
+
+        if (shouldClipPath)
+            canvas.clipPath(m_mask->m_clipPath.makeTransform(matrix), true);
+        else if (auto maskShader = maskImage->makeShader({ SkFilterMode::kLinear, SkMipmapMode::kNone }, &matrix))
+            canvas.clipShader(maskShader);
     }
 
     auto filter = this->filter();
-    if (!filter && !mask) {
+    if (!filter) {
         paintSelfAndChildren(canvas, context);
         return;
     }
 
-    if (filter && !mask) {
-        SkColorFilter* colorFilterPtr = nullptr;
-        if (filter->filter->asAColorFilter(&colorFilterPtr)) {
-            // If we have a filter (and no mask) that can be simplified as a color filter
-            // we don't need to create an intermediate surface.
-            sk_sp<SkColorFilter> colorFilter(colorFilterPtr);
-            SetForScope scopedColorFilter(context.colorFilter, colorFilter);
-            paintSelfAndChildren(canvas, context);
-            return;
-        }
+    // If we have a filter that can be simplified as a color filter
+    // we don't need to create an intermediate surface.
+    SkColorFilter* colorFilterPtr = nullptr;
+    if (filter->filter->asAColorFilter(&colorFilterPtr)) {
+        sk_sp<SkColorFilter> colorFilter(colorFilterPtr);
+        SetForScope scopedColorFilter(context.colorFilter, colorFilter);
+        paintSelfAndChildren(canvas, context);
+        return;
     }
 
     // Restrict intermediate surface size to the consolidated overlap region rects,
     // matching TextureMapperLayer::paintSelfChildrenFilterAndMask behavior.
-    auto mode = mask ? ComputeOverlapRegionMode::Mask : ComputeOverlapRegionMode::Union;
+    auto mode = m_mask ? ComputeOverlapRegionMode::Mask : ComputeOverlapRegionMode::Union;
     auto overlapRects = computeConsolidatedOverlapRegionRects(canvas, context, mode);
 
 #if ENABLE(DAMAGE_TRACKING)
@@ -782,8 +824,7 @@ void SkiaCompositingLayer::paintSelfAndChildrenWithFilterAndMask(SkCanvas& canva
 #endif
 
     SkPaint paint;
-    if (filter)
-        paint.setImageFilter(filter->filter);
+    paint.setImageFilter(filter->filter);
 
     for (const auto& rect : overlapRects) {
 #if ENABLE(DAMAGE_TRACKING)
@@ -795,24 +836,17 @@ void SkiaCompositingLayer::paintSelfAndChildrenWithFilterAndMask(SkCanvas& canva
             m_accumulatedOverlapRegionFrameDamage.unite(damageRect);
         }
 #endif
-        if (mask && filter) {
+
+        if (m_mask) {
             // Mask and filter: the filter should be applied first and then the mask on the result.
             paintWithIntermediateSurface(canvas, context, rect, nullptr, [&](SkCanvas& canvas, PaintContext& context) {
                 paintWithIntermediateSurface(canvas, context, rect, &paint, [&](SkCanvas& canvas, PaintContext& context) {
                     paintSelfAndChildren(canvas, context);
                 });
-
-                SetForScope scopedMask(context.isMask, true);
-                mask->paintSelf(canvas, context);
             });
         } else {
             paintWithIntermediateSurface(canvas, context, rect, &paint, [&](SkCanvas& canvas, PaintContext& context) {
                 paintSelfAndChildren(canvas, context);
-
-                if (mask) {
-                    SetForScope scopedMask(context.isMask, true);
-                    mask->paintSelf(canvas, context);
-                }
             });
         }
     }

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -126,7 +126,6 @@ private:
         }
 
         float opacity { 1 };
-        bool isMask { false };
         IntSize offset;
         sk_sp<SkColorFilter> colorFilter;
         TransformationMatrix accumulatedReplicaTransform;
@@ -151,6 +150,7 @@ private:
     Vector<IntRect, 1> computeConsolidatedOverlapRegionRects(const SkCanvas&, const PaintContext&, ComputeOverlapRegionMode);
     TransformationMatrix replicaTransform() const;
     IntRect clipBounds(const SkCanvas&, const PaintContext&) const;
+    sk_sp<SkImage> maskImage();
     void collect3DRenderingContextLayers(Vector<Ref<SkiaCompositingLayer>>&);
 
     enum class IncludesReplica : bool { No, Yes };
@@ -214,6 +214,7 @@ private:
     FloatRoundedRect m_contentsClippingRect;
     float m_opacity { 1 };
     SkPath m_clipPath;
+    sk_sp<SkImage> m_maskImage;
     RefPtr<SkiaCompositingLayer> m_mask;
     RefPtr<SkiaCompositingLayer> m_replica;
     WeakPtr<SkiaCompositingLayer> m_replicatedLayer;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -44,6 +44,7 @@ public:
     ~CoordinatedBackingStore() = default;
 
     void resize(const FloatSize&, float scale);
+    float scale() const { return m_scale; }
 
     void createTile(uint32_t tileID);
     void removeTile(uint32_t tileID);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -68,6 +68,8 @@ public:
         void appendUpdate(Vector<uint32_t>&&, Vector<TileUpdate>&&, Vector<uint32_t>&&);
         void waitUntilPaintingComplete();
 
+        bool isEmpty() const { return m_tilesToCreate.isEmpty() && m_tilesToUpdate.isEmpty() && m_tilesToRemove.isEmpty(); }
+
     private:
         Vector<uint32_t> m_tilesToCreate;
         Vector<TileUpdate> m_tilesToUpdate;


### PR DESCRIPTION
#### e45d2509032d4e1c9e0aa60a26d09bc8a37c40f1
<pre>
[GTK][WPE] Skia Compositor: use SkCanvas::clipShader for image masks instead of intermediate surface
<a href="https://bugs.webkit.org/show_bug.cgi?id=312557">https://bugs.webkit.org/show_bug.cgi?id=312557</a>

Reviewed by Nikolas Zimmermann.

Not only we avoid the intermediate surface creation, we can paint the
mask image only once with no transforms, and then create a SkShader from
the cached image for the current transform.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::invalidate):
(WebCore::SkiaCompositingLayer::setUseBackingStore):
(WebCore::SkiaCompositingLayer::updateBackingStore):
(WebCore::SkiaCompositingLayer::paintSelf):
(WebCore::SkiaCompositingLayer::maskImage):
(WebCore::SkiaCompositingLayer::paintSelfAndChildrenWithFilterAndMask):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:

Canonical link: <a href="https://commits.webkit.org/311674@main">https://commits.webkit.org/311674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d230c62e5db85815483d162621dbf23982b03633

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166537 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31052 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122117 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24403 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102786 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14308 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169026 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/13595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21057 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130285 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130402 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141230 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88577 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23978 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18035 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30286 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94785 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->