### PR TITLE
[WTF] Use std::span SIMDUTF API

### DIFF
--- a/Source/WTF/wtf/SIMDUTF.h
+++ b/Source/WTF/wtf/SIMDUTF.h
@@ -34,7 +34,8 @@ IGNORE_WARNINGS_BEGIN("cast-qual")
 IGNORE_WARNINGS_BEGIN("cast-align")
 IGNORE_WARNINGS_BEGIN("documentation")
 
-#define SIMDUTF_CPLUSPLUS20 0
+#define SIMDUTF_CPLUSPLUS20 1
+#define SIMDUTF_CPLUSPLUS23 0
 
 #include <wtf/simdutf/simdutf_impl.h>
 

--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -115,7 +115,7 @@ template<typename CharacterType> static void base64EncodeInternal(std::span<cons
     ASSERT(calculateBase64EncodedSize(inputDataBuffer.size(), options) == destinationDataBuffer.size());
 
     if constexpr (sizeof(CharacterType) == 1) {
-        size_t bytesWritten = simdutf::binary_to_base64(std::bit_cast<const char*>(inputDataBuffer.data()), inputDataBuffer.size(), std::bit_cast<char*>(destinationDataBuffer.data()), toSIMDUTFEncodeOptions(options));
+        size_t bytesWritten = simdutf::binary_to_base64(inputDataBuffer, destinationDataBuffer, toSIMDUTFEncodeOptions(options));
         ASSERT_UNUSED(bytesWritten, bytesWritten == destinationDataBuffer.size());
         return;
     }
@@ -340,11 +340,8 @@ static inline simdutf::last_chunk_handling_options NODELETE toSIMDUTFLastChunkHa
 template<typename CharacterType>
 static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64Impl(std::span<const CharacterType> span, std::span<uint8_t> output, Alphabet alphabet, LastChunkHandling lastChunkHandling)
 {
-    using UTFType = std::conditional_t<sizeof(CharacterType) == 1, char, char16_t>;
-
-    size_t outputLength = output.size();
     constexpr bool decodeUpToBadChar = true;
-    auto result = simdutf::base64_to_binary_safe(std::bit_cast<const UTFType*>(span.data()), span.size(), std::bit_cast<char*>(output.data()), outputLength, toSIMDUTFDecodeOptions(alphabet), toSIMDUTFLastChunkHandling(lastChunkHandling), decodeUpToBadChar);
+    auto [result, outputLength] = simdutf::base64_to_binary_safe(span, output, toSIMDUTFDecodeOptions(alphabet), toSIMDUTFLastChunkHandling(lastChunkHandling), decodeUpToBadChar);
     switch (result.error) {
     case simdutf::error_code::OUTPUT_BUFFER_TOO_SMALL:
     case simdutf::error_code::SUCCESS:
@@ -364,10 +361,9 @@ std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64(StringView str
 
 size_t maxLengthFromBase64(StringView string)
 {
-    size_t length = string.length();
     if (string.is8Bit())
-        return simdutf::maximal_binary_length_from_base64(std::bit_cast<const char*>(string.span8().data()), length);
-    return simdutf::maximal_binary_length_from_base64(std::bit_cast<const char16_t*>(string.span16().data()), length);
+        return simdutf::maximal_binary_length_from_base64(string.span8());
+    return simdutf::maximal_binary_length_from_base64(string.span16());
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringCommon.cpp
+++ b/Source/WTF/wtf/text/StringCommon.cpp
@@ -158,14 +158,14 @@ const char16_t* find16NonASCIIAlignedImpl(std::span<const char16_t> data)
 SUPPRESS_NODELETE
 bool isWellFormedUTF16(std::span<const char16_t> data)
 {
-    return simdutf::validate_utf16(data.data(), data.size());
+    return simdutf::validate_utf16(data);
 }
 
 SUPPRESS_NODELETE
 void toWellFormedUTF16(std::span<const char16_t> input, std::span<char16_t> output)
 {
     ASSERT(input.size() == output.size());
-    simdutf::to_well_formed_utf16(input.data(), input.size(), output.data());
+    simdutf::to_well_formed_utf16(input, output);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -295,14 +295,13 @@ RefPtr<StringImpl> StringImpl::create(std::span<const char8_t> codeUnits)
         return create(byteCast<Latin1Character>(codeUnits));
 
     auto inputLength = codeUnits.size();
-    auto input = reinterpret_cast<const char*>(codeUnits.data());
 
     // We are observing some clients changing the string content while converting!
     // This makes it impossible to use utf16_length_from_utf8 & convert_valid_utf8_to_utf16le
     // because of TOCTOU issue. For now, we use pre-allocated Vector (with maximally possible length)
     // and use convert_utf8_to_utf16 instead.
     Vector<char16_t, 1024> buffer(inputLength);
-    size_t written = simdutf::convert_utf8_to_utf16(input, inputLength, buffer.mutableSpan().data());
+    size_t written = simdutf::convert_utf8_to_utf16(codeUnits, buffer.mutableSpan());
     if (!written)
         return nullptr;
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(written <= inputLength);
@@ -1586,11 +1585,10 @@ Expected<size_t, UTF8ConversionError> StringImpl::utf8ForCharactersIntoBuffer(st
 {
     ASSERT(bufferVector.size() == span.size() * 3);
 
-    auto bufferData = bufferVector.mutableSpan().data();
 #if CPU(BIG_ENDIAN)
-    auto conversionResult = simdutf::convert_utf16be_to_utf8_with_errors(span.data(), span.size(), reinterpret_cast<char*>(bufferData));
+    auto conversionResult = simdutf::convert_utf16be_to_utf8_with_errors(span, bufferVector.mutableSpan());
 #else
-    auto conversionResult = simdutf::convert_utf16le_to_utf8_with_errors(span.data(), span.size(), reinterpret_cast<char*>(bufferData));
+    auto conversionResult = simdutf::convert_utf16le_to_utf8_with_errors(span, bufferVector.mutableSpan());
 #endif
 
     if (conversionResult.error == simdutf::error_code::SUCCESS)
@@ -1615,18 +1613,18 @@ Expected<size_t, UTF8ConversionError> StringImpl::utf8ForCharactersIntoBuffer(st
 size_t StringImpl::utf8LengthFromUTF16(std::span<const char16_t> characters)
 {
 #if CPU(BIG_ENDIAN)
-    return simdutf::utf8_length_from_utf16be(characters.data(), characters.size());
+    return simdutf::utf8_length_from_utf16be(characters);
 #else
-    return simdutf::utf8_length_from_utf16le(characters.data(), characters.size());
+    return simdutf::utf8_length_from_utf16le(characters);
 #endif
 }
 
 size_t StringImpl::tryConvertUTF16ToUTF8(std::span<const char16_t> source, std::span<char8_t> destination)
 {
 #if CPU(BIG_ENDIAN)
-    auto result = simdutf::convert_utf16be_to_utf8_with_errors(source.data(), source.size(), reinterpret_cast<char*>(destination.data()));
+    auto result = simdutf::convert_utf16be_to_utf8_with_errors(source, destination);
 #else
-    auto result = simdutf::convert_utf16le_to_utf8_with_errors(source.data(), source.size(), reinterpret_cast<char*>(destination.data()));
+    auto result = simdutf::convert_utf16le_to_utf8_with_errors(source, destination);
 #endif
     if (result.error == simdutf::error_code::SUCCESS)
         return result.count;

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -117,18 +117,18 @@ template<Replacement replacement = Replacement::None, typename SourceCharacterTy
 ConversionResult<char8_t> convert(std::span<const char16_t> source, std::span<char8_t> buffer)
 {
 #if CPU(BIG_ENDIAN)
-    size_t requiredLength = simdutf::utf8_length_from_utf16be(source.data(), source.size());
+    size_t requiredLength = simdutf::utf8_length_from_utf16be(source);
 #else
-    size_t requiredLength = simdutf::utf8_length_from_utf16le(source.data(), source.size());
+    size_t requiredLength = simdutf::utf8_length_from_utf16le(source);
 #endif
 
     if (buffer.size() < requiredLength)
         return convertInternal(source, buffer);
 
 #if CPU(BIG_ENDIAN)
-    auto result = simdutf::convert_utf16be_to_utf8_with_errors(source.data(), source.size(), reinterpret_cast<char*>(buffer.data()));
+    auto result = simdutf::convert_utf16be_to_utf8_with_errors(source, buffer);
 #else
-    auto result = simdutf::convert_utf16le_to_utf8_with_errors(source.data(), source.size(), reinterpret_cast<char*>(buffer.data()));
+    auto result = simdutf::convert_utf16le_to_utf8_with_errors(source, buffer);
 #endif
 
     if (result.error == simdutf::error_code::SUCCESS) {
@@ -161,17 +161,17 @@ ConversionResult<char16_t> convertReplacingInvalidSequences(std::span<const char
 
 std::span<const char8_t> checkUTF8WithoutUTF16Length(std::span<const char8_t> source)
 {
-    auto result = simdutf::validate_utf8_with_errors(reinterpret_cast<const char*>(source.data()), source.size());
+    auto result = simdutf::validate_utf8_with_errors(source);
     size_t validLength = result.error == simdutf::error_code::SUCCESS ? source.size() : result.count;
     return source.first(validLength);
 }
 
 CheckedUTF8 checkUTF8(std::span<const char8_t> source)
 {
-    auto result = simdutf::validate_utf8_with_errors(reinterpret_cast<const char*>(source.data()), source.size());
+    auto result = simdutf::validate_utf8_with_errors(source);
     size_t validLength = result.error == simdutf::error_code::SUCCESS ? source.size() : result.count;
     auto validSpan = source.first(validLength);
-    size_t lengthUTF16 = simdutf::utf16_length_from_utf8(reinterpret_cast<const char*>(validSpan.data()), validSpan.size());
+    size_t lengthUTF16 = simdutf::utf16_length_from_utf8(validSpan);
     return { validSpan, lengthUTF16, validLength == lengthUTF16 };
 }
 


### PR DESCRIPTION
#### 0d04522925eab514bd07f9c87fc844454f26129d
<pre>
[WTF] Use std::span SIMDUTF API
<a href="https://bugs.webkit.org/show_bug.cgi?id=312705">https://bugs.webkit.org/show_bug.cgi?id=312705</a>
<a href="https://rdar.apple.com/175100059">rdar://175100059</a>

Reviewed by Sosuke Suzuki.

Newer SIMDUTF offers std::span-based API. Let&apos;s use them.

* Source/WTF/wtf/SIMDUTF.h:
* Source/WTF/wtf/text/Base64.cpp:
(WTF::base64EncodeInternal):
(WTF::fromBase64Impl):
(WTF::maxLengthFromBase64):
* Source/WTF/wtf/text/StringCommon.cpp:
(WTF::isWellFormedUTF16):
(WTF::toWellFormedUTF16):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::create):
(WTF::StringImpl::utf8ForCharactersIntoBuffer):
(WTF::StringImpl::utf8LengthFromUTF16):
(WTF::StringImpl::tryConvertUTF16ToUTF8):
* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::convert):
(WTF::Unicode::checkUTF8WithoutUTF16Length):
(WTF::Unicode::checkUTF8):

Canonical link: <a href="https://commits.webkit.org/311549@main">https://commits.webkit.org/311549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab93f61a0711367545be05dbb7dc0913b51b49c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166107 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111365 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3628e8ab-9d4c-41e8-a976-6eb34b3c6f47) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121814 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85524 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6cd1f84b-9044-4a55-a70a-9fde103140bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102482 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f70a61c3-4dff-419e-b06d-5180a978cb48) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23109 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21360 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13878 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149333 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132789 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168592 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18118 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129944 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130052 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140855 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88016 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23927 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24874 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17660 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189301 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29855 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93869 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48567 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29377 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29607 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29504 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->