### PR TITLE
[threaded-animations] Null timelinesController crash in scheduleAssociatedAcceleratedEffectStackUpdate during animation suspension

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/animation-suspension-no-timelines-controller-crash-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/animation-suspension-no-timelines-controller-crash-expected.txt
@@ -1,0 +1,2 @@
+ALERT:
+PASS

--- a/LayoutTests/webanimations/threaded-animations/animation-suspension-no-timelines-controller-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/animation-suspension-no-timelines-controller-crash.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ] -->
+<html>
+<body>
+<script>
+// This test verifies that animation suspension does not crash when
+// the effect's document has no AnimationTimelinesController.
+// See rdar://173391422.
+
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+
+// Create a div and animate it.
+var div = document.createElement('div');
+document.body.appendChild(div);
+var anim = div.animate({ opacity: [0, 1] }, 1000);
+
+// Create a new KeyframeEffect with a null target.
+// m_document will be set to the current document from KeyframeEffect::create()
+// but m_target is null.
+var effect = new KeyframeEffect(null, { opacity: [0, 1] }, 1000);
+anim.effect = effect;
+
+// Set the target to a detached element (not in any document tree).
+// This element's document is the main document. After document.write()
+// replaces the document content, the animation state may become inconsistent.
+effect.target = document.createElement('div');
+
+// Force suspension via alert.
+alert('');
+
+document.open();
+document.write('PASS');
+document.close();
+
+window.testRunner?.notifyDone();
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -3185,7 +3185,10 @@ void KeyframeEffect::scheduleAssociatedAcceleratedEffectStackUpdate(const std::o
         return;
 
     CheckedPtr timelinesController = document()->timelinesController();
-    ASSERT(timelinesController);
+    // The timelines controller may not exist if the effect's document never had a
+    // DocumentTimeline created, which can happen when elements move between documents.
+    if (!timelinesController)
+        return;
     if (previousTarget)
         timelinesController->scheduleAcceleratedEffectStackUpdateForTarget(*previousTarget);
     if (auto currentTarget = targetStyleable())


### PR DESCRIPTION
#### 816e63a20c18a2fca81e619292eaf7385420c226
<pre>
[threaded-animations] Null timelinesController crash in scheduleAssociatedAcceleratedEffectStackUpdate during animation suspension
<a href="https://bugs.webkit.org/show_bug.cgi?id=312595">https://bugs.webkit.org/show_bug.cgi?id=312595</a>
<a href="https://rdar.apple.com/173391422">rdar://173391422</a>

Reviewed by Antoine Quint.

scheduleAssociatedAcceleratedEffectStackUpdate() assumes document()-&gt;timelinesController()
is non-null, but it can be null when the effect&apos;s document never had a DocumentTimeline
created. This can happen when elements move between documents while
ThreadedTimeBasedAnimationsEnabled is on and alert() triggers animation suspension via
PageGroupLoadDeferrer.

Replace the ASSERT with a null check and early return, matching the convention used by
all other callers of timelinesController() in Page.cpp and LocalFrame.cpp.

Test: webanimations/threaded-animations/animation-suspension-no-timelines-controller-crash.html

* LayoutTests/webanimations/threaded-animations/animation-suspension-no-timelines-controller-crash-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/animation-suspension-no-timelines-controller-crash.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::scheduleAssociatedAcceleratedEffectStackUpdate):

Canonical link: <a href="https://commits.webkit.org/311510@main">https://commits.webkit.org/311510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2e92098ac403d4d4840f364958264bc1d5a893a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111235 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121704 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102372 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23002 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21239 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13748 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168461 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12620 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129833 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129941 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35211 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87835 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24765 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17537 "Passed tests") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93739 "Built successfully") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29247 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29477 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29374 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->