### PR TITLE
[CMake][ASan] Pass -fsanitize to sandbox-profile preprocessing

### DIFF
--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -1121,6 +1121,17 @@ function(WEBKIT_DEFINE_XPC_SERVICES)
     if (EXISTS "${CMAKE_BINARY_DIR}/generated-stubs/AppleFeatures/AppleFeatures.h")
         list(APPEND _sb_extra_includes "-isystem" "${CMAKE_BINARY_DIR}/generated-stubs")
     endif ()
+    # Sandbox profiles gate ASan-required syscalls (SYS_sigaltstack, ...) on
+    # #if ASAN_ENABLED, which wtf/Compiler.h derives from
+    # __has_feature(address_sanitizer). Pass -fsanitize so the preprocessor sees
+    # the same feature set the compiled code does -- mirrors $(SANITIZE_FLAGS) in
+    # DerivedSources.make. Without this the WebContent sandbox blocks
+    # sigaltstack() and ASan CHECK-fails inside __asan_handle_no_return.
+    if (ENABLE_SANITIZERS)
+        foreach (_san IN LISTS ENABLE_SANITIZERS)
+            list(APPEND _sb_extra_includes "-fsanitize=${_san}")
+        endforeach ()
+    endif ()
 
     add_custom_command(OUTPUT ${WebKit_RESOURCES_DIR}/com.apple.WebProcess.sb COMMAND
         grep -o "^[^;]*" ${WEBKIT_DIR}/WebProcess/com.apple.WebProcess.sb.in | clang -E -P -w -include wtf/Platform.h -I ${WTF_FRAMEWORK_HEADERS_DIR} -I ${bmalloc_FRAMEWORK_HEADERS_DIR} -I ${WEBKIT_DIR} ${_sb_extra_includes} - > ${WebKit_RESOURCES_DIR}/com.apple.WebProcess.sb


### PR DESCRIPTION
#### 9ed0cbc96b8b0afe8c08338e22f7900e55aa89d2
<pre>
[CMake][ASan] Pass -fsanitize to sandbox-profile preprocessing
<a href="https://bugs.webkit.org/show_bug.cgi?id=312617">https://bugs.webkit.org/show_bug.cgi?id=312617</a>

Reviewed by Geoffrey Garen.

The macOS sandbox profiles gate ASan-required syscalls behind
#if ASAN_ENABLED, which wtf/Compiler.h derives from
__has_feature(address_sanitizer). DerivedSources.make passes
$(SANITIZE_FLAGS) to the clang -E invocation that preprocesses .sb.in
files; the CMake equivalent in WEBKIT_DEFINE_XPC_SERVICES did not, so the
mac-asan preset (312514@main) produced non-ASan sandbox profiles.

The WebContent process then aborts the first time Security.framework
throws a C++ exception during platformInitializeWebProcess: ASan&apos;s
__cxa_throw interceptor calls __asan_handle_no_return -&gt;
PlatformUnpoisonStacks -&gt; sigaltstack(NULL, &amp;oss), which returns EPERM
because SYS_sigaltstack is not in the syscall allowlist, and ASan
CHECK-fails.

Append -fsanitize=&lt;each ENABLE_SANITIZERS entry&gt; to the .sb.in
preprocessing flags, mirroring DerivedSources.make.

* Source/WebKit/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/311517@main">https://commits.webkit.org/311517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69f4dbe2375449348b44efa97c9de6c50a24d0c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165993 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111252 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8a4db73-97eb-4a8b-9a46-0de83f8af48d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121714 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f88b9da3-b6bc-4919-a4f4-4274cd3b4fb4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102382 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e364144f-43b1-435a-a7c2-beb08659bbe2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23005 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21252 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13765 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132685 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168478 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12637 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129846 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129954 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35212 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140749 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87852 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17553 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29742 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93756 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29264 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29494 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29391 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->