### PR TITLE
Fix bug where selection highlight bleeds past text box boundary

### DIFF
--- a/LayoutTests/fast/text/selection-highlight-no-bleed-past-text-box.html
+++ b/LayoutTests/fast/text/selection-highlight-no-bleed-past-text-box.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<head>
+    <link href="https://fonts.googleapis.com/css?family=Arvo" rel="stylesheet">
+    <style>
+        td::selection {
+            background: rgba(0, 0, 0, 0.5);
+            color: white;
+        }
+    </style>
+</head>
+<body>
+    <table style="width: 580px;">
+        <td id="target" style="font-family: 'Arvo', serif;">
+            This allows you, our attendees, to complain efficiently about CSS problems in many browsers at once, while their representatives smile, take .
+        </td>
+    </table>
+    <script>
+        getSelection().selectAllChildren(document.getElementById("target"));
+    </script>
+</body>

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -618,10 +618,12 @@ void TextBoxPainter::paintBackgroundFillForRange(unsigned startOffset, unsigned 
     auto selectionRect = selectionRectForRange(startOffset, endOffset);
 
     if (m_paintTextRun.length() == endOffset - startOffset) {
-        // FIXME: We should reconsider re-measuring the content when non-whitespace runs are joined together (see webkit.org/b/251318).
+        // adjustSelectionRectForText re-measures the text to compute the selection rect,
+        // which can produce a different width than the layout-computed width due to kerning
+        // or ligature adjustments. Use the layout-computed width for the right edge since
+        // the selection gap is painted using layout-computed sizing.
         auto unAdjustedSelectionRectMaxX = LayoutUnit { m_paintRect.x() + m_logicalRect.width() };
-        auto visualRight = std::max(selectionRect.maxX(), unAdjustedSelectionRectMaxX);
-        selectionRect.shiftMaxXEdgeTo(visualRight);
+        selectionRect.shiftMaxXEdgeTo(unAdjustedSelectionRectMaxX);
     }
 
     // FIXME: Support painting combined text. See <https://bugs.webkit.org/show_bug.cgi?id=180993>.


### PR DESCRIPTION
#### c6bc1467dccef5e97ac99aa614ccf93578081100
<pre>
Fix bug where selection highlight bleeds past text box boundary
<a href="https://bugs.webkit.org/show_bug.cgi?id=312500">https://bugs.webkit.org/show_bug.cgi?id=312500</a>
&lt;<a href="https://rdar.apple.com/173410762">rdar://173410762</a>&gt;

Reviewed by NOBODY (OOPS!).

Use layout-computed width for the right edge for selectionhighlight painting
when selecting the entire text run. This bypasses selection rect adjustments
that may cause incorrect run widths for certain fonts due to kerning or ligature.

* LayoutTests/fast/text/selection-highlight-no-bleed-past-text-box.html: Added.
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paintBackgroundFillForRange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6bc1467dccef5e97ac99aa614ccf93578081100

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111937 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31194 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122237 "Found 1 new test failure: fast/text/selection-highlight-no-bleed-past-text-box.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85826 "1 flakes 1 missing results") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160813 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24520 "Found 1 new test failure: fast/text/selection-highlight-no-bleed-past-text-box.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102903 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23576 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21869 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14456 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133257 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169173 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13962 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21187 "Found 1 new test failure: fast/text/selection-highlight-no-bleed-past-text-box.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130408 "Found 1 new test failure: fast/text/selection-highlight-no-bleed-past-text-box.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30938 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25936 "Found 1 new test failure: fast/text/selection-highlight-no-bleed-past-text-box.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130521 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30876 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141358 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88726 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25262 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18164 "Found 1 new test failure: fast/text/selection-highlight-no-bleed-past-text-box.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30428 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95299 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29949 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30179 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30076 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->