### PR TITLE
[JSC] Intl.Segmenter isWordLike returns false for numeric segments due to off-by-one in UBRK_WORD_NONE_LIMIT check

### DIFF
--- a/JSTests/stress/intl-segmenter-word-iswordlike-number.js
+++ b/JSTests/stress/intl-segmenter-word-iswordlike-number.js
@@ -1,0 +1,114 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+// Numeric word segments must have isWordLike === true.
+// ICU returns rule status UBRK_WORD_NUMBER (== 100 == UBRK_WORD_NONE_LIMIT) for
+// pure-number word segments. The "none" range is half-open,
+// [UBRK_WORD_NONE, UBRK_WORD_NONE_LIMIT); treating 100 as "none" wrongly
+// classifies numbers as non-word-like.
+
+{
+    let segmenter = new Intl.Segmenter("en", { granularity: "word" });
+
+    // Pure number, standalone.
+    {
+        let input = "123";
+        let results = [
+            [ 0, 3, "123", true ],
+        ];
+        let cursor = 0;
+        for (let { segment, index, isWordLike } of segmenter.segment(input)) {
+            let result = results[cursor++];
+            shouldBe(result[0], index);
+            shouldBe(result[1], index + segment.length);
+            shouldBe(result[2], segment);
+            shouldBe(result[3], isWordLike);
+        }
+        shouldBe(cursor, results.length);
+    }
+
+    // Number between letter words.
+    {
+        let input = "abc 123 def";
+        let results = [
+            [ 0, 3, "abc", true ],
+            [ 3, 4, " ", false ],
+            [ 4, 7, "123", true ],
+            [ 7, 8, " ", false ],
+            [ 8, 11, "def", true ],
+        ];
+        let cursor = 0;
+        for (let { segment, index, isWordLike } of segmenter.segment(input)) {
+            let result = results[cursor++];
+            shouldBe(result[0], index);
+            shouldBe(result[1], index + segment.length);
+            shouldBe(result[2], segment);
+            shouldBe(result[3], isWordLike);
+        }
+        shouldBe(cursor, results.length);
+    }
+
+    // Mixed alphanumeric, decimal number, letter word.
+    {
+        let input = "v2 3.14 foo";
+        let results = [
+            [ 0, 2, "v2", true ],
+            [ 2, 3, " ", false ],
+            [ 3, 7, "3.14", true ],
+            [ 7, 8, " ", false ],
+            [ 8, 11, "foo", true ],
+        ];
+        let cursor = 0;
+        for (let { segment, index, isWordLike } of segmenter.segment(input)) {
+            let result = results[cursor++];
+            shouldBe(result[0], index);
+            shouldBe(result[1], index + segment.length);
+            shouldBe(result[2], segment);
+            shouldBe(result[3], isWordLike);
+        }
+        shouldBe(cursor, results.length);
+    }
+
+    // Single-digit number in a sentence.
+    {
+        let input = "The 2nd of 3 items";
+        let results = [
+            [ 0, 3, "The", true ],
+            [ 3, 4, " ", false ],
+            [ 4, 7, "2nd", true ],
+            [ 7, 8, " ", false ],
+            [ 8, 10, "of", true ],
+            [ 10, 11, " ", false ],
+            [ 11, 12, "3", true ],
+            [ 12, 13, " ", false ],
+            [ 13, 18, "items", true ],
+        ];
+        let cursor = 0;
+        for (let { segment, index, isWordLike } of segmenter.segment(input)) {
+            let result = results[cursor++];
+            shouldBe(result[0], index);
+            shouldBe(result[1], index + segment.length);
+            shouldBe(result[2], segment);
+            shouldBe(result[3], isWordLike);
+        }
+        shouldBe(cursor, results.length);
+    }
+
+    // %Segments.prototype%.containing must also report isWordLike === true for numbers.
+    {
+        let input = "abc 123 def";
+        let segments = segmenter.segment(input);
+        shouldBe(JSON.stringify(segments.containing(4)), `{"segment":"123","index":4,"input":"abc 123 def","isWordLike":true}`);
+        shouldBe(segments.containing(5).isWordLike, true);
+        shouldBe(segments.containing(0).isWordLike, true);
+        shouldBe(segments.containing(3).isWordLike, false);
+    }
+
+    {
+        let segments = segmenter.segment("123");
+        shouldBe(segments.containing(0).isWordLike, true);
+        shouldBe(segments.containing(2).isWordLike, true);
+    }
+}

--- a/Source/JavaScriptCore/runtime/IntlSegmentDataObject.h
+++ b/Source/JavaScriptCore/runtime/IntlSegmentDataObject.h
@@ -59,7 +59,7 @@ ALWAYS_INLINE JSObject* createSegmentDataObject(JSGlobalObject* globalObject, JS
     if (granularity == IntlSegmenter::Granularity::Word) {
         int32_t ruleStatus = ubrk_getRuleStatus(&segmenter);
         result->putDirectOffset(vm, segmentDataObjectIsWordLikePropertyOffset,
-            jsBoolean(!(ruleStatus >= UBRK_WORD_NONE && ruleStatus <= UBRK_WORD_NONE_LIMIT)));
+            jsBoolean(!(ruleStatus >= UBRK_WORD_NONE && ruleStatus < UBRK_WORD_NONE_LIMIT)));
     }
 
     return result;


### PR DESCRIPTION
#### 0145d169cd9cb6a7d70a4b9c3e67227056f4844a
<pre>
[JSC] Intl.Segmenter isWordLike returns false for numeric segments due to off-by-one in UBRK_WORD_NONE_LIMIT check
<a href="https://bugs.webkit.org/show_bug.cgi?id=312596">https://bugs.webkit.org/show_bug.cgi?id=312596</a>

Reviewed by Yusuke Suzuki.

Intl.Segmenter with granularity &quot;word&quot; reports isWordLike === false for
segments that consist of digits (e.g. &quot;123&quot;, &quot;3.14&quot;, &quot;v2&quot;). V8 returns
true for these segments.

createSegmentDataObject() classifies a segment as non-word-like when its
ICU rule status falls in the &quot;none&quot; range. The check used a closed upper
bound (`&lt;= UBRK_WORD_NONE_LIMIT`), but ICU&apos;s UWordBreak ranges are
half-open and UBRK_WORD_NONE_LIMIT == UBRK_WORD_NUMBER == 100, so
numeric segments were misclassified as &quot;none&quot;. Change to `&lt;` so the
upper bound is exclusive.

* JSTests/stress/intl-segmenter-word-iswordlike-number.js: Added.
* Source/JavaScriptCore/runtime/IntlSegmentDataObject.h:
(JSC::createSegmentDataObject):

Canonical link: <a href="https://commits.webkit.org/311507@main">https://commits.webkit.org/311507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/906e4e90905ba2690f2a22d6ad27f097fa10231a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165923 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111182 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121667 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85432 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102335 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22973 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21200 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13695 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149150 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132653 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168408 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17935 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12567 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129793 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30038 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129901 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140691 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87782 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23909 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24730 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17495 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189063 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29672 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93686 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48525 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->