### PR TITLE
[WIP] BigInt64

### DIFF
--- a/JSTests/microbenchmarks/bigint64-arith.js
+++ b/JSTests/microbenchmarks/bigint64-arith.js
@@ -1,0 +1,71 @@
+// Microbenchmark: BigInt64 arithmetic — add/sub/mul/compare on int64-range BigInts.
+// Run hot enough to reach FTL (~100k iterations per function).
+// All operands deliberately fit in int64 so the BigInt64 representation tier fires.
+
+"use strict";
+
+const WARMUP = 1e5;
+
+// --- Add ---
+// Use a base value above the BigInt32 threshold (2^32 > 2^30 ≈ BigInt32 max).
+// On platforms with USE(BIGINT32), values < 2^30 are stored as tagged int32 rather
+// than HeapBigInt objects, producing a mixed HeapBigInt|BoolInt32|NonBoolInt32
+// prediction that blocks binaryArithShouldSpeculateBigInt64.  Starting from 2^32
+// ensures every operand profiles as pure HeapBigInt from the very first iteration.
+const ADD_BASE = 0x100000000n; // 2^32
+const addLimit = ADD_BASE + BigInt(WARMUP);
+let addResult = ADD_BASE;
+for (let i = ADD_BASE; i < addLimit; i += 1n)
+    addResult += i;
+
+// Expected: ADD_BASE + sum(ADD_BASE .. ADD_BASE+WARMUP-1)
+//         = ADD_BASE*(WARMUP+1) + WARMUP*(WARMUP-1)/2
+const expectedAdd = ADD_BASE * (BigInt(WARMUP) + 1n) + BigInt(WARMUP) * BigInt(WARMUP - 1) / 2n;
+if (addResult !== expectedAdd)
+    throw new Error(`add benchmark gave wrong result: got ${addResult}, expected ${expectedAdd}`);
+
+// --- Sub ---
+let subResult = BigInt(WARMUP);
+for (let i = 0n; i < WARMUP; i++)
+    subResult -= 1n;
+
+if (subResult !== 0n)
+    throw new Error("sub benchmark gave wrong result");
+
+// --- Mul (stays in int64 range: values up to ~1e5) ---
+let mulResult = 1n;
+for (let i = 1n; i <= 18n; i++)
+    mulResult *= i;  // 18! = 6402373705728000 which fits in int64
+
+if (mulResult !== 6402373705728000n)
+    throw new Error("mul benchmark gave wrong result");
+
+// --- Bitwise AND/OR/XOR mask processing ---
+let mask = 0xFFFFFFFFn;
+let andResult = 0n;
+let orResult = 0n;
+let xorResult = 0n;
+for (let i = 0n; i < WARMUP; i++) {
+    andResult += i & mask;
+    orResult += i | mask;
+    xorResult += i ^ mask;
+}
+
+// Rough sanity check — just ensure they ran
+if (andResult === 0n && orResult === 0n && xorResult === 0n)
+    throw new Error("bitwise benchmark produced all zeros");
+
+// --- Comparison chain ---
+let cmpCount = 0;
+let prev = 0n;
+for (let i = 0n; i < WARMUP; i++) {
+    if (i > prev)
+        cmpCount++;
+    prev = i;
+}
+
+if (cmpCount !== WARMUP - 1)
+    throw new Error("comparison benchmark gave wrong count");
+
+// Report timing via print (used by jsc harness)
+print("PASS: bigint64-arith microbenchmark");

--- a/JSTests/stress/bigint64-rep-add.js
+++ b/JSTests/stress/bigint64-rep-add.js
@@ -1,0 +1,89 @@
+// Test BigInt64 representation: add/sub with int64-range values across all JIT tiers.
+// Verifies that DFG/FTL correctly optimizes small HeapBigInt arithmetic without boxing/unboxing
+// overhead, and that OSR exit works correctly when overflow is detected.
+
+"use strict";
+
+function assert(cond, msg) {
+    if (!cond)
+        throw new Error(msg || "assertion failed");
+}
+
+// --- Basic add/sub correctness ---
+function addSub(a, b) {
+    return [a + b, a - b];
+}
+noInline(addSub);
+
+// Warm up with values that fit in int64
+for (let i = 0; i < 10000; i++) {
+    let a = BigInt(i);
+    let b = BigInt(i + 1);
+    let [sum, diff] = addSub(a, b);
+    assert(sum === BigInt(2 * i + 1), `add failed at i=${i}`);
+    assert(diff === -1n, `sub failed at i=${i}`);
+}
+
+// --- Large values: verify graceful fallback (OSR exit) ---
+function addLarge(a, b) {
+    return a + b;
+}
+noInline(addLarge);
+
+// First, warm up with small values to trigger BigInt64 speculation
+for (let i = 0; i < 5000; i++) {
+    let result = addLarge(BigInt(i), 1n);
+    assert(result === BigInt(i + 1));
+}
+
+// Then use a value larger than int64 — this should trigger OSR exit if BigInt64 was speculated
+let large = 2n ** 70n;
+let r = addLarge(large, 1n);
+assert(r === 2n ** 70n + 1n, "large BigInt add failed");
+
+// --- Commutative check ---
+function commutativeCheck(a, b) {
+    return [a + b, b + a];
+}
+noInline(commutativeCheck);
+
+for (let i = 0; i < 10000; i++) {
+    let a = BigInt(i * 7);
+    let b = BigInt(i * 3 + 1);
+    let [ab, ba] = commutativeCheck(a, b);
+    assert(ab === ba, `commutativity failed at i=${i}`);
+}
+
+// --- Negative values ---
+function negativeArith(a) {
+    return a + (-1n) - 100n;
+}
+noInline(negativeArith);
+
+for (let i = 0; i < 10000; i++) {
+    let result = negativeArith(BigInt(i));
+    assert(result === BigInt(i) - 101n, `negative arith failed at i=${i}`);
+}
+
+// --- Mixed int64-range boundary values ---
+const INT64_MAX = 9223372036854775807n;
+const INT64_MIN = -9223372036854775808n;
+
+function boundaryAdd(a, b) {
+    return a + b;
+}
+noInline(boundaryAdd);
+
+// Warm up
+for (let i = 0; i < 1000; i++)
+    boundaryAdd(BigInt(i), BigInt(i));
+
+// Boundary: INT64_MAX + 1 should overflow and trigger OSR exit
+let overflow = boundaryAdd(INT64_MAX, 1n);
+assert(overflow === INT64_MAX + 1n, "INT64_MAX + 1 wrong");
+
+// Boundary: INT64_MIN - 1 should overflow
+let underflow = boundaryAdd(INT64_MIN, -1n);
+assert(underflow === INT64_MIN - 1n, "INT64_MIN - 1 wrong");
+
+print("PASS: bigint64-rep-add");

--- a/JSTests/stress/bigint64-rep-bitwise.js
+++ b/JSTests/stress/bigint64-rep-bitwise.js
@@ -1,0 +1,97 @@
+// Test BigInt64 representation: bitwise operations and/or/xor/not/shift.
+// Verifies DFG/FTL BigInt64 bitwise codegen; also validates Bug Fix #4 (ArithBitNot).
+
+"use strict";
+
+function assert(cond, msg) {
+    if (!cond)
+        throw new Error(msg || "assertion failed");
+}
+
+// --- Bitwise AND ---
+function bitwiseAnd(a, b) {
+    return a & b;
+}
+noInline(bitwiseAnd);
+
+for (let i = 0n; i < 10000n; i++) {
+    assert(bitwiseAnd(i, 0n) === 0n, `AND 0 failed at ${i}`);
+    assert(bitwiseAnd(i, -1n) === i, `AND -1 failed at ${i}`);
+    assert(bitwiseAnd(i, i) === i, `AND self failed at ${i}`);
+}
+
+// --- Bitwise OR ---
+function bitwiseOr(a, b) {
+    return a | b;
+}
+noInline(bitwiseOr);
+
+for (let i = 0n; i < 10000n; i++) {
+    assert(bitwiseOr(i, 0n) === i, `OR 0 failed at ${i}`);
+    assert(bitwiseOr(i, i) === i, `OR self failed at ${i}`);
+}
+
+// --- Bitwise XOR ---
+function bitwiseXor(a, b) {
+    return a ^ b;
+}
+noInline(bitwiseXor);
+
+for (let i = 0n; i < 10000n; i++) {
+    assert(bitwiseXor(i, 0n) === i, `XOR 0 failed at ${i}`);
+    assert(bitwiseXor(i, i) === 0n, `XOR self failed at ${i}`);
+}
+
+// --- Bitwise NOT (Bug Fix #4: FTL ArithBitNot must handle BigInt64RepUse) ---
+function bitwiseNot(a) {
+    return ~a;
+}
+noInline(bitwiseNot);
+
+for (let i = 0n; i < 10000n; i++) {
+    let result = bitwiseNot(i);
+    // ~i for BigInt = -(i + 1)
+    assert(result === -(i + 1n), `NOT failed at ${i}: got ${result}, expected ${-(i + 1n)}`);
+}
+
+// Double NOT should return original
+for (let i = 0n; i < 5000n; i++) {
+    assert(bitwiseNot(bitwiseNot(i)) === i, `double NOT failed at ${i}`);
+}
+
+// --- Left shift ---
+function lshift(a, b) {
+    return a << b;
+}
+noInline(lshift);
+
+for (let i = 0n; i < 60n; i++) {
+    let result = lshift(1n, i);
+    assert(result === 1n << i, `lshift failed at i=${i}`);
+}
+
+// --- Right shift ---
+function rshift(a, b) {
+    return a >> b;
+}
+noInline(rshift);
+
+for (let i = 0n; i < 60n; i++) {
+    let val = 1n << 62n;
+    let result = rshift(val, i);
+    assert(result === val >> i, `rshift failed at i=${i}`);
+}
+
+// --- Mixed bitwise expression ---
+function mixedBitwise(a, b) {
+    return (a & b) | (a ^ b);
+}
+noInline(mixedBitwise);
+
+for (let i = 0n; i < 10000n; i++) {
+    let b = i ^ 0xFFFFn;
+    // (a & b) | (a ^ b) = a | b
+    assert(mixedBitwise(i, b) === (i | b), `mixed bitwise failed at i=${i}`);
+}
+
+print("PASS: bigint64-rep-bitwise");

--- a/JSTests/stress/bigint64-rep-compare.js
+++ b/JSTests/stress/bigint64-rep-compare.js
@@ -1,0 +1,121 @@
+// Test BigInt64 representation: comparisons.
+// Specifically validates Bug Fix #2: comparisonShouldSpeculateBigInt64 requires BOTH sides
+// to be BigInt64, not just one.
+
+"use strict";
+
+function assert(cond, msg) {
+    if (!cond)
+        throw new Error(msg || "assertion failed");
+}
+
+// --- Equal ---
+function eq(a, b) { return a === b; }
+noInline(eq);
+
+for (let i = 0; i < 10000; i++) {
+    let a = BigInt(i);
+    let b = BigInt(i);
+    let c = BigInt(i + 1);
+    assert(eq(a, b) === true, `eq true failed at ${i}`);
+    assert(eq(a, c) === false, `eq false failed at ${i}`);
+}
+
+// --- Not equal (via !=) ---
+function neq(a, b) { return a !== b; }
+noInline(neq);
+
+for (let i = 0; i < 10000; i++) {
+    let a = BigInt(i);
+    assert(neq(a, BigInt(i + 1)) === true, `neq true failed at ${i}`);
+    assert(neq(a, BigInt(i)) === false, `neq false failed at ${i}`);
+}
+
+// --- Less than ---
+function lt(a, b) { return a < b; }
+noInline(lt);
+
+for (let i = 0; i < 10000; i++) {
+    let a = BigInt(i);
+    let b = BigInt(i + 1);
+    assert(lt(a, b) === true, `lt true failed at ${i}`);
+    assert(lt(b, a) === false, `lt false failed at ${i}`);
+    assert(lt(a, a) === false, `lt eq failed at ${i}`);
+}
+
+// --- Less than or equal ---
+function lte(a, b) { return a <= b; }
+noInline(lte);
+
+for (let i = 0; i < 10000; i++) {
+    let a = BigInt(i);
+    let b = BigInt(i + 1);
+    assert(lte(a, b) === true, `lte lt failed at ${i}`);
+    assert(lte(a, a) === true, `lte eq failed at ${i}`);
+    assert(lte(b, a) === false, `lte gt failed at ${i}`);
+}
+
+// --- Greater than ---
+function gt(a, b) { return a > b; }
+noInline(gt);
+
+for (let i = 0; i < 10000; i++) {
+    let a = BigInt(i + 1);
+    let b = BigInt(i);
+    assert(gt(a, b) === true, `gt true failed at ${i}`);
+    assert(gt(b, a) === false, `gt false failed at ${i}`);
+    assert(gt(a, a) === false, `gt eq failed at ${i}`);
+}
+
+// --- Greater than or equal ---
+function gte(a, b) { return a >= b; }
+noInline(gte);
+
+for (let i = 0; i < 10000; i++) {
+    let a = BigInt(i + 1);
+    let b = BigInt(i);
+    assert(gte(a, b) === true, `gte gt failed at ${i}`);
+    assert(gte(a, a) === true, `gte eq failed at ${i}`);
+    assert(gte(b, a) === false, `gte lt failed at ${i}`);
+}
+
+// --- Bug Fix #2 regression: one BigInt64 side, one non-BigInt64 side ---
+// This must NOT cause misspeculation; the comparison should work correctly.
+function compareAsymmetric(a, b) {
+    return a < b;
+}
+noInline(compareAsymmetric);
+
+// Warm up with small BigInts
+for (let i = 0; i < 5000; i++)
+    compareAsymmetric(BigInt(i), BigInt(i + 1));
+
+// Now try: one side is a large BigInt (won't fit in int64), other is small
+let largeBigInt = 2n ** 70n;
+assert(compareAsymmetric(1n, largeBigInt) === true, "asymmetric compare 1 < 2^70 failed");
+assert(compareAsymmetric(largeBigInt, 1n) === false, "asymmetric compare 2^70 < 1 failed");
+assert(compareAsymmetric(largeBigInt, largeBigInt) === false, "asymmetric compare 2^70 < 2^70 failed");
+
+// --- Negative comparisons ---
+function cmpNeg(a, b) { return a < b; }
+noInline(cmpNeg);
+
+for (let i = 0; i < 10000; i++) {
+    assert(cmpNeg(-BigInt(i + 1), -BigInt(i)) === true, `neg lt failed at ${i}`);
+    assert(cmpNeg(-BigInt(i), -BigInt(i + 1)) === false, `neg lt false failed at ${i}`);
+}
+
+// INT64 boundary comparisons
+const INT64_MAX = 9223372036854775807n;
+const INT64_MIN = -9223372036854775808n;
+
+function boundaryCompare(a, b) { return a < b; }
+noInline(boundaryCompare);
+
+for (let i = 0; i < 1000; i++)
+    boundaryCompare(BigInt(i), BigInt(i + 1));
+
+assert(boundaryCompare(INT64_MIN, INT64_MAX) === true, "INT64_MIN < INT64_MAX failed");
+assert(boundaryCompare(INT64_MAX, INT64_MIN) === false, "INT64_MAX < INT64_MIN failed");
+
+print("PASS: bigint64-rep-compare");

--- a/JSTests/stress/bigint64-rep-mul.js
+++ b/JSTests/stress/bigint64-rep-mul.js
@@ -1,0 +1,81 @@
+// Test BigInt64 representation: mul with int64-range values, overflow handling.
+// Specifically tests that:
+// 1. FTL ArithMul uses the CheckMul result directly (Bug Fix #1)
+// 2. Overflow causes correct OSR exit with BigInt64Overflow
+
+"use strict";
+
+function assert(cond, msg) {
+    if (!cond)
+        throw new Error(msg || "assertion failed");
+}
+
+// --- Basic multiply correctness ---
+function mul(a, b) {
+    return a * b;
+}
+noInline(mul);
+
+// Warm up with values that fit in int64
+for (let i = 1n; i <= 10000n; i++) {
+    let result = mul(i, 2n);
+    assert(result === i * 2n, `mul by 2 failed at i=${i}`);
+}
+
+// Commutative check
+for (let i = 0; i < 1000; i++) {
+    let a = BigInt(i);
+    let b = BigInt(i + 7);
+    assert(mul(a, b) === mul(b, a), `commutativity failed at i=${i}`);
+}
+
+// --- Zero multiplicand ---
+function mulZero(a) {
+    return a * 0n;
+}
+noInline(mulZero);
+
+for (let i = 0; i < 10000; i++) {
+    assert(mulZero(BigInt(i)) === 0n, `mul by zero failed at i=${i}`);
+}
+
+// --- Large result overflow (triggers OSR exit from BigInt64) ---
+function mulOverflow(a, b) {
+    return a * b;
+}
+noInline(mulOverflow);
+
+// Warm up with small values first
+for (let i = 1n; i <= 5000n; i++)
+    mulOverflow(i, i);
+
+// Now multiply values that overflow int64
+let big = 1000000000n * 1000000000n * 100n; // 10^20, exceeds int64
+let result = mulOverflow(big, 1n);
+assert(result === big, "big multiply identity failed");
+
+let result2 = mulOverflow(1000000000n, 1000000000n);
+assert(result2 === 1000000000000000000n, "1e9 * 1e9 failed");
+
+// INT64 overflow: 2^32 * 2^32 = 2^64 which overflows int64
+let r = mulOverflow(4294967296n, 4294967296n);
+assert(r === 18446744073709551616n, "2^64 failed");
+
+// --- Negative multiplication ---
+function mulNeg(a, b) {
+    return a * b;
+}
+noInline(mulNeg);
+
+for (let i = 1; i <= 5000; i++) {
+    let result = mulNeg(BigInt(i), -1n);
+    assert(result === -BigInt(i), `neg mul failed at i=${i}`);
+}
+
+// Warm up, then test double-negative
+for (let i = 1; i <= 5000; i++) {
+    let result = mulNeg(-BigInt(i), -1n);
+    assert(result === BigInt(i), `double neg mul failed at i=${i}`);
+}
+
+print("PASS: bigint64-rep-mul");

--- a/JSTests/stress/bigint64-rep-osr.js
+++ b/JSTests/stress/bigint64-rep-osr.js
@@ -1,0 +1,101 @@
+// Test BigInt64 OSR entry/exit round-trip correctness.
+// Verifies that values are correctly boxed/unboxed when transitioning between
+// interpreter and DFG/FTL tiers (DFGOSREntry.cpp and DFGOSRExit.cpp paths).
+
+"use strict";
+
+function assert(cond, msg) {
+    if (!cond)
+        throw new Error(msg || "assertion failed");
+}
+
+// --- OSR entry: function already compiled as BigInt64, called with int64-range BigInts ---
+function osrEntryAdd(n) {
+    let sum = 0n;
+    for (let i = 0n; i < n; i++)
+        sum += i;
+    return sum;
+}
+noInline(osrEntryAdd);
+
+// Warm up to trigger compilation
+let result = osrEntryAdd(10000n);
+// sum 0..9999 = n*(n-1)/2
+assert(result === 10000n * 9999n / 2n, `osrEntryAdd failed: got ${result}`);
+
+// --- OSR exit: function compiled as BigInt64, but loop encounters large BigInt ---
+function osrExitOnLarge(arr) {
+    let sum = 0n;
+    for (let i = 0; i < arr.length; i++)
+        sum += arr[i];
+    return sum;
+}
+noInline(osrExitOnLarge);
+
+// Build array with small BigInts to trigger BigInt64 compilation
+let smallArr = [];
+for (let i = 0; i < 1000; i++)
+    smallArr.push(BigInt(i));
+
+// Warm up
+for (let j = 0; j < 10; j++)
+    osrExitOnLarge(smallArr);
+
+// Expected sum
+let expectedSmall = smallArr.reduce((a, b) => a + b, 0n);
+assert(osrExitOnLarge(smallArr) === expectedSmall, "small array sum wrong");
+
+// Now trigger OSR exit by including a large BigInt mid-array
+let mixedArr = [...smallArr, 2n ** 70n];
+let expectedMixed = expectedSmall + 2n ** 70n;
+let resultMixed = osrExitOnLarge(mixedArr);
+assert(resultMixed === expectedMixed, `mixed array sum wrong: got ${resultMixed}`);
+
+// --- Tier re-entry: after OSR exit, function should still work correctly ---
+// Run the small array again to verify re-compilation with correct types
+for (let j = 0; j < 100; j++) {
+    let r = osrExitOnLarge(smallArr);
+    assert(r === expectedSmall, `post-exit small array sum wrong at j=${j}`);
+}
+
+// --- Value preservation across OSR: local BigInt64 variable must survive ---
+function localBigInt64Survival(n) {
+    let a = 42n;       // should become BigInt64 in DFG
+    let b = 100n;      // same
+    for (let i = 0; i < n; i++) {
+        a = a + b;
+        if (i === 50)
+            b = b + 0n;  // no-op but touches b
+    }
+    return a;
+}
+noInline(localBigInt64Survival);
+
+// 42 + 100 * 10000 = 1000042
+let survivalResult = localBigInt64Survival(10000);
+assert(survivalResult === 42n + 100n * 10000n, `local survival failed: got ${survivalResult}`);
+
+// --- Cross-tier value correctness: return BigInt64 from DFG to interpreter ---
+function bigIntReturn(n) {
+    return BigInt(n) * BigInt(n);
+}
+noInline(bigIntReturn);
+
+for (let i = 0; i < 10000; i++) {
+    let r = bigIntReturn(i);
+    assert(r === BigInt(i) * BigInt(i), `bigIntReturn failed at i=${i}`);
+}
+
+// Verify identity for INT64_MAX
+const INT64_MAX = 9223372036854775807n;
+function identityBigInt64(v) {
+    return v + 0n;
+}
+noInline(identityBigInt64);
+
+for (let i = 0; i < 1000; i++)
+    identityBigInt64(BigInt(i));
+
+assert(identityBigInt64(INT64_MAX) === INT64_MAX, "INT64_MAX identity failed");
+
+print("PASS: bigint64-rep-osr");

--- a/JSTests/stress/bigint64-rep-overflow.js
+++ b/JSTests/stress/bigint64-rep-overflow.js
@@ -1,0 +1,126 @@
+// Test BigInt64 overflow profiling and speculation gating.
+// Verifies that:
+// 1. When large BigInts are observed, BigInt64Overflow profiling fires (Bug Fix #3)
+// 2. DFG/FTL does NOT speculate BigInt64 for operations that have seen large BigInts
+// 3. Gradual overflow: small → large BigInt correctly suppresses speculation
+// This test covers the JetStream 3 regression scenario: crypto BigInts must never
+// trigger BigInt64 speculation.
+
+"use strict";
+
+function assert(cond, msg) {
+    if (!cond)
+        throw new Error(msg || "assertion failed");
+}
+
+// --- Scenario 1: Always-large BigInts — should never speculate BigInt64 ---
+// These simulate JetStream 3 crypto workloads (RSA-style large integers).
+function addLarge(a, b) {
+    return a + b;
+}
+noInline(addLarge);
+
+let base = 2n ** 256n;  // 256-bit integer, well outside int64 range
+for (let i = 0; i < 10000; i++) {
+    let result = addLarge(base + BigInt(i), base + BigInt(i + 1));
+    assert(result === 2n * base + BigInt(2 * i + 1), `large add failed at ${i}`);
+}
+
+// --- Scenario 2: Gradual overflow — start small, then grow beyond int64 ---
+// Profiler must detect BigInt64Overflow and prevent re-speculation after overflow.
+function accumulate(arr) {
+    let sum = 0n;
+    for (let i = 0; i < arr.length; i++)
+        sum += arr[i];
+    return sum;
+}
+noInline(accumulate);
+
+// Phase 1: small values — speculation allowed
+let smallValues = [];
+for (let i = 0; i < 1000; i++)
+    smallValues.push(BigInt(i));
+
+let smallSum = accumulate(smallValues);
+assert(smallSum === 1000n * 999n / 2n, `small accumulate failed: ${smallSum}`);
+
+// Phase 2: introduce large value — must NOT produce wrong result
+let largeValues = [...smallValues, 2n ** 70n];
+let largeSum = accumulate(largeValues);
+assert(largeSum === smallSum + 2n ** 70n, `large accumulate failed: ${largeSum}`);
+
+// Phase 3: go back to small values — profiler has BigInt64Overflow set, won't speculate
+// Result must still be correct even though speculation is suppressed
+for (let run = 0; run < 100; run++) {
+    let result = accumulate(smallValues);
+    assert(result === smallSum, `post-overflow small accumulate failed at run=${run}`);
+}
+
+// --- Scenario 3: Multiplication overflow ---
+function mulAll(arr) {
+    let prod = 1n;
+    for (let i = 0; i < arr.length; i++)
+        prod *= arr[i];
+    return prod;
+}
+noInline(mulAll);
+
+// Small primes — product stays in int64 range for small count
+let primes = [2n, 3n, 5n, 7n, 11n, 13n, 17n, 19n, 23n, 29n];
+
+// Warm up
+for (let i = 0; i < 1000; i++)
+    mulAll(primes);
+
+// Expected product
+let expectedProd = primes.reduce((a, b) => a * b, 1n);
+assert(mulAll(primes) === expectedProd, `prime product failed: ${mulAll(primes)}`);
+
+// Now multiply until overflow
+let bigPrimes = [...primes, 31n, 37n, 41n, 43n, 47n, 53n, 59n, 61n, 67n, 71n, 73n, 79n];
+let bigProd = mulAll(bigPrimes);
+let expectedBig = bigPrimes.reduce((a, b) => a * b, 1n);
+assert(bigProd === expectedBig, `big prime product failed`);
+
+// --- Scenario 4: JetStream 3 simulation — alternating large/small BigInts ---
+// Verify profiling correctly gates speculation for mixed-size workloads.
+function bigintMix(small, large, useLarge) {
+    if (useLarge)
+        return large + large;
+    return small + small;
+}
+noInline(bigintMix);
+
+let big3072 = 2n ** 3072n;  // typical RSA-3072 size
+
+// Alternate to ensure profiler sees both small and large
+for (let i = 0; i < 10000; i++) {
+    let useLarge = (i % 3 === 0);
+    let s = BigInt(i);
+    let result = bigintMix(s, big3072, useLarge);
+    if (useLarge)
+        assert(result === 2n * big3072, `large mix failed at ${i}`);
+    else
+        assert(result === 2n * s, `small mix failed at ${i}`);
+}
+
+// --- Scenario 5: INT64 boundary — exactly at boundary should work ---
+const INT64_MAX = 9223372036854775807n;
+const INT64_MIN = -9223372036854775808n;
+
+function atBoundary(a, b) {
+    return a + b;
+}
+noInline(atBoundary);
+
+for (let i = 0; i < 1000; i++)
+    atBoundary(BigInt(i), BigInt(i));
+
+// INT64_MAX itself (fits in int64) — speculation should handle it
+assert(atBoundary(INT64_MAX, 0n) === INT64_MAX, "INT64_MAX + 0 failed");
+// INT64_MAX + 1 overflows int64 — OSR exit expected if speculated, must give right answer
+assert(atBoundary(INT64_MAX, 1n) === INT64_MAX + 1n, "INT64_MAX + 1 failed");
+// INT64_MIN itself (fits in int64)
+assert(atBoundary(INT64_MIN, 0n) === INT64_MIN, "INT64_MIN + 0 failed");
+
+print("PASS: bigint64-rep-overflow");

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -93,6 +93,7 @@ namespace JSC::B3 {
     macro(JSArrayBufferView_mode, JSArrayBufferView::offsetOfMode(), Mutability::Mutable) \
     macro(JSArrayBufferView_vector, JSArrayBufferView::offsetOfVector(), Mutability::Mutable) \
     macro(JSBigInt_length, JSBigInt::offsetOfLength(), Mutability::Immutable) \
+    macro(JSBigInt_data0, JSBigInt::offsetOfData(), Mutability::Immutable) \
     macro(JSBoundFunction_targetFunction, JSBoundFunction::offsetOfTargetFunction(), Mutability::Mutable) \
     macro(JSBoundFunction_boundThis, JSBoundFunction::offsetOfBoundThis(), Mutability::Mutable) \
     macro(JSBoundFunction_boundArg0, JSBoundFunction::offsetOfBoundArgs() + sizeof(WriteBarrier<Unknown>) * 0, Mutability::Mutable) \

--- a/Source/JavaScriptCore/bytecode/ArithProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArithProfile.h
@@ -76,8 +76,11 @@ public:
         Int52Overflow    = 1 << 4,
         HeapBigInt       = 1 << 5,
         BigInt32         = 1 << 6,
+        // Set when a HeapBigInt value that does NOT fit in int64 was observed.
+        // When set, BigInt64 speculation is unsafe for this operation.
+        BigInt64Overflow = 1 << 7,
     };
-    static constexpr uint32_t numBitsNeeded = 7;
+    static constexpr uint32_t numBitsNeeded = 8;
 
     ObservedResults() = default;
     explicit ObservedResults(uint8_t bits)
@@ -94,6 +97,7 @@ public:
     bool didObserveBigInt32() { return m_bits & BigInt32; }
     bool didObserveInt32Overflow() { return m_bits & Int32Overflow; }
     bool didObserveInt52Overflow() { return m_bits & Int52Overflow; }
+    bool didObserveBigInt64Overflow() { return m_bits & BigInt64Overflow; }
 
 private:
     uint8_t m_bits { 0 };
@@ -116,6 +120,7 @@ public:
     bool didObserveBigInt32() const { return observedResults().didObserveBigInt32(); }
     bool didObserveInt32Overflow() const { return observedResults().didObserveInt32Overflow(); }
     bool didObserveInt52Overflow() const { return observedResults().didObserveInt52Overflow(); }
+    bool didObserveBigInt64Overflow() const { return observedResults().didObserveBigInt64Overflow(); }
 
     void setObservedNonNegZeroDouble() { setBit(ObservedResults::NonNegZeroDouble); }
     void setObservedNegZeroDouble() { setBit(ObservedResults::NegZeroDouble); }
@@ -124,6 +129,7 @@ public:
     void setObservedBigInt32() { setBit(ObservedResults::BigInt32); }
     void setObservedInt32Overflow() { setBit(ObservedResults::Int32Overflow); }
     void setObservedInt52Overflow() { setBit(ObservedResults::Int52Overflow); }
+    void setObservedBigInt64Overflow() { setBit(ObservedResults::BigInt64Overflow); }
 
     void observeResult(JSValue value)
     {

--- a/Source/JavaScriptCore/bytecode/DataFormat.h
+++ b/Source/JavaScriptCore/bytecode/DataFormat.h
@@ -45,6 +45,7 @@ enum DataFormat : uint8_t {
     DataFormatCell = 6,
     DataFormatStorage = 7,
     DataFormatBigInt32 = 8, // FIXME: https://bugs.webkit.org/show_bug.cgi?id=210957 Actually support BigInt32 DataFormat.
+    DataFormatBigInt64 = 9, // Unboxed int64 for HeapBigInt values that fit in int64 (DFG/FTL internal representation).
     DataFormatJS = 16,
     DataFormatJSInt32 = DataFormatJS | DataFormatInt32,
     DataFormatJSDouble = DataFormatJS | DataFormatDouble,
@@ -80,6 +81,8 @@ inline const char* dataFormatToString(DataFormat dataFormat)
         return "Storage";
     case DataFormatBigInt32:
         return "BigInt32";
+    case DataFormatBigInt64:
+        return "BigInt64";
     case DataFormatJS:
         return "JS";
     case DataFormatJSInt32:

--- a/Source/JavaScriptCore/bytecode/ExitKind.h
+++ b/Source/JavaScriptCore/bytecode/ExitKind.h
@@ -61,6 +61,7 @@ enum ExitKind : uint8_t {
     WillThrowOutOfMemoryError, // We exited because we would like to throw OutOfMemory error.
     GenericUnwind, // We exited because we arrived at this OSR exit from genericUnwind.
     BigInt32Overflow, // We exited because of an BigInt32 overflow.
+    BigInt64Overflow, // We exited because the BigInt64 value exceeded int64 range.
     UnexpectedResizableArrayBufferView, // We exited because we made an incorrect assumption about what type of ArrayBufferView we would see.
 };
 

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.h
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.h
@@ -107,19 +107,21 @@ static constexpr SpeculatedType SpecMisc                              = SpecBool
 static constexpr SpeculatedType SpecEmpty                             = 1ull << 47; // It's definitely an empty value marker.
 static constexpr SpeculatedType SpecHeapBigInt                        = 1ull << 48; // It's definitely a BigInt that is allocated on the heap
 static constexpr SpeculatedType SpecBigInt32                          = 1ull << 49; // It's definitely a small BigInt that is inline the JSValue
+static constexpr SpeculatedType SpecDataViewObject                    = 1ull << 50; // It's definitely a JSDataView.
+static constexpr SpeculatedType SpecBigInt64                          = 1ull << 51; // HeapBigInt that fits in int64; unboxed DFG/FTL internal representation (analogous to SpecInt52Any — NOT part of SpecBigInt)
 #if USE(BIGINT32)
 static constexpr SpeculatedType SpecBigInt                            = SpecBigInt32 | SpecHeapBigInt;
 #else
 // We should not include SpecBigInt32. We are using SpecBigInt in various places like prediction. If this includes SpecBigInt32, fixup phase is confused if !USE(BIGINT32) since it is not using AnyBigIntUse.
+// SpecBigInt64 is intentionally excluded — it is a JIT-internal unboxed representation, analogous to SpecInt52Any.
 static constexpr SpeculatedType SpecBigInt                            = SpecHeapBigInt;
 #endif
-static constexpr SpeculatedType SpecDataViewObject                    = 1ull << 50; // It's definitely a JSDataView.
 static constexpr SpeculatedType SpecPrimitive                         = SpecString | SpecSymbol | SpecBytecodeNumber | SpecMisc | SpecBigInt; // It's any non-Object JSValue.
 static constexpr SpeculatedType SpecObject                            = SpecFinalObject | SpecArray | SpecFunction | SpecTypedArrayView | SpecDirectArguments | SpecScopedArguments | SpecStringObject | SpecRegExpObject | SpecDateObject | SpecPromiseObject | SpecMapObject | SpecSetObject | SpecMapIteratorObject | SpecSetIteratorObject | SpecWeakMapObject | SpecWeakSetObject | SpecProxyObject | SpecGlobalProxy | SpecDerivedArray | SpecObjectOther | SpecDataViewObject; // Bitmask used for testing for any kind of object prediction.
 static constexpr SpeculatedType SpecCell                              = SpecObject | SpecString | SpecSymbol | SpecCellOther | SpecHeapBigInt; // It's definitely a JSCell.
-static constexpr SpeculatedType SpecHeapTop                           = SpecCell | SpecBigInt32 | SpecBytecodeNumber | SpecMisc; // It can be any of the above, except for SpecInt52Only and SpecDoubleImpureNaN.
+static constexpr SpeculatedType SpecHeapTop                           = SpecCell | SpecBigInt32 | SpecBytecodeNumber | SpecMisc; // It can be any of the above, except for SpecInt52Only, SpecDoubleImpureNaN, and SpecBigInt64 (which is a JIT-internal unboxed representation, analogous to SpecInt52Any).
 static constexpr SpeculatedType SpecBytecodeTop                       = SpecHeapTop | SpecEmpty; // It can be any of the above, except for SpecInt52Only and SpecDoubleImpureNaN. Corresponds to what could be found in a bytecode local.
-static constexpr SpeculatedType SpecFullTop                           = SpecBytecodeTop | SpecFullNumber; // It can be anything that bytecode could see plus exotic encodings of numbers.
+static constexpr SpeculatedType SpecFullTop                           = SpecBytecodeTop | SpecFullNumber | SpecBigInt64; // It can be anything that bytecode could see plus exotic encodings of numbers and unboxed BigInt64.
 
 static constexpr SpeculatedType SpecTypeofMightBeFunction             = SpecFunction | SpecObjectOther | SpecProxyObject; // If you don't see these types, you can't be callable, and you can't have typeof produce "function". Inverse is not true, however. If you only see these types, you may produce more things than "function" in typeof, and you might not be callable.
 
@@ -224,6 +226,11 @@ inline bool isBigInt32Speculation(SpeculatedType value)
 inline bool isHeapBigIntSpeculation(SpeculatedType value)
 {
     return value == SpecHeapBigInt;
+}
+
+inline bool isBigInt64Speculation(SpeculatedType value)
+{
+    return value == SpecBigInt64;
 }
 
 inline bool isBigIntSpeculation(SpeculatedType value)

--- a/Source/JavaScriptCore/bytecode/ValueRecovery.cpp
+++ b/Source/JavaScriptCore/bytecode/ValueRecovery.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ValueRecovery.h"
 
+#include "JSBigIntInlines.h"
 #include "JSCJSValueInlines.h"
 
 namespace JSC {
@@ -43,6 +44,12 @@ JSValue ValueRecovery::recover(CallFrame* callFrame) const
         return jsNumber(callFrame->r(virtualRegister()).unboxedStrictInt52());
     case DoubleDisplacedInJSStack:
         return jsNumber(purifyNaN(callFrame->r(virtualRegister()).unboxedDouble()));
+    case BigInt64DisplacedInJSStack: {
+        VM& vm = callFrame->deprecatedVM();
+        JSGlobalObject* globalObject = callFrame->lexicalGlobalObject(vm);
+        int64_t rawValue = callFrame->r(virtualRegister()).unboxedInt64();
+        return JSBigInt::makeHeapBigIntOrBigInt32(globalObject, rawValue);
+    }
     case CellDisplacedInJSStack:
         return callFrame->r(virtualRegister()).unboxedCell();
     case BooleanDisplacedInJSStack:
@@ -75,6 +82,9 @@ void ValueRecovery::dumpInContext(PrintStream& out, DumpContext* context) const
         return;
     case UnboxedStrictInt52InGPR:
         out.print("strictInt52(", gpr(), ")");
+        return;
+    case UnboxedBigInt64InGPR:
+        out.print("bigInt64(", gpr(), ")");
         return;
     case UnboxedBooleanInGPR:
         out.print("bool(", gpr(), ")");
@@ -112,6 +122,9 @@ void ValueRecovery::dumpInContext(PrintStream& out, DumpContext* context) const
         return;
     case DoubleDisplacedInJSStack:
         out.print("*double(", virtualRegister(), ")");
+        return;
+    case BigInt64DisplacedInJSStack:
+        out.print("*bigInt64(", virtualRegister(), ")");
         return;
     case CellDisplacedInJSStack:
         out.print("*cell(", virtualRegister(), ")");

--- a/Source/JavaScriptCore/bytecode/ValueRecovery.h
+++ b/Source/JavaScriptCore/bytecode/ValueRecovery.h
@@ -51,6 +51,7 @@ enum ValueRecoveryTechnique : uint8_t {
     UnboxedInt32InGPR,
     UnboxedInt52InGPR,
     UnboxedStrictInt52InGPR,
+    UnboxedBigInt64InGPR,
     UnboxedBooleanInGPR,
     UnboxedCellInGPR,
 #if USE(JSVALUE32_64)
@@ -67,6 +68,7 @@ enum ValueRecoveryTechnique : uint8_t {
 #endif
     Int52DisplacedInJSStack,
     StrictInt52DisplacedInJSStack,
+    BigInt64DisplacedInJSStack,
     DoubleDisplacedInJSStack,
     CellDisplacedInJSStack,
     BooleanDisplacedInJSStack,
@@ -115,6 +117,8 @@ public:
             result.m_technique = UnboxedInt52InGPR;
         else if (dataFormat == DataFormatStrictInt52)
             result.m_technique = UnboxedStrictInt52InGPR;
+        else if (dataFormat == DataFormatBigInt64)
+            result.m_technique = UnboxedBigInt64InGPR;
         else if (dataFormat == DataFormatBoolean)
             result.m_technique = UnboxedBooleanInGPR;
         else if (dataFormat == DataFormatCell)
@@ -169,7 +173,11 @@ public:
         case DataFormatStrictInt52:
             result.m_technique = StrictInt52DisplacedInJSStack;
             break;
-            
+
+        case DataFormatBigInt64:
+            result.m_technique = BigInt64DisplacedInJSStack;
+            break;
+
         case DataFormatDouble:
             result.m_technique = DoubleDisplacedInJSStack;
             break;
@@ -248,6 +256,7 @@ public:
         case UnboxedCellInGPR:
         case UnboxedInt52InGPR:
         case UnboxedStrictInt52InGPR:
+        case UnboxedBigInt64InGPR:
             return true;
         default:
             return false;
@@ -280,6 +289,7 @@ public:
 #endif
         case Int52DisplacedInJSStack:
         case StrictInt52DisplacedInJSStack:
+        case BigInt64DisplacedInJSStack:
         case DoubleDisplacedInJSStack:
         case CellDisplacedInJSStack:
         case BooleanDisplacedInJSStack:
@@ -312,6 +322,9 @@ public:
         case UnboxedStrictInt52InGPR:
         case StrictInt52DisplacedInJSStack:
             return DataFormatStrictInt52;
+        case UnboxedBigInt64InGPR:
+        case BigInt64DisplacedInJSStack:
+            return DataFormatBigInt64;
         case UnboxedBooleanInGPR:
         case BooleanDisplacedInJSStack:
             return DataFormatBoolean;
@@ -388,7 +401,8 @@ public:
         case CellDisplacedInJSStack:
         case BooleanDisplacedInJSStack:
         case Int52DisplacedInJSStack:
-        case StrictInt52DisplacedInJSStack: {
+        case StrictInt52DisplacedInJSStack:
+        case BigInt64DisplacedInJSStack: {
             ValueRecovery result;
             result.m_technique = m_technique;
             UnionType u;
@@ -427,6 +441,7 @@ public:
         case UnboxedCellInGPR:
         case UnboxedInt52InGPR:
         case UnboxedStrictInt52InGPR:
+        case UnboxedBigInt64InGPR:
             func(gpr());
             return;
         case InFPR:

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -582,6 +582,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 #else
             RELEASE_ASSERT_NOT_REACHED();
 #endif
+        } else if (node->child1().useKind() == BigInt64RepUse) {
+            setTypeForNode(node, SpecBigInt64);
+            forNode(node).fixTypeForRepresentation(m_graph, node);
         } else if (node->child1().useKind() == HeapBigIntUse) {
             // FIXME: We will want an arithmetic mode here that allows us to speculate or dictate
             // the format of our result:
@@ -658,6 +661,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 #else
             DFG_CRASH(m_graph, node, "No BigInt32 support");
 #endif
+        } else if (node->isBinaryUseKind(BigInt64RepUse)) {
+            setTypeForNode(node, SpecBigInt64);
+            forNode(node).fixTypeForRepresentation(m_graph, node);
         } else if (node->isBinaryUseKind(HeapBigIntUse)) {
             // FIXME: We will want an arithmetic mode here that allows us to speculate or dictate
             // the format of our result:
@@ -901,6 +907,12 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         forNode(node).fixTypeForRepresentation(m_graph, node);
         break;
     }
+
+    case BigInt64Rep: {
+        setTypeForNode(node, SpecBigInt64);
+        forNode(node).fixTypeForRepresentation(m_graph, node);
+        break;
+    }
         
     case ValueRep: {
         JSValue value = forNode(node->child1()).value();
@@ -920,7 +932,10 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
     case ValueSub:
     case ValueAdd: {
-        if (node->isBinaryUseKind(HeapBigIntUse)) {
+        if (node->isBinaryUseKind(BigInt64RepUse)) {
+            setTypeForNode(node, SpecBigInt64);
+            forNode(node).fixTypeForRepresentation(m_graph, node);
+        } else if (node->isBinaryUseKind(HeapBigIntUse)) {
             // FIXME: We will want an arithmetic mode here that allows us to speculate or dictate
             // the format of our result:
             // https://bugs.webkit.org/show_bug.cgi?id=210982
@@ -1092,6 +1107,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         
     case ValueNegate: {
         // FIXME: we could do much smarter things for BigInts, see ValueAdd/ValueSub.
+        if (node->child1().useKind() == BigInt64RepUse) {
+            setTypeForNode(node, SpecBigInt64);
+            forNode(node).fixTypeForRepresentation(m_graph, node);
+            break;
+        }
         clobberWorld();
         setTypeForNode(node, SpecBytecodeNumber | SpecBigInt);
         break;
@@ -1195,7 +1215,10 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             break;
         }
 
-        if (node->isBinaryUseKind(HeapBigIntUse)) {
+        if (node->isBinaryUseKind(BigInt64RepUse)) {
+            setTypeForNode(node, SpecBigInt64);
+            forNode(node).fixTypeForRepresentation(m_graph, node);
+        } else if (node->isBinaryUseKind(HeapBigIntUse)) {
             // FIXME: We will want an arithmetic mode here that allows us to speculate or dictate
             // the format of our result:
             // https://bugs.webkit.org/show_bug.cgi?id=210982
@@ -1211,7 +1234,10 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
     case ValueMul: {
         // FIXME: why is this code not shared with ValueSub?
-        if (node->isBinaryUseKind(HeapBigIntUse)) {
+        if (node->isBinaryUseKind(BigInt64RepUse)) {
+            setTypeForNode(node, SpecBigInt64);
+            forNode(node).fixTypeForRepresentation(m_graph, node);
+        } else if (node->isBinaryUseKind(HeapBigIntUse)) {
             // FIXME: We will want an arithmetic mode here that allows us to speculate or dictate
             // the format of our result:
             // https://bugs.webkit.org/show_bug.cgi?id=210982
@@ -1290,7 +1316,10 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         if (handleConstantDivOp(node))
             break;
 
-        if (node->isBinaryUseKind(HeapBigIntUse)) {
+        if (node->isBinaryUseKind(BigInt64RepUse)) {
+            setTypeForNode(node, SpecBigInt64);
+            forNode(node).fixTypeForRepresentation(m_graph, node);
+        } else if (node->isBinaryUseKind(HeapBigIntUse)) {
             // FIXME: We will want an arithmetic mode here that allows us to speculate or dictate
             // the format of our result:
             // https://bugs.webkit.org/show_bug.cgi?id=210982
@@ -2471,6 +2500,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 || node->isBinaryUseKind(BigInt32Use)
                 || node->isBinaryUseKind(HeapBigIntUse)
                 || node->isBinaryUseKind(AnyBigIntUse)
+                || node->isBinaryUseKind(BigInt64RepUse)
                 || node->isBinaryUseKind(StringUse)
                 || node->isBinaryUseKind(BooleanUse)
                 || node->isBinaryUseKind(SymbolUse)

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
@@ -166,6 +166,14 @@ void AbstractValue::fixTypeForRepresentation(Graph& graph, NodeFlags representat
             DFG_ASSERT(graph, node, m_value.isAnyInt());
             m_type = int52AwareSpeculationFromValue(m_value);
         }
+    } else if (representation == NodeResultBigInt64) {
+        // Convert any HeapBigInt abstract type to the BigInt64 unboxed representation.
+        if (m_type & SpecHeapBigInt) {
+            m_type &= ~SpecHeapBigInt;
+            m_type |= SpecBigInt64;
+        }
+        if (m_type & ~SpecBigInt64)
+            DFG_CRASH(graph, node, toCString("Abstract value ", *this, " for bigint64 node has type outside SpecBigInt64.\n").data());
     } else {
         if (m_type & SpecInt32AsInt52) {
             m_type &= ~SpecInt32AsInt52;
@@ -174,6 +182,12 @@ void AbstractValue::fixTypeForRepresentation(Graph& graph, NodeFlags representat
         if (m_type & SpecNonInt32AsInt52) {
             m_type &= ~SpecNonInt32AsInt52;
             m_type |= SpecAnyIntAsDouble;
+        }
+        // When a BigInt64 (unboxed int64) is converted back to a JSValue (e.g. by ValueRep),
+        // it becomes a HeapBigInt — the boxed representation of the value.
+        if (m_type & SpecBigInt64) {
+            m_type &= ~SpecBigInt64;
+            m_type |= SpecHeapBigInt;
         }
         if (m_type & ~SpecBytecodeTop)
             DFG_CRASH(graph, node, toCString("Abstract value ", *this, " for value node has type outside SpecBytecodeTop.\n").data());

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -258,6 +258,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case PurifyNaN:
     case ValueRep:
     case Int52Rep:
+    case BigInt64Rep:
     case BooleanToNumber:
     case FiatInt52:
     case MakeRope:
@@ -354,6 +355,12 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
     case ValueBitNot:
         if (node->child1().useKind() == AnyBigIntUse || node->child1().useKind() == BigInt32Use || node->child1().useKind() == HeapBigIntUse) {
+            def(PureValue(node));
+            return;
+        }
+        if (node->child1().useKind() == BigInt64RepUse) {
+            // Unboxed int64 bitwise-not is pure integer arithmetic — no heap access.
+            write(SideState);
             def(PureValue(node));
             return;
         }
@@ -800,7 +807,19 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case HasPrivateName:
     case HasPrivateBrand:
     case HasOwnProperty:
+        clobberTop();
+        return;
+
     case ValueNegate:
+        if (node->child1().useKind() == BigInt64RepUse) {
+            // Unboxed int64 negation is pure integer arithmetic — no heap access.
+            write(SideState);
+            def(PureValue(node));
+            return;
+        }
+        clobberTop();
+        return;
+
     case SetFunctionName:
     case GetDynamicVar:
     case PutDynamicVar:
@@ -891,6 +910,12 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         // FIXME: this use of single-argument isBinaryUseKind would prevent us from specializing (for example) for a HeapBigInt left-operand and a BigInt32 right-operand.
         if (node->isBinaryUseKind(AnyBigIntUse) || node->isBinaryUseKind(BigInt32Use) || node->isBinaryUseKind(HeapBigIntUse)) {
             read(World);
+            write(SideState);
+            def(PureValue(node));
+            return;
+        }
+        if (node->isBinaryUseKind(BigInt64RepUse)) {
+            // Unboxed int64 arithmetic is pure — no heap access needed.
             write(SideState);
             def(PureValue(node));
             return;

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -189,10 +189,10 @@ bool doesGC(Graph& graph, Node* node)
     case HasStructureWithFlags:
     case MultiGetByOffset:
     case MultiDeleteByOffset:
-    case ValueRep:
     case DoubleRep:
     case PurifyNaN:
     case Int52Rep:
+    case BigInt64Rep:
     case GetGetter:
     case GetSetter:
     case GetArrayLength:
@@ -281,6 +281,10 @@ bool doesGC(Graph& graph, Node* node)
     case ArithDiv:
     case ArithMod:
         return false;
+
+    case ValueRep:
+        // ValueRep for BigInt64RepUse allocates a new HeapBigInt — that GCs.
+        return node->child1().useKind() == BigInt64RepUse;
 
 #if ASSERT_ENABLED
     case ArrayPush:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -285,6 +285,14 @@ private:
             Edge& child1 = node->child1();
             Edge& child2 = node->child2();
 
+            if (m_graph.binaryArithShouldSpeculateBigInt64(node, FixupPass)) {
+                fixEdge<BigInt64RepUse>(child1);
+                fixEdge<BigInt64RepUse>(child2);
+                node->setResult(NodeResultBigInt64);
+                node->clearFlags(NodeMustGenerate);
+                break;
+            }
+
             if (m_graph.binaryArithShouldSpeculateHeapBigInt(node)) {
                 fixEdge<HeapBigIntUse>(child1);
                 fixEdge<HeapBigIntUse>(child2);
@@ -331,6 +339,13 @@ private:
         case ValueBitXor:
         case ValueBitOr:
         case ValueBitAnd: {
+            if (m_graph.binaryArithShouldSpeculateBigInt64(node, FixupPass)) {
+                fixEdge<BigInt64RepUse>(node->child1());
+                fixEdge<BigInt64RepUse>(node->child2());
+                node->setResult(NodeResultBigInt64);
+                node->clearFlags(NodeMustGenerate);
+                break;
+            }
             if (m_graph.binaryArithShouldSpeculateHeapBigInt(node)) {
                 fixEdge<HeapBigIntUse>(node->child1());
                 fixEdge<HeapBigIntUse>(node->child2());
@@ -388,7 +403,11 @@ private:
         case ValueBitNot: {
             Edge& operandEdge = node->child1();
 
-            if (m_graph.unaryArithShouldSpeculateHeapBigInt(node)) {
+            if (m_graph.unaryArithShouldSpeculateBigInt64(node, FixupPass)) {
+                node->clearFlags(NodeMustGenerate);
+                node->setResult(NodeResultBigInt64);
+                fixEdge<BigInt64RepUse>(operandEdge);
+            } else if (m_graph.unaryArithShouldSpeculateHeapBigInt(node)) {
                 node->clearFlags(NodeMustGenerate);
                 fixEdge<HeapBigIntUse>(operandEdge);
             } else if (operandEdge.node()->shouldSpeculateBigInt()) {
@@ -501,6 +520,12 @@ private:
                 node->clearFlags(NodeMustGenerate);
                 break;
             }
+            if (m_graph.unaryArithShouldSpeculateBigInt64(node, FixupPass)) {
+                fixEdge<BigInt64RepUse>(node->child1());
+                node->setResult(NodeResultBigInt64);
+                node->clearFlags(NodeMustGenerate);
+                break;
+            }
             if (node->child1()->shouldSpeculateNotCellNorBigInt()) {
                 node->setOp(ArithNegate);
                 fixDoubleOrBooleanEdge(node->child1());
@@ -548,6 +573,13 @@ private:
                 }
             }
 
+            if (m_graph.binaryArithShouldSpeculateBigInt64(node, FixupPass)) {
+                fixEdge<BigInt64RepUse>(child1);
+                fixEdge<BigInt64RepUse>(child2);
+                node->setResult(NodeResultBigInt64);
+                node->clearFlags(NodeMustGenerate);
+                break;
+            }
             if (m_graph.binaryArithShouldSpeculateHeapBigInt(node)) {
                 fixEdge<HeapBigIntUse>(child1);
                 fixEdge<HeapBigIntUse>(child2);
@@ -644,6 +676,13 @@ private:
             Edge& leftChild = node->child1();
             Edge& rightChild = node->child2();
 
+            if (m_graph.binaryArithShouldSpeculateBigInt64(node, FixupPass)) {
+                fixEdge<BigInt64RepUse>(node->child1());
+                fixEdge<BigInt64RepUse>(node->child2());
+                node->setResult(NodeResultBigInt64);
+                node->clearFlags(NodeMustGenerate);
+                break;
+            }
             if (m_graph.binaryArithShouldSpeculateHeapBigInt(node)) {
                 fixEdge<HeapBigIntUse>(node->child1());
                 fixEdge<HeapBigIntUse>(node->child2());
@@ -761,6 +800,13 @@ private:
             Edge& leftChild = node->child1();
             Edge& rightChild = node->child2();
 
+            if (m_graph.binaryArithShouldSpeculateBigInt64(node, FixupPass)) {
+                fixEdge<BigInt64RepUse>(leftChild);
+                fixEdge<BigInt64RepUse>(rightChild);
+                node->setResult(NodeResultBigInt64);
+                node->clearFlags(NodeMustGenerate);
+                break;
+            }
             if (m_graph.binaryArithShouldSpeculateHeapBigInt(node)) {
                 fixEdge<HeapBigIntUse>(leftChild);
                 fixEdge<HeapBigIntUse>(rightChild);
@@ -839,6 +885,13 @@ private:
         }
 
         case ValuePow: {
+            if (m_graph.binaryArithShouldSpeculateBigInt64(node, FixupPass)) {
+                fixEdge<BigInt64RepUse>(node->child1());
+                fixEdge<BigInt64RepUse>(node->child2());
+                node->setResult(NodeResultBigInt64);
+                node->clearFlags(NodeMustGenerate);
+                break;
+            }
             if (m_graph.binaryArithShouldSpeculateHeapBigInt(node)) {
                 fixEdge<HeapBigIntUse>(node->child1());
                 fixEdge<HeapBigIntUse>(node->child2());
@@ -967,6 +1020,12 @@ private:
             if (Node::shouldSpeculateInt52(node->child1().node(), node->child2().node())) {
                 fixEdge<Int52RepUse>(node->child1());
                 fixEdge<Int52RepUse>(node->child2());
+                node->clearFlags(NodeMustGenerate);
+                break;
+            }
+            if (m_graph.comparisonShouldSpeculateBigInt64(node)) {
+                fixEdge<BigInt64RepUse>(node->child1());
+                fixEdge<BigInt64RepUse>(node->child2());
                 node->clearFlags(NodeMustGenerate);
                 break;
             }
@@ -2683,6 +2742,7 @@ private:
         case PurifyNaN:
         case ValueRep:
         case Int52Rep:
+        case BigInt64Rep:
         case Int52Constant:
         case Identity: // This should have been cleaned up.
         case BooleanToNumber:
@@ -4340,11 +4400,14 @@ private:
                 case FlushedInt52:
                     node->setResult(NodeResultInt52);
                     break;
+                case FlushedBigInt64:
+                    node->setResult(NodeResultBigInt64);
+                    break;
                 default:
                     break;
                 }
                 break;
-                
+
             case SetLocal:
                 // NOTE: Any type checks we put here may get hoisted by fixupChecksInBlock(). So, if we
                 // add new type checking use kind for SetLocals, we need to modify that code as well.
@@ -4360,6 +4423,9 @@ private:
                     break;
                 case FlushedInt52:
                     fixEdge<Int52RepUse>(node->child1());
+                    break;
+                case FlushedBigInt64:
+                    fixEdge<BigInt64RepUse>(node->child1());
                     break;
                 case FlushedCell:
                     fixEdge<CellUse>(node->child1());
@@ -4775,6 +4841,10 @@ private:
             break;
         case Int52RepUse:
             if (!isInt32Speculation(variable->prediction()) && isInt32OrInt52Speculation(variable->prediction()))
+                m_profitabilityChanged |= variable->mergeIsProfitableToUnbox(true);
+            break;
+        case BigInt64RepUse:
+            if (isBigInt64Speculation(variable->prediction()))
                 m_profitabilityChanged |= variable->mergeIsProfitableToUnbox(true);
             break;
         case CellUse:
@@ -5615,13 +5685,17 @@ private:
                                 edge.setUseKind(DoubleRepUse);
                             else if (edge->hasInt52Result())
                                 edge.setUseKind(Int52RepUse);
+                            else if (edge->hasBigInt64Result())
+                                edge.setUseKind(BigInt64RepUse);
                             break;
-            
+
                         case RealNumberUse:
                             if (edge->hasDoubleResult())
                                 edge.setUseKind(DoubleRepRealUse);
                             else if (edge->hasInt52Result())
                                 edge.setUseKind(Int52RepUse);
+                            else if (edge->hasBigInt64Result())
+                                edge.setUseKind(BigInt64RepUse);
                             break;
             
                         default:
@@ -5719,15 +5793,33 @@ private:
                         break;
                     }
 
-                    default: {
-                        if (!edge->hasDoubleResult() && !edge->hasInt52Result())
+                    case BigInt64RepUse: {
+                        if (edge->hasBigInt64Result())
                             break;
-            
+
+                        ASSERT(indexForChecks != UINT_MAX);
+                        // Insert a BigInt64Rep node to unbox the HeapBigInt JSValue to int64.
+                        result = m_insertionSet.insertNode(
+                            indexForChecks, SpecBigInt64, BigInt64Rep, originForChecks,
+                            Edge(edge.node(), HeapBigIntUse));
+
+                        edge.setNode(result);
+                        break;
+                    }
+
+                    default: {
+                        if (!edge->hasDoubleResult() && !edge->hasInt52Result() && !edge->hasBigInt64Result())
+                            break;
+
                         ASSERT(indexForChecks != UINT_MAX);
                         if (edge->hasDoubleResult()) {
                             result = m_insertionSet.insertNode(
                                 indexForChecks, SpecBytecodeDouble, ValueRep, originForChecks,
                                 Edge(edge.node(), DoubleRepUse));
+                        } else if (edge->hasBigInt64Result()) {
+                            result = m_insertionSet.insertNode(
+                                indexForChecks, SpecBigInt64, ValueRep, originForChecks,
+                                Edge(edge.node(), BigInt64RepUse));
                         } else {
                             result = m_insertionSet.insertNode(
                                 indexForChecks, SpecInt32Only | SpecAnyIntAsDouble, ValueRep,

--- a/Source/JavaScriptCore/dfg/DFGFlushFormat.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFlushFormat.cpp
@@ -59,6 +59,9 @@ void printInternal(PrintStream& out, FlushFormat format)
     case ConflictingFlush:
         out.print("ConflictingFlush");
         return;
+    case FlushedBigInt64:
+        out.print("FlushedBigInt64");
+        return;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/JavaScriptCore/dfg/DFGFlushFormat.h
+++ b/Source/JavaScriptCore/dfg/DFGFlushFormat.h
@@ -43,7 +43,8 @@ enum FlushFormat : uint8_t {
     FlushedCell,
     FlushedBoolean,
     FlushedJSValue,
-    ConflictingFlush
+    ConflictingFlush,
+    FlushedBigInt64, // Unboxed int64 for HeapBigInt values that fit in int64.
 };
 
 inline NodeFlags resultFor(FlushFormat format)
@@ -62,6 +63,8 @@ inline NodeFlags resultFor(FlushFormat format)
         return NodeResultDouble;
     case FlushedBoolean:
         return NodeResultBoolean;
+    case FlushedBigInt64:
+        return NodeResultBigInt64;
     }
     RELEASE_ASSERT_NOT_REACHED();
     return 0;
@@ -84,6 +87,8 @@ inline UseKind useKindFor(FlushFormat format)
         return DoubleRepUse;
     case FlushedBoolean:
         return BooleanUse;
+    case FlushedBigInt64:
+        return BigInt64RepUse;
     }
     RELEASE_ASSERT_NOT_REACHED();
     return UntypedUse;
@@ -106,6 +111,8 @@ inline UseKind uncheckedUseKindFor(FlushFormat format)
         return DoubleRepUse;
     case FlushedBoolean:
         return KnownBooleanUse;
+    case FlushedBigInt64:
+        return BigInt64RepUse;
     }
     RELEASE_ASSERT_NOT_REACHED();
     return UntypedUse;
@@ -134,6 +141,8 @@ inline DataFormat dataFormatFor(FlushFormat format)
         return DataFormatCell;
     case FlushedBoolean:
         return DataFormatBoolean;
+    case FlushedBigInt64:
+        return DataFormatBigInt64;
     }
     RELEASE_ASSERT_NOT_REACHED();
     return DataFormatDead;

--- a/Source/JavaScriptCore/dfg/DFGGenerationInfo.h
+++ b/Source/JavaScriptCore/dfg/DFGGenerationInfo.h
@@ -96,6 +96,10 @@ public:
     {
         initGPR(node, useCount, reg, DataFormatStrictInt52);
     }
+    void initBigInt64(Node* node, uint32_t useCount, GPRReg reg)
+    {
+        initGPR(node, useCount, reg, DataFormatBigInt64);
+    }
 #if USE(JSVALUE64)
     void initJSValue(Node* node, uint32_t useCount, GPRReg gpr, DataFormat format = DataFormatJS)
     {
@@ -229,7 +233,12 @@ public:
     {
         return isFormat(DataFormatStrictInt52);
     }
-    
+
+    bool isBigInt64()
+    {
+        return isFormat(DataFormatBigInt64);
+    }
+
     bool isJSDouble()
     {
         return isJSFormat(DataFormatJSDouble);
@@ -359,6 +368,10 @@ public:
     void fillStrictInt52(VariableEventStreamBuilder& stream, GPRReg gpr)
     {
         fillGPR(stream, gpr, DataFormatStrictInt52);
+    }
+    void fillBigInt64(VariableEventStreamBuilder& stream, GPRReg gpr)
+    {
+        fillGPR(stream, gpr, DataFormatBigInt64);
     }
     void fillBoolean(VariableEventStreamBuilder& stream, GPRReg gpr)
     {

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -536,6 +536,52 @@ public:
         return prediction && !(prediction & ~(SpecHeapBigInt | SpecOther));
     }
 
+    // A child node qualifies for BigInt64 speculation if it is a HeapBigInt value (whose
+    // int64 fitness will be checked via the ArithProfile of the parent) OR if it is itself
+    // already the result of a BigInt64-speculated operation (SpecBigInt64 prediction), which
+    // enables chained operations like (a + b) * c to stay unboxed end-to-end.
+    static bool childShouldSpeculateHeapBigIntOrBigInt64(Node* child)
+    {
+        return child->shouldSpeculateHeapBigInt() || child->shouldSpeculateBigInt64();
+    }
+
+    // BUG FIX #2: Both operands must qualify for BigInt64 speculation.
+    // The ArithProfile overflow gate (canSpeculateBigInt64) guards against values that
+    // have been observed to exceed int64 range.
+    bool binaryArithShouldSpeculateBigInt64(Node* node, PredictionPass pass)
+    {
+        if (!Options::useBigInt64())
+            return false;
+        if (!node->canSpeculateBigInt64(node->sourceFor(pass)))
+            return false;
+        if (hasExitSite(node, BigInt64Overflow))
+            return false;
+        return childShouldSpeculateHeapBigIntOrBigInt64(node->child1().node())
+            && childShouldSpeculateHeapBigIntOrBigInt64(node->child2().node());
+    }
+
+    bool unaryArithShouldSpeculateBigInt64(Node* node, PredictionPass pass)
+    {
+        if (!Options::useBigInt64())
+            return false;
+        if (!node->canSpeculateBigInt64(node->sourceFor(pass)))
+            return false;
+        if (hasExitSite(node, BigInt64Overflow))
+            return false;
+        return childShouldSpeculateHeapBigIntOrBigInt64(node->child1().node());
+    }
+
+    // BUG FIX #2: Both operands must qualify for BigInt64 comparison speculation.
+    bool comparisonShouldSpeculateBigInt64(Node* node)
+    {
+        if (!Options::useBigInt64())
+            return false;
+        if (hasExitSite(node, BigInt64Overflow))
+            return false;
+        return childShouldSpeculateHeapBigIntOrBigInt64(node->child1().node())
+            && childShouldSpeculateHeapBigIntOrBigInt64(node->child2().node());
+    }
+
     bool variadicArithShouldSpeculateInt32(Node* node, PredictionPass pass)
     {
         bool result = true;

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -486,6 +486,9 @@ void JITCompiler::noticeOSREntry(BasicBlock& basicBlock, JITCompiler::Label bloc
             case FlushedInt52:
                 entry.m_localsForcedAnyInt.set(local);
                 break;
+            case FlushedBigInt64:
+                entry.m_localsForcedBigInt64.set(local);
+                break;
             default:
                 break;
             }

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -92,7 +92,6 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case Branch:
     case Unreachable:
     case DoubleRep:
-    case ValueRep:
     case PurifyNaN:
     case ExtractOSREntryLocal:
     case ExtractCatchLocal:
@@ -145,6 +144,12 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
         }
         break;
     }
+
+    case ValueRep:
+        // ValueRep for BigInt64RepUse allocates a new HeapBigInt and can throw OOM.
+        if (node->child1().useKind() == BigInt64RepUse)
+            return ExitsForExceptions;
+        break;
 
     case Int52Rep:
         switch (node->child1().useKind()) {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1680,7 +1680,12 @@ public:
     {
         return result() == NodeResultInt52;
     }
-    
+
+    bool hasBigInt64Result()
+    {
+        return result() == NodeResultBigInt64;
+    }
+
     bool hasNumberResult()
     {
         return result() == NodeResultNumber;
@@ -3218,7 +3223,12 @@ public:
     {
         return isHeapBigIntSpeculation(prediction());
     }
-    
+
+    bool shouldSpeculateBigInt64()
+    {
+        return isBigInt64Speculation(prediction());
+    }
+
     bool shouldSpeculateBigInt()
     {
         return isBigIntSpeculation(prediction());
@@ -3460,6 +3470,11 @@ public:
         return op1->shouldSpeculateHeapBigInt() && op2->shouldSpeculateHeapBigInt();
     }
 
+    static bool shouldSpeculateBigInt64(Node* op1, Node* op2)
+    {
+        return op1->shouldSpeculateBigInt64() && op2->shouldSpeculateBigInt64();
+    }
+
     static bool shouldSpeculateFinalObject(Node* op1, Node* op2)
     {
         return op1->shouldSpeculateFinalObject() && op2->shouldSpeculateFinalObject();
@@ -3484,7 +3499,12 @@ public:
     {
         return nodeCanSpeculateBigInt32(arithNodeFlags(), source);
     }
-    
+
+    bool canSpeculateBigInt64(RareCaseProfilingSource source)
+    {
+        return nodeCanSpeculateBigInt64(arithNodeFlags(), source);
+    }
+
     RareCaseProfilingSource sourceFor(PredictionPass pass)
     {
         if (pass == PrimaryPass || child1()->sawBooleans() || (child2() && child2()->sawBooleans()))

--- a/Source/JavaScriptCore/dfg/DFGNodeFlags.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlags.cpp
@@ -55,6 +55,9 @@ void dumpNodeFlags(PrintStream& actualOut, NodeFlags flags)
         case NodeResultInt52:
             out.print(comma, "Int52"_s);
             break;
+        case NodeResultBigInt64:
+            out.print(comma, "BigInt64"_s);
+            break;
         case NodeResultBoolean:
             out.print(comma, "Boolean"_s);
             break;

--- a/Source/JavaScriptCore/dfg/DFGNodeFlags.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlags.h
@@ -34,7 +34,10 @@ namespace JSC { namespace DFG {
 
 // Entries in the NodeType enum (below) are composed of an id, a result type (possibly none)
 // and some additional informative flags (must generate, is constant, etc).
-#define NodeResultMask                   0x0007
+//
+// NodeResultMask is 4 bits wide (0x000F) to accommodate BigInt64 as an unboxed representation.
+// All flags above the result mask are shifted one bit left relative to the historical layout.
+#define NodeResultMask                   0x000F
 #define NodeResultJS                     0x0001
 #define NodeResultNumber                 0x0002
 #define NodeResultDouble                 0x0003
@@ -42,39 +45,43 @@ namespace JSC { namespace DFG {
 #define NodeResultInt52                  0x0005
 #define NodeResultBoolean                0x0006
 #define NodeResultStorage                0x0007
+#define NodeResultBigInt64               0x0008 // Unboxed int64 representation for HeapBigInt values
 
-#define NodeMustGenerate                 0x0008 // set on nodes that have side effects, and may not trivially be removed by DCE.
-#define NodeHasVarArgs                   0x0010
+#define NodeMustGenerate                 0x0010 // set on nodes that have side effects, and may not trivially be removed by DCE.
+#define NodeHasVarArgs                   0x0020
 
-#define NodeMayHaveDoubleResult          0x00020
-#define NodeMayOverflowInt52             0x00040
-#define NodeMayOverflowInt32InBaseline   0x00080
-#define NodeMayOverflowInt32InDFG        0x00100
-#define NodeMayNegZeroInBaseline         0x00200
-#define NodeMayNegZeroInDFG              0x00400
-#define NodeMayHaveBigInt32Result        0x00800
-#define NodeMayHaveHeapBigIntResult      0x01000
-#define NodeMayHaveNonNumericResult      0x02000
-#define NodeBehaviorMask                 (NodeMayHaveDoubleResult | NodeMayOverflowInt52 | NodeMayOverflowInt32InBaseline | NodeMayOverflowInt32InDFG | NodeMayNegZeroInBaseline | NodeMayNegZeroInDFG | NodeMayHaveBigInt32Result | NodeMayHaveHeapBigIntResult | NodeMayHaveNonNumericResult)
+#define NodeMayHaveDoubleResult          0x000040
+#define NodeMayOverflowInt52             0x000080
+#define NodeMayOverflowInt32InBaseline   0x000100
+#define NodeMayOverflowInt32InDFG        0x000200
+#define NodeMayNegZeroInBaseline         0x000400
+#define NodeMayNegZeroInDFG              0x000800
+#define NodeMayHaveBigInt32Result        0x001000
+#define NodeMayHaveHeapBigIntResult      0x002000
+#define NodeMayHaveNonNumericResult      0x004000
+// Set when the ArithProfile for this node observed a HeapBigInt that did not fit in int64.
+// When set, BigInt64 speculation is unsafe for this node.
+#define NodeMayOverflowBigInt64          0x1000000
+#define NodeBehaviorMask                 (NodeMayHaveDoubleResult | NodeMayOverflowInt52 | NodeMayOverflowInt32InBaseline | NodeMayOverflowInt32InDFG | NodeMayNegZeroInBaseline | NodeMayNegZeroInDFG | NodeMayHaveBigInt32Result | NodeMayHaveHeapBigIntResult | NodeMayHaveNonNumericResult | NodeMayOverflowBigInt64)
 #define NodeMayHaveNonIntResult          (NodeMayHaveDoubleResult | NodeMayHaveNonNumericResult | NodeMayHaveBigInt32Result | NodeMayHaveHeapBigIntResult)
 
-#define NodeBytecodeUseBottom            0x00000
-#define NodeBytecodeUsesAsNumber         0x04000 // The result of this computation may be used in a context that observes fractional, or bigger-than-int32, results.
-#define NodeBytecodeNeedsNegZero         0x08000 // The result of this computation may be used in a context that observes -0.
-#define NodeBytecodeNeedsNaNOrInfinity   0x10000 // The result of this computation may be used in a context that observes NaN or Infinity.
-#define NodeBytecodeUsesAsOther          0x20000 // The result of this computation may be used in a context that distinguishes between NaN and other things (like undefined).
-#define NodeBytecodeUsesAsInt            0x40000 // The result of this computation is known to be used in a context that prefers, but does not require, integer values.
-#define NodeBytecodePrefersArrayIndex    0x80000 // The result of this computation is known to be used in a context that strongly prefers integer values, to the point that we should avoid using doubles if at all possible.
+#define NodeBytecodeUseBottom            0x000000
+#define NodeBytecodeUsesAsNumber         0x008000 // The result of this computation may be used in a context that observes fractional, or bigger-than-int32, results.
+#define NodeBytecodeNeedsNegZero         0x010000 // The result of this computation may be used in a context that observes -0.
+#define NodeBytecodeNeedsNaNOrInfinity   0x020000 // The result of this computation may be used in a context that observes NaN or Infinity.
+#define NodeBytecodeUsesAsOther          0x040000 // The result of this computation may be used in a context that distinguishes between NaN and other things (like undefined).
+#define NodeBytecodeUsesAsInt            0x080000 // The result of this computation is known to be used in a context that prefers, but does not require, integer values.
+#define NodeBytecodePrefersArrayIndex    0x100000 // The result of this computation is known to be used in a context that strongly prefers integer values, to the point that we should avoid using doubles if at all possible.
 #define NodeBytecodeUsesAsArrayIndex     (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNaNOrInfinity | NodeBytecodeUsesAsOther | NodeBytecodeUsesAsInt | NodeBytecodePrefersArrayIndex)
 #define NodeBytecodeUsesAsValue          (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNegZero | NodeBytecodeNeedsNaNOrInfinity | NodeBytecodeUsesAsOther)
 #define NodeBytecodeBackPropMask         (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNegZero | NodeBytecodeNeedsNaNOrInfinity | NodeBytecodeUsesAsOther | NodeBytecodeUsesAsInt | NodeBytecodePrefersArrayIndex)
 
 #define NodeArithFlagsMask               (NodeBehaviorMask | NodeBytecodeBackPropMask)
 
-#define NodeIsFlushed                   0x100000 // Computed by CPSRethreadingPhase, will tell you which local nodes are backwards-reachable from a Flush.
+#define NodeIsFlushed                   0x200000 // Computed by CPSRethreadingPhase, will tell you which local nodes are backwards-reachable from a Flush.
 
-#define NodeMiscFlag1                   0x200000
-#define NodeMiscFlag2                   0x400000
+#define NodeMiscFlag1                   0x400000
+#define NodeMiscFlag2                   0x800000
 
 typedef uint32_t NodeFlags;
 
@@ -178,6 +185,18 @@ static inline bool nodeCanSpeculateBigInt32(NodeFlags flags, RareCaseProfilingSo
     return !nodeMayHaveHeapBigInt(flags, source);
 }
 
+static inline bool nodeMayOverflowBigInt64(NodeFlags flags, RareCaseProfilingSource)
+{
+    return !!(flags & NodeMayOverflowBigInt64);
+}
+
+// Returns false if the ArithProfile for this node observed a HeapBigInt that did not fit in int64,
+// meaning BigInt64 speculation is unsafe.
+static inline bool nodeCanSpeculateBigInt64(NodeFlags flags, RareCaseProfilingSource source)
+{
+    return !nodeMayOverflowBigInt64(flags, source);
+}
+
 // FIXME: Get rid of this.
 // https://bugs.webkit.org/show_bug.cgi?id=131689
 static inline NodeFlags canonicalResultRepresentation(NodeFlags flags)
@@ -185,6 +204,7 @@ static inline NodeFlags canonicalResultRepresentation(NodeFlags flags)
     switch (flags) {
     case NodeResultDouble:
     case NodeResultInt52:
+    case NodeResultBigInt64:
     case NodeResultStorage:
         return flags;
     default:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -147,6 +147,7 @@ namespace JSC { namespace DFG {
     /* Change the representation of a value. */\
     macro(DoubleRep, NodeResultDouble) \
     macro(Int52Rep, NodeResultInt52) \
+    macro(BigInt64Rep, NodeResultBigInt64) \
     macro(ValueRep, NodeResultJS) \
     macro(PurifyNaN, NodeResultDouble) \
     \

--- a/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
@@ -33,6 +33,8 @@
 #include "CodeBlock.h"
 #include "DFGJITCode.h"
 #include "DFGNode.h"
+#include "JSBigInt.h"
+#include "JSBigIntInlines.h"
 #include "JSCJSValueInlines.h"
 #include "RegisterAtOffsetList.h"
 #include "VMInlines.h"
@@ -202,6 +204,16 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
             }
             value = jsDoubleNumber(value.asNumber());
             format = FlushedDouble;
+        } else if (entry->m_localsForcedBigInt64.get(local)) {
+            if (!value.isHeapBigInt()) {
+                dataLogLnIf(Options::verboseOSR(), "    OSR failed because variable ", localOffset, " is ", value, ", expected HeapBigInt.");
+                return nullptr;
+            }
+            if (!JSBigInt::fitsInInt64(value.asHeapBigInt())) {
+                dataLogLnIf(Options::verboseOSR(), "    OSR failed because variable ", localOffset, " is ", value, ", too large for BigInt64.");
+                return nullptr;
+            }
+            format = FlushedBigInt64;
         } else {
             if (value.isDouble() && abstractValue.isType(SpecInt32Only)) {
                 if (!value.isInt32AsAnyInt()) {
@@ -266,9 +278,15 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
                 *std::bit_cast<double*>(pivot + index) = value.asNumber();
                 continue;
             }
-            
+
             if (entry->m_localsForcedAnyInt.get(reg.toLocal())) {
                 *std::bit_cast<int64_t*>(pivot + index) = value.asAnyInt() << JSValue::int52ShiftAmount;
+                continue;
+            }
+
+            if (entry->m_localsForcedBigInt64.get(reg.toLocal())) {
+                // Store the raw int64 value (already verified to fit in int64 during validation).
+                *std::bit_cast<int64_t*>(pivot + index) = JSBigInt::toBigInt64(value);
                 continue;
             }
 

--- a/Source/JavaScriptCore/dfg/DFGOSREntry.h
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.h
@@ -60,9 +60,10 @@ struct OSREntryData {
     // Use bitvectors here because they tend to only require one word.
     BitVector m_localsForcedDouble;
     BitVector m_localsForcedAnyInt;
+    BitVector m_localsForcedBigInt64;
     FixedVector<OSREntryReshuffling> m_reshufflings;
     BitVector m_machineStackUsed;
-    
+
     void dumpInContext(PrintStream&, DumpContext*) const;
     void dump(PrintStream&) const;
 };

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -504,6 +504,7 @@ void OSRExit::compileExit(CCallHelpers& jit, VM& vm, const OSRExit& exit, const 
         case InGPR:
         case UnboxedInt52InGPR:
         case UnboxedStrictInt52InGPR:
+        case UnboxedBigInt64InGPR:
             jit.store64(recovery.gpr(), scratch + index);
             break;
 #else
@@ -690,6 +691,26 @@ void OSRExit::compileExit(CCallHelpers& jit, VM& vm, const OSRExit& exit, const 
             jit.boxInt52(GPRInfo::regT0, GPRInfo::regT0, GPRInfo::regT1, FPRInfo::fpRegT0);
             jit.store64(GPRInfo::regT0, scratch + index);
             break;
+
+        case UnboxedBigInt64InGPR:
+            jit.load64(scratch + index, GPRInfo::regT0);
+            jit.setupArguments<decltype(operationInt64ToBigInt)>(
+                CCallHelpers::TrustedImmPtr(jit.codeBlock()->globalObject()), GPRInfo::regT0);
+            jit.prepareCallOperation(vm);
+            jit.move(CCallHelpers::TrustedImmPtr(tagCFunction<OperationPtrTag>(operationInt64ToBigInt)), GPRInfo::regT1);
+            jit.call(GPRInfo::regT1, OperationPtrTag);
+            jit.store64(GPRInfo::returnValueGPR, scratch + index);
+            break;
+
+        case BigInt64DisplacedInJSStack:
+            jit.load64(AssemblyHelpers::addressFor(recovery.virtualRegister()), GPRInfo::regT0);
+            jit.setupArguments<decltype(operationInt64ToBigInt)>(
+                CCallHelpers::TrustedImmPtr(jit.codeBlock()->globalObject()), GPRInfo::regT0);
+            jit.prepareCallOperation(vm);
+            jit.move(CCallHelpers::TrustedImmPtr(tagCFunction<OperationPtrTag>(operationInt64ToBigInt)), GPRInfo::regT1);
+            jit.call(GPRInfo::regT1, OperationPtrTag);
+            jit.store64(GPRInfo::returnValueGPR, scratch + index);
+            break;
 #endif
 
         default:
@@ -804,6 +825,8 @@ void OSRExit::compileExit(CCallHelpers& jit, VM& vm, const OSRExit& exit, const 
         case Int52DisplacedInJSStack:
         case UnboxedStrictInt52InGPR:
         case StrictInt52DisplacedInJSStack:
+        case UnboxedBigInt64InGPR:
+        case BigInt64DisplacedInJSStack:
             spooler.loadGPR(index * sizeof(CPURegister));
             spooler.storeGPR(operand.virtualRegister().offset() * sizeof(CPURegister));
             break;

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -220,6 +220,10 @@ private:
             if (left && right) {
                 if (isFullNumberOrBooleanSpeculationExpectingDefined(left) && isFullNumberOrBooleanSpeculationExpectingDefined(right))
                     changed |= mergePrediction(SpecInt32Only);
+#if USE(JSVALUE64)
+                else if (m_graph.binaryArithShouldSpeculateBigInt64(node, m_pass))
+                    changed |= mergePrediction(SpecBigInt64);
+#endif
                 else if (m_graph.binaryArithShouldSpeculateHeapBigInt(node))
                     changed |= mergePrediction(SpecHeapBigInt);
                 else {
@@ -242,6 +246,10 @@ private:
                 else if (m_graph.unaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
 #endif
+#if USE(JSVALUE64)
+                else if (m_graph.unaryArithShouldSpeculateBigInt64(node, m_pass))
+                    changed |= mergePrediction(SpecBigInt64);
+#endif
                 else if (m_graph.unaryArithShouldSpeculateHeapBigInt(node))
                     changed |= mergePrediction(SpecHeapBigInt);
                 else if (isBigIntSpeculation(prediction))
@@ -259,7 +267,7 @@ private:
         case ValueAdd: {
             SpeculatedType left = node->child1()->prediction();
             SpeculatedType right = node->child2()->prediction();
-            
+
             if (left && right) {
                 if (isFullNumberOrBooleanSpeculationExpectingDefined(left)
                     && isFullNumberOrBooleanSpeculationExpectingDefined(right)) {
@@ -276,6 +284,10 @@ private:
 #if USE(BIGINT32)
                 else if (m_graph.binaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
+#endif
+#if USE(JSVALUE64)
+                else if (m_graph.binaryArithShouldSpeculateBigInt64(node, m_pass))
+                    changed |= mergePrediction(SpecBigInt64);
 #endif
                 else if (m_graph.binaryArithShouldSpeculateHeapBigInt(node))
                     changed |= mergePrediction(SpecHeapBigInt);
@@ -352,6 +364,10 @@ private:
                 else if (m_graph.binaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
 #endif
+#if USE(JSVALUE64)
+                else if (m_graph.binaryArithShouldSpeculateBigInt64(node, m_pass))
+                    changed |= mergePrediction(SpecBigInt64);
+#endif
                 else if (m_graph.binaryArithShouldSpeculateHeapBigInt(node))
                     changed |= mergePrediction(SpecHeapBigInt);
                 else if (isBigIntSpeculation(left) && isBigIntSpeculation(right))
@@ -384,6 +400,10 @@ private:
 #if USE(BIGINT32)
                 else if (m_graph.unaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
+#endif
+#if USE(JSVALUE64)
+                else if (m_graph.unaryArithShouldSpeculateBigInt64(node, m_pass))
+                    changed |= mergePrediction(SpecBigInt64);
 #endif
                 else if (m_graph.unaryArithShouldSpeculateHeapBigInt(node))
                     changed |= mergePrediction(SpecHeapBigInt);
@@ -418,6 +438,10 @@ private:
                 else if (node->op() == ToNumeric && m_graph.unaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
 #endif
+#if USE(JSVALUE64)
+                else if (node->op() == ToNumeric && m_graph.unaryArithShouldSpeculateBigInt64(node, m_pass))
+                    changed |= mergePrediction(SpecBigInt64);
+#endif
                 else if (node->op() == ToNumeric && m_graph.unaryArithShouldSpeculateHeapBigInt(node))
                     changed |= mergePrediction(SpecHeapBigInt);
                 else if (node->op() == ToNumeric && isBigIntSpeculation(prediction))
@@ -438,6 +462,11 @@ private:
             SpeculatedType right = node->child2()->prediction();
 
             if (left && right) {
+#if USE(JSVALUE64)
+                if (m_graph.binaryArithShouldSpeculateBigInt64(node, m_pass))
+                    changed |= mergePrediction(SpecBigInt64);
+                else
+#endif
                 if (m_graph.binaryArithShouldSpeculateHeapBigInt(node))
                     changed |= mergePrediction(SpecHeapBigInt);
                 else if (node->child1()->shouldSpeculateBigInt() && node->child2()->shouldSpeculateBigInt())
@@ -461,6 +490,12 @@ private:
                     changed |= mergePrediction(SpecInt52Any);
                 else if (isBytecodeNumberSpeculation(prediction))
                     changed |= mergePrediction(speculatedDoubleTypeForPrediction(node->child1()->prediction()));
+#if USE(JSVALUE64)
+                else if (node->op() == ValueNegate && m_graph.unaryArithShouldSpeculateBigInt64(node, m_pass))
+                    changed |= mergePrediction(SpecBigInt64);
+#endif
+                else if (node->op() == ValueNegate && m_graph.unaryArithShouldSpeculateHeapBigInt(node))
+                    changed |= mergePrediction(SpecHeapBigInt);
                 else {
                     changed |= mergePrediction(SpecInt32Only);
                     if (node->op() == ValueNegate && node->mayHaveBigIntResult())
@@ -513,6 +548,10 @@ private:
                 else if (op == ValueMul && m_graph.binaryArithShouldSpeculateBigInt32(node, m_pass))
                     changed |= mergePrediction(SpecBigInt32);
 #endif
+#if USE(JSVALUE64)
+                else if (op == ValueMul && m_graph.binaryArithShouldSpeculateBigInt64(node, m_pass))
+                    changed |= mergePrediction(SpecBigInt64);
+#endif
                 else if (op == ValueMul && m_graph.binaryArithShouldSpeculateHeapBigInt(node))
                     changed |= mergePrediction(SpecHeapBigInt);
                 else if (op == ValueMul && isBigIntSpeculation(left) && isBigIntSpeculation(right))
@@ -548,7 +587,9 @@ private:
                         changed |= mergePrediction(SpecInt52Any);
                     else
                         changed |= mergePrediction(SpecBytecodeDouble);
-                } else if ((op == ValueDiv || op == ValueMod) && m_graph.binaryArithShouldSpeculateHeapBigInt(node))
+                } else if ((op == ValueDiv || op == ValueMod) && m_graph.binaryArithShouldSpeculateBigInt64(node, m_pass))
+                    changed |= mergePrediction(SpecBigInt64);
+                else if ((op == ValueDiv || op == ValueMod) && m_graph.binaryArithShouldSpeculateHeapBigInt(node))
                     changed |= mergePrediction(SpecHeapBigInt);
                 else if ((op == ValueDiv || op == ValueMod) && isBigIntSpeculation(left) && isBigIntSpeculation(right))
                     changed |= mergePrediction(SpecBigInt);
@@ -1620,6 +1661,7 @@ private:
         case DoubleRep:
         case ValueRep:
         case Int52Rep:
+        case BigInt64Rep:
         case PurifyNaN:
         case Int52Constant:
         case Identity:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -55,6 +55,7 @@ public:
         case DoubleRepUse:
         case DoubleRepRealUse:
         case Int52RepUse:
+        case BigInt64RepUse:
         case NumberUse:
         case RealNumberUse:
         case BooleanUse:
@@ -308,6 +309,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case DoubleRep:
     case PurifyNaN:
     case Int52Rep:
+    case BigInt64Rep:
     case BooleanToNumber:
     case FiatInt52:
     case HasIndexedProperty:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2026,6 +2026,8 @@ bool SpeculativeJIT::compilePeepHoleBranch(Node* node, RelationalCondition condi
 #if USE(JSVALUE64)
         else if (node->isBinaryUseKind(Int52RepUse))
             compilePeepHoleInt52Branch(node, branchNode, condition);
+        else if (node->isBinaryUseKind(BigInt64RepUse))
+            compilePeepHoleBigInt64Branch(node, branchNode, condition);
 #endif // USE(JSVALUE64)
         else if (node->isBinaryUseKind(StringUse) || node->isBinaryUseKind(StringIdentUse)) {
             // Use non-peephole comparison, for now.
@@ -3286,13 +3288,29 @@ void SpeculativeJIT::compileValueRep(Node* node)
     case Int52RepUse: {
         SpeculateStrictInt52Operand value(this, node->child1());
         GPRTemporary result(this);
-        
+
         GPRReg valueGPR = value.gpr();
         GPRReg resultGPR = result.gpr();
-        
+
         boxInt52(valueGPR, resultGPR, DataFormatStrictInt52);
-        
+
         jsValueResult(resultGPR, node);
+        return;
+    }
+
+    case BigInt64RepUse: {
+        SpeculateBigInt64Operand value(this, node->child1());
+        GPRReg valueGPR = value.gpr();
+
+        flushRegisters();
+        JSValueRegsFlushedCallResult result(this);
+        JSValueRegs resultRegs = result.regs();
+
+        // ValueRep with BigInt64RepUse allocates a new HeapBigInt; DFGMayExit marks
+        // this node as ExitsForExceptions so callOperation's exceptionCheck() is valid.
+        callOperation(operationInt64ToBigInt, resultRegs, LinkableConstant::globalObject(*this, node), valueGPR);
+
+        jsValueResult(resultRegs, node);
         return;
     }
 #endif // USE(JSVALUE64)
@@ -4237,6 +4255,18 @@ void SpeculativeJIT::compileValueBitNot(Node* node)
     // FIXME: add support for mixed BigInt32 / HeapBigInt
 #endif
 
+#if USE(JSVALUE64)
+    if (child1.useKind() == BigInt64RepUse) {
+        SpeculateBigInt64Operand operand(this, child1);
+        GPRTemporary result(this, Reuse, operand);
+        GPRReg resultGPR = result.gpr();
+        // ~x for int64: just bitwise NOT
+        not64(resultGPR);
+        bigInt64Result(resultGPR, node);
+        return;
+    }
+#endif // USE(JSVALUE64)
+
     if (child1.useKind() == HeapBigIntUse) {
         SpeculateCellOperand operand(this, child1);
         GPRReg operandGPR = operand.gpr();
@@ -4407,6 +4437,32 @@ void SpeculativeJIT::compileValueBitwiseOp(Node* node)
     }
     // FIXME: add support for mixed BigInt32 / HeapBigInt
 #endif
+
+#if USE(JSVALUE64)
+    if (node->isBinaryUseKind(BigInt64RepUse)) {
+        SpeculateBigInt64Operand left(this, leftChild);
+        SpeculateBigInt64Operand right(this, rightChild);
+        GPRTemporary result(this, Reuse, left);
+        GPRReg resultGPR = result.gpr();
+
+        switch (op) {
+        case ValueBitAnd:
+            and64(right.gpr(), resultGPR);
+            break;
+        case ValueBitOr:
+            or64(right.gpr(), resultGPR);
+            break;
+        case ValueBitXor:
+            xor64(right.gpr(), resultGPR);
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        bigInt64Result(resultGPR, node);
+        return;
+    }
+#endif // USE(JSVALUE64)
 
     if (node->isBinaryUseKind(HeapBigIntUse)) {
         SpeculateCellOperand left(this, node->child1());
@@ -4588,6 +4644,36 @@ void SpeculativeJIT::compileValueLShiftOp(Node* node)
     Edge& leftChild = node->child1();
     Edge& rightChild = node->child2();
 
+#if USE(JSVALUE64)
+    if (node->isBinaryUseKind(BigInt64RepUse)) {
+        SpeculateBigInt64Operand op1(this, leftChild);
+        SpeculateBigInt64Operand op2(this, rightChild);
+        GPRTemporary result(this);
+        GPRTemporary check(this);
+        GPRReg op1GPR = op1.gpr();
+        GPRReg op2GPR = op2.gpr();
+        GPRReg resultGPR = result.gpr();
+        GPRReg checkGPR = check.gpr();
+
+        JumpList overflow;
+        // Exit if shift amount is negative or >= 64 (those cases can produce out-of-range results)
+        overflow.append(branch64(LessThan, op2GPR, TrustedImm32(0)));
+        overflow.append(branch64(GreaterThanOrEqual, op2GPR, TrustedImm32(64)));
+
+        move(op1GPR, resultGPR);
+        lshift64(op2GPR, resultGPR);
+
+        // Overflow check: shift back right and compare
+        move(resultGPR, checkGPR);
+        rshift64(op2GPR, checkGPR);
+        overflow.append(branch64(NotEqual, checkGPR, op1GPR));
+
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr, overflow);
+        bigInt64Result(resultGPR, node);
+        return;
+    }
+#endif // USE(JSVALUE64)
+
     // FIXME: support BigInt32
     if (node->binaryUseKind() == HeapBigIntUse) {
         SpeculateCellOperand left(this, leftChild);
@@ -4614,6 +4700,36 @@ void SpeculativeJIT::compileValueBitRShift(Node* node)
 {
     Edge& leftChild = node->child1();
     Edge& rightChild = node->child2();
+
+#if USE(JSVALUE64)
+    if (node->isBinaryUseKind(BigInt64RepUse)) {
+        SpeculateBigInt64Operand op1(this, leftChild);
+        SpeculateBigInt64Operand op2(this, rightChild);
+        GPRTemporary result(this);
+        GPRReg op1GPR = op1.gpr();
+        GPRReg op2GPR = op2.gpr();
+        GPRReg resultGPR = result.gpr();
+
+        JumpList overflow;
+        // Exit if shift amount is negative or >= 64
+        overflow.append(branch64(LessThan, op2GPR, TrustedImm32(0)));
+
+        Jump inRange = branch64(LessThan, op2GPR, TrustedImm32(64));
+        // shift >= 64: result = all sign bits (0 or -1), use rshift64 by 63
+        move(op1GPR, resultGPR);
+        rshift64(TrustedImm32(63), resultGPR);
+        Jump done = jump();
+
+        inRange.link(this);
+        move(op1GPR, resultGPR);
+        rshift64(op2GPR, resultGPR);
+
+        done.link(this);
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr, overflow);
+        bigInt64Result(resultGPR, node);
+        return;
+    }
+#endif // USE(JSVALUE64)
 
     // FIXME: support BigInt32
     if (node->isBinaryUseKind(HeapBigIntUse)) {
@@ -4728,6 +4844,21 @@ void SpeculativeJIT::compileValueAdd(Node* node)
     // FIXME: add support for mixed BigInt32/HeapBigInt
 #endif // USE(BIGINT32)
 
+#if USE(JSVALUE64)
+    if (node->isBinaryUseKind(BigInt64RepUse)) {
+        SpeculateBigInt64Operand op1(this, leftChild);
+        SpeculateBigInt64Operand op2(this, rightChild);
+        GPRTemporary result(this);
+        GPRReg op1GPR = op1.gpr();
+        GPRReg op2GPR = op2.gpr();
+        GPRReg resultGPR = result.gpr();
+        move(op1GPR, resultGPR);
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr, branchAdd64(Overflow, op2GPR, resultGPR));
+        bigInt64Result(resultGPR, node);
+        return;
+    }
+#endif // USE(JSVALUE64)
+
     if (node->isBinaryUseKind(HeapBigIntUse)) {
         SpeculateCellOperand left(this, leftChild);
         SpeculateCellOperand right(this, rightChild);
@@ -4823,6 +4954,25 @@ void SpeculativeJIT::compileValueSub(Node* node)
         return;
     }
 #endif // USE(BIGINT32)
+
+#if USE(JSVALUE64)
+    if (node->binaryUseKind() == BigInt64RepUse) {
+        SpeculateBigInt64Operand op1(this, leftChild);
+        SpeculateBigInt64Operand op2(this, rightChild);
+        GPRTemporary result(this);
+        GPRReg op1GPR = op1.gpr();
+        GPRReg op2GPR = op2.gpr();
+        GPRReg resultGPR = result.gpr();
+#if CPU(ARM64)
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr, branchSub64(Overflow, op1GPR, op2GPR, resultGPR));
+#else
+        move(op1GPR, resultGPR);
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr, branchSub64(Overflow, op2GPR, resultGPR));
+#endif
+        bigInt64Result(resultGPR, node);
+        return;
+    }
+#endif // USE(JSVALUE64)
 
     if (node->binaryUseKind() == HeapBigIntUse) {
         SpeculateCellOperand left(this, node->child1());
@@ -5485,6 +5635,19 @@ void SpeculativeJIT::compileIncOrDec(Node* node)
 
 void SpeculativeJIT::compileValueNegate(Node* node)
 {
+#if USE(JSVALUE64)
+    if (node->child1().useKind() == BigInt64RepUse) {
+        SpeculateBigInt64Operand op1(this, node->child1());
+        GPRTemporary result(this);
+        GPRReg op1GPR = op1.gpr();
+        GPRReg resultGPR = result.gpr();
+        move(op1GPR, resultGPR);
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr, branchNeg64(Overflow, resultGPR));
+        bigInt64Result(resultGPR, node);
+        return;
+    }
+#endif // USE(JSVALUE64)
+
     // FIXME: add a fast path, at least for BigInt32, but probably also for HeapBigInt here.
     CodeBlock* baselineCodeBlock = m_graph.baselineCodeBlockFor(node->origin.semantic);
     BytecodeIndex bytecodeIndex = node->origin.semantic.bytecodeIndex();
@@ -5687,6 +5850,20 @@ void SpeculativeJIT::compileValueMul(Node* node)
     // FIXME: add support for mixed BigInt32/HeapBigInt
 #endif
 
+#if USE(JSVALUE64)
+    if (node->binaryUseKind() == BigInt64RepUse) {
+        SpeculateBigInt64Operand op1(this, leftChild);
+        SpeculateBigInt64Operand op2(this, rightChild);
+        GPRTemporary result(this);
+        GPRReg op1GPR = op1.gpr();
+        GPRReg op2GPR = op2.gpr();
+        GPRReg resultGPR = result.gpr();
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr, branchMul64(Overflow, op1GPR, op2GPR, resultGPR));
+        bigInt64Result(resultGPR, node);
+        return;
+    }
+#endif // USE(JSVALUE64)
+
     if (leftChild.useKind() == HeapBigIntUse && rightChild.useKind() == HeapBigIntUse) {
         SpeculateCellOperand left(this, leftChild);
         SpeculateCellOperand right(this, rightChild);
@@ -5883,6 +6060,63 @@ void SpeculativeJIT::compileValueDiv(Node* node)
 
     // FIXME: add a fast path for BigInt32. Currently we go through the slow path, because of how ugly the code for Div gets.
     // https://bugs.webkit.org/show_bug.cgi?id=211041
+
+#if USE(JSVALUE64)
+    if (node->isBinaryUseKind(BigInt64RepUse)) {
+        SpeculateBigInt64Operand op1(this, leftChild);
+        SpeculateBigInt64Operand op2(this, rightChild);
+        GPRReg op1GPR = op1.gpr();
+        GPRReg op2GPR = op2.gpr();
+
+        // Handle edge cases: divisor == 0 and INT64_MIN / -1 overflow.
+        GPRTemporary overflowTemp(this);
+        GPRReg overflowTempGPR = overflowTemp.gpr();
+        add64(TrustedImm32(1), op2GPR, overflowTempGPR);
+        Jump safeDenominator = branch64(Above, overflowTempGPR, TrustedImm32(1));
+        // Divisor is 0 or -1.
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr, branchTest64(Zero, op2GPR));
+        // Divisor is -1; check INT64_MIN / -1 overflow.
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr,
+            branch64(Equal, op1GPR, TrustedImm64(std::numeric_limits<int64_t>::min())));
+        safeDenominator.link(this);
+
+#if CPU(X86_64)
+        GPRTemporary eax(this, X86Registers::eax);
+        GPRTemporary edx(this, X86Registers::edx);
+
+        GPRReg op1SaveGPR;
+        if (op1GPR == X86Registers::eax || op1GPR == X86Registers::edx) {
+            op1SaveGPR = allocate();
+            move(op1GPR, op1SaveGPR);
+        } else
+            op1SaveGPR = op1GPR;
+
+        if (op2GPR == X86Registers::eax || op2GPR == X86Registers::edx) {
+            GPRReg op2TempGPR = allocate();
+            move(op2GPR, op2TempGPR);
+            op2GPR = op2TempGPR;
+        }
+
+        move(op1GPR, X86Registers::eax);
+        x86ConvertToQuadWord64();
+        x86Div64(op2GPR);
+
+        if (op1SaveGPR != op1GPR)
+            unlock(op1SaveGPR);
+
+        bigInt64Result(X86Registers::eax, node);
+#elif CPU(ARM64)
+        GPRTemporary quotient(this);
+        GPRReg quotientGPR = quotient.gpr();
+
+        div64(op1GPR, op2GPR, quotientGPR);
+        bigInt64Result(quotientGPR, node);
+#else
+        RELEASE_ASSERT_NOT_REACHED();
+#endif
+        return;
+    }
+#endif // USE(JSVALUE64)
 
     if (node->isBinaryUseKind(HeapBigIntUse)) {
         SpeculateCellOperand left(this, leftChild);
@@ -6187,6 +6421,67 @@ void SpeculativeJIT::compileValueMod(Node* node)
     Edge& rightChild = node->child2();
 
     // FIXME: add a fast path for BigInt32. Currently we go through the slow path, because of how ugly the code for Mod gets.
+
+#if USE(JSVALUE64)
+    if (node->isBinaryUseKind(BigInt64RepUse)) {
+        SpeculateBigInt64Operand op1(this, leftChild);
+        SpeculateBigInt64Operand op2(this, rightChild);
+        GPRReg op1GPR = op1.gpr();
+        GPRReg op2GPR = op2.gpr();
+
+        // Handle edge cases: divisor == 0 and INT64_MIN % -1 (which would trap on x86_64).
+        GPRTemporary overflowTemp(this);
+        GPRReg overflowTempGPR = overflowTemp.gpr();
+        add64(TrustedImm32(1), op2GPR, overflowTempGPR);
+        Jump safeDenominator = branch64(Above, overflowTempGPR, TrustedImm32(1));
+        // Divisor is 0 or -1.
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr, branchTest64(Zero, op2GPR));
+        // Divisor is -1; INT64_MIN % -1 would trap on x86_64 — exit conservatively.
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr,
+            branch64(Equal, op1GPR, TrustedImm64(std::numeric_limits<int64_t>::min())));
+        safeDenominator.link(this);
+
+#if CPU(X86_64)
+        GPRTemporary eax(this, X86Registers::eax);
+        GPRTemporary edx(this, X86Registers::edx);
+
+        GPRReg op1SaveGPR;
+        if (op1GPR == X86Registers::eax || op1GPR == X86Registers::edx) {
+            op1SaveGPR = allocate();
+            move(op1GPR, op1SaveGPR);
+        } else
+            op1SaveGPR = op1GPR;
+
+        if (op2GPR == X86Registers::eax || op2GPR == X86Registers::edx) {
+            GPRReg op2TempGPR = allocate();
+            move(op2GPR, op2TempGPR);
+            op2GPR = op2TempGPR;
+        }
+
+        move(op1GPR, X86Registers::eax);
+        x86ConvertToQuadWord64();
+        x86Div64(op2GPR);
+
+        if (op1SaveGPR != op1GPR)
+            unlock(op1SaveGPR);
+
+        bigInt64Result(X86Registers::edx, node);
+#elif CPU(ARM64)
+        GPRTemporary quotient(this);
+        GPRTemporary remainder(this);
+        GPRReg quotientGPR = quotient.gpr();
+        GPRReg remainderGPR = remainder.gpr();
+
+        div64(op1GPR, op2GPR, quotientGPR);
+        mul64(quotientGPR, op2GPR, remainderGPR);
+        sub64(op1GPR, remainderGPR, remainderGPR);
+        bigInt64Result(remainderGPR, node);
+#else
+        RELEASE_ASSERT_NOT_REACHED();
+#endif
+        return;
+    }
+#endif // USE(JSVALUE64)
 
     if (node->binaryUseKind() == HeapBigIntUse) {
         SpeculateCellOperand left(this, leftChild);
@@ -6975,6 +7270,52 @@ void SpeculativeJIT::compileValuePow(Node* node)
     Edge& rightChild = node->child2();
 
     // FIXME: do we want a fast path for BigInt32 for Pow? I expect it would overflow pretty often.
+#if USE(JSVALUE64)
+    if (node->isBinaryUseKind(BigInt64RepUse)) {
+        // Implement binary exponentiation with inline overflow detection.
+        SpeculateBigInt64Operand op1(this, leftChild);
+        SpeculateBigInt64Operand op2(this, rightChild);
+        GPRReg baseGPR = op1.gpr();
+        GPRReg expGPR = op2.gpr();
+
+        GPRTemporary result(this);
+        GPRTemporary base(this);
+        GPRTemporary exp(this);
+        GPRReg resultGPR = result.gpr();
+        GPRReg baseReg = base.gpr();
+        GPRReg expReg = exp.gpr();
+
+        move(TrustedImm64(1), resultGPR);
+        move(baseGPR, baseReg);
+        move(expGPR, expReg);
+
+        // Negative exponent is a TypeError at the BigInt level — should not be reached
+        // with correct profiling, but guard anyway.
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr,
+            branch64(LessThan, expReg, TrustedImm64(0)));
+
+        // Binary exponentiation loop.
+        Label loopStart = label();
+        // If exp is odd, result *= base (with overflow check).
+        Jump notOdd = branchTest64(Zero, expReg, TrustedImm32(1));
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr,
+            branchMul64(Overflow, baseReg, resultGPR, resultGPR));
+        notOdd.link(this);
+        // exp >>= 1
+        rshift64(TrustedImm32(1), expReg);
+        // If exp == 0, done (no need to square base).
+        Jump done = branchTest64(Zero, expReg);
+        // base *= base (with overflow check).
+        speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr,
+            branchMul64(Overflow, baseReg, baseReg, baseReg));
+        jump().linkTo(loopStart, this);
+        done.link(this);
+
+        bigInt64Result(resultGPR, node);
+        return;
+    }
+#endif // USE(JSVALUE64)
+
     if (node->binaryUseKind() == HeapBigIntUse) {
         SpeculateCellOperand left(this, leftChild);
         SpeculateCellOperand right(this, rightChild);
@@ -7167,6 +7508,11 @@ bool SpeculativeJIT::compare(Node* node, RelationalCondition condition, DoubleCo
         compileInt52Compare(node, condition);
         return false;
     }
+
+    if (node->isBinaryUseKind(BigInt64RepUse)) {
+        compileBigInt64Compare(node, condition);
+        return false;
+    }
 #endif // USE(JSVALUE64)
     
     if (node->isBinaryUseKind(DoubleRepUse)) {
@@ -7307,6 +7653,21 @@ bool SpeculativeJIT::compileStrictEq(Node* node)
             return true;
         }
         compileInt52Compare(node, Equal);
+        return false;
+    }
+
+    if (node->isBinaryUseKind(BigInt64RepUse)) {
+        unsigned branchIndexInBlock = detectPeepHoleBranch();
+        if (branchIndexInBlock != UINT_MAX) {
+            Node* branchNode = m_block->at(branchIndexInBlock);
+            compilePeepHoleBigInt64Branch(node, branchNode, Equal);
+            use(node->child1());
+            use(node->child2());
+            m_indexInBlock = branchIndexInBlock;
+            m_currentNode = branchNode;
+            return true;
+        }
+        compileBigInt64Compare(node, Equal);
         return false;
     }
 #endif // USE(JSVALUE64)
@@ -12722,6 +13083,7 @@ void SpeculativeJIT::speculate(Node*, Edge edge)
         break;
     case DoubleRepUse:
     case Int52RepUse:
+    case BigInt64RepUse:
     case KnownInt32Use:
     case KnownCellUse:
     case KnownStringUse:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -342,6 +342,9 @@ public:
 #if USE(BIGINT32)
     GPRReg fillSpeculateBigInt32(Edge);
 #endif
+#if USE(JSVALUE64)
+    GPRReg fillSpeculateBigInt64(Edge);
+#endif
     GeneratedOperandType checkGeneratedTypeForToInt32(Node*);
 
     void addSlowPathGenerator(std::unique_ptr<SlowPathGenerator>);
@@ -521,7 +524,14 @@ public:
             info.spill(m_stream, spillMe, spillFormat);
             return;
         }
-            
+
+        case DataFormatBigInt64: {
+            // Unboxed int64 BigInt: store raw 64-bit value to the stack slot.
+            store64(info.gpr(), JITCompiler::addressFor(spillMe));
+            info.spill(m_stream, spillMe, DataFormatBigInt64);
+            return;
+        }
+
         default:
             // The following code handles JSValues, int32s, and cells.
             RELEASE_ASSERT(spillFormat == DataFormatCell || spillFormat & DataFormatJS);
@@ -819,6 +829,17 @@ public:
     void strictInt52Result(GPRReg reg, Node* node, UseChildrenMode mode = CallUseChildren)
     {
         int52Result(reg, node, DataFormatStrictInt52, mode);
+    }
+    void bigInt64Result(GPRReg reg, Node* node, UseChildrenMode mode = CallUseChildren)
+    {
+        if (mode == CallUseChildren)
+            useChildren(node);
+
+        VirtualRegister virtualRegister = node->virtualRegister();
+        GenerationInfo& info = generationInfoFromVirtualRegister(virtualRegister);
+
+        m_gprs.retain(reg, virtualRegister, SpillOrderJS);
+        info.initBigInt64(node, node->refCount(), reg);
     }
     void noResult(Node* node, UseChildrenMode mode = CallUseChildren)
     {
@@ -1465,6 +1486,11 @@ public:
 
     void compileInt32Compare(Node*, RelationalCondition);
     void compileInt52Compare(Node*, RelationalCondition);
+#if USE(JSVALUE64)
+    void compileBigInt64Compare(Node*, RelationalCondition);
+    void compilePeepHoleBigInt64Branch(Node*, Node* branchNode, JITCompiler::RelationalCondition);
+    void compileBigInt64Rep(Node*);
+#endif
 #if USE(BIGINT32)
     void compileBigInt32Compare(Node*, RelationalCondition);
 #endif
@@ -2763,6 +2789,56 @@ private:
 };
 
 enum OppositeShiftTag { OppositeShift };
+
+// Gives you an unboxed BigInt64 value (raw int64_t) in a GPR.
+#if USE(JSVALUE64)
+class SpeculateBigInt64Operand {
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(SpeculateBigInt64Operand);
+public:
+    explicit SpeculateBigInt64Operand(SpeculativeJIT* jit, Edge edge)
+        : m_jit(jit)
+        , m_edge(edge)
+        , m_gprOrInvalid(InvalidGPRReg)
+    {
+        RELEASE_ASSERT(edge.useKind() == BigInt64RepUse);
+        if (jit->isFilled(node()))
+            gpr();
+    }
+
+    ~SpeculateBigInt64Operand()
+    {
+        ASSERT(m_gprOrInvalid != InvalidGPRReg);
+        m_jit->unlock(m_gprOrInvalid);
+    }
+
+    Edge edge() const
+    {
+        return m_edge;
+    }
+
+    Node* node() const
+    {
+        return edge().node();
+    }
+
+    GPRReg gpr()
+    {
+        if (m_gprOrInvalid == InvalidGPRReg)
+            m_gprOrInvalid = m_jit->fillSpeculateBigInt64(edge());
+        return m_gprOrInvalid;
+    }
+
+    void use()
+    {
+        m_jit->use(node());
+    }
+
+private:
+    SpeculativeJIT* m_jit;
+    Edge m_edge;
+    GPRReg m_gprOrInvalid;
+};
+#endif // USE(JSVALUE64)
 
 class SpeculateWhicheverInt52Operand {
     WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(SpeculateWhicheverInt52Operand);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -1381,6 +1381,55 @@ GPRReg SpeculativeJIT::fillSpeculateInt52(Edge edge, DataFormat desiredFormat)
     }
 }
 
+GPRReg SpeculativeJIT::fillSpeculateBigInt64(Edge edge)
+{
+    ASSERT(edge.useKind() == BigInt64RepUse);
+    AbstractValue& value = m_state.forNode(edge);
+    SpeculatedType type = value.m_type;
+
+    m_interpreter.filter(value, SpecBigInt64);
+    if (value.isClear()) {
+        if (!type)
+            terminateUnreachableNode();
+        else if (mayHaveTypeCheck(edge.useKind()))
+            terminateSpeculativeExecution(Uncountable, JSValueRegs(), nullptr);
+        return allocate();
+    }
+
+    VirtualRegister virtualRegister = edge->virtualRegister();
+    GenerationInfo& info = generationInfoFromVirtualRegister(virtualRegister);
+
+    switch (info.registerFormat()) {
+    case DataFormatNone: {
+        GPRReg gpr = allocate();
+
+        if (edge->hasConstant()) {
+            // BigInt64 constants should not appear, but handle gracefully.
+            DFG_CRASH(m_graph, m_currentNode, "Unexpected BigInt64 constant");
+            return gpr;
+        }
+
+        DataFormat spillFormat = info.spillFormat();
+        DFG_ASSERT(m_graph, m_currentNode, spillFormat == DataFormatBigInt64, spillFormat);
+
+        m_gprs.retain(gpr, virtualRegister, SpillOrderSpilled);
+        load64(addressFor(virtualRegister), gpr);
+        info.fillBigInt64(m_stream, gpr);
+        return gpr;
+    }
+
+    case DataFormatBigInt64: {
+        GPRReg gpr = info.gpr();
+        lock(gpr);
+        return gpr;
+    }
+
+    default:
+        DFG_CRASH(m_graph, m_currentNode, "Bad data format");
+        return InvalidGPRReg;
+    }
+}
+
 FPRReg SpeculativeJIT::fillSpeculateDouble(Edge edge)
 {
     ASSERT(edge.useKind() == DoubleRepUse || edge.useKind() == DoubleRepRealUse || edge.useKind() == DoubleRepAnyIntUse);
@@ -1946,6 +1995,90 @@ void SpeculativeJIT::compilePeepHoleInt52Branch(Node* node, Node* branchNode, Re
     SpeculateWhicheverInt52Operand op1(this, node->child1());
     SpeculateWhicheverInt52Operand op2(this, node->child2(), op1);
     
+    branch64(condition, op1.gpr(), op2.gpr(), taken);
+    jump(notTaken);
+}
+
+void SpeculativeJIT::compileBigInt64Rep(Node* node)
+{
+    // Unbox a HeapBigInt → int64_t, OSR exiting if the value is out of int64 range.
+    SpeculateCellOperand input(this, node->child1());
+    GPRTemporary result(this);
+    GPRTemporary scratch(this);
+
+    GPRReg inputGPR = input.gpr();
+    GPRReg resultGPR = result.gpr();
+    GPRReg scratchGPR = scratch.gpr();
+
+    speculateHeapBigInt(node->child1(), inputGPR);
+
+    // Default result = 0 (for length == 0).
+    move(TrustedImm64(0), resultGPR);
+
+    // Load length.
+    load32(Address(inputGPR, JSBigInt::offsetOfLength()), scratchGPR);
+
+    // length > 1: value doesn't fit in int64 → overflow.
+    speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr,
+        branch32(GreaterThan, scratchGPR, TrustedImm32(1)));
+
+    // length == 0: done (result = 0).
+    Jump lengthIsZero = branchTest32(Zero, scratchGPR);
+
+    // length == 1: load digit[0].
+    load64(Address(inputGPR, JSBigInt::offsetOfData()), resultGPR);
+
+    // Check sign bit (TypeInfoPerCellBit = 0x80 at typeInfoFlagsOffset()).
+    load8(Address(inputGPR, JSCell::typeInfoFlagsOffset()), scratchGPR);
+    Jump isNegative = branchTest32(NonZero, scratchGPR, TrustedImm32(TypeInfoPerCellBit));
+
+    // Positive: digit must be <= INT64_MAX (bit 63 clear).
+    // Treat the unsigned digit as a signed 64-bit value: if negative bit set, overflow.
+    speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr,
+        branch64(LessThan, resultGPR, TrustedImm64(0)));
+    Jump done = jump();
+
+    isNegative.link(this);
+    // Negative: digit <= 2^63 (= 0x8000000000000000), i.e., -digit >= INT64_MIN.
+    speculationCheck(BigInt64Overflow, JSValueRegs(), nullptr,
+        branch64(Above, resultGPR,
+            TrustedImm64(static_cast<int64_t>(std::numeric_limits<int64_t>::min()))));
+    // result = -digit.
+    neg64(resultGPR);
+
+    done.link(this);
+    lengthIsZero.link(this);
+
+    bigInt64Result(resultGPR, node);
+}
+
+void SpeculativeJIT::compileBigInt64Compare(Node* node, RelationalCondition condition)
+{
+    SpeculateBigInt64Operand op1(this, node->child1());
+    SpeculateBigInt64Operand op2(this, node->child2());
+    GPRTemporary result(this, Reuse, op1);
+
+    compare64(condition, op1.gpr(), op2.gpr(), result.gpr());
+
+    or32(TrustedImm32(JSValue::ValueFalse), result.gpr());
+    jsValueResult(result.gpr(), m_currentNode, DataFormatJSBoolean);
+}
+
+void SpeculativeJIT::compilePeepHoleBigInt64Branch(Node* node, Node* branchNode, RelationalCondition condition)
+{
+    BasicBlock* taken = branchNode->branchData()->taken.block;
+    BasicBlock* notTaken = branchNode->branchData()->notTaken.block;
+
+    if (taken == nextBlock()) {
+        condition = invert(condition);
+        BasicBlock* tmp = taken;
+        taken = notTaken;
+        notTaken = tmp;
+    }
+
+    SpeculateBigInt64Operand op1(this, node->child1());
+    SpeculateBigInt64Operand op2(this, node->child2());
+
     branch64(condition, op1.gpr(), op2.gpr(), taken);
     jump(notTaken);
 }
@@ -3588,6 +3721,11 @@ void SpeculativeJIT::compile(Node* node)
         default:
             DFG_CRASH(m_graph, node, "Bad use kind");
         }
+        break;
+    }
+
+    case BigInt64Rep: {
+        compileBigInt64Rep(node);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGUseKind.cpp
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.cpp
@@ -47,6 +47,9 @@ void printInternal(PrintStream& out, UseKind useKind)
     case Int52RepUse:
         out.print("Int52Rep");
         return;
+    case BigInt64RepUse:
+        out.print("BigInt64Rep");
+        return;
     case AnyIntUse:
         out.print("AnyInt");
         return;

--- a/Source/JavaScriptCore/dfg/DFGUseKind.h
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.h
@@ -107,6 +107,10 @@ enum UseKind : uint8_t {
     //    in a GP register.
     Int52RepUse,
 
+    // 4. The BigInt64 representation for an unboxed int64 value representing a HeapBigInt
+    //    that is known to fit in int64. Stored in a GP register.
+    BigInt64RepUse,
+
     LastUseKind // Must always be the last entry in the enum, as it is used to denote the number of enum elements.
 };
 
@@ -120,6 +124,8 @@ inline SpeculatedType typeFilterFor(UseKind useKind)
         return SpecInt32Only;
     case Int52RepUse:
         return SpecInt52Any;
+    case BigInt64RepUse:
+        return SpecBigInt64;
     case AnyIntUse:
         return SpecInt32Only | SpecAnyIntAsDouble;
     case NumberUse:
@@ -205,7 +211,7 @@ inline SpeculatedType typeFilterFor(UseKind useKind)
     case NotCellUse:
         return ~SpecCellCheck;
     case NotCellNorBigIntUse:
-        return ~SpecCellCheck & ~SpecBigInt;
+        return ~SpecCellCheck & ~SpecBigInt & ~SpecBigInt64;
     case NotDoubleUse:
         return ~SpecFullDouble;
     case NeitherDoubleNorHeapBigIntUse:
@@ -236,6 +242,7 @@ inline bool shouldNotHaveTypeCheck(UseKind kind)
     case KnownOtherUse:
     case Int52RepUse:
     case DoubleRepUse:
+    case BigInt64RepUse:
         return true;
     default:
         return false;
@@ -320,6 +327,8 @@ inline UseKind useKindForResult(NodeFlags result)
     switch (result) {
     case NodeResultInt52:
         return Int52RepUse;
+    case NodeResultBigInt64:
+        return BigInt64RepUse;
     case NodeResultDouble:
         return DoubleRepUse;
     case NodeResultStorage:

--- a/Source/JavaScriptCore/dfg/DFGValueSource.h
+++ b/Source/JavaScriptCore/dfg/DFGValueSource.h
@@ -39,6 +39,7 @@ enum ValueSourceKind {
     ValueInJSStack,
     Int32InJSStack,
     Int52InJSStack,
+    BigInt64InJSStack,
     CellInJSStack,
     BooleanInJSStack,
     DoubleInJSStack,
@@ -53,6 +54,8 @@ static inline ValueSourceKind dataFormatToValueSourceKind(DataFormat dataFormat)
         return Int32InJSStack;
     case DataFormatInt52:
         return Int52InJSStack;
+    case DataFormatBigInt64:
+        return BigInt64InJSStack;
     case DataFormatDouble:
         return DoubleInJSStack;
     case DataFormatBoolean:
@@ -76,6 +79,8 @@ static inline DataFormat valueSourceKindToDataFormat(ValueSourceKind kind)
         return DataFormatInt32;
     case Int52InJSStack:
         return DataFormatInt52;
+    case BigInt64InJSStack:
+        return DataFormatBigInt64;
     case CellInJSStack:
         return DataFormatCell;
     case BooleanInJSStack:
@@ -145,6 +150,8 @@ public:
             return ValueSource(Int32InJSStack, where);
         case FlushedInt52:
             return ValueSource(Int52InJSStack, where);
+        case FlushedBigInt64:
+            return ValueSource(BigInt64InJSStack, where);
         case FlushedCell:
             return ValueSource(CellInJSStack, where);
         case FlushedBoolean:

--- a/Source/JavaScriptCore/dfg/DFGVariableAccessData.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVariableAccessData.cpp
@@ -164,8 +164,16 @@ bool VariableAccessData::couldRepresentInt52()
 {
     if (shouldNeverUnbox())
         return false;
-    
+
     return couldRepresentInt52Impl();
+}
+
+bool VariableAccessData::couldRepresentBigInt64()
+{
+    if (shouldNeverUnbox())
+        return false;
+
+    return couldRepresentBigInt64Impl();
 }
 
 bool VariableAccessData::couldRepresentInt52Impl()
@@ -173,14 +181,27 @@ bool VariableAccessData::couldRepresentInt52Impl()
     // The hardware has to support it.
     if (!enableInt52())
         return false;
-    
+
     // We punt for machine arguments.
     if (operand().isArgument())
         return false;
-    
+
     // The argument-aware prediction -- which merges all of an (inlined or machine)
     // argument's variable access datas' predictions -- must possibly be Int52Any.
     return isInt32OrInt52Speculation(argumentAwarePrediction());
+}
+
+bool VariableAccessData::couldRepresentBigInt64Impl()
+{
+#if USE(JSVALUE64)
+    // We punt for machine arguments.
+    if (operand().isArgument())
+        return false;
+
+    return isBigInt64Speculation(argumentAwarePrediction());
+#else
+    return false;
+#endif
 }
 
 FlushFormat VariableAccessData::flushFormat()
@@ -205,7 +226,10 @@ FlushFormat VariableAccessData::flushFormat()
     
     if (couldRepresentInt52Impl())
         return FlushedInt52;
-    
+
+    if (couldRepresentBigInt64Impl())
+        return FlushedBigInt64;
+
     if (isCellSpeculation(prediction))
         return FlushedCell;
     

--- a/Source/JavaScriptCore/dfg/DFGVariableAccessData.h
+++ b/Source/JavaScriptCore/dfg/DFGVariableAccessData.h
@@ -195,9 +195,10 @@ public:
     }
     
     FlushFormat NODELETE flushFormat();
-    
+
     bool NODELETE couldRepresentInt52();
-    
+    bool NODELETE couldRepresentBigInt64();
+
     FlushedAt flushedAt()
     {
         return FlushedAt(flushFormat(), machineLocal());
@@ -205,6 +206,7 @@ public:
 
 private:
     bool NODELETE couldRepresentInt52Impl();
+    bool NODELETE couldRepresentBigInt64Impl();
     
     // This is slightly space-inefficient, since anything we're unified with
     // will have the same operand and should have the same prediction. But

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -332,6 +332,7 @@ inline CapabilityLevel canCompile(Node* node)
     case DoubleRep:
     case ValueRep:
     case Int52Rep:
+    case BigInt64Rep:
     case PurifyNaN:
     case DoubleConstant:
     case Int52Constant:
@@ -588,6 +589,7 @@ CapabilityLevel canCompile(Graph& graph)
                 case AnyBigIntUse:
                 case BigInt32Use:
                 case HeapBigIntUse:
+                case BigInt64RepUse:
                 case DateObjectUse:
                 case MapObjectUse:
                 case MapIteratorObjectUse:

--- a/Source/JavaScriptCore/ftl/FTLExitValue.cpp
+++ b/Source/JavaScriptCore/ftl/FTLExitValue.cpp
@@ -73,9 +73,12 @@ DataFormat ExitValue::dataFormat() const
             
     case ExitValueInJSStackAsInt52:
         return DataFormatInt52;
-            
+
     case ExitValueInJSStackAsDouble:
         return DataFormatDouble;
+
+    case ExitValueInJSStackAsBigInt64:
+        return DataFormatBigInt64;
     }
         
     RELEASE_ASSERT_NOT_REACHED();
@@ -107,6 +110,9 @@ void ExitValue::dumpInContext(PrintStream& out, DumpContext* context) const
         return;
     case ExitValueInJSStackAsDouble:
         out.print("InJSStackAsDouble:", virtualRegister());
+        return;
+    case ExitValueInJSStackAsBigInt64:
+        out.print("InJSStackAsBigInt64:", virtualRegister());
         return;
     case ExitValueMaterializeNewObject:
         out.print("Materialize(", WTF::RawPointer(objectMaterialization()), ")");

--- a/Source/JavaScriptCore/ftl/FTLExitValue.h
+++ b/Source/JavaScriptCore/ftl/FTLExitValue.h
@@ -56,6 +56,7 @@ enum ExitValueKind : uint8_t {
     ExitValueInJSStackAsInt32,
     ExitValueInJSStackAsInt52,
     ExitValueInJSStackAsDouble,
+    ExitValueInJSStackAsBigInt64,
     ExitValueMaterializeNewObject
 };
 
@@ -116,7 +117,17 @@ public:
         result.m_value = WTF::move(u);
         return result;
     }
-    
+
+    static ExitValue inJSStackAsBigInt64(VirtualRegister reg)
+    {
+        ExitValue result;
+        result.m_kind = ExitValueInJSStackAsBigInt64;
+        UnionType u;
+        u.virtualRegister = reg.offset();
+        result.m_value = WTF::move(u);
+        return result;
+    }
+
     static ExitValue constant(JSValue value)
     {
         ExitValue result;
@@ -149,6 +160,7 @@ public:
         case ExitValueInJSStackAsInt32:
         case ExitValueInJSStackAsInt52:
         case ExitValueInJSStackAsDouble:
+        case ExitValueInJSStackAsBigInt64:
             return true;
         default:
             return false;

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -786,6 +786,9 @@ private:
         case Int52Rep:
             compileInt52Rep();
             break;
+        case BigInt64Rep:
+            compileBigInt64Rep();
+            break;
         case ValueToInt32:
             compileValueToInt32();
             break;
@@ -2348,6 +2351,13 @@ private:
             return;
         }
 
+        case BigInt64RepUse: {
+            JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+            LValue int64Val = lowBigInt64(m_node->child1());
+            setJSValue(vmCall(Int64, operationInt64ToBigInt, weakPointer(globalObject), int64Val));
+            return;
+        }
+
         default:
             DFG_CRASH(m_graph, m_node, "Bad use kind");
         }
@@ -2359,7 +2369,6 @@ private:
         case Int32Use:
             setStrictInt52(m_out.signExt32To64(lowInt32(m_node->child1())));
             return;
-
         case AnyIntUse: {
             bool canIgnoreNegativeZero = bytecodeCanIgnoreNegativeZero(m_node->arithNodeFlags());
             setStrictInt52(jsValueToStrictInt52(m_node->child1(), lowJSValue(m_node->child1(), ManualOperandSpeculation), canIgnoreNegativeZero));
@@ -2391,6 +2400,65 @@ private:
         default:
             RELEASE_ASSERT_NOT_REACHED();
         }
+    }
+
+    void compileBigInt64Rep()
+    {
+        // Unbox a HeapBigInt to a raw int64_t.
+        // Speculates BigInt64Overflow if the value doesn't fit in int64.
+        LValue bigInt = lowCell(m_node->child1());
+        speculateHeapBigInt(m_node->child1(), bigInt);
+
+        LBasicBlock lengthIsZero = m_out.newBlock();
+        LBasicBlock lengthIsOne = m_out.newBlock();
+        LBasicBlock isNegative = m_out.newBlock();
+        LBasicBlock positiveOverflow = m_out.newBlock();
+        LBasicBlock negateDigit = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        // Load length.
+        LValue length = m_out.load32NonNegative(bigInt, m_heaps.JSBigInt_length);
+
+        // If length > 1, overflow.
+        speculate(BigInt64Overflow, noValue(), nullptr, m_out.above(length, m_out.int32One));
+
+        // Branch on length == 0 vs. == 1.
+        m_out.branch(m_out.isZero32(length), unsure(lengthIsZero), unsure(lengthIsOne));
+
+        // length == 0 → result is 0
+        LBasicBlock lastNext = m_out.appendTo(lengthIsZero, lengthIsOne);
+        ValueFromBlock zeroResult = m_out.anchor(m_out.int64Zero);
+        m_out.jump(continuation);
+
+        // length == 1 → load digit
+        m_out.appendTo(lengthIsOne, isNegative);
+        LValue digit = m_out.load64(bigInt, m_heaps.JSBigInt_data0);
+
+        // Check sign bit in typeInfoFlags
+        LValue flags = m_out.load8ZeroExt32(bigInt, m_heaps.JSCell_typeInfoFlags);
+        m_out.branch(
+            m_out.notZero32(m_out.bitAnd(flags, m_out.constInt32(TypeInfoPerCellBit))),
+            unsure(isNegative), unsure(positiveOverflow));
+
+        // Positive: digit must be <= INT64_MAX (bit 63 must be 0)
+        m_out.appendTo(positiveOverflow, isNegative);
+        speculate(BigInt64Overflow, noValue(), nullptr, m_out.lessThan(digit, m_out.int64Zero));
+        ValueFromBlock positiveResult = m_out.anchor(digit);
+        m_out.jump(continuation);
+
+        // Negative: digit is absolute value; digit <= 2^63 → negate → int64
+        // Overflow if digit > 2^63 (i.e. digit > 0x8000000000000000 as unsigned)
+        m_out.appendTo(isNegative, negateDigit);
+        // Unsigned comparison: digit > 0x8000000000000000 → absolute value too large
+        speculate(BigInt64Overflow, noValue(), nullptr, m_out.above(digit, m_out.constInt64(static_cast<uint64_t>(std::numeric_limits<int64_t>::min()))));
+        m_out.jump(negateDigit);
+
+        m_out.appendTo(negateDigit, continuation);
+        ValueFromBlock negativeResult = m_out.anchor(m_out.neg(digit));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setBigInt64(m_out.phi(Int64, zeroResult, positiveResult, negativeResult));
     }
 
     void compileValueToInt32()
@@ -2682,6 +2750,15 @@ private:
             return;
         }
 
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            LValue left = lowBigInt64(m_node->child1());
+            LValue right = lowBigInt64(m_node->child2());
+            CheckValue* result = m_out.speculateAdd(left, right);
+            blessSpeculation(result, BigInt64Overflow, noValue(), nullptr, m_origin);
+            setBigInt64(result);
+            return;
+        }
+
         CodeBlock* baselineCodeBlock = m_ftlState.graph.baselineCodeBlockFor(m_origin.semantic);
         BytecodeIndex bytecodeIndex = m_origin.semantic.bytecodeIndex();
         BinaryArithProfile* arithProfile = baselineCodeBlock->binaryArithProfileForBytecodeIndex(bytecodeIndex);
@@ -2721,6 +2798,15 @@ private:
 
             LValue result = vmCall(pointerType(), operationSubHeapBigInt, weakPointer(globalObject), left, right);
             setJSValue(result);
+            return;
+        }
+
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            LValue left = lowBigInt64(m_node->child1());
+            LValue right = lowBigInt64(m_node->child2());
+            CheckValue* result = m_out.speculateSub(left, right);
+            blessSpeculation(result, BigInt64Overflow, noValue(), nullptr, m_origin);
+            setBigInt64(result);
             return;
         }
 
@@ -2782,6 +2868,15 @@ private:
             return;
         }
 
+        // BUG FIX #1: Use CheckMul result directly; do NOT call m_out.mul() again.
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            LValue left = lowBigInt64(m_node->child1());
+            LValue right = lowBigInt64(m_node->child2());
+            CheckValue* result = m_out.speculateMul(left, right);
+            blessSpeculation(result, BigInt64Overflow, noValue(), nullptr, m_origin);
+            setBigInt64(result);
+            return;
+        }
         CodeBlock* baselineCodeBlock = m_ftlState.graph.baselineCodeBlockFor(m_origin.semantic);
         BytecodeIndex bytecodeIndex = m_origin.semantic.bytecodeIndex();
         BinaryArithProfile* arithProfile = baselineCodeBlock->binaryArithProfileForBytecodeIndex(bytecodeIndex);
@@ -3175,6 +3270,31 @@ private:
             return;
         }
 
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            LValue numerator = lowBigInt64(m_node->child1());
+            LValue denominator = lowBigInt64(m_node->child2());
+
+            LBasicBlock unsafeDenominator = m_out.newBlock();
+            LBasicBlock safeDivision = m_out.newBlock();
+
+            // If denominator ∈ {0, -1}: adjustedDen ∈ {1, 0}; above(x, 1) is false for both.
+            LValue adjustedDen = m_out.add(denominator, m_out.constInt64(1));
+            m_out.branch(
+                m_out.above(adjustedDen, m_out.constInt64(1)),
+                usually(safeDivision), rarely(unsafeDenominator));
+
+            LBasicBlock lastNext = m_out.appendTo(unsafeDenominator, safeDivision);
+            speculate(BigInt64Overflow, noValue(), nullptr, m_out.isZero64(denominator));
+            // denominator == -1 and numerator == INT64_MIN → result 2^63, overflow
+            speculate(BigInt64Overflow, noValue(), nullptr,
+                m_out.equal(numerator, m_out.constInt64(std::numeric_limits<int64_t>::min())));
+            m_out.jump(safeDivision);
+
+            m_out.appendTo(safeDivision, lastNext);
+            setBigInt64(m_out.div(numerator, denominator));
+            return;
+        }
+
         emitBinarySnippet<JITDivGenerator, NeedScratchFPR>(operationValueDiv);
     }
 
@@ -3252,6 +3372,29 @@ private:
 
             LValue result = vmCall(pointerType(), operationModHeapBigInt, weakPointer(globalObject), left, right);
             setJSValue(result);
+            return;
+        }
+
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            LValue numerator = lowBigInt64(m_node->child1());
+            LValue denominator = lowBigInt64(m_node->child2());
+            // Same guards as div: exit on denominator == 0, and on INT64_MIN % -1 (quotient overflows)
+            LBasicBlock unsafeDenominator = m_out.newBlock();
+            LBasicBlock safeMod = m_out.newBlock();
+
+            LValue adjustedDen = m_out.add(denominator, m_out.constInt64(1));
+            m_out.branch(
+                m_out.above(adjustedDen, m_out.constInt64(1)),
+                usually(safeMod), rarely(unsafeDenominator));
+
+            LBasicBlock lastNext = m_out.appendTo(unsafeDenominator, safeMod);
+            speculate(BigInt64Overflow, noValue(), nullptr, m_out.isZero64(denominator));
+            speculate(BigInt64Overflow, noValue(), nullptr,
+                m_out.equal(numerator, m_out.constInt64(std::numeric_limits<int64_t>::min())));
+            m_out.jump(safeMod);
+
+            m_out.appendTo(safeMod, lastNext);
+            setBigInt64(m_out.mod(numerator, denominator));
             return;
         }
 
@@ -3496,6 +3639,51 @@ private:
 
             LValue result = vmCall(pointerType(), operationPowHeapBigInt, weakPointer(globalObject), base, exponent);
             setJSValue(result);
+            return;
+        }
+
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            JSGlobalObject* globalObject2 = m_graph.globalObjectFor(m_origin.semantic);
+            LValue base = lowBigInt64(m_node->child1());
+            LValue exp = lowBigInt64(m_node->child2());
+            // Negative exponent → fractional result → overflow exit.
+            speculate(BigInt64Overflow, noValue(), nullptr, m_out.lessThan(exp, m_out.int64Zero));
+            // Box both operands as HeapBigInt, call operationPowHeapBigInt, then unbox.
+            // The result may be larger than int64 → handled by compileBigInt64Rep on the result.
+            // For simplicity, call operationInt64ToBigInt for each operand, then pow, then re-unbox.
+            LValue bigBase = vmCall(Int64, operationInt64ToBigInt, weakPointer(globalObject2), base);
+            LValue bigExp = vmCall(Int64, operationInt64ToBigInt, weakPointer(globalObject2), exp);
+            LValue bigResult = vmCall(pointerType(), operationPowHeapBigInt, weakPointer(globalObject2), bigBase, bigExp);
+            // bigResult is a HeapBigInt JSValue; unbox it inline (same logic as compileBigInt64Rep).
+            // Use a vmCall to a helper that returns int64 or signals overflow via exception.
+            // For correctness, speculate via length check on the result BigInt.
+            LValue resultCell = bigResult; // it's a cell (HeapBigInt pointer)
+            LValue resLen = m_out.load32NonNegative(resultCell, m_heaps.JSBigInt_length);
+            speculate(BigInt64Overflow, noValue(), nullptr, m_out.above(resLen, m_out.int32One));
+            LBasicBlock resultIsZero = m_out.newBlock();
+            LBasicBlock resultIsOne = m_out.newBlock();
+            LBasicBlock resultIsNeg = m_out.newBlock();
+            LBasicBlock resultCont = m_out.newBlock();
+            m_out.branch(m_out.isZero32(resLen), unsure(resultIsZero), unsure(resultIsOne));
+            LBasicBlock lastNext2 = m_out.appendTo(resultIsZero, resultIsOne);
+            ValueFromBlock zeroVal = m_out.anchor(m_out.int64Zero);
+            m_out.jump(resultCont);
+            m_out.appendTo(resultIsOne, resultIsNeg);
+            LValue digit = m_out.load64(resultCell, m_heaps.JSBigInt_data0);
+            LValue resFlags = m_out.load8ZeroExt32(resultCell, m_heaps.JSCell_typeInfoFlags);
+            m_out.branch(m_out.notZero32(m_out.bitAnd(resFlags, m_out.constInt32(TypeInfoPerCellBit))),
+                unsure(resultIsNeg), unsure(resultCont));
+            // Positive: check no overflow
+            speculate(BigInt64Overflow, noValue(), nullptr, m_out.lessThan(digit, m_out.int64Zero));
+            ValueFromBlock posVal = m_out.anchor(digit);
+            m_out.jump(resultCont);
+            m_out.appendTo(resultIsNeg, resultCont);
+            speculate(BigInt64Overflow, noValue(), nullptr,
+                m_out.above(digit, m_out.constInt64(static_cast<uint64_t>(std::numeric_limits<int64_t>::min()))));
+            ValueFromBlock negVal = m_out.anchor(m_out.neg(digit));
+            m_out.jump(resultCont);
+            m_out.appendTo(resultCont, lastNext2);
+            setBigInt64(m_out.phi(Int64, zeroVal, posVal, negVal));
             return;
         }
 
@@ -3833,6 +4021,13 @@ private:
 
     void compileValueNegate()
     {
+        if (m_node->child1().useKind() == BigInt64RepUse) {
+            LValue value = lowBigInt64(m_node->child1());
+            CheckValue* result = m_out.speculateSub(m_out.int64Zero, value);
+            blessSpeculation(result, BigInt64Overflow, noValue(), nullptr, m_origin);
+            setBigInt64(result);
+            return;
+        }
         DFG_ASSERT(m_graph, m_node, m_node->child1().useKind() == UntypedUse);
         CodeBlock* baselineCodeBlock = m_ftlState.graph.baselineCodeBlockFor(m_origin.semantic);
         BytecodeIndex bytecodeIndex = m_origin.semantic.bytecodeIndex();
@@ -3919,6 +4114,13 @@ private:
             return;
         }
 
+        // BUG FIX #4: Add BigInt64RepUse case (was missing, causing stall at DFG).
+        if (m_node->child1().useKind() == BigInt64RepUse) {
+            LValue operand = lowBigInt64(m_node->child1());
+            setBigInt64(m_out.bitNot(operand));
+            return;
+        }
+
         DFG_ASSERT(m_graph, m_node, m_node->child1().useKind() == UntypedUse || m_node->child1().useKind() == AnyBigIntUse);
         LValue operand = lowJSValue(m_node->child1(), ManualOperandSpeculation);
         speculate(m_node, m_node->child1());
@@ -3955,6 +4157,11 @@ private:
             return;
         }
 
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            setBigInt64(m_out.bitAnd(lowBigInt64(m_node->child1()), lowBigInt64(m_node->child2())));
+            return;
+        }
+
         emitBinaryBitOpSnippet<JITBitAndGenerator>(operationValueBitAnd);
     }
 
@@ -3987,6 +4194,11 @@ private:
             return;
         }
 
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            setBigInt64(m_out.bitOr(lowBigInt64(m_node->child1()), lowBigInt64(m_node->child2())));
+            return;
+        }
+
         emitBinaryBitOpSnippet<JITBitOrGenerator>(operationValueBitOr);
     }
 
@@ -4016,6 +4228,11 @@ private:
 
             LValue result = vmCall(pointerType(), operationBitXorHeapBigInt, weakPointer(globalObject), left, right);
             setJSValue(result);
+            return;
+        }
+
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            setBigInt64(m_out.bitXor(lowBigInt64(m_node->child1()), lowBigInt64(m_node->child2())));
             return;
         }
 
@@ -4058,6 +4275,20 @@ private:
             return;
         }
 
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            LValue value = lowBigInt64(m_node->child1());
+            LValue shift = lowBigInt64(m_node->child2());
+            // For BigInt, right-shift by negative is a left-shift — treat large shifts as overflow.
+            speculate(BigInt64Overflow, noValue(), nullptr, m_out.lessThan(shift, m_out.int64Zero));
+            // Shifts >= 64 produce 0 (arithmetic right shift; fill with sign bit → all-ones for neg, 0 for pos)
+            // Use aShr with amount masked to 63 to avoid UB; clamp large amounts.
+            LValue clampedShift = m_out.select(
+                m_out.above(m_out.castToInt32(shift), m_out.constInt32(63)),
+                m_out.constInt32(63), m_out.castToInt32(shift));
+            setBigInt64(m_out.aShr(value, clampedShift));
+            return;
+        }
+
         emitRightShiftSnippet(JITRightShiftGenerator::SignedShift);
     }
 
@@ -4085,6 +4316,23 @@ private:
 
             LValue result = vmCall(pointerType(), operationBitLShiftHeapBigInt, weakPointer(globalObject), left, right);
             setJSValue(result);
+            return;
+        }
+
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            LValue value = lowBigInt64(m_node->child1());
+            LValue shift = lowBigInt64(m_node->child2());
+            // Negative left-shift is right-shift for BigInt — treat as overflow.
+            speculate(BigInt64Overflow, noValue(), nullptr, m_out.lessThan(shift, m_out.int64Zero));
+            // Large left shifts will overflow; check for amount >= 64.
+            LValue shiftAmount = m_out.castToInt32(shift);
+            speculate(BigInt64Overflow, noValue(), nullptr,
+                m_out.above(shiftAmount, m_out.constInt32(63)));
+            // Perform the shift and verify round-trip to detect signed overflow.
+            LValue shiftResult = m_out.shl(value, shiftAmount);
+            speculate(BigInt64Overflow, noValue(), nullptr,
+                m_out.notEqual(m_out.aShr(shiftResult, shiftAmount), value));
+            setBigInt64(shiftResult);
             return;
         }
 
@@ -12223,7 +12471,8 @@ IGNORE_CLANG_WARNINGS_END
             || m_node->isBinaryUseKind(StringUse)
             || m_node->isBinaryUseKind(BigInt32Use)
             || m_node->isBinaryUseKind(HeapBigIntUse)
-            || m_node->isBinaryUseKind(AnyBigIntUse)) {
+            || m_node->isBinaryUseKind(AnyBigIntUse)
+            || m_node->isBinaryUseKind(BigInt64RepUse)) {
             compileCompareStrictEq();
             return;
         }
@@ -12369,6 +12618,13 @@ IGNORE_CLANG_WARNINGS_END
             Int52Kind kind;
             LValue left = lowWhicheverInt52(m_node->child1(), kind);
             LValue right = lowInt52(m_node->child2(), kind);
+            setBoolean(m_out.equal(left, right));
+            return;
+        }
+
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            LValue left = lowBigInt64(m_node->child1());
+            LValue right = lowBigInt64(m_node->child2());
             setBoolean(m_out.equal(left, right));
             return;
         }
@@ -19448,6 +19704,13 @@ IGNORE_CLANG_WARNINGS_END
         }
 #endif
 
+        if (m_node->isBinaryUseKind(BigInt64RepUse)) {
+            LValue left = lowBigInt64(m_node->child1());
+            LValue right = lowBigInt64(m_node->child2());
+            setBoolean(intFunctor(left, right));
+            return;
+        }
+
         if (m_node->isBinaryUseKind(StringIdentUse)) {
             LValue left = lowStringIdent(m_node->child1());
             LValue right = lowStringIdent(m_node->child2());
@@ -23131,6 +23394,19 @@ IGNORE_CLANG_WARNINGS_END
         return lowInt52(edge, StrictInt52);
     }
 
+    LValue lowBigInt64(Edge edge)
+    {
+        DFG_ASSERT(m_graph, m_node, edge.useKind() == BigInt64RepUse, edge.useKind());
+
+        LoweredNodeValue value = m_bigInt64Values.get(edge.node());
+        if (isValid(value))
+            return value.value();
+
+        if (mayHaveTypeCheck(edge.useKind()))
+            terminate(Uncountable);
+        return m_out.int64Zero;
+    }
+
     bool betterUseStrictInt52(Node* node)
     {
         return !isValid(m_int52Values.get(node));
@@ -25453,6 +25729,9 @@ IGNORE_CLANG_WARNINGS_END
         case FlushedInt52:
             return ExitValue::inJSStackAsInt52(flush.virtualRegister());
 
+        case FlushedBigInt64:
+            return ExitValue::inJSStackAsBigInt64(flush.virtualRegister());
+
         case FlushedDouble:
             return ExitValue::inJSStackAsDouble(flush.virtualRegister());
         }
@@ -25502,6 +25781,10 @@ IGNORE_CLANG_WARNINGS_END
         value = m_strictInt52Values.get(node);
         if (isValid(value))
             return exitArgument(arguments, DataFormatStrictInt52, value.value());
+
+        value = m_bigInt64Values.get(node);
+        if (isValid(value))
+            return exitArgument(arguments, DataFormatBigInt64, value.value());
 
         value = m_booleanValues.get(node);
         if (isValid(value))
@@ -25573,6 +25856,10 @@ IGNORE_CLANG_WARNINGS_END
     {
         m_strictInt52Values.set(node, LoweredNodeValue(value, m_highBlock));
     }
+    void setBigInt64(Node* node, LValue value)
+    {
+        m_bigInt64Values.set(node, LoweredNodeValue(value, m_highBlock));
+    }
     void setInt52(Node* node, LValue value, Int52Kind kind)
     {
         switch (kind) {
@@ -25624,6 +25911,10 @@ IGNORE_CLANG_WARNINGS_END
     void setInt52(LValue value, Int52Kind kind)
     {
         setInt52(m_node, value, kind);
+    }
+    void setBigInt64(LValue value)
+    {
+        setBigInt64(m_node, value);
     }
     void setJSValue(LValue value)
     {
@@ -25886,6 +26177,7 @@ IGNORE_CLANG_WARNINGS_END
     UncheckedKeyHashMap<Node*, LoweredNodeValue> m_int32Values;
     UncheckedKeyHashMap<Node*, LoweredNodeValue> m_strictInt52Values;
     UncheckedKeyHashMap<Node*, LoweredNodeValue> m_int52Values;
+    UncheckedKeyHashMap<Node*, LoweredNodeValue> m_bigInt64Values;
     UncheckedKeyHashMap<Node*, LoweredNodeValue> m_jsValueValues;
     UncheckedKeyHashMap<Node*, LoweredNodeValue> m_booleanValues;
     UncheckedKeyHashMap<Node*, LoweredNodeValue> m_storageValues;

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -32,6 +32,7 @@
 #include "BytecodeStructs.h"
 #include "CheckpointOSRExitSideState.h"
 #include "DFGOSRExitCompilerCommon.h"
+#include "DFGOperations.h"
 #include "FTLJITCode.h"
 #include "FTLLocation.h"
 #include "FTLOSRExit.h"
@@ -53,7 +54,8 @@ namespace JSC { namespace FTL {
 using namespace DFG;
 
 static void reboxAccordingToFormat(
-    DataFormat format, AssemblyHelpers& jit, GPRReg value, GPRReg scratch1, GPRReg scratch2)
+    DataFormat format, CCallHelpers& jit, GPRReg value, GPRReg scratch1, GPRReg scratch2,
+    JSGlobalObject* globalObject)
 {
     switch (format) {
     case DataFormatInt32: {
@@ -97,6 +99,19 @@ static void reboxAccordingToFormat(
         break;
     }
 
+    case DataFormatBigInt64: {
+        // Box the raw int64 to a HeapBigInt (or BigInt32 if it fits).
+        ASSERT(globalObject);
+        VM& vm = jit.codeBlock()->vm();
+        jit.setupArguments<decltype(operationInt64ToBigInt)>(
+            CCallHelpers::TrustedImmPtr(globalObject), value);
+        jit.prepareCallOperation(vm);
+        jit.move(CCallHelpers::TrustedImmPtr(tagCFunction<OperationPtrTag>(operationInt64ToBigInt)), scratch1);
+        jit.call(scratch1, OperationPtrTag);
+        jit.move(GPRInfo::returnValueGPR, value);
+        break;
+    }
+
     default:
         RELEASE_ASSERT_NOT_REACHED();
         break;
@@ -107,7 +122,8 @@ static void compileRecovery(
     CCallHelpers& jit, const ExitValue& value,
     const FixedVector<B3::ValueRep>& valueReps,
     char* registerScratch,
-    const UncheckedKeyHashMap<ExitTimeObjectMaterialization*, EncodedJSValue*>& materializationToPointer)
+    const UncheckedKeyHashMap<ExitTimeObjectMaterialization*, EncodedJSValue*>& materializationToPointer,
+    JSGlobalObject* globalObject)
 {
     switch (value.kind()) {
     case ExitValueDead: {
@@ -115,34 +131,39 @@ static void compileRecovery(
         jit.move(MacroAssembler::TrustedImm64(deadValue), GPRInfo::regT0);
         break;
     }
-            
+
     case ExitValueConstant:
         jit.move(MacroAssembler::TrustedImm64(JSValue::encode(value.constant())), GPRInfo::regT0);
         break;
-            
+
     case ExitValueArgument:
         Location::forValueRep(valueReps[value.exitArgument().argument()]).restoreInto(
             jit, registerScratch, GPRInfo::regT0);
         break;
-            
+
     case ExitValueInJSStack:
     case ExitValueInJSStackAsInt32:
     case ExitValueInJSStackAsInt52:
     case ExitValueInJSStackAsDouble:
         jit.load64(AssemblyHelpers::addressFor(value.virtualRegister()), GPRInfo::regT0);
         break;
-            
+
+    case ExitValueInJSStackAsBigInt64:
+        jit.load64(AssemblyHelpers::addressFor(value.virtualRegister()), GPRInfo::regT0);
+        // value is now the raw int64; let reboxAccordingToFormat box it via operationInt64ToBigInt
+        break;
+
     case ExitValueMaterializeNewObject:
         jit.loadPtr(materializationToPointer.get(value.objectMaterialization()), GPRInfo::regT0);
         break;
-            
+
     default:
         RELEASE_ASSERT_NOT_REACHED();
         break;
     }
-        
+
     reboxAccordingToFormat(
-        value.dataFormat(), jit, GPRInfo::regT0, GPRInfo::regT1, GPRInfo::regT2);
+        value.dataFormat(), jit, GPRInfo::regT0, GPRInfo::regT1, GPRInfo::regT2, globalObject);
 }
 
 static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit, CodeBlock* codeBlock)
@@ -213,7 +234,8 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
         compileRecovery(
             jit, value,
             exit.m_valueReps,
-            registerScratch, materializationToPointer);
+            registerScratch, materializationToPointer,
+            codeBlock->globalObject());
     };
     
     // Note that we come in here, the stack used to be as B3 left it except that someone called pushToSave().
@@ -260,7 +282,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
     // Do some value profiling.
     if (exit.m_descriptor->m_profileDataFormat != DataFormatNone) {
         Location::forValueRep(exit.m_valueReps[0]).restoreInto(jit, registerScratch, GPRInfo::regT0);
-        reboxAccordingToFormat(exit.m_descriptor->m_profileDataFormat, jit, GPRInfo::regT0, GPRInfo::regT1, GPRInfo::regT2);
+        reboxAccordingToFormat(exit.m_descriptor->m_profileDataFormat, jit, GPRInfo::regT0, GPRInfo::regT1, GPRInfo::regT2, codeBlock->globalObject());
         
         if (exit.m_kind == BadCache || exit.m_kind == BadIndexingType) {
             CodeOrigin codeOrigin = exit.m_codeOriginForExitProfile;

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -56,6 +56,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "JSAsyncGenerator.h"
 #include "JSAsyncGeneratorFunction.h"
 #include "JSBoundFunction.h"
+#include "JSBigIntInlines.h"
 #include "JSCInlines.h"
 #include "JSCPtrTag.h"
 #include "JSGeneratorFunction.h"
@@ -104,11 +105,28 @@ ALWAYS_INLINE ICSlowPathCallFrameTracer::ICSlowPathCallFrameTracer(VM& vm, CallF
     callFrame->setCallSiteIndex(propertyCache->callSiteIndex);
 }
 
+// For BigInt64 speculation: set BigInt64Overflow in the profile if any of the three values
+// (left operand, right operand, result) is a HeapBigInt that doesn't fit in int64.
+// This prevents the DFG/FTL from speculatively compiling an operation as BigInt64 when the
+// observed data includes values outside the int64 range.
+static ALWAYS_INLINE void checkBigInt64Overflow(BinaryArithProfile& arithProfile, JSValue result, JSValue op1, JSValue op2)
+{
+    if (!result.isHeapBigInt())
+        return;
+    if (!JSBigInt::fitsInInt64(result.asHeapBigInt()))
+        arithProfile.setObservedBigInt64Overflow();
+    if (op1.isHeapBigInt() && !JSBigInt::fitsInInt64(op1.asHeapBigInt()))
+        arithProfile.setObservedBigInt64Overflow();
+    if (op2.isHeapBigInt() && !JSBigInt::fitsInInt64(op2.asHeapBigInt()))
+        arithProfile.setObservedBigInt64Overflow();
+}
+
 ALWAYS_INLINE JSValue profiledAdd(JSGlobalObject* globalObject, JSValue op1, JSValue op2, BinaryArithProfile& arithProfile)
 {
     arithProfile.observeLHSAndRHS(op1, op2);
     JSValue result = jsAdd(globalObject, op1, op2);
     arithProfile.observeResult(result);
+    checkBigInt64Overflow(arithProfile, result, op1, op2);
     return result;
 }
 
@@ -4847,6 +4865,7 @@ JSC_DEFINE_JIT_OPERATION(operationValueAddProfiledOptimize, EncodedJSValue, (JSG
     
     JSValue result = jsAdd(globalObject, op1, op2);
     arithProfile->observeResult(result);
+    checkBigInt64Overflow(*arithProfile, result, op1, op2);
 
     OPERATION_RETURN(scope, JSValue::encode(result));
 }
@@ -4921,6 +4940,7 @@ ALWAYS_INLINE static EncodedJSValue profiledMul(JSGlobalObject* globalObject, En
     JSValue result = jsMul(globalObject, op1, op2);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     arithProfile.observeResult(result);
+    checkBigInt64Overflow(arithProfile, result, op1, op2);
     return JSValue::encode(result);
 }
 
@@ -5168,6 +5188,7 @@ ALWAYS_INLINE static EncodedJSValue profiledSub(VM& vm, JSGlobalObject* globalOb
     JSValue result = jsSub(globalObject, op1, op2);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     arithProfile.observeResult(result);
+    checkBigInt64Overflow(arithProfile, result, op1, op2);
     return JSValue::encode(result);
 }
 

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -38,6 +38,7 @@
 #include "FrameTracers.h"
 #include "IteratorOperations.h"
 #include "JSArrayIterator.h"
+#include "JSBigIntInlines.h"
 #include "JSAsyncGenerator.h"
 #include "JSBoundFunction.h"
 #include "JSCInlines.h"
@@ -477,13 +478,22 @@ static void updateArithProfileForBinaryArithOp(JSGlobalObject*, CodeBlock* codeB
                     profile.setObservedInt52Overflow();
             }
         }
-    } else if (result.isHeapBigInt())
+    } else if (result.isHeapBigInt()) {
         profile.setObservedHeapBigInt();
+        // For BigInt64 speculation: if any operand or the result doesn't fit in int64,
+        // mark BigInt64Overflow to prevent speculative BigInt64 compilation at this site.
+        if (!JSBigInt::fitsInInt64(result.asHeapBigInt()))
+            profile.setObservedBigInt64Overflow();
+        if (left.isHeapBigInt() && !JSBigInt::fitsInInt64(left.asHeapBigInt()))
+            profile.setObservedBigInt64Overflow();
+        if (right.isHeapBigInt() && !JSBigInt::fitsInInt64(right.asHeapBigInt()))
+            profile.setObservedBigInt64Overflow();
+    }
 #if USE(BIGINT32)
     else if (result.isBigInt32())
         profile.setObservedBigInt32();
 #endif
-    else 
+    else
         profile.setObservedNonNumeric();
 }
 #else

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -458,6 +458,8 @@ public:
 
     inline static uint64_t toBigUInt64(JSValue); // Defined in JSBigIntInlines.h
     inline static int64_t toBigInt64(JSValue); // Defined in JSBigIntInlines.h
+    // Returns true if this HeapBigInt's value fits in int64_t (i.e., [-2^63, 2^63-1]).
+    static bool fitsInInt64(JSBigInt*); // Defined in JSBigIntInlines.h
 
     Digit digit(unsigned);
     void setDigit(unsigned, Digit); // Use only when initializing.

--- a/Source/JavaScriptCore/runtime/JSBigIntInlines.h
+++ b/Source/JavaScriptCore/runtime/JSBigIntInlines.h
@@ -98,4 +98,30 @@ ALWAYS_INLINE std::optional<double> JSBigInt::tryExtractDouble(JSValue value)
     return std::nullopt;
 }
 
+// Returns true if bigInt's value fits in int64_t (i.e., in the range [-2^63, 2^63-1]).
+inline bool JSBigInt::fitsInInt64(JSBigInt* bigInt)
+{
+    if (!bigInt->length())
+        return true; // zero
+
+    uint64_t integer;
+    if constexpr (sizeof(Digit) == 8) {
+        if (bigInt->length() != 1)
+            return false;
+        integer = bigInt->digit(0);
+    } else {
+        ASSERT(sizeof(Digit) == 4);
+        if (bigInt->length() > 2)
+            return false;
+        integer = bigInt->digit(0);
+        if (bigInt->length() == 2)
+            integer |= (static_cast<uint64_t>(bigInt->digit(1)) << 32);
+    }
+
+    if (!bigInt->sign())
+        return integer <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+    // Negative: -(integer) must be >= INT64_MIN. INT64_MIN = -(2^63), so abs(INT64_MIN) = 2^63.
+    return integer <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1u;
+}
+
 }

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -253,6 +253,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useOSREntryToFTL, true, Normal, nullptr) \
     \
     v(Bool, useFTLJIT, true, Normal, "allows the FTL JIT to be used if true"_s) \
+    v(Bool, useBigInt64, true, Normal, "allows the BigInt64 unboxed representation tier in DFG/FTL for HeapBigInts that fit in int64"_s) \
     v(Bool, validateFTLOSRExitLiveness, false, Normal, nullptr) \
     v(Bool, poisonDeadOSRExitVariables, false, Normal, "Put 0xbad0beef into dead OSR exit values rather than jsUndefined"_s) \
     v(Unsigned, defaultB3OptLevel, 2, Normal, nullptr) \


### PR DESCRIPTION
#### f70134915f34278d4c5cda35285684f73ed97022
<pre>
[WIP] BigInt64
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f70134915f34278d4c5cda35285684f73ed97022

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111360 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04dd8677-80fd-4000-82d7-170a4803f636) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121808 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85522 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fabae488-e5ec-4b3a-b97d-4f1dee58037e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102476 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66edc0c5-c3c5-453e-b898-dd0b5592ba50) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23108 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21356 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13873 "Built successfully") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149328 "Found 349 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Conversions/ImplicitConversions.js.default, microbenchmarks/bigint64-arith.js.dfg-eager-no-cjit-validate, microbenchmarks/bigint64-arith.js.eager-jettison-no-cjit, microbenchmarks/bigint64-arith.js.ftl-eager-no-cjit, microbenchmarks/bigint64-arith.js.ftl-eager-no-cjit-b3o1, microbenchmarks/bigint64-arith.js.ftl-no-cjit-b3o0, microbenchmarks/bigint64-arith.js.ftl-no-cjit-no-inline-validate, microbenchmarks/bigint64-arith.js.ftl-no-cjit-no-put-stack-validate, microbenchmarks/bigint64-arith.js.ftl-no-cjit-small-pool, microbenchmarks/bigint64-arith.js.ftl-no-cjit-validate-sampling-profiler ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168587 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18113 "Found 330 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Conversions/ImplicitConversions.js.default, microbenchmarks/bigint64-arith.js.dfg-eager-no-cjit-validate, microbenchmarks/bigint64-arith.js.eager-jettison-no-cjit, microbenchmarks/bigint64-arith.js.ftl-eager-no-cjit-b3o1, microbenchmarks/bigint64-arith.js.ftl-no-cjit-b3o0, microbenchmarks/bigint64-arith.js.ftl-no-cjit-no-inline-validate, microbenchmarks/bigint64-arith.js.ftl-no-cjit-no-put-stack-validate, microbenchmarks/bigint64-arith.js.ftl-no-cjit-small-pool, microbenchmarks/bigint64-arith.js.ftl-no-cjit-validate-sampling-profiler, microbenchmarks/bigint64-arith.js.no-cjit-validate-phases ... (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12745 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20678 "Found 45 new test failures: http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/abs.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/distance.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/frexp.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/modf.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/pow.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/sign.html http/tests/webgpu/webgpu/shader/execution/expression/unary/af_assignment.html http/tests/webgpu/webgpu/shader/execution/expression/unary/ai_complement.html http/tests/webgpu/webgpu/shader/execution/expression/unary/f32_conversion.html http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/abs.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129941 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30216 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25434 "Found 43 new test failures: http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/dot.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/frexp.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/modf.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/pow.html http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/sign.html http/tests/webgpu/webgpu/shader/execution/expression/unary/af_assignment.html http/tests/webgpu/webgpu/shader/execution/expression/unary/ai_complement.html http/tests/webgpu/webgpu/shader/execution/expression/unary/f16_conversion.html http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/abs.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130049 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88007 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24871 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17657 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189296 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29850 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93864 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48566 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29372 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29602 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29499 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->