### PR TITLE
[JSC] Refine clobberize rule for `ArrayIsArray`

### DIFF
--- a/JSTests/microbenchmarks/array-is-array-cse.js
+++ b/JSTests/microbenchmarks/array-is-array-cse.js
@@ -1,0 +1,20 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
+function test(x)
+{
+    let r = 0;
+    r += Array.isArray(x) ? 1 : 0;
+    r += Array.isArray(x) ? 1 : 0;
+    r += Array.isArray(x) ? 1 : 0;
+    r += Array.isArray(x) ? 1 : 0;
+    r += Array.isArray(x) ? 1 : 0;
+    r += Array.isArray(x) ? 1 : 0;
+    r += Array.isArray(x) ? 1 : 0;
+    r += Array.isArray(x) ? 1 : 0;
+    return r;
+}
+noInline(test);
+
+let inputs = [[1, 2, 3], { length: 3 }, "abc", 42];
+for (let i = 0; i < 1e6; ++i)
+    test(inputs[i & 3]);

--- a/JSTests/stress/array-is-array-clobberize.js
+++ b/JSTests/stress/array-is-array-clobberize.js
@@ -1,0 +1,109 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(fn, errorType) {
+    let threw = false;
+    try {
+        fn();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof errorType))
+            throw new Error(`expected ${errorType.name} but got ${e}`);
+    }
+    if (!threw)
+        throw new Error("did not throw");
+}
+
+// CSE: redundant Array.isArray calls on the same value should produce the same result.
+(function testCSE() {
+    function go(x) {
+        let a = Array.isArray(x);
+        let b = Array.isArray(x);
+        let c = Array.isArray(x);
+        return (a ? 1 : 0) + (b ? 1 : 0) + (c ? 1 : 0);
+    }
+    noInline(go);
+
+    let arr = [1];
+    let obj = {};
+    let proxy = new Proxy([1], {});
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBe(go(arr), 3);
+        shouldBe(go(obj), 0);
+        shouldBe(go(42), 0);
+        shouldBe(go(proxy), 3);
+    }
+})();
+
+// ArrayIsArray must not clobber loads. obj.x should still be 1 after Array.isArray.
+(function testNoClobber() {
+    function go(x, obj) {
+        let v = obj.x;
+        let r = Array.isArray(x);
+        return v + obj.x + (r ? 100 : 0);
+    }
+    noInline(go);
+
+    let obj = { x: 1 };
+    let arr = [1];
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBe(go(arr, obj), 102);
+        shouldBe(go(obj, obj), 2);
+    }
+})();
+
+// Revoked proxy must still throw, and must not be incorrectly CSE'd across the
+// revoke() call (which is a normal Call node and clobbers MiscFields).
+(function testRevokedProxy() {
+    function go(x) {
+        return Array.isArray(x);
+    }
+    noInline(go);
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        let { proxy, revoke } = Proxy.revocable([1], {});
+        shouldBe(go(proxy), true);
+        revoke();
+        shouldThrow(() => go(proxy), TypeError);
+    }
+})();
+
+// Same-block CSE must observe revocation done by an effectful call between checks.
+(function testNoCSEAcrossRevoke() {
+    function go(x, revoke) {
+        let a = Array.isArray(x);
+        revoke();
+        let b = Array.isArray(x);
+        return a && b;
+    }
+    noInline(go);
+
+    let nopRevoke = () => {};
+    for (let i = 0; i < testLoopCount; ++i) {
+        let { proxy, revoke } = Proxy.revocable([1], {});
+        if (i & 1) {
+            shouldThrow(() => go(proxy, revoke), TypeError);
+        } else {
+            shouldBe(go(proxy, nopRevoke), true);
+            revoke();
+        }
+    }
+})();
+
+// Derived arrays.
+(function testDerivedArray() {
+    class Derived extends Array {}
+    function go(x) {
+        return Array.isArray(x) && Array.isArray(x);
+    }
+    noInline(go);
+
+    let d = new Derived();
+    let o = {};
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBe(go(d), true);
+        shouldBe(go(o), false);
+    }
+})();

--- a/JSTests/stress/array-is-array-proxy-effects.js
+++ b/JSTests/stress/array-is-array-proxy-effects.js
@@ -1,0 +1,83 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(fn, errorType) {
+    let threw = false;
+    try {
+        fn();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof errorType))
+            throw new Error(`expected ${errorType.name} but got ${e}`);
+    }
+    if (!threw)
+        throw new Error("did not throw");
+}
+
+// IsArray must not invoke any Proxy trap. This is the core assumption that makes
+// the refined clobberize rule sound (no arbitrary JS execution).
+(function testNoTrapInvocation() {
+    let trapCalled = false;
+    let handler = new Proxy({}, {
+        get() { trapCalled = true; return undefined; }
+    });
+    let proxy = new Proxy([1], handler);
+    function go(x) {
+        return Array.isArray(x) && Array.isArray(x);
+    }
+    noInline(go);
+
+    for (let i = 0; i < testLoopCount; ++i)
+        shouldBe(go(proxy), true);
+    shouldBe(trapCalled, false);
+})();
+
+// Nested proxies, including a revoked proxy mid-chain.
+(function testNestedProxy() {
+    function go(x) {
+        return Array.isArray(x);
+    }
+    noInline(go);
+
+    let deep = [1];
+    for (let i = 0; i < 10; ++i)
+        deep = new Proxy(deep, {});
+    let { proxy: inner, revoke } = Proxy.revocable([1], {});
+    let outer = new Proxy(inner, {});
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBe(go(deep), true);
+        shouldBe(go(outer), true);
+    }
+    revoke();
+    shouldThrow(() => go(outer), TypeError);
+})();
+
+// write(SideState) must prevent LICM from hoisting a potentially-throwing
+// ArrayIsArray past control flow that guards it.
+(function testNoHoistPastGuard() {
+    function go(x, cond, n) {
+        let r = 0;
+        for (let i = 0; i < n; ++i) {
+            if (cond)
+                r += Array.isArray(x) ? 1 : 0;
+        }
+        return r;
+    }
+    noInline(go);
+
+    let arr = [1];
+    let obj = {};
+    for (let i = 0; i < testLoopCount; ++i) {
+        go(arr, true, 10);
+        go(obj, true, 10);
+    }
+    let { proxy, revoke } = Proxy.revocable([1], {});
+    revoke();
+    // cond=false: must not throw even though x is a revoked proxy.
+    shouldBe(go(proxy, false, 100), 0);
+    // cond=true: must throw on first iteration.
+    shouldThrow(() => go(proxy, true, 100), TypeError);
+})();

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2098,34 +2098,28 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         AbstractValue& child = forNode(node->child1());
         if (JSValue v = child.value()) {
             if (!v.isCell()) {
-                didFoldClobberWorld();
                 setConstant(node, jsBoolean(false));
                 break;
             }
             JSType type = v.asCell()->type();
             if (type == ArrayType || type == DerivedArrayType) {
-                didFoldClobberWorld();
                 setConstant(node, jsBoolean(true));
                 break;
             }
             if (type != ProxyObjectType) {
-                didFoldClobberWorld();
                 setConstant(node, jsBoolean(false));
                 break;
             }
         } else {
             if (!(child.m_type & (SpecArray | SpecDerivedArray | SpecProxyObject))) {
-                didFoldClobberWorld();
                 setConstant(node, jsBoolean(false));
                 break;
             }
             if (!(child.m_type & ~(SpecArray | SpecDerivedArray))) {
-                didFoldClobberWorld();
                 setConstant(node, jsBoolean(true));
                 break;
             }
         }
-        clobberWorld();
         setNonCellTypeForNode(node, SpecBoolean);
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -680,7 +680,9 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case ArrayIsArray:
-        clobberTop();
+        read(MiscFields);
+        write(SideState);
+        def(HeapLocation(ArrayIsArrayLoc, MiscFields, node->child1()), LazyNode(node));
         return;
 
     case MatchStructure:

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.h
@@ -67,6 +67,7 @@ enum LocationKind {
     InvalidationPointLoc,
     IsCallableLoc,
     IsConstructorLoc,
+    ArrayIsArrayLoc,
     TypeOfIsObjectLoc,
     TypeOfIsFunctionLoc,
     NamedPropertyLoc,


### PR DESCRIPTION
#### bc02c09f91bbf76ce60c324268bce9be26dbb583
<pre>
[JSC] Refine clobberize rule for `ArrayIsArray`
<a href="https://bugs.webkit.org/show_bug.cgi?id=312700">https://bugs.webkit.org/show_bug.cgi?id=312700</a>

Reviewed by Yusuke Suzuki.

ArrayIsArray was falling through to clobberTop(), preventing CSE and
invalidating all structure information around every Array.isArray() call.

Per spec, IsArray never invokes user JS[1]: it reads the immutable JSCell type,
and for ProxyObject walks the immutable [[ProxyTarget]] chain checking only
whether [[ProxyHandler]] is null. No proxy trap is defined for IsArray. The
only side effect is a TypeError when a revoked proxy is encountered.

This patch gives ArrayIsArray a precise rule:
- read(MiscFields): the proxy handler slot is mutated only by
  ProxyObject::revoke(), whose sole caller is the performProxyRevoke host
  function. As a Call node it clobbers Heap (which includes MiscFields),
  so a revoke between two ArrayIsArray nodes correctly kills the def.
- write(SideState): models the conditional throw so LICM won&apos;t hoist the
  node past a guarding branch and throw on an otherwise-unreached path.
- def(ArrayIsArrayLoc): enables CSE of redundant checks on the same value,
  matching the IsCallable / IsConstructor pattern.

The abstract interpreter no longer calls clobberWorld() since the node
writes neither Heap nor JSCell_structureID.

                            TipOfTree                  Patched

array-is-array-cse        5.7308+-0.1379     ^      3.2529+-0.2866        ^ definitely 1.7617x faster

[1]: <a href="https://tc39.es/ecma262/#sec-isarray">https://tc39.es/ecma262/#sec-isarray</a>

Tests: JSTests/microbenchmarks/array-is-array-cse.js
       JSTests/stress/array-is-array-clobberize.js
       JSTests/stress/array-is-array-proxy-effects.js

* JSTests/microbenchmarks/array-is-array-cse.js: Added.
(test):
* JSTests/stress/array-is-array-clobberize.js: Added.
(shouldBe):
(shouldThrow):
(testCSE.go):
(testCSE):
(testNoClobber.go):
(testNoClobber):
(testRevokedProxy.go):
(testRevokedProxy):
(testNoCSEAcrossRevoke.go):
(testDerivedArray.Derived):
(testDerivedArray.go):
(testDerivedArray):
* JSTests/stress/array-is-array-proxy-effects.js: Added.
(shouldBe):
(shouldThrow):
(testNoTrapInvocation.go):
(testNestedProxy.go):
(testNestedProxy):
(testNoHoistPastGuard.go):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGHeapLocation.h:

Canonical link: <a href="https://commits.webkit.org/311553@main">https://commits.webkit.org/311553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0777e9817814c297b4f651cd9b42cb3363ee933

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111359 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121804 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85521 "3 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23104 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21352 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13872 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149327 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168586 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18112 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12744 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129937 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130045 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35237 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140848 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88006 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17653 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29849 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93863 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48565 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29371 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29601 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->