### PR TITLE
Allow U+0000 in VTTCue

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -609,11 +609,14 @@ webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual
 webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/text/canvas.2d.offscreen.worker.direction.inherit.html [ ImageOnlyFailure ]
 
 # These are the WebVTT rendering WPT we are already passing.
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_remove_cue_while_paused.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_cascade_priority.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_cascade_priority_layer.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_imports_blocked.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_invalid_format.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_media_queries.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_media_queries_resized.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_selectors.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_urls.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_404_omit_subtitles.html [ Pass ]
@@ -626,6 +629,8 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/navigate_cue_position.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50.html [ Pass ]
 
 # These WebVTT rendering WPT are flaky.

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML-expected.txt
@@ -9,6 +9,7 @@ PASS VTTCue.getCueAsHTML(), <ruby>
 PASS VTTCue.getCueAsHTML(), <rt>
 PASS VTTCue.getCueAsHTML(), <v>
 PASS VTTCue.getCueAsHTML(), <v a b>
+PASS VTTCue.getCueAsHTML(), <v Foo&amp;Bar>
 PASS VTTCue.getCueAsHTML(), <1:00:00.500>
-FAIL VTTCue.getCueAsHTML(), x\0 assert_equals: data expected "x\0" but got "x\ufffd"
+PASS VTTCue.getCueAsHTML(), x\0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML.html
@@ -9,10 +9,10 @@ test(function(){
     var video = document.createElement('video');
     var t1 = video.addTextTrack('subtitles');
     document.body.appendChild(video);
-    var c1 = new VTTCue(0, 1, '<c></c><c.a.b></c><i></i><b></b><u></u><ruby><rt></rt></ruby><v></v><v a b></v><1:00:00.500>x\0');
+    var c1 = new VTTCue(0, 1, '<c></c><c.a.b></c><i></i><b></b><u></u><ruby><rt></rt></ruby><v></v><v a b></v><v Foo&amp;Bar>text</v><1:00:00.500>x\0');
     t1.addCue(c1);
     window.frag = c1.getCueAsHTML();
-    assert_equals(frag.childNodes.length, 10, 'childNodes.length');
+    assert_equals(frag.childNodes.length, 11, 'childNodes.length');
     assert_true(frag instanceof DocumentFragment, 'getCueAsHTML() should return DocumentFragment');
 }, document.title+', creating the cue');
 test(function(){
@@ -82,12 +82,21 @@ test(function(){
     assert_true(frag.childNodes[7] instanceof HTMLElement, 'instanceof');
 }, document.title+', <v a b>');
 test(function(){
-    assert_equals(frag.childNodes[8].target, 'timestamp', 'target');
-    assert_equals(frag.childNodes[8].data, '01:00:00.500', 'data');
-    assert_true(frag.childNodes[8] instanceof ProcessingInstruction, 'instanceof');
+    assert_equals(frag.childNodes[8].namespaceURI, 'http://www.w3.org/1999/xhtml', 'namespaceURI');
+    assert_equals(frag.childNodes[8].localName, 'span', 'localName');
+    assert_equals(frag.childNodes[8].attributes.length, 1, 'attributes');
+    assert_equals(frag.childNodes[8].getAttributeNS('', 'title'), 'Foo&Bar', 'title attribute');
+    assert_true(frag.childNodes[8].hasChildNodes(), 'hasChildNodes()');
+    assert_equals(frag.childNodes[8].firstChild.data, 'text', 'child text');
+    assert_true(frag.childNodes[8] instanceof HTMLElement, 'instanceof');
+}, document.title+', <v Foo&amp;Bar>');
+test(function(){
+    assert_equals(frag.childNodes[9].target, 'timestamp', 'target');
+    assert_equals(frag.childNodes[9].data, '01:00:00.500', 'data');
+    assert_true(frag.childNodes[9] instanceof ProcessingInstruction, 'instanceof');
 }, document.title+', <1:00:00.500>');
 test(function(){
-    assert_equals(frag.childNodes[9].data, 'x\0', 'data');
-    assert_true(frag.childNodes[9] instanceof Text, 'instanceof');
+    assert_equals(frag.childNodes[10].data, 'x\0', 'data');
+    assert_true(frag.childNodes[10] instanceof Text, 'instanceof');
 }, document.title+', x\\0');
 </script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4721,6 +4721,7 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u0041_first.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir.html [ Skip ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/disable_controls_reposition.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text_while_paused.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text.html [ Pass ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8215,6 +8215,7 @@ webkit.org/b/296707 imported/w3c/web-platform-tests/screen-orientation/non-fully
 
 webkit.org/b/296709 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/navigate_cue_position.html [ Skip ]
 
 webkit.org/b/296816 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside-012.html [ Pass Failure ]
 

--- a/Source/WebCore/html/track/WebVTTTokenizer.cpp
+++ b/Source/WebCore/html/track/WebVTTTokenizer.cpp
@@ -34,27 +34,25 @@
 
 #if ENABLE(VIDEO)
 
-#include "CSSTokenizerInputStream.h"
 #include "HTMLEntityParser.h"
 #include "MarkupTokenizerInlines.h"
 #include <wtf/text/StringBuilder.h>
-#include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
 
 #define WEBVTT_ADVANCE_TO(stateName)                        \
     do {                                                    \
-        ASSERT(!m_input.isEmpty());                         \
-        m_preprocessor.advance(m_input);                    \
-        character = m_preprocessor.nextInputCharacter();    \
+        ASSERT(input.hasCharactersRemaining());             \
+        input.advance();                                    \
+        if (!input.atEnd())                                 \
+            character = *input;                             \
         goto stateName;                                     \
     } while (false)
 #define WEBVTT_SWITCH_TO(stateName)                         \
-    do { \
-        ASSERT(!m_input.isEmpty()); \
-        m_preprocessor.peek(m_input); \
-        character = m_preprocessor.nextInputCharacter(); \
-        goto stateName; \
+    do {                                                    \
+        if (!input.atEnd())                                 \
+            character = *input;                             \
+        goto stateName;                                     \
     } while (false)
 
 static void addNewClass(StringBuilder& classes, const StringBuilder& newClass)
@@ -64,32 +62,17 @@ static void addNewClass(StringBuilder& classes, const StringBuilder& newClass)
     classes.append(newClass);
 }
 
-inline bool emitToken(WebVTTToken& resultToken, const WebVTTToken& token)
+static bool emitToken(WebVTTToken& resultToken, const WebVTTToken& token)
 {
     resultToken = token;
     return true;
 }
 
-inline bool advanceAndEmitToken(SegmentedString& source, WebVTTToken& resultToken, const WebVTTToken& token)
-{
-    source.advance();
-    return emitToken(resultToken, token);
-}
-
-WebVTTTokenizer::WebVTTTokenizer(const String& input)
-    : m_input(input)
-    , m_preprocessor(*this)
-{
-    // Append an EOF marker and close the input "stream".
-    ASSERT(!m_input.isClosed());
-    m_input.append(span(kEndOfFileMarker));
-    m_input.close();
-}
-
-static void ProcessEntity(SegmentedString& source, StringBuilder& result, char16_t additionalAllowedCharacter = 0)
+template<typename CharacterType>
+static void processEntity(StringParsingBuffer<CharacterType>& source, StringBuilder& result, char16_t additionalAllowedCharacter = 0)
 {
     auto decoded = consumeHTMLEntity(source, additionalAllowedCharacter);
-    if (decoded.failed() || decoded.notEnoughCharacters())
+    if (decoded.failed())
         result.append('&');
     else {
         for (auto character : decoded.span())
@@ -97,16 +80,28 @@ static void ProcessEntity(SegmentedString& source, StringBuilder& result, char16
     }
 }
 
+WebVTTTokenizer::WebVTTTokenizer(const String& input)
+    : m_input(input)
+    , m_buffer(input.is8Bit()
+        ? decltype(m_buffer) { StringParsingBuffer { input.span8() } }
+        : decltype(m_buffer) { StringParsingBuffer { input.span16() } })
+{
+}
+
 bool WebVTTTokenizer::nextToken(WebVTTToken& token)
 {
-    if (m_input.isEmpty() || !m_preprocessor.peek(m_input))
+    return WTF::switchOn(m_buffer, [&](auto& buffer) {
+        return nextTokenImpl(buffer, token);
+    });
+}
+
+template<typename CharacterType>
+bool WebVTTTokenizer::nextTokenImpl(StringParsingBuffer<CharacterType>& input, WebVTTToken& token)
+{
+    if (input.atEnd())
         return false;
 
-    char16_t character = m_preprocessor.nextInputCharacter();
-    if (character == kEndOfFileMarker) {
-        m_preprocessor.advance(m_input);
-        return false;
-    }
+    char16_t character = *input;
 
     StringBuilder buffer;
     StringBuilder result;
@@ -114,6 +109,8 @@ bool WebVTTTokenizer::nextToken(WebVTTToken& token)
 
 // 4.8.10.13.4 WebVTT cue text tokenizer
 DataState:
+    if (input.atEnd())
+        return emitToken(token, WebVTTToken::StringToken(result.toString()));
     if (character == '&') {
         WEBVTT_ADVANCE_TO(HTMLCharacterReferenceInDataState);
     } else if (character == '<') {
@@ -124,14 +121,16 @@ DataState:
             // (On the next call to nextToken we will see '<' again, but take the other branch in this if instead.)
             return emitToken(token, WebVTTToken::StringToken(result.toString()));
         }
-    } else if (character == kEndOfFileMarker)
-        return advanceAndEmitToken(m_input, token, WebVTTToken::StringToken(result.toString()));
-    else {
+    } else {
         result.append(character);
         WEBVTT_ADVANCE_TO(DataState);
     }
 
 TagState:
+    if (input.atEnd()) {
+        ASSERT(result.isEmpty());
+        return emitToken(token, WebVTTToken::StartTag(result.toString()));
+    }
     if (isTokenizerWhitespace(character)) {
         ASSERT(result.isEmpty());
         WEBVTT_ADVANCE_TO(StartTagAnnotationState);
@@ -143,27 +142,36 @@ TagState:
     } else if (isASCIIDigit(character)) {
         result.append(character);
         WEBVTT_ADVANCE_TO(TimestampTagState);
-    } else if (character == '>' || character == kEndOfFileMarker) {
+    } else if (character == '>') {
         ASSERT(result.isEmpty());
-        return advanceAndEmitToken(m_input, token, WebVTTToken::StartTag(result.toString()));
+        input.advance();
+        return emitToken(token, WebVTTToken::StartTag(result.toString()));
     } else {
         result.append(character);
         WEBVTT_ADVANCE_TO(StartTagState);
     }
 
 StartTagState:
+    if (input.atEnd())
+        return emitToken(token, WebVTTToken::StartTag(result.toString()));
     if (isTokenizerWhitespace(character))
         WEBVTT_ADVANCE_TO(StartTagAnnotationState);
     else if (character == '.')
         WEBVTT_ADVANCE_TO(StartTagClassState);
-    else if (character == '>' || character == kEndOfFileMarker)
-        return advanceAndEmitToken(m_input, token, WebVTTToken::StartTag(result.toString()));
-    else {
+    else if (character == '>') {
+        input.advance();
+        return emitToken(token, WebVTTToken::StartTag(result.toString()));
+    } else {
         result.append(character);
         WEBVTT_ADVANCE_TO(StartTagState);
     }
 
 StartTagClassState:
+    if (input.atEnd()) {
+        addNewClass(classes, buffer);
+        buffer.clear();
+        return emitToken(token, WebVTTToken::StartTag(result.toString(), classes.toAtomString()));
+    }
     if (isTokenizerWhitespace(character)) {
         addNewClass(classes, buffer);
         buffer.clear();
@@ -172,44 +180,57 @@ StartTagClassState:
         addNewClass(classes, buffer);
         buffer.clear();
         WEBVTT_ADVANCE_TO(StartTagClassState);
-    } else if (character == '>' || character == kEndOfFileMarker) {
+    } else if (character == '>') {
         addNewClass(classes, buffer);
         buffer.clear();
-        return advanceAndEmitToken(m_input, token, WebVTTToken::StartTag(result.toString(), classes.toAtomString()));
+        input.advance();
+        return emitToken(token, WebVTTToken::StartTag(result.toString(), classes.toAtomString()));
     } else {
         buffer.append(character);
         WEBVTT_ADVANCE_TO(StartTagClassState);
     }
 
 StartTagAnnotationState:
+    if (input.atEnd())
+        return emitToken(token, WebVTTToken::StartTag(result.toString(), classes.toAtomString(), buffer.toAtomString()));
     if (character == '&')
         WEBVTT_ADVANCE_TO(HTMLCharacterReferenceInAnnotationState);
-    else if (character == '>' || character == kEndOfFileMarker)
-        return advanceAndEmitToken(m_input, token, WebVTTToken::StartTag(result.toString(), classes.toAtomString(), buffer.toAtomString()));
+    else if (character == '>') {
+        input.advance();
+        return emitToken(token, WebVTTToken::StartTag(result.toString(), classes.toAtomString(), buffer.toAtomString()));
+    }
     buffer.append(character);
     WEBVTT_ADVANCE_TO(StartTagAnnotationState);
 
 EndTagState:
-    if (character == '>' || character == kEndOfFileMarker)
-        return advanceAndEmitToken(m_input, token, WebVTTToken::EndTag(result.toString()));
+    if (input.atEnd())
+        return emitToken(token, WebVTTToken::EndTag(result.toString()));
+    if (character == '>') {
+        input.advance();
+        return emitToken(token, WebVTTToken::EndTag(result.toString()));
+    }
     result.append(character);
     WEBVTT_ADVANCE_TO(EndTagState);
 
 TimestampTagState:
-    if (character == '>' || character == kEndOfFileMarker)
-        return advanceAndEmitToken(m_input, token, WebVTTToken::TimestampTag(result.toString()));
+    if (input.atEnd())
+        return emitToken(token, WebVTTToken::TimestampTag(result.toString()));
+    if (character == '>') {
+        input.advance();
+        return emitToken(token, WebVTTToken::TimestampTag(result.toString()));
+    }
     result.append(character);
     WEBVTT_ADVANCE_TO(TimestampTagState);
 
 HTMLCharacterReferenceInDataState:
-    ProcessEntity(m_input, result);
+    processEntity(input, result);
     WEBVTT_SWITCH_TO(DataState);
 
 HTMLCharacterReferenceInAnnotationState:
-    ProcessEntity(m_input, result, '>');
+    processEntity(input, buffer, '>');
     WEBVTT_SWITCH_TO(StartTagAnnotationState);
 }
 
-}
+} // namespace WebCore
 
 #endif

--- a/Source/WebCore/html/track/WebVTTTokenizer.h
+++ b/Source/WebCore/html/track/WebVTTTokenizer.h
@@ -33,8 +33,9 @@
 
 #if ENABLE(VIDEO)
 
-#include "InputStreamPreprocessor.h"
 #include "WebVTTToken.h"
+#include <wtf/Variant.h>
+#include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {
 
@@ -43,11 +44,12 @@ public:
     explicit WebVTTTokenizer(const String&);
     bool nextToken(WebVTTToken&);
 
-    static bool neverSkipNullCharacters() { return false; }
-
 private:
-    SegmentedString m_input;
-    InputStreamPreprocessor<WebVTTTokenizer> m_preprocessor;
+    template<typename CharacterType>
+    bool nextTokenImpl(StringParsingBuffer<CharacterType>&, WebVTTToken&);
+
+    String m_input;
+    Variant<StringParsingBuffer<Latin1Character>, StringParsingBuffer<char16_t>> m_buffer;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c10d579db7bce936c0574ec8a4188e3b839e0644
<pre>
Allow U+0000 in VTTCue
<a href="https://bugs.webkit.org/show_bug.cgi?id=312686">https://bugs.webkit.org/show_bug.cgi?id=312686</a>
<a href="https://rdar.apple.com/175084171">rdar://175084171</a>

Reviewed by Chris Dumez.

The WebVTT cue text tokenizer was using InputStreamPreprocessor, which
replaced U+0000 NULL with U+FFFD. This was wrong for getCueAsHTML().

So instead we use StringParsingBuffer, which preserves all characters
as-is.

We also fix a pre-existing bug where entity-decoded characters in voice
annotations (e.g., &lt;v Foo&amp;amp;Bar&gt;) were appended to the tag name
instead of the annotation text, and unskip five already-passing
rendering tests.

Upstream:

    <a href="https://github.com/web-platform-tests/wpt/pull/59331">https://github.com/web-platform-tests/wpt/pull/59331</a>

Canonical link: <a href="https://commits.webkit.org/311539@main">https://commits.webkit.org/311539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9aab73b574d4bb9c76bd69e638343bf6cc0f38f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157258 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166082 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111340 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24e848f2-a1f3-4009-904a-7cb6150eadf0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121791 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85509 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc8c0973-50c6-4c77-acd5-099583cfd6c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102459 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0e6ec62-5deb-43ae-88b7-5d54f6bfd9e4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23087 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21335 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13853 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168567 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12725 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129924 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130032 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87969 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23921 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17636 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29830 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93844 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29352 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29582 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->