### PR TITLE
canva.com: web content crash when moving elements around. (WebCore::LayoutIntegration::BoxGeometryUpdater::updateLayoutBoxDimensions)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-stale-layoutbox-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-stale-layoutbox-crash.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=312602">
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 100px 100px;
+    grid-template-rows: 100px;
+    width: 200px;
+}
+.item1 {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+}
+.item2 {
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
+}
+</style>
+<div class="grid">
+    <div class="item1"></div>
+    <div class="item2"></div>
+</div>
+<script>
+document.body.offsetHeight;
+
+const grid = document.querySelector('.grid');
+grid.removeChild(grid.lastElementChild);
+const thirdItem = document.createElement('div');
+thirdItem.className = 'item2';
+grid.appendChild(thirdItem);
+
+document.body.offsetHeight;
+</script>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -50,6 +50,13 @@ GridLayout::GridLayout(RenderGrid& renderGrid)
 {
 }
 
+GridLayout::~GridLayout()
+{
+    CheckedRef renderer = gridBoxRenderer();
+    const_cast<CheckedPtr<Layout::ElementBox>&>(m_gridBox) = nullptr;
+    BoxTreeUpdater { renderer }.tearDown();
+}
+
 void GridLayout::updateFormattingContextGeometries()
 {
     auto boxGeometryUpdater = BoxGeometryUpdater { layoutState(), gridBox() };

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -47,6 +47,7 @@ namespace LayoutIntegration {
 class GridLayout {
 public:
     GridLayout(RenderGrid&);
+    ~GridLayout();
 
     void updateFormattingContextGeometries();
 


### PR DESCRIPTION
#### 889513d41a3470acfe26cca1ec26d09828e236f0
<pre>
canva.com: web content crash when moving elements around. (WebCore::LayoutIntegration::BoxGeometryUpdater::updateLayoutBoxDimensions)
<a href="https://bugs.webkit.org/show_bug.cgi?id=312602">https://bugs.webkit.org/show_bug.cgi?id=312602</a>
<a href="https://rdar.apple.com/174932208">rdar://174932208</a>

Reviewed by Brent Fulgham, Alan Baradlay, and Vitor Roriz.

When a grid item is removed from underneath a grid box we fail to
properly clean up the tree. This is because we do not have any
integration logic that hooks into the layout tree for grid when a
RenderGrid loses a renderer. This may end up causing a crash in the grid
integration code when we try to access a renderer that was removed from
the render tree.

For now we can just tear down the subtree at the end of grid layout,
which is what we currently do for FFC as well. We will probably want to
revisit this later but it is a good start to at least avoid these types
of crashes.

Test: imported/w3c/web-platform-tests/css/css-grid/grid-stale-layoutbox-crash.html
Canonical link: <a href="https://commits.webkit.org/311552@main">https://commits.webkit.org/311552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50abd3699797ada0daf6f51cb7d9a17a8ed31a2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111354 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/301f6555-e12b-4eb3-aee5-f874f561f7e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121801 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85517 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59dc2ff5-58a7-4395-836a-4d263f4be3d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102469 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4dd697b8-d765-4b2b-908a-4302989d7b33) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23102 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21349 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13867 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168581 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18107 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12739 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129934 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130042 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35236 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140844 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87997 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24863 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17649 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189290 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29844 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93858 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/189290 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29366 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29596 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29493 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->