### PR TITLE
Preload scanner should not skip <source> with empty type attribute in <picture>

### DIFF
--- a/LayoutTests/http/tests/preload/picture-type-expected.txt
+++ b/LayoutTests/http/tests/preload/picture-type-expected.txt
@@ -34,6 +34,12 @@ PASS internals.isPreloaded('/resources/square20.jpg?12'); is false
 PASS internals.isPreloaded('/resources/square20.jpg?13&preload'); is true
 PASS internals.isPreloaded('/resources/square20.jpg?13&bad'); is false
 PASS internals.isPreloaded('/resources/square20.jpg?13&invalid'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?14&preload'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?14'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?15&preload'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?15'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?16&preload'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?16'); is false
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/preload/picture-type.html
+++ b/LayoutTests/http/tests/preload/picture-type.html
@@ -59,6 +59,15 @@
         shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?13&preload');");
         shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?13&bad');");
         shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?13&invalid');");
+
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?14&preload');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?14');");
+
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?15&preload');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?15');");
+
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?16&preload');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?16');");
     }
 </script>
 <!-- Control group -->
@@ -126,6 +135,22 @@
     <source type="image/bad" media="(min-width: 1px)" srcset="/resources/square20.jpg?13&bad">
     <source type="image/invalid" media="(min-width: 1px)" srcset="/resources/square20.jpg?13&invalid">
     <img src="/resources/square20.jpg?13&preload">
+</picture>
+
+<!-- Empty type - should not be skipped -->
+<picture>
+    <source type="" srcset="/resources/square20.jpg?14&preload">
+    <img src="/resources/square20.jpg?14">
+</picture>
+<!-- Whitespace type - should not be skipped -->
+<picture>
+    <source type=" " srcset="/resources/square20.jpg?15&preload">
+    <img src="/resources/square20.jpg?15">
+</picture>
+<!-- Parameter-only type - empty after stripping params, should not be skipped -->
+<picture>
+    <source type=";params=only" srcset="/resources/square20.jpg?16&preload">
+    <img src="/resources/square20.jpg?16">
 </picture>
 
 </body>

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -271,6 +271,14 @@ static String extractMIMETypeFromTypeAttributeForLookup(const String& typeAttrib
     return StringView(typeAttribute).left(semicolonIndex).trim(isASCIIWhitespace<char16_t>).toStringWithoutCopying();
 }
 
+bool HTMLImageElement::isSupportedImageSourceType(const String& typeAttribute)
+{
+    auto type = extractMIMETypeFromTypeAttributeForLookup(typeAttribute);
+    if (type.isEmpty())
+        return true;
+    return MIMETypeRegistry::isSupportedImageVideoOrSVGMIMEType(type);
+}
+
 ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()
 {
     RefPtr picture = pictureElement();
@@ -290,8 +298,7 @@ ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()
 
         auto& typeAttribute = source->attributeWithoutSynchronization(typeAttr);
         if (!typeAttribute.isNull()) {
-            auto type = extractMIMETypeFromTypeAttributeForLookup(typeAttribute);
-            if (!type.isEmpty() && !MIMETypeRegistry::isSupportedImageVideoOrSVGMIMEType(type))
+            if (!isSupportedImageSourceType(typeAttribute))
                 continue;
         }
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -151,6 +151,8 @@ public:
 
     bool NODELETE isDeferred() const;
 
+    static bool isSupportedImageSourceType(const String& typeAttribute);
+
     bool isDroppedImagePlaceholder() const { return m_isDroppedImagePlaceholder; }
     void setIsDroppedImagePlaceholder() { m_isDroppedImagePlaceholder = true; }
 

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -271,7 +271,7 @@ private:
             if (match(attributeName, typeAttr) && m_typeAttribute.isNull()) {
                 // when multiple type attributes present: first value wins, ignore subsequent (to match ImageElement parser and Blink behaviours)
                 m_typeAttribute = attributeValue.toString();
-                m_typeMatched &= MIMETypeRegistry::isSupportedImageVideoOrSVGMIMEType(m_typeAttribute);
+                m_typeMatched &= HTMLImageElement::isSupportedImageSourceType(m_typeAttribute);
             }
             break;
         case TagId::Script:


### PR DESCRIPTION
#### 8d8bd7b533234d8443a92ab4690b4099205ab3fc
<pre>
Preload scanner should not skip &lt;source&gt; with empty type attribute in &lt;picture&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=312695">https://bugs.webkit.org/show_bug.cgi?id=312695</a>
<a href="https://rdar.apple.com/175094037">rdar://175094037</a>

Reviewed by Chris Dumez.

The preload scanner passed the raw type attribute value directly to
isSupportedImageVideoOrSVGMIMEType(), which returns false for empty
strings. This caused &lt;source&gt; elements with type=&quot;&quot; or type=&quot; &quot; to be
skipped during preloading, even though the main rendering path in
bestFitSourceFromPictureElement() correctly treats them as having no
type constraint.

Add HTMLImageElement::isSupportedImageSourceType() as a shared helper
that extracts the MIME type from the type attribute (trimming whitespace
and stripping parameters after &apos;;&apos;) and returns true when the result is
empty. Both bestFitSourceFromPictureElement() and the preload scanner
now call this single function, matching other browser engine (i.e. Blink).

* LayoutTests/http/tests/preload/picture-type-expected.txt:
* LayoutTests/http/tests/preload/picture-type.html:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::isSupportedImageSourceType):
(WebCore::HTMLImageElement::bestFitSourceFromPictureElement):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):

Canonical link: <a href="https://commits.webkit.org/311568@main">https://commits.webkit.org/311568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/848e04facf93946da3ac41079ef810cc3bb6211b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166091 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111349 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4234aa3-c1a2-4099-8330-dbad746c2aaf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121797 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85541 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f7b675a3-1bcf-4212-a2c0-cd0e6a8a9720) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102465 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1b48521-5ff0-46c1-a6bf-7aad21e0df6d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23095 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21342 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13862 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168576 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12734 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20666 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129930 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130038 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35250 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87990 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24858 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17645 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29839 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93853 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29361 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29591 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29488 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->