### PR TITLE
[WebKit][Main+SU] [fdae418b9cd3d6ba] WK_SEC | WebCore::EventTarget::fireEventListeners; WebCore::LocalDOMWindow::dispatchEvent; WebCore::dispatchPrintEvent

### DIFF
--- a/LayoutTests/fast/pdf-plugin-destruction-dispatches-print-event-crash-expected.txt
+++ b/LayoutTests/fast/pdf-plugin-destruction-dispatches-print-event-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash.
+
+

--- a/LayoutTests/fast/pdf-plugin-destruction-dispatches-print-event-crash.html
+++ b/LayoutTests/fast/pdf-plugin-destruction-dispatches-print-event-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<p>PASS if no crash.</p>
+<embed id="embed" style="top: 200vmin; visibility: hidden;" type="application/pdf" src="about:blank"></embed>
+<script>
+  window.testRunner?.dumpAsText();
+  window.testRunner?.waitUntilDone();
+  window.addEventListener("load", _ => {
+    embed.setAttribute("onsubmit", "");
+    window.print();
+      requestAnimationFrame(_ => requestAnimationFrame(_ => window.testRunner?.notifyDone()));
+  });
+</script>

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2094,9 +2094,12 @@ void DocumentLoader::addPlugInStreamLoader(ResourceLoader& loader)
 void DocumentLoader::removePlugInStreamLoader(ResourceLoader& loader)
 {
     ASSERT(m_plugInStreamLoaders.contains(&loader));
-
     m_plugInStreamLoaders.remove(&loader);
-    checkLoadComplete();
+    if (m_frame && m_frame->document()) {
+        protect(m_frame->document())->eventLoop().queueTask(TaskSource::Networking, [protectedThis = Ref { *this }]() {
+            protectedThis->checkLoadComplete();
+        });
+    }
 }
 
 bool DocumentLoader::isMultipartReplacingLoad() const


### PR DESCRIPTION
#### 7fec1840ae0adc257994d9f0f5c723df5013a232
<pre>
[WebKit][Main+SU] [fdae418b9cd3d6ba] WK_SEC | WebCore::EventTarget::fireEventListeners; WebCore::LocalDOMWindow::dispatchEvent; WebCore::dispatchPrintEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=303411">https://bugs.webkit.org/show_bug.cgi?id=303411</a>
<a href="https://rdar.apple.com/165712958">rdar://165712958</a>

Reviewed by Ryosuke Niwa.

Document::updateStyleIfNeeded() forbids script execution in main thread
by creating a ScriptDisallowedScope. However, it can also trigger the
destruction of a PluginView, which may end up dispatching a print event,
triggering an assertion with security implication for
ScriptDisallowedScope::isScriptAllowedInMainThread(). In order to avoid
that issue, we ensure the print event is dispatched asynchronously.

Test: fast/pdf-plugin-destruction-dispatches-print-event-crash.html

* LayoutTests/fast/pdf-plugin-destruction-dispatches-print-event-crash-expected.txt: Added.
* LayoutTests/fast/pdf-plugin-destruction-dispatches-print-event-crash.html: Added.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::removePlugInStreamLoader): Perform the load completion check asynchronously, so that we don&apos;t execute any script in this context.

Originally-landed-as: 302196.12@webkit-2025.11-embargoed (308756637681). <a href="https://rdar.apple.com/174957681">rdar://174957681</a>
Canonical link: <a href="https://commits.webkit.org/311496@main">https://commits.webkit.org/311496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e366415724584a707a463fd02d724ed5b38bcb8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111185 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e3b07e7-a992-48e0-8b89-4d8b14fbf282) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121670 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26601f5c-bf84-4940-aa20-46956d3ee919) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102338 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bce42cab-abf7-43bf-b2ef-8397fe01b765) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22971 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21203 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13698 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168411 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12570 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129795 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129903 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35198 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140695 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87785 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24737 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17499 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29675 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93689 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29197 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29427 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29324 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->