### PR TITLE
innerText getter: preserve contents of <option> elements inside <select>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -150,8 +150,8 @@ PASS <fieldset> contents preserved ("<div><fieldset>abc")
 PASS <fieldset> <legend> contents preserved ("<div><fieldset><legend>abc")
 PASS <input> contents ignored ("<div><input type='text' value='abc'>")
 PASS <textarea> contents ignored ("<div><textarea>abc")
-FAIL <select size='1'> contents of options preserved ("<div><select size='1'><option>abc</option><option>def") assert_equals: innerText expected "abc\ndef" but got ""
-FAIL <select size='2'> contents of options preserved ("<div><select size='2'><option>abc</option><option>def") assert_equals: innerText expected "abc\ndef" but got ""
+PASS <select size='1'> contents of options preserved ("<div><select size='1'><option>abc</option><option>def")
+PASS <select size='2'> contents of options preserved ("<div><select size='2'><option>abc</option><option>def")
 PASS <iframe> contents ignored ("<div><iframe>abc")
 PASS  <iframe> subdocument ignored ("<div><iframe src='data:text/html,abc'>")
 PASS <audio> contents ignored ("<div><audio>abc")

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -32,6 +32,7 @@
 #include "ComposedTreeIterator.h"
 #include "Document.h"
 #include "Editing.h"
+#include "ElementChildIteratorInlines.h"
 #include "ElementInlines.h"
 #include "ElementRareData.h"
 #include "FontCascade.h"
@@ -45,8 +46,11 @@
 #include "HTMLLegendElement.h"
 #include "HTMLMeterElement.h"
 #include "HTMLNames.h"
+#include "HTMLOptGroupElement.h"
+#include "HTMLOptionElement.h"
 #include "HTMLParagraphElement.h"
 #include "HTMLProgressElement.h"
+#include "HTMLSelectElement.h"
 #include "HTMLSlotElement.h"
 #include "HTMLTextAreaElement.h"
 #include "HTMLTextFormControlElement.h"
@@ -796,6 +800,25 @@ void TextIterator::handleTextNodeFirstLetter(RenderTextFragment& renderer)
     m_handledFirstLetter = true;
 }
 
+static String collectSelectInnerText(const HTMLSelectElement& selectElement)
+{
+    StringBuilder builder;
+    for (Ref child : childrenOfType<HTMLElement>(selectElement)) {
+        if (auto* option = dynamicDowncast<HTMLOptionElement>(child.get())) {
+            if (!builder.isEmpty())
+                builder.append('\n');
+            builder.append(option->text());
+        } else if (auto* optgroup = dynamicDowncast<HTMLOptGroupElement>(child.get())) {
+            for (Ref option : childrenOfType<HTMLOptionElement>(*optgroup)) {
+                if (!builder.isEmpty())
+                    builder.append('\n');
+                builder.append(option->text());
+            }
+        }
+    }
+    return builder.toString();
+}
+
 bool TextIterator::handleReplacedElement()
 {
     if (m_fullyClippedStack.top())
@@ -888,6 +911,19 @@ bool TextIterator::handleReplacedElement()
             m_copyableText.set(WTF::move(altText));
             m_text = m_copyableText.text();
             return true;
+        }
+    }
+
+    if (m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec)) {
+        if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(m_currentNode)) {
+            m_handledChildren = true;
+            if (String selectText = collectSelectInnerText(*selectElement); !selectText.isEmpty()) {
+                m_hasEmitted = true;
+                m_lastCharacter = selectText[selectText.length() - 1];
+                m_copyableText.set(WTF::move(selectText));
+                m_text = m_copyableText.text();
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
#### 1ad23df7317368e222ffaa18375c6039fb8e8481
<pre>
innerText getter: preserve contents of &lt;option&gt; elements inside &lt;select&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=312558">https://bugs.webkit.org/show_bug.cgi?id=312558</a>

Reviewed by Anne van Kesteren.

The TextIterator treats &lt;select&gt; as a replaced element (via HTMLFormControlElement),
which causes handleReplacedElement() to skip all children. This means innerText on
a &lt;select&gt; (or a parent containing one) returns &quot;&quot; instead of the option text.

Add special handling in handleReplacedElement() for &lt;select&gt; elements in innerText
mode: walk the select&apos;s &lt;option&gt; and &lt;optgroup&gt; children and emit their text content
separated by newlines.

No new tests, rebaselined existing test. Chrome was already passing those 2
subtests. Firefox is passing only the second one.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt:
Rebaselined.

* Source/WebCore/editing/TextIterator.cpp:
(WebCore::collectSelectInnerText):
Walks a select element&apos;s option/optgroup children and collects option text
separated by newlines.

(WebCore::TextIterator::handleReplacedElement):
In innerText mode, emit collected option text for select elements instead
of skipping them.

Canonical link: <a href="https://commits.webkit.org/311449@main">https://commits.webkit.org/311449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adff6ef4dba422a29402fe1abc334ee1266c59f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165851 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121608 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102276 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13623 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168336 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12495 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20458 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129735 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29966 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129843 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35166 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87693 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17436 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93614 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29122 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29352 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29249 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->