### PR TITLE
[JSC][WASM][Debugger] Remove DebugServer::stop() and State enum

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4515,11 +4515,6 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
         vm.derefSuppressingSaferCPPChecking();
     }
 
-#if ENABLE(WEBASSEMBLY_DEBUGGER)
-    if (Options::enableWasmDebugger()) [[unlikely]]
-        Wasm::DebugServer::singleton().stop();
-#endif
-
     return result;
 }
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -83,13 +83,6 @@ DebugServer::DebugServer()
 
 bool DebugServer::start()
 {
-    if (isState(State::Running) || isState(State::Starting)) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Server already running or is starting");
-        return true;
-    }
-
-    setState(State::Starting);
-
     if (!createAndBindServerSocket())
         return false;
 
@@ -98,7 +91,8 @@ bool DebugServer::start()
     m_moduleManager = makeUnique<ModuleManager>();
     m_executionHandler = makeUnique<ExecutionHandler>(*this, *m_moduleManager);
 
-    setState(State::Running);
+    setIsInService();
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Wasm Debug Server listening. Connect with: lldb -o 'gdb-remote localhost:", m_port, "'");
     startAcceptThread();
     return true;
 }
@@ -106,101 +100,14 @@ bool DebugServer::start()
 #if ENABLE(REMOTE_INSPECTOR)
 void DebugServer::startRWI(Function<bool(const String&)>&& rwiResponseHandler)
 {
-    if (isState(State::Running) || isState(State::Starting)) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Server already running or is starting");
-        return;
-    }
-
-    setState(State::Starting);
-
     m_moduleManager = makeUnique<ModuleManager>();
     m_executionHandler = makeUnique<ExecutionHandler>(*this, *m_moduleManager);
     m_rwiResponseHandler = WTF::move(rwiResponseHandler);
 
-    // RWI mode: No thread creation needed!
-    // IPC messages are received by WasmDebuggerDispatcher on its WorkQueue thread
-    // and directly call handlePacket() on that thread
-
-    setState(State::Running);
+    setIsInService();
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Wasm Debug Server started in RWI mode (WorkQueue-based)");
 }
 #endif
-
-void DebugServer::stop()
-{
-    if (isState(State::Stopped) || isState(State::Stopping)) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Server already stopped or is stopping");
-        return;
-    }
-
-    setState(State::Stopping);
-
-    closeSocket(m_serverSocket);
-    closeSocket(m_clientSocket);
-    if (RefPtr thread = m_acceptThread) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Waiting for accept thread to terminate...");
-        thread->waitForCompletion();
-        m_acceptThread = nullptr;
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Accept thread terminated");
-    }
-
-    // FIXME: Here we just enforce resetting everything.
-    resetAll();
-
-    setState(State::Stopped);
-}
-
-void DebugServer::setState(State state)
-{
-    switch (state) {
-    case State::Stopped:
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Debug Server is stopped");
-        break;
-    case State::Starting:
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Starting Debug Server...");
-        break;
-    case State::Running:
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Wasm Debug Server listening. Connect with: lldb -o 'gdb-remote localhost:", m_port);
-        break;
-    case State::Stopping:
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Stopping Debug Server...");
-        break;
-    }
-    m_state.store(state);
-}
-
-bool DebugServer::isState(State state) const
-{
-    bool result = m_state.load() == state;
-    if (result && state == State::Running) {
-#if ENABLE(REMOTE_INSPECTOR)
-        if (isRWIMode())
-            return result;
-#endif
-        RELEASE_ASSERT(isSocketValid(m_serverSocket));
-    }
-    return result;
-}
-
-void DebugServer::resetAll()
-{
-    m_state.store(State::Stopped);
-    m_port = defaultPort;
-    closeSocket(m_serverSocket);
-    closeSocket(m_clientSocket);
-    m_acceptThread = nullptr;
-
-    m_noAckMode = false;
-    m_queryHandler = nullptr;
-    m_memoryHandler = nullptr;
-    m_executionHandler = nullptr;
-
-    m_moduleManager = nullptr;
-
-#if ENABLE(REMOTE_INSPECTOR)
-    m_rwiResponseHandler = nullptr;
-#endif
-}
 
 union SocketAddress {
     sockaddr_in in;
@@ -264,7 +171,7 @@ void DebugServer::startAcceptThread()
     m_acceptThread = WTF::Thread::create("WasmDebugServer", [this]() {
         m_executionHandler->setDebugServerThreadId(Thread::currentSingleton().uid());
 
-        while (isState(State::Running)) {
+        while (isInService()) {
             dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Waiting for client connections...");
             SocketAddress clientAddress;
             socklen_t clientLen = sizeof(clientAddress.in);
@@ -564,7 +471,7 @@ void DebugServer::untrackModule(Module& module)
 
 bool DebugServer::hasDebugger() const
 {
-    if (!isState(State::Running))
+    if (!isInService())
         return false;
 #if ENABLE(REMOTE_INSPECTOR)
     if (isRWIMode())

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -77,13 +77,6 @@ class DebugServer {
     WTF_MAKE_TZONE_ALLOCATED(DebugServer);
 
 public:
-    enum class State : uint8_t {
-        Stopped, // Initial state, server is not running
-        Starting, // Transitional state during startup
-        Running, // Server is fully operational and accepting connections
-        Stopping, // Transitional state during shutdown
-    };
-
     JS_EXPORT_PRIVATE static DebugServer& singleton();
 
 #if OS(WINDOWS)
@@ -100,7 +93,6 @@ public:
     ~DebugServer() = default;
 
     JS_EXPORT_PRIVATE bool start();
-    JS_EXPORT_PRIVATE void stop();
 
 #if ENABLE(REMOTE_INSPECTOR)
     // DebugServer supports two modes:
@@ -148,13 +140,12 @@ public:
 
 private:
 
-    void setState(State);
-    JS_EXPORT_PRIVATE bool NODELETE isState(State) const;
+    bool isInService() const { return m_isInService.load(std::memory_order_acquire); }
+    void setIsInService() { m_isInService.store(true, std::memory_order_release); }
 
     bool createAndBindServerSocket();
     void startAcceptThread();
     void acceptClientConnections();
-    void resetAll();
     void closeSocket(SocketType&);
 
     void handleClient();
@@ -180,7 +171,8 @@ private:
     friend class RegisterHandler;
     friend class ExecutionHandler;
 
-    std::atomic<State> m_state { State::Stopped };
+    // Set once on start()/startRWI() and never cleared — DebugServer is a process-lifetime singleton.
+    std::atomic<bool> m_isInService { false };
     std::atomic<bool> m_hasContinued { false };
     std::atomic<bool> m_isDebuggerReady { false };
     uint16_t m_port { defaultPort };


### PR DESCRIPTION
#### 13c5aeda0703cc514a7ba78957d8362c0ba509e3
<pre>
[JSC][WASM][Debugger] Remove DebugServer::stop() and State enum
<a href="https://bugs.webkit.org/show_bug.cgi?id=312704">https://bugs.webkit.org/show_bug.cgi?id=312704</a>
<a href="https://rdar.apple.com/175100088">rdar://175100088</a>

Reviewed by Mark Lam.

stop() was called only at jsc process exit, where the OS reclaims all
sockets and threads anyway. Removing it lets the 4-value State enum
(Stopped/Starting/Running/Stopping) collapse to a single atomic bool
m_isInService, with isInService()/setIsInService() accessors using
acquire/release barriers.

Canonical link: <a href="https://commits.webkit.org/311608@main">https://commits.webkit.org/311608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13dd621fec24b9a2c3185af368050c394aad6f1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24011 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/166305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111563 "Build is in progress. Recent messages:") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bfe1a596-74ca-4e0d-bcf7-1c200501a72d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30820 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/166305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/111563 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/921233f3-782c-4e44-867f-85242d4eda99) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141407 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/166305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12b5fe56-81fd-443a-b57a-d386fefe7e5f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23285 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21535 "Passed tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/14076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149532 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132964 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168791 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18316 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13096 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20855 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130101 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30419 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130210 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88283 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23949 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25045 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17834 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/189554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94253 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/189554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29575 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29702 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->