### PR TITLE
Always use UTF-8 to decode workers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/constructor-utf16-bom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/constructor-utf16-bom-expected.txt
@@ -1,4 +1,6 @@
 
-FAIL Worker with UTF-16BE BOM assert_unreached: Worker with UTF-16BE BOM should result to a compile error Reached unreachable code
-FAIL Worker with UTF-16LE BOM assert_unreached: Worker with UTF-16LE BOM should result to a compile error Reached unreachable code
+Harness Error (FAIL), message = SyntaxError: Invalid character '\ufffd'
+
+PASS Worker with UTF-16BE BOM
+PASS Worker with UTF-16LE BOM
 

--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
@@ -51,7 +51,7 @@ Ref<WorkerModuleScriptLoader> WorkerModuleScriptLoader::create(ModuleScriptLoade
 
 WorkerModuleScriptLoader::WorkerModuleScriptLoader(ModuleScriptLoaderClient& client, DeferredPromise& promise, WorkerScriptFetcher& scriptFetcher, RefPtr<JSC::ScriptFetchParameters>&& parameters)
     : ModuleScriptLoader(client, promise, scriptFetcher, WTF::move(parameters))
-    , m_scriptLoader(WorkerScriptLoader::create(WorkerScriptLoader::AlwaysUseUTF8::Yes))
+    , m_scriptLoader(WorkerScriptLoader::create())
 {
 }
 

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -60,9 +60,8 @@ static void accessWorkerScriptLoaderMap(CompletionHandler<void(HashMap<ScriptExe
     callback(map.get());
 }
 
-WorkerScriptLoader::WorkerScriptLoader(AlwaysUseUTF8 alwaysUseUTF8)
+WorkerScriptLoader::WorkerScriptLoader()
     : m_script(ScriptBuffer::empty())
-    , m_alwaysUseUTF8(alwaysUseUTF8 == AlwaysUseUTF8::Yes)
 {
 }
 
@@ -290,8 +289,7 @@ void WorkerScriptLoader::didReceiveData(const SharedBuffer& buffer)
     if (!m_decoder) {
         // FIXME: Share more code with CachedScript / CachedScriptSourceProvider.
         Ref decoder = TextResourceDecoder::create("text/javascript"_s, "UTF-8"_s);
-        if (m_alwaysUseUTF8)
-            decoder->setAlwaysUseUTF8();
+        decoder->setAlwaysUseUTF8();
         lazyInitialize(m_decoder, WTF::move(decoder));
     }
 

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -60,10 +60,9 @@ enum class CertificateInfoPolicy : uint8_t;
 class WorkerScriptLoader final : public RefCounted<WorkerScriptLoader>, public ThreadableLoaderClient {
     WTF_MAKE_TZONE_ALLOCATED(WorkerScriptLoader);
 public:
-    enum class AlwaysUseUTF8 : bool { No, Yes };
-    static Ref<WorkerScriptLoader> create(AlwaysUseUTF8 alwaysUseUTF8 = AlwaysUseUTF8::No)
+    static Ref<WorkerScriptLoader> create()
     {
-        return adoptRef(*new WorkerScriptLoader(alwaysUseUTF8));
+        return adoptRef(*new WorkerScriptLoader);
     }
 
     enum class Source : uint8_t { ClassicWorkerScript, ClassicWorkerImport, ModuleScript };
@@ -135,7 +134,7 @@ private:
     friend class RefCounted<WorkerScriptLoader>;
     friend struct std::default_delete<WorkerScriptLoader>;
 
-    explicit WorkerScriptLoader(AlwaysUseUTF8);
+    WorkerScriptLoader();
     ~WorkerScriptLoader();
 
     std::unique_ptr<ResourceRequest> createResourceRequest(const String& initiatorIdentifier);
@@ -155,7 +154,6 @@ private:
     String m_referrerPolicy;
     CrossOriginEmbedderPolicy m_crossOriginEmbedderPolicy;
     Markable<ResourceLoaderIdentifier> m_identifier;
-    bool m_alwaysUseUTF8 { false };
     bool m_failed { false };
     bool m_finishing { false };
     bool m_isRedirected { false };


### PR DESCRIPTION
#### 404faf2f5c07a531a9774f73fb821a614d173d2e
<pre>
Always use UTF-8 to decode workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=312708">https://bugs.webkit.org/show_bug.cgi?id=312708</a>

Reviewed by Sam Weinig and Chris Dumez.

The progressed test still has a harness error due to an unrelated bug.

Canonical link: <a href="https://commits.webkit.org/311761@main">https://commits.webkit.org/311761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dca2421152ba1a04fa00cafc44295edd9979f96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111411 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22aa7f0d-bcc1-4bb4-a818-3e1ee3766c4c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121852 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85564 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b42d088-9864-485c-b18c-59bb1d4c380c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102520 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d782331-eff9-45a2-b520-df12fb4195aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23152 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21399 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13924 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168638 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12796 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20721 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129985 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130092 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35364 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140895 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88103 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24914 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17700 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29901 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93915 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29423 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29653 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29550 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->