### PR TITLE
[GLIB] [Debug] ASSERT error in accessibility/aria-flowto.html

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1040,7 +1040,7 @@ accessibility/visible-character-range-height-changes.html [ Skip ]
 accessibility/visible-character-range-scrolling.html [ Skip ]
 accessibility/visible-character-range-vertical-rl.html [ Skip ]
 
-[ Release ] accessibility/display-contents/tree-and-treeitems.html [ Failure ]
+accessibility/display-contents/tree-and-treeitems.html [ Failure ]
 
 webkit.org/b/212805 accessibility/svg-text.html [ Failure ]
 
@@ -5144,20 +5144,6 @@ webkit.org/b/298433 [ Release ] imported/w3c/web-platform-tests/selection/caret/
 fast/text/glyph-display-lists [ Skip ]
 fast/repaint/table-in-inline-repaint.html [ Failure ]
 fast/repaint/block-in-inline-fast-path-repaint.html [ Failure ]
-
-# Tests crashing in Debug
-webkit.org/b/299092 [ Debug ] accessibility/aria-flowto.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/aria-selected.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/display-contents/element-roles.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/display-contents/list.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/display-contents/table-dynamic.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/display-contents/tree-and-treeitems.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/node-only-object-aria-owns-hang.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/node-only-object-element-rect.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/url-test.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/non-data-table-cell-title-ui-element.html [ Crash ]
-webkit.org/b/299092 [ Debug ] imported/w3c/web-platform-tests/css/css-display/parsing/display-computed.html [ Crash Pass ]
-webkit.org/b/299092 [ Debug ] imported/w3c/web-platform-tests/css/css-display/focus/display-contents-focus.html [ Crash Pass ]
 
 # Depends on 'UIScriptController::singleTapAtPointWithModifiers', which is not implemented yet for GLIB.
 webkit.org/b/278719 fast/events/touch/touch-fractional-coordinates.html [ Skip ]

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -744,6 +744,9 @@ void AccessibilityObject::insertChild(AccessibilityObject& child, unsigned index
     auto insert = [this] (Ref<AXCoreObject>&& object, unsigned index) {
         std::ignore = setChildIndexInParent(object.get(), index);
         m_children.insert(index, WTF::move(object));
+        // Update child-index for children after the newly inserted object.
+        for (unsigned i = index + 1; i < m_children.size(); i++)
+            std::ignore = setChildIndexInParent(m_children[i].get(), i);
     };
 
     auto thisAncestorFlags = computeAncestorFlags();


### PR DESCRIPTION
#### 86601950f4ebbae91bc7497b73e6d64e9b6e2e2f
<pre>
[GLIB] [Debug] ASSERT error in accessibility/aria-flowto.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=299092">https://bugs.webkit.org/show_bug.cgi?id=299092</a>

Reviewed by Tyler Wilcock.

The lambda used to insert children doesn&apos;t update the child-index
for elements after the inserted one, which leaves their index
corrupt. This doesn&apos;t seem to be an issue in non-atspi accessibility,
because this method seems to be called to append children. In
the atspi case, there can be items prepended, which can corrupt
the indexes and cause this assertion to fire.

Covered by existing tests, that can be unskipped now that they
don&apos;t crash.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::insertChild):

Canonical link: <a href="https://commits.webkit.org/311528@main">https://commits.webkit.org/311528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17ea6fe00d666f233bf7ff8eb5e244fa31a78bf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166064 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159112 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121776 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102444 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23070 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13836 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132750 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168549 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12708 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129909 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130017 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35220 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140814 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87936 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24834 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17619 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29813 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93827 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29565 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->