### PR TITLE
[JSC] Introduce Canonicalized TimeZone mechanism

### DIFF
--- a/JSTests/complex.yaml
+++ b/JSTests/complex.yaml
@@ -64,6 +64,54 @@
           runComplexTest [], [], "TZ=UNDEFINED", "--useDollarVM=1", "--useTemporal=1"
       end
 
+- path: complex/intl-default-timezone-backward-link.js
+  cmd: |
+      if ($hostOS == "windows" || $hostOS == "linux")
+          skip
+      else
+          runComplexTest [], [], "TZ=Asia/Calcutta", "--useDollarVM=1", "--useTemporal=1"
+      end
+
+- path: complex/intl-default-timezone-utc-alias.js
+  cmd: |
+      if ($hostOS == "windows")
+          skip
+      else
+          runComplexTest [], [], "TZ=Etc/UTC", "--useDollarVM=1", "--useTemporal=1"
+      end
+
+- path: complex/intl-default-timezone-three-letter-alias.js
+  cmd: |
+      if ($hostOS == "windows")
+          skip
+      else
+          runComplexTest [], [], "TZ=ACT", "--useDollarVM=1", "--useTemporal=1"
+      end
+
+- path: complex/intl-default-timezone-etc-gmt-offset.js
+  cmd: |
+      if ($hostOS == "windows")
+          skip
+      else
+          runComplexTest [], [], "TZ=Etc/GMT+5", "--useDollarVM=1", "--useTemporal=1"
+      end
+
+- path: complex/intl-default-timezone-region-alias.js
+  cmd: |
+      if ($hostOS == "windows")
+          skip
+      else
+          runComplexTest [], [], "TZ=US/Eastern", "--useDollarVM=1", "--useTemporal=1"
+      end
+
+- path: complex/intl-default-timezone-etc-unknown.js
+  cmd: |
+      if ($hostOS == "windows")
+          skip
+      else
+          runComplexTest [], [], "TZ=Etc/Unknown", "--useDollarVM=1", "--useTemporal=1"
+      end
+
 - path: complex/for-in-clobberize.js
   cmd: runComplexTest [], [], nil, "--destroy-vm"
 

--- a/JSTests/complex/intl-default-timezone-backward-link.js
+++ b/JSTests/complex/intl-default-timezone-backward-link.js
@@ -1,0 +1,9 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// IANA Backward link must collapse to the IANA primary identifier when used
+// as the host time zone. https://bugs.webkit.org/show_bug.cgi?id=310866
+shouldBe(Intl.DateTimeFormat().resolvedOptions().timeZone, `Asia/Kolkata`);
+shouldBe(Temporal.Now.timeZoneId(), `Asia/Kolkata`);

--- a/JSTests/complex/intl-default-timezone-etc-gmt-offset.js
+++ b/JSTests/complex/intl-default-timezone-etc-gmt-offset.js
@@ -1,0 +1,10 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// Etc/GMT+N and Etc/GMT-N (with non-zero N) are real IANA primary zones, not
+// aliases, so they must round-trip unchanged. Only Etc/GMT+0 and Etc/GMT-0
+// collapse to "UTC" (covered separately by intl-default-timezone-utc-alias.js).
+shouldBe(Intl.DateTimeFormat().resolvedOptions().timeZone, `Etc/GMT+5`);
+shouldBe(Temporal.Now.timeZoneId(), `Etc/GMT+5`);

--- a/JSTests/complex/intl-default-timezone-etc-unknown.js
+++ b/JSTests/complex/intl-default-timezone-etc-unknown.js
@@ -1,0 +1,11 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// "Etc/Unknown" is ICU's special sentinel for "no specific zone known".
+// ucal_getIanaTimeZoneID returns U_ILLEGAL_ARGUMENT_ERROR for it, and the
+// fallback canonical form is not in our IANA primary index, so the host TZ
+// resolves to UTC via TimeZone's default constructor.
+shouldBe(Intl.DateTimeFormat().resolvedOptions().timeZone, `UTC`);
+shouldBe(Temporal.Now.timeZoneId(), `UTC`);

--- a/JSTests/complex/intl-default-timezone-region-alias.js
+++ b/JSTests/complex/intl-default-timezone-region-alias.js
@@ -1,0 +1,9 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// Country/region aliases like "US/Eastern", "GB", "Brazil/East", "Canada/*"
+// are IANA Backward links and must canonicalize to their primary identifier.
+shouldBe(Intl.DateTimeFormat().resolvedOptions().timeZone, `America/New_York`);
+shouldBe(Temporal.Now.timeZoneId(), `America/New_York`);

--- a/JSTests/complex/intl-default-timezone-three-letter-alias.js
+++ b/JSTests/complex/intl-default-timezone-three-letter-alias.js
@@ -1,0 +1,10 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// Non-IANA legacy three-letter aliases (ACT, AET, AGT, ...) are accepted as
+// host time zones via ICU but must canonicalize to their IANA primary so
+// Intl.supportedValuesOf("timeZone") and resolvedOptions().timeZone agree.
+shouldBe(Intl.DateTimeFormat().resolvedOptions().timeZone, `Australia/Darwin`);
+shouldBe(Temporal.Now.timeZoneId(), `Australia/Darwin`);

--- a/JSTests/complex/intl-default-timezone-utc-alias.js
+++ b/JSTests/complex/intl-default-timezone-utc-alias.js
@@ -1,0 +1,10 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// UTC-equivalent host time zone must normalize to "UTC", not "Etc/UTC" or
+// the literal alias name. ECMA-402 mandates "UTC" as the primary identifier
+// for UTC-equivalent zones.
+shouldBe(Intl.DateTimeFormat().resolvedOptions().timeZone, `UTC`);
+shouldBe(Temporal.Now.timeZoneId(), `UTC`);

--- a/JSTests/stress/intl-canonical-gmt.js
+++ b/JSTests/stress/intl-canonical-gmt.js
@@ -3,4 +3,4 @@ function shouldBe(actual, expected) {
         throw new Error('bad value: ' + actual);
 }
 
-shouldBe(new Intl.DateTimeFormat('en', { timeZone: "GMT" }).resolvedOptions().timeZone, "GMT")
+shouldBe(new Intl.DateTimeFormat('en', { timeZone: "GMT" }).resolvedOptions().timeZone, "UTC")

--- a/JSTests/stress/intl-canonical-iana-time-zone.js
+++ b/JSTests/stress/intl-canonical-iana-time-zone.js
@@ -1,0 +1,108 @@
+//@ skip if $hostOS == "windows" || $hostOS == "linux"
+//@ requireOptions("--useTemporal=1")
+// https://bugs.webkit.org/show_bug.cgi?id=310866
+// Linked time zones (IANA "Backward" file) must canonicalize to the IANA
+// primary identifier per https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+function shouldBeTrue(actual) { shouldBe(actual, true); }
+function shouldBeFalse(actual) { shouldBe(actual, false); }
+
+function resolved(tz) {
+    return new Intl.DateTimeFormat("en", { timeZone: tz }).resolvedOptions().timeZone;
+}
+
+// Backward links collapse onto IANA primary identifiers, regardless of the
+// caller's casing.
+shouldBe(resolved("Asia/Calcutta"), "Asia/Kolkata");
+shouldBe(resolved("asia/calcutta"), "Asia/Kolkata");
+shouldBe(resolved("Asia/Kolkata"), "Asia/Kolkata");
+
+shouldBe(resolved("America/Buenos_Aires"), "America/Argentina/Buenos_Aires");
+shouldBe(resolved("America/Argentina/Buenos_Aires"), "America/Argentina/Buenos_Aires");
+
+shouldBe(resolved("Europe/Kiev"), "Europe/Kyiv");
+shouldBe(resolved("Europe/Kyiv"), "Europe/Kyiv");
+
+// UTC-equivalent zones normalize to "UTC", overriding IANA's "Etc/UTC" primary.
+shouldBe(resolved("UTC"), "UTC");
+shouldBe(resolved("Etc/UTC"), "UTC");
+shouldBe(resolved("GMT"), "UTC");
+shouldBe(resolved("Etc/GMT"), "UTC");
+shouldBe(resolved("Universal"), "UTC");
+shouldBe(resolved("Zulu"), "UTC");
+shouldBe(resolved("Greenwich"), "UTC");
+
+// Intl.supportedValuesOf("timeZone") exposes IANA primary identifiers, not the
+// older CLDR canonical aliases.
+const all = Intl.supportedValuesOf("timeZone");
+shouldBeTrue(all.includes("Asia/Kolkata"));
+shouldBeFalse(all.includes("Asia/Calcutta"));
+shouldBeTrue(all.includes("Europe/Kyiv"));
+shouldBeFalse(all.includes("Europe/Kiev"));
+shouldBeTrue(all.includes("America/Argentina/Buenos_Aires"));
+shouldBeFalse(all.includes("America/Buenos_Aires"));
+
+// Concern (1): Even though we now feed ICU the IANA primary ID rather than the
+// CLDR canonical, ICU must still resolve correct offsets, DST transitions, and
+// localized zone names. A legacy input and its primary must format identically.
+function fmt(tz, instant) {
+    const f = new Intl.DateTimeFormat("en", {
+        timeZone: tz,
+        timeZoneName: "long",
+        year: "numeric", month: "2-digit", day: "2-digit",
+        hour: "2-digit", minute: "2-digit", second: "2-digit",
+        hour12: false,
+    });
+    return f.format(instant);
+}
+const summer = new Date("2024-06-15T12:00:00Z").getTime();
+const winter = new Date("2024-01-15T12:00:00Z").getTime();
+for (const t of [summer, winter]) {
+    shouldBe(fmt("Asia/Calcutta", t),         fmt("Asia/Kolkata", t));
+    shouldBe(fmt("America/Buenos_Aires", t),  fmt("America/Argentina/Buenos_Aires", t));
+    shouldBe(fmt("Europe/Kiev", t),           fmt("Europe/Kyiv", t));
+    shouldBe(fmt("Asia/Katmandu", t),         fmt("Asia/Kathmandu", t));
+    shouldBe(fmt("US/Pacific", t),            fmt("America/Los_Angeles", t));
+    shouldBe(fmt("GB", t),                    fmt("Europe/London", t));
+    shouldBe(fmt("Brazil/East", t),           fmt("America/Sao_Paulo", t));
+}
+
+// Concern (2): Legacy non-primary IANA names must still be accepted as input.
+// Internally JSC canonicalizes to the primary, but rejection would be a
+// compatibility regression.
+const legacy = [
+    "Asia/Calcutta", "America/Buenos_Aires", "Europe/Kiev", "Asia/Katmandu",
+    "US/Pacific", "US/Eastern", "GB", "Brazil/East", "Canada/Eastern",
+    "Australia/ACT", "UCT", "Universal", "Zulu", "GMT",
+];
+for (const tz of legacy) {
+    // Should not throw on either Intl.DateTimeFormat or Date.prototype.toLocaleString.
+    new Intl.DateTimeFormat("en", { timeZone: tz });
+    new Date(0).toLocaleString("en", { timeZone: tz });
+}
+
+// Temporal.TimeZone uses the same hashmap-backed TimeZoneID lookup as Intl, so
+// legacy aliases must also be accepted there and resolve to the same primary.
+if (typeof Temporal !== "undefined") {
+    const pairs = [
+        ["Asia/Calcutta",          "Asia/Kolkata"],
+        ["America/Buenos_Aires",   "America/Argentina/Buenos_Aires"],
+        ["Europe/Kiev",            "Europe/Kyiv"],
+        ["Asia/Katmandu",          "Asia/Kathmandu"],
+        ["US/Pacific",             "America/Los_Angeles"],
+        ["GB",                     "Europe/London"],
+        ["Brazil/East",            "America/Sao_Paulo"],
+        ["UCT",                    "UTC"],
+        ["Etc/UTC",                "UTC"],
+        ["Zulu",                   "UTC"],
+    ];
+    for (const [legacy, primary] of pairs) {
+        shouldBe(new Temporal.TimeZone(legacy).id, primary);
+        shouldBe(Temporal.TimeZone.from(legacy).id, primary);
+    }
+}

--- a/JSTests/stress/intl-datetimeformat.js
+++ b/JSTests/stress/intl-datetimeformat.js
@@ -253,32 +253,33 @@ shouldBe(Intl.DateTimeFormat('en', { timeZone: 'AMERICA/LOS_ANGELES' }).resolved
 // Default time zone is a valid canonical time zone.
 shouldBe(Intl.DateTimeFormat('en', { timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone }).resolvedOptions().timeZone, Intl.DateTimeFormat().resolvedOptions().timeZone);
 
-// Time zone should be preserved and not canonicalized.
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/ACT' }).resolvedOptions().timeZone, 'Australia/ACT');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/North' }).resolvedOptions().timeZone, 'Australia/North');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/South' }).resolvedOptions().timeZone, 'Australia/South');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/West' }).resolvedOptions().timeZone, 'Australia/West');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/East' }).resolvedOptions().timeZone, 'Brazil/East');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/West' }).resolvedOptions().timeZone, 'Brazil/West');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Atlantic' }).resolvedOptions().timeZone, 'Canada/Atlantic');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Central' }).resolvedOptions().timeZone, 'Canada/Central');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Eastern' }).resolvedOptions().timeZone, 'Canada/Eastern');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Mountain' }).resolvedOptions().timeZone, 'Canada/Mountain');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Pacific' }).resolvedOptions().timeZone, 'Canada/Pacific');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GB' }).resolvedOptions().timeZone, 'GB');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT+0' }).resolvedOptions().timeZone, 'GMT+0');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT-0' }).resolvedOptions().timeZone, 'GMT-0');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT0' }).resolvedOptions().timeZone, 'GMT0');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Greenwich' }).resolvedOptions().timeZone, 'Greenwich');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'UCT' }).resolvedOptions().timeZone, 'UCT');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Central' }).resolvedOptions().timeZone, 'US/Central');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Eastern' }).resolvedOptions().timeZone, 'US/Eastern');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Michigan' }).resolvedOptions().timeZone, 'US/Michigan');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Mountain' }).resolvedOptions().timeZone, 'US/Mountain');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Pacific' }).resolvedOptions().timeZone, 'US/Pacific');
+// Linked time zones canonicalize to their IANA primary zone identifier.
+// https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/ACT' }).resolvedOptions().timeZone, 'Australia/Sydney');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/North' }).resolvedOptions().timeZone, 'Australia/Darwin');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/South' }).resolvedOptions().timeZone, 'Australia/Adelaide');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/West' }).resolvedOptions().timeZone, 'Australia/Perth');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/East' }).resolvedOptions().timeZone, 'America/Sao_Paulo');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/West' }).resolvedOptions().timeZone, 'America/Manaus');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Atlantic' }).resolvedOptions().timeZone, 'America/Halifax');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Central' }).resolvedOptions().timeZone, 'America/Winnipeg');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Eastern' }).resolvedOptions().timeZone, 'America/Toronto');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Mountain' }).resolvedOptions().timeZone, 'America/Edmonton');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Pacific' }).resolvedOptions().timeZone, 'America/Vancouver');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GB' }).resolvedOptions().timeZone, 'Europe/London');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT+0' }).resolvedOptions().timeZone, 'UTC');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT-0' }).resolvedOptions().timeZone, 'UTC');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT0' }).resolvedOptions().timeZone, 'UTC');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Greenwich' }).resolvedOptions().timeZone, 'UTC');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'UCT' }).resolvedOptions().timeZone, 'UTC');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Central' }).resolvedOptions().timeZone, 'America/Chicago');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Eastern' }).resolvedOptions().timeZone, 'America/New_York');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Michigan' }).resolvedOptions().timeZone, 'America/Detroit');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Mountain' }).resolvedOptions().timeZone, 'America/Denver');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Pacific' }).resolvedOptions().timeZone, 'America/Los_Angeles');
 shouldBe(Intl.DateTimeFormat('en', { timeZone: 'UTC' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Universal' }).resolvedOptions().timeZone, 'Universal');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Zulu' }).resolvedOptions().timeZone, 'Zulu');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Universal' }).resolvedOptions().timeZone, 'UTC');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Zulu' }).resolvedOptions().timeZone, 'UTC');
 
 // Timezone-sensitive format().
 shouldBe(Intl.DateTimeFormat('en', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/2015');

--- a/JSTests/stress/temporal-timezone.js
+++ b/JSTests/stress/temporal-timezone.js
@@ -1,3 +1,4 @@
+//@ skip if $hostOS == "windows" || $hostOS == "linux"
 //@ requireOptions("--useTemporal=1")
 function shouldBe(actual, expected) {
     if (actual !== expected)
@@ -63,7 +64,7 @@ for (let text of failures) {
     }, RangeError);
 }
 
-shouldBe(new Temporal.TimeZone("+00:00").id, `+00:00`);
+shouldBe(new Temporal.TimeZone("+00:00").id, `UTC`);
 shouldBe(new Temporal.TimeZone("+01:00").id, `+01:00`);
 shouldBe(new Temporal.TimeZone("+01:59").id, `+01:59`);
 shouldBe(new Temporal.TimeZone("-01:59").id, `-01:59`);
@@ -88,7 +89,7 @@ shouldBe(new Temporal.TimeZone("UTC").id, `UTC`);
 shouldBe(new Temporal.TimeZone('UTC').id, `UTC`);
 shouldBe(new Temporal.TimeZone('Africa/Cairo').id, `Africa/Cairo`);
 shouldBe(new Temporal.TimeZone('america/VANCOUVER').id, `America/Vancouver`);
-shouldBe(new Temporal.TimeZone('Asia/Katmandu').id, `Asia/Katmandu`);
+shouldBe(new Temporal.TimeZone('Asia/Katmandu').id, `Asia/Kathmandu`);
 shouldBe(new Temporal.TimeZone('-04:00').id, `-04:00`);
 shouldBe(new Temporal.TimeZone('+0645').id, `+06:45`);
 
@@ -97,7 +98,7 @@ shouldBe(Temporal.TimeZone.from('Africa/Cairo').id, `Africa/Cairo`);
 shouldBe(Temporal.TimeZone.from('Africa/Cairo').toString(), `Africa/Cairo`);
 shouldBe(Temporal.TimeZone.from('Africa/Cairo').toJSON(), `Africa/Cairo`);
 shouldBe(Temporal.TimeZone.from('america/VANCOUVER').id, `America/Vancouver`);
-shouldBe(Temporal.TimeZone.from('Asia/Katmandu').id, `Asia/Katmandu`);
+shouldBe(Temporal.TimeZone.from('Asia/Katmandu').id, `Asia/Kathmandu`);
 shouldBe(Temporal.TimeZone.from('-04:00').id, `-04:00`);
 shouldBe(Temporal.TimeZone.from('+0645').id, `+06:45`);
 shouldBe(Temporal.TimeZone.from('+0645').toString(), `+06:45`);

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1180,6 +1180,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSPIContext.h
     runtime/JSPIContextInlines.h
     runtime/JSCPtrTag.h
+    runtime/JSCTimeZone.h
     runtime/JSCustomGetterFunction.h
     runtime/JSCustomSetterFunction.h
     runtime/JSDataView.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1549,6 +1549,7 @@
 		9E72940B190F0514001A91B5 /* BundlePath.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E72940A190F0514001A91B5 /* BundlePath.h */; };
 		9F63434577274FAFB9336C38 /* ModuleNamespaceAccessCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CE978E385A8498199052153 /* ModuleNamespaceAccessCase.h */; };
 		A12BBFF21B044A8B00664B69 /* IntlObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A12BBFF11B044A8B00664B69 /* IntlObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B1D7736A1D0A42A4B9017DE0 /* JSCTimeZone.h in Headers */ = {isa = PBXBuildFile; fileRef = 24FF4DFDAD3D4D97BE486930 /* JSCTimeZone.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1587D6E1B4DC14100D69849 /* IntlDateTimeFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = A1587D681B4DC14100D69849 /* IntlDateTimeFormat.h */; };
 		A1587D701B4DC14100D69849 /* IntlDateTimeFormatConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A1587D6A1B4DC14100D69849 /* IntlDateTimeFormatConstructor.h */; };
 		A1587D721B4DC14100D69849 /* IntlDateTimeFormatPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A1587D6C1B4DC14100D69849 /* IntlDateTimeFormatPrototype.h */; };
@@ -5199,6 +5200,7 @@
 		A125846C1B45A36000CC7F6C /* IntlNumberFormatConstructor.lut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlNumberFormatConstructor.lut.h; sourceTree = "<group>"; };
 		A125846D1B45A36000CC7F6C /* IntlNumberFormatPrototype.lut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlNumberFormatPrototype.lut.h; sourceTree = "<group>"; };
 		A12BBFF11B044A8B00664B69 /* IntlObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlObject.h; sourceTree = "<group>"; };
+		24FF4DFDAD3D4D97BE486930 /* JSCTimeZone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCTimeZone.h; sourceTree = "<group>"; };
 		A12BBFF31B044A9800664B69 /* IntlObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntlObject.cpp; sourceTree = "<group>"; };
 		A1587D671B4DC14100D69849 /* IntlDateTimeFormat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntlDateTimeFormat.cpp; sourceTree = "<group>"; };
 		A1587D681B4DC14100D69849 /* IntlDateTimeFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlDateTimeFormat.h; sourceTree = "<group>"; };
@@ -8911,6 +8913,7 @@
 				CDBF70762EBCFE6D00F6D00B /* JSCJSValueStructure.h */,
 				FE1E2C3C2240C1EF00F6B729 /* JSCPtrTag.cpp */,
 				FE7497E5209001B00003565B /* JSCPtrTag.h */,
+				24FF4DFDAD3D4D97BE486930 /* JSCTimeZone.h */,
 				84323E7D25D5EC6A00F97776 /* JSCustomGetterFunction.cpp */,
 				84323E7C25D5EC6900F97776 /* JSCustomGetterFunction.h */,
 				276B39002A71D2B200252F4E /* JSCustomGetterFunctionInlines.h */,
@@ -11934,6 +11937,7 @@
 				148CD1D8108CF902008163C6 /* JSContextRefPrivate.h in Headers */,
 				FE7497E6209001B10003565B /* JSCPtrTag.h in Headers */,
 				A72028B81797601E0098028C /* JSCTestRunnerUtils.h in Headers */,
+				B1D7736A1D0A42A4B9017DE0 /* JSCTimeZone.h in Headers */,
 				84323E8025D5EC6A00F97776 /* JSCustomGetterFunction.h in Headers */,
 				276B39182A71D2B600252F4E /* JSCustomGetterFunctionInlines.h in Headers */,
 				84323E7F25D5EC6A00F97776 /* JSCustomSetterFunction.h in Headers */,

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -52,12 +52,7 @@ static constexpr int64_t nsPerMicrosecond = 1000LL;
 
 std::optional<TimeZoneID> parseTimeZoneName(StringView string)
 {
-    const auto& timeZones = intlAvailableTimeZones();
-    for (unsigned index = 0; index < timeZones.size(); ++index) {
-        if (equalIgnoringASCIICase(timeZones[index], string))
-            return index;
-    }
-    return std::nullopt;
+    return intlResolveTimeZoneID(string);
 }
 
 template<typename CharType>

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -312,8 +312,6 @@ private:
 };
 static_assert(sizeof(PlainDate) == sizeof(int32_t));
 
-using TimeZone = Variant<TimeZoneID, int64_t>;
-
 class PlainYearMonth final {
     WTF_MAKE_TZONE_ALLOCATED(PlainYearMonth);
 public:

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -112,33 +112,6 @@ void IntlDateTimeFormat::setBoundFormat(VM& vm, JSBoundFunction* format)
     m_boundFormat.set(vm, this, format);
 }
 
-// https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier
-static String availableNamedTimeZoneIdentifier(StringView timeZoneName)
-{
-    UErrorCode status = U_ZERO_ERROR;
-    auto timeZones = std::unique_ptr<UEnumeration, ICUDeleter<uenum_close>>(ucal_openTimeZones(&status));
-    ASSERT(U_SUCCESS(status));
-
-    do {
-        status = U_ZERO_ERROR;
-        int32_t ianaTimeZoneLength;
-        // Time zone names are represented as char16_t[] in all related ICU APIs.
-        const char16_t* ianaTimeZone = uenum_unext(timeZones.get(), &ianaTimeZoneLength, &status);
-        ASSERT(U_SUCCESS(status));
-
-        // End of enumeration.
-        if (!ianaTimeZone)
-            break;
-
-        StringView ianaTimeZoneView(std::span(ianaTimeZone, ianaTimeZoneLength));
-        if (!equalIgnoringASCIICase(timeZoneName, ianaTimeZoneView) || isNonIANA(ianaTimeZoneView))
-            continue;
-        return ianaTimeZoneView.toString();
-    } while (true);
-
-    return String();
-}
-
 Vector<String> IntlDateTimeFormat::localeData(const String& locale, RelevantExtensionKey key)
 {
     Vector<String> keyLocaleData;
@@ -739,33 +712,24 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         tzValue = options->get(globalObject, vm.propertyNames->timeZone);
         RETURN_IF_EXCEPTION(scope, void());
     }
-    String tz;
-    String timeZoneForICU;
+    TimeZone tz;
     if (!tzValue.isUndefined()) {
         String originalTz = tzValue.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, void());
-        if (auto minutesValue = ISO8601::parseUTCOffsetInMinutes(originalTz)) {
-            int64_t minutes = minutesValue.value();
-            int64_t absMinutes = std::abs(minutes);
-            tz = makeString(minutes < 0 ? '-' : '+', pad('0', 2, absMinutes / 60), ':', pad('0', 2, absMinutes % 60));
-            timeZoneForICU = makeString("GMT"_s, minutes < 0 ? '-' : '+', pad('0', 2, absMinutes / 60), pad('0', 2, absMinutes % 60));
-        } else {
-            tz = availableNamedTimeZoneIdentifier(originalTz);
-            if (tz.isNull()) {
-                String message = tryMakeString("invalid time zone: "_s, originalTz);
-                if (!message)
-                    message = "invalid time zone"_s;
-                throwRangeError(globalObject, scope, message);
-                return;
-            }
+        if (auto minutesValue = ISO8601::parseUTCOffsetInMinutes(originalTz))
+            tz = TimeZone::fromUTCOffset(minutesValue.value() * 60LL * 1000 * 1000 * 1000);
+        else if (auto id = intlResolveTimeZoneID(originalTz))
+            tz = TimeZone::fromID(id.value());
+        else {
+            String message = tryMakeString("invalid time zone: "_s, originalTz);
+            if (!message)
+                message = "invalid time zone"_s;
+            throwRangeError(globalObject, scope, message);
+            return;
         }
     } else
         tz = vm.dateCache.defaultTimeZone();
     m_timeZone = tz;
-    if (!timeZoneForICU.isNull())
-        m_timeZoneForICU = WTF::move(timeZoneForICU);
-    else
-        m_timeZoneForICU = tz;
 
     Weekday weekday = intlOption<Weekday>(globalObject, options, vm.propertyNames->weekday, { { "narrow"_s, Weekday::Narrow }, { "short"_s, Weekday::Short }, { "long"_s, Weekday::Long } }, "weekday must be \"narrow\", \"short\", or \"long\""_s, Weekday::None);
     RETURN_IF_EXCEPTION(scope, void());
@@ -851,7 +815,8 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         // First, we create UDateFormat via dateStyle and timeStyle. And then convert it to pattern string.
         // After updating this pattern string with hourCycle, we create a final UDateFormat with the updated pattern string.
         UErrorCode status = U_ZERO_ERROR;
-        StringView timeZoneView(m_timeZoneForICU);
+        String timeZoneForICU = m_timeZone.toICUString();
+        StringView timeZoneView(timeZoneForICU);
         auto dateFormatFromStyle = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_open(parseUDateFormatStyle(m_timeStyle), parseUDateFormatStyle(m_dateStyle), dataLocaleWithExtensions.data(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), nullptr, -1, &status));
         if (U_FAILURE(status)) {
             throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
@@ -951,7 +916,8 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     dataLogLnIf(IntlDateTimeFormatInternal::verbose, "locale:(", m_locale, "),dataLocale:(", dataLocaleWithExtensions, "),pattern:(", pattern, ")");
 
     UErrorCode status = U_ZERO_ERROR;
-    StringView timeZoneView(m_timeZoneForICU);
+    String timeZoneForICU = m_timeZone.toICUString();
+    StringView timeZoneView(timeZoneForICU);
     m_dateFormat = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_open(UDAT_PATTERN, UDAT_PATTERN, dataLocaleWithExtensions.data(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), pattern.upconvertedCharacters(), pattern.length(), &status));
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
@@ -1183,7 +1149,7 @@ JSObject* IntlDateTimeFormat::resolvedOptions(JSGlobalObject* globalObject) cons
     options->putDirect(vm, vm.propertyNames->locale, jsNontrivialString(vm, m_locale));
     options->putDirect(vm, vm.propertyNames->calendar, jsNontrivialString(vm, m_calendar));
     options->putDirect(vm, vm.propertyNames->numberingSystem, jsNontrivialString(vm, m_numberingSystem));
-    options->putDirect(vm, vm.propertyNames->timeZone, jsNontrivialString(vm, m_timeZone));
+    options->putDirect(vm, vm.propertyNames->timeZone, jsNontrivialString(vm, m_timeZone.toString()));
 
     if (m_hourCycle != HourCycle::None) {
         options->putDirect(vm, vm.propertyNames->hourCycle, jsNontrivialString(vm, hourCycleString(m_hourCycle)));
@@ -1438,7 +1404,8 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
     CString dataLocaleWithExtensions = localeBuilder.toString().utf8();
 
     UErrorCode status = U_ZERO_ERROR;
-    StringView timeZoneView(m_timeZoneForICU);
+    String timeZoneForICU = m_timeZone.toICUString();
+    StringView timeZoneView(timeZoneForICU);
     m_dateIntervalFormat = std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter>(udtitvfmt_open(dataLocaleWithExtensions.data(), skeleton.span().data(), skeleton.size(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), &status));
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "failed to initialize DateIntervalFormat"_s);

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "ISO8601.h"
 #include "JSObject.h"
 #include <unicode/udat.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
@@ -133,8 +134,7 @@ private:
     String m_dataLocale;
     String m_calendar;
     String m_numberingSystem;
-    String m_timeZone;
-    String m_timeZoneForICU;
+    TimeZone m_timeZone;
     HourCycle m_hourCycle { HourCycle::None };
     Weekday m_weekday { Weekday::None };
     Era m_era { Era::None };

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -32,6 +32,7 @@
 #include "Error.h"
 #include "FunctionPrototype.h"
 #include "GlobalObjectMethodTable.h"
+#include "ISO8601.h"
 #include "IntlCollator.h"
 #include "IntlCollatorConstructor.h"
 #include "IntlCollatorPrototype.h"
@@ -69,10 +70,12 @@
 #include <unicode/uloc.h>
 #include <unicode/unumsys.h>
 #include <wtf/Assertions.h>
+#include <wtf/HashMap.h>
 #include <wtf/Language.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringHash.h>
 #include <wtf/text/StringImpl.h>
 #include <wtf/text/StringParsingBuffer.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
@@ -1909,8 +1912,44 @@ static std::optional<String> canonicalizeTimeZoneNameFromICUTimeZone(String&& ti
     return std::make_optional(WTF::move(timeZoneName));
 }
 
+// Map a known-valid IANA time zone ID to its primary IANA zone identifier. On ICU 74+,
+// ucal_getIanaTimeZoneID honors the IANA "Backward" links and returns up-to-date
+// names (e.g. "Asia/Calcutta" -> "Asia/Kolkata", "America/Buenos_Aires" ->
+// "America/Argentina/Buenos_Aires"). Older ICU falls back to CLDR's canonical
+// form. UTC-equivalent zones are normalized to "UTC" per ECMA-402.
+String toPrimaryIanaTimeZoneIdentifier(std::span<const char16_t> timeZone)
+{
+    Vector<char16_t, 32> buffer;
+#if U_ICU_VERSION_MAJOR_NUM >= 74
+    if (U_SUCCESS(callBufferProducingFunction(ucal_getIanaTimeZoneID, timeZone.data(), static_cast<int32_t>(timeZone.size()), buffer))) {
+        if (isUTCEquivalent(StringView(buffer.span())))
+            return "UTC"_s;
+        return String(buffer);
+    }
+    // ucal_getIanaTimeZoneID returns U_ILLEGAL_ARGUMENT_ERROR for "Etc/Unknown"; fall through.
+    buffer.clear();
+#endif
+    if (U_SUCCESS(callBufferProducingFunction(ucal_getCanonicalTimeZoneID, timeZone.data(), static_cast<int32_t>(timeZone.size()), buffer, nullptr))) {
+        if (isUTCEquivalent(StringView(buffer.span())))
+            return "UTC"_s;
+        return String(buffer);
+    }
+    return String(timeZone);
+}
+
+String toPrimaryIanaTimeZoneIdentifier(StringView timeZone)
+{
+    if (timeZone.is8Bit()) {
+        auto upconverted = timeZone.upconvertedCharacters();
+        return toPrimaryIanaTimeZoneIdentifier(upconverted.span());
+    }
+    return toPrimaryIanaTimeZoneIdentifier(timeZone.span16());
+}
+
 // https://tc39.es/ecma402/#sup-availablenamedtimezoneidentifiers
-const Vector<String>& intlAvailableTimeZones()
+// IANA primary time zone identifiers, indexed by TimeZoneID. This is the list
+// returned by Intl.supportedValuesOf("timeZone").
+static const Vector<String>& intlAvailableTimeZones()
 {
     static LazyNeverDestroyed<Vector<String>> availableTimeZones;
     static std::once_flag initializeOnce;
@@ -1928,10 +1967,15 @@ const Vector<String>& intlAvailableTimeZones()
             const char* pointer = uenum_next(enumeration.get(), &length, &status);
             ASSERT(U_SUCCESS(status));
             String timeZone(unsafeMakeSpan(pointer, static_cast<size_t>(length)));
-            if (isValidTimeZoneNameFromICUTimeZone(timeZone)) {
-                if (auto mapped = canonicalizeTimeZoneNameFromICUTimeZone(WTF::move(timeZone)))
-                    temporary.append(WTF::move(mapped.value()));
-            }
+            if (!isValidTimeZoneNameFromICUTimeZone(timeZone))
+                continue;
+            // UCAL_ZONE_TYPE_CANONICAL yields CLDR canonical IDs, which lag behind the IANA
+            // primary identifiers required by Intl.supportedValuesOf("timeZone")
+            // (e.g. "Asia/Calcutta" instead of "Asia/Kolkata"). Map each one to its IANA
+            // primary; duplicates collapse during the sort+unique step below.
+            String primary = toPrimaryIanaTimeZoneIdentifier(timeZone);
+            if (auto mapped = canonicalizeTimeZoneNameFromICUTimeZone(WTF::move(primary)))
+                temporary.append(WTF::move(mapped.value()));
         }
 
         // The AvailableTimeZones abstract operation returns a List, ordered as if an Array of the same
@@ -1952,15 +1996,125 @@ const Vector<String>& intlAvailableTimeZones()
     return availableTimeZones;
 }
 
+const String& intlTimeZoneIDToString(TimeZoneID id)
+{
+    return intlAvailableTimeZones()[id];
+}
+
+// Index from any accepted time zone string (case-insensitive) to the
+// TimeZoneID of its IANA primary. Multiple input forms (legacy IANA Backward
+// links, UTC-equivalent aliases, the primary itself) collapse onto the same
+// TimeZoneID. Built once on first use; the time zone list is fixed by the
+// linked ICU/CLDR version, so a fixed map is safe. Stored keys must be
+// immortal so the read-only map can be shared across VM threads — same
+// requirement that intlAvailableTimeZones() satisfies via createStaticStringImpl.
+static const HashMap<String, TimeZoneID, ASCIICaseInsensitiveHash>& intlAvailableTimeZoneIndex()
+{
+    static LazyNeverDestroyed<HashMap<String, TimeZoneID, ASCIICaseInsensitiveHash>> index;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [&] {
+        const auto& primaries = intlAvailableTimeZones();
+        HashMap<String, TimeZoneID, ASCIICaseInsensitiveHash> table;
+
+        // Primary identifiers from intlAvailableTimeZones() are already immortal
+        // static StringImpls, so reuse them directly as keys.
+        for (unsigned i = 0; i < primaries.size(); ++i)
+            table.add(primaries[i], i);
+
+        auto createImmortalThreadSafeString = [](StringView view) -> String {
+            if (view.is8Bit())
+                return StringImpl::createStaticStringImpl(view.span8());
+            return StringImpl::createStaticStringImpl(view.span16());
+        };
+
+        // Walk every ICU-known zone name (canonical + Backward links) so legacy
+        // inputs such as "Asia/Calcutta" or "America/Buenos_Aires" can resolve to
+        // their primary's TimeZoneID. Skip ICU's non-IANA legacy three-letter
+        // aliases ("ACT", "AET", ...) for the same reason availableNamedTimeZone-
+        // Identifier did before.
+        UErrorCode status = U_ZERO_ERROR;
+        auto enumeration = std::unique_ptr<UEnumeration, ICUDeleter<uenum_close>>(ucal_openTimeZones(&status));
+        ASSERT(U_SUCCESS(status));
+        while (true) {
+            status = U_ZERO_ERROR;
+            int32_t length = 0;
+            const char16_t* name = uenum_unext(enumeration.get(), &length, &status);
+            ASSERT(U_SUCCESS(status));
+            if (!name)
+                break;
+            std::span nameSpan { name, static_cast<size_t>(length) };
+            StringView nameView(nameSpan);
+            if (isNonIANA(nameView))
+                continue;
+            // Skip names already keyed as a primary; avoids allocating a
+            // duplicate static string.
+            if (table.find<ASCIICaseInsensitiveStringViewHashTranslator>(nameView) != table.end())
+                continue;
+            String primary = toPrimaryIanaTimeZoneIdentifier(nameSpan);
+            if (primary.isNull())
+                continue;
+            auto primaryEntry = table.find(primary);
+            if (primaryEntry == table.end())
+                continue;
+            table.add(createImmortalThreadSafeString(nameView), primaryEntry->value);
+        }
+
+        index.construct(WTF::move(table));
+    });
+    return index.get();
+}
+
+std::optional<TimeZoneID> intlResolveTimeZoneID(StringView name)
+{
+    const auto& index = intlAvailableTimeZoneIndex();
+    auto entry = index.find<ASCIICaseInsensitiveStringViewHashTranslator>(name);
+    if (entry == index.end())
+        return std::nullopt;
+    return entry->value;
+}
+
+// https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier
+String availableNamedTimeZoneIdentifier(StringView timeZoneName)
+{
+    auto id = intlResolveTimeZoneID(timeZoneName);
+    if (!id)
+        return String();
+    return intlTimeZoneIDToString(*id);
+}
+
+String TimeZone::toString() const
+{
+    if (isID())
+        return intlTimeZoneIDToString(m_id);
+    if (!m_offset)
+        return intlTimeZoneIDToString(utcTimeZoneID());
+    return ISO8601::formatTimeZoneOffsetString(m_offset);
+}
+
+String TimeZone::toICUString() const
+{
+    if (isID())
+        return intlTimeZoneIDToString(m_id);
+    if (!m_offset)
+        return intlTimeZoneIDToString(utcTimeZoneID());
+    // ICU expects offsets in "GMT[+-]HHMM" form, no colon, four digits.
+    int64_t offset = m_offset;
+    bool negative = offset < 0;
+    if (negative)
+        offset = -offset;
+    constexpr int64_t nsPerMinute = 1000LL * 1000 * 1000 * 60;
+    int64_t totalMinutes = offset / nsPerMinute;
+    return makeString("GMT"_s, negative ? '-' : '+', pad('0', 2, totalMinutes / 60), pad('0', 2, totalMinutes % 60));
+}
+
 TimeZoneID utcTimeZoneIDStorage { std::numeric_limits<TimeZoneID>::max() };
 TimeZoneID utcTimeZoneIDSlow()
 {
     static std::once_flag initializeOnce;
     std::call_once(initializeOnce, [&] {
-        auto& timeZones = intlAvailableTimeZones();
-        auto index = timeZones.find("UTC"_s);
-        RELEASE_ASSERT(index != WTF::notFound);
-        utcTimeZoneIDStorage = index;
+        auto id = intlResolveTimeZoneID("UTC"_s);
+        RELEASE_ASSERT(id);
+        utcTimeZoneIDStorage = *id;
     });
     return utcTimeZoneIDStorage;
 }

--- a/Source/JavaScriptCore/runtime/IntlObject.h
+++ b/Source/JavaScriptCore/runtime/IntlObject.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/JSCTimeZone.h>
 #include <JavaScriptCore/JSObject.h>
 #include <wtf/RobinHoodHashSet.h>
 
@@ -115,12 +116,25 @@ inline CalendarID iso8601CalendarID()
     return value;
 }
 
-using TimeZoneID = unsigned;
-const Vector<String>& intlAvailableTimeZones();
+// Resolve any accepted time zone string (case-insensitive; accepts IANA primary
+// identifiers, IANA Backward links such as "Asia/Calcutta", and UTC-equivalent
+// aliases such as "GMT" / "Etc/UTC") to the TimeZoneID of its IANA primary,
+// or std::nullopt if the input is not a recognized IANA zone. Multiple input
+// forms collapse to the same TimeZoneID.
+JS_EXPORT_PRIVATE std::optional<TimeZoneID> intlResolveTimeZoneID(StringView);
 
-extern TimeZoneID utcTimeZoneIDStorage;
-TimeZoneID utcTimeZoneIDSlow();
-CalendarID utcTimeZoneID();
+// Map a known-valid IANA time zone ID to its primary IANA zone identifier,
+// using ICU 74's ucal_getIanaTimeZoneID when available and falling back to
+// ucal_getCanonicalTimeZoneID otherwise. UTC-equivalent zones are normalized
+// to "UTC" per ECMA-402.
+JS_EXPORT_PRIVATE String toPrimaryIanaTimeZoneIdentifier(std::span<const char16_t> timeZone);
+JS_EXPORT_PRIVATE String toPrimaryIanaTimeZoneIdentifier(StringView timeZone);
+
+// https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier
+// Look up timeZoneName case-insensitively against ICU's full time zone list
+// (canonical + Backward links) and return the matched zone's IANA primary
+// identifier, or a null String if the name is not a recognized IANA zone.
+JS_EXPORT_PRIVATE String availableNamedTimeZoneIdentifier(StringView timeZoneName);
 
 TriState intlBooleanOption(JSGlobalObject*, JSObject* options, PropertyName);
 String intlStringOption(JSGlobalObject*, JSObject* options, PropertyName, std::initializer_list<ASCIILiteral> values, ASCIILiteral notFound, ASCIILiteral fallback);
@@ -170,14 +184,5 @@ struct UFieldPositionIteratorDeleter {
 std::optional<String> mapICUCollationKeywordToBCP47(const String&);
 std::optional<String> mapICUCalendarKeywordToBCP47(const String&);
 std::optional<String> mapBCP47ToICUCalendarKeyword(const String&);
-
-
-inline CalendarID utcTimeZoneID()
-{
-    unsigned value = utcTimeZoneIDStorage;
-    if (value == std::numeric_limits<TimeZoneID>::max())
-        return utcTimeZoneIDSlow();
-    return value;
-}
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSCTimeZone.h
+++ b/Source/JavaScriptCore/runtime/JSCTimeZone.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/JSExportMacros.h>
+#include <cstdint>
+#include <limits>
+#include <wtf/Assertions.h>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+
+using TimeZoneID = unsigned;
+
+extern JS_EXPORT_PRIVATE TimeZoneID utcTimeZoneIDStorage;
+JS_EXPORT_PRIVATE TimeZoneID utcTimeZoneIDSlow();
+
+inline TimeZoneID utcTimeZoneID()
+{
+    unsigned value = utcTimeZoneIDStorage;
+    if (value == std::numeric_limits<TimeZoneID>::max())
+        return utcTimeZoneIDSlow();
+    return value;
+}
+
+// Look up the IANA primary identifier for a TimeZoneID. id must have been
+// produced by intlResolveTimeZoneID() or utcTimeZoneID().
+JS_EXPORT_PRIVATE const String& intlTimeZoneIDToString(TimeZoneID);
+
+class TimeZone final {
+public:
+    TimeZone()
+        : TimeZone(utcTimeZoneID(), 0)
+    {
+    }
+
+    static TimeZone fromID(TimeZoneID id) { return TimeZone(id, 0); }
+    static TimeZone fromUTCOffset(int64_t offsetNanoseconds) { return TimeZone(utcTimeZoneID(), offsetNanoseconds); }
+
+    bool isUTCOffset() const { return m_id == utcTimeZoneID(); }
+    bool isID() const { return !isUTCOffset(); }
+
+    TimeZoneID id() const { ASSERT(isID()); return m_id; }
+    int64_t utcOffsetNanoseconds() const { ASSERT(isUTCOffset()); return m_offset; }
+
+    // IANA primary identifier for non-UTC named zones, "UTC" for offset 0, or formatted
+    // "+HH:MM[:SS[.fff...]]" for non-zero UTC offsets.
+    JS_EXPORT_PRIVATE String toString() const;
+
+    // ICU accepts named identifiers as-is, and offsets only in "GMT+HHMM" form.
+    JS_EXPORT_PRIVATE String toICUString() const;
+
+    friend bool operator==(const TimeZone&, const TimeZone&) = default;
+
+private:
+    constexpr TimeZone(TimeZoneID id, int64_t offset) : m_id(id), m_offset(offset) { }
+
+    TimeZoneID m_id { };
+    int64_t m_offset { };
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -73,6 +73,8 @@
 #include "JSDateMath.h"
 
 #include "ExceptionHelpers.h"
+#include "ISO8601.h"
+#include "IntlObject.h"
 #include "VM.h"
 #include <limits>
 #include <wtf/DateMath.h>
@@ -100,7 +102,7 @@ class OpaqueICUTimeZone {
     WTF_MAKE_TZONE_ALLOCATED(OpaqueICUTimeZone);
 public:
     std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> m_calendar;
-    String m_canonicalTimeZoneID;
+    TimeZone m_canonicalTimeZone;
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(OpaqueICUTimeZone);
@@ -425,9 +427,9 @@ double DateCache::parseDate(JSGlobalObject* globalObject, VM& vm, const String& 
 }
 
 // https://tc39.es/ecma402/#sec-defaulttimezone
-String DateCache::defaultTimeZone()
+TimeZone DateCache::defaultTimeZone()
 {
-    return timeZoneCache()->m_canonicalTimeZoneID;
+    return timeZoneCache()->m_canonicalTimeZone;
 }
 
 String DateCache::timeZoneDisplayName(bool isDST)
@@ -475,38 +477,38 @@ DateCache::DateCache()
 #endif
 }
 
-static std::tuple<String, Vector<char16_t, 32>> retrieveTimeZoneInformation()
+static TimeZone retrieveTimeZoneInformation()
 {
     Locker locker { timeZoneCacheLock };
-    static NeverDestroyed<std::tuple<String, Vector<char16_t, 32>, uint64_t>> globalCache;
+    static NeverDestroyed<std::tuple<TimeZone, uint64_t>> globalCache;
 
     bool isCacheStale = true;
     uint64_t currentID = 0;
 #if PLATFORM(COCOA)
     currentID = lastTimeZoneID.load();
-    isCacheStale = std::get<2>(globalCache.get()) != currentID;
+    isCacheStale = std::get<1>(globalCache.get()) != currentID;
 #endif
     if (isCacheStale) {
         Vector<char16_t, 32> timeZoneID;
         getTimeZoneOverride(timeZoneID);
-        String canonical;
+        TimeZone canonical;
         UErrorCode status = U_ZERO_ERROR;
         if (timeZoneID.isEmpty()) {
             status = callBufferProducingFunction(ucal_getHostTimeZone, timeZoneID);
             ASSERT_UNUSED(status, U_SUCCESS(status));
         }
         if (U_SUCCESS(status)) {
-            Vector<char16_t, 32> canonicalBuffer;
-            auto status = callBufferProducingFunction(ucal_getCanonicalTimeZoneID, timeZoneID.mutableSpan().data(), timeZoneID.size(), canonicalBuffer, nullptr);
-            if (U_SUCCESS(status))
-                canonical = String(canonicalBuffer);
+            // Resolve through intlResolveTimeZoneID so the host TZ collapses onto its IANA
+            // primary identifier (e.g. "Asia/Calcutta" -> "Asia/Kolkata") and UTC-equivalent
+            // names map to the UTC TimeZoneID.
+            String primary = toPrimaryIanaTimeZoneIdentifier(timeZoneID.span());
+            if (auto id = intlResolveTimeZoneID(primary))
+                canonical = TimeZone::fromID(id.value());
         }
-        if (canonical.isNull() || isUTCEquivalent(canonical))
-            canonical = "UTC"_s;
 
-        globalCache.get() = std::tuple { canonical.isolatedCopy(), WTF::move(timeZoneID), currentID };
+        globalCache.get() = std::tuple { canonical, currentID };
     }
-    return std::tuple { std::get<0>(globalCache.get()).isolatedCopy(), std::get<1>(globalCache.get()) };
+    return std::get<0>(globalCache.get());
 }
 
 DateCache::~DateCache() = default;
@@ -519,11 +521,14 @@ Ref<DateInstanceData> DateCache::cachedDateInstanceData(double millisecondsFromE
 void DateCache::timeZoneCacheSlow()
 {
     ASSERT(!m_timeZoneCache);
-    auto [canonical, timeZoneID] = retrieveTimeZoneInformation();
+    TimeZone canonical = retrieveTimeZoneInformation();
+    String timeZoneForICU = canonical.toICUString();
+    StringView timeZoneView(timeZoneForICU);
+    auto upconverted = timeZoneView.upconvertedCharacters();
     auto* cache = new OpaqueICUTimeZone;
-    cache->m_canonicalTimeZoneID = WTF::move(canonical);
+    cache->m_canonicalTimeZone = canonical;
     UErrorCode status = U_ZERO_ERROR;
-    cache->m_calendar = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_open(timeZoneID.span().data(), timeZoneID.size(), "", UCAL_DEFAULT, &status));
+    cache->m_calendar = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_open(upconverted, timeZoneView.length(), "", UCAL_DEFAULT, &status));
     ASSERT_UNUSED(status, U_SUCCESS(status));
     ucal_setGregorianChange(cache->m_calendar.get(), minECMAScriptTime, &status); // Ignore "unsupported" error.
     m_timeZoneCache = std::unique_ptr<OpaqueICUTimeZone, OpaqueICUTimeZoneDeleter>(cache);

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -44,6 +44,7 @@
 #pragma once
 
 #include <JavaScriptCore/DateInstanceCache.h>
+#include <JavaScriptCore/JSCTimeZone.h>
 #include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/Compiler.h>
 #include <wtf/DateMath.h>
@@ -112,7 +113,7 @@ public:
 
     JS_EXPORT_PRIVATE void resetIfNecessarySlow();
 
-    String defaultTimeZone();
+    TimeZone defaultTimeZone();
     String timeZoneDisplayName(bool isDST);
     Ref<DateInstanceData> NODELETE cachedDateInstanceData(double millisecondsFromEpoch);
 

--- a/Source/JavaScriptCore/runtime/TemporalNow.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalNow.cpp
@@ -85,7 +85,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalNowFuncInstant, (JSGlobalObject* globalObject, 
 JSC_DEFINE_HOST_FUNCTION(temporalNowFuncTimeZoneId, (JSGlobalObject* globalObject, CallFrame*))
 {
     VM& vm = globalObject->vm();
-    return JSValue::encode(jsNontrivialString(vm, vm.dateCache.defaultTimeZone()));
+    return JSValue::encode(jsNontrivialString(vm, vm.dateCache.defaultTimeZone().toString()));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalTimeZone.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZone.cpp
@@ -33,16 +33,9 @@ namespace JSC {
 
 const ClassInfo TemporalTimeZone::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TemporalTimeZone) };
 
-TemporalTimeZone* TemporalTimeZone::createFromID(VM& vm, Structure* structure, TimeZoneID identifier)
+TemporalTimeZone* TemporalTimeZone::create(VM& vm, Structure* structure, TimeZone timeZone)
 {
-    TemporalTimeZone* format = new (NotNull, allocateCell<TemporalTimeZone>(vm)) TemporalTimeZone(vm, structure, TimeZone { WTF::InPlaceIndexT<0>(), identifier });
-    format->finishCreation(vm);
-    return format;
-}
-
-TemporalTimeZone* TemporalTimeZone::createFromUTCOffset(VM& vm, Structure* structure, int64_t utcOffset)
-{
-    TemporalTimeZone* format = new (NotNull, allocateCell<TemporalTimeZone>(vm)) TemporalTimeZone(vm, structure, TimeZone { WTF::InPlaceIndexT<1>(), utcOffset });
+    TemporalTimeZone* format = new (NotNull, allocateCell<TemporalTimeZone>(vm)) TemporalTimeZone(vm, structure, timeZone);
     format->finishCreation(vm);
     return format;
 }
@@ -98,15 +91,15 @@ JSObject* TemporalTimeZone::from(JSGlobalObject* globalObject, JSValue timeZoneL
 
     std::optional<int64_t> utcOffset = ISO8601::parseUTCOffset(timeZoneString);
     if (utcOffset)
-        return TemporalTimeZone::createFromUTCOffset(vm, globalObject->timeZoneStructure(), utcOffset.value());
+        return TemporalTimeZone::create(vm, globalObject->timeZoneStructure(), TimeZone::fromUTCOffset(utcOffset.value()));
 
     std::optional<TimeZoneID> identifier = ISO8601::parseTimeZoneName(timeZoneString);
     if (identifier)
-        return TemporalTimeZone::createFromID(vm, globalObject->timeZoneStructure(), identifier.value());
+        return TemporalTimeZone::create(vm, globalObject->timeZoneStructure(), TimeZone::fromID(identifier.value()));
 
     std::optional<int64_t> utcOffsetFromInstant = parseTemporalTimeZoneString(timeZoneString);
     if (utcOffsetFromInstant)
-        return TemporalTimeZone::createFromUTCOffset(vm, globalObject->timeZoneStructure(), utcOffsetFromInstant.value());
+        return TemporalTimeZone::create(vm, globalObject->timeZoneStructure(), TimeZone::fromUTCOffset(utcOffsetFromInstant.value()));
 
     throwRangeError(globalObject, scope, "argument needs to be UTC offset string, TimeZone identifier, or temporal Instant string"_s);
     return { };

--- a/Source/JavaScriptCore/runtime/TemporalTimeZone.h
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZone.h
@@ -41,13 +41,10 @@ public:
         return vm.temporalTimeZoneSpace<mode>();
     }
 
-    static TemporalTimeZone* createFromID(VM&, Structure*, TimeZoneID);
-    static TemporalTimeZone* createFromUTCOffset(VM&, Structure*, int64_t);
+    static TemporalTimeZone* create(VM&, Structure*, TimeZone);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;
-
-    using TimeZone = ISO8601::TimeZone;
 
     TimeZone timeZone() const { return m_timeZone; }
 
@@ -56,7 +53,6 @@ public:
 private:
     TemporalTimeZone(VM&, Structure*, TimeZone);
 
-    // TimeZoneID or UTC offset.
     TimeZone m_timeZone;
 };
 

--- a/Source/JavaScriptCore/runtime/TemporalTimeZoneConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZoneConstructor.cpp
@@ -91,14 +91,14 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalTimeZone, (JSGlobalObject* globalObjec
 
     std::optional<int64_t> utcOffset = ISO8601::parseUTCOffset(timeZoneString);
     if (utcOffset)
-        return JSValue::encode(TemporalTimeZone::createFromUTCOffset(vm, structure, utcOffset.value()));
+        return JSValue::encode(TemporalTimeZone::create(vm, structure, TimeZone::fromUTCOffset(utcOffset.value())));
 
     std::optional<TimeZoneID> identifier = ISO8601::parseTimeZoneName(timeZoneString);
     if (!identifier) {
         throwRangeError(globalObject, scope, "argument needs to be UTC offset string or TimeZone identifier"_s);
         return { };
     }
-    return JSValue::encode(TemporalTimeZone::createFromID(vm, structure, identifier.value()));
+    return JSValue::encode(TemporalTimeZone::create(vm, structure, TimeZone::fromID(identifier.value())));
 }
 
 JSC_DEFINE_HOST_FUNCTION(callTemporalTimeZone, (JSGlobalObject* globalObject, CallFrame*))

--- a/Source/JavaScriptCore/runtime/TemporalTimeZonePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZonePrototype.cpp
@@ -93,15 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalTimeZonePrototypeFuncToString, (JSGlobalObject*
     if (!timeZone)
         return throwVMTypeError(globalObject, scope, "Temporal.TimeZone.prototype.toString called on value that's not a TimeZone"_s);
 
-    auto variant = timeZone->timeZone();
-    auto string = WTF::switchOn(variant,
-        [](TimeZoneID identifier) -> String {
-            return intlAvailableTimeZones()[identifier];
-        },
-        [](int64_t offset) -> String {
-            return ISO8601::formatTimeZoneOffsetString(offset);
-        });
-    return JSValue::encode(jsString(vm, WTF::move(string)));
+    return JSValue::encode(jsString(vm, timeZone->timeZone().toString()));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.tojson


### PR DESCRIPTION
#### e6fae9eeaf4e6f45efc031ac1ee487daa657b392
<pre>
[JSC] Introduce Canonicalized TimeZone mechanism
<a href="https://bugs.webkit.org/show_bug.cgi?id=312699">https://bugs.webkit.org/show_bug.cgi?id=312699</a>
<a href="https://rdar.apple.com/175098682">rdar://175098682</a>

Reviewed by Sosuke Suzuki.

This patch adds canonicalized TimeZone mechanism. We add a new class
JSC::TimeZone, which holds TimeZoneID and offset. So this can represent
canonicalized TimeZone throughout JSC code.

We start using ucal_getIanaTimeZoneID (which is available from ICU 74),
which can generate primary IANA TimeZone ID instead of legacy ID
primarily used inside ICU. So,

1. Internally TimeZoneID is mapped to primary IANA IDs. So this
   represents the canonicalized ID.
2. But we still keep accepting various legacy ID correctly. And then we
   map the result to the canonicalized ID via
   intlAvailableTimeZoneIndex.

Tests: JSTests/complex/intl-default-timezone-backward-link.js
       JSTests/complex/intl-default-timezone-etc-gmt-offset.js
       JSTests/complex/intl-default-timezone-etc-unknown.js
       JSTests/complex/intl-default-timezone-posix.js
       JSTests/complex/intl-default-timezone-region-alias.js
       JSTests/complex/intl-default-timezone-three-letter-alias.js
       JSTests/complex/intl-default-timezone-utc-alias.js
       JSTests/stress/intl-canonical-iana-time-zone.js

* JSTests/complex.yaml:
* JSTests/complex/intl-default-timezone-backward-link.js: Added.
(shouldBe):
* JSTests/complex/intl-default-timezone-etc-gmt-offset.js: Added.
(shouldBe):
* JSTests/complex/intl-default-timezone-etc-unknown.js: Added.
(shouldBe):
* JSTests/complex/intl-default-timezone-region-alias.js: Added.
(shouldBe):
* JSTests/complex/intl-default-timezone-three-letter-alias.js: Added.
(shouldBe):
* JSTests/complex/intl-default-timezone-utc-alias.js: Added.
(shouldBe):
* JSTests/stress/intl-canonical-gmt.js:
* JSTests/stress/intl-canonical-iana-time-zone.js: Added.
(shouldBe):
(shouldBeTrue):
(shouldBeFalse):
(resolved):
(fmt):
* JSTests/stress/intl-datetimeformat.js:
* JSTests/stress/temporal-timezone.js:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseTimeZoneName):
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):
(JSC::IntlDateTimeFormat::resolvedOptions const):
(JSC::IntlDateTimeFormat::createDateIntervalFormatIfNecessary):
(JSC::availableNamedTimeZoneIdentifier): Deleted.
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.h:
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::toPrimaryIanaTimeZoneIdentifier):
(JSC::intlAvailableTimeZones):
(JSC::intlTimeZoneIDToString):
(JSC::intlAvailableTimeZoneIndex):
(JSC::intlResolveTimeZoneID):
(JSC::availableNamedTimeZoneIdentifier):
(JSC::TimeZone::toString const):
(JSC::TimeZone::toICUString const):
(JSC::utcTimeZoneIDSlow):
* Source/JavaScriptCore/runtime/IntlObject.h:
(JSC::utcTimeZoneID): Deleted.
* Source/JavaScriptCore/runtime/JSCTimeZone.h: Added.
(JSC::utcTimeZoneID):
* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::DateCache::defaultTimeZone):
(JSC::retrieveTimeZoneInformation):
(JSC::DateCache::timeZoneCacheSlow):
* Source/JavaScriptCore/runtime/JSDateMath.h:
* Source/JavaScriptCore/runtime/TemporalNow.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalTimeZone.cpp:
(JSC::TemporalTimeZone::create):
(JSC::TemporalTimeZone::from):
(JSC::TemporalTimeZone::createFromID): Deleted.
(JSC::TemporalTimeZone::createFromUTCOffset): Deleted.
* Source/JavaScriptCore/runtime/TemporalTimeZone.h:
* Source/JavaScriptCore/runtime/TemporalTimeZoneConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalTimeZonePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/311604@main">https://commits.webkit.org/311604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/987cdff66fe0681f80e74a812978af823574fbf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166194 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111452 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b632990-4b55-485c-9689-4424803febab) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121887 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85595 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/746c79cb-c25d-47a7-8b60-a9b96928bfc8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102555 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d9d210a-ea20-4d5d-bbf4-8563c06dafbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23188 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21436 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13965 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149421 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168679 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18205 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12837 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20757 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130023 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130130 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140931 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88162 "Hash 987cdff6 for PR 63050 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23946 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24952 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17736 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189391 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93956 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48648 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29464 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29694 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29591 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->