### PR TITLE
Download Prompt Origin Spoofing via Back-Forward Navigation

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7897,6 +7897,7 @@ webkit.org/b/290285 imported/w3c/web-platform-tests/svg/struct/scripted/use-load
 
 # This test hits an assert in debug
 webkit.org/b/290133 [ Debug ] svg/dom/SVGGeometry-isPointInFill-with-null-path.html [ Skip ]
+[ Debug ] svg/dom/SVGGeometry-isPointInStroke-with-null-path.html [ Skip ]
 
 # The color input only has a swatch overlay on macOS
 fast/forms/color/input-color-swatch-overlay-appearance.html [ Skip ]

--- a/LayoutTests/fast/dom/Document/open-triggered-by-mutation-observer-on-element-from-a-parsed-doc-crash-expected.txt
+++ b/LayoutTests/fast/dom/Document/open-triggered-by-mutation-observer-on-element-from-a-parsed-doc-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/dom/Document/open-triggered-by-mutation-observer-on-element-from-a-parsed-doc-crash.html
+++ b/LayoutTests/fast/dom/Document/open-triggered-by-mutation-observer-on-element-from-a-parsed-doc-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<body>
+  <script>
+    window.testRunner?.dumpAsText();
+    const element = (new DOMParser()).parseFromString("<!DOCTYPE html><p>foo</p>","text/html").documentElement;
+    (new MutationObserver(_ => document.open())).observe(element, {attributes: true});
+    element.setAttribute("class", "bar");
+    document.body.innerHTML = "PASS if no crash.";
+  </script>
+</body>

--- a/LayoutTests/fast/reflections/reflection-removed-crash-2-expected.txt
+++ b/LayoutTests/fast/reflections/reflection-removed-crash-2-expected.txt
@@ -1,0 +1,1 @@
+this test passes if it doesn't crash.

--- a/LayoutTests/fast/reflections/reflection-removed-crash-2.html
+++ b/LayoutTests/fast/reflections/reflection-removed-crash-2.html
@@ -1,0 +1,20 @@
+<style>
+ rt {
+     translate: 23% 80cap 1svi;
+     -webkit-box-reflect: below;
+ }
+</style>
+  <script>
+   (async () => {
+       let n1 = document.createElement('ruby');
+       document.documentElement.appendChild(n1);
+       n1.appendChild(document.createElement('rt'));
+       let n7 = document.createElement('object');
+       n7.id = 'n4';
+       n1.append(document.createElement('rt'));
+   })();
+  testRunner?.dumpAsText();
+  </script>
+<div>
+    this test passes if it doesn't crash.
+</div>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5064,6 +5064,7 @@ webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_c
 webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html [ Skip ]
 
 webkit.org/b/290133 svg/dom/SVGGeometry-isPointInFill-with-null-path.html [ Skip ]
+svg/dom/SVGGeometry-isPointInStroke-with-null-path.html [ Skip ]
 
 fast/images/embed-image.html [ Failure ]
 fast/images/object-image.html [ Failure ]

--- a/LayoutTests/svg/dom/SVGGeometry-isPointInStroke-with-null-path-expected.txt
+++ b/LayoutTests/svg/dom/SVGGeometry-isPointInStroke-with-null-path-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/svg/dom/SVGGeometry-isPointInStroke-with-null-path.html
+++ b/LayoutTests/svg/dom/SVGGeometry-isPointInStroke-with-null-path.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<time>
+  <svg style="stroke: black; display: table-caption">
+    <polygon id="polygon"></polygon>
+  </svg>
+</time>
+<script>
+  window.testRunner?.dumpAsText();
+  document.getElementById("polygon").isPointInStroke();
+  document.body.innerHTML = "PASS if no crash.";
+</script>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -482,7 +482,7 @@ void RenderLayer::addChild(RenderLayer& child, RenderLayer* beforeChild)
 
 void RenderLayer::removeChild(RenderLayer& oldChild)
 {
-    if (!renderer().renderTreeBeingDestroyed())
+    if (!renderer().renderTreeBeingDestroyed() && !isReflectionLayer(oldChild))
         compositor().layerWillBeRemoved(*this, oldChild);
 
     // remove the child

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -88,9 +88,8 @@ void RenderSVGShape::strokeShape(GraphicsContext& context) const
 
 bool RenderSVGShape::shapeDependentStrokeContains(const FloatPoint& point, PointCoordinateSpace pointCoordinateSpace)
 {
-    ASSERT(m_path);
-
     if (hasNonScalingStroke() && pointCoordinateSpace != LocalCoordinateSpace) {
+        ASSERT(m_path);
         AffineTransform nonScalingTransform = nonScalingStrokeTransform();
         Path* usePath = nonScalingStrokePath(m_path.get(), nonScalingTransform);
         return usePath->strokeContains(nonScalingTransform.mapPoint(point), [this] (GraphicsContext& context) {
@@ -98,7 +97,7 @@ bool RenderSVGShape::shapeDependentStrokeContains(const FloatPoint& point, Point
         });
     }
 
-    return m_path->strokeContains(point, [this] (GraphicsContext& context) {
+    return ensurePath().strokeContains(point, [this] (GraphicsContext& context) {
         SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
     });
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -94,9 +94,8 @@ void LegacyRenderSVGShape::strokeShape(GraphicsContext& context) const
 
 bool LegacyRenderSVGShape::shapeDependentStrokeContains(const FloatPoint& point, PointCoordinateSpace pointCoordinateSpace)
 {
-    ASSERT(m_path);
-
     if (hasNonScalingStroke() && pointCoordinateSpace != LocalCoordinateSpace) {
+        ASSERT(m_path);
         AffineTransform nonScalingTransform = nonScalingStrokeTransform();
         Path* usePath = nonScalingStrokePath(m_path.get(), nonScalingTransform);
         return usePath->strokeContains(nonScalingTransform.mapPoint(point), [this] (GraphicsContext& context) {
@@ -104,7 +103,7 @@ bool LegacyRenderSVGShape::shapeDependentStrokeContains(const FloatPoint& point,
         });
     }
 
-    return m_path->strokeContains(point, [this] (GraphicsContext& context) {
+    return ensurePath().strokeContains(point, [this] (GraphicsContext& context) {
         SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
     });
 }

--- a/Source/WebKit/UIProcess/API/APINavigationResponse.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigationResponse.cpp
@@ -48,9 +48,14 @@ FrameInfo* NavigationResponse::navigationInitiatingFrame()
 {
     if (!m_navigation)
         return nullptr;
+
+    if (m_navigation->targetItem() || m_navigation->isRequestFromClientOrUserInput())
+        return nullptr;
+
     auto& frameInfo = m_navigation->originatingFrameInfo();
     if (!frameInfo)
         return nullptr;
+
     RefPtr frame = WebKit::WebFrameProxy::webFrame(frameInfo->frameID);
     m_sourceFrame = FrameInfo::create(WebKit::FrameInfoData { *frameInfo });
     return m_sourceFrame.get();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm
@@ -41,6 +41,7 @@
 #import <WebKit/WKNavigationActionPrivate.h>
 #import <WebKit/WKNavigationDelegatePrivate.h>
 #import <WebKit/WKNavigationPrivate.h>
+#import <WebKit/WKNavigationResponsePrivate.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKURLRequest.h>
@@ -5289,4 +5290,80 @@ TEST(Navigation, FormResubmited)
     TestWebKitAPI::Util::run(&didReceiveForm);
 
     EXPECT_TRUE(requestHadSecFetchSiteCrossOrigin.value_or(false));
+}
+
+TEST(Navigation, NavigationInitiatingFrameInGoBackNavigation)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/firstSite"_s, { "firstSite"_s } },
+        { "/secondSite"_s, { "secondSite"_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300) configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://firstSite.com/firstSite"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://secondSite.com/secondSite"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    __block bool done = false;
+
+    navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *, void (^completionHandler)(WKNavigationActionPolicy)) {
+        completionHandler(WKNavigationActionPolicyAllow);
+    };
+
+    navigationDelegate.get().decidePolicyForNavigationResponse = ^(WKNavigationResponse *response, void (^completionHandler)(WKNavigationResponsePolicy)) {
+        EXPECT_NULL(response._navigationInitiatingFrame);
+
+        done = true;
+        completionHandler(WKNavigationResponsePolicyAllow);
+    };
+
+    [webView _clearBackForwardCache];
+    [webView goBack];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(Navigation, NavigationInitiatingFrameInClientInputNavigation)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/firstSite"_s, { "firstSite"_s } },
+        { "/secondSite"_s, { "secondSite"_s } },
+        { "/thirdSite"_s, { "thirdSite"_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300) configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://firstSite.com/firstSite"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://secondSite.com/secondSite"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    __block bool done = false;
+
+    navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *, void (^completionHandler)(WKNavigationActionPolicy)) {
+        completionHandler(WKNavigationActionPolicyAllow);
+    };
+
+    navigationDelegate.get().decidePolicyForNavigationResponse = ^(WKNavigationResponse *response, void (^completionHandler)(WKNavigationResponsePolicy)) {
+        EXPECT_NULL(response._navigationInitiatingFrame);
+
+        done = true;
+        completionHandler(WKNavigationResponsePolicyAllow);
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://thirdSite.com/thirdSite"]]];
+    TestWebKitAPI::Util::run(&done);
 }


### PR DESCRIPTION
#### a9f2dfaaf8a7b81ed38d2d29dcf59bd8c167301e
<pre>
Download Prompt Origin Spoofing via Back-Forward Navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=308396">https://bugs.webkit.org/show_bug.cgi?id=308396</a>
<a href="https://rdar.apple.com/153668219">rdar://153668219</a>

Reviewed by Brady Eidson.

When a navigation occurs, WebKit calls the delegate function:
webView:decidePolicyForNavigationResponse:decisionHandler: and passes in a
WKNavigationResponse object. The client may use the _navigationInitiatingFrame
property to show which triggered this Navigation (or is requesting a download)

In the case where the navigation is started as a result of a back-forward
navigation, WebKit currently says the initiating frame is the frame that
is currently displayed in the WebView that is on the screen. Which means
the following sequence of events is possible:

1. Navigate to site1.com
2. Navigate to site2.com
3. Go back &lt;--- somehow this starts a download
                (maybe a malicicous script intervenes)
4. A prompt may show saying that &quot;site2.com wants to start a download&quot;

But site2 did not start the download. This message is misleading.

We fix this by ensuring that in a back-forward navigation, the initiating
frame information is empty, rather than being the information of the site
currently displayed in the WebView.

A second scenario is also possible:

1. Navigate to site1.com
2. User types in site2.com to navigate there &lt;--- somehow starting a download
                                                  (maybe a malicicous script intervenes)
3. A prompt may show saying that &quot;site1.com wants to start a download&quot;

Again, the download should not be attributed to site1.

We make the same change here--for a client initiated navigation, the
initiating frame information is empty, rather than being the information of
the site currently displayed in the WebView.

This is tested by two new API tests.

A similar fix was made in <a href="https://commits.webkit.org/298732@main">https://commits.webkit.org/298732@main</a>

* Source/WebKit/UIProcess/API/APINavigationResponse.cpp:
(API::NavigationResponse::navigationInitiatingFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(Navigation, NavigationInitiatingFrameInGoBackNavigation)):
(TEST(Navigation, NavigationInitiatingFrameInClientInputNavigation)):

Originally-landed-as: 305413.338@safari-7624-branch (816b1f464d4d). <a href="https://rdar.apple.com/173973970">rdar://173973970</a>
Canonical link: <a href="https://commits.webkit.org/311486@main">https://commits.webkit.org/311486@main</a>
</pre>
----------------------------------------------------------------------
#### ecde527ba8fbc8ea323542880a066133826ced3f
<pre>
[WebKit][Main] [Fuzz Blocker] [e5518f91af2befa2] WK_SEC | WebCore::RenderLayerCompositor::repaintInCompositedAncestor; WebCore::RenderLayerCompositor::layerWillBeRemoved; WebCore::RenderLayer::removeChild
<a href="https://bugs.webkit.org/show_bug.cgi?id=306841">https://bugs.webkit.org/show_bug.cgi?id=306841</a>
<a href="https://rdar.apple.com/169436867">rdar://169436867</a>

Reviewed by Simon Fraser.

When a render layer that contains a reflection layer is deleted, we first
remove that reflection layer. The code path for layer removal causes
the layer to be repainted in its composited ancestor. However, when
the compositor ancestor is the original layer that is being deleted,
we are actually dealing with a layer that is in the process of destruction.

In order to prevent this reentrancy, we can avoid going
down RenderLayerCompositor::layerWillBeRemoved() if the layer being removed
is a reflection layer, since this doesn&apos;t seem to be needed in reality (and
all tests involving -webkit-reflect-box pass after this change).

This bug was uncovered in main after 306315@main introduced a checked pointer
for the compositedAncestor variable in RenderLayerCompositor::repaintInCompositedAncestor(),
which fails an assertion when it goes out of scope, because the underlying
RenderLayer is already in the process of destruction. This doesn&apos;t assert
or crash before that change, but assuming that we don&apos;t want to take risks
I prefer to land this change in embargoed instead so that it&apos;s backported
wherever it&apos;s necessary before making this change public in main.

Test: fast/reflections/reflection-removed-crash-2.html

* LayoutTests/fast/reflections/reflection-removed-crash-2-expected.txt: Added.
* LayoutTests/fast/reflections/reflection-removed-crash-2.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::removeChild):

Originally-landed-as: 305413.3@webkit-2026.1-embargoed (218d25f508a7). <a href="https://rdar.apple.com/174957077">rdar://174957077</a>
Canonical link: <a href="https://commits.webkit.org/311485@main">https://commits.webkit.org/311485@main</a>
</pre>
----------------------------------------------------------------------
#### 389fcd914b790dc05013c66d5bc0d5a32e2ef9ba
<pre>
Crash in shapeDependentStrokeContains() via isPointInStroke()
<a href="https://bugs.webkit.org/show_bug.cgi?id=306154">https://bugs.webkit.org/show_bug.cgi?id=306154</a>
<a href="https://rdar.apple.com/168055632">rdar://168055632</a>

Reviewed by Darin Adler.

Ensure the path exists when calling the function with legacy and LSBE code
from isPointInStroke() (which implies pointCoordinateSpace is
LocalCoordinateSpace). This is similar to <a href="https://commits.webkit.org/292730@main">https://commits.webkit.org/292730@main</a>

Test: svg/dom/SVGGeometry-isPointInStroke-with-null-path.html

* LayoutTests/TestExpectations: Skip the test because it hits an assertion failure.
* LayoutTests/platform/glib/TestExpectations: Ditto.
* LayoutTests/svg/dom/SVGGeometry-isPointInStroke-with-null-path-expected.txt: Added.
* LayoutTests/svg/dom/SVGGeometry-isPointInStroke-with-null-path.html: Added.
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::shapeDependentStrokeContains): Ensure path exists.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::shapeDependentStrokeContains): Ditto.

Originally-landed-as: 305413.4@webkit-2026.1-embargoed (82934b97537c). <a href="https://rdar.apple.com/174957149">rdar://174957149</a>
Canonical link: <a href="https://commits.webkit.org/311484@main">https://commits.webkit.org/311484@main</a>
</pre>
----------------------------------------------------------------------
#### 6767475946c16797002b8fa0e36680e8d6ff97ec
<pre>
[WebKit][Main+SU?] [a3b9e8b1b7c6c7b7] ASAN_SEGV | WebCore::firstDOMWindow; WebCore::jsDocumentPrototypeFunction_write; ADDRESS
<a href="https://bugs.webkit.org/show_bug.cgi?id=300372">https://bugs.webkit.org/show_bug.cgi?id=300372</a>
<a href="https://rdar.apple.com/162173350">rdar://162173350</a>

Reviewed by Ryosuke Niwa.

Add a regression test for [1], which was later reverted in [2].

[1] <a href="https://commits.webkit.org/300757@main">https://commits.webkit.org/300757@main</a>
[2] <a href="https://commits.webkit.org/300886@main">https://commits.webkit.org/300886@main</a>

* LayoutTests/fast/dom/Document/open-triggered-by-mutation-observer-on-element-from-a-parsed-doc-crash-expected.txt: Added.
* LayoutTests/fast/dom/Document/open-triggered-by-mutation-observer-on-element-from-a-parsed-doc-crash.html: Added.

Originally-landed-as: 297297.15@webkit-2025.7-embargoed (cb9035f59bbb). <a href="https://rdar.apple.com/174959210">rdar://174959210</a>
Canonical link: <a href="https://commits.webkit.org/311483@main">https://commits.webkit.org/311483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0577464829959b0db9b4c382d4f5f85243449557

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111168 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2173928-0ac6-42b5-983b-0312f2c64e4b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121658 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d01a1def-7a42-41ac-8714-0ce8ae03e985) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102326 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cd507b7-3722-4465-a594-235908fd8e5f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22965 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21191 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13681 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168394 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12553 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129785 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25269 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129893 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35194 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140685 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87768 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17489 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29658 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93672 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29180 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29410 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29307 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->