### PR TITLE
[macOS] WebKit processes can use incorrect sandbox profile by following symlinks

### DIFF
--- a/LayoutTests/fast/webcodecs/resetting-audio-decoder-with-zero-size-crash-expected.txt
+++ b/LayoutTests/fast/webcodecs/resetting-audio-decoder-with-zero-size-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/webcodecs/resetting-audio-decoder-with-zero-size-crash.html
+++ b/LayoutTests/fast/webcodecs/resetting-audio-decoder-with-zero-size-crash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<p>PASS if no crash.</p>
+<script>
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+window.addEventListener("load", async _ => {
+  if (!"AudioDecoder" in window) {
+    window.testRunner?.notifyDone();
+    return;
+  }
+  const decoder = new AudioDecoder({output: _ => {}, error: _ => {}});
+  decoder.configure({ codec: "opus", sampleRate: 48000, numberOfChannels: 2 });
+
+  const chunk = new EncodedAudioChunk({
+    type: 'key',
+    timestamp: 0,
+    duration: 1000000,  // 1 second
+    data: new Uint8Array(0)
+  });
+  decoder.decode(chunk);
+  await decoder.flush();
+  window.testRunner?.notifyDone();
+});
+</script>

--- a/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
@@ -83,11 +83,24 @@ private:
                     case GetGlobalLexicalVariable:
                     case MultiGetByOffset:
                     case GetByOffset: {
-                        if (node->child1().useKind() == RealNumberUse || node->child1().useKind() == NumberUse) {
-                            if (node->child1()->origin.exitOK)
-                                candidates.add(node->child1().node());
+                        if (node->child1().useKind() != RealNumberUse && node->child1().useKind() != NumberUse)
                             break;
+                        if (!node->child1()->origin.exitOK)
+                            break;
+                        if (node->child1()->op() == MultiGetByOffset) {
+                            bool isCandidate = true;
+                            MultiGetByOffsetData& data = node->child1()->multiGetByOffsetData();
+                            for (unsigned i = 0; i < data.cases.size(); ++i) {
+                                GetByOffsetMethod& method = data.cases[i].method();
+                                if (method.kind() == GetByOffsetMethod::Constant && !method.constant()->value().toNumberFromPrimitive()) {
+                                    isCandidate = false;
+                                    break;
+                                }
+                            }
+                            if (!isCandidate)
+                                break;
                         }
+                        candidates.add(node->child1().node());
                         break;
                     }
                     default:

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h
@@ -128,6 +128,7 @@ private:
     const Options m_options;
     std::atomic<unsigned> m_defaultBitRate { 0 };
     std::atomic<unsigned> m_preSkip { 0 };
+    bool m_skipEmptyBlock { false };
 };
 
 }

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm
@@ -184,6 +184,25 @@ OSStatus AudioSampleBufferConverter::initAudioConverterForSourceFormatDescriptio
     if (!audioFormatListItem)
         return kCMSampleBufferError_InvalidMediaFormat;
     m_sourceFormat = audioFormatListItem->mASBD;
+    m_skipEmptyBlock = [](AudioFormatID format) {
+        switch (format) {
+        case kAudioFormatLinearPCM:
+        case kAudioFormatMPEG4AAC:
+        case kAudioFormatMPEG4AAC_LD:
+        case kAudioFormatMPEG4AAC_HE:
+        case kAudioFormatMPEG4AAC_HE_V2:
+        case kAudioFormatMPEG4AAC_ELD:
+        case kAudioFormatMPEGLayer3:
+        case kAudioFormatOpus:
+        case kAudioFormatALaw:
+        case kAudioFormatULaw:
+        case kAudioFormatFLAC:
+        case 'vorb':
+            return true;
+        default:
+            return false;
+        }
+    }(m_sourceFormat.mFormatID);
 
     if (!m_destinationFormat.mFormatID || !m_destinationFormat.mSampleRate) {
         m_destinationFormat.mFormatID = outputFormatID;
@@ -414,43 +433,55 @@ OSStatus AudioSampleBufferConverter::provideSourceDataNumOutputPackets(UInt32* n
     if (packetDescriptionOut)
         *packetDescriptionOut = NULL;
 
-    if (PAL::CMBufferQueueIsEmpty(m_inputBufferQueue.get())) {
-        *numOutputPacketsPtr = 0;
-        return m_isDraining ? noErr : kNoMoreDataErr;
+    *numOutputPacketsPtr = 0;
+
+    while (!PAL::CMBufferQueueIsEmpty(m_inputBufferQueue.get())) {
+        RetainPtr sampleBuffer = adoptCF((CMSampleBufferRef)(const_cast<void*>(PAL::CMBufferQueueDequeueAndRetain(m_inputBufferQueue.get()))));
+        size_t listSize = 0;
+        if (auto result = PAL::CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(sampleBuffer.get(), &listSize, nullptr, 0, kCFAllocatorSystemDefault, kCFAllocatorSystemDefault, kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, nullptr))
+            return result;
+
+        std::unique_ptr<AudioBufferList> list { static_cast<AudioBufferList*>(::operator new (listSize)) };
+        CMBlockBufferRef buffer = nullptr;
+        if (auto result = PAL::CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(sampleBuffer.get(), nullptr, list.get(), listSize, kCFAllocatorSystemDefault, kCFAllocatorSystemDefault, kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, &buffer))
+            return result;
+        m_blockBuffer = adoptCF(buffer);
+
+        if (audioBufferList->mNumberBuffers != list->mNumberBuffers)
+            return kAudioConverterErr_BadPropertySizeError;
+
+        if (!m_options.generateTimestamp)
+            setTimeFromSample(sampleBuffer.get());
+
+        auto audioBufferListSpan = span(*audioBufferList);
+        bool skipBlock = false;
+        for (auto [destination, source] : zippedRange(audioBufferListSpan, span(*list))) {
+            if (source.mDataByteSize && !source.mData) {
+                RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter AudioSampleBufferConverter::provideSourceDataNumOutputPackets invalid content");
+                return kAudioConverterErr_InvalidInputSize;
+            }
+            if (!source.mDataByteSize && m_skipEmptyBlock) {
+                skipBlock = true;
+                break;
+            }
+            destination = source;
+        }
+        if (skipBlock)
+            continue;
+
+        m_packetDescriptions = getPacketDescriptions(sampleBuffer.get());
+        if (packetDescriptionOut) {
+            *numOutputPacketsPtr = m_packetDescriptions.size();
+            *packetDescriptionOut = m_packetDescriptions.mutableSpan().data();
+        } else if (m_sourceFormat.mFormatID == kAudioFormatLinearPCM) {
+            ASSERT(audioBufferList->mNumberBuffers && m_sourceFormat.mBytesPerPacket);
+            *numOutputPacketsPtr = (audioBufferListSpan[0].mDataByteSize / m_sourceFormat.mBytesPerPacket);
+        } else
+            *numOutputPacketsPtr = 1;
+
+        return noErr;
     }
-
-    auto sampleBuffer = adoptCF((CMSampleBufferRef)(const_cast<void*>(PAL::CMBufferQueueDequeueAndRetain(m_inputBufferQueue.get()))));
-    size_t listSize = 0;
-    if (auto result = PAL::CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(sampleBuffer.get(), &listSize, nullptr, 0, kCFAllocatorSystemDefault, kCFAllocatorSystemDefault, kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, nullptr))
-        return result;
-
-    std::unique_ptr<AudioBufferList> list { static_cast<AudioBufferList*>(::operator new (listSize)) };
-    CMBlockBufferRef buffer = nullptr;
-    if (auto result = PAL::CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(sampleBuffer.get(), nullptr, list.get(), listSize, kCFAllocatorSystemDefault, kCFAllocatorSystemDefault, kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment, &buffer))
-        return result;
-    m_blockBuffer = adoptCF(buffer);
-
-    if (audioBufferList->mNumberBuffers != list->mNumberBuffers)
-        return kAudioConverterErr_BadPropertySizeError;
-
-    if (!m_options.generateTimestamp)
-        setTimeFromSample(sampleBuffer.get());
-
-    auto audioBufferListSpan = span(*audioBufferList);
-    for (auto [destination, source] : zippedRange(audioBufferListSpan, span(*list)))
-        destination = source;
-
-    m_packetDescriptions = getPacketDescriptions(sampleBuffer.get());
-    if (packetDescriptionOut) {
-        *numOutputPacketsPtr = m_packetDescriptions.size();
-        *packetDescriptionOut = m_packetDescriptions.mutableSpan().data();
-    } else if (m_sourceFormat.mFormatID == kAudioFormatLinearPCM) {
-        ASSERT(audioBufferList->mNumberBuffers && m_sourceFormat.mBytesPerPacket);
-        *numOutputPacketsPtr = (audioBufferListSpan[0].mDataByteSize / m_sourceFormat.mBytesPerPacket);
-    } else
-        *numOutputPacketsPtr = 1;
-
-    return noErr;
+    return m_isDraining ? noErr : kNoMoreDataErr;
 }
 
 bool AudioSampleBufferConverter::isPCM() const

--- a/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
@@ -140,6 +140,11 @@ RemoteCommandListenerCocoa::RemoteCommandListenerCocoa(RemoteCommandListenerClie
 
     ThreadSafeWeakPtr weakThis { *this };
     m_commandHandler = MRMediaRemoteAddAsyncCommandHandlerBlock(^(MRMediaRemoteCommand command, CFDictionaryRef options, void(^completion)(CFArrayRef)) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis) {
+            completion((__bridge CFArrayRef)@[@(MRMediaRemoteCommandHandlerStatusCommandFailed)]);
+            return;
+        }
 
         LOG(Media, "RemoteCommandListenerCocoa::RemoteCommandListenerCocoa - received command %u", command);
 
@@ -173,7 +178,7 @@ RemoteCommandListenerCocoa::RemoteCommandListenerCocoa(RemoteCommandListenerClie
             platformCommand = PlatformMediaSession::RemoteControlCommandType::EndSeekingBackwardCommand;
             break;
         case MRMediaRemoteCommandSeekToPlaybackPosition: {
-            if (!supportsSeeking()) {
+            if (!protectedThis->supportsSeeking()) {
                 status = MRMediaRemoteCommandHandlerStatusCommandFailed;
                 break;
             }
@@ -192,7 +197,7 @@ RemoteCommandListenerCocoa::RemoteCommandListenerCocoa(RemoteCommandListenerClie
         }
         case MRMediaRemoteCommandSkipForward:
         case MRMediaRemoteCommandSkipBackward:
-            if (!supportsSeeking()) {
+            if (!protectedThis->supportsSeeking()) {
                 status = MRMediaRemoteCommandHandlerStatusCommandFailed;
                 break;
             }
@@ -216,9 +221,8 @@ RemoteCommandListenerCocoa::RemoteCommandListenerCocoa(RemoteCommandListenerClie
             status = MRMediaRemoteCommandHandlerStatusCommandFailed;
         };
 
-        ensureOnMainThread([weakThis, platformCommand, argument] {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->client().didReceiveRemoteControlCommand(platformCommand, argument);
+        ensureOnMainThread([protectedThis = WTF::move(protectedThis), platformCommand, argument] {
+            protectedThis->client().didReceiveRemoteControlCommand(platformCommand, argument);
         });
 
         completion((__bridge CFArrayRef)@[@(status)]);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -411,7 +411,9 @@ void RemoteGraphicsContext::drawGlyphs(RenderingResourceIdentifier fontIdentifie
 {
     RefPtr font = resourceCache().cachedFont(fontIdentifier);
     MESSAGE_CHECK(font);
-    context().drawGlyphs(*font, glyphsAdvances.span<0>(), Vector<GlyphBufferAdvance>(glyphsAdvances.span<1>()), localAnchor, fontSmoothingMode);
+    Vector<GlyphBufferGlyph, 128> glyphs { glyphsAdvances.span<0>() };
+    Vector<GlyphBufferAdvance, 128> advances { glyphsAdvances.span<1>() };
+    context().drawGlyphs(*font, glyphs.span(), advances.span(), localAnchor, fontSmoothingMode);
 }
 
 void RemoteGraphicsContext::drawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect, const FloatRect& srcRect, ImagePaintingOptions options)

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -57,6 +57,7 @@
 #import <wtf/WTFProcess.h>
 #import <wtf/WallTime.h>
 #import <wtf/cocoa/Entitlements.h>
+#import <wtf/spi/darwin/DataVaultSPI.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/MakeString.h>
@@ -209,7 +210,6 @@ static std::optional<Vector<uint8_t>> fileContents(const String& path)
     return contents;
 }
 
-#if USE(APPLE_INTERNAL_SDK)
 // These strings must match the last segment of the "com.apple.rootless.storage.<this part must match>" entry in each
 // process's restricted entitlements file (ex. Configurations/Networking-OSX-restricted.entitlements).
 constexpr ASCIILiteral processStorageClass(WTF::AuxiliaryProcessType type)
@@ -227,7 +227,6 @@ constexpr ASCIILiteral processStorageClass(WTF::AuxiliaryProcessType type)
 #endif
     }
 }
-#endif // USE(APPLE_INTERNAL_SDK)
 
 static std::optional<CString> setAndSerializeSandboxParameters(const SandboxInitializationParameters& initializationParameters, const SandboxParametersPtr& sandboxParameters, const String& profileOrProfilePath, bool isProfilePath)
 {
@@ -271,6 +270,7 @@ static String sandboxDataVaultParentDirectory()
 static String sandboxDirectory(WTF::AuxiliaryProcessType processType, const String& parentDirectory)
 {
     StringBuilder directory;
+    directory.append("/.nofollow"_s);
     directory.append(parentDirectory);
     switch (processType) {
     case WTF::AuxiliaryProcessType::WebContent:
@@ -445,13 +445,11 @@ static SandboxProfilePtr compileAndCacheSandboxProfile(const SandboxInfo& info)
 
 static bool tryApplyCachedSandbox(const SandboxInfo& info)
 {
-#if USE(APPLE_INTERNAL_SDK)
     CString directoryPath = FileSystem::fileSystemRepresentation(info.directoryPath);
     if (directoryPath.isNull())
         return false;
     if (rootless_check_datavault_flag(directoryPath.data(), processStorageClass(info.processType)))
         return false;
-#endif
 
     auto contents = fileContents(info.filePath);
     if (!contents || contents->isEmpty())


### PR DESCRIPTION
#### 69a8331a19dab4220d5ad4ffe669b0b5ce145c44
<pre>
[macOS] WebKit processes can use incorrect sandbox profile by following symlinks
<a href="https://bugs.webkit.org/show_bug.cgi?id=305199">https://bugs.webkit.org/show_bug.cgi?id=305199</a>
<a href="https://rdar.apple.com/166635947">rdar://166635947</a>

Reviewed by Mike Wyrzykowski.

Prepend sandbox profile path with `/.nofollow` prefix to inform the system that symlinks should not be followed.

* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::processStorageClass):
(WebKit::sandboxDirectory):
(WebKit::tryApplyCachedSandbox):

Originally-landed-as: 305413.32@safari-7624-branch (75c13008c3ff). <a href="https://rdar.apple.com/173968809">rdar://173968809</a>
Canonical link: <a href="https://commits.webkit.org/311708@main">https://commits.webkit.org/311708@main</a>
</pre>
----------------------------------------------------------------------
#### 6aacf62000967a62dc5abf7ccf267b1bc115e38d
<pre>
Copy the glyph buffer in RemoteGraphicsContext::drawGlyphs
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=308248">https://bugs.webkit.org/show_bug.cgi?id=308248</a>&gt;
&lt;<a href="https://rdar.apple.com/169563888">rdar://169563888</a>&gt;

Reviewed by Simon Fraser.

Copy the glyph buffer in RemoteGraphicsContext::drawGlyphs

Slight variant of Kimmo&apos;s patch, using inline vector capacity to attempt
clawing back some performance impact when copying the buffer.

No new tests.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp:
(WebKit::RemoteGraphicsContext::drawGlyphs):

Originally-landed-as: 305413.340@safari-7624-branch (035f36c175f9). <a href="https://rdar.apple.com/173968811">rdar://173968811</a>
Canonical link: <a href="https://commits.webkit.org/311707@main">https://commits.webkit.org/311707@main</a>
</pre>
----------------------------------------------------------------------
#### 460528ee4187f90f3aab5ede54fbf11052f2a4f3
<pre>
[JSC] Escape MultiGetByOffset constants that aren&apos;t convertible to double
<a href="https://bugs.webkit.org/show_bug.cgi?id=306986">https://bugs.webkit.org/show_bug.cgi?id=306986</a>
<a href="https://rdar.apple.com/169245825">rdar://169245825</a>

Reviewed by Yusuke Suzuki.

ValueRepReduction for doubles needs to eagerly convert constants in
MultiGetByoffset cases to doubles. This patch escapes MultiGetByOffset
constants that cannot be converted to doubles purely.

* Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp:
(JSC::DFG::ValueRepReductionPhase::convertValueRepsToUnboxed):

Originally-landed-as: 305413.251@safari-7624-branch (d2086e16a217). <a href="https://rdar.apple.com/173968823">rdar://173968823</a>
Canonical link: <a href="https://commits.webkit.org/311706@main">https://commits.webkit.org/311706@main</a>
</pre>
----------------------------------------------------------------------
#### 3cc1e137363f0cda090c9b7adcc56a557859b6a9
<pre>
Crash in WebCore::RemoteCommandListener::supportsSeeking()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=306794">https://bugs.webkit.org/show_bug.cgi?id=306794</a>&gt;
&lt;<a href="https://rdar.apple.com/162768654">rdar://162768654</a>&gt;

Reviewed by Ryosuke Niwa.

The crash occurs when a `RemoteCommandListenerCocoa` object registers a
block with MediaRemote framework, the object is destroyed, but
MediaRemote retains the block and later executes it, accessing freed
memory.

The fix validates the `ThreadSafeWeakPtr weakThis` at the start of the
MediaRemote block and returns early if the object is destroyed.  All
member access is changed to use the protected reference from the weak
pointer instead of direct calls like `supportsSeeking()`.

No new tests since this change is not directly testable.

* Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm:
(WebCore::RemoteCommandListenerCocoa::RemoteCommandListenerCocoa):

Originally-landed-as: 305413.238@safari-7624-branch (49ebebcc212b). <a href="https://rdar.apple.com/173968833">rdar://173968833</a>
Canonical link: <a href="https://commits.webkit.org/311705@main">https://commits.webkit.org/311705@main</a>
</pre>
----------------------------------------------------------------------
#### 47d7e9d235aa78c4b524b58b9ffce1356c1efe62
<pre>
AudioDecoder Crash in CrashIfClientProvidedBogusAudioBufferList if AudioConverterComplexInputDataProc returned an empty input
<a href="https://rdar.apple.com/163644615">rdar://163644615</a>

Reviewed by Youenn Fablet.

For supported audio codecs and for which zero-sized packets have no meaning
skip those packets altogether. See ISO/IEC 14496-12 8.7.3.1.

Added crash test.
* LayoutTests/fast/webcodecs/resetting-audio-decoder-with-zero-size-crash-expected.txt: Added.
* LayoutTests/fast/webcodecs/resetting-audio-decoder-with-zero-size-crash.html: Added.
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm:
(WebCore::AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription):
(WebCore::AudioSampleBufferConverter::provideSourceDataNumOutputPackets):

Originally-landed-as: 305413.236@safari-7624-branch (0eff1a24d485). <a href="https://rdar.apple.com/173968844">rdar://173968844</a>
Canonical link: <a href="https://commits.webkit.org/311704@main">https://commits.webkit.org/311704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fe8694e3175bc700cd4c665913ddff020451835

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111173 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30430 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121662 "Found 1 new test failure: fast/webcodecs/resetting-audio-decoder-with-zero-size-crash.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85428 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c0a4adb-593a-4acb-8448-6d4b233dcd9d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102330 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22962 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21194 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13686 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149141 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168399 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17926 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12558 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20508 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129788 "Found 1 new test failure: fast/webcodecs/resetting-audio-decoder-with-zero-size-crash.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129896 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140682 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87773 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23990 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17486 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189054 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29663 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93677 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48524 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29185 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29415 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29312 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->