### PR TITLE
[Cocoa] Calling -regularFileContents on a directory NSFileWrapper crashes the web content process

### DIFF
--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -737,8 +737,10 @@ static std::optional<AttributedString::AttributeValue> extractValue(id value, Ta
         textAttachment.ignoresOrientation = [value ignoresOrientation];
 #endif
         if (auto fileWrapper = retainPtr([value fileWrapper])) {
-            if (auto data = bridge_cast(retainPtr([fileWrapper regularFileContents])))
-                textAttachment.data = data;
+            if ([fileWrapper isRegularFile]) {
+                if (auto data = bridge_cast(retainPtr([fileWrapper regularFileContents])))
+                    textAttachment.data = data;
+            }
             if (auto preferredFilename = retainPtr([fileWrapper preferredFilename]))
                 textAttachment.preferredFilename = preferredFilename.get();
         }

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -1298,12 +1298,14 @@ BOOL HTMLConverter::_addAttachmentForElement(Element& element, NSURL *url, BOOL 
         NSDictionary *attrs;
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
-        if (RetainPtr data = [fileWrapper regularFileContents]) {
-            RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element);
-            if (imageElement && imageElement->isMultiRepresentationHEIC())
-                attachment = adoptNS([[PlatformNSAdaptiveImageGlyph alloc] initWithImageContent:data.get()]);
-            if (attachment)
-                attributeName = NSAdaptiveImageGlyphAttributeName;
+        if ([fileWrapper isRegularFile]) {
+            if (RetainPtr data = [fileWrapper regularFileContents]) {
+                RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element);
+                if (imageElement && imageElement->isMultiRepresentationHEIC())
+                    attachment = adoptNS([[PlatformNSAdaptiveImageGlyph alloc] initWithImageContent:data.get()]);
+                if (attachment)
+                    attributeName = NSAdaptiveImageGlyphAttributeName;
+            }
         }
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm
@@ -30,6 +30,7 @@
 
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
+#import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebKit/WKPreferencesPrivate.h>
@@ -184,6 +185,31 @@ TEST(CopyRTF, StripsUserSelectNoneQuirks)
         "<div style='-webkit-user-select: none; user-select: none;'>some<br>user-select-none<br>content</div><span inert>foo </span>bar", false);
 
     EXPECT_WK_STREQ([attributedString string].UTF8String, "hello world WebKit\nsome\nuser-select-none\ncontent\nfoo bar");
+}
+
+TEST(CopyRTF, DoesNotCrashWithDirectoryFileWrapperFromImageSrcset)
+{
+    // Regression test: copying an <img> with srcset="." could produce a directory-backed NSFileWrapper.
+    // Calling -regularFileContents on a non-regular file wrapper throws an NSException, which would
+    // terminate the web content process as it propagated through C++ frames in HTMLConverter.
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    __block bool terminated = false;
+    navigationDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        terminated = true;
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    auto preferences = (__bridge WKPreferencesRef)[[webView configuration] preferences];
+    WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging(preferences, true);
+
+    [webView synchronouslyLoadHTMLString:@"<img srcset='.'>"];
+    [webView selectAll:nil];
+    [webView _synchronouslyExecuteEditCommand:@"Copy" argument:nil];
+
+    TestWebKitAPI::Util::runFor(&terminated, 0.5_s);
+    EXPECT_FALSE(terminated);
 }
 
 #endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### dad1793d6498a35aec1d08604ccd58544d3d83f3
<pre>
[Cocoa] Calling -regularFileContents on a directory NSFileWrapper crashes the web content process
<a href="https://bugs.webkit.org/show_bug.cgi?id=312594">https://bugs.webkit.org/show_bug.cgi?id=312594</a>
<a href="https://rdar.apple.com/174642216">rdar://174642216</a>

Reviewed by Ryosuke Niwa.

When copying content containing an &lt;img&gt; element whose resolved URL points to a directory (e.g. srcset=&quot;.&quot;), WebKit
can end up with a directory-backed NSFileWrapper. Calling -regularFileContents on such a wrapper raises an
NSInvalidArgumentException. Because the exception unwinds through C++ stack frames in HTMLConverter and
AttributedString, it is not caught and terminates the web content process.

Fix by guarding both -regularFileContents call sites with -isRegularFile before extracting attachment data. The
preferredFilename and other metadata are still read regardless of file type.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm

* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::extractValue):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(HTMLConverter::_addAttachmentForElement):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm:
(TEST(CopyRTF, DoesNotCrashWithDirectoryFileWrapperFromImageSrcset)):

Canonical link: <a href="https://commits.webkit.org/311610@main">https://commits.webkit.org/311610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/704d7a176d847482ebebb180df96c55172f4e1bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111268 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121726 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85472 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102394 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23016 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21270 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13781 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132696 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168494 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12653 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129861 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30124 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129969 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35268 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140765 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87868 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24791 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17569 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29758 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93772 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29280 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29510 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->