### PR TITLE
[CMake] ccache hashes not portable across worktrees on Apple platforms

### DIFF
--- a/Source/cmake/WebKitCCache.cmake
+++ b/Source/cmake/WebKitCCache.cmake
@@ -1,24 +1,40 @@
 # Enable ccache by default, if installed. To disable it you can:
 # if using script build-webkit: pass --no-use-ccache
 # if using cmake: set environment variable WK_USE_CCACHE=NO
-if (NOT "$ENV{WK_USE_CCACHE}" STREQUAL "NO")
+if (NOT "$ENV{WK_USE_CCACHE}" STREQUAL "NO" AND NOT CMAKE_CXX_COMPILER_LAUNCHER)
     find_program(CCACHE_FOUND ccache)
     if (CCACHE_FOUND)
-        if (NOT DEFINED ENV{CCACHE_SLOPPINESS})
-            if (APPLE)
-                # Apple SDK headers change mtime/ctime across Xcode updates without content
-                # changes; include file_mtime/ctime sloppiness avoids whole-cache invalidation.
-                set(ENV{CCACHE_SLOPPINESS} "pch_defines,time_macros,include_file_mtime,include_file_ctime")
-            else ()
-                set(ENV{CCACHE_SLOPPINESS} time_macros)
-            endif ()
-        endif ()
         # Check if CXX_COMPILER is already a ccache symlink (some distros/brew setups do this).
         execute_process(COMMAND readlink -f ${CMAKE_CXX_COMPILER} RESULT_VARIABLE READLINK_RETCODE OUTPUT_VARIABLE REAL_CXX_PATH OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
         execute_process(COMMAND which ${CCACHE_FOUND} RESULT_VARIABLE WHICH_RETCODE OUTPUT_VARIABLE REAL_CCACHE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
         if (${WHICH_RETCODE} EQUAL 0 AND ${READLINK_RETCODE} EQUAL 0 AND "${REAL_CXX_PATH}" STREQUAL "${REAL_CCACHE_PATH}")
             message(STATUS "Enabling ccache: Compiler path already pointing to ccache. Not setting ccache prefix.")
+        elseif (APPLE)
+            # CCACHE_SLOPPINESS / CCACHE_BASEDIR set via set(ENV{...}) or the
+            # preset's environment block only apply to the cmake process, not to
+            # the ninja that later invokes ccache. Generate a launcher that
+            # exports them at compile time so cache hashes are portable across
+            # worktrees of the same checkout (-fdebug-prefix-map handles the
+            # debug-info side; CCACHE_BASEDIR handles the command-line side).
+            set(_ccache_launcher "${CMAKE_BINARY_DIR}/ccache-launcher")
+            file(WRITE "${_ccache_launcher}"
+                "#!/bin/sh\n"
+                "export CCACHE_BASEDIR='${CMAKE_SOURCE_DIR}'\n"
+                "export CCACHE_NOHASHDIR=true\n"
+                "export CCACHE_SLOPPINESS='pch_defines,time_macros,include_file_mtime,include_file_ctime'\n"
+                "exec '${CCACHE_FOUND}' \"$@\"\n")
+            file(CHMOD "${_ccache_launcher}" PERMISSIONS
+                OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+            message(STATUS "Enabling ccache: Setting ccache prefix via ${_ccache_launcher} (CCACHE_BASEDIR=${CMAKE_SOURCE_DIR}).")
+            set(CMAKE_C_COMPILER_LAUNCHER "${_ccache_launcher}")
+            set(CMAKE_CXX_COMPILER_LAUNCHER "${_ccache_launcher}")
+            set(CMAKE_ASM_COMPILER_LAUNCHER "${_ccache_launcher}")
+            set(CMAKE_OBJC_COMPILER_LAUNCHER "${_ccache_launcher}")
+            set(CMAKE_OBJCXX_COMPILER_LAUNCHER "${_ccache_launcher}")
         else ()
+            if (NOT DEFINED ENV{CCACHE_SLOPPINESS})
+                set(ENV{CCACHE_SLOPPINESS} time_macros)
+            endif ()
             message(STATUS "Enabling ccache: Setting ccache prefix for compiler.")
             set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_FOUND})
             set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_FOUND})


### PR DESCRIPTION
#### b36a53b5d2b8703784679ab1ec1caefa4a1a7178
<pre>
[CMake] ccache hashes not portable across worktrees on Apple platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=312680">https://bugs.webkit.org/show_bug.cgi?id=312680</a>

Reviewed by Geoffrey Garen, Pascoe, and BJ Burg.

WebKitCCache.cmake sets CCACHE_SLOPPINESS via set(ENV{...}), and the mac
presets set CCACHE_BASEDIR via the preset environment block. Both apply
only to the cmake process; when ninja later spawns ccache neither is set,
so cache entries are stored with absolute paths and a second worktree of
the same revision gets ~0% hits. WebKitCCache.cmake also unconditionally
overwrites CMAKE_CXX_COMPILER_LAUNCHER, discarding any -D the user passed.

On APPLE, generate ${CMAKE_BINARY_DIR}/ccache-launcher (a sh wrapper that
exports CCACHE_BASEDIR=${CMAKE_SOURCE_DIR}, CCACHE_NOHASHDIR and the
sloppiness flags before exec&apos;ing ccache) and use it as
CMAKE_{C,CXX,ASM,OBJC,OBJCXX}_COMPILER_LAUNCHER. Skip the block entirely
if CMAKE_CXX_COMPILER_LAUNCHER is already set. Combined with the existing
-fdebug-prefix-map in OptionsMac.cmake this gives 100% hits (99.8%
direct) in a fresh worktree against a cache warmed elsewhere.

* Source/cmake/WebKitCCache.cmake:

Canonical link: <a href="https://commits.webkit.org/311955@main">https://commits.webkit.org/311955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/687d5ae943b7acdc144f0e6c13cb8888c0acd9df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111322 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9c0ad30-7f66-4225-88e0-f7600366aeaf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121775 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85669 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ff5c846-3b87-4383-b796-2c45f3da5b08) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102443 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c74b8a8c-a35a-453c-876d-82adc0ae3732) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23072 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21319 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13835 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149290 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132752 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168548 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18075 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129908 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130016 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35476 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140829 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87935 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24835 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17634 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189258 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29812 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48551 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29334 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29564 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29461 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->