### PR TITLE
[GTK] fast/forms/placeholder-content-line-height.html is failing

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4876,7 +4876,6 @@ fast/text/user-installed-fonts/shadow-family.html [ Skip ]
 fast/text/user-installed-fonts/shadow-postscript-family.html [ Skip ]
 fast/text/user-installed-fonts/shadow-postscript.html [ Skip ]
 fast/text/user-installed-fonts/shadow.html [ Skip ]
-fast/text/user-installed-fonts/system-ui.html [ Skip ]
 
 # This feature is only enabled on Mac and iOS right now.
 contentfiltering/ [ Skip ]
@@ -4909,8 +4908,6 @@ webkit.org/b/217821 imported/w3c/web-platform-tests/density-size-correction/ [ S
 fast/harness/platform-layer-tree-as-text.html [ Skip ]
 
 webkit.org/b/286580 http/tests/media/clearkey/clear-key-session-id.html [ Failure ]
-
-fast/canvas/font-family-system-ui-canvas.html [ ImageOnlyFailure ]
 
 http/tests/iframe-memory-monitor/media-video-autoplay-in-frames.html [ Skip ] # Timeout.
 media/media-source/media-source-rendering-update-count.html [ Skip ] # Timeout.

--- a/LayoutTests/platform/glib/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt
+++ b/LayoutTests/platform/glib/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt
@@ -27,71 +27,71 @@ layer at (0,0) size 800x188
         RenderTextControl {INPUT} at (243,65) size 209x24 [bgcolor=#FAFFBD] [border: (2px inset #808080)]
 layer at (11,53) size 203x18
   RenderFlexibleBox {DIV} at (3,3) size 203x18
-    RenderBlock {DIV} at (90,0) size 113x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 107x18
-        text run at (6,0) width 107: "Strong Password"
-layer at (11,53) size 90x18
-  RenderBlock {DIV} at (0,0) size 90x18
+    RenderBlock {DIV} at (75,0) size 128x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 122x18
+        text run at (6,0) width 122: "Strong Password"
+layer at (11,53) size 75x18
+  RenderBlock {DIV} at (0,0) size 75x18
 layer at (224,53) size 203x18
   RenderFlexibleBox {DIV} at (3,3) size 203x18
-    RenderBlock {DIV} at (90,0) size 113x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 107x18
-        text run at (6,0) width 107: "Strong Password"
-layer at (224,53) size 90x18
-  RenderBlock {DIV} at (0,0) size 90x18
+    RenderBlock {DIV} at (75,0) size 128x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 122x18
+        text run at (6,0) width 122: "Strong Password"
+layer at (224,53) size 75x18
+  RenderBlock {DIV} at (0,0) size 75x18
 layer at (437,53) size 300x18
   RenderFlexibleBox {DIV} at (3,3) size 300x18
-    RenderBlock {DIV} at (187,0) size 113x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 107x18
-        text run at (6,0) width 107: "Strong Password"
-layer at (437,53) size 187x18
-  RenderBlock {DIV} at (0,0) size 187x18
-layer at (747,53) size 20x18 scrollWidth 113 scrollHeight 36
+    RenderBlock {DIV} at (172,0) size 128x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 122x18
+        text run at (6,0) width 122: "Strong Password"
+layer at (437,53) size 172x18
+  RenderBlock {DIV} at (0,0) size 172x18
+layer at (747,53) size 20x18 scrollWidth 128 scrollHeight 36
   RenderFlexibleBox {DIV} at (3,3) size 20x18
-    RenderBlock {DIV} at (0,18) size 113x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 107x18
-        text run at (6,0) width 107: "Strong Password"
+    RenderBlock {DIV} at (0,18) size 128x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 122x18
+        text run at (6,0) width 122: "Strong Password"
 layer at (747,53) size 20x18
   RenderBlock {DIV} at (0,0) size 20x18
 layer at (11,118) size 203x18
   RenderFlexibleBox {DIV} at (3,44) size 203x18
-    RenderBlock {DIV} at (90,0) size 113x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 107x18
-        text run at (6,0) width 107: "Strong Password"
-layer at (11,118) size 90x18
-  RenderBlock {DIV} at (0,0) size 90x18
-layer at (224,118) size 20x18 scrollWidth 113 scrollHeight 36
+    RenderBlock {DIV} at (75,0) size 128x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 122x18
+        text run at (6,0) width 122: "Strong Password"
+layer at (11,118) size 75x18
+  RenderBlock {DIV} at (0,0) size 75x18
+layer at (224,118) size 20x18 scrollWidth 128 scrollHeight 36
   RenderFlexibleBox {DIV} at (3,44) size 20x18
-    RenderBlock {DIV} at (0,18) size 113x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 107x18
-        text run at (6,0) width 107: "Strong Password"
+    RenderBlock {DIV} at (0,18) size 128x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 122x18
+        text run at (6,0) width 122: "Strong Password"
 layer at (224,118) size 20x18
   RenderBlock {DIV} at (0,0) size 20x18
 layer at (254,118) size 203x18
   RenderFlexibleBox {DIV} at (3,3) size 203x18
-    RenderBlock {DIV} at (90,0) size 113x18 [color=#000000CC]
-      RenderText {#text} at (6,0) size 107x18
-        text run at (6,0) width 107: "Strong Password"
-layer at (254,118) size 90x18
-  RenderBlock {DIV} at (0,0) size 90x18
-layer at (11,53) size 90x18 scrollWidth 430
-  RenderBlock {DIV} at (0,0) size 90x18 [color=#00000099]
+    RenderBlock {DIV} at (75,0) size 128x18 [color=#000000CC]
+      RenderText {#text} at (6,0) size 122x18
+        text run at (6,0) width 122: "Strong Password"
+layer at (254,118) size 75x18
+  RenderBlock {DIV} at (0,0) size 75x18
+layer at (11,53) size 75x18 scrollWidth 430
+  RenderBlock {DIV} at (0,0) size 75x18 [color=#00000099]
     RenderText {#text} at (0,0) size 430x18
       text run at (0,0) width 430: "A quick brown fox jumped over the lazy dog."
-layer at (224,53) size 90x18 scrollWidth 430
-  RenderBlock {DIV} at (0,0) size 90x18 [color=#00000099]
+layer at (224,53) size 75x18 scrollWidth 430
+  RenderBlock {DIV} at (0,0) size 75x18 [color=#00000099]
     RenderText {#text} at (0,0) size 430x18
       text run at (0,0) width 430: "A quick brown fox jumped over the lazy dog."
-layer at (437,53) size 187x18 scrollWidth 430
-  RenderBlock {DIV} at (0,0) size 187x18 [color=#00000099]
+layer at (437,53) size 172x18 scrollWidth 430
+  RenderBlock {DIV} at (0,0) size 172x18 [color=#00000099]
     RenderText {#text} at (0,0) size 430x18
       text run at (0,0) width 430: "A quick brown fox jumped over the lazy dog."
 layer at (747,53) size 20x18 scrollWidth 430
   RenderBlock {DIV} at (0,0) size 20x18 [color=#00000099]
     RenderText {#text} at (0,0) size 430x18
       text run at (0,0) width 430: "A quick brown fox jumped over the lazy dog."
-layer at (11,118) size 90x18 scrollWidth 430
-  RenderBlock {DIV} at (0,0) size 90x18 [color=#00000099]
+layer at (11,118) size 75x18 scrollWidth 430
+  RenderBlock {DIV} at (0,0) size 75x18 [color=#00000099]
     RenderText {#text} at (0,0) size 430x18
       text run at (0,0) width 430: "A quick brown fox jumped over the lazy dog."
 layer at (224,118) size 20x18 scrollWidth 430

--- a/LayoutTests/platform/glib/fast/html/details-marker-style-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-marker-style-expected.txt
@@ -1,29 +1,29 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x320
-  RenderBlock {HTML} at (0,0) size 800x320
-    RenderBody {BODY} at (8,8) size 784x304
+layer at (0,0) size 800x322
+  RenderBlock {HTML} at (0,0) size 800x322
+    RenderBody {BODY} at (8,8) size 784x306
       RenderBlock {DIV} at (0,0) size 784x28
         RenderBlock {DETAILS} at (0,0) size 784x28
           RenderListItem {SUMMARY} at (0,0) size 784x28
-            RenderListMarker at (0,1) size 24x26: "\x{25B6}"
-            RenderText {#text} at (24,1) size 94x26
-              text run at (24,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,28) size 27x124
-        RenderBlock {DETAILS} at (0,0) size 27x124
-          RenderListItem {SUMMARY} at (0,0) size 27x124
-            RenderListMarker at (0,0) size 27x30: "\x{25BC}"
-            RenderText {#text} at (0,30) size 27x94
-              text run at (0,30) width 95: "Summary"
-      RenderBlock {DIV} at (0,152) size 784x28
+            RenderListMarker at (0,1) size 25x26: "\x{25B6}"
+            RenderText {#text} at (25,1) size 94x26
+              text run at (25,1) width 94: "Summary"
+      RenderBlock {DIV} at (0,28) size 27x125
+        RenderBlock {DETAILS} at (0,0) size 27x125
+          RenderListItem {SUMMARY} at (0,0) size 27x125
+            RenderListMarker at (0,0) size 27x31: "\x{25BC}"
+            RenderText {#text} at (0,31) size 27x94
+              text run at (0,31) width 95: "Summary"
+      RenderBlock {DIV} at (0,153) size 784x28
         RenderBlock {DETAILS} at (0,0) size 784x28
           RenderListItem {SUMMARY} at (0,0) size 784x28
-            RenderListMarker at (0,1) size 24x26: "\x{25B6}"
-            RenderText {#text} at (24,1) size 94x26
-              text run at (24,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,180) size 27x124
-        RenderBlock {DETAILS} at (0,0) size 27x124
-          RenderListItem {SUMMARY} at (0,0) size 27x124
-            RenderListMarker at (0,0) size 27x30: "\x{25BC}"
-            RenderText {#text} at (0,30) size 27x94
-              text run at (0,30) width 95: "Summary"
+            RenderListMarker at (0,1) size 25x26: "\x{25B6}"
+            RenderText {#text} at (25,1) size 94x26
+              text run at (25,1) width 94: "Summary"
+      RenderBlock {DIV} at (0,181) size 27x125
+        RenderBlock {DETAILS} at (0,0) size 27x125
+          RenderListItem {SUMMARY} at (0,0) size 27x125
+            RenderListMarker at (0,0) size 27x31: "\x{25BC}"
+            RenderText {#text} at (0,31) size 27x94
+              text run at (0,31) width 95: "Summary"

--- a/LayoutTests/platform/glib/fast/html/details-marker-style-mixed-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-marker-style-mixed-expected.txt
@@ -1,29 +1,29 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x320
-  RenderBlock {HTML} at (0,0) size 800x320
-    RenderBody {BODY} at (8,8) size 784x304
+layer at (0,0) size 800x322
+  RenderBlock {HTML} at (0,0) size 800x322
+    RenderBody {BODY} at (8,8) size 784x306
       RenderBlock {DIV} at (0,0) size 784x28
         RenderBlock {DETAILS} at (0,0) size 784x28
           RenderListItem {SUMMARY} at (0,0) size 784x28
-            RenderListMarker at (0,1) size 24x26: "\x{25B6}"
-            RenderText {#text} at (24,1) size 94x26
-              text run at (24,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,28) size 27x124
-        RenderBlock {DETAILS} at (0,0) size 27x124
-          RenderListItem {SUMMARY} at (0,0) size 27x124
-            RenderListMarker at (0,0) size 27x30: "\x{25BC}"
-            RenderText {#text} at (0,30) size 27x94
-              text run at (0,30) width 95: "Summary"
-      RenderBlock {DIV} at (0,152) size 784x28
+            RenderListMarker at (0,1) size 25x26: "\x{25B6}"
+            RenderText {#text} at (25,1) size 94x26
+              text run at (25,1) width 94: "Summary"
+      RenderBlock {DIV} at (0,28) size 27x125
+        RenderBlock {DETAILS} at (0,0) size 27x125
+          RenderListItem {SUMMARY} at (0,0) size 27x125
+            RenderListMarker at (0,0) size 27x31: "\x{25BC}"
+            RenderText {#text} at (0,31) size 27x94
+              text run at (0,31) width 95: "Summary"
+      RenderBlock {DIV} at (0,153) size 784x28
         RenderBlock {DETAILS} at (0,0) size 784x28
           RenderListItem {SUMMARY} at (0,0) size 784x28
-            RenderListMarker at (0,1) size 24x26: "\x{25B6}"
-            RenderText {#text} at (24,1) size 94x26
-              text run at (24,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,180) size 27x124
-        RenderBlock {DETAILS} at (0,0) size 27x124
-          RenderListItem {SUMMARY} at (0,0) size 27x124
-            RenderListMarker at (0,0) size 27x30: "\x{25BC}"
-            RenderText {#text} at (0,30) size 27x94
-              text run at (0,30) width 95: "Summary"
+            RenderListMarker at (0,1) size 25x26: "\x{25B6}"
+            RenderText {#text} at (25,1) size 94x26
+              text run at (25,1) width 94: "Summary"
+      RenderBlock {DIV} at (0,181) size 27x125
+        RenderBlock {DETAILS} at (0,0) size 27x125
+          RenderListItem {SUMMARY} at (0,0) size 27x125
+            RenderListMarker at (0,0) size 27x31: "\x{25BC}"
+            RenderText {#text} at (0,31) size 27x94
+              text run at (0,31) width 95: "Summary"

--- a/LayoutTests/platform/glib/fast/text/system-font-features-expected.html
+++ b/LayoutTests/platform/glib/fast/text/system-font-features-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+This test makes sure that font features are applied to -apple-system and system-ui.
+<div style="font: 50px 'Liberation Sans';">0123456789</div>
+<div style="font: 50px 'Liberation Sans';">0123456789</div>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -503,9 +503,6 @@ imported/w3c/web-platform-tests/css/css-text/hyphens/hyphenate-character-002.htm
 
 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-non-integer-screeny.html [ Failure ]
 
-webkit.org/b/209727 fast/forms/placeholder-content-line-height.html [ ImageOnlyFailure ]
-webkit.org/b/209727 fast/forms/placeholder-content-center.html [ ImageOnlyFailure ]
-
 webkit.org/b/212233 fast/repaint/iframe-on-subpixel-position.html [ Failure ]
 
 webkit.org/b/214454 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-margin-root-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/gtk/fonts/systemFont.html
+++ b/LayoutTests/platform/gtk/fonts/systemFont.html
@@ -4,8 +4,8 @@
         <meta charset="utf-8" />
 		<title>SystemFont</title>
 		<style type="text/css">
-		p.system-font { font-family: -webkit-system-font }
-		p.system-ui { font-family: -webkit-system-ui }
+		p.system-font { font-family: system-font }
+		p.system-ui { font-family: system-ui }
 		</style>
 	</head>
 	<body>

--- a/LayoutTests/platform/wpe/fast/forms/placeholder-content-center-expected.html
+++ b/LayoutTests/platform/wpe/fast/forms/placeholder-content-center-expected.html
@@ -1,0 +1,14 @@
+<style>
+div {
+  padding-top: 7px;
+  padding-left: 1px;
+
+  color: black;
+
+  font-size: 22px;
+  font-style: normal;
+  font-weight: 400;
+  font-variant-caps: normal;
+}
+</style>
+<div>PASS if placeholder text is fully visible</div>

--- a/LayoutTests/platform/wpe/fast/forms/placeholder-content-line-height-expected.html
+++ b/LayoutTests/platform/wpe/fast/forms/placeholder-content-line-height-expected.html
@@ -1,0 +1,14 @@
+<style>
+div {
+  padding-top: 7px;
+  padding-left: 1px;
+
+  color: black;
+
+  font-size: 22px;
+  font-style: normal;
+  font-weight: 400;
+  font-variant-caps: normal;
+}
+</style>
+<div>PASS if placeholder text is fully visible</div>

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -204,8 +204,26 @@ Vector<FontSelectionCapabilities> FontCache::getFontSelectionCapabilitiesInFamil
     return { };
 }
 
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+static bool isSystemUIFamilyFont(const String& family)
+{
+    return family == "-apple-system-font"_s
+        || family == "-apple-system"_s
+        || family == "-webkit-system-font"_s
+        || family == "-webkit-system-ui"_s
+        || family == "system-font"_s
+        || family == "system-ui"_s
+        || family == "ui-sans-serif"_s;
+}
+#endif
+
 static String getFamilyNameStringFromFamily(const String& family)
 {
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+    if (isSystemUIFamilyFont(family))
+        return SystemSettings::singleton().defaultSystemFont();
+#endif
+
     // If we're creating a fallback font (e.g. "-webkit-monospace"), convert the name into
     // the fallback name (like "monospace") that fontconfig understands.
     if (family.length() && !family.startsWith("-webkit-"_s))
@@ -223,11 +241,6 @@ static String getFamilyNameStringFromFamily(const String& family)
         return "fantasy"_s;
     if (family == *familyNamesData->at(FamilyNamesIndex::MathFamily))
         return "math"_s;
-
-#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
-    if (family == *familyNamesData->at(FamilyNamesIndex::SystemUiFamily) || family == "-webkit-system-font"_s)
-        return SystemSettings::singleton().defaultSystemFont();
-#endif
 
     return emptyString();
 }


### PR DESCRIPTION
#### a49dbdc4147c9bb7c5ff41ddff357073496f7db2
<pre>
[GTK] fast/forms/placeholder-content-line-height.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=209727">https://bugs.webkit.org/show_bug.cgi?id=209727</a>

Reviewed by Carlos Garcia Campos.

Modify &apos;getFamilyNameStringFromFamily&apos; function to check at its preamble
whether the requested font is any of the keywords for a system font. In that
case, resolve the requested font name to the system&apos;s default system font.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/fast/forms/auto-fill-button/input-strong-password-auto-fill-button-expected.txt:
* LayoutTests/platform/glib/fast/html/details-marker-style-expected.txt:
* LayoutTests/platform/glib/fast/html/details-marker-style-mixed-expected.txt:
* LayoutTests/platform/glib/fast/text/system-font-features-expected.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/gtk/fonts/systemFont.html:
* LayoutTests/platform/wpe/fast/forms/placeholder-content-center-expected.html: Added.
* LayoutTests/platform/wpe/fast/forms/placeholder-content-line-height-expected.html: Added.
* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
(WebCore::isSystemUIFamilyFont):
(WebCore::getFamilyNameStringFromFamily):

Canonical link: <a href="https://commits.webkit.org/312073@main">https://commits.webkit.org/312073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72bb724566c9a693739ecce1023810c9cb1b653d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112871 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123020 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86347 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142646 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103689 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24339 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22738 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15388 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170108 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15851 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131206 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31903 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131320 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142219 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89825 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24163 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26014 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19028 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31359 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97373 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30879 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31152 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->