### PR TITLE
Fix srcset w-descriptor images not re-selecting on viewport resize

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2295,7 +2295,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/invalid-src.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-events.html [ Skip ]
 
 # These tests time out (fail) because they only work in engines that support Ogg Vorbis video.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT srcset w-descriptor: narrow to wide selects higher-density candidate Test timed out
+PASS srcset w-descriptor: narrow to wide selects higher-density candidate
 

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -115,7 +115,12 @@ std::optional<float> SizesAttributeParser::parse(CSSParserTokenRange tokens, con
         auto length = parseLength(lengthTokenStart.rangeUntil(lengthTokenEnd), context);
         if (!length)
             continue;
-        auto mediaCondition = MQ::MediaQueryParser::parseCondition(mediaConditionStart.rangeUntil(lengthTokenStart), context);
+
+        auto mediaConditionRange = mediaConditionStart.rangeUntil(lengthTokenStart);
+        if (mediaConditionRange.atEnd())
+            return length;
+
+        auto mediaCondition = MQ::MediaQueryParser::parseCondition(mediaConditionRange, context);
         if (!mediaCondition)
             continue;
         bool matches = mediaConditionMatches(*mediaCondition);
@@ -138,6 +143,9 @@ std::optional<float> SizesAttributeParser::parseDimension(CSSParserTokenRange to
     auto unit = CSS::toLengthUnit(token.unitType());
     if (!unit)
         return std::nullopt;
+
+    if (CSS::isViewportPercentageLength(*unit))
+        m_usesViewportRelativeUnits = true;
 
     auto conversionData = this->conversionData();
     if (!conversionData)

--- a/Source/WebCore/css/parser/SizesAttributeParser.h
+++ b/Source/WebCore/css/parser/SizesAttributeParser.h
@@ -50,6 +50,7 @@ public:
     bool isAuto() const { return m_isAuto; }
 
     const Vector<MQ::MediaQueryResult>& dynamicMediaQueryResults() const LIFETIME_BOUND { return m_dynamicMediaQueryResults; }
+    bool usesViewportRelativeUnits() const { return m_usesViewportRelativeUnits; }
 
 private:
     std::optional<float> parse(CSSParserTokenRange, const CSSParserContext&);
@@ -67,6 +68,7 @@ private:
     Vector<MQ::MediaQueryResult> m_dynamicMediaQueryResults;
     std::optional<float> m_result;
     bool m_isAuto { false };
+    bool m_usesViewportRelativeUnits { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -315,6 +315,7 @@ ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()
         SizesAttributeParser sizesParser(sizesString, document.get());
 
         m_dynamicMediaQueryResults.appendVector(sizesParser.dynamicMediaQueryResults());
+        m_sizesUseViewportUnits |= sizesParser.usesViewportRelativeUnits();
 
         auto sourceSize = sizesParser.effectiveSize();
         if (sizesParser.isAuto() && isLazyLoadable()) {
@@ -353,8 +354,15 @@ void HTMLImageElement::evaluateDynamicMediaQueryDependencies()
         return false;
     }();
 
-    if (!hasChanges)
-        return;
+    if (!hasChanges) {
+        if (!m_sizesUseViewportUnits)
+            return;
+        if (CheckedPtr view = document().view()) {
+            auto viewportSize = view->sizeForCSSDefaultViewportUnits();
+            if (m_lastViewportSizeForSizes && *m_lastViewportSizeForSizes == viewportSize)
+                return;
+        }
+    }
 
     selectImageSource(RelevantMutation::No);
 }
@@ -362,6 +370,7 @@ void HTMLImageElement::evaluateDynamicMediaQueryDependencies()
 void HTMLImageElement::selectImageSource(RelevantMutation relevantMutation)
 {
     m_dynamicMediaQueryResults = { };
+    m_sizesUseViewportUnits = false;
     Ref document = this->document();
     document->removeDynamicMediaQueryDependentImage(*this);
 
@@ -387,6 +396,7 @@ void HTMLImageElement::selectImageSource(RelevantMutation relevantMutation)
             // If we don't have a <picture> or didn't find a source, then we use our own attributes.
             SizesAttributeParser sizesParser(attributeWithoutSynchronization(sizesAttr).string(), document.get());
             m_dynamicMediaQueryResults.appendVector(sizesParser.dynamicMediaQueryResults());
+            m_sizesUseViewportUnits |= sizesParser.usesViewportRelativeUnits();
             auto sourceSize = sizesParser.effectiveSize();
             if (sizesParser.isAuto() && isLazyLoadable()) {
                 if (auto layoutWidth = autoSizesLayoutWidth())
@@ -400,7 +410,12 @@ void HTMLImageElement::selectImageSource(RelevantMutation relevantMutation)
     setBestFitURLAndDPRFromImageCandidate(candidate);
     m_imageLoader->updateFromElementIgnoringPreviousError(relevantMutation);
 
-    if (!m_dynamicMediaQueryResults.isEmpty())
+    if (m_sizesUseViewportUnits) {
+        if (CheckedPtr view = document->view())
+            m_lastViewportSizeForSizes = view->sizeForCSSDefaultViewportUnits();
+    }
+
+    if (!m_dynamicMediaQueryResults.isEmpty() || m_sizesUseViewportUnits)
         document->addDynamicMediaQueryDependentImage(*this);
 }
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -272,6 +272,8 @@ private:
     WeakPtr<HTMLSourceElement, WeakPtrImplWithEventTargetData> m_sourceElement;
 
     Vector<MQ::MediaQueryResult> m_dynamicMediaQueryResults;
+    bool m_sizesUseViewportUnits { false };
+    std::optional<FloatSize> m_lastViewportSizeForSizes;
 
     friend class HTMLPictureElement;
 };


### PR DESCRIPTION
#### 2b6cdbf1e5a8d073c1a8343d1869c96e88a08711
<pre>
Fix srcset w-descriptor images not re-selecting on viewport resize
<a href="https://bugs.webkit.org/show_bug.cgi?id=312694">https://bugs.webkit.org/show_bug.cgi?id=312694</a>
<a href="https://rdar.apple.com/175092674">rdar://175092674</a>

Reviewed by NOBODY (OOPS!).

DRAFT - WIP - Don&apos;t review YET.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Images using srcset with w-descriptors and viewport-relative sizes
(e.g., sizes=&quot;100vw&quot;) were not re-selecting candidates when the
viewport changed. Two issues:

1. SizesAttributeParser::parse() did not handle bare size values
 (no media condition) per the &quot;parse a sizes attribute&quot; algorithm.
 The spec says when the remaining tokens are empty after extracting
 the size, return the size immediately. Instead, the parser tried
 to parse the empty range as a media condition, which failed, and
 the entry was skipped. The correct value was still returned via
 effectiveSizeDefaultValue(), masking the bug.

2. Viewport-relative units in the sizes length value were not tracked,
 so images were never registered for viewport change notifications.
 The dynamic dependency system only tracked media query conditions,
 not viewport-relative lengths.

Fix by:
- Returning bare size values immediately in parse(), matching the spec.
- Adding m_usesViewportRelativeUnits tracking to SizesAttributeParser,
 set when parseDimension() encounters a viewport-relative unit.
- Wiring the flag through HTMLImageElement so images with
 viewport-relative sizes register as dynamic media query dependent
 and re-evaluate on viewport changes.

When the sizes attribute is absent or fails to parse, the default
fallback is 100vw. However, setting m_usesViewportRelativeUnits for
this case marks all images with srcset as viewport-dependent,
including those using x-descriptors where the sizes value is
irrelevant. This causes images to be spuriously re-loaded on any
viewport resize or layout-triggered media query re-evaluation.
Only set the flag when parseDimension() encounters an explicit
viewport-relative unit.

* LayoutTests/TestExpectations: Unskip Test
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize-expected.txt: Progression
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
(WebCore::SizesAttributeParser::parse):
(WebCore::SizesAttributeParser::parseDimension):
* Source/WebCore/css/parser/SizesAttributeParser.h:
(WebCore::SizesAttributeParser::usesViewportRelativeUnits const):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::bestFitSourceFromPictureElement):
(WebCore::HTMLImageElement::evaluateDynamicMediaQueryDependencies):
(WebCore::HTMLImageElement::selectImageSource):
* Source/WebCore/html/HTMLImageElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b6cdbf1e5a8d073c1a8343d1869c96e88a08711

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111383 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f2faa49-18a2-4d19-b6a5-9c19e97c4336) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121827 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85544 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/20ec0d7d-984f-45bd-9987-ef21f05e7421) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102495 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9cbf105-79a1-400b-b1be-f8e92559d056) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23128 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/avoid-reload-on-resize.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21375 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13896 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132807 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168610 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12768 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129961 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130068 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140871 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88041 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24892 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17676 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29873 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93887 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29395 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29625 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29522 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->