### PR TITLE
Correct IDL union handling of ArrayBuffer & friends

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data.crossOriginIsolated.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data.crossOriginIsolated.https.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test construction and copyTo() using a SharedArrayBuffer Type error
-FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) Type error
+FAIL Test construction and copyTo() using a SharedArrayBuffer SharedArrayBuffer is not allowed
+FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) SharedArrayBuffer is not allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test isConfigSupported() and configure() using a SharedArrayBuffer promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Test isConfigSupported() and configure() using a Uint8Array(SharedArrayBuffer) promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Test isConfigSupported() and configure() using a SharedArrayBuffer promise_test: Unhandled rejection with value: object "TypeError: SharedArrayBuffer is not allowed"
+FAIL Test isConfigSupported() and configure() using a Uint8Array(SharedArrayBuffer) promise_test: Unhandled rejection with value: object "TypeError: SharedArrayBuffer is not allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test isConfigSupported() and configure() using a SharedArrayBuffer promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Test isConfigSupported() and configure() using a Uint8Array(SharedArrayBuffer) promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Test isConfigSupported() and configure() using a SharedArrayBuffer promise_test: Unhandled rejection with value: object "TypeError: SharedArrayBuffer is not allowed"
+FAIL Test isConfigSupported() and configure() using a Uint8Array(SharedArrayBuffer) promise_test: Unhandled rejection with value: object "TypeError: SharedArrayBuffer is not allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-data-sharedarraybuffer.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-data-sharedarraybuffer.any-expected.txt
@@ -1,44 +1,16 @@
 
-FAIL sending a SharedArrayBuffer assert_throws_js: function "function() {
-        xhr.send(buf)
-    }" did not throw
-FAIL sending a Int8Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Uint8Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Uint8ClampedArray backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Int16Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Uint16Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Int32Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Uint32Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a BigInt64Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a BigUint64Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Float16Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Float32Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Float64Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a DataView backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
+PASS sending a SharedArrayBuffer
+PASS sending a Int8Array backed by a SharedArrayBuffer
+PASS sending a Uint8Array backed by a SharedArrayBuffer
+PASS sending a Uint8ClampedArray backed by a SharedArrayBuffer
+PASS sending a Int16Array backed by a SharedArrayBuffer
+PASS sending a Uint16Array backed by a SharedArrayBuffer
+PASS sending a Int32Array backed by a SharedArrayBuffer
+PASS sending a Uint32Array backed by a SharedArrayBuffer
+PASS sending a BigInt64Array backed by a SharedArrayBuffer
+PASS sending a BigUint64Array backed by a SharedArrayBuffer
+PASS sending a Float16Array backed by a SharedArrayBuffer
+PASS sending a Float32Array backed by a SharedArrayBuffer
+PASS sending a Float64Array backed by a SharedArrayBuffer
+PASS sending a DataView backed by a SharedArrayBuffer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-data-sharedarraybuffer.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-data-sharedarraybuffer.any.worker-expected.txt
@@ -1,44 +1,16 @@
 
-FAIL sending a SharedArrayBuffer assert_throws_js: function "function() {
-        xhr.send(buf)
-    }" did not throw
-FAIL sending a Int8Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Uint8Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Uint8ClampedArray backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Int16Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Uint16Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Int32Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Uint32Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a BigInt64Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a BigUint64Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Float16Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Float32Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a Float64Array backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
-FAIL sending a DataView backed by a SharedArrayBuffer assert_throws_js: function "function() {
-            xhr.send(arr)
-        }" did not throw
+PASS sending a SharedArrayBuffer
+PASS sending a Int8Array backed by a SharedArrayBuffer
+PASS sending a Uint8Array backed by a SharedArrayBuffer
+PASS sending a Uint8ClampedArray backed by a SharedArrayBuffer
+PASS sending a Int16Array backed by a SharedArrayBuffer
+PASS sending a Uint16Array backed by a SharedArrayBuffer
+PASS sending a Int32Array backed by a SharedArrayBuffer
+PASS sending a Uint32Array backed by a SharedArrayBuffer
+PASS sending a BigInt64Array backed by a SharedArrayBuffer
+PASS sending a BigUint64Array backed by a SharedArrayBuffer
+PASS sending a Float16Array backed by a SharedArrayBuffer
+PASS sending a Float32Array backed by a SharedArrayBuffer
+PASS sending a Float64Array backed by a SharedArrayBuffer
+PASS sending a DataView backed by a SharedArrayBuffer
 

--- a/LayoutTests/webgl/resources/webgl_test_files/conformance/extensions/webgl-multi-draw.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance/extensions/webgl-multi-draw.html
@@ -842,10 +842,8 @@ function doTest(ext, instanced) {
     runPixelTests(bufferUsage, false);
   }
 
-  // Run a subset of the pixel tests with SharedArrayBuffer if supported.
-  if (window.SharedArrayBuffer) {
-    runPixelTests(bufferUsageSet[0], true);
-  }
+  // FIXME: Run a subset of the pixel tests with SharedArrayBuffer if supported.
+  // This requires adding [AllowShared] to Int32List in WebGLMultiDraw.idl.
 }
 
 function waitForComposite() {

--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -368,7 +368,7 @@ inline To* dynamicDowncast(JSC::JSValue& value)
         return nullptr;
     JSC::JSCell* cell = value.asCell();
     if (JSC::JSCastingHelpers::InheritsTraits<To>::inherits(cell)) [[likely]]
-        return static_cast<To*>(cell);
+        SUPPRESS_MEMORY_UNSAFE_CAST return static_cast<To*>(cell);
     return nullptr;
 }
 

--- a/Source/JavaScriptCore/runtime/JSDataView.cpp
+++ b/Source/JavaScriptCore/runtime/JSDataView.cpp
@@ -104,6 +104,44 @@ bool JSDataView::setIndex(JSGlobalObject*, size_t, JSValue)
     return false;
 }
 
+RefPtr<DataView> JSDataView::toWrapped(VM&, JSValue value)
+{
+    auto* view = dynamicDowncast<JSDataView>(value);
+    if (!view)
+        return nullptr;
+    if (view->isShared() || view->isResizableOrGrowableShared())
+        return nullptr;
+    return view->unsharedTypedImpl();
+}
+
+RefPtr<DataView> JSDataView::toWrappedAllowResizable(VM&, JSValue value)
+{
+    auto* view = dynamicDowncast<JSDataView>(value);
+    if (!view)
+        return nullptr;
+    if (view->isShared())
+        return nullptr;
+    return view->unsharedTypedImpl();
+}
+
+RefPtr<DataView> JSDataView::toWrappedAllowShared(VM&, JSValue value)
+{
+    auto* view = dynamicDowncast<JSDataView>(value);
+    if (!view)
+        return nullptr;
+    if (view->isResizableOrGrowableShared())
+        return nullptr;
+    return view->possiblySharedTypedImpl();
+}
+
+RefPtr<DataView> JSDataView::toWrappedAllowSharedAndResizable(VM&, JSValue value)
+{
+    auto* view = dynamicDowncast<JSDataView>(value);
+    if (!view)
+        return nullptr;
+    return view->possiblySharedTypedImpl();
+}
+
 RefPtr<DataView> JSDataView::possiblySharedTypedImpl()
 {
     return DataView::create(possiblySharedBuffer(), byteOffsetRaw(), isAutoLength() ? std::nullopt : std::optional { lengthRaw() });

--- a/Source/JavaScriptCore/runtime/JSDataView.h
+++ b/Source/JavaScriptCore/runtime/JSDataView.h
@@ -93,6 +93,11 @@ public:
     
     static constexpr TypedArrayType TypedArrayStorageType = TypeDataView;
 
+    JS_EXPORT_PRIVATE static RefPtr<DataView> toWrapped(VM&, JSValue);
+    JS_EXPORT_PRIVATE static RefPtr<DataView> toWrappedAllowResizable(VM&, JSValue);
+    JS_EXPORT_PRIVATE static RefPtr<DataView> toWrappedAllowShared(VM&, JSValue);
+    JS_EXPORT_PRIVATE static RefPtr<DataView> toWrappedAllowSharedAndResizable(VM&, JSValue);
+
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
     
     DECLARE_EXPORT_INFO;

--- a/Source/WebCore/bindings/js/JSDOMConvertBufferSource.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertBufferSource.h
@@ -144,6 +144,29 @@ struct BufferSourceConverter {
             return Result { object.releaseNonNull() };
         }
     }
+
+    static std::optional<Result> tryConvert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
+    {
+        auto& vm = JSC::getVM(&lexicalGlobalObject);
+
+        RefPtr object = WrapperType::toWrappedAllowSharedAndResizable(vm, value);
+        if (!object)
+            return std::nullopt;
+
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        if constexpr (mode == BufferSourceConverterAllowSharedMode::Disallow) {
+            if (object->isShared()) {
+                throwTypeError(&lexicalGlobalObject, scope, "SharedArrayBuffer is not allowed"_s);
+                return Result::exception();
+            }
+        }
+        // FIXME: Add an AllowResizable mode and make this conditional once [AllowResizable] is supported.
+        if (object->isResizableOrGrowableShared()) {
+            throwTypeError(&lexicalGlobalObject, scope, "Resizable ArrayBuffer is not allowed"_s);
+            return Result::exception();
+        }
+        return Result { object.releaseNonNull() };
+    }
 };
 
 template<typename IDL, typename Wrapper>

--- a/Source/WebCore/bindings/js/JSDOMConvertUnion.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUnion.h
@@ -202,62 +202,56 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
         //     1. If types includes ArrayBuffer, then return the result of converting V to ArrayBuffer.
         //     2. If types includes object, then return the IDL value that is a reference to the object V.
         constexpr bool hasArrayBufferType = brigand::any<TypeList, IsIDLArrayBuffer<brigand::_1>>::value;
-        if constexpr (hasArrayBufferType || hasObjectType) {
-            RefPtr arrayBuffer = (brigand::any<TypeList, IsIDLArrayBufferAllowShared<brigand::_1>>::value) ? JSC::JSArrayBuffer::toWrappedAllowSharedAndResizable(vm, value) : JSC::JSArrayBuffer::toWrappedAllowResizable(vm, value);
-            if (arrayBuffer) {
-                if (arrayBuffer->isResizableOrGrowableShared()) {
-                    throwTypeError(&lexicalGlobalObject, scope, "ArrayBuffer cannot be resizable"_s);
-                    return functor(ConversionResultException());
-                }
-                if constexpr (hasArrayBufferType) {
-                    return functor(arrayBuffer.releaseNonNull());
-                } else if constexpr (hasObjectType) {
-                    scope.release();
-                    return functor(Converter<ObjectType>::convert(lexicalGlobalObject, value));
-                }
+        if constexpr (hasArrayBufferType) {
+            constexpr auto arrayBufferAllowSharedMode = (brigand::any<TypeList, IsIDLArrayBufferAllowShared<brigand::_1>>::value)
+                ? Detail::BufferSourceConverterAllowSharedMode::Allow
+                : Detail::BufferSourceConverterAllowSharedMode::Disallow;
+            auto result = Detail::BufferSourceConverter<IDLArrayBuffer, arrayBufferAllowSharedMode>::tryConvert(lexicalGlobalObject, value);
+            if (result)
+                return functor(WTF::move(*result));
+        }
+        if constexpr (!hasArrayBufferType && hasObjectType) {
+            if (JSC::JSArrayBuffer::toWrappedAllowSharedAndResizable(vm, value)) {
+                scope.release();
+                return functor(Converter<ObjectType>::convert(lexicalGlobalObject, value));
             }
         }
 
         constexpr bool hasArrayBufferViewType = brigand::any<TypeList, IsIDLArrayBufferView<brigand::_1>>::value;
-        if constexpr (hasArrayBufferViewType || hasObjectType) {
-            RefPtr arrayBufferView = (brigand::any<TypeList, IsIDLArrayBufferViewAllowShared<brigand::_1>>::value) ? JSC::JSArrayBufferView::toWrappedAllowSharedAndResizable(vm, value) : JSC::JSArrayBufferView::toWrappedAllowResizable(vm, value);
-            if (arrayBufferView) {
-                if (arrayBufferView->isResizableOrGrowableShared()) {
-                    throwTypeError(&lexicalGlobalObject, scope, "ArrayBufferView cannot be resizable"_s);
-                    return functor(ConversionResultException());
-                }
-                if constexpr (hasArrayBufferViewType) {
-                    return functor(arrayBufferView.releaseNonNull());
-                } else if constexpr (hasObjectType) {
-                    scope.release();
-                    return functor(Converter<ObjectType>::convert(lexicalGlobalObject, value));
-                }
+        if constexpr (hasArrayBufferViewType) {
+            constexpr auto arrayBufferViewAllowSharedMode = (brigand::any<TypeList, IsIDLArrayBufferViewAllowShared<brigand::_1>>::value)
+                ? Detail::BufferSourceConverterAllowSharedMode::Allow
+                : Detail::BufferSourceConverterAllowSharedMode::Disallow;
+            auto result = Detail::BufferSourceConverter<IDLArrayBufferView, arrayBufferViewAllowSharedMode>::tryConvert(lexicalGlobalObject, value);
+            if (result)
+                return functor(WTF::move(*result));
+        }
+        if constexpr (!hasArrayBufferViewType && hasObjectType) {
+            if (JSC::JSArrayBufferView::toWrappedAllowSharedAndResizable(vm, value)) {
+                scope.release();
+                return functor(Converter<ObjectType>::convert(lexicalGlobalObject, value));
             }
         }
 
         // FIXME: Add support for step 7.
         //
-        // 7. If V is an Object, V, has an [[ArrayBufferData]] internal slot, and IsSharedArrayBuffer(V) is true, then:
-        //     1. If types includes SharedArrayBuffer, then return the result of converting V to SharedArrayBuffer..
+        // 7. If V is an Object, V has an [[ArrayBufferData]] internal slot, and IsSharedArrayBuffer(V) is true, then:
+        //     1. If types includes SharedArrayBuffer, then return the result of converting V to SharedArrayBuffer.
         //     2. If types includes object, then return the IDL value that is a reference to the object V.
 
         // 8. If Type(V) is Object and V has a [[DataView]] internal slot, then:
         //     1. If types includes DataView, then return the result of converting V to DataView.
         //     2. If types includes object, then return the IDL value that is a reference to the object V.
         constexpr bool hasDataViewType = brigand::any<TypeList, std::is_same<IDLDataView, brigand::_1>>::value;
-        if constexpr (hasDataViewType || hasObjectType) {
-            RefPtr dataView = JSC::JSDataView::toWrappedAllowResizable(vm, value);
-            if (dataView) {
-                if (dataView->isResizableOrGrowableShared()) {
-                    throwTypeError(&lexicalGlobalObject, scope, "DataView cannot be resizable"_s);
-                    return functor(ConversionResultException());
-                }
-                if constexpr (hasDataViewType) {
-                    return functor(dataView.releaseNonNull());
-                } else if constexpr (hasObjectType) {
-                    scope.release();
-                    return functor(Converter<ObjectType>::convert(lexicalGlobalObject, value));
-                }
+        if constexpr (hasDataViewType) {
+            auto result = Detail::BufferSourceConverter<IDLDataView, Detail::BufferSourceConverterAllowSharedMode::Disallow>::tryConvert(lexicalGlobalObject, value);
+            if (result)
+                return functor(WTF::move(*result));
+        }
+        if constexpr (!hasDataViewType && hasObjectType) {
+            if (JSC::JSDataView::toWrappedAllowSharedAndResizable(vm, value)) {
+                scope.release();
+                return functor(Converter<ObjectType>::convert(lexicalGlobalObject, value));
             }
         }
 
@@ -267,23 +261,17 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
         //         (FIXME: Add support for step 9.2)
         constexpr bool hasTypedArrayType = brigand::any<TypeList, IsIDLTypedArray<brigand::_1>>::value;
         if constexpr (hasTypedArrayType) {
+            constexpr auto typedArrayAllowSharedMode = (brigand::any<TypeList, IsIDLTypedArrayAllowShared<brigand::_1>>::value)
+                ? Detail::BufferSourceConverterAllowSharedMode::Allow
+                : Detail::BufferSourceConverterAllowSharedMode::Disallow;
             std::optional<FunctorResultType> returnValue;
             forEach<TypedArrayTypeList>([&]<typename Type>() {
                 if (returnValue)
                     return;
 
-                using WrapperType = typename Converter<Type>::WrapperType;
-
-                RefPtr castedValue = (brigand::any<TypeList, IsIDLTypedArrayAllowShared<brigand::_1>>::value) ? WrapperType::toWrappedAllowSharedAndResizable(vm, value) : WrapperType::toWrappedAllowResizable(vm, value);
-                if (!castedValue)
-                    return;
-
-                if (castedValue->isResizableOrGrowableShared()) {
-                    throwTypeError(&lexicalGlobalObject, scope, "TypedArray cannot be resizable"_s);
-                    returnValue = functor(ConversionResultException());
-                    return;
-                }
-                returnValue = functor(ConversionResult<Type> { castedValue.releaseNonNull() });
+                auto result = Detail::BufferSourceConverter<Type, typedArrayAllowSharedMode>::tryConvert(lexicalGlobalObject, value);
+                if (result)
+                    returnValue = functor(WTF::move(*result));
             });
 
             if (returnValue)


### PR DESCRIPTION
#### 7eb28729693cba0485fd77f5890c3a504aac3a03
<pre>
Correct IDL union handling of ArrayBuffer &amp; friends
<a href="https://bugs.webkit.org/show_bug.cgi?id=254864">https://bugs.webkit.org/show_bug.cgi?id=254864</a>
<a href="https://rdar.apple.com/107786134">rdar://107786134</a>

Reviewed by Chris Dumez.

Instead of rejecting SharedArrayBuffer when not explicitly allowed, we
would let it fall through and ended up stringifying the object in
unions where a string was one of the alternatives (such as with
XMLHttpRequest&apos;s send()).

Comment out SharedArrayBuffer in webgl-multi-draw.html as all we were
testing before was conversion to sequence&lt;GLint&gt; and with this change
the test would fail.

Canonical link: <a href="https://commits.webkit.org/311536@main">https://commits.webkit.org/311536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37c627ff30a5e0a653fadc54a1a9a76110144e46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166060 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111319 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76be0ee1-626b-4581-8a89-8f59bcc3c581) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121772 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85495 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de459aca-af84-4426-96fa-28b5ceced189) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102440 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/023c3c98-e5a3-43d0-b296-a780d89c835c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23069 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21315 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13832 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149287 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132749 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168545 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18072 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12704 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129905 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130013 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35229 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140810 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87930 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17615 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189255 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29809 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93823 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48549 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29331 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29561 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29458 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->