### PR TITLE
Use UTR#50 Vertical_Orientation for SVG glyph-orientation-vertical: auto

### DIFF
--- a/LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50-expected.txt
+++ b/LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50-expected.txt
@@ -1,0 +1,24 @@
+一
+月
+A
+z
+§
+×
+℃
+°
+—
+…
+A一§°
+
+PASS CJK ideograph U+4E00 is upright (VO=U)
+PASS CJK ideograph U+6708 is upright (VO=U)
+PASS Latin A is sideways (VO=R)
+PASS Latin z is sideways (VO=R)
+PASS U+00A7 SECTION SIGN is upright (EAW=A, VO=U)
+PASS U+00D7 MULTIPLICATION SIGN is upright (EAW=A, VO=U)
+PASS U+2103 DEGREE CELSIUS is upright (EAW=A, VO=U)
+PASS U+00B0 DEGREE SIGN is sideways (EAW=A, VO=R)
+PASS U+2014 EM DASH is sideways (EAW=A, VO=R)
+PASS U+2026 HORIZONTAL ELLIPSIS is sideways (EAW=A, VO=R)
+PASS Mixed string: per-character orientation matches UTR#50
+

--- a/LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50.html
+++ b/LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<title>glyph-orientation-vertical: auto should use UTR#50 Vertical_Orientation</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#GlyphOrientationVerticalProperty">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#glyph-orientation">
+<link rel="help" href="https://www.unicode.org/reports/tr50/">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<svg id="container" width="800" height="600" style="writing-mode: tb; glyph-orientation-vertical: auto;"></svg>
+<script>
+const container = document.querySelector('#container');
+
+function createText(content) {
+  const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+  text.setAttribute('x', '50');
+  text.setAttribute('y', '50');
+  text.textContent = content;
+  container.appendChild(text);
+  return text;
+}
+
+// CJK ideographs: UTR#50 Vertical_Orientation=U (Upright) -> 0 degrees
+test(() => {
+  const el = createText('\u4E00');
+  assert_equals(el.getRotationOfChar(0), 0, 'U+4E00 CJK ideograph should be upright');
+}, 'CJK ideograph U+4E00 is upright (VO=U)');
+
+test(() => {
+  const el = createText('\u6708');
+  assert_equals(el.getRotationOfChar(0), 0, 'U+6708 CJK ideograph should be upright');
+}, 'CJK ideograph U+6708 is upright (VO=U)');
+
+// Latin letters: UTR#50 Vertical_Orientation=R (Rotated) -> 90 degrees
+test(() => {
+  const el = createText('A');
+  assert_equals(el.getRotationOfChar(0), 90, 'Latin A should be sideways');
+}, 'Latin A is sideways (VO=R)');
+
+test(() => {
+  const el = createText('z');
+  assert_equals(el.getRotationOfChar(0), 90, 'Latin z should be sideways');
+}, 'Latin z is sideways (VO=R)');
+
+// EAW=Ambiguous, UTR#50 VO=U (Upright): should be upright (0 degrees).
+// Both old EAW logic and UTR#50 agree on these.
+test(() => {
+  const el = createText('\u00A7');
+  assert_equals(el.getRotationOfChar(0), 0, 'U+00A7 SECTION SIGN should be upright per UTR#50');
+}, 'U+00A7 SECTION SIGN is upright (EAW=A, VO=U)');
+
+test(() => {
+  const el = createText('\u00D7');
+  assert_equals(el.getRotationOfChar(0), 0, 'U+00D7 MULTIPLICATION SIGN should be upright per UTR#50');
+}, 'U+00D7 MULTIPLICATION SIGN is upright (EAW=A, VO=U)');
+
+test(() => {
+  const el = createText('\u2103');
+  assert_equals(el.getRotationOfChar(0), 0, 'U+2103 DEGREE CELSIUS should be upright per UTR#50');
+}, 'U+2103 DEGREE CELSIUS is upright (EAW=A, VO=U)');
+
+// EAW=Ambiguous, UTR#50 VO=R (Rotated): should be sideways (90 degrees).
+// The old EAW-based logic incorrectly treated Ambiguous as upright (0 degrees).
+test(() => {
+  const el = createText('\u00B0');
+  assert_equals(el.getRotationOfChar(0), 90, 'U+00B0 DEGREE SIGN should be sideways per UTR#50');
+}, 'U+00B0 DEGREE SIGN is sideways (EAW=A, VO=R)');
+
+test(() => {
+  const el = createText('\u2014');
+  assert_equals(el.getRotationOfChar(0), 90, 'U+2014 EM DASH should be sideways per UTR#50');
+}, 'U+2014 EM DASH is sideways (EAW=A, VO=R)');
+
+test(() => {
+  const el = createText('\u2026');
+  assert_equals(el.getRotationOfChar(0), 90, 'U+2026 HORIZONTAL ELLIPSIS should be sideways per UTR#50');
+}, 'U+2026 HORIZONTAL ELLIPSIS is sideways (EAW=A, VO=R)');
+
+// Mixed string: verify per-character orientation in a single text element.
+test(() => {
+  const el = createText('A\u4E00\u00A7\u00B0');
+  assert_equals(el.getRotationOfChar(0), 90, 'A should be sideways');
+  assert_equals(el.getRotationOfChar(1), 0, 'U+4E00 should be upright');
+  assert_equals(el.getRotationOfChar(2), 0, 'U+00A7 should be upright');
+  assert_equals(el.getRotationOfChar(3), 90, 'U+00B0 should be sideways');
+}, 'Mixed string: per-character orientation matches UTR#50');
+</script>

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -152,21 +152,16 @@ float SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle(bool isVertica
     if (isVerticalText) {
         return Style::valueRepresentation(style.glyphOrientationVertical(),
             [&](const CSS::Keyword::Auto&) {
-                // Spec: Fullwidth ideographic and fullwidth Latin text will be set with a glyph-orientation of 0-degrees.
-                // Text which is not fullwidth will be set with a glyph-orientation of 90-degrees.
-                // FIXME: There's not an accurate way to tell if text is fullwidth by looking at a single character.
-                switch (static_cast<UEastAsianWidth>(u_getIntPropertyValue(character, UCHAR_EAST_ASIAN_WIDTH))) {
-                case U_EA_NEUTRAL:
-                case U_EA_HALFWIDTH:
-                case U_EA_NARROW:
-                    return 90.0f;
-                case U_EA_AMBIGUOUS:
-                case U_EA_FULLWIDTH:
-                case U_EA_WIDE:
+                auto verticalOrientation = static_cast<UVerticalOrientation>(u_getIntPropertyValue(character, UCHAR_VERTICAL_ORIENTATION));
+                switch (verticalOrientation) {
+                case U_VO_UPRIGHT:
+                case U_VO_TRANSFORMED_UPRIGHT:
                     return 0.0f;
+                case U_VO_ROTATED:
+                case U_VO_TRANSFORMED_ROTATED:
+                    return 90.0f;
                 }
-                ASSERT_NOT_REACHED();
-                return 0.0f;
+                RELEASE_ASSERT_NOT_REACHED();
             },
             [](const Style::Angle<>& angle) {
                 return Style::evaluate<float>(angle);


### PR DESCRIPTION
#### 4c22d3192a194f0a17bcb35996864803f9e5dcef
<pre>
Use UTR#50 Vertical_Orientation for SVG glyph-orientation-vertical: auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=312665">https://bugs.webkit.org/show_bug.cgi?id=312665</a>
<a href="https://rdar.apple.com/175064567">rdar://175064567</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

SVG 2 obsoletes glyph-orientation-vertical and defines that &apos;auto&apos;
must alias to text-orientation: mixed [1], which uses UTR#50 [2] to
determine whether a character is rendered upright or sideways in
vertical text [3].

Our implementation used East Asian Width (UCHAR_EAST_ASIAN_WIDTH) to
determine orientation, which incorrectly treated all EAW=Ambiguous
characters as upright. This caused characters like U+00B0 DEGREE SIGN,
U+2014 EM DASH, and U+2026 HORIZONTAL ELLIPSIS to render upright when
they should be sideways per UTR#50.

Replace the East Asian Width switch with UCHAR_VERTICAL_ORIENTATION
from ICU, mapping U_VO_UPRIGHT and U_VO_TRANSFORMED_UPRIGHT to 0
degrees, and U_VO_ROTATED and U_VO_TRANSFORMED_ROTATED to 90 degrees.

Inspired by a similar fix in Blink:
<a href="https://chromium.googlesource.com/chromium/src.git/+/2754c16948f97fcf655d5f23613468fcd63ccb76">https://chromium.googlesource.com/chromium/src.git/+/2754c16948f97fcf655d5f23613468fcd63ccb76</a>

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/text.html#GlyphOrientationVerticalProperty">https://w3c.github.io/svgwg/svg2-draft/text.html#GlyphOrientationVerticalProperty</a>
[2] <a href="http://www.unicode.org/reports/tr50/">http://www.unicode.org/reports/tr50/</a>
[3] <a href="https://drafts.csswg.org/css-writing-modes-3/#glyph-orientation">https://drafts.csswg.org/css-writing-modes-3/#glyph-orientation</a>

* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
(WebCore::SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle const):

&gt; This test is not WPT since other browsers don&apos;t support (glyph-vertical-orientation):
* LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50.html
* LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50-expected.txt

Canonical link: <a href="https://commits.webkit.org/312008@main">https://commits.webkit.org/312008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ff5469544402de16dc11595dc532c47e760d752

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112690 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7429449e-68d6-43c7-965d-f735d43e664d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122857 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86212 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9094a874-30dc-4ffe-8f0b-9cdd700fb8dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103526 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc05b025-614c-496b-b10c-6abe080d7f1b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24167 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15207 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133854 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169926 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15670 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21879 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131042 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131156 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35510 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142047 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89573 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25846 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18855 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31178 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97192 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30698 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30852 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->