### PR TITLE
LibWebRTCCodecs webrtc encoder may fail encoding if a frame is submitted before its connection is initialized

### DIFF
--- a/LayoutTests/webrtc/h264-encoder-race-expected.txt
+++ b/LayoutTests/webrtc/h264-encoder-race-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Multiple tracks H264 encoding
+

--- a/LayoutTests/webrtc/h264-encoder-race.html
+++ b/LayoutTests/webrtc/h264-encoder-race.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Testing H264 encoder race condition fix</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="video1" autoplay playsInline width="320" height="240"></video>
+        <video id="video2" autoplay playsInline width="320" height="240"></video>
+        <canvas id="canvas" width="320" height="240"></canvas>
+        <script src="routines.js"></script>
+        <script>
+async function getCodecFromStats(connection) {
+    const stats = await connection.getStats();
+    let codecName = null;
+    stats.forEach((stat) => {
+        if (stat.type === 'inbound-rtp' && stat.kind === 'video') {
+            const codecId = stat.codecId;
+            stats.forEach((codecStat) => {
+                if (codecStat.id === codecId) {
+                    codecName = codecStat.mimeType;
+                }
+            });
+        }
+    });
+    return codecName;
+}
+
+function setupTransceiver(transceiver)
+{
+    // Set codec preferences: H264 first, VP8 as fallback
+    const capabilities = RTCRtpSender.getCapabilities('video');
+    const h264Codecs = capabilities.codecs.filter(codec => codec.mimeType === 'video/H264');
+    const vp8Codecs = capabilities.codecs.filter(codec => codec.mimeType === 'video/VP8');
+    transceiver.setCodecPreferences([...h264Codecs, ...vp8Codecs]);
+}
+
+promise_test(async (test) => {
+    if (window.internals)
+        internals.clearWebRTCCodecsConnection();
+
+    const localStream1 = await navigator.mediaDevices.getUserMedia({video: {width: 320, height: 240}});
+    const localStream2 = await navigator.mediaDevices.getUserMedia({video: {width: 320, height: 240}});
+
+    const receivingConnection = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            firstConnection.addTrack(localStream1.getVideoTracks()[0], localStream1);
+            firstConnection.addTrack(localStream2.getVideoTracks()[0], localStream2);
+            for (const transceiver of firstConnection.getTransceivers())
+                setupTransceiver(transceiver);
+        }, (secondConnection) => {
+            secondConnection.ontrack = (trackEvent) => {
+                if (!video1.srcObject) {
+                    video1.srcObject = trackEvent.streams[0];
+                    return;
+                }
+                video2.srcObject = trackEvent.streams[0];
+                resolve(secondConnection);
+            };
+        });
+        setTimeout(() => reject("Test timed out for setting up connections"), 5000);
+    });
+
+    await video1.play();
+    await video2.play();
+
+    const codec = await getCodecFromStats(receivingConnection);
+    assert_true(codec.includes('H264'), 'First connection should be using H264 codec, not VP8 fallback');
+
+    localStream1.getTracks().forEach(track => track.stop());
+    localStream2.getTracks().forEach(track => track.stop());
+}, "Multiple tracks H264 encoding");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
@@ -125,6 +125,8 @@ public:
     };
     virtual std::unique_ptr<SuspendableSocketFactory> createSocketFactory(String&& /* userAgent */, ScriptExecutionContextIdentifier, bool /* isFirstParty */, RegistrableDomain&&, bool /* enableServiceClass */);
 
+    virtual void clearCodecsConnectionForTesting() { }
+
 protected:
     LibWebRTCProvider();
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1954,6 +1954,16 @@ void Internals::clearPeerConnectionFactory()
         page->webRTCProvider().clearFactory();
 }
 
+void Internals::clearWebRTCCodecsConnection()
+{
+#if USE(LIBWEBRTC)
+    if (auto* page = contextDocument()->page()) {
+        auto& rtcProvider = downcast<LibWebRTCProvider>(page->webRTCProvider());
+        rtcProvider.clearCodecsConnectionForTesting();
+    }
+#endif
+}
+
 void Internals::applyRotationForOutgoingVideoSources(RTCPeerConnection& connection)
 {
     connection.applyRotationForOutgoingVideoSources();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -816,6 +816,7 @@ public:
     void NODELETE setEnumeratingAllNetworkInterfacesEnabled(bool);
     void stopPeerConnection(RTCPeerConnection&);
     void clearPeerConnectionFactory();
+    void clearWebRTCCodecsConnection();
     void applyRotationForOutgoingVideoSources(RTCPeerConnection&);
     void setWebRTCH265Support(bool);
     void setWebRTCVP9Support(bool supportVP9Profile0, bool supportVP9Profile2);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1113,6 +1113,7 @@ enum ContentsFormat {
     [Conditional=WEB_RTC] undefined setEnumeratingAllNetworkInterfacesEnabled(boolean enabled);
     [Conditional=WEB_RTC] undefined stopPeerConnection(RTCPeerConnection connection);
     [Conditional=WEB_RTC] undefined clearPeerConnectionFactory();
+    [Conditional=WEB_RTC] undefined clearWebRTCCodecsConnection();
     [Conditional=WEB_RTC] undefined setEnableWebRTCEncryption(boolean enabled);
     [Conditional=WEB_RTC] boolean hasPeerConnectionEnabledServiceClass(RTCPeerConnection connection);
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -48,6 +48,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/threads/BinarySemaphore.h>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <webrtc/webkit_sdk/WebKit/WebKitDecoder.h>
@@ -567,7 +568,16 @@ static inline webrtc::VideoCodecType NODELETE toWebRTCCodecType(WebCore::VideoCo
 
 LibWebRTCCodecs::Encoder* LibWebRTCCodecs::createEncoder(WebCore::VideoCodecType type, const std::map<std::string, std::string>& parameters)
 {
-    return createEncoderInternal(type, { }, parameters, true, true, VideoEncoderScalabilityMode::L1T1, [](auto*) { });
+    // Should be called from libwebrtc encoding thread.
+    ASSERT(!isMainRunLoop());
+    ASSERT(!workQueue().isCurrent());
+
+    BinarySemaphore semaphore;
+    auto* encoder = createEncoderInternal(type, { }, parameters, true, true, VideoEncoderScalabilityMode::L1T1, [&semaphore](auto*) {
+        semaphore.signal();
+    });
+    semaphore.wait();
+    return encoder;
 }
 
 #if ENABLE(WEB_CODECS)
@@ -853,12 +863,15 @@ CVPixelBufferPoolRef LibWebRTCCodecs::pixelBufferPool(size_t width, size_t heigh
     return m_pixelBufferPool.get();
 }
 
-void LibWebRTCCodecs::gpuProcessConnectionDidClose(GPUProcessConnection&)
+void LibWebRTCCodecs::clearConnection()
 {
     ASSERT(isMainRunLoop());
 
     Locker locker { m_connectionLock };
     RefPtr connection = std::exchange(m_connection, nullptr);
+    if (!connection)
+        return;
+
     connection->removeWorkQueueMessageReceiver(Messages::LibWebRTCCodecs::messageReceiverName());
     if (!m_needsGPUProcessConnection)
         return;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -195,6 +195,8 @@ public:
 
     WorkQueue& workQueue() const { return m_queue; }
 
+    void clearConnectionForTesting() { clearConnection(); }
+
 private:
     LibWebRTCCodecs();
     void ensureGPUProcessConnectionAndDispatchToThread(Function<void()>&&);
@@ -212,7 +214,9 @@ private:
     RetainPtr<CVPixelBufferRef> convertToBGRA(CVPixelBufferRef);
 
     // GPUProcessConnection::Client
-    void gpuProcessConnectionDidClose(GPUProcessConnection&);
+    void gpuProcessConnectionDidClose(GPUProcessConnection&) { clearConnection(); }
+
+    void clearConnection();
 
     IPC::Connection* NODELETE encoderConnection(Encoder&) WTF_REQUIRES_LOCK(m_encodersConnectionLock);
     void setEncoderConnection(Encoder&, RefPtr<IPC::Connection>&&) WTF_REQUIRES_LOCK(m_encodersConnectionLock);

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -212,6 +212,13 @@ void LibWebRTCProvider::willCreatePeerConnectionFactory()
 #endif
 }
 
+void LibWebRTCProvider::clearCodecsConnectionForTesting()
+{
+#if PLATFORM(COCOA)
+    protect(WebProcess::singleton().libWebRTCCodecs())->clearConnectionForTesting();
+#endif
+}
+
 } // namespace WebKit
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -72,6 +72,8 @@ public:
 private:
     bool isLibWebRTCProvider() const final { return true; }
 
+    void clearCodecsConnectionForTesting() final;
+
     std::unique_ptr<SuspendableSocketFactory> createSocketFactory(String&& /* userAgent */, WebCore::ScriptExecutionContextIdentifier, bool /* isFirstParty */, WebCore::RegistrableDomain&&, bool /* enableServiceClass */) final;
 
     webrtc::scoped_refptr<webrtc::PeerConnectionInterface> createPeerConnection(WebCore::ScriptExecutionContextIdentifier, webrtc::PeerConnectionObserver&, webrtc::PacketSocketFactory*, webrtc::PeerConnectionInterface::RTCConfiguration&&) final;


### PR DESCRIPTION
#### e3f4c5f3c2385953a9def894af1c41276c6f4fee
<pre>
LibWebRTCCodecs webrtc encoder may fail encoding if a frame is submitted before its connection is initialized
<a href="https://rdar.apple.com/174786491">rdar://174786491</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312551">https://bugs.webkit.org/show_bug.cgi?id=312551</a>

Reviewed by Eric Carlson.

There is a race for WebRTC encoder between setting up the encoder (get its IPC connection in particular) and receving the first frame to encode from the libwebrtc backend.
If the frame is received before we finished setting up the encoder, we were sending an encoder error.
The webrtc backend was then trying to switch of encoder which is unexpected.

To prevent that issue, we block the webrtc thread until the setup (done in work queue mostly) is done with a BinarySemaphore.
As a a way to speed things up, whenever LibWebRTCCodecs::initializeIfNeeded() is used to ensure that we know whether there is AV1/VP9 HW support,
we set up LibWebRTCCodecs::m_connection. This allows to no longer hop to main thread for the first encoder of LibWebRTCCodecs.

Covered by a test which ensures that only H264 is used and not VP8 (fallback encoder).

Canonical link: <a href="https://commits.webkit.org/311603@main">https://commits.webkit.org/311603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5019d7d5d0d5f8acc800696341fc33ef25a09a20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157052 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111134 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c531a99-cec2-452c-8331-f0694ea82efe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121629 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85402 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/529ef34f-f86d-4423-9c92-d1f8e71a0154) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102297 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22929 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21161 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13647 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168360 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12519 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129755 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129863 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35266 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29913 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140652 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87732 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24694 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17456 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29624 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93638 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29146 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29376 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29273 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->