### PR TITLE
Update CSP report-multiple-violations layout tests imported from Blink to match WebKit output

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2982,8 +2982,6 @@ webkit.org/b/153155 http/tests/security/contentSecurityPolicy/1.1/stylenonce-svg
 webkit.org/b/153159 http/tests/security/contentSecurityPolicy/image-document-default-src-none.html [ Failure ]
 webkit.org/b/153160 http/tests/security/contentSecurityPolicy/plugin-in-iframe-with-csp.html [ Failure ]
 webkit.org/b/153161 http/tests/security/contentSecurityPolicy/register-bypassing-scheme-partial.html [ Failure ]
-webkit.org/b/153162 http/tests/security/contentSecurityPolicy/report-multiple-violations-01.py [ Failure ]
-webkit.org/b/153162 http/tests/security/contentSecurityPolicy/report-multiple-violations-02.py [ Failure ]
 webkit.org/b/154522 http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-base-uri-deny.html
 
 # WK CSP extension support is WebKit2 only

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-01-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-01-expected.txt
@@ -1,8 +1,5 @@
-CONSOLE MESSAGE: [Report Only] Refused to load the image 'http://127.0.0.1:8000/security/resources/abe.png' because it violates the following Content Security Policy directive: "img-src 'none'".
-
-CONSOLE MESSAGE: [Report Only] Refused to load the image 'http://127.0.0.1:8000/security/resources/eba.png' because it violates the following Content Security Policy directive: "img-src 'none'".
-
-PingLoader dispatched to 'http://127.0.0.1:8000/security/contentSecurityPolicy/resources/does-not-exist'.
-This tests that multiple violations on a page trigger multiple reports. The test passes if two PingLoader callbacks are visible in the output.
+CONSOLE MESSAGE: [Report Only] Refused to load http://127.0.0.1:8000/security/resources/abe.png because it does not appear in the img-src directive of the Content Security Policy.
+CONSOLE MESSAGE: [Report Only] Refused to load http://127.0.0.1:8000/security/resources/eba.png because it does not appear in the img-src directive of the Content Security Policy.
+This tests that multiple violations on a page trigger multiple reports. The test passes if two CSP violation console messages are visible in the output.
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-01.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-01.py
@@ -10,8 +10,12 @@ sys.stdout.write(
 print('''<!DOCTYPE html>
 <html>
 <body>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText(false);
+</script>
 <p>This tests that multiple violations on a page trigger multiple reports.
-The test passes if two PingLoader callbacks are visible in the output.</p>
+The test passes if two CSP violation console messages are visible in the output.</p>
 <img src="../resources/abe.png">
 <img src="../resources/eba.png">
 </body>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-02-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-02-expected.txt
@@ -1,11 +1,6 @@
-CONSOLE MESSAGE: [Report Only] Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline' 'self'".
-
-CONSOLE MESSAGE: [Report Only] Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline' 'self'".
-
-CONSOLE MESSAGE: [Report Only] Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline' 'self'".
-
-CONSOLE MESSAGE: [Report Only] Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline' 'self'".
-
-CONSOLE MESSAGE: [Report Only] Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline' 'self'".
-
-This tests that multiple violations on a page trigger multiple reports if and only if the violations are distinct. This test passes if only one. PingLoader callback is visible in the output.
+CONSOLE MESSAGE: [Report Only] Refused to execute a script because 'unsafe-eval' and 'trusted-types-eval' does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: [Report Only] Refused to execute a script because 'unsafe-eval' and 'trusted-types-eval' does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: [Report Only] Refused to execute a script because 'unsafe-eval' and 'trusted-types-eval' does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: [Report Only] Refused to execute a script because 'unsafe-eval' and 'trusted-types-eval' does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: [Report Only] Refused to execute a script because 'unsafe-eval' and 'trusted-types-eval' does not appear in the script-src directive of the Content Security Policy.
+This tests that multiple violations on a page trigger multiple reports if and only if the violations are distinct. This test passes if five identical CSP violation console messages are visible in the output.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-02.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-02.py
@@ -10,12 +10,23 @@ sys.stdout.write(
 print('''<!DOCTYPE html>
 <html>
 <body>
-<p>This tests that multiple violations on a page trigger multiple reports
-if and only if the violations are distinct. This test passes if only one.
-PingLoader callback is visible in the output.</p>
 <script>
-for (var i = 0; i< 5; i++)
-    setTimeout("alert('PASS: setTimeout #" + i + " executed.');", 0);
+if (window.testRunner) {
+    testRunner.dumpAsText(false);
+    testRunner.waitUntilDone();
+}
+var callbackCount = 0;
+function done() {
+    if (++callbackCount === 5 && window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+<p>This tests that multiple violations on a page trigger multiple reports
+if and only if the violations are distinct. This test passes if five
+identical CSP violation console messages are visible in the output.</p>
+<script>
+for (var i = 0; i < 5; i++)
+    setTimeout("done()", 0);
 </script>
 </body>
 </html>''')


### PR DESCRIPTION
#### 2e6da037b0666a95df17b4682c2fe24e51fb54d7
<pre>
Update CSP report-multiple-violations layout tests imported from Blink to match WebKit output
<a href="https://bugs.webkit.org/show_bug.cgi?id=312618">https://bugs.webkit.org/show_bug.cgi?id=312618</a>
<a href="https://rdar.apple.com/175049303">rdar://175049303</a>

Reviewed by Brent Fulgham.

Tests http/tests/security/contentSecurityPolicy/report-multiple-violations-01.py and
http/tests/security/contentSecurityPolicy/report-multiple-violations-02.py were imported from
Blink (171356@main) and have been marked as longtime test failures. The current expected test
outputs are not compatible with WebKit&apos;s current implementation and test infrastructure.

This patch adds testRunner.dumpAsText() to both tests, updates the expected files to match WebKit&apos;s
CSP violation message format, and removes the [ Failure ] entries in the TestExpectations file.

The entries were previously associated with webkit.org/b/153162 which is currently tracking
implementing CSP violation report deduplication. That feature is not addressed in this patch and will
be handled in a future task.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-01-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-01.py:
* LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-02-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-02.py:

Canonical link: <a href="https://commits.webkit.org/311680@main">https://commits.webkit.org/311680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cbc56112f01ac7bb5d9e2a60de4c9b723861fed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111336 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da67e934-2358-4960-a397-ceb9792cd91e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121788 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85504 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43e7dcfb-1ea4-4fd1-9769-afedb53aa2e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102456 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db2abd99-8926-44c3-af79-1085812fcd5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23084 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21332 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13849 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132764 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168563 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129921 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35310 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140827 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87964 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24848 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17632 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29826 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29348 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29578 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29475 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->