### PR TITLE
[JSC] Intl.Locale needs to canonicalize before override language

### DIFF
--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -50,9 +50,6 @@ skip:
     - test/built-ins/Function/prototype/restricted-property-arguments.js
     - test/built-ins/Function/prototype/restricted-property-caller.js
 
-    # New ICU (66~) raises a different failure
-    - test/intl402/Locale/constructor-apply-options-canonicalizes-twice.js
-
     # ICU canonicalization bug
     # https://unicode-org.atlassian.net/browse/ICU-21367
     - test/intl402/Intl/getCanonicalLocales/unicode-ext-canonicalize-yes-to-true.js

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -79,6 +79,7 @@ DEFINE_VISIT_CHILDREN(IntlLocale);
 class LocaleIDBuilder final {
 public:
     bool initialize(const String&);
+    bool canonicalize();
     CString toCanonical();
 
     void overrideLanguageScriptRegionVariants(StringView language, StringView script, StringView region, StringView variants = { });
@@ -106,6 +107,20 @@ CString LocaleIDBuilder::toCanonical()
         return { };
 
     return canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(WTF::move(buffer.value())).span();
+}
+
+bool LocaleIDBuilder::canonicalize()
+{
+    ASSERT(m_buffer.size());
+
+    auto buffer = canonicalizeLocaleIDWithoutNullTerminator(m_buffer.span().data());
+    if (!buffer)
+        return false;
+
+    auto canonicalized = canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(WTF::move(buffer.value()));
+    canonicalized.append('\0');
+    m_buffer = WTF::move(canonicalized);
+    return true;
 }
 
 // Because ICU's C API doesn't have set[Language|Script|Region|Variants] functions...
@@ -391,8 +406,13 @@ void IntlLocale::initializeLocale(JSGlobalObject* globalObject, const String& ta
         }
     }
 
-    if (!language.isNull() || !script.isNull() || !region.isNull() || !variants.isNull())
+    if (!language.isNull() || !script.isNull() || !region.isNull() || !variants.isNull()) {
+        if (!localeID.canonicalize()) {
+            throwTypeError(globalObject, scope, "failed to initialize Locale"_s);
+            return;
+        }
         localeID.overrideLanguageScriptRegionVariants(language, script, region, variants);
+    }
 
     String calendar = intlStringOption(globalObject, options, vm.propertyNames->calendar, { }, { }, { });
     RETURN_IF_EXCEPTION(scope, void());


### PR DESCRIPTION
#### 325456987d1d6270880f79c825d23f0a7dc631b9
<pre>
[JSC] Intl.Locale needs to canonicalize before override language
<a href="https://bugs.webkit.org/show_bug.cgi?id=312693">https://bugs.webkit.org/show_bug.cgi?id=312693</a>
<a href="https://rdar.apple.com/175092327">rdar://175092327</a>

Reviewed by Sosuke Suzuki.

In <a href="https://tc39.es/ecma402/#sec-Intl.Locale">https://tc39.es/ecma402/#sec-Intl.Locale</a>, step 13
CanonicalizeUnicodeLocaleId needs to be called before UpdateLanguageId.
So we add canonicalization before UpdateLanguageId phase.

For new Intl.Locale(&quot;und-Armn-SU&quot;, {language: &quot;ru&quot;}):

- Before: und-Armn-SU -&gt; override language -&gt; ru-Armn-SU -&gt; canonicalize -&gt; ru-Armn-RU (wrong)
- After: und-Armn-SU -&gt; canonicalize -&gt; und-Armn-AM -&gt; override language -&gt; ru-Armn-AM -&gt; canonicalize -&gt; ru-Armn-AM

* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::LocaleIDBuilder::canonicalize):
(JSC::IntlLocale::initializeLocale):

Canonical link: <a href="https://commits.webkit.org/311538@main">https://commits.webkit.org/311538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e894a0bc52a2f9210529d788e318e052f424c4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111343 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61e1e894-166c-445f-9cda-ddade7959037) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121795 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85512 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/beaa3bd6-09c7-4b22-b56d-bf5e4bc52d0b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102463 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4450cba-d482-4df4-a460-6febc202815e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23091 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21339 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13856 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149311 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132771 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168570 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18096 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12728 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20661 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129928 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130036 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140835 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87978 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23920 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24854 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17640 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189279 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29833 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93847 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48558 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29355 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29482 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->