### PR TITLE
Remove URL's isEmpty()

### DIFF
--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -134,7 +134,6 @@ public:
     WTF_EXPORT_PRIVATE URL isolatedCopy() &&;
 
     bool isNull() const;
-    bool isEmpty() const;
     bool isValid() const;
 
     // Since we overload operator NSURL * we have this to prevent accidentally using that operator
@@ -362,11 +361,6 @@ inline URL::URL(HashTableDeletedValueType)
 inline bool URL::isNull() const
 {
     return m_string.isNull();
-}
-
-inline bool URL::isEmpty() const
-{
-    return m_string.isEmpty();
 }
 
 inline bool URL::isValid() const

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -59,8 +59,11 @@ RetainPtr<CFURLRef> URL::createCFURL() const
     if (isNull())
         return nullptr;
 
-    if (isEmpty())
+    if (m_string.isEmpty()) {
+        if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ConvertsInvalidURLsToNull))
+            return nullptr;
         return emptyCFURL();
+    }
 
     if (!isValid() && linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ConvertsInvalidURLsToNull))
         return nullptr;

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -342,7 +342,7 @@ Vector<ApplicationManifest::Icon> ApplicationManifestParser::parseIcons(const JS
             continue;
         }
         URL srcURL(m_manifestURL, srcStringValue);
-        if (srcURL.isEmpty())
+        if (srcURL.isNull())
             continue;
         if (!srcURL.isValid()) {
             logManifestPropertyInvalidURL("src"_s);
@@ -421,7 +421,7 @@ Vector<ApplicationManifest::Shortcut> ApplicationManifestParser::parseShortcuts(
         }
 
         URL shortcutURL(m_manifestURL, urlStringValue);
-        if (shortcutURL.isEmpty())
+        if (shortcutURL.isNull())
             continue;
         if (!shortcutURL.isValid()) {
             logManifestPropertyInvalidURL("url"_s);
@@ -440,7 +440,7 @@ Vector<ApplicationManifest::Shortcut> ApplicationManifestParser::parseShortcuts(
 static bool isInScope(const URL& scopeURL, const URL& targetURL)
 {
     // 1. If scopeURL is undefined (i.e., it is unbounded because of an error or it was not declared in the manifest), return true.
-    if (scopeURL.isNull() || scopeURL.isEmpty())
+    if (scopeURL.isNull())
         return true;
 
     // 2. Let target be a new URL using targetURL as input. If target is failure, return false.

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -290,7 +290,7 @@ void HTMLModelElement::setSourceURL(const URL& url)
     m_readyPromise = makeUniqueRef<ReadyPromise>(*this, &HTMLModelElement::readyPromiseResolve);
     m_shouldCreateModelPlayerUponRendererAttachment = false;
 
-    if (m_sourceURL.isEmpty()) {
+    if (m_sourceURL.isNull()) {
         ActiveDOMObject::queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
         reportExtraMemoryCost();
         return;
@@ -434,7 +434,7 @@ void HTMLModelElement::didConvertModelData(ModelPlayer& modelPlayer, Ref<SharedB
 
 void HTMLModelElement::didFinishEnvironmentMapLoading(ModelPlayer&, bool succeeded)
 {
-    if (!m_environmentMapURL.isEmpty() && !m_environmentMapReadyPromise->isFulfilled()) {
+    if (!m_environmentMapURL.isNull() && !m_environmentMapReadyPromise->isFulfilled()) {
         if (succeeded)
             m_environmentMapReadyPromise->resolve();
         else {
@@ -609,7 +609,7 @@ void HTMLModelElement::createModelPlayer()
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
     if (m_environmentMapData)
         modelPlayer->setEnvironmentMap(m_environmentMapData.takeBufferAsContiguous().get());
-    else if (!m_environmentMapURL.isEmpty())
+    else if (!m_environmentMapURL.isNull())
         environmentMapRequestResource();
 #endif
 
@@ -705,7 +705,7 @@ void HTMLModelElement::reloadModelPlayer()
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
     if (m_environmentMapData)
         modelPlayer->setEnvironmentMap(m_environmentMapData.takeBufferAsContiguous().get());
-    else if (!m_environmentMapURL.isEmpty())
+    else if (!m_environmentMapURL.isNull())
         environmentMapRequestResource();
 #endif
 }
@@ -1221,7 +1221,7 @@ void HTMLModelElement::setEnvironmentMap(const URL& url)
     environmentMapResetAndReject(Exception { ExceptionCode::AbortError });
     m_environmentMapReadyPromise = makeUniqueRef<EnvironmentMapPromise>();
 
-    if (m_environmentMapURL.isEmpty()) {
+    if (m_environmentMapURL.isNull()) {
         // sending a message with empty data to indicate resource removal
         if (m_modelPlayer)
             m_modelPlayer->setEnvironmentMap(SharedBuffer::create());
@@ -1788,7 +1788,7 @@ size_t HTMLModelElement::externalMemoryCost() const
 
 void HTMLModelElement::sourceRequestResource()
 {
-    if (m_sourceURL.isEmpty())
+    if (m_sourceURL.isNull())
         return triggerModelPlayerCreationCallbacksIfNeeded(Exception { ExceptionCode::AbortError, "The source URL is empty"_s });
 
     auto request = createResourceRequest(m_sourceURL, FetchOptions::Destination::Model);

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
@@ -80,7 +80,7 @@ void NotificationResourcesLoader::start(CompletionHandler<void(RefPtr<Notificati
     if (resourceIsSupportedInPlatform(Resource::Icon)) {
         Ref notification = m_notification.get();
         const URL& iconURL = notification->icon();
-        if (!iconURL.isEmpty()) {
+        if (!iconURL.isNull()) {
             Ref loader = ResourceLoader::create(*protect(notification->scriptExecutionContext()), iconURL, [this](ResourceLoader* loader, RefPtr<BitmapImage>&& image) {
                 if (m_stopped)
                     return;

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -298,7 +298,7 @@ AtomString YouTubePluginReplacement::youTubeURLFromAbsoluteURL(const URL& srcURL
     bool isYouTubeShortenedURL = false;
     String possiblyMalformedQuery;
     URL youTubeURL = processAndCreateYouTubeURL(srcURL, isYouTubeShortenedURL, possiblyMalformedQuery);
-    if (youTubeURL.isEmpty())
+    if (youTubeURL.isNull())
         return srcString;
 
     // Transform the youtubeURL (youtube:VideoID) to iframe embed url which has the format: http://www.youtube.com/embed/VideoID

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -394,7 +394,7 @@ ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionCo
     String protocol, username, password, hostname, port, pathname, search, hash;
 
     if (URL* inputURL = std::get_if<URL>(&input)) {
-        ASSERT(!inputURL->isEmpty() && inputURL->isValid());
+        ASSERT(inputURL->isValid());
         matchHelperAssignInputsFromURL(*inputURL, protocol, username, password, hostname, port, pathname, search, hash);
         result.inputs = Vector<URLPatternInput> { String { inputURL->string() } };
     } else {

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -491,7 +491,7 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRole()
 
     // FIXME: When the URL changes, we should recompute an object's role.
     if (isImageMapLink())
-        return !url().isEmpty() ? AccessibilityRole::Link : AccessibilityRole::Generic;
+        return !url().isNull() ? AccessibilityRole::Link : AccessibilityRole::Generic;
 
     auto roleFromNode = determineAccessibilityRoleFromNode();
 
@@ -1027,7 +1027,7 @@ bool AccessibilityNodeObject::computeIsIgnored() const
     if (decision == AccessibilityObjectInclusion::IgnoreObject)
         return true;
 
-    if (isImageMapLink() && !url().isEmpty())
+    if (isImageMapLink() && !url().isNull())
         return false;
 
     auto role = this->role();

--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -59,7 +59,7 @@ static SecurityOriginData resolveOriginForRealm(LocalFrame& localFrame)
     if (RefPtr document = localFrame.document())
         return document->securityOrigin().data();
 
-    if (RefPtr loader = localFrame.loader().activeDocumentLoader(); loader && !loader->url().isEmpty())
+    if (RefPtr loader = localFrame.loader().activeDocumentLoader(); loader && !loader->url().isNull())
         return SecurityOriginData::fromURL(loader->url());
 
     return SecurityOriginData::createOpaque();

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -226,10 +226,10 @@ std::optional<String> customTrackerBlockingMessageForConsole(const ContentRuleLi
         return std::nullopt;
 
     auto trackerBlockingMessage = "Blocked connection to known tracker"_s;
-    if (!requestURL.isEmpty() && !documentURL.isEmpty())
+    if (!requestURL.isNull() && !documentURL.isNull())
         return makeString(trackerBlockingMessage, ' ', requestURL.string(), " in frame displaying "_s, documentURL.string());
 
-    if (!requestURL.isEmpty())
+    if (!requestURL.isNull())
         return makeString(trackerBlockingMessage, ' ', requestURL.string());
 
     return trackerBlockingMessage;
@@ -494,7 +494,7 @@ void applyResultsToRequest(ContentRuleListResults&& results, Page* page, Resourc
     for (auto& action : results.summary.modifyHeadersActions)
         action.applyToRequest(request, headerNameToFirstOperationApplied);
 
-    if (redirectURL.isEmpty()) {
+    if (redirectURL.isNull()) {
         for (auto& pair : results.summary.redirectActions)
             pair.first.applyToRequest(request, pair.second);
     } else

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -338,7 +338,7 @@ bool CSSStyleSheet::canAccessRules() const
         return m_isOriginClean.value();
 
     URL baseURL = m_contents->baseURL();
-    if (baseURL.isEmpty())
+    if (baseURL.isNull())
         return true;
 
     RefPtr document = ownerDocument();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -707,7 +707,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     // See fast/dom/early-frame-url.html
     // and fast/dom/location-new-window-no-crash.html, respectively.
     // FIXME: Can/should we unify this behavior?
-    if ((frame && frame->ownerElement()) || !url.isEmpty())
+    if ((frame && frame->ownerElement()) || !url.isNull())
         setURL(URL { url });
 
     if (!frame)
@@ -2048,7 +2048,7 @@ void Document::setReadyState(ReadyState readyState)
             if (auto eventTiming = documentEventTimingFromNavigationTiming())
                 eventTiming->domLoading = now;
             // We do this here instead of in the Document constructor because monotonicTimestamp() is 0 when the Document constructor is running.
-            if (!url().isEmpty())
+            if (!url().isNull())
                 WTFBeginSignpostWithTimeDelta(this, NavigationAndPaintTiming, -Seconds(monotonicTimestamp()), "Loading %" PRIVATE_LOG_STRING " | isMainFrame: %d", url().string().utf8().data(), frame() && frame()->isMainFrame());
             WTFEmitSignpost(this, NavigationAndPaintTiming, "domLoading");
         }
@@ -4579,7 +4579,7 @@ String Document::documentURI() const
 
 void Document::setURL(URL&& url)
 {
-    URL newURL = url.isEmpty() ? aboutBlankURL() : WTF::move(url);
+    URL newURL = url.isNull() ? aboutBlankURL() : WTF::move(url);
     if (newURL == m_url)
         return;
 
@@ -4610,7 +4610,7 @@ void Document::setURL(URL&& url)
 const URL& Document::urlForBindings()
 {
     auto shouldAdjustURL = [this] {
-        if (m_url.url().isEmpty() || !loader() || !isTopDocument() || !frame())
+        if (m_url.url().isNull() || !loader() || !isTopDocument() || !frame())
             return false;
 
         Ref protectedThis { *this };
@@ -4623,7 +4623,7 @@ const URL& Document::urlForBindings()
             return false;
 
         auto preNavigationURL = URL { documentLoader->originalRequest().httpReferrer() };
-        if (preNavigationURL.isEmpty() || RegistrableDomain { preNavigationURL }.matches(securityOrigin().data())) {
+        if (preNavigationURL.isNull() || RegistrableDomain { preNavigationURL }.matches(securityOrigin().data())) {
             // Only apply the protections below following a cross-origin navigation.
             return false;
         }
@@ -4653,7 +4653,7 @@ const URL& Document::urlForBindings()
             if (!m_hasLoadedThirdPartyScript)
                 return false;
 
-            if (auto sourceURL = currentSourceURL(); !sourceURL.isEmpty()) {
+            if (auto sourceURL = currentSourceURL(); !sourceURL.isNull()) {
                 if (RegistrableDomain { sourceURL }.matches(securityOrigin().data()))
                     return false;
 
@@ -4681,7 +4681,7 @@ const URL& Document::urlForBindings()
     if (shouldAdjustURL)
         return m_adjustedURL;
 
-    return m_url.url().isEmpty() ? aboutBlankURL() : m_url.url();
+    return m_url.url().isNull() ? aboutBlankURL() : m_url.url();
 }
 
 URL Document::adjustedURL() const
@@ -4723,9 +4723,9 @@ void Document::updateBaseURL()
     // DOM 3 Core: When the Document supports the feature "HTML" [DOM Level 2 HTML], the base URI is computed using
     // first the value of the href attribute of the HTML BASE element if any, and the value of the documentURI attribute
     // from the Document interface otherwise.
-    if (!m_baseElementURL.isEmpty())
+    if (!m_baseElementURL.isNull())
         m_baseURL = m_baseElementURL;
-    else if (!m_baseURLOverride.isEmpty())
+    else if (!m_baseURLOverride.isNull())
         m_baseURL = m_baseURLOverride;
     else
         m_baseURL = fallbackBaseURL();
@@ -4894,12 +4894,12 @@ void Document::processBaseElement()
     if (!href.isNull())
         baseElementURL = completeURL(href, fallbackBaseURL());
     if (m_baseElementURL != baseElementURL) {
-        if (settings().shouldRestrictBaseURLSchemes() && !baseElementURL.isEmpty() && !baseElementURL.isValid()) {
+        if (settings().shouldRestrictBaseURLSchemes() && !baseElementURL.isNull() && !baseElementURL.isValid()) {
             m_baseElementURL = { };
             addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Blocked setting "_s, baseElementURL.stringCenterEllipsizedToLength(), " as the base URL because it is not a valid URL."_s));
         } else if (!protect(contentSecurityPolicy())->allowBaseURI(baseElementURL))
             m_baseElementURL = { };
-        else if (settings().shouldRestrictBaseURLSchemes() && !baseElementURL.isEmpty() && !SecurityPolicy::isBaseURLSchemeAllowed(baseElementURL)) {
+        else if (settings().shouldRestrictBaseURLSchemes() && !baseElementURL.isNull() && !SecurityPolicy::isBaseURLSchemeAllowed(baseElementURL)) {
             m_baseElementURL = { };
             addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Blocked setting "_s, baseElementURL.stringCenterEllipsizedToLength(), " as the base URL because it does not have an allowed scheme."_s));
         } else
@@ -7231,7 +7231,7 @@ ExceptionOr<String> Document::cookie()
         return Exception { ExceptionCode::SecurityError };
 
     URL cookieURL = this->cookieURL();
-    if (cookieURL.isEmpty())
+    if (cookieURL.isNull())
         return String();
 
     if (!isDOMCookieCacheValid() && page())
@@ -7252,7 +7252,7 @@ ExceptionOr<void> Document::setCookie(const String& value)
         return Exception { ExceptionCode::SecurityError };
 
     URL cookieURL = this->cookieURL();
-    if (cookieURL.isEmpty())
+    if (cookieURL.isNull())
         return { };
 
     invalidateDOMCookieCache();
@@ -7417,7 +7417,7 @@ void Document::setDecoder(RefPtr<TextResourceDecoder>&& decoder)
 
 URL Document::baseURLForComplete(const URL& baseURLOverride) const
 {
-    return ((baseURLOverride.isEmpty() || baseURLOverride == aboutBlankURL()) && parentDocument()) ? parentDocument()->baseURL() : baseURLOverride;
+    return ((baseURLOverride.isNull() || baseURLOverride == aboutBlankURL()) && parentDocument()) ? parentDocument()->baseURL() : baseURLOverride;
 }
 
 URL Document::completeURL(const String& url, const URL& baseURLOverride, ForceUTF8 forceUTF8) const
@@ -10714,7 +10714,7 @@ void Document::wasLoadedWithDataTransferFromPrevalentResource()
 void Document::downgradeReferrerToRegistrableDomain()
 {
     URL referrerURL { referrer() };
-    if (referrerURL.isEmpty())
+    if (!referrerURL.isValid())
         return;
 
     auto domainString = RegistrableDomain { referrerURL }.string();

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1815,7 +1815,7 @@ void Editor::copyImage(const HitTestResult& result)
         return;
 
     URL url = result.absoluteLinkURL();
-    if (url.isEmpty())
+    if (url.isNull())
         url = result.absoluteImageURL();
 
 #if !PLATFORM(WIN)

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -438,7 +438,7 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
         return enclosingLink->absoluteLinkURL();
     }();
 
-    if (RetainPtr linkNSURL = linkURL.createNSURL(); linkURL.isEmpty() || !linkNSURL)
+    if (RetainPtr linkNSURL = linkURL.createNSURL(); linkURL.isNull() || !linkNSURL)
         [attributes removeObjectForKey:NSLinkAttributeName];
     else
         [attributes setObject:linkNSURL.get() forKey:NSLinkAttributeName];

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -922,7 +922,7 @@ bool WebContentReader::readFilePath(const String& path, PresentationSize preferr
 
 bool WebContentReader::readURL(const URL& url, const String& title)
 {
-    if (url.isEmpty())
+    if (url.isNull())
         return false;
 
     Ref frame = this->frame();

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -111,7 +111,7 @@ void Editor::writeImageToPasteboard(Pasteboard& pasteboard, Element& imageElemen
 
     auto imageSourceURL = imageElement.document().completeURL(imageElement.imageSourceURL());
 
-    auto pasteboardImageURL = url.isEmpty() ? imageSourceURL : url;
+    auto pasteboardImageURL = url.isNull() ? imageSourceURL : url;
     if (!pasteboardImageURL.protocolIsFile()) {
         pasteboardImage.url.url = pasteboardImageURL;
         pasteboardImage.url.title = title;

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1311,7 +1311,7 @@ static void restoreAttachmentElementsInFragment(DocumentFragment& fragment)
         auto blobURL = attachment->blobURL();
         if (!attachmentPath.isEmpty())
             attachment->setFile(File::create(ownerDocument.get(), attachmentPath));
-        else if (!blobURL.isEmpty())
+        else if (!blobURL.isNull())
             attachment->setFile(File::deserialize(ownerDocument.get(), { }, blobURL, attachment->attachmentType(), attachment->attachmentTitle()));
 
         // Remove temporary attributes that were previously added in StyledMarkupAccumulator::appendCustomAttributes.
@@ -1353,7 +1353,7 @@ Ref<DocumentFragment> createFragmentFromMarkup(Document& document, const String&
 
     fragment->parseHTML(markup, fakeBody, parserContentPolicy);
     restoreAttachmentElementsInFragment(fragment);
-    if (!baseURL.isEmpty() && baseURL != aboutBlankURL() && baseURL != document.baseURL())
+    if (!baseURL.isNull() && baseURL != aboutBlankURL() && baseURL != document.baseURL())
         completeURLs(fragment.ptr(), baseURL);
 
     return fragment;

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.h
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.h
@@ -46,7 +46,7 @@ public:
 
     operator const URL&() const LIFETIME_BOUND { return m_url; }
     const URL& url() const LIFETIME_BOUND { return m_url; }
-    bool isEmpty() const { return m_url.isEmpty(); }
+    bool isEmpty() const { return m_url.isNull(); }
     std::optional<SecurityOriginData> topOrigin() const { return m_topOrigin; }
 
     void clear();

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -133,7 +133,7 @@ static bool canCacheLocalFrame(LocalFrame& frame, DiagnosticLoggingClient& diagn
     URL currentURL = documentLoader->url();
     RefPtr provisionalDocumentLoader = frameLoader->provisionalDocumentLoader();
     URL newURL = provisionalDocumentLoader ? provisionalDocumentLoader->url() : URL();
-    if (!newURL.isEmpty())
+    if (!newURL.isNull())
         PCLOG(" Determining if frame can be cached navigating from ("_s, currentURL.string(), ") to ("_s, newURL.string(), "):"_s);
     else
         PCLOG(" Determining if subframe with URL ("_s, currentURL.string(), ") can be cached:"_s);
@@ -147,7 +147,7 @@ static bool canCacheLocalFrame(LocalFrame& frame, DiagnosticLoggingClient& diagn
     }
 
     // Do not cache error pages (these can be recognized as pages with substitute data or unreachable URLs).
-    if (documentLoader->substituteData().isValid() && !documentLoader->substituteData().failingURL().isEmpty()) {
+    if (documentLoader->substituteData().isValid() && !documentLoader->substituteData().failingURL().isNull()) {
         PCLOG("   -Frame is an error page"_s);
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::isErrorPageKey());
         isCacheable = false;

--- a/Source/WebCore/html/DOMURL.cpp
+++ b/Source/WebCore/html/DOMURL.cpp
@@ -105,7 +105,7 @@ String DOMURL::createObjectURL(ScriptExecutionContext& scriptExecutionContext, B
 String DOMURL::createPublicURL(ScriptExecutionContext& scriptExecutionContext, URLRegistrable& registrable)
 {
     URL publicURL = BlobURL::createPublicURL(protect(scriptExecutionContext.securityOrigin()).get());
-    if (publicURL.isEmpty())
+    if (publicURL.isNull())
         return String();
 
     protect(scriptExecutionContext.publicURLManager())->registerURL(publicURL, registrable);

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -406,7 +406,7 @@ std::optional<RegistrableDomain> HTMLAnchorElement::mainDocumentRegistrableDomai
 {
     Ref document = this->document();
     if (RefPtr page = document->page()) {
-        if (auto mainFrameURL = page->mainFrameURL(); !mainFrameURL.isEmpty())
+        if (auto mainFrameURL = page->mainFrameURL(); !mainFrameURL.isNull())
             return RegistrableDomain(mainFrameURL);
     }
 
@@ -517,7 +517,7 @@ std::optional<PrivateClickMeasurement> HTMLAnchorElement::parsePrivateClickMeasu
     }
 
     auto& mainURL = page->mainFrameURL();
-    if (mainURL.isEmpty()) {
+    if (mainURL.isNull()) {
         protect(document())->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, "Could not find a main document to use as source site for Private Click Measurement."_s);
         return std::nullopt;
     }

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -242,7 +242,7 @@ String HTMLImageElement::imageSourceURL() const
 const AtomString& HTMLImageElement::currentSrc()
 {
     if (m_currentSrc.isNull()) {
-        if (!m_currentURL.isEmpty())
+        if (!m_currentURL.isNull())
             m_currentSrc = AtomString(m_currentURL.string());
     }
     return m_currentSrc;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1924,7 +1924,7 @@ static VideoRendererPreferences videoRendererPreferences(const Settings& setting
 
 void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& initialContentType)
 {
-    ASSERT(initialURL.isEmpty() || isSafeToLoadURL(initialURL, InvalidURLAction::Complain));
+    ASSERT(initialURL.isNull() || isSafeToLoadURL(initialURL, InvalidURLAction::Complain));
 
     auto logSiteIdentifier = LOGIDENTIFIER;
     INFO_LOG(logSiteIdentifier, initialURL, initialContentType);
@@ -1954,7 +1954,7 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
         return;
     }
 #elif USE(GSTREAMER)
-    if (!url.isEmpty() && !frame->loader().willLoadMediaElementURL(url, *this)) {
+    if (!url.isNull() && !frame->loader().willLoadMediaElementURL(url, *this)) {
         mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
         return;
     }
@@ -2098,7 +2098,7 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
             protectedThis->mediaPlayerRenderingModeChanged();
     };
 
-    if (needsContentTypeToPlay() && !url.isEmpty()) {
+    if (needsContentTypeToPlay() && !url.isNull()) {
         if (contentType.isEmpty() && url.protocolIsData())
             contentType = ContentType(mimeTypeFromDataURL(url.string()));
         else {
@@ -7247,7 +7247,7 @@ bool HTMLMediaElement::hasWirelessPlaybackTargetAlternative() const
         return false;
     for (Ref source : childrenOfType<HTMLSourceElement>(*this)) {
         auto mediaURL = source->getNonEmptyURLAttribute(srcAttr);
-        bool maybeSuitable = !mediaURL.isEmpty();
+        bool maybeSuitable = !mediaURL.isNull();
 #if ENABLE(MEDIA_SOURCE)
         maybeSuitable &= !mediaURL.protocolIs(mediaSourceBlobProtocol);
 #endif
@@ -8560,7 +8560,7 @@ Vector<Ref<PlatformTextTrack>> HTMLMediaElement::outOfBandTrackSources()
     Vector<Ref<PlatformTextTrack>> outOfBandTrackSources;
     for (Ref trackElement : childrenOfType<HTMLTrackElement>(*this)) {
         URL url = trackElement->getNonEmptyURLAttribute(srcAttr);
-        if (url.isEmpty())
+        if (url.isNull())
             continue;
 
         if (!isAllowedToLoadMediaURL(*this, url, trackElement->isInUserAgentShadowTree()))

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1053,7 +1053,7 @@ private:
     bool isBlocked() const;
     bool isBlockedOnMediaController() const;
     void setCurrentSrc(const URL&);
-    bool hasCurrentSrc() const override { return !m_currentSrc.isEmpty(); }
+    bool hasCurrentSrc() const override { return !m_currentSrc.isNull(); }
     bool isLiveStream() const override { return movieLoadType() == MovieLoadType::LiveStream; }
 
     void updateSleepDisabling();

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -218,7 +218,7 @@ bool HTMLTrackElement::canLoadURL(const URL& url)
     // 4. Download: If URL is not the empty string, perform a potentially CORS-enabled fetch of URL, with the
     // mode being the state of the media element's crossorigin content attribute, the origin being the
     // origin of the media element's Document, and the default origin behaviour set to fail.
-    if (url.isEmpty())
+    if (url.isNull())
         return false;
 
     Ref document = this->document();

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -338,7 +338,7 @@ bool HTMLVideoElement::shouldDisplayPosterImage() const
     if (!showPosterFlag())
         return false;
 
-    if (posterImageURL().isEmpty())
+    if (posterImageURL().isNull())
         return false;
 
     CheckedPtr renderer = this->renderer();

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5102,7 +5102,7 @@ ExceptionOr<bool> WebGLRenderingContextBase::validateHTMLImageElement(ASCIILiter
         return false;
     }
     const URL& url = image.cachedImage()->response().url();
-    if (url.isNull() || url.isEmpty() || !url.isValid()) {
+    if (!url.isValid()) {
         synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "invalid image"_s);
         return false;
     }

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -512,7 +512,7 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
         }
         if (tagId == TagId::Base) {
             // The first <base> element is the one that wins.
-            if (!m_predictedBaseElementURL.isEmpty())
+            if (!m_predictedBaseElementURL.isNull())
                 return;
             updatePredictedBaseURL(token, document.settings().shouldRestrictBaseURLSchemes());
             return;
@@ -536,7 +536,7 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
 
 void TokenPreloadScanner::updatePredictedBaseURL(const HTMLToken& token, bool shouldRestrictBaseURLSchemes)
 {
-    ASSERT(m_predictedBaseElementURL.isEmpty());
+    ASSERT(m_predictedBaseElementURL.isNull());
     static constexpr auto hrefAsUTF16 = std::to_array<char16_t>({ 'h', 'r', 'e', 'f' });
     auto* hrefAttribute = findAttribute(token.attributes(), hrefAsUTF16);
     if (!hrefAttribute)
@@ -564,7 +564,7 @@ void HTMLPreloadScanner::scan(HTMLResourcePreloader& preloader, Document& docume
     const URL& startingBaseElementURL = document.baseElementURL();
 
     // When we start scanning, our best prediction of the baseElementURL is the real one!
-    if (!startingBaseElementURL.isEmpty())
+    if (!startingBaseElementURL.isNull())
         m_scanner.setPredictedBaseElementURL(startingBaseElementURL);
 
     PreloadRequestStream requests;

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -45,7 +45,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLResourcePreloader);
 
 URL PreloadRequest::completeURL(Document& document)
 {
-    return document.completeURL(m_resourceURL, m_baseURL.isEmpty() ? document.baseURL() : m_baseURL);
+    return document.completeURL(m_resourceURL, m_baseURL.isNull() ? document.baseURL() : m_baseURL);
 }
 
 CachedResourceRequest PreloadRequest::resourceRequest(Document& document)

--- a/Source/WebCore/html/track/LoadableTextTrack.cpp
+++ b/Source/WebCore/html/track/LoadableTextTrack.cpp
@@ -56,7 +56,7 @@ Ref<LoadableTextTrack> LoadableTextTrack::create(HTMLTrackElement& track, const 
 
 void LoadableTextTrack::scheduleLoad(const URL& url)
 {
-    ASSERT(!url.isEmpty());
+    ASSERT(!url.isNull());
 
     if (url == m_url)
         return;

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -708,7 +708,7 @@ Ref<JSON::ArrayOf<Inspector::Protocol::CSS::Grouping>> InspectorStyleSheet::buil
                 String sourceURL;
                 if (RefPtr ownerDocument = styleSheet->ownerDocument())
                     sourceURL = ownerDocument->url().string();
-                else if (!styleSheet->contents().baseURL().isEmpty())
+                else if (!styleSheet->contents().baseURL().isNull())
                     sourceURL = styleSheet->contents().baseURL().string();
                 if (!sourceURL.isEmpty())
                     sheetGroupingPayload->setSourceURL(sourceURL);
@@ -1033,7 +1033,7 @@ Ref<InspectorStyleSheet> InspectorStyleSheet::create(Inspector::IdentifierRegist
 
 String InspectorStyleSheet::styleSheetURL(CSSStyleSheet* pageStyleSheet)
 {
-    if (pageStyleSheet && !pageStyleSheet->contents().baseURL().isEmpty())
+    if (pageStyleSheet && !pageStyleSheet->contents().baseURL().isNull())
         return pageStyleSheet->contents().baseURL().string();
     return emptyString();
 }

--- a/Source/WebCore/loader/ContentFilter.cpp
+++ b/Source/WebCore/loader/ContentFilter.cpp
@@ -200,7 +200,7 @@ void ContentFilter::startFilteringMainResource(const URL& url)
 
     LOG(ContentFiltering, "ContentFilter will start filtering main resource at <%{sensitive}s>.\n", url.string().ascii().data());
     m_state = State::Filtering;
-    ASSERT(m_mainResourceURL.isEmpty());
+    ASSERT(m_mainResourceURL.isNull());
     m_mainResourceURL = url;
 }
 

--- a/Source/WebCore/loader/CookieJar.cpp
+++ b/Source/WebCore/loader/CookieJar.cpp
@@ -143,7 +143,7 @@ void CookieJar::setCookies(Document& document, const URL& url, const String& coo
 bool CookieJar::cookiesEnabled(Document& document)
 {
     auto cookieURL = document.cookieURL();
-    if (cookieURL.isEmpty())
+    if (cookieURL.isNull())
         return false;
 
     auto pageID = document.pageID();

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -259,7 +259,7 @@ void DocumentLoader::setRequest(ResourceRequest&& req)
     // Replacing an unreachable URL with alternate content looks like a server-side
     // redirect at this point, but we can replace a committed dataSource.
     bool handlingUnreachableURL = false;
-    handlingUnreachableURL = m_substituteData.isValid() && !m_substituteData.failingURL().isEmpty();
+    handlingUnreachableURL = m_substituteData.isValid() && !m_substituteData.failingURL().isNull();
 
     bool shouldNotifyAboutProvisionalURLChange = false;
     if (handlingUnreachableURL)
@@ -586,7 +586,7 @@ void DocumentLoader::handleSubstituteDataLoadNow()
     }
 
     ResourceResponse response = m_substituteData.response();
-    if (response.url().isEmpty())
+    if (response.url().isNull())
         response = ResourceResponse(URL { m_request.url() }, String { m_substituteData.mimeType() }, m_substituteData.content()->size(), String { m_substituteData.textEncoding() });
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -1318,7 +1318,7 @@ void DocumentLoader::commitData(const SharedBuffer& data)
         if (shouldEnableResourceMonitor(*frame)) {
             URL url = documentURL();
 
-            if (!url.isEmpty() && url.protocolIsInHTTPFamily())
+            if (url.protocolIsInHTTPFamily())
                 protect(document->resourceMonitor())->setDocumentURL(WTF::move(url));
         }
 #endif
@@ -1638,7 +1638,7 @@ void DocumentLoader::loadApplicationManifest(CompletionHandler<void(const std::o
     if (!document->isTopDocument())
         return;
 
-    if (document->url().isEmpty() || document->url().protocolIsAbout())
+    if (document->url().isNull() || document->url().protocolIsAbout())
         return;
 
     RefPtr head = document->head();
@@ -1652,7 +1652,7 @@ void DocumentLoader::loadApplicationManifest(CompletionHandler<void(const std::o
             continue;
 
         auto href = link->href();
-        if (href.isEmpty() || !href.isValid())
+        if (!href.isValid())
             continue;
 
         if (!link->mediaAttributeMatches())
@@ -1663,7 +1663,7 @@ void DocumentLoader::loadApplicationManifest(CompletionHandler<void(const std::o
         break;
     }
 
-    if (manifestURL.isEmpty() || !manifestURL.isValid())
+    if (!manifestURL.isValid())
         return;
 
     Ref applicationManifestLoader = ApplicationManifestLoader::create(*this, manifestURL, useCredentials);
@@ -1980,12 +1980,12 @@ URL DocumentLoader::documentURL() const
 {
     URL url = substituteData().response().url();
 #if ENABLE(WEB_ARCHIVE)
-    if (RefPtr archive = m_archive; url.isEmpty() && archive && archive->shouldUseMainResourceURL())
+    if (RefPtr archive = m_archive; url.isNull() && archive && archive->shouldUseMainResourceURL())
         url = archive->mainResource()->url();
 #endif
-    if (url.isEmpty())
+    if (url.isNull())
         url = m_request.url();
-    if (url.isEmpty())
+    if (url.isNull())
         url = m_response.url();
     return url;
 }
@@ -2106,7 +2106,7 @@ bool DocumentLoader::isMultipartReplacingLoad() const
 
 bool DocumentLoader::maybeLoadEmpty()
 {
-    bool shouldLoadEmpty = !m_substituteData.isValid() && (m_request.url().isEmpty() || LegacySchemeRegistry::shouldLoadURLSchemeAsEmptyDocument(m_request.url().protocol()));
+    bool shouldLoadEmpty = !m_substituteData.isValid() && (m_request.url().isNull() || LegacySchemeRegistry::shouldLoadURLSchemeAsEmptyDocument(m_request.url().protocol()));
     Ref frameLoaderClient = frameLoader()->client();
     if (!shouldLoadEmpty && !frameLoaderClient->representationExistsForURLScheme(m_request.url().protocol()))
         return false;
@@ -2114,7 +2114,7 @@ bool DocumentLoader::maybeLoadEmpty()
     if (m_request.url().protocolIsAbout() && isHandledByAboutSchemeHandler())
         return false;
 
-    if (m_request.url().isEmpty() && !frameLoader()->stateMachine().creatingInitialEmptyDocument()) {
+    if (m_request.url().isNull() && !frameLoader()->stateMachine().creatingInitialEmptyDocument()) {
         m_request.setURL(URL { aboutBlankURL() });
         if (isLoadingMainResource())
             frameLoaderClient->dispatchDidChangeProvisionalURL();
@@ -2475,7 +2475,7 @@ void DocumentLoader::startIconLoading()
     if (!m_frame->isMainFrame())
         return;
 
-    if (document->url().isEmpty() || document->url().protocolIsAbout())
+    if (document->url().isNull() || document->url().protocolIsAbout())
         return;
 
     m_linkIcons = LinkIconCollector { *document }.iconsOfTypes({ LinkIconType::Favicon, LinkIconType::TouchIcon, LinkIconType::TouchPrecomposedIcon });
@@ -2505,7 +2505,7 @@ void DocumentLoader::didGetLoadDecisionForIcon(bool decision, uint64_t loadIdent
     // If the LinkIcon we just took is empty, then the DocumentLoader had all of its loaders stopped
     // while this icon load decision was pending.
     // In this case we need to notify the client that the icon finished loading with empty data.
-    if (icon.url.isEmpty())
+    if (icon.url.isNull())
         return completionHandler(nullptr);
 
     Ref iconLoader = IconLoader::create(*this, icon.url);

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -420,7 +420,7 @@ LocalFrame& FrameLoader::frame() const
 void FrameLoader::init()
 {
     // This somewhat odd set of steps gives the frame an initial empty document.
-    setPolicyDocumentLoader(m_client->createDocumentLoader(ResourceRequest(URL({ }, emptyString())), SubstituteData()));
+    setPolicyDocumentLoader(m_client->createDocumentLoader(ResourceRequest(URL()), SubstituteData()));
     setProvisionalDocumentLoader(m_policyDocumentLoader.copyRef());
     protect(m_provisionalDocumentLoader)->startLoadingMainResource();
     setPolicyDocumentLoader(nullptr);
@@ -553,7 +553,7 @@ void FrameLoader::submitForm(Ref<FormSubmission>&& submission)
     if (!frame->page())
         return;
 
-    if (submission->action().isEmpty())
+    if (submission->action().isNull())
         return;
 
     RefPtr document = frame->document();
@@ -1204,7 +1204,7 @@ String FrameLoader::outgoingOrigin() const
 
 bool FrameLoader::checkIfFormActionAllowedByCSP(const URL& url, bool didReceiveRedirectResponse, const URL& preRedirectURL) const
 {
-    if (m_submittedFormURL.isEmpty())
+    if (m_submittedFormURL.isNull())
         return true;
 
     Ref document = *m_frame->document();
@@ -1861,7 +1861,7 @@ void FrameLoader::load(DocumentLoader& newDocumentLoader, const SecurityOrigin* 
         type = FrameLoadType::Same;
     } else if (shouldTreatURLAsSameAsCurrent(requesterOrigin, newDocumentLoader.unreachableURL()) && isReload(m_loadType))
         type = m_loadType;
-    else if ((m_loadType == FrameLoadType::RedirectWithLockedBackForwardList || policyChecker().loadType() == FrameLoadType::RedirectWithLockedBackForwardList) && ((!newDocumentLoader.unreachableURL().isEmpty() && newDocumentLoader.substituteData().isValid()) || shouldTreatCurrentLoadAsContinuingLoad()))
+    else if ((m_loadType == FrameLoadType::RedirectWithLockedBackForwardList || policyChecker().loadType() == FrameLoadType::RedirectWithLockedBackForwardList) && ((!newDocumentLoader.unreachableURL().isNull() && newDocumentLoader.substituteData().isValid()) || shouldTreatCurrentLoadAsContinuingLoad()))
         type = FrameLoadType::RedirectWithLockedBackForwardList;
     else
         type = FrameLoadType::Standard;
@@ -1960,7 +1960,7 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
 
     policyChecker().stopCheck();
     setPolicyDocumentLoader(loader);
-    if (loader->triggeringAction().isEmpty()) {
+    if (loader->triggeringAction().isNull()) {
         NavigationAction action = loader->crossSiteRequester() ? NavigationAction { *loader->crossSiteRequester(), loader->request(), InitiatedByMainFrame::Unknown, loader->isRequestFromClientOrUserInput(), policyChecker().loadType(), isFormSubmission } : NavigationAction { protect(frame->document()).releaseNonNull(), loader->request(), InitiatedByMainFrame::Unknown, loader->isRequestFromClientOrUserInput(), policyChecker().loadType(), isFormSubmission };
         action.setIsContentRuleListRedirect(loader->isContentRuleListRedirect());
         action.setNavigationAPIType(determineNavigationType(type, NavigationHistoryBehavior::Auto));
@@ -2010,7 +2010,7 @@ void FrameLoader::reportLocalLoadFailed(LocalFrame* frame, const String& url)
 
 void FrameLoader::reportBlockedLoadFailed(LocalFrame& frame, const URL& url)
 {
-    ASSERT(!url.isEmpty());
+    ASSERT(!url.isNull());
     auto restrictedHostPort = isIPAddressDisallowed(url) ? makeString("host \""_s, url.host(), "\""_s) : makeString("port "_s, url.port().value());
     auto message = makeString("Not allowed to use restricted network "_s, restrictedHostPort, ": "_s, url.stringCenterEllipsizedToLength());
     protect(frame.document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
@@ -2043,7 +2043,7 @@ bool FrameLoader::shouldReloadToHandleUnreachableURL(DocumentLoader& docLoader)
 {
     URL unreachableURL = docLoader.unreachableURL();
 
-    if (unreachableURL.isEmpty())
+    if (unreachableURL.isNull())
         return false;
 
     if (!isBackForwardLoadType(policyChecker().loadType()))
@@ -2070,7 +2070,7 @@ void FrameLoader::reloadWithOverrideEncoding(const String& encoding)
 
     ResourceRequest request = documentLoader->request();
     URL unreachableURL = documentLoader->unreachableURL();
-    if (!unreachableURL.isEmpty())
+    if (!unreachableURL.isNull())
         request.setURL(WTF::move(unreachableURL));
 
     // FIXME: If the resource is a result of form submission and is not cached, the form will be silently resubmitted.
@@ -2096,7 +2096,7 @@ void FrameLoader::reload(OptionSet<ReloadOption> options, bool isRequestFromClie
 
     // If a window is created by javascript, its main frame can have an empty but non-nil URL.
     // Reloading in this case will lose the current contents (see 4151001).
-    if (documentLoader->request().url().isEmpty())
+    if (documentLoader->request().url().isNull())
         return;
 
     FRAMELOADER_RELEASE_LOG_FORWARDABLE(FrameLoaderReload);
@@ -2104,7 +2104,7 @@ void FrameLoader::reload(OptionSet<ReloadOption> options, bool isRequestFromClie
     // Replace error-page URL with the URL we were trying to reach.
     ResourceRequest initialRequest = documentLoader->request();
     URL unreachableURL = documentLoader->unreachableURL();
-    if (!unreachableURL.isEmpty())
+    if (!unreachableURL.isNull())
         initialRequest.setURL(WTF::move(unreachableURL));
 
     // Create a new document loader for the reload, this will become m_documentLoader eventually,
@@ -2935,7 +2935,7 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
         // while handling provisional load failures is too heavy. For example, the current
         // load will fail to cancel another ongoing load. That might prevent clients' page
         // load state being handled properly.
-        if (!m_provisionalLoadErrorBeingHandledURL.isEmpty())
+        if (!m_provisionalLoadErrorBeingHandledURL.isNull())
             return;
 
         RefPtr provisionalDocumentLoader = m_provisionalDocumentLoader;
@@ -2993,7 +2993,7 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
                 clearProvisionalLoad();
             else if (activeDocumentLoader()) {
                 URL unreachableURL = activeDocumentLoader()->unreachableURL();
-                if (!unreachableURL.isEmpty() && unreachableURL == provisionalDocumentLoader->request().url())
+                if (!unreachableURL.isNull() && unreachableURL == provisionalDocumentLoader->request().url())
                     shouldReset = false;
             }
         }
@@ -3107,7 +3107,7 @@ void FrameLoader::setOriginalURLForDownloadRequest(ResourceRequest& request)
         originalURL = initiator->firstPartyForCookies();
         // If there is no main document URL, it means that this document is newly opened and just for download purpose.
         // In this case, we need to set the originalURL to this document's opener's main document URL.
-        if (originalURL.isEmpty()) {
+        if (originalURL.isNull()) {
             if (RefPtr localOpener = dynamicDowncast<LocalFrame>(m_frame->opener()); localOpener && localOpener->document()) {
                 originalURL = localOpener->document()->firstPartyForCookies();
                 initiator = localOpener->document();
@@ -3451,7 +3451,7 @@ void FrameLoader::updateRequestAndAddExtraFields(Frame& targetFrame, ResourceReq
     // But make sure to set it on all requests regardless of protocol, as it has significance beyond the cookie policy (<rdar://problem/6616664>).
     bool isMainResource = mainResource == IsMainResource::Yes;
     bool isMainFrameMainResource = isMainResource && (targetFrame.isMainFrame() || willOpenInNewWindow == WillOpenInNewWindow::Yes);
-    if (request.firstPartyForCookies().isEmpty()) {
+    if (request.firstPartyForCookies().isNull()) {
         if (isMainFrameMainResource)
             request.setFirstPartyForCookies(request.url());
         else if (document)
@@ -3489,7 +3489,7 @@ void FrameLoader::updateRequestAndAddExtraFields(Frame& targetFrame, ResourceReq
         request.setCachePolicy(defaultRequestCachingPolicy(request, loadType, isMainResource));
 
     // The remaining modifications are only necessary for HTTP and HTTPS.
-    if (!request.url().isEmpty() && !request.url().protocolIsInHTTPFamily())
+    if (!request.url().isNull() && !request.url().protocolIsInHTTPFamily())
         return;
 
     if (!hasSpecificCachePolicy && request.cachePolicy() == ResourceRequestCachePolicy::ReloadIgnoringCacheData) {
@@ -4090,7 +4090,7 @@ void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& reque
     // If we loaded an alternate page to replace an unreachableURL, we'll get in here with a
     // nil policyDataSource because loading the alternate page will have passed
     // through this method already, nested; otherwise, policyDataSource should still be set.
-    ASSERT(m_policyDocumentLoader || !m_provisionalDocumentLoader->unreachableURL().isEmpty());
+    ASSERT(m_policyDocumentLoader || !m_provisionalDocumentLoader->unreachableURL().isNull());
 
     Ref frame = m_frame.get();
 
@@ -5046,7 +5046,7 @@ void FrameLoader::prefetchDNSIfNeeded(const URL& url)
         return;
 #endif
 
-    if (url.isValid() && !url.isEmpty() && url.protocolIsInHTTPFamily())
+    if (url.protocolIsInHTTPFamily())
         client().prefetchDNS(url.host().toString());
 }
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -562,13 +562,13 @@ void HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
 
     RefPtr documentLoader = frameLoader->documentLoader();
     if (!frameLoader->documentLoader()->isClientRedirect()) {
-        if (!historyURL.isEmpty()) {
+        if (!historyURL.isNull()) {
             if (updateType != UpdateAllExceptBackForwardList)
                 updateBackForwardListClippedAtTarget(true);
             if (canRecordHistory) {
                 protect(frameLoader->client())->updateGlobalHistory();
                 documentLoader->setDidCreateGlobalHistoryEntry(true);
-                if (documentLoader->unreachableURL().isEmpty())
+                if (documentLoader->unreachableURL().isNull())
                     protect(frameLoader->client())->updateGlobalHistoryRedirectLinks();
             }
         }
@@ -577,11 +577,11 @@ void HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
         updateCurrentItem();
     }
 
-    if (!historyURL.isEmpty() && canRecordHistory) {
+    if (!historyURL.isNull() && canRecordHistory) {
         if (RefPtr page = m_frame->page())
             addVisitedLink(*page, historyURL);
 
-        if (!documentLoader->didCreateGlobalHistoryEntry() && documentLoader->unreachableURL().isEmpty() && !m_frame->document()->url().isEmpty())
+        if (!documentLoader->didCreateGlobalHistoryEntry() && documentLoader->unreachableURL().isNull() && !m_frame->document()->url().isNull())
             protect(frameLoader->client())->updateGlobalHistoryRedirectLinks();
     }
 }
@@ -596,13 +596,13 @@ void HistoryController::updateForRedirectWithLockedBackForwardList()
 
     if (documentLoader && documentLoader->isClientRedirect()) {
         if (!m_currentItem && m_frame->isMainFrame()) {
-            if (!historyURL.isEmpty()) {
+            if (!historyURL.isNull()) {
                 updateBackForwardListClippedAtTarget(true);
                 if (canRecordHistory) {
                     Ref frameLoader = m_frame->loader();
                     protect(frameLoader->client())->updateGlobalHistory();
                     documentLoader->setDidCreateGlobalHistoryEntry(true);
-                    if (documentLoader->unreachableURL().isEmpty())
+                    if (documentLoader->unreachableURL().isNull())
                         protect(frameLoader->client())->updateGlobalHistoryRedirectLinks();
                 }
             }
@@ -621,12 +621,12 @@ void HistoryController::updateForRedirectWithLockedBackForwardList()
         }
     }
 
-    if (!historyURL.isEmpty() && canRecordHistory) {
+    if (!historyURL.isNull() && canRecordHistory) {
         Ref frame = m_frame.get();
         if (RefPtr page = frame->page())
             addVisitedLink(*page, historyURL);
 
-        if (!documentLoader->didCreateGlobalHistoryEntry() && documentLoader->unreachableURL().isEmpty())
+        if (!documentLoader->didCreateGlobalHistoryEntry() && documentLoader->unreachableURL().isNull())
             protect(frame->loader().client())->updateGlobalHistoryRedirectLinks();
     }
 }
@@ -645,7 +645,7 @@ void HistoryController::updateForClientRedirect()
     bool canRecordHistory = canRecordHistoryForFrame(m_frame);
     const URL& historyURL = protect(m_frame->loader().documentLoader())->urlForHistory();
 
-    if (!historyURL.isEmpty() && canRecordHistory) {
+    if (!historyURL.isNull() && canRecordHistory) {
         if (RefPtr page = m_frame->page())
             addVisitedLink(*page, historyURL);
     }
@@ -659,7 +659,7 @@ void HistoryController::updateForCommit()
     FrameLoadType type = frameLoader->loadType();
     if (isBackForwardLoadType(type)
         || isMultipartReplaceLoadTypeWithProvisionalItem(type)
-        || (isReloadTypeWithProvisionalItem(type) && !frameLoader->provisionalDocumentLoader()->unreachableURL().isEmpty())) {
+        || (isReloadTypeWithProvisionalItem(type) && !frameLoader->provisionalDocumentLoader()->unreachableURL().isNull())) {
         // Once committed, we want to use current item for saving DocState, and
         // the provisional item for restoring state.
         // Note previousItem must be set before we close the URL, which will
@@ -738,7 +738,7 @@ void HistoryController::recursiveUpdateForCommit()
 void HistoryController::updateForSameDocumentNavigation()
 {
     Ref frame = m_frame.get();
-    if (frame->document()->url().isEmpty())
+    if (frame->document()->url().isNull())
         return;
 
     RefPtr page = frame->page();
@@ -835,7 +835,7 @@ void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader>
     URL url;
     URL originalURL;
 
-    if (!unreachableURL.isEmpty()) {
+    if (!unreachableURL.isNull()) {
         url = unreachableURL;
         originalURL = unreachableURL;
     } else {
@@ -848,9 +848,9 @@ void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader>
     // deal with such things, so we nip that in the bud here.
     // Later we may want to learn to live with nil for URL.
     // See bug 3368236 and related bugs for more information.
-    if (url.isEmpty())
+    if (url.isNull())
         url = aboutBlankURL();
-    if (originalURL.isEmpty())
+    if (originalURL.isNull())
         originalURL = aboutBlankURL();
 
     StringWithDirection title = documentLoader->title();
@@ -862,7 +862,7 @@ void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader>
     item.setTitle(WTF::move(title.string));
     item.setOriginalURLString(originalURL.string());
 
-    if (!unreachableURL.isEmpty() || documentLoader->response().httpStatusCode() >= 400)
+    if (!unreachableURL.isNull() || documentLoader->response().httpStatusCode() >= 400)
         item.setLastVisitWasFailure(true);
 
     item.setShouldOpenExternalURLsPolicy(documentLoader->shouldOpenExternalURLsPolicyToPropagate());
@@ -1004,7 +1004,7 @@ void HistoryController::updateBackForwardListClippedAtTarget(bool doClip)
     if (!page)
         return;
 
-    if (protect(frame->loader().documentLoader())->urlForHistory().isEmpty())
+    if (protect(frame->loader().documentLoader())->urlForHistory().isNull())
         return;
 
     RefPtr item = protect(frame->loader().client())->createHistoryItemTree(doClip, BackForwardItemIdentifier::generate());
@@ -1021,7 +1021,7 @@ void HistoryController::updateCurrentItem()
         return;
 
     RefPtr documentLoader = m_frame->loader().documentLoader();
-    if (!documentLoader || !documentLoader->unreachableURL().isEmpty())
+    if (!documentLoader || !documentLoader->unreachableURL().isNull())
         return;
 
     if (currentItem->url() != documentLoader->url()) {

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -103,7 +103,7 @@ void MediaResourceLoader::sendH2Ping(const URL& url, CompletionHandler<void(Expe
 
 static LoadedFromOpaqueSource computeLoadedFromOpaqueSource(const Document& document, const HashSet<URL>& nonOpaqueLoadURLs, const URL& url, const std::optional<LoadedFromOpaqueSource> loadedFromOpaqueSource)
 {
-    if (!document.settings().enableOpaqueLoadingForMedia() || url.isEmpty())
+    if (!document.settings().enableOpaqueLoadingForMedia() || url.isNull())
         return LoadedFromOpaqueSource::No;
 
     if (loadedFromOpaqueSource.value_or(LoadedFromOpaqueSource::No) == LoadedFromOpaqueSource::No)
@@ -120,7 +120,7 @@ RefPtr<PlatformMediaResource> MediaResourceLoader::requestResource(ResourceReque
     if (!document)
         return nullptr;
 
-    if (!m_loadedFromOpaqueSource && !request.url().isEmpty())
+    if (!m_loadedFromOpaqueSource && !request.url().isNull())
         m_nonOpaqueLoadURLs.add(request.url());
 
     DataBufferingPolicy bufferingPolicy = options & LoadOption::BufferData ? DataBufferingPolicy::BufferData : DataBufferingPolicy::DoNotBufferData;
@@ -269,7 +269,7 @@ bool MediaResourceLoader::verifyMediaResponse(const URL& requestURL, const Resou
 
 void MediaResourceLoader::redirectReceived(const URL& url)
 {
-    ASSERT(!url.isEmpty());
+    ASSERT(!url.isNull());
     if (!m_loadedFromOpaqueSource)
         m_nonOpaqueLoadURLs.add(url);
 }

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -99,7 +99,7 @@ public:
 
     NavigationAction copyWithShouldOpenExternalURLsPolicy(ShouldOpenExternalURLsPolicy) const;
 
-    bool isEmpty() const { return !m_requester || m_requester->url.isEmpty() || m_originalRequest.url().isEmpty(); }
+    bool isNull() const { return !m_requester || m_requester->url.isNull() || m_originalRequest.url().isNull(); }
 
     URL url() const { return m_originalRequest.url(); }
     const ResourceRequest& originalRequest() const LIFETIME_BOUND { return m_originalRequest; }

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -642,7 +642,7 @@ void NavigationScheduler::scheduleRedirect(Document& initiatingDocument, double 
         return;
     if (delay < 0 || delay > INT_MAX / 1000)
         return;
-    if (url.isEmpty())
+    if (url.isNull())
         return;
 
     // We want a new back/forward list item if the refresh timeout is > 1 second.
@@ -779,7 +779,7 @@ void NavigationScheduler::scheduleRefresh(Document& initiatingDocument)
         return;
     Ref frame = downcast<LocalFrame>(m_frame.get());
     const URL& url = frame->document()->url();
-    if (url.isEmpty())
+    if (url.isNull())
         return;
 
     schedule(makeUnique<ScheduledRefresh>(initiatingDocument, protect(protect(frame->document())->securityOrigin()).ptr(), url, frame->loader().outgoingReferrer()));

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -125,7 +125,7 @@ URLKeepingBlobAlive PolicyChecker::extendBlobURLLifetimeIfNecessary(const Resour
     if (mode != PolicyDecisionMode::Asynchronous || !request.url().protocolIsBlob())
         return { };
 
-    bool haveTriggeringRequester = m_frame->loader().policyDocumentLoader() && !m_frame->loader().policyDocumentLoader()->triggeringAction().isEmpty() && m_frame->loader().policyDocumentLoader()->triggeringAction().requester();
+    bool haveTriggeringRequester = m_frame->loader().policyDocumentLoader() && !m_frame->loader().policyDocumentLoader()->triggeringAction().isNull() && m_frame->loader().policyDocumentLoader()->triggeringAction().requester();
     auto& topOrigin = haveTriggeringRequester ? m_frame->loader().policyDocumentLoader()->triggeringAction().requester()->topOrigin->data() : document.topOrigin().data();
     return { request.url(), topOrigin };
 }
@@ -134,7 +134,7 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
 {
     NavigationAction action = loader->triggeringAction();
     Ref frame = m_frame.get();
-    if (action.isEmpty()) {
+    if (action.isNull()) {
         action = NavigationAction { protect(frame->document()).releaseNonNull(), request, InitiatedByMainFrame::Unknown, loader->isRequestFromClientOrUserInput(), NavigationType::Other, loader->shouldOpenExternalURLsPolicyToPropagate() };
         action.setIsContentRuleListRedirect(loader->isContentRuleListRedirect());
         if (navigationAPIType)
@@ -149,8 +149,8 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
 
     // Don't ask more than once for the same request or if we are loading an empty URL.
     // This avoids confusion on the part of the client.
-    if (equalIgnoringHeaderFields(request, loader->lastCheckedRequest()) || (!request.isNull() && request.url().isEmpty())) {
-        if (!request.isNull() && request.url().isEmpty())
+    if (equalIgnoringHeaderFields(request, loader->lastCheckedRequest()) || (!request.isNull() && request.url().isNull())) {
+        if (!request.isNull() && request.url().isNull())
             POLICYCHECKER_RELEASE_LOG("checkNavigationPolicy: continuing because the URL is empty");
         else
             POLICYCHECKER_RELEASE_LOG("checkNavigationPolicy: continuing because the URL is the same as the last request");
@@ -162,7 +162,7 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
     // We are always willing to show alternate content for unreachable URLs;
     // treat it like a reload so it maintains the right state for b/f list.
     auto& substituteData = loader->substituteData();
-    if (substituteData.isValid() && !substituteData.failingURL().isEmpty()) {
+    if (substituteData.isValid() && !substituteData.failingURL().isNull()) {
         bool shouldContinue = true;
 #if ENABLE(CONTENT_FILTERING)
         if (RefPtr loader = frameLoader->activeDocumentLoader())

--- a/Source/WebCore/loader/ResourceMonitor.cpp
+++ b/Source/WebCore/loader/ResourceMonitor.cpp
@@ -94,7 +94,7 @@ void ResourceMonitor::setDocumentURL(URL&& url)
     didReceiveResponse(m_frameURL, m_frame->isMainFrame() ? ContentExtensions::ResourceType::TopDocument : ContentExtensions::ResourceType::ChildDocument);
 
     if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(frame->ownerElement())) {
-        if (auto& url = iframe->initiatorSourceURL(); !url.isEmpty())
+        if (auto& url = iframe->initiatorSourceURL(); !url.isNull())
             didReceiveResponse(url, ContentExtensions::ResourceType::Script);
     }
 }

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -640,7 +640,7 @@ static HashMap<Ref<CSSStyleSheet>, String> addSubresourcesForCSSStyleSheetsIfNec
                 continue;
 
             auto url = currentCSSStyleSheet->baseURL();
-            if (url.isNull() || url.isEmpty())
+            if (url.isNull())
                 continue;
 
             auto addResult = uniqueCSSStyleSheets.add(currentCSSStyleSheet.copyRef(), emptyString());
@@ -736,7 +736,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::createInternal(const String& markupSt
             if (auto subframeArchive = createInternal(*localChildFrame->document(), options, frameFilter)) {
                 RefPtr subframeMainResource = subframeArchive->mainResource();
                 auto subframeMainResourceURL = subframeMainResource ? subframeMainResource->url() : URL { };
-                if (!subframeMainResourceURL.isEmpty()) {
+                if (!subframeMainResourceURL.isNull()) {
                     auto subframeMainResourceRelativePath = frame.isMainFrame() ? subframeMainResource->relativeFilePath() : FileSystem::lastComponentOfPathIgnoringTrailingSlash(subframeMainResource->relativeFilePath());
                     uniqueSubresources.add(makeString(childFrame->frameID().toUInt64()), subframeMainResourceRelativePath);
                 }
@@ -817,7 +817,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::createInternal(const String& markupSt
         if (!document)
             return nullptr;
 
-        if (responseURL.isEmpty())
+        if (responseURL.isNull())
             return nullptr;
 
         auto extension = MIMETypeRegistry::preferredExtensionForMIMEType(textHTMLContentTypeAtom());
@@ -831,7 +831,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::createInternal(const String& markupSt
         bool baseElementExcluded = std::ranges::any_of(options.markupExclusionRules, [&](auto& rule) {
             return rule.elementLocalName == "base"_s;
         });
-        if (!document->baseElementURL().isEmpty() && baseElementExcluded)
+        if (!document->baseElementURL().isNull() && baseElementExcluded)
             resolveURLs = ResolveURLs::Yes;
 
         String updatedMarkupString = serializeFragmentWithURLReplacement(*document, SerializedNodes::SubtreeIncludingNode, nullptr, resolveURLs, std::nullopt, WTF::move(uniqueSubresources), WTF::move(uniqueCSSStyleSheets), SerializeShadowRoots::AllForInterchange, { }, options.markupExclusionRules);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -755,7 +755,7 @@ static bool shouldPerformHTTPSUpgrade(const URL& originalURL, const URL& newURL,
     if (!frame.isMainFrame() || type != CachedResource::Type::MainResource)
         return false;
 
-    bool isSameSiteNavigation = (originalURL.isEmpty() || RegistrableDomain(newURL) == RegistrableDomain(originalURL));
+    bool isSameSiteNavigation = (originalURL.isNull() || RegistrableDomain(newURL) == RegistrableDomain(originalURL));
     const bool isSameSiteBypassEnabled =
         isSameSiteNavigation
         && (advancedPrivacyProtections.contains(AdvancedPrivacyProtections::HTTPSOnlyExplicitlyBypassedForDomain) || frame.loader().shouldNavigateWithHTTP(isSameSiteNavigation) || originalURL.protocolIs("http"_s));

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -184,7 +184,7 @@ static void prepareContextForQRCode(ContextMenuContext& context)
     if (!node || !node->document().settings().contextMenuQRCodeDetectionEnabled())
         return;
 
-    if (result.image() || !result.absoluteLinkURL().isEmpty())
+    if (result.image() || !result.absoluteLinkURL().isNull())
         return;
 
     RefPtr nodeElement = dynamicDowncast<Element>(*node);
@@ -390,7 +390,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         break;
     case ContextMenuItemTagOpenFrameInNewWindow: {
         RefPtr loader = frame->loader().documentLoader();
-        if (!loader->unreachableURL().isEmpty())
+        if (!loader->unreachableURL().isNull())
             openNewWindow(loader->unreachableURL(), *frame, nullptr, ShouldOpenExternalURLsPolicy::ShouldNotAllow);
         else
             openNewWindow(loader->url(), *frame, nullptr, ShouldOpenExternalURLsPolicy::ShouldNotAllow);
@@ -1136,7 +1136,7 @@ void ContextMenuController::populate()
     if (!m_context.hitTestResult().isContentEditable()) {
         Ref loader = frame->loader();
         URL linkURL = m_context.hitTestResult().absoluteLinkURL();
-        const bool linkURLEmpty = linkURL.isEmpty();
+        const bool linkURLEmpty = linkURL.isNull();
         if (!linkURLEmpty) {
             if (loader->client().canHandleRequest(ResourceRequest(WTF::move(linkURL)))) {
                 appendItem(OpenLinkItem, m_contextMenu.get());
@@ -1147,7 +1147,7 @@ void ContextMenuController::populate()
         }
 
         URL imageURL = m_context.hitTestResult().absoluteImageURL();
-        if (!imageURL.isEmpty()) {
+        if (!imageURL.isNull()) {
             if (!linkURLEmpty)
                 appendItem(*separatorItem(), m_contextMenu.get());
 
@@ -1187,9 +1187,9 @@ void ContextMenuController::populate()
         }
 
         URL mediaURL = m_context.hitTestResult().absoluteMediaURL();
-        const bool mediaURLEmpty = mediaURL.isEmpty();
+        const bool mediaURLEmpty = mediaURL.isNull();
         if (!mediaURLEmpty) {
-            if (!linkURLEmpty || !imageURL.isEmpty())
+            if (!linkURLEmpty || !imageURL.isNull())
                 appendItem(*separatorItem(), m_contextMenu.get());
 
             appendItem(MediaPlayPause, m_contextMenu.get());
@@ -1216,8 +1216,8 @@ void ContextMenuController::populate()
 
         auto selectedRange = frame->selection().selection().range();
         bool selectionIsInsideImageOverlay = selectedRange && ImageOverlay::isInsideOverlay(*selectedRange);
-        if (selectionIsInsideImageOverlay || (linkURLEmpty && mediaURLEmpty && imageURL.isEmpty())) {
-            if (!imageURL.isEmpty())
+        if (selectionIsInsideImageOverlay || (linkURLEmpty && mediaURLEmpty && imageURL.isNull())) {
+            if (!imageURL.isNull())
                 appendItem(*separatorItem(), m_contextMenu.get());
             
             RefPtr page = frame->page();
@@ -1381,7 +1381,7 @@ void ContextMenuController::populate()
 
         Ref loader = frame->loader();
         URL linkURL = m_context.hitTestResult().absoluteLinkURL();
-        if (!linkURL.isEmpty()) {
+        if (!linkURL.isNull()) {
             if (loader->client().canHandleRequest(ResourceRequest(WTF::move(linkURL)))) {
                 appendItem(OpenLinkItem, m_contextMenu.get());
                 appendItem(OpenLinkInNewWindowItem, m_contextMenu.get());
@@ -1531,7 +1531,7 @@ void ContextMenuController::addDebuggingItems()
     appendItem(InspectElementItem, m_contextMenu.get());
 
 #if ENABLE(VIDEO)
-    if (page->settings().showMediaStatsContextMenuItemEnabled() && !m_context.hitTestResult().absoluteMediaURL().isEmpty()) {
+    if (page->settings().showMediaStatsContextMenuItemEnabled() && !m_context.hitTestResult().absoluteMediaURL().isNull()) {
         ContextMenuItem ShowMediaStats(ContextMenuItemType::CheckableAction, ContextMenuItemTagShowMediaStats, contextMenuItemTagShowMediaStats());
         appendItem(ShowMediaStats, m_contextMenu.get());
     }

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -965,13 +965,13 @@ void DragController::prepareForDragStart(LocalFrame& source, OptionSet<DragSourc
 
     RefPtr image = getImage(element);
     auto imageURL = hitTestResult->absoluteImageURL();
-    if (actionMask.contains(DragSourceAction::Image) && !imageURL.isEmpty() && image && !image->isNull()) {
+    if (actionMask.contains(DragSourceAction::Image) && !imageURL.isNull() && image && !image->isNull()) {
         editor->writeImageToPasteboard(pasteboard, element, imageURL, { });
         return;
     }
 
     auto linkURL = hitTestResult->absoluteLinkURL();
-    if (actionMask.contains(DragSourceAction::Link) && !linkURL.isEmpty() && protect(source.document()->securityOrigin())->canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton()))
+    if (actionMask.contains(DragSourceAction::Link) && !linkURL.isNull() && protect(source.document()->securityOrigin())->canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton()))
         editor->copyURL(linkURL, hitTestResult->textContent().simplifyWhiteSpace(deprecatedIsSpaceOrNewline), pasteboard);
 #else
     // FIXME: Make this work on Windows by implementing Editor::writeSelectionToPasteboard and Editor::writeImageToPasteboard.
@@ -1037,12 +1037,12 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         // We allow DHTML/JS to set the drag image, even if its a link, image or text we're dragging.
         // This is in the spirit of the IE API, which allows overriding of pasteboard data and DragOp.
         if (dragImage) {
-            dragLoc = dragLocForDHTMLDrag(mouseDraggedPoint, dragOrigin, dragImageOffset, !linkURL.isEmpty());
+            dragLoc = dragLocForDHTMLDrag(mouseDraggedPoint, dragOrigin, dragImageOffset, !linkURL.isNull());
             m_dragOffset = dragImageOffset;
         }
     }
 
-    if (state.type == DragSourceAction::Selection || !imageURL.isEmpty() || !linkURL.isEmpty()) {
+    if (state.type == DragSourceAction::Selection || !imageURL.isNull() || !linkURL.isNull()) {
         // Selection, image, and link drags receive a default set of allowed drag operations that
         // follows from:
         // http://trac.webkit.org/browser/trunk/WebKit/mac/WebView/WebHTMLView.mm?rev=48526#L3430
@@ -1135,7 +1135,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         return false;
     }
 
-    if (!imageURL.isEmpty() && image && !image->isNull() && m_dragSourceAction.contains(DragSourceAction::Image)) {
+    if (!imageURL.isNull() && image && !image->isNull() && m_dragSourceAction.contains(DragSourceAction::Image)) {
         // We shouldn't be starting a drag for an image that can't provide an extension.
         // This is an early detection for problems encountered later upon drop.
         ASSERT(!image->filenameExtension().isEmpty());
@@ -1151,7 +1151,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
             if (element->isContentRichlyEditable())
                 selectElement(element);
             if (!attachmentInfo)
-                declareAndWriteDragImage(dataTransfer, element, !linkURL.isEmpty() ? linkURL : imageURL, hitTestResult->altDisplayString());
+                declareAndWriteDragImage(dataTransfer, element, !linkURL.isNull() ? linkURL : imageURL, hitTestResult->altDisplayString());
         }
 
         client().willPerformDragSourceAction(DragSourceAction::Image, dragOrigin, dataTransfer);
@@ -1166,7 +1166,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         return true;
     }
 
-    if (!linkURL.isEmpty() && m_dragSourceAction.contains(DragSourceAction::Link)) {
+    if (!linkURL.isNull() && m_dragSourceAction.contains(DragSourceAction::Link)) {
         PasteboardWriterData pasteboardWriterData;
 
         String textContentWithSimplifiedWhiteSpace = hitTestResult->textContent().simplifyWhiteSpace(deprecatedIsSpaceOrNewline);

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -689,7 +689,7 @@ static URL urlForElement(const Element& element)
 static void collectMediaAndLinkURLsRecursive(const Element& element, HashSet<URL>& urls)
 {
     auto addURLForElement = [&urls](const Element& element) {
-        if (auto url = urlForElement(element); !url.isEmpty() && !url.protocolIsData() && !url.protocolIsBlob())
+        if (auto url = urlForElement(element); !url.isNull() && !url.protocolIsData() && !url.protocolIsBlob())
             urls.add(WTF::move(url));
     };
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2827,8 +2827,8 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
     if (!activeDocument)
         return RefPtr<Frame> { nullptr };
 
-    URL completedURL = urlString.isEmpty() ? URL({ }, emptyString()) : protect(firstFrame.document())->completeURL(urlString);
-    if (!completedURL.isEmpty() && !completedURL.isValid())
+    URL completedURL = urlString.isEmpty() ? URL() : protect(firstFrame.document())->completeURL(urlString);
+    if (!completedURL.isNull() && !completedURL.isValid())
         return Exception { ExceptionCode::SyntaxError };
 
     WindowFeatures windowFeatures = initialWindowFeatures;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5595,7 +5595,7 @@ void LocalFrameView::updateControlTints()
     // to define when controls get the tint and to call this function when that changes.
     
     // Optimize the common case where we bring a window to the front while it's still empty.
-    if (m_frame->document()->url().isEmpty())
+    if (m_frame->document()->url().isNull())
         return;
 
     // As noted above, this is a "fake" paint, so we should pause counting relevant repainted objects.

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5818,7 +5818,7 @@ void Page::flushDeferredIntersectionObservations()
 
 bool Page::reportScriptTrackingPrivacy(const URL& url, ScriptTrackingPrivacyCategory category)
 {
-    return !url.isEmpty() && m_scriptTrackingPrivacyReports.add({ url, category }).isNewEntry;
+    return !url.isNull() && m_scriptTrackingPrivacyReports.add({ url, category }).isNewEntry;
 }
 
 bool Page::shouldAllowScriptAccess(const URL& url, const SecurityOrigin& topOrigin, ScriptTrackingPrivacyCategory category) const

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2048,7 +2048,7 @@ String Quirks::scriptToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
     if (!m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk))
         return { };
 
-    if (scriptURL.isEmpty())
+    if (scriptURL.isNull())
         return { };
 
     // iheart.com rdar://171198911
@@ -2070,7 +2070,7 @@ String Quirks::scriptToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
         return chromeUserAgentScript;
 
     // nba.com rdar://147429596
-    if (m_quirksData.isNBA && !scriptURL.isEmpty()) [[unlikely]]
+    if (m_quirksData.isNBA && !scriptURL.isNull()) [[unlikely]]
         return nbaSeekBarFixScript;
 
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
@@ -2608,7 +2608,7 @@ bool Quirks::shouldReportVisibleDueToActivePictureInPictureContent() const
 
 URL Quirks::topDocumentURL() const
 {
-    if (!m_topDocumentURLForTesting.isEmpty()) [[unlikely]]
+    if (!m_topDocumentURLForTesting.isNull()) [[unlikely]]
         return m_topDocumentURLForTesting;
 
     return protect(m_document)->topURL();
@@ -3705,7 +3705,7 @@ void Quirks::determineRelevantQuirks()
 #endif
 
     auto quirksURL = topDocumentURL();
-    if (quirksURL.isEmpty())
+    if (quirksURL.isNull())
         return;
 
     RegistrableDomain registrableDomain { quirksURL };

--- a/Source/WebCore/page/SecurityPolicy.cpp
+++ b/Source/WebCore/page/SecurityPolicy.cpp
@@ -88,7 +88,7 @@ String SecurityPolicy::generateReferrerHeader(ReferrerPolicy referrerPolicy, con
     ASSERT(referrer.string() == URL { referrer.string() }.strippedForUseAsReferrer().string
         || referrer.string() == SecurityOrigin::create(URL { referrer.string() })->toString());
 
-    if (referrer.isEmpty())
+    if (referrer.isNull())
         return String();
 
     if (!referrer.protocolIsInHTTPFamily())
@@ -172,7 +172,7 @@ bool SecurityPolicy::shouldInheritSecurityOriginFromOwner(const URL& url)
     //
     // Note: We generalize this to invalid URLs because we treat such URLs as about:blank.
     // FIXME: We also allow some URLs like "about:BLANK". We should probably block navigation to these URLs, see rdar://problem/57966056.
-    return url.isEmpty() || url.isAboutBlank() || url.isAboutSrcDoc() || equalIgnoringASCIICase(url.string(), aboutBlankURL().string());
+    return url.isNull() || url.isAboutBlank() || url.isAboutSrcDoc() || equalIgnoringASCIICase(url.string(), aboutBlankURL().string());
 }
 
 bool SecurityPolicy::isBaseURLSchemeAllowed(const URL& url)

--- a/Source/WebCore/page/UserScript.cpp
+++ b/Source/WebCore/page/UserScript.cpp
@@ -91,7 +91,7 @@ static void removeSourceString(const String& string)
 
 UserScript::UserScript(String&& source, URL&& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserScriptInjectionTime injectionTime, UserContentInjectedFrames injectedFrames, UserContentMatchParentFrame matchParentFrame)
     : m_source(internedSourceString(source))
-    , m_url(url.isEmpty() ? generateUserScriptUniqueURL() : WTF::move(url))
+    , m_url(url.isNull() ? generateUserScriptUniqueURL() : WTF::move(url))
     , m_allowlist(WTF::move(allowlist))
     , m_blocklist(WTF::move(blocklist))
     , m_injectionTime(injectionTime)

--- a/Source/WebCore/page/UserStyleSheet.cpp
+++ b/Source/WebCore/page/UserStyleSheet.cpp
@@ -90,7 +90,7 @@ static void removeStyleString(const String& string)
 
 UserStyleSheet::UserStyleSheet(const String& source, const URL& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserContentInjectedFrames injectedFrames, UserContentMatchParentFrame matchParentFrame, UserStyleLevel level, std::optional<PageIdentifier> pageID)
     : m_source(internedStyleString(source))
-    , m_url(url.isEmpty() ? generateUserStyleUniqueURL() : url)
+    , m_url(url.isNull() ? generateUserStyleUniqueURL() : url)
     , m_allowlist(WTF::move(allowlist))
     , m_blocklist(WTF::move(blocklist))
     , m_injectedFrames(injectedFrames)

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -90,7 +90,7 @@ static String consoleMessageForViolation(const ContentSecurityPolicyDirective& v
         name = ContentSecurityPolicyDirectiveNames::styleSrc;
 
     return makeString(violatedDirective.directiveList().isReportOnly() ? "[Report Only] "_s : ""_s,
-        prefix, blockedURL.isEmpty() ? ""_s : " "_s, blockedURL.stringCenterEllipsizedToLength(), " because "_s, subject,
+        prefix, blockedURL.isNull() ? ""_s : " "_s, blockedURL.stringCenterEllipsizedToLength(), " because "_s, subject,
         isDefaultSrc ? " appears in neither the "_s : " does not appear in the "_s,
         name,
         isDefaultSrc ? " directive nor the default-src directive of the Content Security Policy."_s : " directive of the Content Security Policy."_s);
@@ -492,9 +492,9 @@ bool ContentSecurityPolicy::allowNonParserInsertedScripts(const URL& sourceURL, 
 
     auto handleViolatedDirective = [checkedThis = CheckedRef { *this }, &sourceURL, &contextURL, &contextLine, &scriptContent] (const ContentSecurityPolicyDirective& violatedDirective) {
         TextPosition sourcePosition(contextLine, OrdinalNumber());
-        const auto message = sourceURL.isEmpty() ? "Refused to execute a script"_s : "Refused to load"_s;
+        const auto message = sourceURL.isNull() ? "Refused to execute a script"_s : "Refused to load"_s;
         String consoleMessage = consoleMessageForViolation(violatedDirective, sourceURL, message);
-        checkedThis->reportViolation(violatedDirective, sourceURL.isEmpty() ? "inline"_s : sourceURL.string(), consoleMessage, contextURL.string(), scriptContent, sourcePosition);
+        checkedThis->reportViolation(violatedDirective, sourceURL.isNull() ? "inline"_s : sourceURL.string(), consoleMessage, contextURL.string(), scriptContent, sourcePosition);
     };
 
     auto subResourceIntegrityDigests = parseSubResourceIntegrityIntoDigests(subResourceIntegrity);

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -264,7 +264,7 @@ const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violat
         || checkNonce(operativeDirective, nonce)
         || operativeDirective->containsAllHashes(subResourceIntegrityDigests)
         || (checkSource(operativeDirective, url) && !strictDynamicIncluded())
-        || (url.isEmpty() && checkInline(operativeDirective)))
+        || (url.isNull() && checkInline(operativeDirective)))
         return nullptr;
     return operativeDirective;
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.cpp
@@ -45,7 +45,7 @@ ContentSecurityPolicySourceListDirective::ContentSecurityPolicySourceListDirecti
 
 bool ContentSecurityPolicySourceListDirective::allows(const URL& url, bool didReceiveRedirectResponse, ShouldAllowEmptyURLIfSourceListIsNotNone shouldAllowEmptyURLIfSourceListEmpty)
 {
-    if (url.isEmpty())
+    if (url.isNull())
         return shouldAllowEmptyURLIfSourceListEmpty == ShouldAllowEmptyURLIfSourceListIsNotNone::Yes && !m_sourceList.isNone();
     return m_sourceList.matches(url, didReceiveRedirectResponse);
 }

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -517,7 +517,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
 
     if (element->isLink()) {
         if (auto href = element->attributeWithoutSynchronization(HTMLNames::hrefAttr); !href.isEmpty()) {
-            if (auto url = protect(element->document())->completeURL(href); !url.isEmpty()) {
+            if (auto url = protect(element->document())->completeURL(href); !url.isNull()) {
                 if (context.mergeParagraphs)
                     return { WTF::move(url) };
 

--- a/Source/WebCore/platform/glib/PasteboardGLib.cpp
+++ b/Source/WebCore/platform/glib/PasteboardGLib.cpp
@@ -159,7 +159,7 @@ void Pasteboard::writePlainText(const String& text, SmartReplaceOption smartRepl
 
 void Pasteboard::write(const PasteboardURL& pasteboardURL)
 {
-    ASSERT(!pasteboardURL.url.isEmpty());
+    ASSERT(!pasteboardURL.url.isNull());
     if (m_selectionData) {
         m_selectionData->clearAll();
         m_selectionData->setURL(pasteboardURL.url, pasteboardURL.title);
@@ -179,14 +179,14 @@ void Pasteboard::write(const PasteboardImage& pasteboardImage)
 {
     if (m_selectionData) {
         m_selectionData->clearAll();
-        if (!pasteboardImage.url.url.isEmpty()) {
+        if (!pasteboardImage.url.url.isNull()) {
             m_selectionData->setURL(pasteboardImage.url.url, pasteboardImage.url.title);
             m_selectionData->setMarkup(pasteboardImage.url.markup);
         }
         m_selectionData->setImage(pasteboardImage.image.get());
     } else {
         SelectionData data;
-        if (!pasteboardImage.url.url.isEmpty()) {
+        if (!pasteboardImage.url.url.isNull()) {
             data.setURL(pasteboardImage.url.url, pasteboardImage.url.title);
             data.setMarkup(pasteboardImage.url.markup);
         }

--- a/Source/WebCore/platform/glib/SelectionData.cpp
+++ b/Source/WebCore/platform/glib/SelectionData.cpp
@@ -36,7 +36,7 @@ SelectionData::SelectionData(const String& text, const String& markup, const URL
         setText(text);
     if (!markup.isEmpty())
         setMarkup(markup);
-    if (!url.isEmpty())
+    if (!url.isNull())
         setURL(url, String());
     if (!uriList.isEmpty())
         setURIList(uriList);

--- a/Source/WebCore/platform/glib/SelectionData.h
+++ b/Source/WebCore/platform/glib/SelectionData.h
@@ -43,7 +43,7 @@ public:
     void setURL(const URL&, const String&);
     const URL& url() const LIFETIME_BOUND { return m_url; }
     const String& urlLabel() const LIFETIME_BOUND;
-    bool hasURL() const { return !m_url.isEmpty() && m_url.isValid(); }
+    bool hasURL() const { return m_url.isValid(); }
     void clearURL() { m_url = URL(); }
 
     void setURIList(const String&);

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -734,7 +734,7 @@ void MediaPlayerPrivateAVFoundation::setPreload(MediaPlayer::Preload preload)
 {
     ALWAYS_LOG(LOGIDENTIFIER, " - ", static_cast<int>(preload));
     m_preload = preload;
-    if (m_assetURL.isEmpty())
+    if (m_assetURL.isNull())
         return;
 
     if (m_preload >= MediaPlayer::Preload::MetaData && assetStatus() == MediaPlayerAVAssetStatusDoesNotExist)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -786,7 +786,7 @@ void MediaPlayerPrivateAVFoundationObjC::synchronizeTextTrackState()
 
 static RetainPtr<NSURL> canonicalURL(const URL& url)
 {
-    if (url.isEmpty())
+    if (url.isNull())
         return URL::emptyNSURL();
 
     return URLByCanonicalizingURL(url.createNSURL().get());

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -194,8 +194,8 @@ void MediaPlayerPrivateWebM::setPreload(MediaPlayer::Preload preload)
 void MediaPlayerPrivateWebM::doPreload()
 {
     assertIsMainThread();
-    if (m_assetURL.isEmpty() || m_networkState >= MediaPlayerNetworkState::FormatError) {
-        INFO_LOG(LOGIDENTIFIER, " - hasURL = ", static_cast<int>(m_assetURL.isEmpty()), " networkState = ", static_cast<int>(m_networkState.load()));
+    if (m_assetURL.isNull() || m_networkState >= MediaPlayerNetworkState::FormatError) {
+        INFO_LOG(LOGIDENTIFIER, " - hasURL = ", static_cast<int>(m_assetURL.isNull()), " networkState = ", static_cast<int>(m_networkState.load()));
         return;
     }
 

--- a/Source/WebCore/platform/ios/PasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PasteboardIOS.mm
@@ -288,7 +288,7 @@ static void readURLAlongsideAttachmentIfNecessary(PasteboardWebContentReader& re
 
     String title;
     auto url = strategy.readURLFromPasteboard(itemIndex, pasteboardName, title, context);
-    if (!url.isEmpty())
+    if (!url.isNull())
         reader.readURL(url, title);
 }
 

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -212,7 +212,7 @@ static long writeURLForTypes(const Vector<String>& types, const String& pasteboa
 {
     auto newChangeCount = platformStrategies()->pasteboardStrategy()->setTypes(types, pasteboardName, context);
     
-    ASSERT(!pasteboardURL.url.isEmpty());
+    ASSERT(!pasteboardURL.url.isNull());
     
     RetainPtr nsURL = pasteboardURL.url.createNSURL();
     RetainPtr userVisibleString = pasteboardURL.userVisibleForm.createNSString();

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -112,7 +112,7 @@ bool ResourceRequestBase::isEmpty() const
 {
     updateResourceRequest(); 
     
-    return url().isEmpty();
+    return url().isNull();
 }
 
 bool ResourceRequestBase::isNull() const

--- a/Source/WebCore/platform/network/cocoa/ResourceErrorCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceErrorCocoa.mm
@@ -101,7 +101,7 @@ static RetainPtr<NSError> createNSErrorFromResourceErrorBase(const ResourceError
     if (!resourceError.localizedDescription().isEmpty())
         [userInfo setValue:resourceError.localizedDescription().createNSString().get() forKey:NSLocalizedDescriptionKey];
 
-    if (!resourceError.failingURL().isEmpty()) {
+    if (!resourceError.failingURL().isNull()) {
 #if USE(NSURL_ERROR_FAILING_URL_STRING_KEY)
         [userInfo setValue:resourceError.failingURL().string().createNSString().get() forKey:NSURLErrorFailingURLStringErrorKey];
 #endif

--- a/Source/WebCore/platform/network/curl/CookieJarDB.cpp
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.cpp
@@ -543,7 +543,7 @@ bool CookieJarDB::setCookie(const URL& firstParty, const URL& url, const String&
     if (!isEnabled() || !m_database.isOpen())
         return false;
 
-    if (url.isEmpty() || body.isEmpty())
+    if (url.isNull() || body.isEmpty())
         return false;
 
     auto cookie = CookieUtil::parseCookieHeader(body);

--- a/Source/WebCore/platform/network/curl/CurlProxySettings.cpp
+++ b/Source/WebCore/platform/network/curl/CurlProxySettings.cpp
@@ -135,7 +135,7 @@ static std::optional<uint16_t> getProxyPort(const URL& url)
 
 static std::optional<String> createProxyUrl(const URL &url)
 {
-    if (url.isEmpty() || url.host().isEmpty())
+    if (url.isNull() || url.host().isEmpty())
         return std::nullopt;
 
     if (!url.protocolIsInHTTPFamily() && !protocolIsInSocksFamily(url))

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -410,7 +410,7 @@ static bool writeURL(WCDataObject *data, const URL& url, String title, bool with
 {
     ASSERT(data);
 
-    if (url.isEmpty())
+    if (url.isNull())
         return false;
 
     if (title.isEmpty()) {
@@ -747,7 +747,7 @@ void Pasteboard::writeURLToDataObject(const URL& kurl, const String& titleStr)
 
 void Pasteboard::write(const PasteboardURL& pasteboardURL)
 {
-    ASSERT(!pasteboardURL.url.isEmpty());
+    ASSERT(!pasteboardURL.url.isNull());
 
     clear();
 

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -260,7 +260,7 @@ bool HitTestResult::isSelected() const
 bool HitTestResult::allowsFollowingLink() const
 {
     auto linkURL = absoluteLinkURL();
-    if (linkURL.isEmpty())
+    if (linkURL.isNull())
         return false;
 
     RefPtr innerFrame = innerNodeFrame();
@@ -277,7 +277,7 @@ bool HitTestResult::allowsFollowingLink() const
 bool HitTestResult::allowsFollowingImageURL() const
 {
     auto linkURL = absoluteImageURL();
-    if (linkURL.isEmpty())
+    if (linkURL.isNull())
         return false;
 
     RefPtr innerFrame = innerNodeFrame();
@@ -460,7 +460,7 @@ IntRect HitTestResult::imageRect() const
 bool HitTestResult::hasEntireImage() const
 {
     auto imageURL = absoluteImageURL();
-    if (imageURL.isEmpty() || imageRect().isEmpty())
+    if (imageURL.isNull() || imageRect().isEmpty())
         return false;
 
     RefPtr innerFrame = innerNodeFrame();
@@ -777,7 +777,7 @@ URL HitTestResult::absoluteLinkURL() const
 bool HitTestResult::hasLocalDataForLinkURL() const
 {
     auto linkURL = absoluteLinkURL();
-    if (linkURL.isEmpty())
+    if (linkURL.isNull())
         return false;
 
     if (RefPtr page = m_innerURLElement->document().page())

--- a/Source/WebCore/style/values/images/StyleImageWrapper.cpp
+++ b/Source/WebCore/style/values/images/StyleImageWrapper.cpp
@@ -142,7 +142,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const ImageWrapper& value)
     Ref image = value.value;
 
     ts << "image"_s;
-    if (!image->url().resolved.isEmpty())
+    if (!image->url().resolved.isNull())
         ts << '(' << image->url().resolved << ')';
     return ts;
 }

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -498,7 +498,7 @@ void WorkerMessagingProxy::setAppBadge(std::optional<uint64_t> badge)
     postTaskToLoader([badge = WTF::move(badge), this, protectedThis = Ref { *this }] (auto& context) {
         ASSERT(isMainThread());
 
-        if (m_scriptURL.isEmpty())
+        if (m_scriptURL.isNull())
             return;
 
         auto* document = downcast<Document>(&context);

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -527,7 +527,7 @@ static void* openFunc(const char* uri)
             options.credentials = FetchOptions::Credentials::Include;
             cachedResourceLoader->frame()->loader().loadResourceSynchronously(URL { url }, ClientCredentialPolicy::MayAskClientForCredentials, options, { }, error, response, data);
 
-            if (response.url().isEmpty()) {
+            if (response.url().isNull()) {
                 if (RefPtr frame = document ? document->frame() : nullptr)
                     frame->console().addMessage(MessageSource::Security, MessageLevel::Error, makeString("Did not parse external entity resource at '"_s, url.stringCenterEllipsizedToLength(), "' because cross-origin loads are not allowed."_s));
                 return &globalDescriptor;

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -217,7 +217,7 @@ uint64_t PendingDownload::messageSenderDestinationID() const
 URL PendingDownload::mainDocumentURL() const
 {
     auto firstParty = m_networkLoad->currentRequest().firstPartyForCookies();
-    if (!firstParty.isEmpty())
+    if (!firstParty.isNull())
         return firstParty;
 
     RefPtr topOrigin = m_networkLoad->parameters().topOrigin;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -958,8 +958,8 @@ void NetworkConnectionToWebProcess::setRawCookie(const URL& firstParty, const UR
 
 void NetworkConnectionToWebProcess::deleteCookie(const URL& firstParty, const URL& url, const String& cookieName, CompletionHandler<void()>&& completionHandler)
 {
-    MESSAGE_CHECK_COMPLETION(!firstParty.isEmpty() && firstParty.isValid(), completionHandler());
-    MESSAGE_CHECK_COMPLETION(!url.isEmpty() && url.isValid(), completionHandler());
+    MESSAGE_CHECK_COMPLETION(firstParty.isValid(), completionHandler());
+    MESSAGE_CHECK_COMPLETION(url.isValid(), completionHandler());
     MESSAGE_CHECK_COMPLETION(!cookieName.isEmpty(), completionHandler());
     auto allowCookieAccess = m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, firstParty);
     MESSAGE_CHECK_COMPLETION(allowCookieAccess != NetworkProcess::AllowCookieAccess::Terminate, completionHandler());
@@ -1136,7 +1136,7 @@ static bool shouldCheckBlobFileAccess()
 
 void NetworkConnectionToWebProcess::registerInternalFileBlobURL(const URL& url, const String& path, const String& replacementPath, SandboxExtension::Handle&& extensionHandle, const String& contentType)
 {
-    MESSAGE_CHECK(!url.isEmpty());
+    MESSAGE_CHECK(!url.isNull());
 
     CheckedPtr session = networkSession();
     if (!session)
@@ -1170,7 +1170,7 @@ void NetworkConnectionToWebProcess::registerBlobURL(const URL& url, const URL& s
 
 void NetworkConnectionToWebProcess::registerInternalBlobURLOptionallyFileBacked(URL&& url, URL&& srcURL, const String& fileBackedPath, String&& contentType)
 {
-    MESSAGE_CHECK(!url.isEmpty() && !srcURL.isEmpty() && !fileBackedPath.isEmpty());
+    MESSAGE_CHECK(!url.isNull() && !srcURL.isNull() && !fileBackedPath.isEmpty());
     CheckedPtr session = networkSession();
     if (!session)
         return;

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -60,10 +60,10 @@ static constexpr auto webKitBlobResourceDomain = "WebKitBlobResource"_s;
 static RefPtr<BlobData> blobDataFrom(NetworkSession& session, const WebCore::ResourceRequest& request, const SecurityOrigin* topOrigin)
 {
     // We use request.firstPartyForCookies() to indicate if the request originated from the DOM or WebView API.
-    ASSERT(topOrigin || request.firstPartyForCookies().isEmpty());
+    ASSERT(topOrigin || request.firstPartyForCookies().isNull());
 
     std::optional<SecurityOriginData> topOriginData = topOrigin ? std::optional { topOrigin->data() } : std::nullopt;
-    if (!topOriginData && !request.firstPartyForCookies().isEmpty() && request.firstPartyForCookies().isValid()) {
+    if (!topOriginData && !request.firstPartyForCookies().isNull() && request.firstPartyForCookies().isValid()) {
         RELEASE_LOG(Network, "Got request for blob without topOrigin but request specifies firstPartyForCookies");
         topOriginData = SecurityOriginData::fromURLWithoutStrictOpaqueness(request.firstPartyForCookies());
     }

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -579,7 +579,7 @@ ContentSecurityPolicy* NetworkLoadChecker::contentSecurityPolicy()
         m_contentSecurityPolicy = makeUnique<ContentSecurityPolicy>(URL { protect(origin())->toRawString() }, nullptr, m_networkResourceLoader.get());
         CheckedPtr checkedContentSecurityPolicy = m_contentSecurityPolicy.get();
         checkedContentSecurityPolicy->didReceiveHeaders(*m_cspResponseHeaders, String { m_referrer }, ContentSecurityPolicy::ReportParsingErrors::No);
-        if (!m_documentURL.isEmpty())
+        if (!m_documentURL.isNull())
             checkedContentSecurityPolicy->setDocumentURL(m_documentURL);
     }
     return m_contentSecurityPolicy.get();

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2374,11 +2374,11 @@ void NetworkProcess::findPendingDownloadLocation(NetworkDataTask& networkDataTas
 
 #if PLATFORM(COCOA)
         URL publishURL;
-        if (usePlaceholder == UseDownloadPlaceholder::No && !alternatePlaceholderURL.isEmpty())
+        if (usePlaceholder == UseDownloadPlaceholder::No && !alternatePlaceholderURL.isNull())
             publishURL = alternatePlaceholderURL;
         else
             publishURL = URL::fileURLWithFileSystemPath(destination);
-        if (usePlaceholder == UseDownloadPlaceholder::Yes || !alternatePlaceholderURL.isEmpty())
+        if (usePlaceholder == UseDownloadPlaceholder::Yes || !alternatePlaceholderURL.isNull())
 #if HAVE(MODERN_DOWNLOADPROGRESS)
             publishDownloadProgress(downloadID, publishURL, placeholderBookmarkData, usePlaceholder, activityAccessToken);
 #else

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
@@ -144,7 +144,7 @@ void PrivateClickMeasurementManager::getTokenPublicKey(PrivateClickMeasurement&&
             return;
     }
 
-    if (tokenPublicKeyURL.isEmpty() || !tokenPublicKeyURL.isValid())
+    if (!tokenPublicKeyURL.isValid())
         return;
 
     if (debugModeEnabled())
@@ -193,7 +193,7 @@ void PrivateClickMeasurementManager::getTokenPublicKey(AttributionTriggerData&& 
             return;
     }
 
-    if (tokenPublicKeyURL.isEmpty() || !tokenPublicKeyURL.isValid())
+    if (!tokenPublicKeyURL.isValid())
         return;
 
     if (debugModeEnabled())
@@ -266,7 +266,7 @@ void PrivateClickMeasurementManager::getSignedUnlinkableTokenForSource(PrivateCl
     URL tokenSignatureURL;
     configureForTokenSigning(pcmDataCarried, tokenSignatureURL, measurement.tokenSignatureURL());
 
-    if (tokenSignatureURL.isEmpty() || !tokenSignatureURL.isValid())
+    if (!tokenSignatureURL.isValid())
         return;
 
     RELEASE_LOG_INFO(PrivateClickMeasurement, "About to fire a unlinkable token signing request for the click source.");
@@ -313,7 +313,7 @@ void PrivateClickMeasurementManager::getSignedUnlinkableTokenForDestination(Sour
     URL tokenSignatureURL;
     configureForTokenSigning(pcmDataCarried, tokenSignatureURL, attributionTriggerData.tokenSignatureURL());
 
-    if (tokenSignatureURL.isEmpty() || !tokenSignatureURL.isValid())
+    if (!tokenSignatureURL.isValid())
         return;
 
     RELEASE_LOG_INFO(PrivateClickMeasurement, "About to fire a unlinkable token signing request for the click destination.");
@@ -587,7 +587,7 @@ void PrivateClickMeasurementManager::fireConversionRequestImpl(const PrivateClic
         attributionURL = m_attributionReportTestConfig ? m_attributionReportTestConfig->attributionReportClickDestinationURL : attribution.attributionReportClickDestinationURL();
     }
 
-    if (attributionURL.isEmpty() || !attributionURL.isValid())
+    if (!attributionURL.isValid())
         return;
 
     auto pcmDataCarried = debugModeEnabled() ? PrivateClickMeasurement::PcmDataCarried::PersonallyIdentifiable : PrivateClickMeasurement::PcmDataCarried::NonPersonallyIdentifiable;
@@ -718,14 +718,14 @@ void PrivateClickMeasurementManager::toStringForTesting(CompletionHandler<void(S
 
 void PrivateClickMeasurementManager::setTokenPublicKeyURLForTesting(URL&& testURL)
 {
-    if (testURL.isEmpty())
+    if (testURL.isNull())
         return;
     m_tokenPublicKeyURLForTesting = WTF::move(testURL);
 }
 
 void PrivateClickMeasurementManager::setTokenSignatureURLForTesting(URL&& testURL)
 {
-    if (testURL.isEmpty())
+    if (testURL.isNull())
         m_tokenSignatureURLForTesting = { };
     else
         m_tokenSignatureURLForTesting = WTF::move(testURL);
@@ -733,7 +733,7 @@ void PrivateClickMeasurementManager::setTokenSignatureURLForTesting(URL&& testUR
 
 void PrivateClickMeasurementManager::setAttributionReportURLsForTesting(URL&& sourceURL, URL&& destinationURL)
 {
-    if (sourceURL.isEmpty() || destinationURL.isEmpty())
+    if (sourceURL.isNull() || destinationURL.isNull())
         m_attributionReportTestConfig = std::nullopt;
     else
         m_attributionReportTestConfig = AttributionReportTestConfig { WTF::move(sourceURL), WTF::move(destinationURL) };

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -45,7 +45,7 @@ namespace WebKit {
 String CacheStorageCache::computeKeyURL(const URL& url)
 {
     RELEASE_ASSERT(url.isValid());
-    RELEASE_ASSERT(!url.isEmpty());
+    RELEASE_ASSERT(!url.isNull());
     URL keyURL { url };
     keyURL.removeQueryAndFragmentIdentifier();
     auto keyURLString = keyURL.string();

--- a/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.cpp
@@ -298,7 +298,7 @@ URL WebExtensionRegisteredScriptsSQLiteStore::databaseURL()
     if (useInMemoryDatabase())
         return WebExtensionSQLiteDatabase::inMemoryDatabaseURL();
 
-    ASSERT(!directory().isEmpty());
+    ASSERT(!directory().isNull());
     return URL(URL { makeString(directory().string(), "/"_s) }, "RegisteredContentScripts.db"_s);
 }
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
@@ -159,7 +159,7 @@ bool WebExtensionSQLiteDatabase::openWithAccessType(AccessType accessType, RefPt
     else if (m_url == privateOnDiskDatabaseURL())
         databasePath = ""_s;
     else {
-        ASSERT(!m_url.isEmpty());
+        ASSERT(!m_url.isNull());
 
         databasePath = m_url.fileSystemPath();
 

--- a/Source/WebKit/Shared/ScriptTrackingPrivacyFilter.cpp
+++ b/Source/WebKit/Shared/ScriptTrackingPrivacyFilter.cpp
@@ -94,7 +94,7 @@ bool ScriptTrackingPrivacyFilter::matches(const URL& url, const WebCore::Securit
 
 bool ScriptTrackingPrivacyFilter::shouldAllowAccess(const URL& url, const WebCore::SecurityOrigin& topOrigin, WebCore::ScriptTrackingPrivacyCategory category)
 {
-    if (url.isEmpty())
+    if (url.isNull())
         return false;
 
 #if PLATFORM(COCOA)
@@ -111,7 +111,7 @@ bool ScriptTrackingPrivacyFilter::shouldAllowAccess(const URL& url, const WebCor
 
 bool ScriptTrackingPrivacyFilter::shouldBlockRequest(const URL& url, const WebCore::SecurityOrigin& topOrigin)
 {
-    if (url.isEmpty())
+    if (url.isNull())
         return true;
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1035,7 +1035,7 @@ static void populateJSONForItem(JSON::Object& jsonObject, const TextExtraction::
             }
         },
         [&](const TextExtraction::ImageItemData& imageData) {
-            if (!imageData.completedSource.isEmpty() && aggregator.includeURLs())
+            if (!imageData.completedSource.isNull() && aggregator.includeURLs())
                 jsonObject.setString("src"_s, aggregator.stringForURL(imageData));
             if (!imageData.altText.isEmpty())
                 jsonObject.setString("alt"_s, imageData.altText);
@@ -1101,7 +1101,7 @@ static void populateJSONForItem(JSON::Object& jsonObject, const TextExtraction::
                 jsonObject.setString("name"_s, formData.name);
         },
         [&](const TextExtraction::LinkItemData& linkData) {
-            if (!linkData.completedURL.isEmpty() && aggregator.includeURLs())
+            if (!linkData.completedURL.isNull() && aggregator.includeURLs())
                 jsonObject.setString("url"_s, aggregator.stringForURL(linkData));
             if (!linkData.target.isEmpty())
                 jsonObject.setString("target"_s, linkData.target);
@@ -1501,7 +1501,7 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
             if (aggregator.useHTMLOutput()) {
                 auto attributes = partsForItem(item, aggregator, includeRectForParentItem);
 
-                if (!linkData.completedURL.isEmpty() && aggregator.includeURLs())
+                if (!linkData.completedURL.isNull() && aggregator.includeURLs())
                     attributes.append(makeString("href='"_s, aggregator.stringForURL(linkData), '\''));
 
                 if (attributes.isEmpty())
@@ -1512,7 +1512,7 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
                 parts.append("link"_s);
                 parts.appendVector(partsForItem(item, aggregator, includeRectForParentItem));
 
-                if (!linkData.completedURL.isEmpty() && aggregator.includeURLs())
+                if (!linkData.completedURL.isNull() && aggregator.includeURLs())
                     parts.append(makeString("url="_s, quoteValue(aggregator.stringForURL(linkData), streamlined)));
             }
 
@@ -1606,7 +1606,7 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
             if (aggregator.useHTMLOutput()) {
                 auto attributes = partsForItem(item, aggregator, includeRectForParentItem);
 
-                if (!imageData.completedSource.isEmpty() && aggregator.includeURLs())
+                if (!imageData.completedSource.isNull() && aggregator.includeURLs())
                     attributes.append(makeString("src='"_s, aggregator.stringForURL(imageData), '\''));
 
                 if (!imageData.altText.isEmpty())
@@ -1631,7 +1631,7 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
                 parts.append("image"_s);
                 parts.appendVector(partsForItem(item, aggregator, includeRectForParentItem));
 
-                if (!imageData.completedSource.isEmpty() && aggregator.includeURLs())
+                if (!imageData.completedSource.isNull() && aggregator.includeURLs())
                     parts.append(makeString("src="_s, quoteValue(aggregator.stringForURL(imageData), streamlined)));
 
                 if (!imageData.altText.isEmpty())

--- a/Source/WebKit/Shared/TextExtractionURLCache.cpp
+++ b/Source/WebKit/Shared/TextExtractionURLCache.cpp
@@ -39,7 +39,7 @@ void TextExtractionURLCache::clear()
 
 String TextExtractionURLCache::add(const String& shortenedString, const URL& originalURL, ExtractedURLType type)
 {
-    if (shortenedString.isEmpty() || originalURL.isEmpty())
+    if (shortenedString.isEmpty() || originalURL.isNull())
         return shortenedString;
 
     if (auto existingString = m_urlToShortenedStringMap.get(originalURL); !existingString.isEmpty())

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1323,7 +1323,7 @@ struct WKWebsiteData {
     WebCore::NotificationData notificationData = constNotificationData;
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
-    if (!notificationData.navigateURL.isEmpty() && _websiteDataStore->configuration().isDeclarativeWebPushEnabled()) {
+    if (!notificationData.navigateURL.isNull() && _websiteDataStore->configuration().isDeclarativeWebPushEnabled()) {
         RELEASE_LOG(Push, "Sending persistent notification clicked with default action URL. Requesting navigation to it now.");
 
         _websiteDataStore->client().navigationToNotificationActionURL(notificationData.navigateURL);

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -164,7 +164,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (auto strongSelf = weakSelf.get()) {
             // If the download happened instantly, the call to finish might have come before this
             // loadHandler. In that case, call the completionHandler here.
-            if (!strongSelf->_downloadedURL.isEmpty())
+            if (!strongSelf->_downloadedURL.isNull())
                 completionHandler(strongSelf->_downloadedURL.createNSURL().get(), nil);
             else
                 [strongSelf setCompletionHandler:completionHandler];

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -97,7 +97,7 @@ WebExtension::WebExtension(NSBundle *appExtensionBundle, NSURL *resourceURL, Ref
 
     if (m_bundle) {
         auto *bundleResourceURL = m_bundle.get().resourceURL.URLByStandardizingPath.absoluteURL;
-        if (m_resourceBaseURL.isEmpty())
+        if (m_resourceBaseURL.isNull())
             m_resourceBaseURL = bundleResourceURL;
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2112,7 +2112,7 @@ void WebExtensionContext::userGesturePerformed(WebExtensionTab& tab)
         return;
 
     auto currentURL = tab.url();
-    if (currentURL.isEmpty())
+    if (currentURL.isNull())
         return;
 
     switch (permissionState(currentURL, &tab)) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -66,7 +66,7 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
         URL frameDocumentURL = task->frameInfo().request().url();
         URL requestURL = task->request().url();
 
-        if (task->frameInfo().request().url().isEmpty() || task->frameInfo().request().url().isAboutBlank()) {
+        if (task->frameInfo().request().url().isNull() || task->frameInfo().request().url().isAboutBlank()) {
             frameDocumentURL = task->request().firstPartyForCookies();
 
             if (!task->frameInfo().isMainFrame()) {

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -189,7 +189,7 @@ WebExtension::WebExtension(Resources&& resources)
 
 WebExtension::~WebExtension()
 {
-    if (m_resourcesAreTemporary && !m_resourceBaseURL.isEmpty())
+    if (m_resourcesAreTemporary && !m_resourceBaseURL.isNull())
         FileSystem::deleteNonEmptyDirectory(m_resourceBaseURL.fileSystemPath());
 }
 
@@ -520,7 +520,7 @@ URL WebExtension::resourceFileURLForPath(const String& originalPath)
     if (path.startsWith('/'))
         path = path.substring(1);
 
-    if (!path.length() || m_resourceBaseURL.isEmpty())
+    if (!path.length() || m_resourceBaseURL.isNull())
         return { };
 
     URL result { m_resourceBaseURL, path };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -845,7 +845,7 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
 
 WebExtensionContext::PermissionState WebExtensionContext::permissionState(const URL& url, WebExtensionTab* tab, OptionSet<PermissionStateOptions> options)
 {
-    if (url.isEmpty())
+    if (url.isNull())
         return PermissionState::Unknown;
 
     if (isURLForThisExtension(url))
@@ -1087,7 +1087,7 @@ void WebExtensionContext::setPermissionState(PermissionState state, const String
 
 void WebExtensionContext::setPermissionState(PermissionState state, const URL& url, WallTime expirationDate)
 {
-    ASSERT(!url.isEmpty());
+    ASSERT(!url.isNull());
     ASSERT(!expirationDate.isNaN());
 
     RefPtr pattern = WebExtensionMatchPattern::getOrCreate(url);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
@@ -292,7 +292,7 @@ URL WebExtensionDeclarativeNetRequestSQLiteStore::databaseURL()
 
     String databaseName = "DeclarativeNetRequestRules.db"_s;
 
-    ASSERT(!directory().isEmpty());
+    ASSERT(!directory().isNull());
 
     return URL(URL { makeString(directory().string(), "/"_s) }, databaseName);
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
@@ -137,7 +137,7 @@ RefPtr<WebExtensionMatchPattern> WebExtensionMatchPattern::getOrCreate(const Str
 
 RefPtr<WebExtensionMatchPattern> WebExtensionMatchPattern::getOrCreate(const URL& url, OptionSet<CreateOptions> options)
 {
-    ASSERT(!url.isEmpty());
+    ASSERT(!url.isNull());
 
     String scheme = "*"_s;
     if (options.contains(CreateOptions::MatchExactScheme) || !url.protocolIsInHTTPFamily())

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionStorageSQLiteStore.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionStorageSQLiteStore.cpp
@@ -416,7 +416,7 @@ URL WebExtensionStorageSQLiteStore::databaseURL()
         return { };
     }
 
-    ASSERT(!directory().isEmpty());
+    ASSERT(!directory().isNull());
 
     return URL(URL { makeString(directory().string(), "/"_s) }, databaseName);
 }

--- a/Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp
+++ b/Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp
@@ -104,7 +104,7 @@ Expected<Ref<API::Data>, RefPtr<API::Error>> WebExtension::resourceDataForPath(c
     }
 
     auto resourceURL = resourceFileURLForPath(path);
-    if (resourceURL.isEmpty()) {
+    if (resourceURL.isNull()) {
         if (suppressErrors == SuppressNotFoundErrors::No)
             return makeUnexpected(createError(Error::ResourceNotFound, WEB_UI_FORMAT_STRING("Unable to find \"%s\" in the extension’s resources. It is an invalid path.", "WKWebExtensionErrorResourceNotFound description with invalid file path", path.utf8().data())));
         return makeUnexpected(nullptr);

--- a/Source/WebKit/UIProcess/FrameLoadState.cpp
+++ b/Source/WebKit/UIProcess/FrameLoadState.cpp
@@ -44,7 +44,7 @@ void FrameLoadState::removeObserver(FrameLoadStateObserver& observer)
 
 void FrameLoadState::didStartProvisionalLoad(URL&& url)
 {
-    ASSERT(m_provisionalURL.isEmpty());
+    ASSERT(m_provisionalURL.isNull());
 
     m_state = State::Provisional;
     m_provisionalURL = WTF::move(url);
@@ -117,7 +117,7 @@ void FrameLoadState::didCommitLoad()
 void FrameLoadState::didFinishLoad()
 {
     ASSERT(m_state == State::Committed);
-    ASSERT(m_provisionalURL.isEmpty());
+    ASSERT(m_provisionalURL.isNull());
 
     m_state = State::Finished;
 
@@ -129,7 +129,7 @@ void FrameLoadState::didFinishLoad()
 void FrameLoadState::didFailLoad()
 {
     ASSERT(m_state == State::Committed);
-    ASSERT(m_provisionalURL.isEmpty());
+    ASSERT(m_provisionalURL.isNull());
 
     m_state = State::Finished;
     forEachObserver([&](FrameLoadStateObserver& observer) {

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.h
@@ -68,7 +68,7 @@ public:
     PAL::SessionID sessionID() const { return m_data.sourceSession; }
 
     const WebCore::NotificationData& data() const LIFETIME_BOUND { return m_data; }
-    bool isPersistentNotification() const { return !m_data.serviceWorkerRegistrationURL.isEmpty(); }
+    bool isPersistentNotification() const { return !m_data.serviceWorkerRegistrationURL.isNull(); }
 
     API::SecurityOrigin& origin() const { return m_origin; }
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
@@ -54,7 +54,7 @@ void WebNotificationManagerMessageHandler::showNotification(IPC::Connection& con
 {
     RELEASE_LOG(Push, "WebNotificationManagerMessageHandler showNotification called");
 
-    if (!data.serviceWorkerRegistrationURL.isEmpty()) {
+    if (!data.serviceWorkerRegistrationURL.isNull()) {
         ServiceWorkerNotificationHandler::singleton().showNotification(connection, data, WTF::move(resources), WTF::move(callback));
         return;
     }

--- a/Source/WebKit/UIProcess/PageLoadState.cpp
+++ b/Source/WebKit/UIProcess/PageLoadState.cpp
@@ -195,7 +195,7 @@ const URL& PageLoadState::activeURL(const Data& data)
     if (!data.pendingAPIRequest.url.isNull())
         return data.pendingAPIRequest.url;
 
-    if (!data.unreachableURL.isEmpty())
+    if (!data.unreachableURL.isNull())
         return data.unreachableURL;
 
     switch (data.state) {
@@ -280,7 +280,7 @@ void PageLoadState::didExplicitOpen(const Transaction::Token& token, const URL& 
 void PageLoadState::didStartProvisionalLoad(const Transaction::Token& token, const URL& url, const URL& unreachableURL)
 {
     ASSERT_UNUSED(token, &token.m_pageLoadState == this);
-    ASSERT(m_uncommittedState.provisionalURL.isEmpty());
+    ASSERT(m_uncommittedState.provisionalURL.isNull());
 
     m_uncommittedState.state = State::Provisional;
 
@@ -334,7 +334,7 @@ void PageLoadState::didFinishLoad(const Transaction::Token& token)
 {
     ASSERT_UNUSED(token, &token.m_pageLoadState == this);
     ASSERT(m_uncommittedState.state == State::Committed);
-    ASSERT(m_uncommittedState.provisionalURL.isEmpty());
+    ASSERT(m_uncommittedState.provisionalURL.isNull());
 
     m_uncommittedState.state = State::Finished;
 }
@@ -342,7 +342,7 @@ void PageLoadState::didFinishLoad(const Transaction::Token& token)
 void PageLoadState::didFailLoad(const Transaction::Token& token)
 {
     ASSERT_UNUSED(token, &token.m_pageLoadState == this);
-    ASSERT(m_uncommittedState.provisionalURL.isEmpty());
+    ASSERT(m_uncommittedState.provisionalURL.isNull());
 
     m_uncommittedState.state = State::Finished;
 }
@@ -350,7 +350,7 @@ void PageLoadState::didFailLoad(const Transaction::Token& token)
 void PageLoadState::didSameDocumentNavigation(const Transaction::Token& token, const URL& url)
 {
     ASSERT_UNUSED(token, &token.m_pageLoadState == this);
-    ASSERT(!m_uncommittedState.url.isEmpty());
+    ASSERT(!m_uncommittedState.url.isNull());
 
     m_uncommittedState.url = url;
 }

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -146,12 +146,12 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
     if (m_isServerRedirect) {
         // FIXME: When <rdar://116203552> is fixed we should not need this case here
         // because main frame redirect messages won't come from the web content process.
-        if (protect(page.preferences())->siteIsolationEnabled() && !m_mainFrame->frameLoadState().provisionalURL().isEmpty())
+        if (protect(page.preferences())->siteIsolationEnabled() && !m_mainFrame->frameLoadState().provisionalURL().isNull())
             m_mainFrame->frameLoadState().didReceiveServerRedirectForProvisionalLoad(URL { m_request.url() });
         else
             m_mainFrame->frameLoadState().didStartProvisionalLoad(URL { m_request.url() });
         page.didReceiveServerRedirectForProvisionalLoadForFrameShared(WTF::move(process), m_mainFrame->frameID(), m_navigationID, WTF::move(m_request), { });
-    } else if (previousMainFrame && !previousMainFrame->provisionalURL().isEmpty() && !m_shouldReuseMainFrame) {
+    } else if (previousMainFrame && !previousMainFrame->provisionalURL().isNull() && !m_shouldReuseMainFrame) {
         // In case of a process swap after response policy, the didStartProvisionalLoad already happened but the new main frame doesn't know about it
         // so we need to tell it so it can update its provisional URL.
         protect(mainFrame())->didStartProvisionalLoad(URL { previousMainFrame->provisionalURL() });
@@ -226,7 +226,7 @@ void ProvisionalPageProxy::cancel()
 {
     // If the provisional load started, then indicate that it failed due to cancellation by calling didFailProvisionalLoadForFrame().
     RefPtr mainFrame = m_mainFrame;
-    if (m_provisionalLoadURL.isEmpty() || !mainFrame)
+    if (m_provisionalLoadURL.isNull() || !mainFrame)
         return;
 
     ASSERT(process().state() == WebProcessProxy::State::Running);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2050,7 +2050,7 @@ void WebPageProxy::maybeInitializeSandboxExtensionHandle(WebProcessProxy& proces
         return handle;
     };
 
-    if (!resourceDirectoryURL.isEmpty()) {
+    if (!resourceDirectoryURL.isNull()) {
         if (!url.string().startsWith(resourceDirectoryURL.string()))
             WEBPAGEPROXY_RELEASE_LOG_ERROR(Sandbox, "maybeInitializeSandboxExtensionHandle: url is not inside resource directory url");
 
@@ -2219,7 +2219,7 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
 
     auto url = request.url();
 #if PLATFORM(COCOA)
-    bool urlIsInvalidButNotEmpty = !url.isValid() && !url.isEmpty();
+    bool urlIsInvalidButNotEmpty = !url.isValid() && !url.isNull();
     if (urlIsInvalidButNotEmpty && WTF::linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ConvertsInvalidURLsToNull)) {
         RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, request, navigation = protect(navigation)] mutable {
             RefPtr protectedThis = weakThis.get();
@@ -5987,9 +5987,9 @@ SessionState WebPageProxy::sessionState(WTF::Function<bool (WebBackForwardListIt
 #endif
 
     auto& pendingURL = internals().pageLoadState.pendingAPIRequestURL();
-    auto& provisionalURL = !pendingURL.isEmpty() ? pendingURL : internals().pageLoadState.provisionalURL();
+    auto& provisionalURL = !pendingURL.isNull() ? pendingURL : internals().pageLoadState.provisionalURL();
 
-    if (!provisionalURL.isEmpty())
+    if (!provisionalURL.isNull())
         sessionState.provisionalURL = provisionalURL;
 
     sessionState.renderTreeSize = renderTreeSize();
@@ -7673,7 +7673,7 @@ void WebPageProxy::didReceiveServerRedirectForProvisionalLoadForFrameShared(Ref<
         // If the main frame in a provisional page is getting a server-side redirect, make sure the
         // committed page's provisional URL is kept up-to-date too.
         RefPtr mainFrame = m_mainFrame;
-        if (frame != mainFrame && !mainFrame->frameLoadState().provisionalURL().isEmpty())
+        if (frame != mainFrame && !mainFrame->frameLoadState().provisionalURL().isNull())
             mainFrame->didReceiveServerRedirectForProvisionalLoad(URL { requestURL });
     }
     frame->didReceiveServerRedirectForProvisionalLoad(WTF::move(requestURL));
@@ -7810,7 +7810,7 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
         // Update current main frame when provisional main frame load fails, because it
         // is updated when provisional main frame load starts or gets redirected.
         RefPtr mainFrame = m_mainFrame;
-        if (&frame != mainFrame && !mainFrame->frameLoadState().provisionalURL().isEmpty())
+        if (&frame != mainFrame && !mainFrame->frameLoadState().provisionalURL().isNull())
             mainFrame->didFailProvisionalLoad();
     }
 
@@ -12472,7 +12472,7 @@ String WebPageProxy::currentURL() const
 {
     auto& url = pageLoadState().activeURL();
     RefPtr currentItem = backForwardList().currentItem();
-    if (url.isEmpty() && currentItem)
+    if (url.isNull() && currentItem)
         return currentItem->url();
     return url.string();
 }
@@ -12480,7 +12480,7 @@ String WebPageProxy::currentURL() const
 URL WebPageProxy::currentResourceDirectoryURL() const
 {
     auto resourceDirectoryURL = internals().pageLoadState.resourceDirectoryURL();
-    if (!resourceDirectoryURL.isEmpty())
+    if (!resourceDirectoryURL.isNull())
         return resourceDirectoryURL;
     if (auto* item = backForwardList().currentItem())
         return item->resourceDirectoryURL();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2358,7 +2358,7 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
     else
         sourceURL = pageSourceURL;
 
-    if (sourceURL.isEmpty()) {
+    if (sourceURL.isNull()) {
         if (RefPtr relatedPage = pageConfiguration->relatedPage()) {
             sourceURL = relatedPage->pageLoadState().url();
             WEBPROCESSPOOL_RELEASE_LOG(ProcessSwapping, "processForNavigationInternal: Using related page's URL as source URL for process swap decision (page=%p)", pageConfiguration->relatedPage());
@@ -2369,7 +2369,7 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
     if (!m_configuration->processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol() && !sourceURL.protocolIsInHTTPFamily() && sourceURL.protocol() == targetURL.protocol() && !siteIsolationEnabled)
         return { WTF::move(sourceProcess), nullptr, "Navigation within the same non-HTTP(s) protocol"_s };
 
-    bool sourceURLIsInvalid = !sourceURL.isValid() || sourceURL.isEmpty();
+    bool sourceURLIsInvalid = !sourceURL.isValid();
     if (!siteIsolationEnabled && (sourceURLIsInvalid || !targetURL.isValid() || targetSite.domain().matches(sourceURL)))
         return { WTF::move(sourceProcess), nullptr, "Navigation is same-site"_s };
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1160,7 +1160,7 @@ void WebsiteDataStore::isPrevalentResource(const URL& url, CompletionHandler<voi
 {
     ASSERT(RunLoop::isMain());
     
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler(false);
         return;
     }
@@ -1172,7 +1172,7 @@ void WebsiteDataStore::isGrandfathered(const URL& url, CompletionHandler<void(bo
 {
     ASSERT(RunLoop::isMain());
     
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler(false);
         return;
     }
@@ -1184,7 +1184,7 @@ void WebsiteDataStore::setPrevalentResource(const URL& url, CompletionHandler<vo
 {
     ASSERT(RunLoop::isMain());
     
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler();
         return;
     }
@@ -1196,7 +1196,7 @@ void WebsiteDataStore::setPrevalentResourceForDebugMode(const URL& url, Completi
 {
     ASSERT(RunLoop::isMain());
     
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler();
         return;
     }
@@ -1208,7 +1208,7 @@ void WebsiteDataStore::isVeryPrevalentResource(const URL& url, CompletionHandler
 {
     ASSERT(RunLoop::isMain());
     
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler(false);
         return;
     }
@@ -1220,7 +1220,7 @@ void WebsiteDataStore::setVeryPrevalentResource(const URL& url, CompletionHandle
 {
     ASSERT(RunLoop::isMain());
     
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler();
         return;
     }
@@ -1239,7 +1239,7 @@ void WebsiteDataStore::setSubframeUnderTopFrameDomain(const URL& subFrameURL, co
 {
     ASSERT(RunLoop::isMain());
     
-    if (subFrameURL.protocolIsAbout() || subFrameURL.isEmpty() || topFrameURL.protocolIsAbout() || topFrameURL.isEmpty()) {
+    if (subFrameURL.protocolIsAbout() || subFrameURL.isNull() || topFrameURL.protocolIsAbout() || topFrameURL.isNull()) {
         completionHandler();
         return;
     }
@@ -1258,7 +1258,7 @@ void WebsiteDataStore::setSubresourceUnderTopFrameDomain(const URL& subresourceU
 {
     ASSERT(RunLoop::isMain());
     
-    if (subresourceURL.protocolIsAbout() || subresourceURL.isEmpty() || topFrameURL.protocolIsAbout() || topFrameURL.isEmpty()) {
+    if (subresourceURL.protocolIsAbout() || subresourceURL.isNull() || topFrameURL.protocolIsAbout() || topFrameURL.isNull()) {
         completionHandler();
         return;
     }
@@ -1277,7 +1277,7 @@ void WebsiteDataStore::setSubresourceUniqueRedirectTo(const URL& subresourceURL,
 {
     ASSERT(RunLoop::isMain());
     
-    if (subresourceURL.protocolIsAbout() || subresourceURL.isEmpty() || urlRedirectedTo.protocolIsAbout() || urlRedirectedTo.isEmpty()) {
+    if (subresourceURL.protocolIsAbout() || subresourceURL.isNull() || urlRedirectedTo.protocolIsAbout() || urlRedirectedTo.isNull()) {
         completionHandler();
         return;
     }
@@ -1289,7 +1289,7 @@ void WebsiteDataStore::setSubresourceUniqueRedirectFrom(const URL& subresourceUR
 {
     ASSERT(RunLoop::isMain());
     
-    if (subresourceURL.protocolIsAbout() || subresourceURL.isEmpty() || urlRedirectedFrom.protocolIsAbout() || urlRedirectedFrom.isEmpty()) {
+    if (subresourceURL.protocolIsAbout() || subresourceURL.isNull() || urlRedirectedFrom.protocolIsAbout() || urlRedirectedFrom.isNull()) {
         completionHandler();
         return;
     }
@@ -1301,7 +1301,7 @@ void WebsiteDataStore::setTopFrameUniqueRedirectTo(const URL& topFrameURL, const
 {
     ASSERT(RunLoop::isMain());
     
-    if (topFrameURL.protocolIsAbout() || topFrameURL.isEmpty() || urlRedirectedTo.protocolIsAbout() || urlRedirectedTo.isEmpty()) {
+    if (topFrameURL.protocolIsAbout() || topFrameURL.isNull() || urlRedirectedTo.protocolIsAbout() || urlRedirectedTo.isNull()) {
         completionHandler();
         return;
     }
@@ -1313,7 +1313,7 @@ void WebsiteDataStore::setTopFrameUniqueRedirectFrom(const URL& topFrameURL, con
 {
     ASSERT(RunLoop::isMain());
     
-    if (topFrameURL.protocolIsAbout() || topFrameURL.isEmpty() || urlRedirectedFrom.protocolIsAbout() || urlRedirectedFrom.isEmpty()) {
+    if (topFrameURL.protocolIsAbout() || topFrameURL.isNull() || urlRedirectedFrom.protocolIsAbout() || urlRedirectedFrom.isNull()) {
         completionHandler();
         return;
     }
@@ -1332,7 +1332,7 @@ void WebsiteDataStore::clearPrevalentResource(const URL& url, CompletionHandler<
 {
     ASSERT(RunLoop::isMain());
         
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler();
         return;
     }
@@ -1426,7 +1426,7 @@ void WebsiteDataStore::statisticsDatabaseHasAllTables(CompletionHandler<void(boo
 
 void WebsiteDataStore::setLastSeen(const URL& url, Seconds seconds, CompletionHandler<void()>&& completionHandler)
 {
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler();
         return;
     }
@@ -1443,7 +1443,7 @@ void WebsiteDataStore::domainIDExistsInDatabase(int domainID, CompletionHandler<
 
 void WebsiteDataStore::mergeStatisticForTesting(const URL& url, const URL& topFrameUrl1, const URL& topFrameUrl2, Seconds lastSeen, bool hadUserInteraction, Seconds mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, unsigned dataRecordsRemoved, CompletionHandler<void()>&& completionHandler)
 {
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler();
         return;
     }
@@ -1453,7 +1453,7 @@ void WebsiteDataStore::mergeStatisticForTesting(const URL& url, const URL& topFr
 
 void WebsiteDataStore::insertExpiredStatisticForTesting(const URL& url, unsigned numberOfOperatingDaysPassed, bool hadUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent, CompletionHandler<void()>&& completionHandler)
 {
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler();
         return;
     }
@@ -1519,7 +1519,7 @@ void WebsiteDataStore::setTimeToLiveUserInteraction(Seconds seconds, CompletionH
 
 void WebsiteDataStore::didHaveUserInteractionForSiteIsolation(const URL& url)
 {
-    if (url.protocolIsAbout() || url.isEmpty())
+    if (url.protocolIsAbout() || url.isNull())
         return;
 
     WebCore::RegistrableDomain registrableDomain { url };
@@ -1538,7 +1538,7 @@ void WebsiteDataStore::logUserInteraction(const URL& url, CompletionHandler<void
 {
     ASSERT(RunLoop::isMain());
     
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler();
         return;
     }
@@ -1550,7 +1550,7 @@ void WebsiteDataStore::hasHadUserInteraction(const URL& url, CompletionHandler<v
 {
     ASSERT(RunLoop::isMain());
     
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler(false);
         return;
     }
@@ -1562,7 +1562,7 @@ void WebsiteDataStore::isRelationshipOnlyInDatabaseOnce(const URL& subUrl, const
 {
     ASSERT(RunLoop::isMain());
     
-    if (subUrl.protocolIsAbout() || subUrl.isEmpty() || topUrl.protocolIsAbout() || topUrl.isEmpty()) {
+    if (subUrl.protocolIsAbout() || subUrl.isNull() || topUrl.protocolIsAbout() || topUrl.isNull()) {
         completionHandler(false);
         return;
     }
@@ -1574,7 +1574,7 @@ void WebsiteDataStore::clearUserInteraction(const URL& url, CompletionHandler<vo
 {
     ASSERT(RunLoop::isMain());
     
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler();
         return;
     }
@@ -1586,7 +1586,7 @@ void WebsiteDataStore::setGrandfathered(const URL& url, bool isGrandfathered, Co
 {
     ASSERT(RunLoop::isMain());
     
-    if (url.protocolIsAbout() || url.isEmpty()) {
+    if (url.protocolIsAbout() || url.isNull()) {
         completionHandler();
         return;
     }

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -351,7 +351,7 @@ void DragDropInteractionState::stageDragItem(const DragItem& item, DragSourceSta
         item.image.textIndicator(),
         item.image.visiblePath(),
         item.title.isEmpty() ? nil : item.title.createNSString().get(),
-        item.url.isEmpty() ? nil : item.url.createNSURL().get(),
+        item.url.isNull() ? nil : item.url.createNSURL().get(),
         true, // We assume here that drag previews need to be updated until proven otherwise in updatePreviewsForActiveDragSources().
         item.containsSelection,
         ++currentDragSourceItemIdentifier

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -444,7 +444,7 @@ static bool isJavaScriptURL(NSURL *url)
             [self cleanupSheet];
     };
 
-    if (_positionInformation->url.isEmpty() && _positionInformation->image && [delegate respondsToSelector:@selector(actionSheetAssistant:getAlternateURLForImage:completion:)]) {
+    if (_positionInformation->url.isNull() && _positionInformation->image && [delegate respondsToSelector:@selector(actionSheetAssistant:getAlternateURLForImage:completion:)]) {
         RetainPtr<UIImage> uiImage = adoptNS([[UIImage alloc] initWithCGImage:protect(_positionInformation->image)->createPlatformImage().get()]);
 
         _hasPendingActionSheet = YES;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -13077,7 +13077,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
         auto previewOptions = adoptNS([[NSMutableDictionary alloc] initWithCapacity:2]);
         if (_visualSearchPreviewImageURL)
             [previewOptions setObject:_visualSearchPreviewImageURL.get() forKey:@"imageURL"];
-        if (auto pageURL = URL { protect(_page)->currentURL() }; !pageURL.isEmpty())
+        if (auto pageURL = URL { protect(_page)->currentURL() }; !pageURL.isNull())
             [previewOptions setObject:pageURL.createNSURL().get() forKey:@"pageURL"];
         if ([previewOptions count])
             [item setPreviewOptions:previewOptions.get()];
@@ -15285,7 +15285,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     URL linkURL = _positionInformation.url;
 
-    if (_positionInformation.isLink && linkURL.isEmpty())
+    if (_positionInformation.isLink && linkURL.isNull())
         return continueWithContextMenuConfiguration(nil);
 
     auto uiDelegate = static_cast<id<WKUIDelegatePrivate>>(self.webView.UIDelegate);
@@ -15636,7 +15636,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (_positionInformation.isImage) {
             if ([uiDelegate respondsToSelector:@selector(_webView:commitPreviewedImageWithURL:)]) {
                 const auto& imageURL = _positionInformation.imageURL;
-                if (imageURL.isEmpty() || !(imageURL.protocolIsInHTTPFamily() || imageURL.protocolIs("data"_s)))
+                if (imageURL.isNull() || !(imageURL.protocolIsInHTTPFamily() || imageURL.protocolIs("data"_s)))
                     return;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
                 [uiDelegate _webView:self.webView commitPreviewedImageWithURL:imageURL.createNSURL().get()];
@@ -15785,7 +15785,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             return [uiDelegate webView:self.webView shouldPreviewElement:previewElementInfo.get()];
         }
 ALLOW_DEPRECATED_DECLARATIONS_END
-        if (linkURL.isEmpty())
+        if (linkURL.isNull())
             return NO;
         if (linkURL.protocolIsInHTTPFamily())
             return YES;
@@ -15826,7 +15826,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return nil;
 
     const URL& linkURL = _positionInformation.url;
-    if (!useImageURLForLink && (linkURL.isEmpty() || (!linkURL.protocolIsInHTTPFamily() && !isDataDetectorLink))) {
+    if (!useImageURLForLink && (linkURL.isNull() || (!linkURL.protocolIsInHTTPFamily() && !isDataDetectorLink))) {
         if (canShowLinkPreview && !canShowImagePreview)
             return nil;
         canShowLinkPreview = NO;
@@ -15901,7 +15901,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     NSURL *targetURL = controller.previewData[UIPreviewDataLink];
     URL coreTargetURL = targetURL;
-    bool isValidURLForImagePreview = !coreTargetURL.isEmpty() && (coreTargetURL.protocolIsInHTTPFamily() || coreTargetURL.protocolIs("data"_s));
+    bool isValidURLForImagePreview = !coreTargetURL.isNull() && (coreTargetURL.protocolIsInHTTPFamily() || coreTargetURL.protocolIs("data"_s));
 
     if ([_previewItemController type] == UIPreviewItemTypeLink) {
         _longPressCanClick = NO;
@@ -15993,7 +15993,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if ([_previewItemController type] == UIPreviewItemTypeImage) {
         if ([uiDelegate respondsToSelector:@selector(_webView:commitPreviewedImageWithURL:)]) {
             const URL& imageURL = _positionInformation.imageURL;
-            if (imageURL.isEmpty() || !(imageURL.protocolIsInHTTPFamily() || imageURL.protocolIs("data"_s)))
+            if (imageURL.isNull() || !(imageURL.protocolIsInHTTPFamily() || imageURL.protocolIs("data"_s)))
                 return;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             [uiDelegate _webView:self.webView commitPreviewedImageWithURL:imageURL.createNSURL().get()];

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -488,7 +488,7 @@ RetainPtr<NSMenuItem> WebContextMenuProxyMac::createShareMenuItem(ShareMenuItemT
 
     if (!hitTestData.absoluteLinkURL.isEmpty()) {
         auto absoluteLinkURL = URL({ }, hitTestData.absoluteLinkURL);
-        if (!absoluteLinkURL.isEmpty()) {
+        if (!absoluteLinkURL.isNull()) {
             if (RetainPtr url = absoluteLinkURL.createNSURL())
                 [items addObject:url.get()];
         }
@@ -496,7 +496,7 @@ RetainPtr<NSMenuItem> WebContextMenuProxyMac::createShareMenuItem(ShareMenuItemT
 
     if (hitTestData.isDownloadableMedia && !hitTestData.absoluteMediaURL.isEmpty()) {
         auto downloadableMediaURL = URL({ }, hitTestData.absoluteMediaURL);
-        if (!downloadableMediaURL.isEmpty()) {
+        if (!downloadableMediaURL.isNull()) {
             if (RetainPtr url = downloadableMediaURL.createNSURL())
                 [items addObject:url.get()];
         }

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1115,7 +1115,7 @@ void WebAutomationSessionProxy::getCookiesForFrame(WebCore::PageIdentifier pageI
 
     // This returns the same list of cookies as when evaluating `document.cookies` in JavaScript.
     Vector<WebCore::Cookie> foundCookies;
-    if (!document->cookieURL().isEmpty())
+    if (!document->cookieURL().isNull())
         page->corePage()->cookieJar().getRawCookies(*document, document->cookieURL(), foundCookies);
 
     completionHandler(std::nullopt, foundCookies);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -967,7 +967,7 @@ void WebExtensionAPITabs::captureVisibleTab(WebPageProxyIdentifier webPageProxyI
             return;
         }
 
-        if (result.value().isEmpty()) {
+        if (result.value().isNull()) {
             // This is a safer cpp false positive (rdar://163760990).
             SUPPRESS_UNCOUNTED_ARG callback->call(JSValueMakeString(callback->globalContext(), toJSString(emptyDataURLValue).get()));
             return;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -543,7 +543,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         // the blob. Deriving from the URL is correct since the main frame IS the top frame.
         bool shouldUseBlobRequesterTopOrigin = request.url().protocolIsBlob()
             && resourceLoader.documentLoader()
-            && !resourceLoader.documentLoader()->triggeringAction().isEmpty()
+            && !resourceLoader.documentLoader()->triggeringAction().isNull()
             && resourceLoader.documentLoader()->triggeringAction().requester()
             && resourceLoader.documentLoader()->triggeringAction().type() != NavigationType::BackForward;
         if (shouldUseBlobRequesterTopOrigin)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -415,7 +415,7 @@ void PluginView::initializePlugin()
     Ref plugin = m_plugin;
     plugin->setView(*this);
 
-    if (!m_shouldUseManualLoader && !m_mainResourceURL.isEmpty())
+    if (!m_shouldUseManualLoader && !m_mainResourceURL.isNull())
         loadMainResource();
 
     m_isInitialized = true;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1389,7 +1389,7 @@ void WebLocalFrameLoaderClient::updateGlobalHistoryRedirectLinks()
         return;
 
     RefPtr loader = m_localFrame->loader().documentLoader();
-    ASSERT(loader->unreachableURL().isEmpty());
+    ASSERT(loader->unreachableURL().isNull());
 
     // Client redirect
     if (!loader->clientRedirectSourceForHistory().isNull()) {
@@ -2126,7 +2126,7 @@ void WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold()
         return;
 
     auto url = document->url();
-    if (url.isEmpty())
+    if (url.isNull())
         return;
 
     WebLocalFrameLoaderClient_RELEASE_LOG(ResourceMonitoring, "didExceedNetworkUsageThreshold host=%" SENSITIVE_LOG_STRING, url.host().utf8().data());

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -369,7 +369,7 @@ void WebResourceLoadObserver::logWebSocketLoading(const URL& targetURL, const UR
 void WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution(const Document& document)
 {
     auto& url = document.url();
-    if (url.protocolIsAbout() || url.protocolIsFile() || url.isEmpty())
+    if (url.protocolIsAbout() || url.protocolIsFile() || url.isNull())
         return;
 
     RegistrableDomain topFrameDomain { url };

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -672,13 +672,13 @@ InteractionInformationAtPosition positionInformationForWebPage(WebPage& page, co
 #endif
 
 #if ENABLE(MODEL_ELEMENT)
-    if (RefPtr modelElement = dynamicDowncast<WebCore::HTMLModelElement>(hitTestNode); modelElement && !modelElement->currentSrc().isEmpty())
+    if (RefPtr modelElement = dynamicDowncast<WebCore::HTMLModelElement>(hitTestNode); modelElement && !modelElement->currentSrc().isNull())
         info.modelURL = modelElement->currentSrc();
 #endif
 
 #if ENABLE(PDF_PLUGIN) && PLATFORM(IOS_FAMILY)
     if (pluginView) {
-        if (auto&& [url, bounds, textIndicator] = pluginView->linkDataAtPoint(request.point); !url.isEmpty()) {
+        if (auto&& [url, bounds, textIndicator] = pluginView->linkDataAtPoint(request.point); !url.isNull()) {
             info.isLink = true;
             info.url = WTF::move(url);
             info.bounds = enclosingIntRect(bounds);

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -253,7 +253,7 @@ bool WebCookieJar::remoteCookiesEnabledSync(Document& document) const
         return false;
 
     auto cookieURL = document.cookieURL();
-    if (cookieURL.isEmpty())
+    if (cookieURL.isNull())
         return false;
 
     std::optional<FrameIdentifier> frameID = webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt;
@@ -274,7 +274,7 @@ void WebCookieJar::remoteCookiesEnabled(const Document& document, CompletionHand
         return completionHandler(false);
 
     auto cookieURL = document.cookieURL();
-    if (cookieURL.isEmpty())
+    if (cookieURL.isNull())
         return completionHandler(false);
 
     std::optional<FrameIdentifier> frameID = webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2030,7 +2030,7 @@ void WebPage::close()
     m_isClosed = true;
 
     // If there is still no URL, then we never loaded anything in this page, so nothing to report.
-    if (!m_mainFrame->url().isEmpty())
+    if (!m_mainFrame->url().isNull())
         reportUsedFeatures();
 
     if (WebProcess::singleton().injectedBundle())

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2572,7 +2572,7 @@ void WebPage::performActionOnElement(uint32_t action, const String& authorizatio
             URL urlToCopy;
             String titleToCopy;
             if (RefPtr linkElement = containingLinkAnchorElement(*element)) {
-                if (auto url = linkElement->href(); !url.isEmpty() && !url.protocolIsJavaScript()) {
+                if (auto url = linkElement->href(); !url.isNull() && !url.protocolIsJavaScript()) {
                     urlToCopy = url;
                     titleToCopy = linkElement->attributeWithoutSynchronization(HTMLNames::titleAttr);
                     if (!titleToCopy.length())

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -808,7 +808,7 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FrameIdentifier f
     };
 
     URL absoluteLinkURL = hitTestResult.absoluteLinkURL();
-    if (auto urlElement = RefPtr { hitTestResult.URLElement() }; !absoluteLinkURL.isEmpty() && urlElement) {
+    if (auto urlElement = RefPtr { hitTestResult.URLElement() }; !absoluteLinkURL.isNull() && urlElement) {
         auto elementRange = makeRangeSelectingNodeContents(*urlElement);
         immediateActionResult.linkTextIndicator = TextIndicator::createWithRange(elementRange, indicatorOptions(elementRange), TextIndicatorPresentationTransition::FadeIn);
     }

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -1222,7 +1222,7 @@ void WebPushDaemon::setAppBadge(PushClientConnection& connection, WebCore::Secur
     // FIXME: Establish the app page URL for Mac apps here
 #endif
 
-    if (!appPageURL.isEmpty()) {
+    if (!appPageURL.isNull()) {
         auto badgeOrigin = badgeOriginData.securityOrigin();
         auto appOrigin = WebCore::SecurityOrigin::create(appPageURL);
         if (!badgeOrigin->isSameSiteAs(appOrigin.get()))

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -473,7 +473,7 @@ WebHistoryItem *kit(HistoryItem* item)
 - (NSURL *)URL
 {
     const URL& url = core(_private)->url();
-    if (url.isEmpty())
+    if (url.isNull())
         return nil;
     return url.createNSURL().autorelease();
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1083,7 +1083,7 @@ void WebFrameLoaderClient::updateGlobalHistoryRedirectLinks()
     WebHistoryDelegateImplementationCache* implementations = [view.get() historyDelegate] ? WebViewGetHistoryDelegateImplementations(view.get()) : 0;
 
     auto* loader = core(m_webFrame.get())->loader().documentLoader();
-    ASSERT(loader->unreachableURL().isEmpty());
+    ASSERT(loader->unreachableURL().isNull());
 
     if (!loader->clientRedirectSourceForHistory().isNull()) {
         if (implementations) {

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -349,7 +349,7 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
 - (NSURL *)_URL
 {
     const URL& url = toPrivate(_private)->loader->url();
-    if (url.isEmpty())
+    if (url.isNull())
         return nil;
     return url.createNSURL().autorelease();
 }
@@ -516,7 +516,7 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
 - (NSURL *)unreachableURL
 {
     const URL& unreachableURL = toPrivate(_private)->loader->unreachableURL();
-    if (unreachableURL.isEmpty())
+    if (unreachableURL.isNull())
         return nil;
     return unreachableURL.createNSURL().autorelease();
 }

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -2490,9 +2490,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     // Some users of WebKit API incorrectly use "file path as URL" style requests which are invalid.
     // By re-writing those URLs here we technically break the -[WebDataSource initialRequest] API
     // but that is necessary to implement this quirk only at the API boundary.
-    // Note that other users of WebKit API use nil requests or requests with nil URLs or empty URLs, so we
-    // only implement this workaround when the request had a non-nil or non-empty URL.
-    if (!resourceRequest.url().isValid() && !resourceRequest.url().isEmpty())
+    // Note that other users of WebKit API use nil requests or requests with nil URLs, so we
+    // only implement this workaround when the request had a non-nil URL.
+    if (!resourceRequest.url().isValid() && !resourceRequest.url().isNull())
         resourceRequest.setURL([NSURL URLWithString:[@"file:" stringByAppendingString:[[request URL] absoluteString]]]);
 
     coreFrame->loader().load(WebCore::FrameLoadRequest(*coreFrame, WTF::move(resourceRequest)));

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -3563,12 +3563,12 @@ static RetainPtr<NSMenuItem> createShareMenuItem(const WebCore::HitTestResult& h
 {
     auto items = adoptNS([[NSMutableArray alloc] init]);
 
-    if (!hitTestResult.absoluteLinkURL().isEmpty()) {
+    if (!hitTestResult.absoluteLinkURL().isNull()) {
         RetainPtr absoluteLinkURL = hitTestResult.absoluteLinkURL().createNSURL();
         [items addObject:absoluteLinkURL.get()];
     }
 
-    if (!hitTestResult.absoluteMediaURL().isEmpty() && hitTestResult.isDownloadableMedia()) {
+    if (!hitTestResult.absoluteMediaURL().isNull() && hitTestResult.isDownloadableMedia()) {
         RetainPtr downloadableMediaURL = hitTestResult.absoluteMediaURL().createNSURL();
         [items addObject:downloadableMediaURL.get()];
     }
@@ -4367,7 +4367,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             return nil; 
 
         const URL& imageURL = page->dragController().draggingImageURL();
-        if (!imageURL.isEmpty())
+        if (!imageURL.isNull())
             draggingElementURL = imageURL.createNSURL();
 
         wrapper = [[self _dataSource] _fileWrapperForURL:draggingElementURL.get()];

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1916,7 +1916,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image textIndicator:WTF::move(textIndicator) scale:_private->page->deviceScaleFactor()]);
     else
         _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image scale:_private->page->deviceScaleFactor()]);
-    _private->draggedLinkURL = dragItem.url.isEmpty() ? RetainPtr<NSURL>() : dragItem.url.createNSURL();
+    _private->draggedLinkURL = dragItem.url.isNull() ? RetainPtr<NSURL>() : dragItem.url.createNSURL();
     _private->draggedLinkTitle = dragItem.title.isEmpty() ? nil : dragItem.title.createNSString().get();
     _private->dragPreviewFrameInRootViewCoordinates = dragItem.dragPreviewFrameInRootViewCoordinates;
     _private->dragSourceAction = kit(dragItem.sourceAction);

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -49,7 +49,6 @@ TEST_F(WTF_URL, URLConstructorDefault)
 {
     URL kurl;
 
-    EXPECT_TRUE(kurl.isEmpty());
     EXPECT_TRUE(kurl.isNull());
     EXPECT_FALSE(kurl.isValid());
 }
@@ -58,7 +57,6 @@ TEST_F(WTF_URL, URLConstructorConstChar)
 {
     URL kurl("http://username:password@www.example.com:8080/index.html?var=val#fragment"_s);
 
-    EXPECT_FALSE(kurl.isEmpty());
     EXPECT_FALSE(kurl.isNull());
     EXPECT_TRUE(kurl.isValid());
 
@@ -79,6 +77,24 @@ static URL createURL(ASCIILiteral urlAsString)
 {
     return URL(urlAsString);
 };
+
+TEST_F(WTF_URL, URLThreeStates)
+{
+    // Null URL: default-constructed, never set.
+    URL nullURL;
+    EXPECT_TRUE(nullURL.isNull());
+    EXPECT_FALSE(nullURL.isValid());
+
+    // Non-null invalid URL: parse was attempted but failed.
+    URL emptyURL(""_s);
+    EXPECT_FALSE(emptyURL.isNull());
+    EXPECT_FALSE(emptyURL.isValid());
+
+    // Non-null valid URL: parse succeeded.
+    URL validURL("https://example.com/"_s);
+    EXPECT_FALSE(validURL.isNull());
+    EXPECT_TRUE(validURL.isValid());
+}
 
 TEST_F(WTF_URL, URLProtocolHostAndPort)
 {

--- a/Tools/TestWebKitAPI/Tests/WebCore/PrivateClickMeasurement.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PrivateClickMeasurement.cpp
@@ -137,8 +137,8 @@ TEST(PrivateClickMeasurement, InvalidSourceHost)
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { emptyURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { WebCore::PCM::AttributionTriggerData::MaxEntropy, WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(WebCore::PCM::AttributionTriggerData::Priority::MaxEntropy), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
-    ASSERT_TRUE(attribution.attributionReportClickSourceURL().isEmpty());
-    ASSERT_TRUE(attribution.attributionReportClickDestinationURL().isEmpty());
+    ASSERT_TRUE(attribution.attributionReportClickSourceURL().isNull());
+    ASSERT_TRUE(attribution.attributionReportClickDestinationURL().isNull());
 }
 
 TEST(PrivateClickMeasurement, InvalidDestinationHost)
@@ -146,8 +146,8 @@ TEST(PrivateClickMeasurement, InvalidDestinationHost)
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { emptyURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { WebCore::PCM::AttributionTriggerData::MaxEntropy, WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(WebCore::PCM::AttributionTriggerData::Priority::MaxEntropy), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
-    ASSERT_TRUE(attribution.attributionReportClickSourceURL().isEmpty());
-    ASSERT_TRUE(attribution.attributionReportClickDestinationURL().isEmpty());
+    ASSERT_TRUE(attribution.attributionReportClickSourceURL().isNull());
+    ASSERT_TRUE(attribution.attributionReportClickDestinationURL().isNull());
 }
 
 TEST(PrivateClickMeasurement, AttributionTriggerData)
@@ -155,8 +155,8 @@ TEST(PrivateClickMeasurement, AttributionTriggerData)
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { (WebCore::PCM::AttributionTriggerData::MaxEntropy + 1), WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(WebCore::PCM::AttributionTriggerData::Priority::MaxEntropy), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
-    ASSERT_TRUE(attribution.attributionReportClickSourceURL().isEmpty());
-    ASSERT_TRUE(attribution.attributionReportClickDestinationURL().isEmpty());
+    ASSERT_TRUE(attribution.attributionReportClickSourceURL().isNull());
+    ASSERT_TRUE(attribution.attributionReportClickDestinationURL().isNull());
 }
 
 TEST(PrivateClickMeasurement, InvalidPriority)
@@ -164,16 +164,16 @@ TEST(PrivateClickMeasurement, InvalidPriority)
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { WebCore::PCM::AttributionTriggerData::MaxEntropy, WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(WebCore::PCM::AttributionTriggerData::Priority::MaxEntropy + 1), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
-    ASSERT_TRUE(attribution.attributionReportClickSourceURL().isEmpty());
-    ASSERT_TRUE(attribution.attributionReportClickDestinationURL().isEmpty());
+    ASSERT_TRUE(attribution.attributionReportClickSourceURL().isNull());
+    ASSERT_TRUE(attribution.attributionReportClickDestinationURL().isNull());
 }
 
 TEST(PrivateClickMeasurement, InvalidMissingConversion)
 {
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
 
-    ASSERT_TRUE(attribution.attributionReportClickSourceURL().isEmpty());
-    ASSERT_TRUE(attribution.attributionReportClickDestinationURL().isEmpty());
+    ASSERT_TRUE(attribution.attributionReportClickSourceURL().isNull());
+    ASSERT_TRUE(attribution.attributionReportClickDestinationURL().isNull());
     ASSERT_FALSE(attribution.timesToSend().sourceEarliestTimeToSend && attribution.timesToSend().destinationEarliestTimeToSend);
 }
 


### PR DESCRIPTION
#### 57420d7d13cef27289cfe89eefe2cf2dfc93ed32
<pre>
Remove URL&apos;s isEmpty()
<a href="https://bugs.webkit.org/show_bug.cgi?id=312565">https://bugs.webkit.org/show_bug.cgi?id=312565</a>

Reviewed by NOBODY (OOPS!).

Ideally a URL would always be isValid() as it is in the specification,
but for performance reasons we also have to support the inverse. And
for conciseness we also want to keep isNull() around rather than
relying on std::optional. Similar to how we do with strings. But there
is no reason for isEmpty() to exist. That does not match anything in
the specification.

We remove isEmpty() checks where they were redundant with isValid()
checks and replace the remainder with isNull(), except for:

- Document::downgradeReferrerToRegistrableDomain: here we only want to
  obtain a RegistrableDomain from an isValid() URL and the referrer
  could really be the empty string so isNull() would not quite cut it.
- In URLCF we replace the isEmpty() check by preserving behavior for
  legacy code, but otherwise align with the !isValid() code path.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57420d7d13cef27289cfe89eefe2cf2dfc93ed32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157036 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23563 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165859 "Hash 57420d7d for PR 62970 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111118 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ac86fa8-ae82-48eb-b836-38b0cf8aa61f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30375 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/165859 "Hash 57420d7d for PR 62970 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85393 "4 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3b2d1b8-c2ae-48c9-bdc4-63f3e624d8cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159994 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23862 "Found 2 new test failures: http/tests/security/aboutBlank/security-context-window-open.html http/tests/security/xss-DENIED-synchronous-frame-load-in-javascript-url.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141021 "Found 4 new API test failures: TestWebKitAPI.SiteIsolation.OpenAboutBlankFromAboutBlank, TestWebKitAPI.WebKit.PageLoadEmptyURL, TestWebKitAPI.WebArchive.SaveResourcesBlobURL, TestWebKitAPI.SiteIsolation.OpenEmptySiteFromProcessWithNonEmptySite (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/165859 "Hash 57420d7d for PR 62970 does not build (failure)") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22916 "Found 3 new test failures: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/creating_browsing_context_test_01.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/document-base-url-window-open-about-blank.https.window.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21145 "Found 4 new API test failures: TestWebKitAPI.SiteIsolation.OpenAboutBlankFromAboutBlank, TestWebKitAPI.WebKit.PageLoadEmptyURL, TestWebKitAPI.WebArchive.SaveResourcesBlobURL, TestWebKitAPI.SiteIsolation.OpenEmptySiteFromProcessWithNonEmptySite (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13631 "Hash 57420d7d for PR 62970 does not build (failure)") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149086 "Found 1 new JSC binary failure: testapi (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132597 "Found 3 new API test failures: TestWebKitAPI.SiteIsolation.OpenAboutBlankFromAboutBlank, TestWebKitAPI.WebArchive.SaveResourcesBlobURL, TestWebKitAPI.SiteIsolation.OpenEmptySiteFromProcessWithNonEmptySite (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18849 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168344 "Hash 57420d7d for PR 62970 does not build (failure)") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17871 "Found 1 new JSC binary failure: testapi (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12503 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20469 "Found 7 new test failures: http/tests/media/media-document-referer.html http/tests/security/aboutBlank/security-context-window-open.html http/tests/security/history-username-password.html http/tests/security/xss-DENIED-synchronous-frame-load-in-javascript-url.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/creating_browsing_context_test_01.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/document-base-url-window-open-about-blank.https.window.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/168344 "Hash 57420d7d for PR 62970 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29974 "Hash 57420d7d for PR 62970 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25223 "Found 7 new test failures: http/tests/media/media-document-referer.html http/tests/security/aboutBlank/security-context-window-open.html http/tests/security/history-username-password.html http/tests/security/xss-DENIED-synchronous-frame-load-in-javascript-url.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/creating_browsing_context_test_01.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/document-base-url-window-open-about-blank.https.window.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/168344 "Hash 57420d7d for PR 62970 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29897 "Hash 57420d7d for PR 62970 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140643 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87705 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/29897 "Hash 57420d7d for PR 62970 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17447 "Found 7 new test failures: http/tests/media/media-document-referer.html http/tests/security/aboutBlank/security-context-window-open.html http/tests/security/history-username-password.html http/tests/security/xss-DENIED-synchronous-frame-load-in-javascript-url.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/creating_browsing_context_test_01.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/document-base-url-window-open-about-blank.https.window.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188999 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93622 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48517 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29130 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29360 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->