### PR TITLE
[JSC][WASM][Debugger] Add Swift fatalError trap test

### DIFF
--- a/JSTests/wasm/debugger/resources/swift-wasm/build.sh
+++ b/JSTests/wasm/debugger/resources/swift-wasm/build.sh
@@ -19,7 +19,7 @@ else
     exit 1
 fi
 
-SDK=swift-6.2.3-RELEASE_wasm
+SDK=swift-6.3.1-RELEASE_wasm
 
 if [ -z "$1" ]; then
     echo "Usage: $0 <test-folder>"

--- a/JSTests/wasm/debugger/resources/swift-wasm/fatal-error-test/Package.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/fatal-error-test/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "fatal-error-test",
+    targets: [
+        .executableTarget(
+            name: "fatal-error-test",
+            path: "Sources/fatal-error-test",
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "--export=trigger_fatal_error"])
+            ]
+        )
+    ]
+)

--- a/JSTests/wasm/debugger/resources/swift-wasm/fatal-error-test/Sources/fatal-error-test/main.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/fatal-error-test/Sources/fatal-error-test/main.swift
@@ -1,0 +1,14 @@
+@_cdecl("trigger_fatal_error")
+public func triggerFatalError(_ condition: Int32) -> Int32 {
+    guard condition != 0 else {
+        fatalError("condition must not be zero")
+    }
+    return condition * 2
+}
+
+@main
+struct FatalErrorTest {
+    static func main() {
+        _ = triggerFatalError
+    }
+}

--- a/JSTests/wasm/debugger/resources/swift-wasm/fatal-error-test/main.js
+++ b/JSTests/wasm/debugger/resources/swift-wasm/fatal-error-test/main.js
@@ -1,0 +1,55 @@
+var wasm_code = read('fatal-error-test.wasm', 'binary');
+var wasm_module = new WebAssembly.Module(wasm_code);
+
+// fd_write must record nwritten so Swift's runtime doesn't retry the write forever.
+var memory = null;
+
+var imports = {
+    wasi_snapshot_preview1: {
+        proc_exit: function (code) {
+            print("Program exited with code:", code);
+        },
+        args_get: function () { return 0; },
+        args_sizes_get: function () { return 0; },
+        environ_get: function () { return 0; },
+        environ_sizes_get: function () { return 0; },
+        fd_write: function (fd, iovs_ptr, iovs_len, nwritten_ptr) {
+            if (memory) {
+                var view = new DataView(memory.buffer);
+                var total = 0;
+                for (var i = 0; i < iovs_len; i++)
+                    total += view.getUint32(iovs_ptr + i * 8 + 4, true);
+                view.setUint32(nwritten_ptr, total, true);
+            }
+            return 0;
+        },
+        fd_read: function () { return 0; },
+        fd_close: function () { return 0; },
+        fd_seek: function () { return 0; },
+        fd_fdstat_get: function () { return 0; },
+        fd_prestat_get: function () { return 8; },
+        fd_prestat_dir_name: function () { return 8; },
+        path_open: function () { return 8; },
+        random_get: function () { return 0; },
+        clock_time_get: function () { return 0; }
+    }
+};
+
+var instance = new WebAssembly.Instance(wasm_module, imports);
+memory = instance.exports.memory;
+
+print("Available exports:", Object.keys(instance.exports));
+
+let triggerFatalError = instance.exports.trigger_fatal_error;
+
+let iteration = 0;
+for (;;) {
+    try {
+        triggerFatalError(0);
+    } catch (e) {
+        // Catch the trap so the loop keeps running until lldb attaches.
+    }
+    iteration += 1;
+    if (iteration % 1e3 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -2158,3 +2158,25 @@ class StreamingModuleLoadTestCase(BaseTestCase):
         self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "->  0x4000000000000023: end"])
 
         self.send_lldb_command_or_raise("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+
+class SwiftWasmFatalErrorTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/swift-wasm/fatal-error-test/main.js")
+
+        try:
+            for _ in range(1):
+                self.test()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def test(self):
+        for _ in range(10):
+            self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped"])
+
+        self.send_lldb_command_or_raise("bt", patterns=["main.swift:4",])


### PR DESCRIPTION
#### 7e7a59f05cf089d89b7c13f449839b674c783af3
<pre>
[JSC][WASM][Debugger] Add Swift fatalError trap test
<a href="https://bugs.webkit.org/show_bug.cgi?id=312592">https://bugs.webkit.org/show_bug.cgi?id=312592</a>
<a href="https://rdar.apple.com/175024728">rdar://175024728</a>

Reviewed by Keith Miller.

Add a new Swift WASM test (fatal-error-test) that verifies the debugger
correctly intercepts a Swift fatalError() trap. Swift&apos;s _assertionFailure
triggers an out-of-bounds memory access in the minimal WASI stub environment,
which the debugger intercepts as an &quot;Out of bounds memory access&quot; stop. The
test confirms reliable fault interception across 10 iterations and that the
backtrace includes the fatalError call site at main.swift:4.

fd_write is implemented properly (writing nwritten back to memory) to prevent
Swift&apos;s runtime from spinning in a retry loop when attempting to print the
error message.

Also bumps the Swift WASM SDK version in build.sh from 6.2.3 to 6.3.1.

Canonical link: <a href="https://commits.webkit.org/311466@main">https://commits.webkit.org/311466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b0b0835dbccb568ea794a8b6660043ea5bce7fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157087 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165910 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30426 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23903 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102328 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13682 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/149137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168395 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17922 "Built successfully and passed tests") | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/20504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30025 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129895 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140678 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23902 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24719 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17482 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/189050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29659 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/189050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29181 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29411 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29308 "Failed to checkout and rebase branch from PR 62992") | | | | 
<!--EWS-Status-Bubble-End-->