### PR TITLE
SVGTests::isValid() does not correctly implement systemLanguage matching per SVG2

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-matching-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-matching-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Exact match with navigator.language renders the element
+PASS Case-insensitive exact match renders the element
+PASS Non-matching language tag does not render
+PASS Empty systemLanguage evaluates to false
+PASS Absent systemLanguage evaluates to true
+PASS Comma-separated list with matching tag first renders
+PASS Comma-separated list with matching tag second renders
+PASS Comma-separated list with matching tag in the middle renders
+PASS Comma-separated list with no matching tag does not render
+PASS BCP 47 prefix matching: user language prefix matches listed tag with extra subtag
+PASS switch element: first matching child renders, others do not
+PASS switch element: skips non-matching, renders first match
+PASS switch element: fallback child without systemLanguage renders when no match
+PASS switch element: nothing renders when no child matches and no fallback
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-matching.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-matching.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<title>systemLanguage attribute matching per BCP 47 basic filtering</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#ConditionalProcessingSystemLanguageAttribute">
+<link rel="help" href="https://www.rfc-editor.org/rfc/rfc4647#section-3.3.1">
+<meta name="assert" content="The systemLanguage attribute evaluates to true if any user preferred language matches any listed tag per BCP 47 basic filtering.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="svg" width="400" height="400" style="position: absolute; top: -9999px;">
+</svg>
+<script>
+const svgNS = "http://www.w3.org/2000/svg";
+const svg = document.getElementById("svg");
+const userLang = navigator.language;
+
+function isRendered(el) {
+    const bbox = el.getBoundingClientRect();
+    return bbox.width > 0 && bbox.height > 0;
+}
+
+function createRect(systemLanguage) {
+    const rect = document.createElementNS(svgNS, "rect");
+    rect.setAttribute("width", "10");
+    rect.setAttribute("height", "10");
+    if (systemLanguage !== null)
+        rect.setAttribute("systemLanguage", systemLanguage);
+    svg.appendChild(rect);
+    return rect;
+}
+
+function createSwitchWithRects(langList) {
+    const sw = document.createElementNS(svgNS, "switch");
+    const rects = [];
+    for (const lang of langList) {
+        const rect = document.createElementNS(svgNS, "rect");
+        rect.setAttribute("width", "10");
+        rect.setAttribute("height", "10");
+        if (lang !== null)
+            rect.setAttribute("systemLanguage", lang);
+        sw.appendChild(rect);
+        rects.push(rect);
+    }
+    svg.appendChild(sw);
+    return rects;
+}
+
+test(() => {
+    const el = createRect(userLang);
+    assert_true(isRendered(el), `systemLanguage="${userLang}" should match user language "${userLang}"`);
+}, "Exact match with navigator.language renders the element");
+
+test(() => {
+    const el = createRect(userLang.toUpperCase());
+    assert_true(isRendered(el), `systemLanguage="${userLang.toUpperCase()}" should match "${userLang}" case-insensitively`);
+}, "Case-insensitive exact match renders the element");
+
+test(() => {
+    const el = createRect("x-nonexistent");
+    assert_false(isRendered(el), `systemLanguage="x-nonexistent" should not match`);
+}, "Non-matching language tag does not render");
+
+test(() => {
+    const el = createRect("");
+    assert_false(isRendered(el), `systemLanguage="" should evaluate to false`);
+}, "Empty systemLanguage evaluates to false");
+
+test(() => {
+    const el = createRect(null);
+    assert_true(isRendered(el), "Element without systemLanguage should render");
+}, "Absent systemLanguage evaluates to true");
+
+test(() => {
+    const el = createRect(userLang + ", x-nonexistent");
+    assert_true(isRendered(el), `systemLanguage="${userLang}, x-nonexistent" should match`);
+}, "Comma-separated list with matching tag first renders");
+
+test(() => {
+    const el = createRect("x-nonexistent, " + userLang);
+    assert_true(isRendered(el), `systemLanguage="x-nonexistent, ${userLang}" should match`);
+}, "Comma-separated list with matching tag second renders");
+
+test(() => {
+    const el = createRect("x-aa, x-bb, " + userLang + ", x-cc");
+    assert_true(isRendered(el), "Any matching tag in a list should suffice");
+}, "Comma-separated list with matching tag in the middle renders");
+
+test(() => {
+    const el = createRect("x-aa, x-bb, x-cc");
+    assert_false(isRendered(el), "No matching tag in list");
+}, "Comma-separated list with no matching tag does not render");
+
+test(() => {
+    const el = createRect(userLang + "-subtag");
+    assert_true(isRendered(el),
+        `User language "${userLang}" should prefix-match "${userLang}-subtag"`);
+}, "BCP 47 prefix matching: user language prefix matches listed tag with extra subtag");
+
+test(() => {
+    const rects = createSwitchWithRects([userLang, "x-nonexistent"]);
+    assert_true(isRendered(rects[0]), "First matching child should render");
+    assert_false(isRendered(rects[1]), "Second child should not render");
+}, "switch element: first matching child renders, others do not");
+
+test(() => {
+    const rects = createSwitchWithRects(["x-nonexistent", userLang]);
+    assert_false(isRendered(rects[0]), "Non-matching first child should not render");
+    assert_true(isRendered(rects[1]), "Matching second child should render");
+}, "switch element: skips non-matching, renders first match");
+
+test(() => {
+    const rects = createSwitchWithRects(["x-aa", "x-bb", null]);
+    assert_false(isRendered(rects[0]), "Non-matching first child");
+    assert_false(isRendered(rects[1]), "Non-matching second child");
+    assert_true(isRendered(rects[2]), "Fallback child without systemLanguage renders");
+}, "switch element: fallback child without systemLanguage renders when no match");
+
+test(() => {
+    const rects = createSwitchWithRects(["x-aa", "x-bb"]);
+    assert_false(isRendered(rects[0]), "Non-matching first child");
+    assert_false(isRendered(rects[1]), "Non-matching second child");
+}, "switch element: nothing renders when no child matches and no fallback");
+</script>

--- a/LayoutTests/svg/dom/systemLanguage-matching-expected.txt
+++ b/LayoutTests/svg/dom/systemLanguage-matching-expected.txt
@@ -1,0 +1,29 @@
+systemLanguage matches against the same primary user language that navigator.language exposes. Parent language tags are synthesized from the primary language per the SVG2 5.6.5 implementation note.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+--- User language en-US: parent-tag synthesis matches en, en-US, en-Latn-US ---
+PASS isRendered(createRect("en")) is true
+PASS isRendered(createRect("en-US")) is true
+PASS isRendered(createRect("en-Latn-US")) is true
+PASS isRendered(createRect("eng")) is false
+PASS isRendered(createRect("fr")) is false
+
+--- User language zh-Hans-CN: parent-tag synthesis matches zh, zh-Hans, zh-Hans-CN ---
+PASS isRendered(createRect("zh")) is true
+PASS isRendered(createRect("zh-Hans")) is true
+PASS isRendered(createRect("zh-Hans-CN")) is true
+PASS isRendered(createRect("zh-Hant")) is true
+
+--- Privacy: only the primary user language is matched, not secondary preferences ---
+PASS isRendered(createRect("fr")) is true
+PASS isRendered(createRect("fr-FR")) is true
+PASS isRendered(createRect("en")) is false
+PASS isRendered(createRect("en-US")) is false
+PASS isRendered(createRect("ja")) is false
+PASS isRendered(createRect("ja-JP")) is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/dom/systemLanguage-matching.html
+++ b/LayoutTests/svg/dom/systemLanguage-matching.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<title>systemLanguage matches only the primary user language, with parent-tag synthesis</title>
+<script src="../../resources/js-test.js"></script>
+<svg id="svg" width="400" height="400" style="position: absolute; top: -9999px;">
+</svg>
+<script>
+description("systemLanguage matches against the same primary user language that navigator.language exposes. Parent language tags are synthesized from the primary language per the SVG2 5.6.5 implementation note.");
+
+const svgNS = "http://www.w3.org/2000/svg";
+const svg = document.getElementById("svg");
+let savedLanguages;
+
+function isRendered(el) {
+    const bbox = el.getBoundingClientRect();
+    return bbox.width > 0 && bbox.height > 0;
+}
+
+function createRect(systemLanguage) {
+    const rect = document.createElementNS(svgNS, "rect");
+    rect.setAttribute("width", "10");
+    rect.setAttribute("height", "10");
+    rect.setAttribute("systemLanguage", systemLanguage);
+    svg.appendChild(rect);
+    return rect;
+}
+
+function setLanguages(langs) {
+    while (svg.firstChild)
+        svg.removeChild(svg.firstChild);
+    internals.setUserPreferredLanguages(langs);
+}
+
+function cleanup() {
+    while (svg.firstChild)
+        svg.removeChild(svg.firstChild);
+    internals.setUserPreferredLanguages(savedLanguages);
+}
+
+if (window.internals) {
+    savedLanguages = internals.userPreferredLanguages();
+
+    debug("--- User language en-US: parent-tag synthesis matches en, en-US, en-Latn-US ---");
+
+    setLanguages(["en-US"]);
+    shouldBeTrue('isRendered(createRect("en"))');
+    shouldBeTrue('isRendered(createRect("en-US"))');
+    shouldBeTrue('isRendered(createRect("en-Latn-US"))');
+    shouldBeFalse('isRendered(createRect("eng"))');
+    shouldBeFalse('isRendered(createRect("fr"))');
+
+    debug("");
+    debug("--- User language zh-Hans-CN: parent-tag synthesis matches zh, zh-Hans, zh-Hans-CN ---");
+
+    setLanguages(["zh-Hans-CN"]);
+    shouldBeTrue('isRendered(createRect("zh"))');
+    shouldBeTrue('isRendered(createRect("zh-Hans"))');
+    shouldBeTrue('isRendered(createRect("zh-Hans-CN"))');
+    // FIXME: RFC 4647 Basic Filtering with parent language tags causes "zh" to
+    // match "zh-Hant" even when the user prefers "zh-Hans". Extended Filtering
+    // (RFC 4647 3.3.2) would be script-aware but SVG2 specifies Basic Filtering.
+    // This matches Chrome and Firefox behavior.
+    shouldBeTrue('isRendered(createRect("zh-Hant"))');
+
+    debug("");
+    debug("--- Privacy: only the primary user language is matched, not secondary preferences ---");
+
+    setLanguages(["fr-FR", "en-US", "ja-JP"]);
+    // Primary "fr-FR" — matches and synthesizes parent "fr".
+    shouldBeTrue('isRendered(createRect("fr"))');
+    shouldBeTrue('isRendered(createRect("fr-FR"))');
+    // Secondary "en-US" — must NOT match. Matching would let a page probe the
+    // user's preference list with finer granularity than navigator.languages.
+    shouldBeFalse('isRendered(createRect("en"))');
+    shouldBeFalse('isRendered(createRect("en-US"))');
+    // Tertiary "ja-JP" — must NOT match for the same reason.
+    shouldBeFalse('isRendered(createRect("ja"))');
+    shouldBeFalse('isRendered(createRect("ja-JP"))');
+
+    cleanup();
+} else {
+    testFailed("This test requires window.internals");
+}
+</script>

--- a/Source/WebCore/svg/SVGTests.cpp
+++ b/Source/WebCore/svg/SVGTests.cpp
@@ -29,7 +29,6 @@
 #include "SVGPropertyOwnerRegistry.h"
 #include "SVGStringList.h"
 #include <wtf/Language.h>
-#include <wtf/SortedArrayMap.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MATHML)
@@ -68,18 +67,50 @@ bool SVGTests::hasExtension(const String& extension)
     return extension == HTMLNames::xhtmlNamespaceURI;
 }
 
+// FIXME: RFC 4647 Basic Filtering with parent language tags can cause cross-script
+// matches (e.g., "zh" matching "zh-Hant" when user prefers "zh-Hans"). Consider
+// Extended Filtering (RFC 4647 3.3.2) for script-aware matching.
+static bool matchesLanguageTag(StringView range, StringView tag)
+{
+    if (range.isEmpty())
+        return false;
+    if (range.length() == tag.length())
+        return equalIgnoringASCIICase(range, tag);
+    return range.length() < tag.length()
+        && tag[range.length()] == '-'
+        && equalIgnoringASCIICase(range, tag.left(range.length()));
+}
+
+// SVG2 5.6.5 implementation note: try the full user language tag, then iteratively
+// strip subtags to synthesize parent language tags (e.g. "zh-Hans-CN" → "zh-Hans" → "zh").
+static bool userLanguageMatchesAnyListedTag(StringView userLanguage, const Vector<String>& listedTags)
+{
+    for (StringView range = userLanguage; !range.isEmpty(); ) {
+        for (auto& listedTag : listedTags) {
+            if (matchesLanguageTag(range, listedTag))
+                return true;
+        }
+        auto hyphenIndex = range.reverseFind('-');
+        if (hyphenIndex == notFound)
+            return false;
+        range = range.left(hyphenIndex);
+    }
+    return false;
+}
+
 bool SVGTests::isValid() const
 {
     auto attributes = conditionalProcessingAttributesIfExists();
     if (!attributes)
         return true;
 
-    String defaultLanguage = WTF::defaultLanguage();
-    auto genericDefaultLanguage = StringView(defaultLanguage).left(2);
-    for (auto& language : attributes->systemLanguage().items()) {
-        if (language != genericDefaultLanguage)
+    auto& systemLanguageList = attributes->systemLanguage().items();
+    if (!systemLanguageList.isEmpty()) {
+        // Match against the same value navigator.language / navigator.languages exposes.
+        if (!userLanguageMatchesAnyListedTag(defaultLanguage(), systemLanguageList))
             return false;
     }
+
     for (auto& extension : attributes->requiredExtensions().items()) {
         if (!hasExtension(extension))
             return false;


### PR DESCRIPTION
#### bcfac781bec780c78e7ef90f71293d8792a1d517
<pre>
SVGTests::isValid() does not correctly implement systemLanguage matching per SVG2
<a href="https://bugs.webkit.org/show_bug.cgi?id=262140">https://bugs.webkit.org/show_bug.cgi?id=262140</a>
<a href="https://rdar.apple.com/116424326">rdar://116424326</a>

Reviewed by Nikolas Zimmermann and Anne van Kesteren.

SVGTests::isValid() did not correctly implement the systemLanguage
matching algorithm defined in SVG2 5.6.5 and RFC 4647 3.3.1 (Basic
Filtering). It had four bugs:

1. Required ALL listed tags to match (should be: true if ANY
user preference matches ANY listed tag).
2. Truncated the user language to 2 characters, losing script
and region subtags (e.g. &quot;zh-Hans&quot; became &quot;zh&quot;).
3. Used case-sensitive comparison.
4. Did not implement BCP 47 prefix matching (user &quot;en&quot; should
match listed &quot;en-US&quot;).

The fix replaces the broken loop with two static helpers
matchesLanguageTag() implementing RFC 4647 Basic Filtering,
and userLanguageMatchesAnyListedTag() synthesizing parent language tags
by iterative subtag stripping and iterates over userPreferredLanguages()
instead of truncating defaultLanguage().

BUT in a way that preserve the privacy of the end users. This is the way
WebKit is architectured. The code deviates from the specification on
purpose.

Tests: imported/w3c/web-platform-tests/svg/struct/systemLanguage-matching.html
       svg/dom/systemLanguage-matching.html

* LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-matching-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-matching.html: Added.
* LayoutTests/svg/dom/systemLanguage-matching-expected.txt: Added.
* LayoutTests/svg/dom/systemLanguage-matching.html: Added.
* Source/WebCore/svg/SVGTests.cpp:
  (WebCore::matchesLanguageTag):
  (WebCore::userLanguageMatchesAnyListedTag):
  (WebCore::SVGTests::isValid const):

Canonical link: <a href="https://commits.webkit.org/315952@main">https://commits.webkit.org/315952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ac466d7370d40a04676c43fc08078a2908ce8aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127893 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f215556f-9b4b-4d8b-8e8f-d6ee090a401d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132666 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93498 "13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/896d0e39-3fb1-4ee6-b697-998b4236eb27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113167 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7554e49d-c7cd-4adc-9119-795b6a32ea0b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34440 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32799 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28239 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182140 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34929 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36967 "Found 1 new test failure: http/tests/site-isolation/frame-index.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141117 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140941 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38045 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44450 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29478 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108836 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36209 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116330 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42960 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7577 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42352 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42606 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42495 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->