### PR TITLE
Update wasm data segment implementation to support multimemory

### DIFF
--- a/JSTests/wasm/stress/data-segment-multimemory.js
+++ b/JSTests/wasm/stress/data-segment-multimemory.js
@@ -1,0 +1,56 @@
+//@ requireOptions("--useWasmMultiMemory=1")
+
+import * as assert from "../assert.js";
+
+// Test that active data segments target the correct memory in a multi-memory
+// module. The bundled WABT doesn't support multi-memory data segment syntax,
+// so we construct the binary directly.
+//
+// Equivalent WAT:
+//   (module
+//     (memory 1)
+//     (memory 1)
+//     (func (export "load_m0") (param i32) (result i64) (local.get 0) (i64.load (memory 0)))
+//     (func (export "load_m1") (param i32) (result i64) (local.get 0) (i64.load (memory 1)))
+//     (data (memory 0) (i32.const 0) "\01")
+//     (data (memory 1) (i32.const 0) "\02")
+//   )
+
+const bytes = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, // magic
+    0x01, 0x00, 0x00, 0x00, // version
+
+    // type section: one type (i32) -> (i64)
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7e,
+
+    // function section: two functions, both type 0
+    0x03, 0x03, 0x02, 0x00, 0x00,
+
+    // memory section: two memories, each 1 page
+    0x05, 0x05, 0x02, 0x00, 0x01, 0x00, 0x01,
+
+    // export section: "load_m0" -> func 0, "load_m1" -> func 1
+    0x07, 0x15, 0x02,
+    0x07, 0x6c, 0x6f, 0x61, 0x64, 0x5f, 0x6d, 0x30, 0x00, 0x00,
+    0x07, 0x6c, 0x6f, 0x61, 0x64, 0x5f, 0x6d, 0x31, 0x00, 0x01,
+
+    // code section: two function bodies
+    0x0a, 0x12, 0x02,
+    // func 0: local.get 0, i64.load align=3 offset=0 (memory 0)
+    0x07, 0x00, 0x20, 0x00, 0x29, 0x03, 0x00, 0x0b,
+    // func 1: local.get 0, i64.load align=3 offset=0 (memory 1, bit 6 set)
+    0x08, 0x00, 0x20, 0x00, 0x29, 0x43, 0x01, 0x00, 0x0b,
+
+    // data section: two active segments
+    0x0b, 0x0e, 0x02,
+    // segment 0: flag=0x00 (active, memory 0), offset=i32.const 0, 1 byte: 0x01
+    0x00, 0x41, 0x00, 0x0b, 0x01, 0x01,
+    // segment 1: flag=0x02 (active, explicit memory index), memory=1, offset=i32.const 0, 1 byte: 0x02
+    0x02, 0x01, 0x41, 0x00, 0x0b, 0x01, 0x02,
+]);
+
+const module = new WebAssembly.Module(bytes.buffer);
+const instance = new WebAssembly.Instance(module);
+
+assert.eq(instance.exports.load_m0(0), 1n);
+assert.eq(instance.exports.load_m1(0), 2n);

--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -46,7 +46,7 @@ bool WasmCallableFunction::isJS() const
     return boxedCallee == CalleeBits { &WasmToJSCallee::singleton() };
 }
 
-std::unique_ptr<Segment> Segment::tryCreate(std::optional<I32InitExpr> offset, uint32_t sizeInBytes, Kind kind)
+std::unique_ptr<Segment> Segment::tryCreate(std::optional<I32InitExpr> offset, uint32_t sizeInBytes, Kind kind, uint32_t memoryIndex)
 {
     auto result = tryFastZeroedMalloc(allocationSize(sizeInBytes));
     void* memory;
@@ -54,7 +54,7 @@ std::unique_ptr<Segment> Segment::tryCreate(std::optional<I32InitExpr> offset, u
         return nullptr;
 
     ASSERT(kind == Kind::Passive || !!offset);
-    return std::unique_ptr<Segment>(new (memory) Segment(sizeInBytes, kind, WTF::move(offset)));
+    return std::unique_ptr<Segment>(new (memory) Segment(sizeInBytes, kind, WTF::move(offset), memoryIndex));
 }
 
 String makeString(const Name& characters)

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -723,23 +723,26 @@ public:
     }
     uint32_t sizeInBytes() const { return Base::size(); }
 
-    Segment(size_t sizeInBytes, Kind passedKind, std::optional<I32InitExpr>&& passedOffsetIfActive)
+    Segment(size_t sizeInBytes, Kind passedKind, std::optional<I32InitExpr>&& passedOffsetIfActive, uint32_t memoryIndex = 0)
         : Base(sizeInBytes)
         , m_kind(passedKind)
         , m_offsetIfActive(WTF::move(passedOffsetIfActive))
+        , m_memoryIndex(memoryIndex)
     {
     }
 
-    static std::unique_ptr<Segment> tryCreate(std::optional<I32InitExpr>, uint32_t, Kind);
+    static std::unique_ptr<Segment> tryCreate(std::optional<I32InitExpr>, uint32_t, Kind, uint32_t memoryIndex = 0);
 
     bool isActive() const { return m_kind == Kind::Active; }
     bool isPassive() const { return m_kind == Kind::Passive; }
     Kind kind() const { return m_kind; }
     std::optional<I32InitExpr> offsetIfActive() const { return m_offsetIfActive; }
+    uint32_t memoryIndex() const { return m_memoryIndex; }
 
 private:
     const Kind m_kind;
     const std::optional<I32InitExpr> m_offsetIfActive;
+    const uint32_t m_memoryIndex;
 };
 
 struct Element {

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -1356,7 +1356,7 @@ auto SectionParser::parseData() -> PartialResult
             WASM_PARSER_FAIL_IF(!parseVarUInt32(dataByteLength), "can't get "_s, segmentNumber, "th Data segment's data byte length"_s);
             WASM_PARSER_FAIL_IF(dataByteLength > maxModuleSize, segmentNumber, "th Data segment's data byte length is too big "_s, dataByteLength, " maximum "_s, maxModuleSize);
 
-            auto segment = Segment::tryCreate(*initExpr, dataByteLength, Segment::Kind::Active);
+            auto segment = Segment::tryCreate(*initExpr, dataByteLength, Segment::Kind::Active, memoryIndex);
             WASM_PARSER_FAIL_IF(!segment, "can't allocate enough memory for "_s, segmentNumber, "th Data segment of size "_s, dataByteLength);
 
             WASM_PARSER_FAIL_IF(source().size() < dataByteLength || (source().size() - dataByteLength) < m_offset, "can't get data bytes from "_s, segmentNumber, "th Data segment"_s);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -895,13 +895,14 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
     };
 
     auto forEachActiveDataSegment = [&] (auto fn) {
-        auto& wasmMemory = m_instance->memory()->memory();
-        uint8_t* memory = static_cast<uint8_t*>(wasmMemory.basePointer());
-        uint64_t sizeInBytes = wasmMemory.size();
-
         for (const auto& segment : data) {
             if (!segment->isActive())
                 continue;
+
+            auto& wasmMemory = m_instance->memory(segment->memoryIndex())->memory();
+            uint8_t* memory = static_cast<uint8_t*>(wasmMemory.basePointer());
+            uint64_t sizeInBytes = wasmMemory.size();
+
             uint32_t offset = 0;
             if (segment->offsetIfActive()->isGlobalImport())
                 offset = static_cast<uint32_t>(m_instance->loadI32Global(segment->offsetIfActive()->globalImportIndex()));


### PR DESCRIPTION
#### e40405afe9a4f0dceae60d5bd593e309748e9a64
<pre>
Update wasm data segment implementation to support multimemory
<a href="https://bugs.webkit.org/show_bug.cgi?id=312589">https://bugs.webkit.org/show_bug.cgi?id=312589</a>
<a href="https://rdar.apple.com/175020377">rdar://175020377</a>

Reviewed by Yusuke Suzuki.

Right now the implementation of wasm data segments doesn&apos;t know about
multimemory and doesn&apos;t have any code to handle a memory index
associated with a data segment. This patch updates it to correctly
handle data segments that specify memory indices other than 0.

Test: JSTests/wasm/stress/data-segment-multimemory.js

* JSTests/wasm/stress/data-segment-multimemory.js: Added.
* Source/JavaScriptCore/wasm/WasmFormat.cpp:
(JSC::Wasm::Segment::tryCreate):
* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseData):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::evaluate):

Canonical link: <a href="https://commits.webkit.org/311477@main">https://commits.webkit.org/311477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49d27f201cb7017ef9d2d689f8c779025a4f652a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165900 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111159 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f40dd21f-6ef9-49a8-86f7-af0287d15f57) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121659 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bcd54a1d-5dde-4c0d-902b-84bc12a69e47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102327 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3c0c5b3-8032-4b4d-885b-65a7b1154fcf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22952 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21184 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13672 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149127 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168385 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17912 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20500 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129783 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129891 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35188 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140674 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87759 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24715 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17478 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189040 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29649 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93663 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48521 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29171 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29401 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29298 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->