### PR TITLE
Generated commit messages should always sort Bugzilla link before alternate bug trackers

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/commit.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/commit.py
@@ -25,7 +25,7 @@ import sys
 
 from .command import Command
 
-from webkitbugspy import Tracker
+from webkitbugspy import Tracker, bugzilla
 from webkitcorepy import run, string_utils, arguments
 from webkitscmpy import local
 
@@ -69,14 +69,15 @@ class Commit(Command):
         if not issue:
             return ''
 
-        bug_urls = [issue.link]
+        issues = [(issue.link, issue.tracker)]
         types = [type(issue.tracker)]
         for related in issue.references:
             if type(related.tracker) in types:
                 continue
-            bug_urls.append(related.link)
+            issues.append((related.link, related.tracker))
             types.append(type(related.tracker))
-        return bug_urls
+        issues.sort(key=lambda x: not isinstance(x[1], bugzilla.Tracker))
+        return [url for url, _ in issues]
 
     @classmethod
     def main(cls, args, repository, command=None, representation=None, **kwargs):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
@@ -619,3 +619,44 @@ class TestDoCommit(testing.PathTestCase):
             '')
         self.assertEqual(captured.stdout.getvalue(), "")
         self.assertEqual(captured.stderr.getvalue(), "")
+
+    def test_commit_with_radar_primary_bug_url_ordering(self):
+        import copy
+        from webkitbugspy import Issue
+        # Create issues where Radar issue 1 has a comment referencing Bugzilla issue 2,
+        # so resolving rdar://1 produces a cross-tracker reference.
+        issues = copy.deepcopy(bmocks.ISSUES)
+        issues[0]['comments'] = list(issues[0].get('comments', [])) + [
+            Issue.Comment(
+                user=bmocks.USERS['Tim Contributor'],
+                timestamp=1639536300,
+                content='{}/show_bug.cgi?id=2'.format(self.BUGZILLA),
+            ),
+        ]
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(
+                projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(
+                self.BUGZILLA.split('://')[-1],
+                projects=bmocks.PROJECTS, issues=issues,
+                environment=Environment(
+                    BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                    BUGS_EXAMPLE_COM_PASSWORD='password',
+                )), bmocks.Radar(issues=issues), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA), radar.Tracker()],
+        ), mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn():
+            repo.staged['added.txt'] = 'added'
+            self.assertEqual(0, program.main(
+                args=('commit', '-i', 'rdar://1'),
+                path=self.path,
+            ))
+            # Bugzilla URL must come before Radar URL in the commit message
+            self.assertEqual(
+                'Example issue 1\n'
+                '{bugzilla}/show_bug.cgi?id=2\n'
+                'rdar://1\n'
+                'Reviewed by Jonathan Bedard\n\n'
+                ' * added.txt\n'.format(bugzilla=self.BUGZILLA),
+                repo.head.message,
+            )


### PR DESCRIPTION
#### 25e87df15e5142655bfdceb1272083858dbd2d81
<pre>
Generated commit messages should always sort Bugzilla link before alternate bug trackers
<a href="https://bugs.webkit.org/show_bug.cgi?id=312633">https://bugs.webkit.org/show_bug.cgi?id=312633</a>
<a href="https://rdar.apple.com/175062395">rdar://175062395</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Currently, depending on the order in which bug references are learned about,
we will generate a commit message with any bug tracker&apos;s link as the &quot;primary&quot;.
For example, if you use `git webkit pr` and give it a rdar:// link to start with,
that becomes the primary reference, and the tool promptly turns around and generates
a commit header:

TITLE
RADAR LINK
BUGZILLA LINK

But this really isn&apos;t how the WebKit project works. The Bugzilla reference should
always come first. Bugzilla is the primary bug tracker. The rest are all secondary.

To fix this, sort the references before generating the header, always preferring Bugzilla.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/commit.py:
(Commit.bug_urls):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py:

Canonical link: <a href="https://commits.webkit.org/311651@main">https://commits.webkit.org/311651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a3698483371b1929f7997fb5a3eb88e50dfb7c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111288 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121747 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85484 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102415 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/156527 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23042 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21289 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13801 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132722 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168514 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20610 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129880 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/156604 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129988 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35293 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140784 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87888 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24804 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17588 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29778 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29300 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29530 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29427 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->