### PR TITLE
[WPT export friction] Run WPT lint as part of WebKit development via check-webkit-style

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/wpt.py
+++ b/Tools/Scripts/webkitpy/style/checkers/wpt.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Runs the web-platform-tests linter against changed WPT files."""
+
+import logging
+import os
+import pathlib
+import subprocess
+import sys
+
+from webkitpy.w3c.wpt_linter import WPTLinter
+
+_log = logging.getLogger(__name__)
+
+WPT_DIR = os.path.join('LayoutTests', 'imported', 'w3c', 'web-platform-tests')
+
+
+def filter_wpt_paths(paths):
+    """Filter a list of paths to only those under the imported WPT directory.
+
+    Returns paths relative to the WPT repo root, using POSIX separators
+    (which is what `./wpt lint` expects).
+    """
+    wpt_root = pathlib.PurePath(WPT_DIR)
+    wpt_paths = []
+    for path in paths:
+        p = pathlib.PurePath(path)
+        if p.is_relative_to(wpt_root):
+            wpt_paths.append(p.relative_to(wpt_root).as_posix())
+    return wpt_paths
+
+
+def run_wpt_lint(checkout_root, changed_files):
+    """Run the WPT linter on any changed WPT files.
+
+    Returns the number of lint errors found.
+    """
+    wpt_paths = filter_wpt_paths(changed_files)
+    if not wpt_paths:
+        return 0
+
+    wpt_repo_dir = os.path.join(checkout_root, WPT_DIR)
+    if not os.path.isdir(wpt_repo_dir):
+        _log.debug("WPT directory not found, skipping WPT lint")
+        return 0
+
+    _log.info("Running WPT linter on %d file(s)..." % len(wpt_paths))
+    linter = WPTLinter(wpt_repo_dir)
+    return_code, output = linter.lint(wpt_paths)
+
+    if output:
+        sys.stderr.write(output)
+        if not output.endswith('\n'):
+            sys.stderr.write('\n')
+
+    if return_code != 0:
+        _log.info("WPT linter found errors")
+
+    return return_code

--- a/Tools/Scripts/webkitpy/style/checkers/wpt_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/wpt_unittest.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+from webkitpy.style.checkers.wpt import filter_wpt_paths, run_wpt_lint
+
+from webkitcorepy import OutputCapture
+
+
+class FilterWPTPathsTest(unittest.TestCase):
+
+    def test_no_wpt_files(self):
+        paths = ['Source/WebCore/foo.cpp', 'Tools/Scripts/bar.py']
+        self.assertEqual(filter_wpt_paths(paths), [])
+
+    def test_wpt_files_only(self):
+        prefix = os.path.join('LayoutTests', 'imported', 'w3c', 'web-platform-tests') + os.sep
+        paths = [prefix + 'css/css-grid/test.html', prefix + 'html/dom/test.html']
+        self.assertEqual(filter_wpt_paths(paths), ['css/css-grid/test.html', 'html/dom/test.html'])
+
+    def test_mixed_files(self):
+        prefix = os.path.join('LayoutTests', 'imported', 'w3c', 'web-platform-tests') + os.sep
+        paths = [
+            'Source/WebCore/foo.cpp',
+            prefix + 'css/css-grid/test.html',
+            'LayoutTests/fast/dom/test.html',
+        ]
+        self.assertEqual(filter_wpt_paths(paths), ['css/css-grid/test.html'])
+
+    def test_http_wpt_files_not_included(self):
+        paths = [os.path.join('LayoutTests', 'http', 'wpt', 'test.html')]
+        self.assertEqual(filter_wpt_paths(paths), [])
+
+
+class RunWPTLintTest(unittest.TestCase):
+
+    def test_no_wpt_files_returns_zero(self):
+        result = run_wpt_lint('/checkout', ['Source/WebCore/foo.cpp'])
+        self.assertEqual(result, 0)
+
+    @patch('webkitpy.style.checkers.wpt.WPTLinter')
+    @patch('os.path.isdir', return_value=True)
+    def test_wpt_files_invokes_linter(self, mock_isdir, MockLinter):
+        mock_linter_instance = MagicMock()
+        mock_linter_instance.lint.return_value = (0, '')
+        MockLinter.return_value = mock_linter_instance
+
+        prefix = os.path.join('LayoutTests', 'imported', 'w3c', 'web-platform-tests') + os.sep
+        changed_files = [prefix + 'css/css-grid/test.html']
+
+        with OutputCapture(level=logging.INFO):
+            result = run_wpt_lint('/checkout', changed_files)
+
+        self.assertEqual(result, 0)
+        mock_linter_instance.lint.assert_called_once_with(['css/css-grid/test.html'])
+
+    @patch('webkitpy.style.checkers.wpt.WPTLinter')
+    @patch('os.path.isdir', return_value=True)
+    def test_wpt_lint_errors_returned(self, mock_isdir, MockLinter):
+        mock_linter_instance = MagicMock()
+        mock_linter_instance.lint.return_value = (3, 'ERROR: some lint error\n')
+        MockLinter.return_value = mock_linter_instance
+
+        prefix = os.path.join('LayoutTests', 'imported', 'w3c', 'web-platform-tests') + os.sep
+        changed_files = [prefix + 'css/css-grid/test.html']
+
+        with OutputCapture(level=logging.INFO):
+            result = run_wpt_lint('/checkout', changed_files)
+
+        self.assertEqual(result, 3)
+
+    @patch('os.path.isdir', return_value=False)
+    def test_missing_wpt_dir_returns_zero(self, mock_isdir):
+        prefix = os.path.join('LayoutTests', 'imported', 'w3c', 'web-platform-tests') + os.sep
+        changed_files = [prefix + 'css/css-grid/test.html']
+
+        with OutputCapture(level=logging.DEBUG):
+            result = run_wpt_lint('/checkout', changed_files)
+
+        self.assertEqual(result, 0)

--- a/Tools/Scripts/webkitpy/style/main.py
+++ b/Tools/Scripts/webkitpy/style/main.py
@@ -26,6 +26,7 @@ import sys
 import webkitpy.style.checker as checker
 from webkitpy.common.host import Host
 from webkitpy.style.checker import StyleProcessor
+from webkitpy.style.checkers.wpt import run_wpt_lint
 from webkitpy.style.filereader import TextFileReader
 from webkitpy.style.patchreader import PatchReader
 
@@ -125,16 +126,24 @@ class CheckWebKitStyle(object):
         if paths and not options.diff_files:
             file_reader.process_paths(paths)
             file_reader.do_association_check(host.scm().checkout_root)
+            changed_files = paths
         else:
-            changed_files = paths if options.diff_files else None
-            patch = host.scm().create_patch(options.git_commit, changed_files=changed_files, git_index=options.git_index, commit_message=False, find_branch=True)
+            changed_files_list = paths if options.diff_files else None
+            patch = host.scm().create_patch(options.git_commit, changed_files=changed_files_list, git_index=options.git_index, commit_message=False, find_branch=True)
             patch_checker = PatchReader(file_reader)
             patch_checker.check(patch)
+            changed_files = host.scm().changed_files(options.git_commit, find_branch=True) if not changed_files_list else changed_files_list
 
         error_count = style_processor.error_count
         file_count = file_reader.file_count
         delete_only_file_count = file_reader.delete_only_file_count
 
+        # Run WPT linter on any changed web-platform-tests files.
+        if options.wpt_lint and changed_files:
+            checkout_root = host.scm().checkout_root
+            error_count += run_wpt_lint(checkout_root, changed_files)
+
         _log.info("Total errors found: %d in %d files" % (error_count, file_count))
+
         # We fail when style errors are found or there are no checked files.
         return error_count > 0 or (file_count == 0 and delete_only_file_count == 0)

--- a/Tools/Scripts/webkitpy/style/optparser.py
+++ b/Tools/Scripts/webkitpy/style/optparser.py
@@ -149,7 +149,8 @@ class CommandOptionValues(object):
                  min_confidence=1,
                  output_format="emacs",
                  commit_queue=False,
-                 git_index=False):
+                 git_index=False,
+                 wpt_lint=True):
         if filter_rules is None:
             filter_rules = []
 
@@ -171,6 +172,7 @@ class CommandOptionValues(object):
         self.output_format = output_format
         self.commit_queue = commit_queue
         self.git_index = git_index
+        self.wpt_lint = wpt_lint
 
     # Useful for unit testing.
     def __eq__(self, other):
@@ -188,6 +190,8 @@ class CommandOptionValues(object):
         if self.output_format != other.output_format:
             return False
         if self.git_index != other.git_index:
+            return False
+        if self.wpt_lint != other.wpt_lint:
             return False
 
         return True
@@ -310,6 +314,9 @@ class ArgumentParser(object):
         parser.add_option("--commit-queue", action="store_true", dest="commit_queue", default=False, help=commit_queue_help)
         parser.add_option("--git-index", action="store_true", dest="git_index", default=False, help="Scan staged files only")
 
+        no_wpt_lint_help = "skip running the WPT linter on web-platform-tests files"
+        parser.add_option("--no-wpt-lint", action="store_true", dest="no_wpt_lint", default=False, help=no_wpt_lint_help)
+
         # Override OptionParser's error() method so that option help will
         # also display when an error occurs.  Normally, just the usage
         # string displays and not option help.
@@ -397,6 +404,7 @@ class ArgumentParser(object):
         output_format = options.output_format
         commit_queue = options.commit_queue
         git_index = options.git_index
+        wpt_lint = not options.no_wpt_lint
 
         if filter_value is not None and not filter_value:
             # Then the user explicitly passed no filter, for
@@ -428,6 +436,7 @@ class ArgumentParser(object):
                                       min_confidence=min_confidence,
                                       output_format=output_format,
                                       commit_queue=commit_queue,
-                                      git_index=git_index)
+                                      git_index=git_index,
+                                      wpt_lint=wpt_lint)
 
         return (paths, options)

--- a/Tools/Scripts/webkitpy/w3c/wpt_linter.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_linter.py
@@ -24,13 +24,49 @@
  This script is a wrapper for the web-platform-tests linter
 """
 
+import logging
+import os
 import subprocess
+import tempfile
+
+_log = logging.getLogger(__name__)
 
 
 class WPTLinter(object):
-    def __init__(self, repository_directory, filesystem):
+    def __init__(self, repository_directory):
         self.wpt_path = repository_directory
 
-    def lint(self):
-        proc = subprocess.Popen(['./wpt', 'lint'], cwd=self.wpt_path)
-        return proc.wait()
+    def lint(self, paths=None):
+        """Run the WPT linter.
+
+        Args:
+            paths: Optional list of file paths (relative to the WPT repo root)
+                   to lint. If None, lints all changed files.
+
+        Returns:
+            A tuple of (return_code, output) where return_code is 0 if no
+            errors were found, and output is the linter's stdout/stderr.
+        """
+        cmd = ['./wpt', 'lint', '--json']
+
+        if paths:
+            paths_file = None
+            try:
+                with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+                    paths_file = f.name
+                    for path in paths:
+                        f.write(path + '\n')
+                cmd.extend(['--paths-file', paths_file])
+                return self._run_lint(cmd)
+            finally:
+                if paths_file and os.path.exists(paths_file):
+                    os.unlink(paths_file)
+        else:
+            return self._run_lint(cmd)
+
+    def _run_lint(self, cmd):
+        _log.debug("Running WPT linter: %s (cwd=%s)", ' '.join(cmd), self.wpt_path)
+        result = subprocess.run(cmd, cwd=self.wpt_path,
+                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                text=True)
+        return (result.returncode, result.stdout)


### PR DESCRIPTION
#### d2fe54c0d4b5355b3d9077ec6d6d949e9ea4741d
<pre>
[WPT export friction] Run WPT lint as part of WebKit development via check-webkit-style
<a href="https://bugs.webkit.org/show_bug.cgi?id=257853">https://bugs.webkit.org/show_bug.cgi?id=257853</a>
<a href="https://rdar.apple.com/110843279">rdar://110843279</a>

Reviewed by NOBODY (OOPS!).

Detect if any WPT have changed in check-webkit-style, and, if so, run the WPT linter on them.

Adds `webkitpy/style/checkers/wpt.py` which wraps the WPT linter, and is tested
by `wpt_unittest.py`.

Modifies `webkitpy/w3c/wpt_linter.py` to write the list of files to lint into
a temporary file to feed to the WPTLinter, and be callable from `check-webkit-style`.

Adds a `--no-wpt-lint` argument to `check-webkit-style` to avoid running the
WPT linter.

The WPTLinter only knows how to run on file paths, so can&apos;t work with `-g` or `--git-index`,
but this is similar to how `check-webkit-style` already works.

* Tools/Scripts/webkitpy/style/checkers/wpt.py: Added.
(filter_wpt_paths):
(run_wpt_lint):
* Tools/Scripts/webkitpy/style/checkers/wpt_unittest.py: Added.
(FilterWPTPathsTest):
(FilterWPTPathsTest.test_no_wpt_files):
(FilterWPTPathsTest.test_wpt_files_only):
(FilterWPTPathsTest.test_mixed_files):
(FilterWPTPathsTest.test_http_wpt_files_not_included):
(RunWPTLintTest):
(RunWPTLintTest.test_no_wpt_files_returns_zero):
(RunWPTLintTest.test_wpt_files_invokes_linter):
(RunWPTLintTest.test_wpt_lint_errors_returned):
(RunWPTLintTest.test_missing_wpt_dir_returns_zero):
* Tools/Scripts/webkitpy/style/main.py:
(CheckWebKitStyle.main):
* Tools/Scripts/webkitpy/style/optparser.py:
(CommandOptionValues.__init__):
(CommandOptionValues.__eq__):
(ArgumentParser._create_option_parser):
(ArgumentParser.parse):
* Tools/Scripts/webkitpy/w3c/wpt_linter.py:
(WPTLinter.__init__):
(WPTLinter.lint):
(WPTLinter):
(WPTLinter._run_lint):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2fe54c0d4b5355b3d9077ec6d6d949e9ea4741d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168235 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113781 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123501 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86688 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104165 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/158723 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24802 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23259 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16006 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170727 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131707 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131820 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142750 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90589 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19559 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31975 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31495 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31768 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31650 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->