### PR TITLE
Ensure Enhanced Security handles HTTPFirst correctly

### DIFF
--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
@@ -27,6 +27,8 @@
 #include "config.h"
 #include "EnhancedSecurityTracking.h"
 
+#include "APIWebsitePolicies.h"
+#include "WebPreferences.h"
 #include <WebCore/IPAddressSpace.h>
 #include <WebCore/SecurityOrigin.h>
 #include <wtf/Condition.h>
@@ -171,7 +173,26 @@ void EnhancedSecurityTracking::trackSameSiteNavigation(const API::Navigation& na
     }
 }
 
-bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigation)
+static bool shouldExpectHTTPSUpgrade(const URL& requestURL, API::WebsitePolicies* websitePolicies, const WebPreferences& preferences, const URL& sourceURL, bool httpFallbackInProgress)
+{
+    if (!requestURL.protocolIs("http"_s) || SecurityOrigin::isLocalHostOrLoopbackIPAddress(requestURL.host()))
+        return false;
+
+    bool httpsByDefaultEnabled = (websitePolicies && (websitePolicies->isUpgradeWithAutomaticFallbackEnabled() || websitePolicies->isUpgradeWithUserMediatedFallbackEnabled()))
+        || preferences.httpSByDefaultEnabled();
+
+    if (!httpsByDefaultEnabled || httpFallbackInProgress)
+        return false;
+
+    bool isSameSite = sourceURL.isEmpty() || RegistrableDomain(requestURL) == RegistrableDomain(sourceURL);
+    bool isSameSiteBypassEnabled = isSameSite
+        && ((websitePolicies && websitePolicies->advancedPrivacyProtections().contains(WebCore::AdvancedPrivacyProtections::HTTPSOnlyExplicitlyBypassedForDomain))
+            || sourceURL.protocolIs("http"_s));
+
+    return !isSameSiteBypassEnabled;
+}
+
+bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigation, API::WebsitePolicies* websitePolicies, const WebPreferences& preferences, const URL& sourceURL, bool httpFallbackInProgress)
 {
     if (navigation.isEnhancedSecurityLinkForCurrentSite()) {
         enableFor(EnhancedSecurityReason::LinkSecurity, navigation);
@@ -181,7 +202,8 @@ bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigatio
     auto currentRequestURL = navigation.currentRequest().url();
 
     if (currentRequestURL.protocolIs("http"_s)
-        && !SecurityOrigin::isLocalHostOrLoopbackIPAddress(currentRequestURL.host())) {
+        && !SecurityOrigin::isLocalHostOrLoopbackIPAddress(currentRequestURL.host())
+        && !shouldExpectHTTPSUpgrade(currentRequestURL, websitePolicies, preferences, sourceURL, httpFallbackInProgress)) {
         enableFor(EnhancedSecurityReason::InsecureProvisional, navigation);
         return true;
     }
@@ -200,7 +222,7 @@ void EnhancedSecurityTracking::handleBackForwardNavigation(const API::Navigation
         enableFor(reasonForEnhancedSecurity(priorState), navigation);
 }
 
-void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation, bool hasOpenedPage)
+void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation, bool hasOpenedPage, API::WebsitePolicies* websitePolicies, const WebPreferences& preferences, const URL& sourceURL, bool httpFallbackInProgress)
 {
     auto lastNavigationAction = navigation.lastNavigationAction();
     if (lastNavigationAction && lastNavigationAction->hasOpener)
@@ -223,7 +245,7 @@ void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation
     if (m_activeState != ActivationState::None && isInitialUIDriven && !isReload)
         reset();
 
-    if (m_activeState != ActivationState::Active && enableIfRequired(navigation))
+    if (m_activeState != ActivationState::Active && enableIfRequired(navigation, websitePolicies, preferences, sourceURL, httpFallbackInProgress))
         return;
 
     if (m_activeState == ActivationState::Active

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.h
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.h
@@ -34,13 +34,19 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/Seconds.h>
 
+namespace API {
+class WebsitePolicies;
+}
+
 namespace WebKit {
+
+class WebPreferences;
 
 class EnhancedSecurityTracking final : public CanMakeWeakPtr<EnhancedSecurityTracking> {
 public:
     void initializeWithWebsiteDataStore(WebsiteDataStore&);
 
-    void trackNavigation(const API::Navigation&, bool hasOpenedPage);
+    void trackNavigation(const API::Navigation&, bool hasOpenedPage, API::WebsitePolicies*, const WebPreferences&, const URL& sourceURL, bool httpFallbackInProgress);
 
     bool isEnhancedSecurityEnabled() const { return isEnhancedSecurityEnabledForState(enhancedSecurityState()); }
     EnhancedSecurity NODELETE enhancedSecurityState() const;
@@ -58,7 +64,7 @@ private:
     void handleBackForwardNavigation(const API::Navigation&);
 
     void enableFor(EnhancedSecurityReason, const API::Navigation&);
-    bool enableIfRequired(const API::Navigation&);
+    bool enableIfRequired(const API::Navigation&, API::WebsitePolicies*, const WebPreferences&, const URL& sourceURL, bool httpFallbackInProgress);
 
     void trackSameSiteNavigation(const API::Navigation&);
     void trackChangingSiteNavigation();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5377,7 +5377,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
 
     Ref browsingContextGroup = browsingContextGroupForNavigation(frame, navigation, websiteDataStore, processSwapRequestedByClient);
     if (frame.isMainFrame() && preferences->enhancedSecurityHeuristicsEnabled())
-        internals().enhancedSecurityTracker.trackNavigation(navigation, hasOpenedPage());
+        internals().enhancedSecurityTracker.trackNavigation(navigation, hasOpenedPage(), websitePolicies.get(), preferences.get(), sourceURL, internals().pageLoadState.httpFallbackInProgress());
 
     auto enhancedSecurity = currentEnhancedSecurityState(websitePolicies.get());
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
@@ -334,6 +334,44 @@ static void runHttpLocalhostLoad(bool useSiteIsolation)
 }
 TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpLocalhostLoad)
 
+// MARK: - HTTPS First Upgrade Tests
+
+static void runHttpsFirstUpgradeDisablesEnhancedSecurity(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://example.internal/"_s, { "<script>alert('insecure-page')</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>alert('upgraded-page')</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    [webView configuration].defaultWebpagePreferences._networkConnectionIntegrityPolicy |= _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst;
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://example.internal/", {
+        { "upgraded-page"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpsFirstUpgradeDisablesEnhancedSecurity)
+
+static void runHttpsFirstFailureEnablesEnhancedSecurity(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://example.internal/"_s, { "<script>alert('insecure-page')</script>"_s } },
+    });
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, nullptr, useSiteIsolation);
+
+    [webView configuration].defaultWebpagePreferences._networkConnectionIntegrityPolicy |= _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst;
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://example.internal/", {
+        { "insecure-page"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpsFirstFailureEnablesEnhancedSecurity)
+
 // MARK: - Frame Tests
 
 static void runHttpEmbeddingHttpIframe(bool useSiteIsolation)


### PR DESCRIPTION
#### 68ec5f328d2394c1583128ee07306c7f053336df
<pre>
Ensure Enhanced Security handles HTTPFirst correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=312578">https://bugs.webkit.org/show_bug.cgi?id=312578</a>
<a href="https://rdar.apple.com/173934437">rdar://173934437</a>

Reviewed by Matthew Finkel.

Currently, when a http:// URL is received with the HTTPSFirst network
policy set, we opt in to Enhanced Security. However, WebContent will
attempt to upgrade this to HTTPS on seeing the set policy automatically
and never pass the decision back through WebPageProxy if the upgrade
succeeds.

To address this, we determine if a HTTPS upgrade is going to be
attempted and, in this case, do not opt into Enhanced Security. If the
upgrade later fails, this will pass through didFailProvisionalLoad and
revisit the Enhanced Security decision in WebPageProxy.

Two new tests are added which confirm the expected behaviour for
HTTPSFirst in the success case, and ensure that when HTTPSFirst fails
that Enhanced Security is still enabled.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm

* Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp:
(WebKit::shouldExpectHTTPSUpgrade):
(WebKit::EnhancedSecurityTracking::enableIfRequired):
(WebKit::EnhancedSecurityTracking::trackNavigation):
* Source/WebKit/UIProcess/EnhancedSecurityTracking.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm:
(runHttpsFirstUpgradeDisablesEnhancedSecurity):
(runHttpsFirstFailureEnablesEnhancedSecurity):

Canonical link: <a href="https://commits.webkit.org/312342@main">https://commits.webkit.org/312342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5be4ff5eb5df1801e41c20217bbebd15d0eaa4bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111139 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2e04ab9d-1ac3-4672-8161-c7869dd61f37) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121633 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85408 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/229be2c6-c140-4a0a-ae49-5b17e2d18f48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102301 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c29df07-564d-448c-9314-fa2283123874) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22932 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21163 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13652 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168365 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12524 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129759 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129867 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35722 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140659 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87738 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24693 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17463 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29629 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93643 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29151 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29278 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->