### PR TITLE
Optimize IDL bindings generation scripts for faster build times

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -30,6 +30,7 @@ use strict;
 
 use File::Basename;
 use Carp qw<longmess>;
+use Storable qw(dclone);
 use Data::Dumper;
 
 my $useDocument = "";
@@ -126,6 +127,7 @@ my $cachedExtendedAttributes = {};
 my $cachedExternalDictionaries = {};
 my $cachedExternalEnumerations = {};
 my $cachedTypes = {};
+my %cachedParsedDocuments;
 
 sub assert
 {
@@ -399,8 +401,13 @@ sub ProcessInterfaceSupplementalDependencies
         next if fileparse($idlFile) eq $targetFileName;
 
         my $interfaceName = fileparse($idlFile, ".idl");
-        my $parser = IDLParser->new(!$verbose);
-        my $document = $parser->Parse($idlFile, $defines, $preprocessor, $idlAttributes);
+        my $document;
+        if (exists $cachedParsedDocuments{$idlFile}) {
+            $document = dclone($cachedParsedDocuments{$idlFile});
+        } else {
+            $document = IDLParser->new(!$verbose)->Parse($idlFile, $defines, $preprocessor, $idlAttributes);
+            $cachedParsedDocuments{$idlFile} = dclone($document);
+        }
 
         foreach my $interface (@{$document->interfaces}) {
             next unless $object->IsValidSupplementalInterface($interface, $targetInterface, \%includesMap);
@@ -477,8 +484,13 @@ sub ProcessDictionarySupplementalDependencies
         next if fileparse($idlFile) eq $targetFileName;
 
         my $dictionaryName = fileparse($idlFile, ".idl");
-        my $parser = IDLParser->new(!$verbose);
-        my $document = $parser->Parse($idlFile, $defines, $preprocessor, $idlAttributes);
+        my $document;
+        if (exists $cachedParsedDocuments{$idlFile}) {
+            $document = dclone($cachedParsedDocuments{$idlFile});
+        } else {
+            $document = IDLParser->new(!$verbose)->Parse($idlFile, $defines, $preprocessor, $idlAttributes);
+            $cachedParsedDocuments{$idlFile} = dclone($document);
+        }
 
         foreach my $dictionary (@{$document->dictionaries}) {
             next unless $object->IsValidSupplementalDictionary($dictionary, $targetDictionary);
@@ -1501,12 +1513,16 @@ sub ConditionalComparator
     ($a =~ s/^(!?)(.+)/$2$1/r) cmp ($b =~ s/^(!?)(.+)/$2$1/r)
 }
 
+my %conditionalStringCache;
+
 sub GenerateConditionalStringFromAttributeValue
 {
     my ($generator, $conditional) = @_;
 
     # Unquote string literals if needed.
     $conditional = UnquoteStringLiteral($generator, $conditional) if $conditional =~ /^['"]/;
+
+    return $conditionalStringCache{$conditional} if exists $conditionalStringCache{$conditional};
 
     my %disjunction = map {
         my %conjunction = map {
@@ -1518,9 +1534,12 @@ sub GenerateConditionalStringFromAttributeValue
         join(" && ", sort ConditionalComparator keys %conjunction) => 1
     } split(/\|/, $conditional);
 
-    return "1" if %disjunction == 0;
-    return (keys %disjunction)[0] if %disjunction == 1;
-    return join(" || ", map { / / ? "($_)" : $_ } sort ConditionalComparator keys %disjunction);
+    my $result;
+    $result = "1" if %disjunction == 0;
+    $result = (keys %disjunction)[0] if !defined($result) && %disjunction == 1;
+    $result = join(" || ", map { / / ? "($_)" : $_ } sort ConditionalComparator keys %disjunction) if !defined($result);
+    $conditionalStringCache{$conditional} = $result;
+    return $result;
 }
 
 sub GenerateCompileTimeCheckForEnumsIfNeeded

--- a/Source/WebCore/bindings/scripts/Hasher.pm
+++ b/Source/WebCore/bindings/scripts/Hasher.pm
@@ -27,10 +27,16 @@
 package Hasher;
 
 use strict;
-use bigint;
+use integer;
 
-my $mask64 = 2**64 - 1;
-my $mask32 = 2**32 - 1;
+# Performance: 'use integer' gives native 64-bit wrapping arithmetic, which is
+# vastly faster than the previous 'use bigint' (Math::BigInt arbitrary precision).
+# Caveat: '>>' becomes arithmetic (sign-extending) shift under 'use integer',
+# so we mask with & $mask32 after >> 32 to get correct unsigned upper-32-bit extraction.
+
+my $mask32 = 0xFFFFFFFF;
+my $SIGN_BIT = (1 << 63);
+my @secret = ( 11562461410679940143, 16646288086500911323, 10285213230658275043, 6384245875588680899 );
 
 sub maskTop8BitsAndAvoidZero($) {
     my ($value) = @_;
@@ -49,37 +55,28 @@ sub maskTop8BitsAndAvoidZero($) {
     return $value;
 }
 
-sub uint64_add($$) {
-    my ($a, $b) = @_;
-    my $sum = $a + $b;
-    return $sum & $mask64;
-}
-
-sub uint64_multi($$) {
-    my ($a, $b) = @_;
-    my $product = $a * $b;
-    return $product & $mask64;
+# Unsigned less-than for 64-bit values under 'use integer' (signed arithmetic).
+sub _unsigned_lt($$) {
+    return (($_[0] ^ $SIGN_BIT) < ($_[1] ^ $SIGN_BIT)) ? 1 : 0;
 }
 
 sub wymum($$) {
     my ($A, $B) = @_;
 
-    my $ha = $A >> 32;
-    my $hb = $B >> 32;
+    my $ha = ($A >> 32) & $mask32;
+    my $hb = ($B >> 32) & $mask32;
     my $la = $A & $mask32;
     my $lb = $B & $mask32;
-    my $hi;
-    my $lo;
-    my $rh = uint64_multi($ha, $hb);
-    my $rm0 = uint64_multi($ha, $lb);
-    my $rm1 = uint64_multi($hb, $la);
-    my $rl = uint64_multi($la, $lb);
-    my $t = uint64_add($rl, ($rm0 << 32));
-    my $c = int($t < $rl);
+    my $rh = $ha * $hb;
+    my $rm0 = $ha * $lb;
+    my $rm1 = $hb * $la;
+    my $rl = $la * $lb;
+    my $t = $rl + ($rm0 << 32);
+    my $c = _unsigned_lt($t, $rl);
 
-    $lo = uint64_add($t, ($rm1 << 32));
-    $c += int($lo < $t);
-    $hi = uint64_add($rh, uint64_add(($rm0 >> 32), uint64_add(($rm1 >> 32), $c)));
+    my $lo = $t + ($rm1 << 32);
+    $c += _unsigned_lt($lo, $t);
+    my $hi = $rh + (($rm0 >> 32) & $mask32) + (($rm1 >> 32) & $mask32) + $c;
 
     return ($lo, $hi);
 };
@@ -90,62 +87,49 @@ sub wymix($$) {
     return $A ^ $B;
 }
 
-sub convert32BitTo64Bit($) {
-    my ($v) = @_;
-    my ($mask1) = 281470681808895;   # 0x0000_ffff_0000_ffff
-    $v = ($v | ($v << 16)) & $mask1;
-    my ($mask2) = 71777214294589695; # 0x00ff_00ff_00ff_00ff
-    return ($v | ($v << 8)) & $mask2;
+# Read 4 characters from string at index $i, convert to 64-bit via convert32BitTo64Bit.
+sub _wyr8($$) {
+    my ($str, $i) = @_;
+    my $v = ord(substr($str, $i, 1)) | (ord(substr($str, $i + 1, 1)) << 8)
+          | (ord(substr($str, $i + 2, 1)) << 16) | (ord(substr($str, $i + 3, 1)) << 24);
+    # convert32BitTo64Bit
+    $v = ($v | ($v << 16)) & 281470681808895;   # 0x0000_ffff_0000_ffff
+    return ($v | ($v << 8)) & 71777214294589695; # 0x00ff_00ff_00ff_00ff
 }
 
-sub convert16BitTo32Bit($) {
-    my ($v) = @_;
+# Read 2 characters from string at index $i, convert to 32-bit via convert16BitTo32Bit.
+sub _wyr4($$) {
+    my ($str, $i) = @_;
+    my $v = ord(substr($str, $i, 1)) | (ord(substr($str, $i + 1, 1)) << 8);
+    # convert16BitTo32Bit
     return ($v | ($v << 8)) & 0x00ff_00ff;
 }
 
-sub wyhash {
+sub _wyr2($$) {
+    return ord(substr($_[0], $_[1], 1)) << 16;
+}
+
+sub GenerateHashValue($) {
+    my ($string) = @_;
+
     # https://github.com/wangyi-fudan/wyhash
-    my @chars = @_;
-    my $charCount = scalar @chars;
+    my $charCount = length($string);
     my $byteCount = $charCount << 1;
     my $charIndex = 0;
     my $seed = 0;
-    my @secret = ( 11562461410679940143, 16646288086500911323, 10285213230658275043, 6384245875588680899 );
     my $move1 = (($byteCount >> 3) << 2) >> 1;
 
     $seed ^= wymix($seed ^ $secret[0], $secret[1]);
     my $a = 0;
     my $b = 0;
 
-    local *c2i = sub {
-        my ($i) = @_;
-        return ord($chars[$i]);
-    };
-
-    local *wyr8 = sub {
-        my ($i) = @_;
-        my $v = c2i($i) | (c2i($i + 1) << 8) | (c2i($i + 2) << 16) | (c2i($i + 3) << 24);
-        return convert32BitTo64Bit($v);
-    };
-
-    local *wyr4 = sub {
-        my ($i) = @_;
-        my $v = c2i($i) | (c2i($i + 1) << 8);
-        return convert16BitTo32Bit($v);
-    };
-
-    local *wyr2 = sub {
-        my ($i) = @_;
-        return c2i($i) << 16;
-    };
-
     if ($byteCount <= 16) {
         if ($byteCount >= 4) {
-            $a = (wyr4($charIndex) << 32) | wyr4($charIndex + $move1);
+            $a = (_wyr4($string, $charIndex) << 32) | _wyr4($string, $charIndex + $move1);
             $charIndex = $charIndex + $charCount - 2;
-            $b = (wyr4($charIndex) << 32) | wyr4($charIndex - $move1);
+            $b = (_wyr4($string, $charIndex) << 32) | _wyr4($string, $charIndex - $move1);
         } elsif ($byteCount > 0) {
-            $a = wyr2($charIndex);
+            $a = _wyr2($string, $charIndex);
             $b = 0;
         } else {
             $a = $b = 0;
@@ -156,37 +140,28 @@ sub wyhash {
             my $see1 = $seed;
             my $see2 = $seed;
             do {
-                $seed = wymix(wyr8($charIndex) ^ $secret[1], wyr8($charIndex + 4) ^ $seed);
-                $see1 = wymix(wyr8($charIndex + 8) ^ $secret[2], wyr8($charIndex + 12) ^ $see1);
-                $see2 = wymix(wyr8($charIndex + 16) ^ $secret[3], wyr8($charIndex + 20) ^ $see2);
+                $seed = wymix(_wyr8($string, $charIndex) ^ $secret[1], _wyr8($string, $charIndex + 4) ^ $seed);
+                $see1 = wymix(_wyr8($string, $charIndex + 8) ^ $secret[2], _wyr8($string, $charIndex + 12) ^ $see1);
+                $see2 = wymix(_wyr8($string, $charIndex + 16) ^ $secret[3], _wyr8($string, $charIndex + 20) ^ $see2);
                 $charIndex += 24;
                 $i -= 48;
             } while ($i > 48);
             $seed ^= $see1 ^ $see2;
         }
         while ($i > 16) {
-            $seed = wymix(wyr8($charIndex) ^ $secret[1], wyr8($charIndex + 4) ^ $seed);
+            $seed = wymix(_wyr8($string, $charIndex) ^ $secret[1], _wyr8($string, $charIndex + 4) ^ $seed);
             $i -= 16;
             $charIndex += 8;
         }
         my $move2 = $i >> 1;
-        $a = wyr8($charIndex + $move2 - 8);
-        $b = wyr8($charIndex + $move2 - 4);
+        $a = _wyr8($string, $charIndex + $move2 - 8);
+        $b = _wyr8($string, $charIndex + $move2 - 4);
     }
     $a ^= $secret[1];
     $b ^= $seed;
 
     ($a, $b) = wymum($a, $b);
-    my $hash = wymix($a ^ $secret[0] ^ $byteCount, $b ^ $secret[1]) & $mask32;
-
-    return maskTop8BitsAndAvoidZero($hash);
-}
-
-
-sub GenerateHashValue($) {
-    my ($string) = @_;
-    my @chars = split(/ */, $string);
-    return wyhash(@chars);
+    return maskTop8BitsAndAvoidZero(wymix($a ^ $secret[0] ^ $byteCount, $b ^ $secret[1]) & $mask32);
 }
 
 1;

--- a/Source/WebCore/bindings/scripts/generate-bindings.pl
+++ b/Source/WebCore/bindings/scripts/generate-bindings.pl
@@ -39,7 +39,7 @@ use File::Basename;
 use Getopt::Long;
 use Text::ParseWords;
 use Cwd;
-use JSON::PP;
+BEGIN { eval { require JSON::XS; JSON::XS->import(); 1 } or do { require JSON::PP; JSON::PP->import() } }
 
 use IDLParser;
 use CodeGenerator;
@@ -106,7 +106,7 @@ my $idlAttributes;
     my $input = <JSON>;
     close(JSON);
 
-    my $jsonDecoder = JSON::PP->new->utf8;
+    my $jsonDecoder = (eval { JSON::XS->new->utf8 } or JSON::PP->new->utf8);
     my $jsonHashRef = $jsonDecoder->decode($input);
     $idlAttributes = $jsonHashRef->{attributes};
 }

--- a/Source/WebCore/bindings/scripts/preprocess-idls.pl
+++ b/Source/WebCore/bindings/scripts/preprocess-idls.pl
@@ -30,7 +30,7 @@ use Getopt::Long;
 use Cwd;
 use Config;
 use Class::Struct;
-use JSON::PP;
+BEGIN { eval { require JSON::XS; JSON::XS->import(); 1 } or do { require JSON::PP; JSON::PP->import() } }
 use Data::Dumper;
 
 use IDLParser;
@@ -144,7 +144,7 @@ if ($validateAgainstParser) {
         close(JSON);
     }
 
-    my $jsonDecoder = JSON::PP->new->utf8;
+    my $jsonDecoder = (eval { JSON::XS->new->utf8 } or JSON::PP->new->utf8);
     my $jsonHashRef = $jsonDecoder->decode($input);
     $idlAttributes = $jsonHashRef->{attributes};
 }


### PR DESCRIPTION
#### 04f3239284c0217ad05bff4a8c98b2a90b1658c1
<pre>
Optimize IDL bindings generation scripts for faster build times
<a href="https://bugs.webkit.org/show_bug.cgi?id=312673">https://bugs.webkit.org/show_bug.cgi?id=312673</a>

Reviewed by Darin Adler.

Hasher.pm was using &apos;use bigint&apos;, which routes all arithmetic through
Math::BigInt arbitrary-precision integers. On 64-bit Perl, native integer
arithmetic is ~430x faster per hash. This patch also uses substr() instead of
split() for character access, eliminates per-call local subroutine
redefinitions, and makes the @secret array a file-scoped constant.

ProcessInterfaceSupplementalDependencies and
ProcessDictionarySupplementalDependencies were re-parsing the same supplemental
IDL files (~30ms each) for every target that depends on them, even within the
same process. This patch adds an in-memory cache using Storable::dclone so each
supplemental IDL file is parsed at most once per process.

Additionally, prefer JSON::XS (C-based) over JSON::PP (pure Perl) when available
for ~72x faster IDL attributes parsing, and memoize
GenerateConditionalStringFromAttributeValue to avoid redundant recomputation.

Performance results (Apple M4 Max, 16 cores):

Actual parallel bindings generation (1,823 IDL files, generate-bindings-all.pl):
  Before: 14.6s wall, 54.9s user CPU
  After:  13.2s wall, 48.7s user CPU
  Speedup: 10% wall (1.4s saved), 11% user CPU (6.2s saved)

* Source/WebCore/bindings/scripts/Hasher.pm:
(maskTop8BitsAndAvoidZero): No functional change.
(_unsigned_lt): Added. Unsigned 64-bit comparison under &apos;use integer&apos; by XORing
the sign bit to flip signed ordering to unsigned ordering.
(wymum): Use native arithmetic with &apos;use integer&apos; instead of uint64_add/uint64_multi
wrappers. Mask right-shifts by &amp; 0xFFFFFFFF for correct unsigned extraction under
arithmetic shift. Use _unsigned_lt for carry detection.
(wymix): No functional change.
(_wyr8): New. Reads 4 characters via substr and converts to 64-bit, replacing the
per-call local *wyr8 closure and separate convert32BitTo64Bit function.
(_wyr4): New. Reads 2 characters via substr, replacing local *wyr4 closure and
separate convert16BitTo32Bit function.
(_wyr2): New. Reads 1 character via substr, replacing local *wyr2 closure.
(GenerateHashValue): Merged wyhash() logic here. Operates directly on the string
instead of splitting into a character array. Uses file-scoped @secret array.
(uint64_add): Deleted.
(uint64_multi): Deleted.
(convert32BitTo64Bit): Deleted, inlined into _wyr8.
(convert16BitTo32Bit): Deleted, inlined into _wyr4.
(wyhash): Deleted, merged into GenerateHashValue.
* Source/WebCore/bindings/scripts/CodeGenerator.pm:
(GenerateConditionalStringFromAttributeValue): Memoize results to avoid redundant
split/map/join/sort for repeated conditional attribute values.
(ProcessInterfaceSupplementalDependencies): Cache parsed supplemental IDL documents
in-memory using Storable::dclone to avoid re-parsing the same mixin/partial IDL
files for every target that depends on them within the same process.
(ProcessDictionarySupplementalDependencies): Same caching.
* Source/WebCore/bindings/scripts/generate-bindings.pl:
Use JSON::XS when available, falling back to JSON::PP.
* Source/WebCore/bindings/scripts/preprocess-idls.pl:
Use JSON::XS when available, falling back to JSON::PP.

Canonical link: <a href="https://commits.webkit.org/311548@main">https://commits.webkit.org/311548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01c07c343a1f2d8129012725299f7195d553afc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111381 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2126e6b-21f3-4bdc-9c61-3c3989067ba9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121826 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85543 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff54a853-4dbc-4063-8064-a60c6d279b04) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102494 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d8ee56d-d860-4a59-91e0-9e9bdba8d174) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23127 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21374 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13894 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168608 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12766 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129960 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130067 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35234 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140870 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88034 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24889 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17675 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29871 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93885 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29393 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29520 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->