### PR TITLE
[JSC][WASM][Debugger] Fix DebugServer::reset() deadlock on reconnect after   detach

### DIFF
--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -204,13 +204,12 @@ void DebugServer::reset()
     // Reset to the init state without stopping the debug server.
     m_isDebuggerReady.store(false, std::memory_order_release);
     m_hasContinued.store(false, std::memory_order_release);
-    closeSocket(m_clientSocket);
     m_noAckMode = false;
     m_packetParser.reset();
-    // Gate VM threads out before touching ExecutionHandler: close the socket so
-    // hasDebugger() returns false, and clear isDebuggerReady so no new traps enter
-    // the debugger path.
+    // m_isDebuggerReady=false before reset() gates new traps; socket closed after so
+    // hasDebugger() stays true for wasmDebuggerOnResumeCallback() during resumeImpl().
     m_executionHandler->reset();
+    closeSocket(m_clientSocket);
 }
 
 static void dumpReceivedBytes(std::span<const uint8_t> buffer)


### PR DESCRIPTION
#### f45de3a3d2a7e65c625a8463b7c625064f9c9b8f
<pre>
[JSC][WASM][Debugger] Fix DebugServer::reset() deadlock on reconnect after   detach
<a href="https://bugs.webkit.org/show_bug.cgi?id=312706">https://bugs.webkit.org/show_bug.cgi?id=312706</a>
<a href="https://rdar.apple.com/175100149">rdar://175100149</a>

Reviewed by Mark Lam.

Close the client socket after m_executionHandler-&gt;reset() instead of
before. resumeImpl() inside reset() blocks on m_debuggerContinue waiting
for wasmDebuggerOnResumeCallback() to call handlePostResume(). That
callback gates on hasDebugger() == isSocketValid(m_clientSocket), so
closing the socket first made hasDebugger() return false, causing the
callback to take the &quot;not connected&quot; early-return path and never notify
m_debuggerContinue. This deadlocked the accept thread, preventing any
subsequent LLDB reconnection after a detach (D packet).

m_isDebuggerReady=false is sufficient to gate new VM traps from entering
the debugger path while resumeImpl() runs.

Canonical link: <a href="https://commits.webkit.org/311703@main">https://commits.webkit.org/311703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/584d189dc59831073cbd3289a1cc58925d63d631

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111367 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd83df9c-970b-474e-a610-5677b5d07c46) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121813 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85526 "2 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15df2e3f-ccd2-4536-abd2-a4f53246dbe7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102481 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5aa0143-b537-4c60-805c-d60a775225af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23114 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21361 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13880 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149335 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168594 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18120 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12752 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129946 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130054 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140857 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88018 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23989 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17662 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189303 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29857 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93871 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48569 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29379 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29609 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->