### PR TITLE
[threaded-animations] additive transform animations use matrix interpolation which does not account for additivity

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-additive-animation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-additive-animation-expected.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<meta charset="utf-8">
+<title>Reference for additive transform animation behavior</title>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+    transform-origin: top left;
+    transform: translateX(100px) scale(2);
+}
+
+</style>
+<body>
+  <div></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-additive-animation-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-additive-animation-ref.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<meta charset="utf-8">
+<title>Reference for additive transform animation behavior</title>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+    transform-origin: top left;
+    transform: translateX(100px) scale(2);
+}
+
+</style>
+<body>
+  <div></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-additive-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-additive-animation.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>Verify additive transform animation behavior</title>
+<link rel="match" href="transform-additive-animation-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#ctm">
+<script src="/common/reftest-wait.js"></script>
+<style>
+
+@keyframes scale {
+  0%, 100% { transform: scale(2) }
+}
+
+#target {
+  width: 100px;
+  height: 100px;
+  background-color: black;
+
+  transform-origin: top left;
+  transform: translateX(100px);
+
+  animation: scale 1s infinite;
+  animation-composition: add;
+}
+
+</style>
+<body>
+  <div id="target"></div>
+
+<script>
+
+'use strict';
+
+(async function() {
+    // Wait for the animation to be committed on the compositor.
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    takeScreenshot();
+})();
+
+</script>
+</body>

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
@@ -75,6 +75,18 @@ bool TransformOperations::containsNonInvertibleMatrix() const
 
 TransformOperations blend(const TransformOperations& from, const TransformOperations& to, const BlendingContext& context)
 {
+    if (context.compositeOperation == CompositeOperation::Add) {
+        ASSERT(context.progress == 1.0);
+
+        Vector<Ref<TransformOperation>> operations;
+        operations.reserveInitialCapacity(from.size() + to.size());
+        for (auto& fromOperation : from)
+            operations.append(fromOperation);
+        for (auto& toOperation : to)
+            operations.append(toOperation);
+        return TransformOperations { WTF::move(operations) };
+    }
+
     bool shouldFallBackToDiscreteInterpolation = from.containsNonInvertibleMatrix() || to.containsNonInvertibleMatrix();
 
     auto createBlendedMatrixOperationFromOperationsSuffix = [&](unsigned start) -> Ref<TransformOperation> {


### PR DESCRIPTION
#### 31a9b521263743e9bd99ead35f352856899ff6c6
<pre>
[threaded-animations] additive transform animations use matrix interpolation which does not account for additivity
<a href="https://bugs.webkit.org/show_bug.cgi?id=312606">https://bugs.webkit.org/show_bug.cgi?id=312606</a>
<a href="https://rdar.apple.com/175039068">rdar://175039068</a>

Reviewed by Simon Fraser.

Ensure that we have a correct code path for additivity blending for `transform` in the remote layer tree.

Tests: imported/w3c/web-platform-tests/css/css-transforms/animation/transform-additive-animation.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-additive-animation-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-additive-animation-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-additive-animation.html: Added.
* Source/WebCore/platform/graphics/transforms/TransformOperations.cpp:
(WebCore::blend):

Canonical link: <a href="https://commits.webkit.org/311516@main">https://commits.webkit.org/311516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec2218e010e9be17c22911bd6d4437a5d0476091

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165974 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111233 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c72b63b8-bb89-491c-a363-9b0eac2bf814) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121701 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a205c0d9-bcac-4263-a85b-112e2361039e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102369 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/628ae75f-ba2a-4067-a902-00f22520533b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22998 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21237 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13746 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168459 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12618 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129832 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129940 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140732 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87833 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23915 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24763 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17536 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29723 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93737 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29245 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29475 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29372 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->