### PR TITLE
[CMake] Skip -dead_strip in Debug builds on macOS

### DIFF
--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -323,8 +323,9 @@ if (ENABLE_SANITIZERS)
     endif ()
 endif ()
 
-# Dead-strip unused symbols and dylibs.
-add_link_options(-Wl,-dead_strip)
+# Dead-strip unused symbols and dylibs. Mirrors Xcode's DEAD_CODE_STRIPPING,
+# which is YES for release configs and NO for Debug.
+add_link_options("$<$<NOT:$<CONFIG:Debug>>:-Wl,-dead_strip>")
 add_link_options(-Wl,-dead_strip_dylibs)
 
 if (CMAKE_GENERATOR STREQUAL "Ninja")


### PR DESCRIPTION
#### e53d07efdb3a7e0fbe6566d3138d6df29e0643c8
<pre>
[CMake] Skip -dead_strip in Debug builds on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=312609">https://bugs.webkit.org/show_bug.cgi?id=312609</a>
<a href="https://rdar.apple.com/175041322">rdar://175041322</a>

Reviewed by Brandon Stewart.

Source/cmake/OptionsMac.cmake unconditionally passed -Wl,-dead_strip
to the linker, while the Xcode build sets DEAD_CODE_STRIPPING = NO
for Debug (DEAD_CODE_STRIPPING[config=Debug] = NO in the various
Base.xcconfig files). This made CMake Debug builds slower to link
and stripped symbols that are useful while debugging.

Gate the option behind a generator expression so it only applies to
non-Debug configurations, matching Xcode. -dead_strip_dylibs is left
unchanged.

* Source/cmake/OptionsMac.cmake:

Canonical link: <a href="https://commits.webkit.org/311794@main">https://commits.webkit.org/311794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a2df37f9164f01c93ad7bc4e572cdf1ef403861

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111234 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88901669-4554-45bd-b17e-c498303bb926) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121705 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85449 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b53fe75a-fd54-4c95-80ad-95ef2908dcd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102373 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/691f6dc4-564c-4f69-8f5a-217a4e3cb7c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23001 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21238 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13747 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149202 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132681 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168460 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17987 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129834 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129942 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35385 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140730 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87834 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17534 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189115 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29724 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48534 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29246 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29373 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->