### PR TITLE
AX: TimeoutSafeSemaphore should use ThreadSafeRefCounted since it is shared across threads

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -50,6 +50,7 @@
 #include <wtf/Platform.h>
 #include <wtf/ProcessID.h>
 #include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WallTime.h>
 #include <wtf/threads/BinarySemaphore.h>
@@ -1704,7 +1705,7 @@ template<typename U> inline void performFunctionOnMainThread(U&& lambda)
 }
 
 template<typename T = std::monostate>
-struct TimeoutSafeSemaphore : RefCounted<TimeoutSafeSemaphore<T>> {
+struct TimeoutSafeSemaphore : ThreadSafeRefCounted<TimeoutSafeSemaphore<T>> {
     // This struct is useful for passing in lambdas from one thread to another, as it is ref-counted,
     // meaning it won't be destroyed out from any thread involved even when a timeout happens
     // and one of the threads moves on (which would normally destroy the semaphore it had on


### PR DESCRIPTION
#### c9366c348f0c9235aa1a848fec53767146a018f0
<pre>
AX: TimeoutSafeSemaphore should use ThreadSafeRefCounted since it is shared across threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=312601">https://bugs.webkit.org/show_bug.cgi?id=312601</a>
<a href="https://rdar.apple.com/174954164">rdar://174954164</a>

Reviewed by Joshua Hoffman.

TimeoutSafeSemaphore is designed to be shared between the AX thread (which
creates it) and the main thread (which executes a lambda capturing a Ref to
it). Using RefCounted (non-thread-safe) causes two problems:

1. The RefCountDebugger fires ASSERT_WITH_SECURITY_IMPLICATION when the main
 thread derefs while the AX thread still holds a reference, since it detects
 a cross-thread deref with refcount &gt; 1.

2. The underlying uint32_t refcount is non-atomic, so concurrent ref/deref
 from both threads is a data race.

Change the base class to ThreadSafeRefCounted, which provides an atomic
refcount and thus avoids the threading-safety assertion.

* Source/WebCore/accessibility/AXCoreObject.h:

Canonical link: <a href="https://commits.webkit.org/311533@main">https://commits.webkit.org/311533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/616d043534bd2e5a6494e50cb713014c1f4c4d6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111216 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97a7e335-f300-4c5a-bb4d-cca6d80e79ea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121688 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85440 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6f78c42-8077-4121-a401-8e00413a8946) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102356 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c34b6c4c-d226-4030-ab54-b2c008d6fff7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22990 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21226 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13729 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132670 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168442 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12601 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129820 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129928 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35226 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140734 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87816 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24755 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17538 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29706 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93720 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29228 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29458 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29355 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->