### PR TITLE
[threaded-animations] animating incompatible filter values across multiple effects yields a CAPresentationModifier exception

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/composition-of-incompatible-filters-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/composition-of-incompatible-filters-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Composing incompatible filter values throughout multiple effects does not allow acceleration.
+

--- a/LayoutTests/webanimations/threaded-animations/composition-of-incompatible-filters.html
+++ b/LayoutTests/webanimations/threaded-animations/composition-of-incompatible-filters.html
@@ -1,0 +1,38 @@
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<style>
+
+@keyframes hue-rotate {
+    to { filter: hue-rotate(180deg) }
+}
+
+@keyframes contrast {
+    to { filter: contrast(0%) }
+}
+
+#target {
+    animation-name: contrast, hue-rotate;
+    animation-duration: 1000s;
+}
+
+</style>
+
+<div id="target"></div>
+
+<script>
+
+promise_test(async test => {
+    // Wait until the animations are commited to the remote layer tree.
+    await Promise.all(target.getAnimations().map(animation => animation.ready));
+    await threadedAnimationsCommit();
+
+    assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 0);
+
+    // Wait one more frame for remote effects to be applied to ensure that
+    // the remote layer tree is in a consistent state and does not crash.
+    await new Promise(requestAnimationFrame);
+}, "Composing incompatible filter values throughout multiple effects does not allow acceleration.");
+
+</script>

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4645,10 +4645,19 @@ void RenderLayerBacking::updateAcceleratedEffectsAndBaseValues(HashSet<Ref<Accel
                 allAcceleratedProperties.add(acceleratedProperties);
                 if (effect->isRunningAccelerated())
                     interpolatingProperties.add(acceleratedProperties);
-                if (!hasEffectAffectingFilter && acceleratedProperties.contains(AcceleratedEffectProperty::Filter))
+                // We can only handle one effect in the stack targeting the filter and backdrop-filter properties
+                // because of the complexities involved with possibly blending across multiple filter types. Since
+                // this is bound to be rare, it's a lot easier to simply disallow acceleration in this case.
+                if (acceleratedProperties.contains(AcceleratedEffectProperty::Filter)) {
+                    if (hasEffectAffectingFilter && !replacedAcceleratedProperties.contains(AcceleratedEffectProperty::Filter))
+                        disallowedAcceleratedProperties.add(AcceleratedEffectProperty::Filter);
                     hasEffectAffectingFilter = true;
-                if (!hasEffectAffectingBackdropFilter && acceleratedProperties.contains(AcceleratedEffectProperty::BackdropFilter))
+                }
+                if (acceleratedProperties.contains(AcceleratedEffectProperty::BackdropFilter)) {
+                    if (hasEffectAffectingBackdropFilter && !replacedAcceleratedProperties.contains(AcceleratedEffectProperty::BackdropFilter))
+                        disallowedAcceleratedProperties.add(AcceleratedEffectProperty::BackdropFilter);
                     hasEffectAffectingBackdropFilter = true;
+                }
                 effectTimelines.add(Ref { *acceleratedEffect->timeline() });
                 acceleratedEffects.append(WTF::move(acceleratedEffect));
             }
@@ -4659,7 +4668,7 @@ void RenderLayerBacking::updateAcceleratedEffectsAndBaseValues(HashSet<Ref<Accel
     acceleratedEffects.reverse();
 
     // Now let's prune any effect that only animates a non-interpolating property.
-    auto nonInterpolatingProperties = allAcceleratedProperties ^ interpolatingProperties;
+    auto nonInterpolatingProperties = allAcceleratedProperties ^ interpolatingProperties ^ disallowedAcceleratedProperties;
     if (!nonInterpolatingProperties.isEmpty()) {
         // Make a copy of our current list of effects and clear the the original list as well
         // as the set of timelines. We'll re-populate both without effects that are only animating


### PR DESCRIPTION
#### c9feb0cc3bfd35f3933bcd94d1f8deebb0918f49
<pre>
[threaded-animations] animating incompatible filter values across multiple effects yields a CAPresentationModifier exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=312569">https://bugs.webkit.org/show_bug.cgi?id=312569</a>
<a href="https://rdar.apple.com/172747293">rdar://172747293</a>

Reviewed by Sam Weinig.

We have a system to disallow the acceleration of filter properties if we are not able to successfully
interpolate them with a single `CAPresentationModifier` in the remote layer tree, but this system only
is able to reason within the scope of a single accelerated effect. However, it is possible for an effect
stack to compose filters such that they are individually blending to supported configurations but will not
blend when composing.

Correctly determining if we are in such a situation is complex since we&apos;d essentially have to resolve
all possible keyframe combinations throughout the stack accounting for relative timing, iterations, etc.

Since the composition of animations targeting `filter` or `backdrop-filter` is very unlikely to be found
in Web content, we can simply disallow threaded animations of such properties if we have more than a single
effect in an accelerated effect stack. As such, we adjust `RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()`
to track those properties in `disallowedAcceleratedProperties` and correctly subtract them from `allAcceleratedProperties`
when computing `nonInterpolatingProperties`, allowing for any effects targeting those properties to be
removed from the stack.

Test: webanimations/threaded-animations/composition-of-incompatible-filters.html

* LayoutTests/webanimations/threaded-animations/composition-of-incompatible-filters-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/composition-of-incompatible-filters.html: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):

Canonical link: <a href="https://commits.webkit.org/311468@main">https://commits.webkit.org/311468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/735b1d375e94abd53efed6f6feff468b744101f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157064 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30400 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165887 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111146 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84e7df8f-a3de-498b-851f-5126a9a77837) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121640 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/beb0cc30-9d78-4ee2-b3dd-a9ddd3d72d14) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102308 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa9ad22e-85ae-472c-8f64-ca9cc6fb183e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22943 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21168 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13659 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168372 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12531 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129764 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129872 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140664 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87746 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23903 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24704 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17468 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93650 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29158 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29388 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29285 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->