### PR TITLE
[css-anchor-position-1] Use localToContainerQuad to compute anchor rect in container

### DIFF
--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2489,6 +2489,12 @@ void RenderBox::mapLocalToContainer(const RenderLayerModelObject* ancestorContai
     if (mode.contains(MapCoordinatesMode::IgnoreStickyOffsets) && isStickilyPositioned())
         containerOffset -= stickyPositionOffset();
 
+    // Clamp overscroll if requested, so we don't layout into it.
+    if (mode.contains(MapCoordinatesMode::ClampOverscroll)) {
+        if (CheckedPtr boxContainer = dynamicDowncast<RenderBox>(container); boxContainer && boxContainer->hasPotentiallyScrollableOverflow())
+            containerOffset += boxContainer->scrollPosition() - boxContainer->constrainedScrollPosition();
+    }
+
     pushOntoTransformState(transformState, mode, ancestorContainer, container, containerOffset, containerSkipped);
     if (containerSkipped)
         return;

--- a/Source/WebCore/rendering/RenderObjectEnums.h
+++ b/Source/WebCore/rendering/RenderObjectEnums.h
@@ -57,6 +57,7 @@ enum class MapCoordinatesMode : uint8_t {
     UseTransforms       = 1 << 1,
     ApplyContainerFlip  = 1 << 2,
     IgnoreStickyOffsets = 1 << 3,
+    ClampOverscroll     = 1 << 4,
 };
 
 }

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -440,47 +440,33 @@ static bool NODELETE anchorSideMatchesInsetProperty(CSSValueID anchorSideID, Box
     }
 }
 
-static LayoutSize offsetFromAncestorContainer(const RenderElement& descendantContainer, const RenderElement& ancestorContainer)
+static LayoutRect boxBoundingBoxInContainer(const RenderBoxModelObject& box, const RenderLayerModelObject& container)
 {
-    LayoutSize offset;
-    LayoutPoint referencePoint;
-    CheckedPtr currentContainer = &descendantContainer;
-    CheckedPtr maxContainer = &ancestorContainer;
-    if (CheckedPtr ancestorInline = dynamicDowncast<RenderInline>(&ancestorContainer))
-        maxContainer = ancestorInline->containingBlock();
-    do {
-        CheckedPtr nextContainer = currentContainer->container();
-        ASSERT(nextContainer); // This means we reached the top without finding container.
-        if (!nextContainer)
-            break;
-        LayoutSize currentOffset = currentContainer->offsetFromContainer(*nextContainer, referencePoint);
+    bool wasFixed = false;
+    // FIXME: figure out if OverscrollClamp is still needed.
+    auto boxQuadInContainer = box.localToContainerQuad(FloatQuad { box.borderBoundingBox() }, &container, { MapCoordinatesMode::ClampOverscroll }, &wasFixed);
+    LayoutRect boundingBox { boxQuadInContainer.boundingBox() };
 
-        if (CheckedPtr boxContainer = dynamicDowncast<RenderBox>(*nextContainer)) {
-            // Clamp overscroll so we don't layout into it.
-            if (boxContainer->hasPotentiallyScrollableOverflow())
-                currentOffset += boxContainer->scrollPosition() - boxContainer->constrainedScrollPosition();
-        }
+    if (wasFixed) {
+        // Undo the scrolling transform applied by RenderView when the box is fixed positioned.
+        boundingBox.moveBy(-box.frame().view()->scrollPositionRespectingCustomFixedPosition());
+    }
 
-        offset += currentOffset;
-        referencePoint.move(currentOffset);
-        currentContainer = WTF::move(nextContainer);
-    } while (currentContainer != maxContainer);
-
-    if (CheckedPtr descendantInline = dynamicDowncast<RenderInline>(&descendantContainer)) {
+    if (CheckedPtr descendantInline = dynamicDowncast<RenderInline>(&box)) {
         // RenderInline objects do not automatically account for their offset above,
         // so we incorporate this offset here.
-        offset += toLayoutSize(descendantInline->linesBoundingBox().location());
+        boundingBox.moveBy(descendantInline->linesBoundingBox().location());
     }
-    if (descendantContainer.containingBlock() == ancestorContainer.containingBlock()) {
+    if (box.containingBlock() == container.containingBlock()) {
         // Account for 'position: relative' inline containing blocks by shifting back down into them.
-        if (CheckedPtr ancestorInline = dynamicDowncast<RenderInline>(&ancestorContainer))
-            offset -= toLayoutSize(ancestorInline->firstInlineBoxTopLeft()); // FIXME: Handle RTL.
+        if (CheckedPtr ancestorInline = dynamicDowncast<RenderInline>(&container))
+            boundingBox.moveBy(-ancestorInline->firstInlineBoxTopLeft()); // FIXME: Handle RTL.
     }
 
-    if (auto ancestorBox = dynamicDowncast<RenderBox>(ancestorContainer)) // Zero out containing block scroll position.
-        offset += toLayoutSize(ancestorBox->constrainedScrollPosition());
+    if (auto ancestorBox = dynamicDowncast<RenderBox>(container)) // Zero out containing block scroll position.
+        boundingBox.moveBy(ancestorBox->constrainedScrollPosition());
 
-    return offset;
+    return boundingBox;
 }
 
 void AnchorPositionEvaluator::addAnchorFunctionScrollCompensatedAxis(RenderStyle& style, const RenderBox& anchored, const RenderBoxModelObject& anchor, BoxAxis axis)
@@ -502,7 +488,7 @@ void AnchorPositionEvaluator::addAnchorFunctionScrollCompensatedAxis(RenderStyle
     style.setAnchorFunctionScrollCompensatedAxes(axes);
 }
 
-static LayoutRect boundingRectForFragmentedAnchor(const RenderBoxModelObject& anchorBox, const RenderElement& containingBlock, const RenderFragmentedFlow& fragmentedFlow)
+static LayoutRect boundingRectForFragmentedAnchor(const RenderBoxModelObject& anchorBox, const RenderLayerModelObject& containingBlock, const RenderFragmentedFlow& fragmentedFlow)
 {
     // Compute the bounding box of the fragments.
     // Location is relative to the fragmented flow.
@@ -533,15 +519,17 @@ static LayoutRect boundingRectForFragmentedAnchor(const RenderBoxModelObject& an
     fragmentsBoundingBox.moveBy(fragmentedFlowRect.location());
 
     // Change the location to be relative to the anchor's containing block.
-    if (fragmentedFlowContainer.get() != &containingBlock)
-        fragmentsBoundingBox.move(offsetFromAncestorContainer(*fragmentedFlowContainer, containingBlock));
+    if (fragmentedFlowContainer.get() != &containingBlock) {
+        auto fragmentedFlowContainerInContainingBlock = boxBoundingBoxInContainer(*fragmentedFlowContainer, containingBlock);
+        fragmentsBoundingBox.moveBy(fragmentedFlowContainerInContainingBlock.location());
+    }
 
     return fragmentsBoundingBox;
 }
 
 // This computes the top left location, physical width, and physical height of the specified
 // anchor element. The location is computed relative to the specified containing block.
-LayoutRect AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderElement& containingBlock, const RenderBox& anchoredBox)
+LayoutRect AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchor, const RenderLayerModelObject& containingBlock, const RenderBox& anchoredBox)
 {
     // Fragmented flows are a little tricky to deal with. One example of a fragmented
     // flow is a block anchor element that is "fragmented" or split across multiple columns
@@ -549,35 +537,24 @@ LayoutRect AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(C
     // bounding rectangle of the fragments' border boxes" and make that our anchorHeight/Width.
     // We also need to adjust the anchor's top left location to match that of the bounding box
     // instead of the first fragment.
-    if (CheckedPtr fragmentedFlow = anchorBox->enclosingFragmentedFlow();
+    if (CheckedPtr fragmentedFlow = anchor->enclosingFragmentedFlow();
         fragmentedFlow && fragmentedFlow->isDescendantOf(&containingBlock))
-        return boundingRectForFragmentedAnchor(anchorBox, containingBlock, *fragmentedFlow);
+        return boundingRectForFragmentedAnchor(anchor, containingBlock, *fragmentedFlow);
 
-    auto anchorWidth = anchorBox->offsetWidth();
-    auto anchorHeight = anchorBox->offsetHeight();
-    auto anchorLocation = LayoutPoint { offsetFromAncestorContainer(anchorBox, containingBlock) };
+    auto anchorBox = boxBoundingBoxInContainer(anchor, containingBlock);
 
-    if (&containingBlock == &containingBlock.view() && anchoredBox.isFixedPositioned()) {
-        // Handle fixed positioning x scrolling anchor.
-        bool isFixedAnchor = false;
-        for (const RenderElement* box = anchorBox.ptr(); box && box != &containingBlock; box = box->container()) {
-            if (box->isFixedPositioned()) {
-                isFixedAnchor = true;
-                break;
-            }
-        }
-        if (!isFixedAnchor) {
-            CheckedRef view = anchorBox->view().frameView();
-            anchorLocation.moveBy(-view->constrainedScrollPosition(ScrollPosition(view->scrollPositionRespectingCustomFixedPosition())));
-        }
+    // Handle fixed positioning x scrolling anchor.
+    if (&containingBlock == &containingBlock.view() && isFixed(anchoredBox) && !isFixed(anchor)) {
+        CheckedRef view = anchor->view().frameView();
+        anchorBox.moveBy(-view->constrainedScrollPosition(ScrollPosition(view->scrollPositionRespectingCustomFixedPosition())));
     }
 
     if (CheckedPtr containingBox = dynamicDowncast<RenderBox>(containingBlock)) {
         if (containingBox->shouldPlaceVerticalScrollbarOnLeft())
-            anchorLocation.move(-containingBox->verticalScrollbarWidth(), 0);
+            anchorBox.move(-containingBox->verticalScrollbarWidth(), 0);
     }
 
-    return LayoutRect(anchorLocation, LayoutSize(anchorWidth, anchorHeight));
+    return anchorBox;
 }
 
 static bool inline NODELETE isInsetPropertyContainerStartSide(CSSPropertyID insetPropertyID, PositionedLayoutConstraints& constraints)
@@ -750,7 +727,7 @@ static LayoutUnit computeInsetValue(CSSPropertyID insetPropertyID, CheckedRef<co
     if (constraints.startIsBefore() == isFlipped)
         anchorPercentage = 1 - anchorPercentage;
 
-    CheckedPtr containingBlock = anchorPositionedRenderer->container();
+    CheckedPtr containingBlock = dynamicDowncast<RenderLayerModelObject>(anchorPositionedRenderer->container());
     ASSERT(containingBlock);
     auto anchorRect = AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(anchorBox, *containingBlock, anchorPositionedRenderer.get());
     auto anchorRange = constraints.extractRange(anchorRect);
@@ -993,7 +970,7 @@ std::optional<double> AnchorPositionEvaluator::evaluateSize(BuilderState& builde
     if (!anchorPositionedElement)
         return { };
 
-    CheckedPtr anchorPositionedRenderer = anchorPositionedElement->renderer();
+    CheckedPtr anchorPositionedRenderer = dynamicDowncast<RenderBox>(anchorPositionedElement->renderer());
     ASSERT(anchorPositionedRenderer);
 
     CheckedPtr anchorPositionedContainerRenderer = anchorPositionedRenderer->container();

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -52,6 +52,7 @@ class LayoutSize;
 class RenderBlock;
 class RenderBox;
 class RenderBoxModelObject;
+class RenderLayerModelObject;
 class RenderElement;
 class RenderStyle;
 class RenderView;
@@ -200,7 +201,7 @@ public:
     static void updateScrollAdjustments(RenderView&);
     static void updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility(Element&, const RenderStyle&, AnchorPositionedStates&);
 
-    static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderElement& containingBlock, const RenderBox& anchoredBox);
+    static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderLayerModelObject& containingBlock, const RenderBox& anchoredBox);
     static void captureScrollSnapshots(RenderBox& anchored, bool invalidateStyleForScrollPositionChanges = true);
 
     static AnchorToAnchorPositionedMap makeAnchorPositionedForAnchorMap(AnchorPositionedToAnchorMap&);


### PR DESCRIPTION
#### b04fe9e14617304510fe7674ded5a1b8432751ce
<pre>
[css-anchor-position-1] Use localToContainerQuad to compute anchor rect in container
<a href="https://rdar.apple.com/175037950">rdar://175037950</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312605">https://bugs.webkit.org/show_bug.cgi?id=312605</a>

Reviewed by Antti Koivisto.

AnchorPositionEvaluator uses offsetFromAncestorContainer (local static) to compute
the location of a box relative to its ancestor. It is identical to
RenderObject::offsetFromAncestorContainer, just with some anchor positioning fixups.
It does not take transforms into account though, therefore it&apos;ll not work correctly
with a transformed box. To make anchor positioning work with transformed anchor boxes,
this patch refactors the function to use RenderObject::localToContainerQuad,
which can be configured to use transforms. For now this is disabled to preserve
old behavior, future patches will enable it to make transformed anchors work with
anchor positioning.

Refactoring, tested by existing anchor positioning tests.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::mapLocalToContainer const):
    - Add MapCoordinatesMode to clamp overscroll; this behavior was in
      offsetFromAncestorContainer and is preserved here.
* Source/WebCore/rendering/RenderObjectEnums.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::boxBoundingBoxInContainer):
    - Renamed from offsetFromAncestorContainer, this function now returns both the box
      location and size (as both can be affected by transforms)
    - Switch to using RenderObject::localToContainerQuad.
    - Rename arguments name to be shorter.
(WebCore::Style::boundingRectForFragmentedAnchor):
(WebCore::Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock):
    - Use anchor width/height computed from boxBoundingBoxInContainer instead of taking
      it directly from the renderer.
    - Use isFixed() to determine if an anchor/anchor-positioned is fixed positioned.
(WebCore::Style::computeInsetValue):
(WebCore::Style::AnchorPositionEvaluator::evaluateSize):
(WebCore::Style::offsetFromAncestorContainer): Deleted.
* Source/WebCore/style/AnchorPositionEvaluator.h:

Canonical link: <a href="https://commits.webkit.org/311715@main">https://commits.webkit.org/311715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76c6241c1f70f2c5bc196d3d2e4ce0ccb11fcba0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157662 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111744 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122075 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85748 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102744 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23417 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21699 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14257 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168975 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13489 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21016 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130244 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130361 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35331 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141189 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88521 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17994 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30235 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94673 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29756 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29986 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29883 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->