### PR TITLE
`AppKitGesturesTests.clickingChangesSelection` API test can sometimes fail

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
@@ -53,29 +53,3 @@ extension AsyncSequence {
         }
     }
 }
-
-/// Repeatedly invokes a condition until it evaluates to true or until a timeout has been reached.
-///
-/// - Parameters:
-///   - timeout: The timeout to wait until before exiting this function and throwing an Error.
-///   - interval: The duration to wait between consecutive evaluations of the condition
-///   - function: The function of the source location where this is called.
-///   - line: The line number of the source location where this is called.
-///   - condition: The predicate condition to evaluate.
-/// - Throws: An Error if the condition throws an Error, or if the timeout duration is reached.
-public nonisolated(nonsending) func waitUntil(
-    timeout: Duration = .seconds(10),
-    interval: Duration = .milliseconds(100),
-    function: StaticString = #function,
-    line: Int = #line,
-    condition: () async throws -> Bool,
-) async throws {
-    let deadline = ContinuousClock.now + timeout
-    while ContinuousClock.now < deadline {
-        if try await condition() {
-            return
-        }
-        try await Task.sleep(for: interval)
-    }
-    throw CancellationError()
-}

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -72,7 +72,7 @@ struct AppKitGesturesTests {
             return range.getBoundingClientRect().toJSON();
             """
 
-        let crazyBoundsDictionary = try await #require(page.callJavaScript(getSelectionBounds) as? [String: Int])
+        let crazyBoundsDictionary = try await #require(page.callJavaScript(getSelectionBounds) as? [String: Double])
         let crazyBoundsInViewportCoordinates = CGRect(
             x: crazyBoundsDictionary["x", default: 0],
             y: crazyBoundsDictionary["y", default: 0],
@@ -103,14 +103,23 @@ struct AppKitGesturesTests {
 
         try await page.callJavaScript(moveSelectionToStart)
 
+        let waitForSelectionChange = """
+            return await new Promise(resolve => {
+                document.addEventListener("selectionchange", () => {
+                    const offset = window.getSelection().focusOffset;
+                    resolve(offset);
+                });
+            });
+            """
+
+        async let newSelection = page.callJavaScript(waitForSelectionChange) as? Int
+
+        // Ensure the JS `selectionchange` event listener is installed before performing the click.
+        await Task.yield()
+
         page.click(at: middleOfCrazy)
 
-        try await waitUntil {
-            let selection = try await page.callJavaScript("return window.getSelection().focusOffset") as? Int
-            return selection != 0
-        }
-
-        let selection = try await page.callJavaScript("return window.getSelection().focusOffset") as? Int
+        let selection = try await newSelection
         let expected = "Here's to the cra".count
         #expect(selection == expected)
     }


### PR DESCRIPTION
#### a7ce61829fa2dce0a61a117991be95361d1638d4
<pre>
`AppKitGesturesTests.clickingChangesSelection` API test can sometimes fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=312666">https://bugs.webkit.org/show_bug.cgi?id=312666</a>
<a href="https://rdar.apple.com/175064939">rdar://175064939</a>

Reviewed by Aditya Keerthi.

The JS `getBoundingClientRect` function can return non-integer values, so fix the cast to use `Double` instead of `Int`.

Drive-by fix: Use a JS event listener instead of a polling function to listen to selection change.

* Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.clickingChangesSelection):

Canonical link: <a href="https://commits.webkit.org/311596@main">https://commits.webkit.org/311596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6eec981950bbf39f39c37961deb6a52f2270b833

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111293 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121751 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85485 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21b9a2c6-30fb-43db-9328-5822cc98fad7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102419 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23046 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21294 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13806 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132726 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168519 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129884 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129992 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35261 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87893 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24808 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17594 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29783 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29305 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29535 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29432 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->