### PR TITLE
ANGLE: Metal: Add BufferSlice to associate BufferRef, offset pairs

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
@@ -85,19 +85,14 @@ constexpr uint32_t kMaxTriFanLineLoopBuffersPerFrame = 10;
 angle::Result AllocateTriangleFanBufferFromPool(ContextMtl *context,
                                                 GLsizei vertexCount,
                                                 mtl::BufferPool *pool,
-                                                mtl::BufferRef *bufferOut,
-                                                uint32_t *offsetOut,
+                                                mtl::BufferSlice *outBuffer,
                                                 uint32_t *numElemsOut)
 {
     uint32_t numIndices;
     ANGLE_TRY(mtl::GetTriangleFanIndicesCount(context, vertexCount, &numIndices));
 
-    size_t offset;
     pool->releaseInFlightBuffers(context);
-    ANGLE_TRY(pool->allocate(context, numIndices * sizeof(uint32_t), nullptr, bufferOut, &offset,
-                             nullptr));
-
-    *offsetOut   = static_cast<uint32_t>(offset);
+    ANGLE_TRY(pool->allocate(context, numIndices * sizeof(uint32_t), nullptr, outBuffer));
     *numElemsOut = numIndices;
 
     return angle::Result::Continue;
@@ -106,15 +101,10 @@ angle::Result AllocateTriangleFanBufferFromPool(ContextMtl *context,
 angle::Result AllocateBufferFromPool(ContextMtl *context,
                                      GLsizei indicesToReserve,
                                      mtl::BufferPool *pool,
-                                     mtl::BufferRef *bufferOut,
-                                     uint32_t *offsetOut)
+                                     mtl::BufferSlice *outBuffer)
 {
-    size_t offset;
     pool->releaseInFlightBuffers(context);
-    ANGLE_TRY(pool->allocate(context, indicesToReserve * sizeof(uint32_t), nullptr, bufferOut,
-                             &offset, nullptr));
-
-    *offsetOut = static_cast<uint32_t>(offset);
+    ANGLE_TRY(pool->allocate(context, indicesToReserve * sizeof(uint32_t), nullptr, outBuffer));
 
     return angle::Result::Continue;
 }
@@ -138,7 +128,7 @@ class LineLoopLastSegmentHelper
 
     ~LineLoopLastSegmentHelper()
     {
-        if (!mLineLoopIndexBuffer)
+        if (mLineLoopIndexBuffer.empty())
         {
             return;
         }
@@ -146,7 +136,8 @@ class LineLoopLastSegmentHelper
         // Draw last segment of line loop here
         mtl::RenderCommandEncoder *encoder = mContextMtl->getRenderCommandEncoder();
         ASSERT(encoder);
-        encoder->drawIndexed(MTLPrimitiveTypeLine, 2, MTLIndexTypeUInt32, mLineLoopIndexBuffer, 0);
+        encoder->drawIndexed(MTLPrimitiveTypeLine, 2, MTLIndexTypeUInt32,
+                             mLineLoopIndexBuffer.buffer(), mLineLoopIndexBuffer.offset());
     }
 
     angle::Result begin(const gl::Context *context,
@@ -161,13 +152,14 @@ class LineLoopLastSegmentHelper
         indexBufferPool->releaseInFlightBuffers(mContextMtl);
 
         ANGLE_TRY(indexBufferPool->allocate(mContextMtl, 2 * sizeof(uint32_t), nullptr,
-                                            &mLineLoopIndexBuffer, nullptr, nullptr));
+                                            &mLineLoopIndexBuffer));
 
         if (indexTypeOrNone == gl::DrawElementsType::InvalidEnum)
         {
             ANGLE_TRY(mContextMtl->getDisplay()->getUtils().generateLineLoopLastSegment(
                 mContextMtl, firstVertex, firstVertex + vertexOrIndexCount - 1,
-                mLineLoopIndexBuffer, 0));
+                mLineLoopIndexBuffer.buffer(),
+                static_cast<uint32_t>(mLineLoopIndexBuffer.offset())));
         }
         else
         {
@@ -175,7 +167,8 @@ class LineLoopLastSegmentHelper
             ANGLE_TRY(
                 mContextMtl->getDisplay()->getUtils().generateLineLoopLastSegmentFromElementsArray(
                     mContextMtl,
-                    {indexTypeOrNone, vertexOrIndexCount, indices, mLineLoopIndexBuffer, 0}));
+                    {indexTypeOrNone, vertexOrIndexCount, indices, mLineLoopIndexBuffer.buffer(),
+                     static_cast<uint32_t>(mLineLoopIndexBuffer.offset())}));
         }
 
         ANGLE_TRY(indexBufferPool->commit(mContextMtl));
@@ -185,7 +178,7 @@ class LineLoopLastSegmentHelper
 
   private:
     ContextMtl *mContextMtl = nullptr;
-    mtl::BufferRef mLineLoopIndexBuffer;
+    mtl::BufferSlice mLineLoopIndexBuffer;
 };
 
 GLint GetOwnershipIdentity(const egl::AttributeMap &attribs)
@@ -342,14 +335,13 @@ angle::Result ContextMtl::drawTriFanArraysLegacy(const gl::Context *context,
                                                  GLsizei instances)
 {
     // Legacy method is only used for GPU lacking instanced base vertex draw capabilities.
-    mtl::BufferRef genIdxBuffer;
-    uint32_t genIdxBufferOffset;
+    mtl::BufferSlice genIdxBuffer;
     uint32_t genIndicesCount;
     ANGLE_TRY(AllocateTriangleFanBufferFromPool(this, count, &mTriFanIndexBuffer, &genIdxBuffer,
-                                                &genIdxBufferOffset, &genIndicesCount));
+                                                &genIndicesCount));
     ANGLE_TRY(getDisplay()->getUtils().generateTriFanBufferFromArrays(
-        this, {static_cast<uint32_t>(first), static_cast<uint32_t>(count), genIdxBuffer,
-               genIdxBufferOffset}));
+        this, {static_cast<uint32_t>(first), static_cast<uint32_t>(count), genIdxBuffer.buffer(),
+               static_cast<uint32_t>(genIdxBuffer.offset())}));
 
     ANGLE_TRY(mTriFanIndexBuffer.commit(this));
 
@@ -360,8 +352,8 @@ angle::Result ContextMtl::drawTriFanArraysLegacy(const gl::Context *context,
     if (!isNoOp)
     {
         mRenderEncoder.drawIndexedInstanced(MTLPrimitiveTypeTriangle, genIndicesCount,
-                                            MTLIndexTypeUInt32, genIdxBuffer, genIdxBufferOffset,
-                                            instances);
+                                            MTLIndexTypeUInt32, genIdxBuffer.buffer(),
+                                            genIdxBuffer.offset(), instances);
     }
     return angle::Result::Continue;
 }
@@ -407,15 +399,13 @@ angle::Result ContextMtl::drawLineLoopArrays(const gl::Context *context,
         return drawLineLoopArraysNonInstanced(context, first, count);
     }
 
-    mtl::BufferRef genIdxBuffer;
-    uint32_t genIdxBufferOffset;
+    mtl::BufferSlice genIdxBuffer;
     uint32_t genIndicesCount = count + 1;
 
-    ANGLE_TRY(AllocateBufferFromPool(this, genIndicesCount, &mLineLoopIndexBuffer, &genIdxBuffer,
-                                     &genIdxBufferOffset));
+    ANGLE_TRY(AllocateBufferFromPool(this, genIndicesCount, &mLineLoopIndexBuffer, &genIdxBuffer));
     ANGLE_TRY(getDisplay()->getUtils().generateLineLoopBufferFromArrays(
-        this, {static_cast<uint32_t>(first), static_cast<uint32_t>(count), genIdxBuffer,
-               genIdxBufferOffset}));
+        this, {static_cast<uint32_t>(first), static_cast<uint32_t>(count), genIdxBuffer.buffer(),
+               static_cast<uint32_t>(genIdxBuffer.offset())}));
 
     ANGLE_TRY(mLineLoopIndexBuffer.commit(this));
 
@@ -428,14 +418,14 @@ angle::Result ContextMtl::drawLineLoopArrays(const gl::Context *context,
         if (baseInstance == 0)
         {
             mRenderEncoder.drawIndexedInstanced(MTLPrimitiveTypeLineStrip, genIndicesCount,
-                                                MTLIndexTypeUInt32, genIdxBuffer,
-                                                genIdxBufferOffset, instances);
+                                                MTLIndexTypeUInt32, genIdxBuffer.buffer(),
+                                                genIdxBuffer.offset(), instances);
         }
         else
         {
             mRenderEncoder.drawIndexedInstancedBaseVertexBaseInstance(
-                MTLPrimitiveTypeLineStrip, genIndicesCount, MTLIndexTypeUInt32, genIdxBuffer,
-                genIdxBufferOffset, instances, 0, baseInstance);
+                MTLPrimitiveTypeLineStrip, genIndicesCount, MTLIndexTypeUInt32,
+                genIdxBuffer.buffer(), genIdxBuffer.offset(), instances, 0, baseInstance);
         }
     }
 
@@ -550,15 +540,15 @@ angle::Result ContextMtl::drawTriFanElements(const gl::Context *context,
 {
     if (count > 3)
     {
-        mtl::BufferRef genIdxBuffer;
-        uint32_t genIdxBufferOffset;
+        mtl::BufferSlice genIdxBuffer;
         uint32_t genIndicesCount;
         bool primitiveRestart = getState().isPrimitiveRestartEnabled();
         ANGLE_TRY(AllocateTriangleFanBufferFromPool(this, count, &mTriFanIndexBuffer, &genIdxBuffer,
-                                                    &genIdxBufferOffset, &genIndicesCount));
+                                                    &genIndicesCount));
 
         ANGLE_TRY(getDisplay()->getUtils().generateTriFanBufferFromElementsArray(
-            this, {type, count, indices, genIdxBuffer, genIdxBufferOffset, primitiveRestart},
+            this, {type, count, indices, genIdxBuffer.buffer(),
+                   static_cast<uint32_t>(genIdxBuffer.offset()), primitiveRestart},
             &genIndicesCount));
 
         ANGLE_TRY(mTriFanIndexBuffer.commit(this));
@@ -569,14 +559,15 @@ angle::Result ContextMtl::drawTriFanElements(const gl::Context *context,
             if (baseVertex == 0 && baseInstance == 0)
             {
                 mRenderEncoder.drawIndexedInstanced(MTLPrimitiveTypeTriangle, genIndicesCount,
-                                                    MTLIndexTypeUInt32, genIdxBuffer,
-                                                    genIdxBufferOffset, instances);
+                                                    MTLIndexTypeUInt32, genIdxBuffer.buffer(),
+                                                    genIdxBuffer.offset(), instances);
             }
             else
             {
                 mRenderEncoder.drawIndexedInstancedBaseVertexBaseInstance(
-                    MTLPrimitiveTypeTriangle, genIndicesCount, MTLIndexTypeUInt32, genIdxBuffer,
-                    genIdxBufferOffset, instances, baseVertex, baseInstance);
+                    MTLPrimitiveTypeTriangle, genIndicesCount, MTLIndexTypeUInt32,
+                    genIdxBuffer.buffer(), genIdxBuffer.offset(), instances, baseVertex,
+                    baseInstance);
             }
         }
 
@@ -619,15 +610,15 @@ angle::Result ContextMtl::drawLineLoopElements(const gl::Context *context,
                                                                       indices);
         }
 
-        mtl::BufferRef genIdxBuffer;
-        uint32_t genIdxBufferOffset;
+        mtl::BufferSlice genIdxBuffer;
         uint32_t reservedIndices = count * 2;
         uint32_t genIndicesCount;
         ANGLE_TRY(AllocateBufferFromPool(this, reservedIndices, &mLineLoopIndexBuffer,
-                                         &genIdxBuffer, &genIdxBufferOffset));
+                                         &genIdxBuffer));
 
         ANGLE_TRY(getDisplay()->getUtils().generateLineLoopBufferFromElementsArray(
-            this, {type, count, indices, genIdxBuffer, genIdxBufferOffset, primitiveRestart},
+            this, {type, count, indices, genIdxBuffer.buffer(),
+                   static_cast<uint32_t>(genIdxBuffer.offset()), primitiveRestart},
             &genIndicesCount));
 
         ANGLE_TRY(mLineLoopIndexBuffer.commit(this));
@@ -638,14 +629,15 @@ angle::Result ContextMtl::drawLineLoopElements(const gl::Context *context,
             if (baseVertex == 0 && baseInstance == 0)
             {
                 mRenderEncoder.drawIndexedInstanced(MTLPrimitiveTypeLineStrip, genIndicesCount,
-                                                    MTLIndexTypeUInt32, genIdxBuffer,
-                                                    genIdxBufferOffset, instances);
+                                                    MTLIndexTypeUInt32, genIdxBuffer.buffer(),
+                                                    genIdxBuffer.offset(), instances);
             }
             else
             {
                 mRenderEncoder.drawIndexedInstancedBaseVertexBaseInstance(
-                    MTLPrimitiveTypeLineStrip, genIndicesCount, MTLIndexTypeUInt32, genIdxBuffer,
-                    genIdxBufferOffset, instances, baseVertex, baseInstance);
+                    MTLPrimitiveTypeLineStrip, genIndicesCount, MTLIndexTypeUInt32,
+                    genIdxBuffer.buffer(), genIdxBuffer.offset(), instances, baseVertex,
+                    baseInstance);
             }
         }
 
@@ -770,17 +762,17 @@ angle::Result ContextMtl::drawElementsImpl(const gl::Context *context,
                                     baseInstance);
     }
 
-    mtl::BufferRef idxBuffer;
+    mtl::BufferSlice idxBuffer;
     mtl::BufferRef drawIdxBuffer;
-    size_t convertedOffset             = 0;
+
     gl::DrawElementsType convertedType = type;
 
     ANGLE_TRY(mVertexArray->getIndexBuffer(context, type, count, indices, &idxBuffer,
-                                           &convertedOffset, &convertedType));
+                                           &convertedType));
 
-    ASSERT(idxBuffer);
-    ASSERT((convertedType == gl::DrawElementsType::UnsignedShort && (convertedOffset % 2) == 0) ||
-           (convertedType == gl::DrawElementsType::UnsignedInt && (convertedOffset % 4) == 0));
+    ASSERT(idxBuffer.buffer());
+    ASSERT((convertedType == gl::DrawElementsType::UnsignedShort && (idxBuffer.offset() % 2) == 0) ||
+           (convertedType == gl::DrawElementsType::UnsignedInt && (idxBuffer.offset() % 4) == 0));
 
     uint32_t convertedCounti32 = (uint32_t)count;
 
@@ -790,13 +782,13 @@ angle::Result ContextMtl::drawElementsImpl(const gl::Context *context,
     {
         // Line strips and triangle strips are rewritten to flat line arrays and tri arrays.
         ANGLE_TRY(mProvokingVertexHelper.preconditionIndexBuffer(
-            mtl::GetImpl(context), idxBuffer, count, convertedOffset,
+            mtl::GetImpl(context), idxBuffer.buffer(), count, idxBuffer.offset(),
             mState.isPrimitiveRestartEnabled(), mode, convertedType, convertedCounti32,
             provokingVertexAdditionalOffset, mode, drawIdxBuffer));
     }
     else
     {
-        drawIdxBuffer = idxBuffer;
+        drawIdxBuffer = idxBuffer.buffer();
     }
     // Draw commands will only be broken up if transform feedback is enabled,
     // if the mode is a simple type, and if the buffer contained any restart
@@ -804,7 +796,7 @@ angle::Result ContextMtl::drawElementsImpl(const gl::Context *context,
     // It's safe to use idxBuffer in this case, as it will contain the same count and restart ranges
     // as drawIdxBuffer.
     const std::vector<DrawCommandRange> drawCommands = mVertexArray->getDrawIndices(
-        context, type, convertedType, mode, idxBuffer, convertedCounti32, convertedOffset);
+        context, type, convertedType, mode, idxBuffer.buffer(), convertedCounti32, idxBuffer.offset());
     bool isNoOp = false;
     ANGLE_TRY(setupDraw(context, 0, count, instances, type, indices, false, &isNoOp));
     if (!isNoOp)

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.h
@@ -284,7 +284,7 @@ class ProgramExecutableMtl : public ProgramExecutableImpl
     // Scratch data:
     // Legalized buffers and their offsets. For example, uniform buffer's offset=1 is not a valid
     // offset, it will be converted to legal offset and the result is stored in this array.
-    std::vector<std::pair<mtl::BufferRef, size_t>> mLegalizedOffsetedUniformBuffers;
+    std::vector<mtl::BufferSlice> mLegalizedOffsetedUniformBuffers;
     // Stores the render stages usage of each uniform buffer. Only used if the buffers are encoded
     // into an argument buffer.
     std::vector<uint32_t> mArgumentBufferRenderStageUsages;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm
@@ -137,8 +137,7 @@ angle::Result ConvertUniformBufferData(ContextMtl *contextMtl,
                                        mtl::BufferPool *dynamicBuffer,
                                        const uint8_t *sourceData,
                                        size_t sizeToCopy,
-                                       mtl::BufferRef *bufferOut,
-                                       size_t *bufferOffsetOut)
+                                       mtl::BufferSlice *outBuffer)
 {
     uint8_t *dst             = nullptr;
     const uint8_t *maxSrcPtr = sourceData + sizeToCopy;
@@ -152,8 +151,7 @@ angle::Result ConvertUniformBufferData(ContextMtl *contextMtl,
     size_t numBlocksToCopy =
         (sizeToCopy + blockConversionInfo.stdSize() - 1) / blockConversionInfo.stdSize();
     size_t bytesToAllocate = numBlocksToCopy * blockConversionInfo.metalSize();
-    ANGLE_TRY(dynamicBuffer->allocate(contextMtl, bytesToAllocate, &dst, bufferOut, bufferOffsetOut,
-                                      nullptr));
+    ANGLE_TRY(dynamicBuffer->allocate(contextMtl, bytesToAllocate, &dst, outBuffer));
 
     const std::vector<sh::BlockMemberInfo> &stdConversions = blockConversionInfo.stdInfo();
     const std::vector<sh::BlockMemberInfo> &mtlConversions = blockConversionInfo.metalInfo();
@@ -1086,18 +1084,17 @@ angle::Result ProgramExecutableMtl::commitUniforms(ContextMtl *context,
             bufferPool->releaseInFlightBuffers(context);
 
             ASSERT(uniformBlock.uniformData.size() <= mtl::kDefaultUniformsMaxSize);
-            mtl::BufferRef mtlBufferOut;
-            size_t offsetOut;
+            mtl::BufferSlice uniformBuffer;
             uint8_t *ptrOut;
             // Allocate a new Uniform buffer
             ANGLE_TRY(bufferPool->allocate(context, uniformBlock.uniformData.size(), &ptrOut,
-                                           &mtlBufferOut, &offsetOut));
+                                           &uniformBuffer));
             // Copy the uniform result
             memcpy(ptrOut, uniformBlock.uniformData.data(), uniformBlock.uniformData.size());
             // Commit
             ANGLE_TRY(bufferPool->commit(context));
             // Set buffer
-            cmdEncoder->setBuffer(shaderType, mtlBufferOut, offsetOut,
+            cmdEncoder->setBuffer(shaderType, uniformBuffer.buffer(), uniformBuffer.offset(),
                                   mtl::kDefaultUniformsBindingIndex);
         }
 
@@ -1221,7 +1218,7 @@ angle::Result ProgramExecutableMtl::updateUniformBuffers(
 
     // This array is only used inside this function and its callees.
     ScopedAutoClearVector<uint32_t> scopeArrayClear(&mArgumentBufferRenderStageUsages);
-    ScopedAutoClearVector<std::pair<mtl::BufferRef, size_t>> scopeArrayClear2(
+    ScopedAutoClearVector<mtl::BufferSlice> scopeArrayClear2(
         &mLegalizedOffsetedUniformBuffers);
     mArgumentBufferRenderStageUsages.resize(blocks.size());
     mLegalizedOffsetedUniformBuffers.resize(blocks.size());
@@ -1268,7 +1265,7 @@ angle::Result ProgramExecutableMtl::updateUniformBuffers(
             continue;
         }
 
-        cmdEncoder->useResource(mLegalizedOffsetedUniformBuffers[bufferIndex].first,
+        cmdEncoder->useResource(mLegalizedOffsetedUniformBuffers[bufferIndex].buffer(),
                                 MTLResourceUsageRead, static_cast<MTLRenderStages>(stages));
     }
 
@@ -1312,9 +1309,12 @@ angle::Result ProgramExecutableMtl::legalizeUniformBufferOffsets(ContextMtl *con
                 angle::Span<const uint8_t> source =
                     bufferMtl->getBufferDataReadOnly(context, conversion->initialSrcOffset());
 
+                mtl::BufferSlice converted;
                 ANGLE_TRY(ConvertUniformBufferData(
                     context, conversionInfo, &conversion->data, source.data(), source.size(),
-                    &conversion->convertedBuffer, &conversion->convertedOffset));
+                    &converted));
+                conversion->convertedBuffer = converted.buffer();
+                conversion->convertedOffset = converted.offset();
 
                 conversion->dirty = false;
             }
@@ -1325,17 +1325,19 @@ angle::Result ProgramExecutableMtl::legalizeUniformBufferOffsets(ContextMtl *con
                 (unsigned int)(dstOffsetSource / conversionInfo.stdSize());
             size_t bytesToOffset = numBlocksToOffset * conversionInfo.metalSize();
 
-            mLegalizedOffsetedUniformBuffers[bufferIndex].first = conversion->convertedBuffer;
-            mLegalizedOffsetedUniformBuffers[bufferIndex].second =
-                conversion->convertedOffset + bytesToOffset;
+            size_t resultOffset = conversion->convertedOffset + bytesToOffset;
+            mLegalizedOffsetedUniformBuffers[bufferIndex] =
+                mtl::BufferSlice(conversion->convertedBuffer).subslice(resultOffset);
             // Ensure that the converted info can fit in the buffer.
             ASSERT(conversion->convertedOffset + bytesToOffset + conversionInfo.metalSize() <=
                    conversion->convertedBuffer->size());
         }
         else
         {
-            mLegalizedOffsetedUniformBuffers[bufferIndex].first = bufferMtl->getCurrentBuffer();
-            mLegalizedOffsetedUniformBuffers[bufferIndex].second = bufferBinding.getOffset();
+            mtl::BufferRef buf   = bufferMtl->getCurrentBuffer();
+            size_t bindingOffset = bufferBinding.getOffset();
+            mLegalizedOffsetedUniformBuffers[bufferIndex] =
+                mtl::BufferSlice(buf).subslice(bindingOffset);
         }
     }
     return angle::Result::Continue;
@@ -1370,8 +1372,8 @@ angle::Result ProgramExecutableMtl::bindUniformBuffersToDiscreteSlots(
             continue;
         }
 
-        mtl::BufferRef mtlBuffer = mLegalizedOffsetedUniformBuffers[bufferIndex].first;
-        size_t offset            = mLegalizedOffsetedUniformBuffers[bufferIndex].second;
+        mtl::BufferRef mtlBuffer = mLegalizedOffsetedUniformBuffers[bufferIndex].buffer();
+        size_t offset            = mLegalizedOffsetedUniformBuffers[bufferIndex].offset();
         cmdEncoder->setBuffer(shaderType, mtlBuffer, offset, actualBufferIdx);
     }
     return angle::Result::Continue;
@@ -1393,19 +1395,18 @@ angle::Result ProgramExecutableMtl::encodeUniformBuffersInfoArgumentBuffer(
     ProgramArgumentBufferEncoderMtl &bufferEncoder =
         mCurrentShaderVariants[shaderType]->uboArgBufferEncoder;
 
-    mtl::BufferRef argumentBuffer;
-    size_t argumentBufferOffset;
+    mtl::BufferSlice argumentBuffer;
     bufferEncoder.bufferPool.releaseInFlightBuffers(context);
     ANGLE_TRY(bufferEncoder.bufferPool.allocate(
-        context, bufferEncoder.metalArgBufferEncoder.get().encodedLength, nullptr, &argumentBuffer,
-        &argumentBufferOffset));
+        context, bufferEncoder.metalArgBufferEncoder.get().encodedLength, nullptr,
+        &argumentBuffer));
 
     // MTLArgumentEncoder is modifying the buffer indirectly on CPU. We need to call map()
     // so that the buffer's data changes could be flushed to the GPU side later.
-    ANGLE_UNUSED_VARIABLE(argumentBuffer->mapNoSync(context));
+    ANGLE_UNUSED_VARIABLE(argumentBuffer.buffer()->mapNoSync(context));
 
-    [bufferEncoder.metalArgBufferEncoder setArgumentBuffer:argumentBuffer->get()
-                                                    offset:argumentBufferOffset];
+    [bufferEncoder.metalArgBufferEncoder setArgumentBuffer:argumentBuffer.buffer()->get()
+                                                    offset:argumentBuffer.offset()];
 
     constexpr gl::ShaderMap<MTLRenderStages> kShaderStageMap = {
         {gl::ShaderType::Vertex, MTLRenderStageVertex},
@@ -1434,18 +1435,18 @@ angle::Result ProgramExecutableMtl::encodeUniformBuffersInfoArgumentBuffer(
             continue;
         }
 
-        mtl::BufferRef mtlBuffer = mLegalizedOffsetedUniformBuffers[bufferIndex].first;
-        size_t offset            = mLegalizedOffsetedUniformBuffers[bufferIndex].second;
+        mtl::BufferRef mtlBuffer = mLegalizedOffsetedUniformBuffers[bufferIndex].buffer();
+        size_t offset            = mLegalizedOffsetedUniformBuffers[bufferIndex].offset();
         [bufferEncoder.metalArgBufferEncoder setBuffer:mtlBuffer->get()
                                                 offset:offset
                                                atIndex:actualBufferIdx];
     }
 
     // Flush changes made by MTLArgumentEncoder to GPU.
-    argumentBuffer->unmapAndFlushSubset(context, argumentBufferOffset,
-                                        bufferEncoder.metalArgBufferEncoder.get().encodedLength);
+    argumentBuffer.buffer()->unmapAndFlushSubset(context, argumentBuffer.offset(),
+                                                 bufferEncoder.metalArgBufferEncoder.get().encodedLength);
 
-    cmdEncoder->setBuffer(shaderType, argumentBuffer, argumentBufferOffset,
+    cmdEncoder->setBuffer(shaderType, argumentBuffer.buffer(), argumentBuffer.offset(),
                           mtl::kUBOArgumentBufferBindingIndex);
     return angle::Result::Continue;
 }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProvokingVertexHelper.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProvokingVertexHelper.mm
@@ -210,16 +210,14 @@ angle::Result ProvokingVertexHelper::preconditionIndexBuffer(ContextMtl *context
     ANGLE_CHECK_GL_MATH(context, indexCountForPrimCount(indexBufferKey, primCount, &newIndexCount));
 
     size_t indexSize   = gl::GetDrawElementsTypeSize(elementsType);
-    size_t newOffset   = 0;
-    mtl::BufferRef newBuffer;
+    mtl::BufferSlice newBuffer;
 
     angle::CheckedNumeric<size_t> checkedBufferSize(newIndexCount);
     checkedBufferSize *= indexSize;
     checkedBufferSize += indexOffset;
 
     ANGLE_CHECK_GL_MATH(context, checkedBufferSize.IsValid());
-    ANGLE_TRY(mIndexBuffers.allocate(context, checkedBufferSize.ValueOrDie(), nullptr, &newBuffer,
-                                     &newOffset));
+    ANGLE_TRY(mIndexBuffers.allocate(context, checkedBufferSize.ValueOrDie(), nullptr, &newBuffer));
     auto threadsPerThreadgroup = MTLSizeMake(MIN(primCount, 64u), 1, 1);
 
     mtl::ComputeCommandEncoder *encoder =
@@ -227,9 +225,8 @@ angle::Result ProvokingVertexHelper::preconditionIndexBuffer(ContextMtl *context
     const bool isForGenerateIndices = false;
     ANGLE_TRY(
         prepareCommandEncoderForFunction(context, encoder, indexBufferKey, isForGenerateIndices));
-    encoder->setBuffer(indexBuffer, static_cast<uint32_t>(indexOffset), 0);
-    encoder->setBufferForWrite(
-        newBuffer, static_cast<uint32_t>(indexOffset) + static_cast<uint32_t>(newOffset), 1);
+    encoder->setBuffer(indexBuffer, indexOffset, 0);
+    encoder->setBufferForWrite(newBuffer.buffer(), indexOffset + newBuffer.offset(), 1);
     encoder->setData(static_cast<uint>(glCount), 2);
     encoder->setData(primCount, 3);
     encoder->dispatch(
@@ -238,9 +235,9 @@ angle::Result ProvokingVertexHelper::preconditionIndexBuffer(ContextMtl *context
                     1, 1),
         threadsPerThreadgroup);
     outIndexCount    = static_cast<uint32_t>(newIndexCount);
-    outIndexOffset   = newOffset;
+    outIndexOffset   = newBuffer.offset();
     outPrimitiveMode = getNewPrimitiveMode(indexBufferKey);
-    outNewBuffer     = newBuffer;
+    outNewBuffer     = newBuffer.buffer();
     return angle::Result::Continue;
 }
 
@@ -265,15 +262,13 @@ angle::Result ProvokingVertexHelper::generateIndexBuffer(ContextMtl *context,
     ANGLE_CHECK_GL_MATH(context, indexCountForPrimCount(indexBufferKey, primCount, &newIndexCount));
 
     size_t indexSize      = gl::GetDrawElementsTypeSize(elementsType);
-    size_t newIndexOffset = 0;
-    mtl::BufferRef newBuffer;
+    mtl::BufferSlice newBuffer;
 
     angle::CheckedNumeric<size_t> checkedBufferSize = newIndexCount;
     checkedBufferSize *= indexSize;
 
     ANGLE_CHECK_GL_MATH(context, checkedBufferSize.IsValid());
-    ANGLE_TRY(mIndexBuffers.allocate(context, checkedBufferSize.ValueOrDie(), nullptr, &newBuffer,
-                                     &newIndexOffset));
+    ANGLE_TRY(mIndexBuffers.allocate(context, checkedBufferSize.ValueOrDie(), nullptr, &newBuffer));
     auto threadsPerThreadgroup = MTLSizeMake(MIN(primCount, 64u), 1, 1);
 
     mtl::ComputeCommandEncoder *encoder =
@@ -281,7 +276,7 @@ angle::Result ProvokingVertexHelper::generateIndexBuffer(ContextMtl *context,
     const bool isForGenerateIndices = true;
     ANGLE_TRY(
         prepareCommandEncoderForFunction(context, encoder, indexBufferKey, isForGenerateIndices));
-    encoder->setBufferForWrite(newBuffer, static_cast<uint>(newIndexOffset), 1);
+    encoder->setBufferForWrite(newBuffer.buffer(), newBuffer.offset(), 1);
     encoder->setData(static_cast<uint>(glCount), 2);
     encoder->setData(primCount, 3);
     encoder->setData(static_cast<uint>(first), 4);
@@ -291,9 +286,9 @@ angle::Result ProvokingVertexHelper::generateIndexBuffer(ContextMtl *context,
                     1, 1),
         threadsPerThreadgroup);
     outIndexCount    = static_cast<uint32_t>(newIndexCount);
-    outIndexOffset   = newIndexOffset;
+    outIndexOffset   = newBuffer.offset();
     outPrimitiveMode = getNewPrimitiveMode(indexBufferKey);
-    outNewBuffer     = newBuffer;
+    outNewBuffer     = newBuffer.buffer();
     return angle::Result::Continue;
 }
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.h
@@ -58,8 +58,7 @@ class VertexArrayMtl : public VertexArrayImpl
                                  gl::DrawElementsType indexType,
                                  size_t indexCount,
                                  const void *sourcePointer,
-                                 mtl::BufferRef *idxBufferOut,
-                                 size_t *idxBufferOffsetOut,
+                                 mtl::BufferSlice *outIdxBuffer,
                                  gl::DrawElementsType *indexTypeOut);
 
     std::vector<DrawCommandRange> getDrawIndices(const gl::Context *glContext,
@@ -81,14 +80,12 @@ class VertexArrayMtl : public VertexArrayImpl
     angle::Result convertIndexBuffer(const gl::Context *glContext,
                                      gl::DrawElementsType indexType,
                                      size_t offset,
-                                     mtl::BufferRef *idxBufferOut,
-                                     size_t *idxBufferOffsetOut);
-    angle::Result streamIndexBufferFromClient(const gl::Context *glContext,
-                                              gl::DrawElementsType indexType,
-                                              size_t indexCount,
-                                              const void *sourcePointer,
-                                              mtl::BufferRef *idxBufferOut,
-                                              size_t *idxBufferOffsetOut);
+                                     mtl::BufferSlice *outIdxBuffer);
+   angle::Result streamIndexBufferFromClient(const gl::Context *glContext,
+                                             gl::DrawElementsType indexType,
+                                             size_t indexCount,
+                                             const void *sourcePointer,
+                                             mtl::BufferSlice *outIdxBuffer);
 
     angle::Result convertIndexBufferGPU(const gl::Context *glContext,
                                         gl::DrawElementsType indexType,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
@@ -43,10 +43,10 @@ angle::Result StreamVertexData(ContextMtl *contextMtl,
 {
     ANGLE_CHECK(contextMtl, vertexLoadFunction, gl::err::kInternalError, GL_INVALID_OPERATION);
     uint8_t *dst = nullptr;
-    mtl::BufferRef newBuffer;
-    ANGLE_TRY(dynamicBuffer->allocate(contextMtl, bytesToAllocate, &dst, &newBuffer,
-                                      bufferOffsetOut, nullptr));
-    bufferHolder->set(newBuffer);
+    mtl::BufferSlice newBuffer;
+    ANGLE_TRY(dynamicBuffer->allocate(contextMtl, bytesToAllocate, &dst, &newBuffer));
+    bufferHolder->set(newBuffer.buffer());
+    *bufferOffsetOut = newBuffer.offset();
     dst += destOffset;
     vertexLoadFunction(sourceData, stride, vertexCount, dst);
 
@@ -86,14 +86,14 @@ angle::Result StreamIndexData(ContextMtl *contextMtl,
                               gl::DrawElementsType indexType,
                               size_t indexCount,
                               bool primitiveRestartEnabled,
-                              mtl::BufferRef *bufferOut,
-                              size_t *bufferOffsetOut)
+                              mtl::BufferSlice *outBuffer)
 {
     dynamicBuffer->releaseInFlightBuffers(contextMtl);
     const size_t amount = GetIndexConvertedBufferSize(indexType, indexCount);
     GLubyte *dst        = nullptr;
+    mtl::BufferSlice buffer;
     ANGLE_TRY(
-        dynamicBuffer->allocate(contextMtl, amount, &dst, bufferOut, bufferOffsetOut, nullptr));
+        dynamicBuffer->allocate(contextMtl, amount, &dst, &buffer));
 
     if (indexType == gl::DrawElementsType::UnsignedByte)
     {
@@ -130,6 +130,7 @@ angle::Result StreamIndexData(ContextMtl *contextMtl,
     }
     ANGLE_TRY(dynamicBuffer->commit(contextMtl));
 
+    *outBuffer = buffer;
     return angle::Result::Continue;
 }
 
@@ -701,8 +702,7 @@ angle::Result VertexArrayMtl::getIndexBuffer(const gl::Context *context,
                                              gl::DrawElementsType type,
                                              size_t count,
                                              const void *indices,
-                                             mtl::BufferRef *idxBufferOut,
-                                             size_t *idxBufferOffsetOut,
+                                             mtl::BufferSlice *outIdxBuffer,
                                              gl::DrawElementsType *indexTypeOut)
 {
     const gl::Buffer *glElementArrayBuffer = getElementArrayBuffer();
@@ -710,23 +710,21 @@ angle::Result VertexArrayMtl::getIndexBuffer(const gl::Context *context,
     size_t convertedOffset = reinterpret_cast<size_t>(indices);
     if (!glElementArrayBuffer)
     {
-        ANGLE_TRY(streamIndexBufferFromClient(context, type, count, indices, idxBufferOut,
-                                              idxBufferOffsetOut));
+        ANGLE_TRY(streamIndexBufferFromClient(context, type, count, indices, outIdxBuffer));
     }
     else
     {
         bool needConversion = type == gl::DrawElementsType::UnsignedByte;
         if (needConversion)
         {
-            ANGLE_TRY(convertIndexBuffer(context, type, convertedOffset, idxBufferOut,
-                                         idxBufferOffsetOut));
+            ANGLE_TRY(convertIndexBuffer(context, type, convertedOffset, outIdxBuffer));
         }
         else
         {
             // No conversion needed:
-            BufferMtl *bufferMtl = mtl::GetImpl(glElementArrayBuffer);
-            *idxBufferOut        = bufferMtl->getCurrentBuffer();
-            *idxBufferOffsetOut  = convertedOffset;
+            BufferMtl *bufferMtl     = mtl::GetImpl(glElementArrayBuffer);
+            mtl::BufferRef bufferRef = bufferMtl->getCurrentBuffer();
+            *outIdxBuffer            = mtl::BufferSlice(bufferRef).subslice(convertedOffset);
         }
     }
 
@@ -847,8 +845,7 @@ std::vector<DrawCommandRange> VertexArrayMtl::getDrawIndices(const gl::Context *
 angle::Result VertexArrayMtl::convertIndexBuffer(const gl::Context *glContext,
                                                  gl::DrawElementsType indexType,
                                                  size_t offset,
-                                                 mtl::BufferRef *idxBufferOut,
-                                                 size_t *idxBufferOffsetOut)
+                                                 mtl::BufferSlice *outIdxBuffer)
 {
     size_t offsetModulo = offset % mtl::kIndexBufferOffsetAlignment;
     ASSERT(offsetModulo != 0 || indexType == gl::DrawElementsType::UnsignedByte);
@@ -871,8 +868,8 @@ angle::Result VertexArrayMtl::convertIndexBuffer(const gl::Context *glContext,
     if (!conversion->dirty)
     {
         // reuse the converted buffer
-        *idxBufferOut       = conversion->convertedBuffer;
-        *idxBufferOffsetOut = conversion->convertedOffset + alignedOffset;
+        size_t resultOffset = conversion->convertedOffset + alignedOffset;
+        *outIdxBuffer = mtl::BufferSlice(conversion->convertedBuffer).subslice(resultOffset);
         return angle::Result::Continue;
     }
 
@@ -881,10 +878,13 @@ angle::Result VertexArrayMtl::convertIndexBuffer(const gl::Context *glContext,
          contextMtl->getRenderCommandEncoder()))
     {
         // We shouldn't use GPU to convert when we are in a middle of a render pass.
+        mtl::BufferSlice streamed;
         ANGLE_TRY(StreamIndexData(contextMtl, &conversion->data,
                                   idxBuffer->getBufferDataReadOnly(contextMtl, offsetModulo).data(),
                                   indexType, indexCount, glState.isPrimitiveRestartEnabled(),
-                                  &conversion->convertedBuffer, &conversion->convertedOffset));
+                                  &streamed));
+        conversion->convertedBuffer = streamed.buffer();
+        conversion->convertedOffset = streamed.offset();
     }
     else
     {
@@ -892,8 +892,8 @@ angle::Result VertexArrayMtl::convertIndexBuffer(const gl::Context *glContext,
                                         conversion));
     }
     // Calculate ranges for prim restart simple types.
-    *idxBufferOut       = conversion->convertedBuffer;
-    *idxBufferOffsetOut = conversion->convertedOffset + alignedOffset;
+    size_t resultOffset = conversion->convertedOffset + alignedOffset;
+    *outIdxBuffer = mtl::BufferSlice(conversion->convertedBuffer).subslice(resultOffset);
 
     return angle::Result::Continue;
 }
@@ -913,8 +913,10 @@ angle::Result VertexArrayMtl::convertIndexBufferGPU(const gl::Context *glContext
     // Allocate new buffer, save it in conversion struct so that we can reuse it when the content
     // of the original buffer is not dirty.
     conversion->data.releaseInFlightBuffers(contextMtl);
-    ANGLE_TRY(conversion->data.allocate(contextMtl, amount, nullptr, &conversion->convertedBuffer,
-                                        &conversion->convertedOffset));
+    mtl::BufferSlice converted;
+    ANGLE_TRY(conversion->data.allocate(contextMtl, amount, nullptr, &converted));
+    conversion->convertedBuffer = converted.buffer();
+    conversion->convertedOffset = converted.offset();
 
     // Do the conversion on GPU.
     ANGLE_TRY(display->getUtils().convertIndexBufferGPU(
@@ -935,16 +937,14 @@ angle::Result VertexArrayMtl::streamIndexBufferFromClient(const gl::Context *con
                                                           gl::DrawElementsType indexType,
                                                           size_t indexCount,
                                                           const void *sourcePointer,
-                                                          mtl::BufferRef *idxBufferOut,
-                                                          size_t *idxBufferOffsetOut)
+                                                          mtl::BufferSlice *outIdxBuffer)
 {
     ASSERT(getElementArrayBuffer() == nullptr);
     ContextMtl *contextMtl = mtl::GetImpl(context);
 
     auto srcData = static_cast<const uint8_t *>(sourcePointer);
     ANGLE_TRY(StreamIndexData(contextMtl, &mDynamicIndexData, srcData, indexType, indexCount,
-                              context->getState().isPrimitiveRestartEnabled(), idxBufferOut,
-                              idxBufferOffsetOut));
+                              context->getState().isPrimitiveRestartEnabled(), outIdxBuffer));
 
     return angle::Result::Continue;
 }
@@ -1079,10 +1079,9 @@ angle::Result VertexArrayMtl::convertVertexBufferGPU(const gl::Context *glContex
 {
     ContextMtl *contextMtl = mtl::GetImpl(glContext);
 
-    mtl::BufferRef newBuffer;
-    size_t newBufferOffset;
-    ANGLE_TRY(conversion->data.allocate(contextMtl, numVertices * targetStride, nullptr, &newBuffer,
-                                        &newBufferOffset));
+    mtl::BufferSlice newBuffer;
+    ANGLE_TRY(conversion->data.allocate(contextMtl, numVertices * targetStride, nullptr,
+                                        &newBuffer));
 
     GLintptr bindingOffset = binding.getOffset();
 
@@ -1091,7 +1090,7 @@ angle::Result VertexArrayMtl::convertVertexBufferGPU(const gl::Context *glContex
         ANGLE_CHECK_GL_MATH(contextMtl, static_cast<std::make_unsigned_t<decltype(bindingOffset)>>(
                                             bindingOffset) <= std::numeric_limits<uint32_t>::max());
     }
-    ANGLE_CHECK_GL_MATH(contextMtl, newBufferOffset <= std::numeric_limits<uint32_t>::max());
+    ANGLE_CHECK_GL_MATH(contextMtl, newBuffer.offset() <= std::numeric_limits<uint32_t>::max());
     ANGLE_CHECK_GL_MATH(contextMtl, numVertices <= std::numeric_limits<uint32_t>::max());
 
     mtl::VertexFormatConvertParams params;
@@ -1108,8 +1107,8 @@ angle::Result VertexArrayMtl::convertVertexBufferGPU(const gl::Context *glContex
     params.srcStride            = binding.getStride();
     params.srcDefaultAlphaData  = convertedFormat.defaultAlpha;
 
-    params.dstBuffer            = newBuffer;
-    params.dstBufferStartOffset = static_cast<uint32_t>(newBufferOffset);
+    params.dstBuffer            = newBuffer.buffer();
+    params.dstBufferStartOffset = static_cast<uint32_t>(newBuffer.offset());
     params.dstStride            = targetStride;
     params.dstComponents        = convertedFormat.actualAngleFormat().channelCount;
 
@@ -1131,8 +1130,8 @@ angle::Result VertexArrayMtl::convertVertexBufferGPU(const gl::Context *glContex
 
     ANGLE_TRY(conversion->data.commit(contextMtl));
 
-    conversion->convertedBuffer = newBuffer;
-    conversion->convertedOffset = newBufferOffset;
+    conversion->convertedBuffer = newBuffer.buffer();
+    conversion->convertedOffset = newBuffer.offset();
 
     return angle::Result::Continue;
 }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.h
@@ -54,13 +54,12 @@ class BufferPool
 
     // This call will allocate a new region at the end of the buffer. It internally may trigger
     // a new buffer to be created (which is returned in the optional parameter
-    // `newBufferAllocatedOut`).  The new region will be in the returned buffer at given offset. If
+    // `newBufferAllocatedOut`).  The new region will be in the returned BufferSlice. If
     // a memory pointer is given, the buffer will be automatically map()ed.
     angle::Result allocate(ContextMtl *contextMtl,
                            size_t sizeInBytes,
                            uint8_t **ptrOut            = nullptr,
-                           BufferRef *bufferOut        = nullptr,
-                           size_t *offsetOut           = nullptr,
+                           BufferSlice *outBuffer      = nullptr,
                            bool *newBufferAllocatedOut = nullptr);
 
     // After a sequence of CPU writes, call commit to ensure the data is visible to the GPU.

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.mm
@@ -155,8 +155,7 @@ angle::Result BufferPool::allocateNewBuffer(ContextMtl *contextMtl)
 angle::Result BufferPool::allocate(ContextMtl *contextMtl,
                                    size_t sizeInBytes,
                                    uint8_t **ptrOut,
-                                   BufferRef *bufferOut,
-                                   size_t *offsetOut,
+                                   BufferSlice *outBuffer,
                                    bool *newBufferAllocatedOut)
 {
     size_t sizeToAllocate = roundUp(sizeInBytes, mAlignment);
@@ -211,11 +210,6 @@ angle::Result BufferPool::allocate(ContextMtl *contextMtl,
 
     ASSERT(mBuffer != nullptr);
 
-    if (bufferOut != nullptr)
-    {
-        *bufferOut = mBuffer;
-    }
-
     // Optionally map() the buffer if possible
     if (ptrOut)
     {
@@ -224,9 +218,9 @@ angle::Result BufferPool::allocate(ContextMtl *contextMtl,
         *ptrOut = mBuffer->mapNoSync(contextMtl, mNextAllocationOffset).data();
     }
 
-    if (offsetOut)
+    if (outBuffer != nullptr)
     {
-        *offsetOut = mNextAllocationOffset;
+        *outBuffer = BufferSlice(mBuffer).subslice(mNextAllocationOffset, sizeInBytes);
     }
     mNextAllocationOffset += sizeToAllocate;
     return angle::Result::Continue;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.h
@@ -45,6 +45,33 @@ using TextureWeakRef = std::weak_ptr<Texture>;
 using BufferRef      = std::shared_ptr<Buffer>;
 using BufferWeakRef  = std::weak_ptr<Buffer>;
 
+class BufferSlice
+{
+  public:
+    BufferSlice() = default;
+    BufferSlice(const BufferSlice &)            = default;
+    BufferSlice(BufferSlice &&)                 = default;
+    BufferSlice &operator=(const BufferSlice &) = default;
+    BufferSlice &operator=(BufferSlice &&)      = default;
+
+    inline explicit BufferSlice(const BufferRef &buffer);
+
+    bool empty() const { return mSize == 0; }
+    const BufferRef &buffer() const { return mBuffer; }
+    size_t size() const { return mSize; }
+    size_t offset() const { return mOffset; }
+
+    inline BufferSlice subslice(size_t offset, size_t count) const;
+    inline BufferSlice subslice(size_t offset) const;
+
+  private:
+    inline BufferSlice(const BufferRef &buffer, size_t offset, size_t size);
+
+    BufferRef mBuffer;
+    size_t mSize   = 0;
+    size_t mOffset = 0;
+};
+
 class Resource : angle::NonCopyable
 {
   public:
@@ -524,12 +551,33 @@ inline angle::Span<uint8_t> Buffer::mapNoSync(ContextMtl *context, size_t offset
 }
 
 inline angle::Span<uint8_t> Buffer::mapWithOpt(ContextMtl *context,
-                                               bool readonly,
-                                               bool noSync,
-                                               size_t offset,
-                                               size_t length)
+                                                bool readonly,
+                                                bool noSync,
+                                                size_t offset,
+                                                size_t length)
 {
     return mapWithOpt(context, readonly, noSync, offset).first(length);
+}
+
+inline BufferSlice::BufferSlice(const BufferRef &buffer)
+    : mBuffer(buffer), mSize(buffer ? buffer->size() : 0), mOffset(0)
+{}
+
+inline BufferSlice::BufferSlice(const BufferRef &buffer, size_t offset, size_t size)
+    : mBuffer(buffer), mSize(size), mOffset(offset)
+{
+    RELEASE_ASSERT(buffer != nullptr && offset + size <= buffer->size());
+}
+
+inline BufferSlice BufferSlice::subslice(size_t offset, size_t count) const
+{
+    RELEASE_ASSERT(offset + count <= mSize);
+    return BufferSlice(mBuffer, mOffset + offset, count);
+}
+
+inline BufferSlice BufferSlice::subslice(size_t offset) const
+{
+    return subslice(offset, mSize - offset);
 }
 
 }  // namespace mtl


### PR DESCRIPTION
#### 7aa25e16d8f37efb8361fb142ff7446042e14883
<pre>
ANGLE: Metal: Add BufferSlice to associate BufferRef, offset pairs
<a href="https://bugs.webkit.org/show_bug.cgi?id=312561">https://bugs.webkit.org/show_bug.cgi?id=312561</a>
<a href="https://rdar.apple.com/174999473">rdar://174999473</a>

Reviewed by Dan Glastonbury.

Many functions operate on BufferRef + offset pair, especially the
cases which allocate from BufferPool.
Add BufferSlice abstraction to manage these in buffer safe manner.
Choose &quot;Slice&quot; since a slice owns its data, as opposed to a &quot;Span&quot; or a
&quot;View&quot;.

In later commits the data consumption points such as the encoders
might release assert that the buffer is large enough.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm:
(rx::ContextMtl::drawTriFanArraysLegacy):
(rx::ContextMtl::drawLineLoopArrays):
(rx::ContextMtl::drawTriFanElements):
(rx::ContextMtl::drawLineLoopElements):
(rx::ContextMtl::drawElementsImpl):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm:
(rx::ProgramExecutableMtl::commitUniforms):
(rx::ProgramExecutableMtl::updateUniformBuffers):
(rx::ProgramExecutableMtl::legalizeUniformBufferOffsets):
(rx::ProgramExecutableMtl::bindUniformBuffersToDiscreteSlots):
(rx::ProgramExecutableMtl::encodeUniformBuffersInfoArgumentBuffer):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProvokingVertexHelper.mm:
(rx::ProvokingVertexHelper::preconditionIndexBuffer):
(rx::ProvokingVertexHelper::generateIndexBuffer):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm:
(rx::VertexArrayMtl::getIndexBuffer):
(rx::VertexArrayMtl::convertIndexBuffer):
(rx::VertexArrayMtl::convertIndexBufferGPU):
(rx::VertexArrayMtl::streamIndexBufferFromClient):
(rx::VertexArrayMtl::convertVertexBufferGPU):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.mm:
(rx::mtl::BufferPool::allocate):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.h:
(rx::mtl::BufferSlice::empty const):
(rx::mtl::BufferSlice::buffer const):
(rx::mtl::BufferSlice::size const):
(rx::mtl::BufferSlice::offset const):
(rx::mtl::Buffer::mapWithOpt):
(rx::mtl::BufferSlice::BufferSlice):
(rx::mtl::BufferSlice::subslice const):

Canonical link: <a href="https://commits.webkit.org/311563@main">https://commits.webkit.org/311563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c6ff55c30d2174761357c9f4220306a8ce51a2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111106 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121606 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85388 "1 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bf8984b-5f96-4a8d-813a-ee105013b971) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102274 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ed42ad5-42ea-440a-bc11-c83b71ed9e7e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22907 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21135 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13619 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168332 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129732 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129840 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35244 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140629 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87689 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24668 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17433 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29596 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29118 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29348 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29245 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->