### PR TITLE
Fix some :has() sibling invalidation issue

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-invalidation-first-in-sibling-chain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-invalidation-first-in-sibling-chain-expected.txt
@@ -1,9 +1,9 @@
 
 PASS subject1 Initial color
-FAIL #subject1 invalidated after adding first sibling assert_equals: expected "rgb(255, 0, 0)" but got "rgb(128, 128, 128)"
+PASS #subject1 invalidated after adding first sibling
 PASS #subject1 invalidated after removing first sibling
 PASS subject2 Initial color
-FAIL #subject2 invalidated after adding first sibling assert_equals: expected "rgb(255, 69, 0)" but got "rgb(128, 128, 128)"
+PASS #subject2 invalidated after adding first sibling
 PASS #subject2 invalidated after removing first sibling
 PASS subject3 Initial color
 FAIL #subject3 invalidated after adding first sibling assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-sibling-insertion-removal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-sibling-insertion-removal-expected.txt
@@ -8,7 +8,7 @@ FAIL subject3: color after #sibling3_1 inserted should be rgb(0, 0, 255) assert_
 PASS subject4: initial color should be rgb(128, 128, 128)
 FAIL subject4: color after #sibling4_1 removed should be rgb(255, 255, 0) assert_equals: expected "rgb(255, 255, 0)" but got "rgb(128, 128, 128)"
 PASS subject5: initial color should be rgb(255, 0, 0)
-FAIL subject5: color after #sibling5_1 removed should be rgb(128, 128, 128) assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
+PASS subject5: color after #sibling5_1 removed should be rgb(128, 128, 128)
 PASS subject6: initial color should be rgb(0, 128, 0)
 FAIL subject6: color after #sibling6_1 inserted should be rgb(128, 128, 128) assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 128, 0)"
 PASS subject7: initial color should be rgb(0, 0, 255)
@@ -18,7 +18,7 @@ FAIL subject8: color after #sibling8_1 inserted should be rgb(128, 128, 128) ass
 PASS subject9: initial color should be rgb(128, 128, 128)
 FAIL subject9: color after #sibling9_1 inserted should be rgb(255, 0, 0) assert_equals: expected "rgb(255, 0, 0)" but got "rgb(128, 128, 128)"
 PASS subject10: initial color should be rgb(128, 128, 128)
-FAIL subject10: color after #sibling10_1 removed should be rgb(0, 128, 0) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS subject10: color after #sibling10_1 removed should be rgb(0, 128, 0)
 PASS subject11: initial color should be rgb(128, 128, 128)
 FAIL subject11: color after #sibling11_1 inserted should be rgb(0, 0, 255) assert_equals: expected "rgb(0, 0, 255)" but got "rgb(128, 128, 128)"
 PASS subject12: initial color should be rgb(128, 128, 128)
@@ -26,5 +26,5 @@ FAIL subject12: color after #sibling12_1 removed should be rgb(255, 255, 0) asse
 PASS subject13: initial color should be rgb(128, 128, 128)
 FAIL subject13: color after #sibling12_1 removed should be rgb(0, 128, 0) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
 PASS subject14: initial color should be rgb(0, 128, 0)
-FAIL subject14: color after #sibling14_2 removed should be rgb(128, 128, 128) assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 128, 0)"
+PASS subject14: color after #sibling14_2 removed should be rgb(128, 128, 128)
 

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1631,23 +1631,31 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
         switch (relation.type) {
         case Style::Relation::ChildrenAffectedByForwardPositionalRules:
         case Style::Relation::ChildrenAffectedByBackwardPositionalRules:
-            checkingContext.styleRelations.append(Style::Relation { *relation.element, Style::Relation::AffectedByHasWithPositionalPseudoClass });
+            checkingContext.styleRelations.append(Style::Relation { *relation.element, Style::Relation::AffectedByHasWithSiblingRelationship });
             return;
         case Style::Relation::ChildrenAffectedByFirstChildRules:
         case Style::Relation::ChildrenAffectedByLastChildRules:
             checkingContext.styleRelations.append(relation);
             return;
         case Style::Relation::AffectedByEmpty:
+            return;
         case Style::Relation::AffectedByPreviousSibling:
-        case Style::Relation::DescendantsAffectedByPreviousSibling:
         case Style::Relation::AffectsNextSibling:
+            if (CheckedPtr parent = relation.element->parentElement())
+                checkingContext.styleRelations.append(Style::Relation { *parent, Style::Relation::AffectedByHasWithAdjacentSiblingRelationship });
+            return;
+        case Style::Relation::DescendantsAffectedByPreviousSibling:
+            if (CheckedPtr parent = relation.element->parentElement())
+                checkingContext.styleRelations.append(Style::Relation { *parent, Style::Relation::AffectedByHasWithSiblingRelationship });
+            return;
         case Style::Relation::DescendantsAffectedByForwardPositionalRules:
         case Style::Relation::DescendantsAffectedByBackwardPositionalRules:
         case Style::Relation::FirstChild:
         case Style::Relation::LastChild:
         case Style::Relation::NthChildIndex:
             return;
-        case Style::Relation::AffectedByHasWithPositionalPseudoClass:
+        case Style::Relation::AffectedByHasWithSiblingRelationship:
+        case Style::Relation::AffectedByHasWithAdjacentSiblingRelationship:
             ASSERT_NOT_REACHED();
             return;
         }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5818,7 +5818,8 @@ void Element::resetComputedStyle()
 void Element::resetStyleRelations()
 {
     clearStyleFlags(NodeStyleFlag::StyleAffectedByEmpty);
-    clearStyleFlags(NodeStyleFlag::AffectedByHasWithPositionalPseudoClass);
+    clearStyleFlags(NodeStyleFlag::AffectedByHasWithSiblingRelationship);
+    clearStyleFlags(NodeStyleFlag::AffectedByHasWithAdjacentSiblingRelationship);
     if (!hasRareData())
         return;
     elementRareData()->setChildIndex(0);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -545,7 +545,8 @@ public:
     bool descendantsAffectedByBackwardPositionalRules() const { return hasStyleFlag(NodeStyleFlag::DescendantsAffectedByBackwardPositionalRules); }
     bool affectsNextSiblingElementStyle() const { return hasStyleFlag(NodeStyleFlag::AffectsNextSiblingElementStyle); }
     bool styleIsAffectedByPreviousSibling() const { return hasStyleFlag(NodeStyleFlag::StyleIsAffectedByPreviousSibling); }
-    bool affectedByHasWithPositionalPseudoClass() const { return hasStyleFlag(NodeStyleFlag::AffectedByHasWithPositionalPseudoClass); }
+    bool affectedByHasWithSiblingRelationship() const { return hasStyleFlag(NodeStyleFlag::AffectedByHasWithSiblingRelationship); }
+    bool affectedByHasWithAdjacentSiblingRelationship() const { return hasStyleFlag(NodeStyleFlag::AffectedByHasWithAdjacentSiblingRelationship); }
     unsigned childIndex() const { return hasRareData() ? rareDataChildIndex() : 0; }
 
     bool NODELETE hasFlagsSetDuringStylingOfChildren() const;
@@ -560,7 +561,8 @@ public:
     void setDescendantsAffectedByBackwardPositionalRules() { setStyleFlag(NodeStyleFlag::DescendantsAffectedByBackwardPositionalRules); }
     void setAffectsNextSiblingElementStyle() { setStyleFlag(NodeStyleFlag::AffectsNextSiblingElementStyle); }
     void setStyleIsAffectedByPreviousSibling() { setStyleFlag(NodeStyleFlag::StyleIsAffectedByPreviousSibling); }
-    void setAffectedByHasWithPositionalPseudoClass() { setStyleFlag(NodeStyleFlag::AffectedByHasWithPositionalPseudoClass); }
+    void setAffectedByHasWithSiblingRelationship() { setStyleFlag(NodeStyleFlag::AffectedByHasWithSiblingRelationship); }
+    void setAffectedByHasWithAdjacentSiblingRelationship() { setStyleFlag(NodeStyleFlag::AffectedByHasWithAdjacentSiblingRelationship); }
     void setChildIndex(unsigned);
 
     const AtomString& effectiveLang() const;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -715,7 +715,7 @@ protected:
         DescendantNeedsStyleResolution                          = 1 << 0,
         DirectChildNeedsStyleResolution                         = 1 << 1,
 
-        AffectedByHasWithPositionalPseudoClass                  = 1 << 2,
+        AffectedByHasWithSiblingRelationship                    = 1 << 2,
         ChildrenAffectedByFirstChildRules                       = 1 << 3,
         ChildrenAffectedByLastChildRules                        = 1 << 4,
         AffectsNextSiblingElementStyle                          = 1 << 5,
@@ -728,6 +728,7 @@ protected:
         DescendantsAffectedByForwardPositionalRules             = 1 << 10,
         ChildrenAffectedByBackwardPositionalRules               = 1 << 11,
         DescendantsAffectedByBackwardPositionalRules            = 1 << 12,
+        AffectedByHasWithAdjacentSiblingRelationship            = 1 << 13,
     };
 
     struct StyleBitfields {

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -184,10 +184,15 @@ void ChildChangeInvalidation::invalidateForHasBeforeMutation()
         return false;
     };
 
-    if (parentElement().affectedByHasWithPositionalPseudoClass()) {
+    if (parentElement().affectedByHasWithSiblingRelationship()) {
         traverseRemainingExistingSiblings([&](auto& changedElement) {
             invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::Sibling);
         });
+    } else if (parentElement().affectedByHasWithAdjacentSiblingRelationship()) {
+        if (m_childChange.previousSiblingElement)
+            invalidateForChangedElement(*m_childChange.previousSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
+        if (m_childChange.nextSiblingElement)
+            invalidateForChangedElement(*m_childChange.nextSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
     } else {
         if (firstChildStateWillStopMatching())
             invalidateForChangedElement(*m_childChange.nextSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
@@ -244,10 +249,15 @@ void ChildChangeInvalidation::invalidateForHasAfterMutation()
         return false;
     };
 
-    if (parentElement().affectedByHasWithPositionalPseudoClass()) {
+    if (parentElement().affectedByHasWithSiblingRelationship()) {
         traverseRemainingExistingSiblings([&](auto& changedElement) {
             invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::Sibling);
         });
+    } else if (parentElement().affectedByHasWithAdjacentSiblingRelationship()) {
+        if (m_childChange.previousSiblingElement)
+            invalidateForChangedElement(*m_childChange.previousSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
+        if (m_childChange.nextSiblingElement)
+            invalidateForChangedElement(*m_childChange.nextSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
     } else {
         if (firstChildStateWillStartMatching(m_childChange.nextSiblingElement))
             invalidateForChangedElement(*m_childChange.nextSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);

--- a/Source/WebCore/style/StyleRelations.cpp
+++ b/Source/WebCore/style/StyleRelations.cpp
@@ -72,7 +72,8 @@ std::unique_ptr<Relations> commitRelationsToRenderStyle(RenderStyle& style, cons
         case Relation::ChildrenAffectedByFirstChildRules:
         case Relation::ChildrenAffectedByLastChildRules:
         case Relation::NthChildIndex:
-        case Relation::AffectedByHasWithPositionalPseudoClass:
+        case Relation::AffectedByHasWithSiblingRelationship:
+        case Relation::AffectedByHasWithAdjacentSiblingRelationship:
             appendStyleRelation(relation);
             break;
         }
@@ -120,8 +121,11 @@ void commitRelations(std::unique_ptr<Relations> relations, Update& update)
         case Relation::ChildrenAffectedByLastChildRules:
             element.setChildrenAffectedByLastChildRules();
             break;
-        case Relation::AffectedByHasWithPositionalPseudoClass:
-            element.setAffectedByHasWithPositionalPseudoClass();
+        case Relation::AffectedByHasWithSiblingRelationship:
+            element.setAffectedByHasWithSiblingRelationship();
+            break;
+        case Relation::AffectedByHasWithAdjacentSiblingRelationship:
+            element.setAffectedByHasWithAdjacentSiblingRelationship();
             break;
         case Relation::FirstChild:
             if (auto* style = update.elementStyle(element))

--- a/Source/WebCore/style/StyleRelations.h
+++ b/Source/WebCore/style/StyleRelations.h
@@ -52,7 +52,8 @@ struct Relation {
         FirstChild,
         LastChild,
         NthChildIndex,
-        AffectedByHasWithPositionalPseudoClass,
+        AffectedByHasWithSiblingRelationship,
+        AffectedByHasWithAdjacentSiblingRelationship,
     };
     const Element* element;
     Type type;


### PR DESCRIPTION
#### 23eb17162e9e8714c648599fcf1f96a37e68b713
<pre>
Fix some :has() sibling invalidation issue
<a href="https://bugs.webkit.org/show_bug.cgi?id=312568">https://bugs.webkit.org/show_bug.cgi?id=312568</a>
<a href="https://rdar.apple.com/175006235">rdar://175006235</a>

Reviewed by Alan Baradlay.

Fix invalidation in cases like :has(.a + .b)

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-invalidation-first-in-sibling-chain-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-sibling-insertion-removal-expected.txt:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchHasPseudoClass const):

Forward AffectedByPreviousSibling, AffectsNextSibling, DescendantsAffectedByPreviousSibling relations.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resetStyleRelations):
=* Source/WebCore/dom/Element.cpp:
=(WebCore::Element::resetStyleRelations):
=* Source/WebCore/dom/Element.h:
=(WebCore::Element::affectedByHasWithSiblingRelationship const):
=(WebCore::Element::affectedByHasWithAdjacentSiblingRelationship const):
=(WebCore::Element::setAffectedByHasWithSiblingRelationship):
=(WebCore::Element::setAffectedByHasWithAdjacentSiblingRelationship):
=(WebCore::Element::affectedByHasWithPositionalPseudoClass const): Deleted.
=(WebCore::Element::setAffectedByHasWithPositionalPseudoClass): Deleted.
=* Source/WebCore/dom/Node.h:
=* Source/WebCore/style/ChildChangeInvalidation.cpp:
=(WebCore::Style::ChildChangeInvalidation::invalidateForHasBeforeMutation):
=(WebCore::Style::ChildChangeInvalidation::invalidateForHasAfterMutation):
=* Source/WebCore/style/StyleRelations.cpp:
=(WebCore::Style::commitRelationsToRenderStyle):
=(WebCore::Style::commitRelations):
=* Source/WebCore/style/StyleRelations.h:

Rename since the value is used for more than just positional pseudo-classes.
Add a new value for the direct adjacent case where we don&apos;t need to check all siblings.

Canonical link: <a href="https://commits.webkit.org/311583@main">https://commits.webkit.org/311583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0b0915e1c631238134dd5d2a304f8c29298297e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166260 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111518 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87b50c0c-a938-4b6c-a449-3c7508d43ab7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30775 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85631 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce802391-e671-4862-8e0a-ef3fc07a49b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141369 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5275c57e-3ef9-4a68-915a-0ee6216b29d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23244 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21495 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14031 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168745 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12903 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130071 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130178 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35256 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140991 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88232 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25008 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17796 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30008 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94022 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29530 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29760 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29657 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->