### PR TITLE
[Site Isolation] Make typing work on iOS

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/text-input.html
+++ b/LayoutTests/http/tests/site-isolation/resources/text-input.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<input id="target" type="text" autocapitalize="none" style="width: 200px; font-size: 16px;">
+<script>
+window.addEventListener("message", (event) => {
+    if (event.data.type === "getInputRect") {
+        const rect = document.getElementById("target").getBoundingClientRect();
+        window.parent.postMessage({
+            type: "inputRect",
+            x: rect.x + rect.width / 2,
+            y: rect.y + rect.height / 2
+        }, "*");
+    } else if (event.data.type === "getInputValue") {
+        window.parent.postMessage({
+            type: "inputValue",
+            value: document.getElementById("target").value
+        }, "*");
+    }
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/type-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/type-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,11 @@
+Tests that focusing an input field inside a cross-origin iframe brings up the keyboard and allows typing when site isolation is enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Keyboard is visible after tapping input in cross-origin iframe.
+PASS typedValue is "hello"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/type-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/type-in-cross-origin-iframe.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+</head>
+<body>
+<script>
+description("Tests that focusing an input field inside a cross-origin iframe brings up the keyboard and allows typing when site isolation is enabled.");
+jsTestIsAsync = true;
+
+window.addEventListener("message", async (event) => {
+    if (event.data.type === "inputValue") {
+        window.typedValue = event.data.value;
+        shouldBeEqualToString("typedValue", "hello");
+        finishJSTest();
+    }
+});
+
+async function runTest() {
+    const iframe = document.getElementById("frame");
+    const iframeRect = iframe.getBoundingClientRect();
+
+    const inputCenter = await new Promise(resolve => {
+        window.addEventListener("message", (event) => {
+            if (event.data.type === "inputRect")
+                resolve(event.data);
+        }, { once: true });
+        iframe.contentWindow.postMessage({ type: "getInputRect" }, "*");
+    });
+
+    const clickX = iframeRect.left + inputCenter.x;
+    const clickY = iframeRect.top + inputCenter.y;
+
+    await UIHelper.activateAt(clickX, clickY);
+    await UIHelper.waitForKeyboardToShow();
+    testPassed("Keyboard is visible after tapping input in cross-origin iframe.");
+
+    for (const character of "hello") {
+        await UIHelper.typeCharacter(character);
+        await UIHelper.ensurePresentationUpdate();
+    }
+
+    iframe.contentWindow.postMessage({ type: "getInputValue" }, "*");
+}
+</script>
+<iframe id="frame" width="300" height="100" src="http://localhost:8000/site-isolation/resources/text-input.html"
+onload="runTest()"></iframe>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -917,17 +917,17 @@ unsigned WKPageGetPageCount(WKPageRef pageRef)
 
 bool WKPageCanDelete(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->canDelete();
+    return protect(toImpl(pageRef))->canDelete();
 }
 
 bool WKPageHasSelectedRange(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->hasSelectedRange();
+    return protect(toImpl(pageRef))->hasSelectedRange();
 }
 
 bool WKPageIsContentEditable(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->isContentEditable();
+    return protect(toImpl(pageRef))->isContentEditable();
 }
 
 void WKPageSetMaintainsInactiveSelection(WKPageRef pageRef, bool newValue)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -394,7 +394,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
         return;
 
     if (bundle.editorState) {
-        if (page->updateEditorState(EditorState { *bundle.editorState }, WebPageProxy::ShouldMergeVisualEditorState::Yes))
+        if (page->updateEditorState(connection, EditorState { *bundle.editorState }, WebPageProxy::ShouldMergeVisualEditorState::Yes))
             page->dispatchDidUpdateEditorState();
     }
 

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "EditorState.h"
 #include "MessageReceiver.h"
 #include "NavigationActionData.h"
 #include "ProcessActivityGroup.h"
@@ -127,6 +128,8 @@ public:
     LayerHostingContextID contextIDForVisibilityPropagationInWebProcess() const { return m_contextIDForVisibilityPropagationInWebProcess; }
 #endif
 
+    EditorState& editorState() { return m_editorState; }
+
 private:
     RemotePageProxy(WebPageProxy&, WebProcessProxy&, const WebCore::Site&, WebPageProxyMessageReceiverRegistration*, std::optional<WebCore::PageIdentifier>);
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -167,6 +170,7 @@ private:
     LayerHostingContextID m_contextIDForVisibilityPropagationInWebProcess { 0 };
 #endif
 
+    EditorState m_editorState;
 };
 
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -264,6 +264,7 @@
 #include <WebCore/PermissionDescriptor.h>
 #include <WebCore/PermissionState.h>
 #include <WebCore/PlatformEvent.h>
+#include <WebCore/ProcessIdentifier.h>
 #include <WebCore/ProcessSwapDisposition.h>
 #include <WebCore/PublicSuffixStore.h>
 #include <WebCore/Quirks.h>
@@ -3633,17 +3634,22 @@ void WebPageProxy::setBaseWritingDirection(WritingDirection direction)
 
 const EditorState& WebPageProxy::editorState() const
 {
+    if (RefPtr frame = focusedFrame()) {
+        if (RefPtr remotePageProxy = protect(m_browsingContextGroup)->remotePageInProcess(*this, protect(frame->process())))
+            return remotePageProxy->editorState();
+    }
+
     return internals().editorState;
 }
 
 bool WebPageProxy::hasSelectedRange() const
 {
-    return internals().editorState.selectionType == WebCore::SelectionType::Range;
+    return editorState().selectionType == WebCore::SelectionType::Range;
 }
 
 bool WebPageProxy::isContentEditable() const
 {
-    return internals().editorState.isContentEditable;
+    return editorState().isContentEditable;
 }
 
 void WebPageProxy::updateFontAttributesAfterEditorStateChange()
@@ -12228,15 +12234,15 @@ void WebPageProxy::didReceiveEvent(IPC::Connection* connection, WebEventType eve
     }
 }
 
-void WebPageProxy::editorStateChanged(EditorState&& editorState)
+void WebPageProxy::editorStateChanged(IPC::Connection& connection, EditorState&& editorState)
 {
     // FIXME: This should not merge VisualData; they should only be merged
     // if the drawing area says to.
-    if (updateEditorState(WTF::move(editorState), ShouldMergeVisualEditorState::Yes))
+    if (updateEditorState(connection, WTF::move(editorState), ShouldMergeVisualEditorState::Yes))
         dispatchDidUpdateEditorState();
 }
 
-bool WebPageProxy::updateEditorState(EditorState&& newEditorState, ShouldMergeVisualEditorState shouldMergeVisualEditorState)
+bool WebPageProxy::updateEditorState(IPC::Connection& connection, EditorState&& newEditorState, ShouldMergeVisualEditorState shouldMergeVisualEditorState)
 {
     if (RefPtr pageClient = this->pageClient())
         pageClient->reconcileEnclosingScrollViewContentOffset(newEditorState);
@@ -12246,8 +12252,15 @@ bool WebPageProxy::updateEditorState(EditorState&& newEditorState, ShouldMergeVi
         shouldMergeVisualEditorState = (!drawingArea || !drawingArea->shouldCoalesceVisualEditorStateUpdates()) ? ShouldMergeVisualEditorState::Yes : ShouldMergeVisualEditorState::No;
     }
 
-    bool isStaleEditorState = newEditorState.identifier < internals().editorState.identifier;
-    bool shouldKeepExistingVisualEditorState = shouldMergeVisualEditorState == ShouldMergeVisualEditorState::No && internals().editorState.hasVisualData();
+    Ref newEditorStateWebProcess = WebProcessProxy::fromConnection(connection);
+    bool newEditorStateIsFromProcessWithCurrentlyFocusedFrame = !m_focusedFrame || m_focusedFrame->process() == newEditorStateWebProcess;
+
+    auto* currentEditorState = &internals().editorState;
+    if (RefPtr remotePageProxy = protect(m_browsingContextGroup)->remotePageInProcess(*this, newEditorStateWebProcess))
+        currentEditorState = &remotePageProxy->editorState();
+
+    bool isStaleEditorState = newEditorState.identifier < currentEditorState->identifier;
+    bool shouldKeepExistingVisualEditorState = shouldMergeVisualEditorState == ShouldMergeVisualEditorState::No && currentEditorState->hasVisualData();
     bool shouldMergeNewVisualEditorState = shouldMergeVisualEditorState == ShouldMergeVisualEditorState::Yes && newEditorState.hasVisualData();
 
 #if PLATFORM(MAC)
@@ -12256,16 +12269,16 @@ bool WebPageProxy::updateEditorState(EditorState&& newEditorState, ShouldMergeVi
 
     std::optional<EditorState> oldEditorState;
     if (!isStaleEditorState) {
-        oldEditorState = std::exchange(internals().editorState, WTF::move(newEditorState));
         if (shouldKeepExistingVisualEditorState)
-            internals().editorState.visualData = oldEditorState->visualData;
+            newEditorState.visualData = currentEditorState->visualData;
+        oldEditorState = std::exchange(*currentEditorState, WTF::move(newEditorState));
     } else if (shouldMergeNewVisualEditorState) {
-        oldEditorState = internals().editorState;
-        internals().editorState.visualData = WTF::move(newEditorState.visualData);
+        oldEditorState = *currentEditorState;
+        currentEditorState->visualData = WTF::move(newEditorState.visualData);
     }
 
-    if (oldEditorState) {
-        didUpdateEditorState(*oldEditorState, internals().editorState);
+    if (oldEditorState && newEditorStateIsFromProcessWithCurrentlyFocusedFrame) {
+        didUpdateEditorState(*oldEditorState, editorState());
         return true;
     }
 
@@ -15087,7 +15100,7 @@ void WebPageProxy::insertTextAsync(const String& text, const EditingRange& repla
     if (!hasRunningProcess())
         return;
 
-    send(Messages::WebPage::InsertTextAsync(text, replacementRange, WTF::move(options)));
+    sendToProcessContainingFrame(focusedOrMainFrame()->frameID(), Messages::WebPage::InsertTextAsync(text, replacementRange, WTF::move(options)));
 }
 
 void WebPageProxy::hasMarkedText(CompletionHandler<void(bool)>&& callback)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1126,10 +1126,10 @@ public:
     void executeEditCommand(const String& commandName, const String& argument, CompletionHandler<void()>&&);
     void validateCommand(const String& commandName, CompletionHandler<void(bool, int32_t)>&&);
 
-    const EditorState& NODELETE editorState() const LIFETIME_BOUND;
+    const EditorState& editorState() const LIFETIME_BOUND;
     bool canDelete() const { return hasSelectedRange() && isContentEditable(); }
-    bool NODELETE hasSelectedRange() const;
-    bool NODELETE isContentEditable() const;
+    bool hasSelectedRange() const;
+    bool isContentEditable() const;
 
     void increaseListLevel();
     void decreaseListLevel();
@@ -2245,9 +2245,9 @@ public:
 #if PLATFORM(COCOA)
     void createSandboxExtensionsIfNeeded(const Vector<String>& files, SandboxExtensionHandle& fileReadHandle, Vector<SandboxExtensionHandle>& fileUploadHandles);
 #endif
-    void editorStateChanged(EditorState&&);
+    void editorStateChanged(IPC::Connection&, EditorState&&);
     enum class ShouldMergeVisualEditorState : uint8_t { No, Yes, Default };
-    bool updateEditorState(EditorState&& newEditorState, ShouldMergeVisualEditorState = ShouldMergeVisualEditorState::Default);
+    bool updateEditorState(IPC::Connection&, EditorState&& newEditorState, ShouldMergeVisualEditorState = ShouldMergeVisualEditorState::Default);
     void scheduleFullEditorStateUpdate();
     void dispatchDidUpdateEditorState();
 
@@ -2584,7 +2584,7 @@ public:
 
 #if ENABLE(WRITING_TOOLS)
 #if PLATFORM(MAC)
-    bool NODELETE shouldEnableWritingToolsRequestedTool(WebCore::WritingTools::RequestedTool) const;
+    bool shouldEnableWritingToolsRequestedTool(WebCore::WritingTools::RequestedTool) const;
 #endif
 #if ENABLE(CONTEXT_MENUS)
     bool canHandleContextMenuWritingTools() const;
@@ -2747,7 +2747,7 @@ public:
 #if ENABLE(WRITING_TOOLS)
     void setWritingToolsActive(bool);
 
-    WebCore::WritingTools::Behavior NODELETE writingToolsBehavior() const;
+    WebCore::WritingTools::Behavior writingToolsBehavior() const;
 
     void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, Vector<WebCore::JSHandleIdentifier>&& preservedNodeIdentifiers, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
 
@@ -3323,7 +3323,7 @@ private:
     void didReceiveEventIPC(IPC::Connection&, WebEventType, bool handled, std::optional<WebCore::RemoteUserInputEventData>&&);
     void didUpdateRenderingAfterCommittingLoad();
 #if PLATFORM(IOS_FAMILY)
-    void interpretKeyEvent(EditorState&&, KeyEventInterpretationContext&&, CompletionHandler<void(bool)>&&);
+    void interpretKeyEvent(IPC::Connection&, EditorState&&, KeyEventInterpretationContext&&, CompletionHandler<void(bool)>&&);
     void showPlaybackTargetPicker(bool hasVideo, const WebCore::IntRect& elementRect, WebCore::RouteSharingPolicy, const String&);
 
     void updateStringForFind(const String&);

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -716,9 +716,9 @@ void WebPageProxy::moveSelectionByOffset(int32_t offset, CompletionHandler<void(
     }, webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::interpretKeyEvent(EditorState&& state, KeyEventInterpretationContext&& context, CompletionHandler<void(bool)>&& completionHandler)
+void WebPageProxy::interpretKeyEvent(IPC::Connection& connection, EditorState&& state, KeyEventInterpretationContext&& context, CompletionHandler<void(bool)>&& completionHandler)
 {
-    updateEditorState(WTF::move(state));
+    updateEditorState(connection, WTF::move(state));
     if (!hasQueuedKeyEvent()) {
         completionHandler(false);
         return;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -698,7 +698,7 @@ public:
     NSRect unionRectInVisibleSelectedRangeInScreen() const;
     NSRect documentVisibleRectInScreen() const;
 
-    bool NODELETE isContentRichlyEditable() const;
+    bool isContentRichlyEditable() const;
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
     void insertMultiRepresentationHEIC(NSData *, NSString *);
@@ -753,7 +753,7 @@ public:
     NSTouchBar *makeTouchBar();
     void updateTouchBar();
     NSTouchBar *currentTouchBar() const LIFETIME_BOUND { return m_currentTouchBar.get(); }
-    NSCandidateListTouchBarItem *NODELETE candidateListTouchBarItem() const;
+    NSCandidateListTouchBarItem *candidateListTouchBarItem() const;
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
     WebCore::PlatformPlaybackSessionInterface* playbackSessionInterface() const;
     bool isPictureInPictureActive();
@@ -767,7 +767,7 @@ public:
 #endif
     void nowPlayingMediaTitleAndArtist(void(^completionHandler)(NSString *, NSString *));
 
-    NSTouchBar *NODELETE textTouchBar() const;
+    NSTouchBar *textTouchBar() const;
     void dismissTextTouchBarPopoverItemWithIdentifier(NSString *);
 
     bool clientWantsMediaPlaybackControlsView() const { return m_clientWantsMediaPlaybackControlsView; }
@@ -888,7 +888,7 @@ private:
     void updateMediaTouchBar();
 
     bool useMediaPlaybackControlsView() const;
-    bool NODELETE isRichlyEditableForTouchBar() const;
+    bool isRichlyEditableForTouchBar() const;
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     void installImageAnalysisOverlayView(RetainPtr<VKCImageAnalysis>&&);
@@ -986,7 +986,7 @@ private:
     int32_t processImageAnalyzerRequest(CocoaImageAnalyzerRequest *, CompletionHandler<void(RetainPtr<CocoaImageAnalysis>&&, NSError *)>&&);
 #endif
 
-    std::optional<EditorState::PostLayoutData> NODELETE postLayoutDataForContentEditable();
+    std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
 
     WeakObjCPtr<WKWebView> m_view;
     const UniqueRef<PageClient> m_pageClient;


### PR DESCRIPTION
#### a91d8f8c973025308054dfcc9138d1cfe7b31884
<pre>
[Site Isolation] Make typing work on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=312858">https://bugs.webkit.org/show_bug.cgi?id=312858</a>
<a href="https://rdar.apple.com/162073012">rdar://162073012</a>

Reviewed by Charlie Wolfe.

Turns out, one of the things people like to do on their devices is type. Who knew?

Unfortunately, on an iOS device with site isolation on, you can&apos;t type into a
cross-site iframe. When you click the input field, the keyboard does show up, but
clicking the keys does not result in them being typed. This is a major livablity
blocker.

The way text gets entered from the keyboard is that UIKit tells WebKit to insert
text by calling the insertText API (in WKContentViewInteraction.mm). With site
isolation on, this is never called.

When deciding to insertText in the contentView, UIKit first checks if the content
is editable (because why try to insert text if the content isn&apos;t editable in the
first place). It does this by asking the WebPageProxy if its content is editable:

[context setDocumentEditable:protect(_page)-&gt;editorState().isContentEditable];

This flag is stored on EditorState. This EditorState is created by the WebPage and
sent to the UIProcess every time the editing state for that web process changes.
This can happen via three different IPC messages:

1. WebPageProxy::editorStateChanged()
2. WebPageProxy::interpretKeyEvent()
3. RemoteLayerTreeDrawingAreaProxy::commitLayerTree()

All three of these will call WebPageProxy::updateEditorState() where WebPageProxy
will possibly store the new EditorState.

The EditorState has a monotonically increasing identifier. Whenever
WebPageProxy::updateEditorState() receives a new EditorState, it only stores and
uses it if this identifier is greater than the one of the current EditorState it
holds. Otherwise this new EditorState is ignored.

This is the root of our problem.

Before site isolation, each contentView is associated with a single web process.
And each WebPage maps to a single WebPageProxy. All frames on that WebPage share
the same EditorState. Anytime one of them makes a change to it, it is sent to the
WebPageProxy, stored there, and its data is used to let UIKit make decisions (like
whether or not to insert text). Let&apos;s consider our case of typing in a iframe:

Site Isolation OFF:

1. Main frame&apos;s EditorState goes through a series of changes as the user uses the
   page. For each change, the web process sends to the UIProcess a new EditorState
   with an incremented identifier.

   Let&apos;s say after this, the EditorState in WebPageProxy has identifier = 10 and
   since the users&apos;s actions didn&apos;t result in the content being editable, the
   isContentEditable flag is false.

2. The iframe&apos;s input element gets tapped on. The iframe gets focused and selection
   changes. This changes the EditorState, so we make a new one (identifier = 11).
   Since the input element is capable of taking in text, isContentEditable is true.

   This EditorState is sent to the UIProcess. Since the identifier is greater than
   the current one, this EditorState replaces the old one.

3. User presses a key on the keyboard. UIKit asks WebPageProxy if the content is
   editable. WebPageProxy has the new EditorState with isContentEditable = true.
   So UIKit calls insertText and the character gets typed.

Site Isolation ON:

1. Same as above. The main frame&apos;s EditorState goes through a series of changes and
   WebPageProxy ends up with an EditorState with identifier = 10 and
   isContentEditable = false.

2. The iframe&apos;s input element gets tapped on. The iframe gets focused and selection
   changes. This changes the EditorState, so we make a new one.

   But this iframe is in a different web process than the main frame. It has not sent
   an EditorState before. So its identifier will begin at 1. The EditorState it sends
   has identifier = 1 and isContentEditable = true.

   This EditorState is sent to the UIProcess. WebPageProxy has no idea that the new
   EditorState it just got is from a different process than the EditorState it holds
   now. All it sees is that the new EditorState&apos;s identifer is less than the one it
   holds currently. So this EditorState is ignored.

3. User presses a key on the keyboard. UIKit asks WebPageProxy if the content is
   editable. WebPageProxy still holds the EditorState from the main frame with
   isContentEditable = false.

   So UIKit DOES NOT call insertText and the character is not typed.

We need to teach WebPageProxy to deal with the fact that with site isolation on,
it may receive EditorStates from different processes.

With site isolation on, a WebPage doesn&apos;t map directly to a WebPageProxy if its
in a web process where the main frame is not local. Rather, it maps to a
RemotePageProxy.

So now, we make RemotePageProxy store the EditorState for its associated WebPage.

WebPageProxy::updateEditorState() will decide whether to store the new EditorState
on either the WebPageProxy itself (if it came from the web process where the main
frame is local) or on the correct RemotePageProxy. To do this, we add a field to
EditorState which indicates which web process generated it.

To ensure that we don&apos;t store old EditorStates, we will still only replace the
currently held EditorState for a web process if the new one has a greater identifier.

There are two problems we must address here:

1. UIKit can still only query one EditorState at a time (it doesn&apos;t know about site
   isolation in WebKit). Given that WebPageProxy (and the RemotePageProxys) for
   a single WebView collectively now each have an EditorStates, WebPageProxy must
   decide which to use when UIKit asks it questions.

   WebPageProxy will use the EditorState for whichever web process currently contains
   the focused frame. If no frame is focused, it will use the main frame&apos;s process.

2. When WebPageProxy::editorStateChanged() gets a new EditorState, if it decides to
   use this in favor of the old one it holds, it calls didUpdateEditorState(), which
   makes changes based on the new EditorState.

   But we may receive new EditorStates from a process that doesn&apos;t currently hold
   the focused frame that have a greater identifier than the current EditorState
   from that web process. In this case, we don&apos;t want to call didUpdateEditorState().

   Similarly to the first issue, we fix this by only calling didUpdateEditorState
   if the newEditorState is from the web process that currently holds the focused
   frame.

After all of this re-architecting, UIKit will now call insertText. But typing still
does not work. There&apos;s one more issue to fix.

insertText calls WebPageProxy::insertTextAsync(). But this function will only send the
text to the main frame&apos;s web process. To ensure the cross-site iframe gets it, we amend
insertTextAsync() to send the text to the web process that contains the currently
focused frame.

Now the flow is:

Site Isolation ON:

1. The main frame&apos;s EditorState goes through a series of changes and WebPageProxy ends
   up with an EditorState with identifier = 10 and isContentEditable = false. This
   is keyed by the main frame&apos;s web process.

2. The iframe&apos;s input element gets tapped on. The iframe gets focused and selection
   changes. This changes the EditorState, so we make a new one. It sends an EditorState
   with identifier = 1 and isContentEditable = true.

   WebPageProxy sees that this is for a different web process. So it stores this
   EditorState on the RemotePageProxy that is associated with this WebPage.

   And, since the iframe is the currently focused frame, we call didUpdateEditorState()
   with the EditorState it sent.

3. User presses a key on the keyboard. UIKit asks WebPageProxy if the content is
   editable. WebPageProxy uses the EditorState from the currently focused iframe&apos;s
   web process and returns isContentEditable = true.

   So UIKit DOES call insertText and WebPageProxy::insertTextAsync() ensures that
   the character is sent to the iframe&apos;s web process and is typed.

This is tested by a new layout test: type-in-cross-origin-iframe.html.

* LayoutTests/http/tests/site-isolation/resources/text-input.html: Added.
* LayoutTests/http/tests/site-isolation/type-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/type-in-cross-origin-iframe.html: Added.
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageCanDelete):
(WKPageHasSelectedRange):
(WKPageIsContentEditable):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
* Source/WebKit/UIProcess/RemotePageProxy.h:

Store the EditorState from the associated WebPage.

(WebKit::RemotePageProxy::editorState):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::editorState const):

When asked about the EditorState, WebPageProxy should use the one from the web
process that contains the currently focused frame (or the main frame if no frame
is focused).

(WebKit::WebPageProxy::hasSelectedRange const):
(WebKit::WebPageProxy::isContentEditable const):
(WebKit::WebPageProxy::editorStateChanged):
(WebKit::WebPageProxy::updateEditorState):

If the new editor state comes from the main frame&apos;s web process, update the
editor state stored by the WebPageProxy. Otherwise, update the editor state
stored by the RemotePageProxy that is associated with the web page that this
editor state comes from.

(WebKit::WebPageProxy::insertTextAsync):

Send the text to the currently focused frame&apos;s web process.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::interpretKeyEvent):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:

Canonical link: <a href="https://commits.webkit.org/312115@main">https://commits.webkit.org/312115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2057781cb18ca071d729c2154f35f3f32c480e59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112958 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123086 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86414 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103755 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24411 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22814 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15475 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170195 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15938 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131276 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131390 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142294 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89942 "Built successfully") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/24185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26089 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19103 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31446 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97460 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30966 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31239 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31120 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->