### PR TITLE
Drop jsDynamicCast<>() in favor of dynamicDowncast<>()

### DIFF
--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -126,7 +126,7 @@ Identifier JSAPIGlobalObject::moduleLoaderResolve(JSGlobalObject* globalObject, 
     RETURN_IF_EXCEPTION(scope, { });
 
     URL base;
-    if (JSString* referrerString = jsDynamicCast<JSString*>(referrer)) {
+    if (JSString* referrerString = dynamicDowncast<JSString>(referrer)) {
         String value = referrerString->value(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
         // It can be invalid URL because dynamic-import will be resolved with caller's source origin (this becomes referrer), and it can be non valid URL.

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -232,7 +232,7 @@ EncodedJSValue JSCallbackObject<Parent>::customToPrimitive(JSGlobalObject* globa
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSCallbackObject* thisObject = jsDynamicCast<JSCallbackObject*>(callFrame->thisValue());
+    JSCallbackObject* thisObject = dynamicDowncast<JSCallbackObject>(callFrame->thisValue());
     if (!thisObject)
         return throwVMTypeError(globalObject, scope, "JSCallbackObject[Symbol.toPrimitive] method called on incompatible |this| value."_s);
     PreferredPrimitiveType hint = toPreferredPrimitiveType(globalObject, callFrame->argument(0));

--- a/Source/JavaScriptCore/API/JSContext.mm
+++ b/Source/JavaScriptCore/API/JSContext.mm
@@ -136,7 +136,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return [JSValue valueWithJSValueRef:result inContext:self];
     }
 
-    auto* apiGlobalObject = JSC::jsDynamicCast<JSC::JSAPIGlobalObject*>(globalObject);
+    auto* apiGlobalObject = dynamicDowncast<JSC::JSAPIGlobalObject>(globalObject);
     if (!apiGlobalObject)
         return [JSValue valueWithNewPromiseRejectedWithReason:[JSValue valueWithNewErrorFromMessage:@"Context does not support module loading" inContext:self] inContext:self];
 

--- a/Source/JavaScriptCore/API/JSObjectRef.cpp
+++ b/Source/JavaScriptCore/API/JSObjectRef.cpp
@@ -864,9 +864,9 @@ JSObjectRef JSObjectGetProxyTarget(JSObjectRef objectRef)
     VM& vm = object->vm();
     JSLockHolder locker(vm);
     JSObject* result = nullptr;
-    if (JSGlobalProxy* proxy = jsDynamicCast<JSGlobalProxy*>(object))
+    if (JSGlobalProxy* proxy = dynamicDowncast<JSGlobalProxy>(object))
         result = proxy->target();
-    else if (ProxyObject* proxy = jsDynamicCast<ProxyObject*>(object))
+    else if (ProxyObject* proxy = dynamicDowncast<ProxyObject>(object))
         result = proxy->target();
     return toRef(result);
 }

--- a/Source/JavaScriptCore/API/JSTypedArray.cpp
+++ b/Source/JavaScriptCore/API/JSTypedArray.cpp
@@ -147,7 +147,7 @@ JSTypedArrayType JSValueGetTypedArrayType(JSContextRef ctx, JSValueRef valueRef,
         return kJSTypedArrayTypeNone;
     JSObject* object = value.getObject();
 
-    if (jsDynamicCast<JSArrayBuffer*>(object))
+    if (is<JSArrayBuffer>(object))
         return kJSTypedArrayTypeArrayBuffer;
 
     return toJSTypedArrayType(object->type());
@@ -204,7 +204,7 @@ JSObjectRef JSObjectMakeTypedArrayWithArrayBuffer(JSContextRef ctx, JSTypedArray
     if (arrayType == kJSTypedArrayTypeNone || arrayType == kJSTypedArrayTypeArrayBuffer)
         return nullptr;
 
-    JSArrayBuffer* jsBuffer = jsDynamicCast<JSArrayBuffer*>(toJS(jsBufferRef));
+    JSArrayBuffer* jsBuffer = dynamicDowncast<JSArrayBuffer>(toJS(jsBufferRef));
     if (!jsBuffer) {
         setException(ctx, exception, createTypeError(globalObject, "JSObjectMakeTypedArrayWithArrayBuffer expects buffer to be an Array Buffer object"_s));
         return nullptr;
@@ -232,7 +232,7 @@ JSObjectRef JSObjectMakeTypedArrayWithArrayBufferAndOffset(JSContextRef ctx, JST
     if (arrayType == kJSTypedArrayTypeNone || arrayType == kJSTypedArrayTypeArrayBuffer)
         return nullptr;
 
-    JSArrayBuffer* jsBuffer = jsDynamicCast<JSArrayBuffer*>(toJS(jsBufferRef));
+    JSArrayBuffer* jsBuffer = dynamicDowncast<JSArrayBuffer>(toJS(jsBufferRef));
     if (!jsBuffer) {
         setException(ctx, exception, createTypeError(globalObject, "JSObjectMakeTypedArrayWithArrayBuffer expects buffer to be an Array Buffer object"_s));
         return nullptr;
@@ -251,7 +251,7 @@ void* JSObjectGetTypedArrayBytesPtr(JSContextRef ctx, JSObjectRef objectRef, JSV
     JSLockHolder locker(vm);
     JSObject* object = toJS(objectRef);
 
-    if (JSArrayBufferView* typedArray = jsDynamicCast<JSArrayBufferView*>(object)) {
+    if (JSArrayBufferView* typedArray = dynamicDowncast<JSArrayBufferView>(object)) {
         if (ArrayBuffer* buffer = typedArray->possiblySharedBuffer()) {
             buffer->pinAndLock();
             return buffer->data();
@@ -266,7 +266,7 @@ size_t JSObjectGetTypedArrayLength(JSContextRef, JSObjectRef objectRef, JSValueR
 {
     JSObject* object = toJS(objectRef);
 
-    if (JSArrayBufferView* typedArray = jsDynamicCast<JSArrayBufferView*>(object))
+    if (JSArrayBufferView* typedArray = dynamicDowncast<JSArrayBufferView>(object))
         return typedArray->length();
 
     return 0;
@@ -276,7 +276,7 @@ size_t JSObjectGetTypedArrayByteLength(JSContextRef, JSObjectRef objectRef, JSVa
 {
     JSObject* object = toJS(objectRef);
 
-    if (JSArrayBufferView* typedArray = jsDynamicCast<JSArrayBufferView*>(object))
+    if (JSArrayBufferView* typedArray = dynamicDowncast<JSArrayBufferView>(object))
         return typedArray->byteLength();
 
     return 0;
@@ -286,7 +286,7 @@ size_t JSObjectGetTypedArrayByteOffset(JSContextRef, JSObjectRef objectRef, JSVa
 {
     JSObject* object = toJS(objectRef);
 
-    if (JSArrayBufferView* typedArray = jsDynamicCast<JSArrayBufferView*>(object))
+    if (JSArrayBufferView* typedArray = dynamicDowncast<JSArrayBufferView>(object))
         return typedArray->byteOffset();
 
     return 0;
@@ -300,7 +300,7 @@ JSObjectRef JSObjectGetTypedArrayBuffer(JSContextRef ctx, JSObjectRef objectRef,
     JSObject* object = toJS(objectRef);
 
 
-    if (JSArrayBufferView* typedArray = jsDynamicCast<JSArrayBufferView*>(object)) {
+    if (JSArrayBufferView* typedArray = dynamicDowncast<JSArrayBufferView>(object)) {
         if (ArrayBuffer* buffer = typedArray->possiblySharedBuffer())
             return toRef(vm.m_typedArrayController->toJS(globalObject, typedArray->realm(), *buffer));
 
@@ -336,7 +336,7 @@ void* JSObjectGetArrayBufferBytesPtr(JSContextRef ctx, JSObjectRef objectRef, JS
     JSLockHolder locker(vm);
     JSObject* object = toJS(objectRef);
 
-    if (JSArrayBuffer* jsBuffer = jsDynamicCast<JSArrayBuffer*>(object)) {
+    if (JSArrayBuffer* jsBuffer = dynamicDowncast<JSArrayBuffer>(object)) {
         ArrayBuffer* buffer = jsBuffer->impl();
         if (buffer->isWasmMemory()) {
             setException(ctx, exception, createTypeError(globalObject, "Cannot get the backing buffer for a WebAssembly.Memory"_s));
@@ -370,7 +370,7 @@ size_t JSObjectGetArrayBufferByteLength(JSContextRef, JSObjectRef objectRef, JSV
         return 0;
     }
 
-    if (JSArrayBuffer* jsBuffer = jsDynamicCast<JSArrayBuffer*>(object))
+    if (JSArrayBuffer* jsBuffer = dynamicDowncast<JSArrayBuffer>(object))
         return jsBuffer->impl()->byteLength();
     
     return 0;

--- a/Source/JavaScriptCore/API/JSWrapperMap.mm
+++ b/Source/JavaScriptCore/API/JSWrapperMap.mm
@@ -278,7 +278,7 @@ static void copyMethodsToObject(JSContext *context, Class objcClass, Protocol *p
             // to override normal builtins e.g. "toString" we check if
             // the existing value on the prototype chain is an ObjC
             // callback already.
-            if ([existingMethod isObject] && JSC::jsDynamicCast<JSC::ObjCCallbackFunction*>(toJS(globalObject, [existingMethod JSValueRef])))
+            if ([existingMethod isObject] && is<JSC::ObjCCallbackFunction>(toJS(globalObject, [existingMethod JSValueRef])))
                 return;
             JSObjectRef method = objCCallbackFunctionForMethod(context, objcClass, protocol, isInstanceMethod, sel, types);
             if (method)

--- a/Source/JavaScriptCore/API/glib/JSCValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCValue.cpp
@@ -1553,7 +1553,7 @@ gboolean jsc_value_is_array_buffer(JSCValue* value)
     if (!jsValue.isObject())
         return FALSE;
 
-    return !!jsDynamicCast<JSArrayBuffer*>(jsValue.getObject());
+    return is<JSArrayBuffer>(jsValue.getObject());
 }
 
 /**

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.cpp
@@ -158,14 +158,14 @@ void ArrayProfile::observeIndexedRead(JSCell* cell, unsigned index)
 {
     m_lastSeenStructureID = cell->structureID();
 
-    if (JSObject* object = jsDynamicCast<JSObject*>(cell)) {
+    if (JSObject* object = dynamicDowncast<JSObject>(cell)) {
         if (hasAnyArrayStorage(object->indexingType()) && index >= object->getVectorLength())
             setOutOfBounds();
         else if (index >= object->getArrayLength())
             setOutOfBounds();
     }
 
-    if (JSString* string = jsDynamicCast<JSString*>(cell)) {
+    if (JSString* string = dynamicDowncast<JSString>(cell)) {
         if (index >= string->length())
             setOutOfBounds();
     }

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -245,7 +245,7 @@ void DataOnlyCallLinkInfo::initialize(VM& vm, CodeBlock* owner, CallType callTyp
 
 std::tuple<CodeBlock*, BytecodeIndex> CallLinkInfo::retrieveCaller(JSCell* owner)
 {
-    auto* codeBlock = jsDynamicCast<CodeBlock*>(owner);
+    auto* codeBlock = dynamicDowncast<CodeBlock>(owner);
     if (!codeBlock)
         return { };
     CodeOrigin codeOrigin = this->codeOrigin();
@@ -292,7 +292,7 @@ JSGlobalObject* CallLinkInfo::globalObjectForSlowPath(JSCell* owner)
     if (codeBlock)
         return codeBlock->globalObject();
 #if ENABLE(WEBASSEMBLY)
-    auto* module = jsDynamicCast<JSWebAssemblyModule*>(owner);
+    auto* module = dynamicDowncast<JSWebAssemblyModule>(owner);
     if (module)
         return module->realm();
 #endif
@@ -554,7 +554,7 @@ CodeBlock* DirectCallLinkInfo::retrieveCodeBlock(FunctionExecutable* functionExe
     if (!codeBlock)
         return nullptr;
 
-    CodeBlock* ownerCodeBlock = jsDynamicCast<CodeBlock*>(owner());
+    CodeBlock* ownerCodeBlock = dynamicDowncast<CodeBlock>(owner());
     if (!ownerCodeBlock)
         return nullptr;
 
@@ -587,7 +587,7 @@ void DirectCallLinkInfo::repatchSpeculatively()
         return;
     }
 
-    FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(m_executable);
+    FunctionExecutable* functionExecutable = dynamicDowncast<FunctionExecutable>(m_executable);
     if (!functionExecutable) {
         initialize();
         return;
@@ -611,7 +611,7 @@ void DirectCallLinkInfo::repatchSpeculatively()
 void DirectCallLinkInfo::validateSpeculativeRepatchOnMainThread(VM&)
 {
     constexpr bool verbose = false;
-    FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(m_executable);
+    FunctionExecutable* functionExecutable = dynamicDowncast<FunctionExecutable>(m_executable);
     if (!functionExecutable)
         return;
 

--- a/Source/JavaScriptCore/bytecode/CallVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/CallVariant.cpp
@@ -60,7 +60,7 @@ void CallVariant::filter(JSValue value)
         return;
     }
     
-    if (JSFunction* function = jsDynamicCast<JSFunction*>(value)) {
+    if (JSFunction* function = dynamicDowncast<JSFunction>(value)) {
         if (function->executable() == executable())
             *this = CallVariant(function);
         else

--- a/Source/JavaScriptCore/bytecode/CallVariant.h
+++ b/Source/JavaScriptCore/bytecode/CallVariant.h
@@ -88,21 +88,21 @@ public:
     
     InternalFunction* internalFunction() const
     {
-        return jsDynamicCast<InternalFunction*>(m_callee);
+        return dynamicDowncast<InternalFunction>(m_callee);
     }
     
     JSFunction* function() const
     {
-        return jsDynamicCast<JSFunction*>(m_callee);
+        return dynamicDowncast<JSFunction>(m_callee);
     }
     
-    bool isClosureCall() const { return !!jsDynamicCast<ExecutableBase*>(m_callee); }
+    bool isClosureCall() const { return is<ExecutableBase>(m_callee); }
     
     ExecutableBase* executable() const
     {
         if (JSFunction* function = this->function())
             return function->executable();
-        return jsDynamicCast<ExecutableBase*>(m_callee);
+        return dynamicDowncast<ExecutableBase>(m_callee);
     }
     
     JSCell* nonExecutableCallee() const
@@ -116,14 +116,14 @@ public:
     FunctionExecutable* functionExecutable() const
     {
         if (ExecutableBase* executable = this->executable())
-            return jsDynamicCast<FunctionExecutable*>(executable);
+            return dynamicDowncast<FunctionExecutable>(executable);
         return nullptr;
     }
 
     NativeExecutable* nativeExecutable() const
     {
         if (ExecutableBase* executable = this->executable())
-            return jsDynamicCast<NativeExecutable*>(executable);
+            return dynamicDowncast<NativeExecutable>(executable);
         return nullptr;
     }
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -410,7 +410,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
 
     // We already have the cloned symbol table for the module environment since we need to instantiate
     // the module environments before linking the code block. We replace the stored symbol table with the already cloned one.
-    if (UnlinkedModuleProgramCodeBlock* unlinkedModuleProgramCodeBlock = jsDynamicCast<UnlinkedModuleProgramCodeBlock*>(unlinkedCodeBlock)) {
+    if (UnlinkedModuleProgramCodeBlock* unlinkedModuleProgramCodeBlock = dynamicDowncast<UnlinkedModuleProgramCodeBlock>(unlinkedCodeBlock)) {
         SymbolTable* clonedSymbolTable = jsCast<ModuleProgramExecutable*>(ownerExecutable)->moduleEnvironmentSymbolTable();
         if (m_unlinkedCode->wasCompiledWithTypeProfilerOpcodes()) {
             ConcurrentJSLocker locker(clonedSymbolTable->m_lock);
@@ -1065,7 +1065,7 @@ Vector<unsigned> CodeBlock::setConstantRegisters(const FixedVector<WriteBarrier<
             if (!constant.isEmpty()) {
                 if (constant.isCell()) {
                     JSCell* cell = constant.asCell();
-                    if (SymbolTable* symbolTable = jsDynamicCast<SymbolTable*>(cell)) {
+                    if (SymbolTable* symbolTable = dynamicDowncast<SymbolTable>(cell)) {
                         if (m_unlinkedCode->wasCompiledWithTypeProfilerOpcodes()) {
                             ConcurrentJSLocker locker(symbolTable->m_lock);
                             symbolTable->prepareForTypeProfiling(locker);
@@ -1084,7 +1084,7 @@ Vector<unsigned> CodeBlock::setConstantRegisters(const FixedVector<WriteBarrier<
                             clone->collectDebuggerInfo(this);
 
                         constant = clone;
-                    } else if (jsDynamicCast<JSTemplateObjectDescriptor*>(cell))
+                    } else if (is<JSTemplateObjectDescriptor>(cell))
                         templateObjectIndices.append(i);
                 }
             }
@@ -1451,7 +1451,7 @@ void CodeBlock::determineLiveness(const ConcurrentJSLocker&, Visitor& visitor)
     bool allAreLiveSoFar = true;
     for (unsigned i = 0; i < dfgCommon->m_weakReferences.size(); ++i) {
         JSCell* reference = dfgCommon->m_weakReferences[i].get();
-        ASSERT(!jsDynamicCast<CodeBlock*>(reference));
+        ASSERT(!is<CodeBlock>(reference));
         if (!visitor.isMarked(reference)) {
             allAreLiveSoFar = false;
             break;
@@ -2471,7 +2471,7 @@ void CodeBlock::noticeIncomingCall(JSCell* caller)
 {
     RELEASE_ASSERT(!m_isJettisoned);
 
-    CodeBlock* callerCodeBlock = jsDynamicCast<CodeBlock*>(caller);
+    CodeBlock* callerCodeBlock = dynamicDowncast<CodeBlock>(caller);
     
     dataLogLnIf(Options::verboseCallLink(), "Noticing call link from ", pointerDump(callerCodeBlock), " to ", *this);
     
@@ -3346,7 +3346,7 @@ String CodeBlock::nameForRegister(VirtualRegister virtualRegister)
     for (auto& constantRegister : m_constantRegisters) {
         if (constantRegister.get().isEmpty())
             continue;
-        if (SymbolTable* symbolTable = jsDynamicCast<SymbolTable*>(constantRegister.get())) {
+        if (SymbolTable* symbolTable = dynamicDowncast<SymbolTable>(constantRegister.get())) {
             ConcurrentJSLocker locker(symbolTable->m_lock);
             auto end = symbolTable->end(locker);
             for (auto ptr = symbolTable->begin(locker); ptr != end; ++ptr) {

--- a/Source/JavaScriptCore/bytecode/ObjectAllocationProfileInlines.h
+++ b/Source/JavaScriptCore/bytecode/ObjectAllocationProfileInlines.h
@@ -160,7 +160,7 @@ ALWAYS_INLINE unsigned ObjectAllocationProfileBase<Derived>::possibleDefaultProp
         JSValue value = prototype->getDirect(vm, propertyNameVector[i]);
 
         // Functions are common, and are usually class-level objects that are not overridden.
-        if (jsDynamicCast<JSFunction*>(value))
+        if (is<JSFunction>(value))
             continue;
 
         ++count;

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -85,7 +85,7 @@ void linkMonomorphicCall(VM& vm, JSCell* owner, CallLinkInfo& callLinkInfo, Code
 {
     ASSERT(!callLinkInfo.stub());
 
-    CodeBlock* callerCodeBlock = jsDynamicCast<CodeBlock*>(owner); // WebAssembly -> JS stubs don't have a valid CodeBlock.
+    CodeBlock* callerCodeBlock = dynamicDowncast<CodeBlock>(owner); // WebAssembly -> JS stubs don't have a valid CodeBlock.
     ASSERT(owner);
 
     if (Options::forceICFailure()) [[unlikely]]
@@ -113,7 +113,7 @@ CodePtr<JSEntryPtrTag> jsToWasmICCodePtr(CodeSpecializationKind kind, JSObject* 
         return nullptr;
     if (kind != CodeSpecializationKind::CodeForCall)
         return nullptr;
-    if (auto* wasmFunction = jsDynamicCast<WebAssemblyFunction*>(callee))
+    if (auto* wasmFunction = dynamicDowncast<WebAssemblyFunction>(callee))
         return wasmFunction->jsCallICEntrypoint();
 #else
     UNUSED_PARAM(kind);
@@ -133,7 +133,7 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
         return;
     }
 
-    CodeBlock* callerCodeBlock = jsDynamicCast<CodeBlock*>(owner); // WebAssembly -> JS stubs don't have a valid CodeBlock.
+    CodeBlock* callerCodeBlock = dynamicDowncast<CodeBlock>(owner); // WebAssembly -> JS stubs don't have a valid CodeBlock.
     ASSERT(owner);
 #if ENABLE(WEBASSEMBLY)
     bool isWebAssembly = owner->inherits<JSWebAssemblyModule>();
@@ -518,12 +518,12 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
                 }
 
                 newCase = AccessCase::create(vm, codeBlock, AccessCase::StringLength, lengthPropertyName);
-            } else if (DirectArguments* arguments = jsDynamicCast<DirectArguments*>(baseCell)) {
+            } else if (DirectArguments* arguments = dynamicDowncast<DirectArguments>(baseCell)) {
                 // If there were overrides, then we can handle this as a normal property load! Guarding
                 // this with such a check enables us to add an IC case for that load if needed.
                 if (!arguments->overrodeThings())
                     newCase = AccessCase::create(vm, codeBlock, AccessCase::DirectArgumentsLength, lengthPropertyName);
-            } else if (ScopedArguments* arguments = jsDynamicCast<ScopedArguments*>(baseCell)) {
+            } else if (ScopedArguments* arguments = dynamicDowncast<ScopedArguments>(baseCell)) {
                 // Ditto.
                 if (!arguments->overrodeThings())
                     newCase = AccessCase::create(vm, codeBlock, AccessCase::ScopedArgumentsLength, lengthPropertyName);
@@ -531,7 +531,7 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
         }
 
         if (!newCase && propertyName == vm.propertyNames->lastIndex) {
-            if (jsDynamicCast<RegExpObject*>(baseCell))
+            if (is<RegExpObject>(baseCell))
                 newCase = AccessCase::create(vm, codeBlock, AccessCase::RegExpLastIndexLoad, CacheableIdentifier::createFromImmortalIdentifier(vm.propertyNames->lastIndex.impl()));
         }
 
@@ -671,7 +671,7 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
 
             JSFunction* getter = nullptr;
             if (slot.isCacheableGetter())
-                getter = jsDynamicCast<JSFunction*>(slot.getterSetter()->getter());
+                getter = dynamicDowncast<JSFunction>(slot.getterSetter()->getter());
 
             std::optional<DOMAttributeAnnotation> domAttribute;
             if (slot.isCacheableCustom() && slot.domAttribute())
@@ -1059,7 +1059,7 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
             if (baseCell->type() == ArrayType)
                 newCase = AccessCase::create(vm, codeBlock, AccessCase::ArrayLengthStore, propertyName);
         } else if (propertyName == vm.propertyNames->lastIndex) {
-            if (jsDynamicCast<RegExpObject*>(baseCell))
+            if (is<RegExpObject>(baseCell))
                 newCase = AccessCase::create(vm, codeBlock, AccessCase::RegExpLastIndexStore, propertyName);
         }
 
@@ -1934,9 +1934,9 @@ static InlineCacheAction tryCacheInstanceOf(JSGlobalObject* globalObject, CodeBl
         JSCell* value = valueValue.asCell();
         Structure* structure = value->structure();
         RefPtr<AccessCase> newCase;
-        JSObject* prototype = jsDynamicCast<JSObject*>(prototypeValue);
+        JSObject* prototype = dynamicDowncast<JSObject>(prototypeValue);
         if (prototype) {
-            if (!jsDynamicCast<JSObject*>(value)) {
+            if (!is<JSObject>(value)) {
                 newCase = InstanceOfAccessCase::create(
                     vm, codeBlock, AccessCase::InstanceOfMiss, structure, ObjectPropertyConditionSet(),
                     prototype);

--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -133,7 +133,7 @@ ALWAYS_INLINE void* linkFor(VM& vm, JSCell* owner, CallFrame* calleeFrame, CallL
     JSValue calleeAsValue = calleeFrame->guaranteedJSValueCallee();
     JSCell* calleeAsFunctionCell = getJSFunction(calleeAsValue);
     if (!calleeAsFunctionCell) {
-        if (auto* internalFunction = jsDynamicCast<InternalFunction*>(calleeAsValue)) {
+        if (auto* internalFunction = dynamicDowncast<InternalFunction>(calleeAsValue)) {
             CodePtr<JSEntryPtrTag> codePtr = vm.getCTIInternalFunctionTrampolineFor(kind);
             RELEASE_ASSERT(!!codePtr);
 
@@ -233,7 +233,7 @@ ALWAYS_INLINE void* virtualForWithFunction(VM& vm, JSCell* owner, CallFrame* cal
     JSValue calleeAsValue = calleeFrame->guaranteedJSValueCallee();
     calleeAsFunctionCell = getJSFunction(calleeAsValue);
     if (!calleeAsFunctionCell) [[unlikely]] {
-        if (jsDynamicCast<InternalFunction*>(calleeAsValue)) {
+        if (is<InternalFunction>(calleeAsValue)) {
             CodePtr<JSEntryPtrTag> codePtr = vm.getCTIInternalFunctionTrampolineFor(kind);
             ASSERT(!!codePtr);
             return codePtr.taggedPtr();

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -179,7 +179,7 @@ void Debugger::attach(JSGlobalObject* globalObject)
         m_vm.heap.objectSpace().forEachLiveCell(iterationScope, [&] (HeapCell* heapCell, HeapCell::Kind kind) {
             if (isJSCellKind(kind)) {
                 auto* cell = static_cast<JSCell*>(heapCell);
-                if (auto* function = jsDynamicCast<JSFunction*>(cell)) {
+                if (auto* function = dynamicDowncast<JSFunction>(cell)) {
                     if (function->scope()->realm() == globalObject && function->executable()->isFunctionExecutable() && !function->isHostOrBuiltinFunction())
                         sourceProviders.add(jsCast<FunctionExecutable*>(function->executable())->source().provider());
                 }
@@ -1175,7 +1175,7 @@ void Debugger::exception(JSGlobalObject* globalObject, CallFrame* callFrame, JSV
     if (m_isPaused)
         return;
 
-    if (JSObject* object = jsDynamicCast<JSObject*>(exception)) {
+    if (JSObject* object = dynamicDowncast<JSObject>(exception)) {
         if (object->isErrorInstance()) {
             ErrorInstance* error = static_cast<ErrorInstance*>(object);
             // FIXME: <https://webkit.org/b/173625> Web Inspector: Should be able to pause and debug a StackOverflow Exception
@@ -1252,7 +1252,7 @@ void Debugger::willAwait(CallFrame* callFrame, JSValue generatorValue)
     if (!m_pauseOnCallFrame || m_pauseOnCallFrame != callFrame)
         return;
 
-    m_pauseForAwaitInGenerator = jsDynamicCast<JSGenerator*>(generatorValue);
+    m_pauseForAwaitInGenerator = dynamicDowncast<JSGenerator>(generatorValue);
     ASSERT(m_pauseForAwaitInGenerator);
     if (!m_pauseForAwaitInGenerator)
         return;
@@ -1276,7 +1276,7 @@ void Debugger::didAwait(CallFrame*, JSValue generatorValue)
     if (!m_pauseForAwaitInGenerator)
         return;
 
-    JSGenerator* generator = jsDynamicCast<JSGenerator*>(generatorValue);
+    JSGenerator* generator = dynamicDowncast<JSGenerator>(generatorValue);
     ASSERT(generator);
     if (m_pauseForAwaitInGenerator != generator)
         return;

--- a/Source/JavaScriptCore/debugger/DebuggerCallFrame.cpp
+++ b/Source/JavaScriptCore/debugger/DebuggerCallFrame.cpp
@@ -133,7 +133,7 @@ String DebuggerCallFrame::functionName(VM& vm) const
         return String();
 
     if (isTailDeleted()) {
-        if (JSFunction* func = jsDynamicCast<JSFunction*>(m_shadowChickenFrame.callee))
+        if (JSFunction* func = dynamicDowncast<JSFunction>(m_shadowChickenFrame.callee))
             return func->calculatedDisplayName(vm);
         return String::fromLatin1(m_shadowChickenFrame.codeBlock->inferredName().data());
     }
@@ -154,7 +154,7 @@ DebuggerScope* DebuggerCallFrame::scope(VM& vm)
             scope = m_shadowChickenFrame.scope;
         else if (codeBlock && codeBlock->scopeRegister().isValid())
             scope = m_validMachineFrame->scope(codeBlock->scopeRegister().offset());
-        else if (JSCallee* callee = jsDynamicCast<JSCallee*>(m_validMachineFrame->jsCallee()))
+        else if (JSCallee* callee = dynamicDowncast<JSCallee>(m_validMachineFrame->jsCallee()))
             scope = callee->scope();
         else
             scope = m_validMachineFrame->lexicalGlobalObject(vm)->globalLexicalEnvironment();
@@ -173,7 +173,7 @@ DebuggerCallFrame::Type DebuggerCallFrame::type(VM&) const
     if (isTailDeleted())
         return FunctionType;
 
-    if (jsDynamicCast<JSFunction*>(m_validMachineFrame->jsCallee()))
+    if (is<JSFunction>(m_validMachineFrame->jsCallee()))
         return FunctionType;
 
     return ProgramType;

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2795,7 +2795,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 if (!arrayConstant)
                     return false;
 
-                JSObject* array = jsDynamicCast<JSObject*>(arrayConstant);
+                JSObject* array = dynamicDowncast<JSObject>(arrayConstant);
                 if (!array)
                     return false;
 
@@ -3387,7 +3387,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         }
 
         if (JSValue globalObjectValue = forNode(node->child1()).m_value) {
-            if (JSGlobalObject* globalObject = jsDynamicCast<JSGlobalObject*>(globalObjectValue)) {
+            if (JSGlobalObject* globalObject = dynamicDowncast<JSGlobalObject>(globalObjectValue)) {
                 if (m_graph.m_plan.isUnlinked() && globalObject != m_graph.globalObjectFor(node->origin.semantic))
                     break;
 
@@ -3658,7 +3658,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case FunctionToString: {
         JSValue value = m_state.forNode(node->child1()).value();
         if (value) {
-            JSFunction* function = jsDynamicCast<JSFunction*>(value);
+            JSFunction* function = dynamicDowncast<JSFunction>(value);
             if (JSString* asString = function->asStringConcurrently()) {
                 setConstant(node, *m_graph.freeze(asString));
                 break;
@@ -3930,7 +3930,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
     case CreateThis: {
         if (JSValue base = forNode(node->child1()).m_value) {
-            if (auto* function = jsDynamicCast<JSFunction*>(base)) {
+            if (auto* function = dynamicDowncast<JSFunction>(base)) {
                 if (FunctionRareData* rareData = function->rareData()) {
                     if (rareData->allocationProfileWatchpointSet().isStillValid() && m_graph.isWatchingStructureCacheClearedWatchpoint(node)) {
                         if (Structure* structure = rareData->objectAllocationStructure()) {
@@ -3957,7 +3957,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 setForNode(node, globalObject->promiseStructure());
                 break;
             }
-            if (auto* function = jsDynamicCast<JSFunction*>(base)) {
+            if (auto* function = dynamicDowncast<JSFunction>(base)) {
                 if (FunctionRareData* rareData = function->rareData()) {
                     if (rareData->allocationProfileWatchpointSet().isStillValid() && m_graph.isWatchingStructureCacheClearedWatchpoint(node)) {
                         Structure* structure = rareData->internalFunctionAllocationStructure();
@@ -3984,7 +3984,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         auto tryToFold = [&] (const ClassInfo* classInfo) -> bool {
             JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
             if (JSValue base = forNode(node->child1()).m_value) {
-                if (auto* function = jsDynamicCast<JSFunction*>(base)) {
+                if (auto* function = dynamicDowncast<JSFunction>(base)) {
                     if (FunctionRareData* rareData = function->rareData()) {
                         if (rareData->allocationProfileWatchpointSet().isStillValid() && m_graph.isWatchingStructureCacheClearedWatchpoint(node)) {
                             Structure* structure = rareData->internalFunctionAllocationStructure();
@@ -4191,7 +4191,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
         
     case GetCallee:
-        if (FunctionExecutable* executable = jsDynamicCast<FunctionExecutable*>(m_codeBlock->ownerExecutable())) {
+        if (FunctionExecutable* executable = dynamicDowncast<FunctionExecutable>(m_codeBlock->ownerExecutable())) {
             if (JSFunction* function = executable->singleton().inferredValue()) {
                 m_graph.watchpoints().addLazily(m_graph, executable);
                 setConstant(node, *m_graph.freeze(function));
@@ -4211,7 +4211,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         
     case GetGetter: {
         if (JSValue base = forNode(node->child1()).m_value) {
-            GetterSetter* getterSetter = jsDynamicCast<GetterSetter*>(base);
+            GetterSetter* getterSetter = dynamicDowncast<GetterSetter>(base);
             if (getterSetter && !getterSetter->isGetterNull()) {
                 setConstant(node, *m_graph.freeze(getterSetter->getterConcurrently()));
                 break;
@@ -4224,7 +4224,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         
     case GetSetter: {
         if (JSValue base = forNode(node->child1()).m_value) {
-            GetterSetter* getterSetter = jsDynamicCast<GetterSetter*>(base);
+            GetterSetter* getterSetter = dynamicDowncast<GetterSetter>(base);
             if (getterSetter && !getterSetter->isSetterNull()) {
                 setConstant(node, *m_graph.freeze(getterSetter->setterConcurrently()));
                 break;
@@ -4238,7 +4238,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case GetScope: {
         JSValue value = forNode(node->child1()).value();
         if (value) {
-            if (JSFunction* function = jsDynamicCast<JSFunction*>(value)) {
+            if (JSFunction* function = dynamicDowncast<JSFunction>(value)) {
                 setConstant(node, *m_graph.freeze(function->scope()));
                 break;
             }
@@ -4266,7 +4266,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
     case SkipScope: {
         if (JSValue child = forNode(node->child1()).value()) {
-            if (JSScope* scope = jsDynamicCast<JSScope*>(child)) {
+            if (JSScope* scope = dynamicDowncast<JSScope>(child)) {
                 if (JSScope* nextScope = scope->next()) {
                     setConstant(node, *m_graph.freeze(JSValue(nextScope)));
                     break;
@@ -4665,7 +4665,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         const RegisteredStructureSet& set = node->structureSet();
         
         if (value.value()) {
-            if (Structure* structure = jsDynamicCast<Structure*>(value.value())) {
+            if (Structure* structure = dynamicDowncast<Structure>(value.value())) {
                 if (set.contains(m_graph.registerStructure(structure)))
                     break;
             }
@@ -4984,7 +4984,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 #if ENABLE(WEBASSEMBLY)
         AbstractValue& base = forNode(node->child1());
         if (base.m_value) {
-            if (auto* instance = jsDynamicCast<JSWebAssemblyInstance*>(base.m_value)) {
+            if (auto* instance = dynamicDowncast<JSWebAssemblyInstance>(base.m_value)) {
                 if (auto* moduleRecord = instance->moduleRecord()) {
                     if (auto* exportsObject = moduleRecord->exportsObject()) {
                         setConstant(node, *m_graph.freeze(exportsObject));
@@ -5027,7 +5027,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         StorageAccessData& data = node->storageAccessData();
         AbstractValue& base = forNode(node->child2());
         JSValue result = m_graph.tryGetConstantProperty(base, data.offset);
-        if (result && jsDynamicCast<GetterSetter*>(result)) {
+        if (result && is<GetterSetter>(result)) {
             setConstant(node, *m_graph.freeze(result));
             break;
         }
@@ -5171,7 +5171,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case GetExecutable: {
         JSValue value = forNode(node->child1()).value();
         if (value) {
-            JSFunction* function = jsDynamicCast<JSFunction*>(value);
+            JSFunction* function = dynamicDowncast<JSFunction>(value);
             if (function) {
                 setConstant(node, *m_graph.freeze(function->executable()));
                 break;
@@ -5577,8 +5577,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         JSValue calleeValue = forNode(calleeNode).m_value;
         JSValue newTargetValue = forNode(newTargetNode).m_value;
         if (calleeValue && newTargetValue) {
-            auto* callee = jsDynamicCast<JSObject*>(calleeValue);
-            auto* newTarget = jsDynamicCast<JSFunction*>(newTargetValue);
+            auto* callee = dynamicDowncast<JSObject>(calleeValue);
+            auto* newTarget = dynamicDowncast<JSFunction>(newTargetValue);
             if (callee && newTarget) {
                 JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
                 if (callee->realmMayBeNull() == globalObject) {

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -393,7 +393,7 @@ private:
             // We have to do some constant-folding here because this enables CreateThis folding. Note
             // that we don't have such watchpoint-based folding for inlined uses of Callee, since in that
             // case if the function is a singleton then we already know it.
-            if (FunctionExecutable* executable = jsDynamicCast<FunctionExecutable*>(m_codeBlock->ownerExecutable())) {
+            if (FunctionExecutable* executable = dynamicDowncast<FunctionExecutable>(m_codeBlock->ownerExecutable())) {
                 if (JSFunction* function = executable->singleton().inferredValue()) {
                     m_graph.watchpoints().addLazily(m_graph, executable);
                     return weakJSConstant(function);
@@ -2292,7 +2292,7 @@ ByteCodeParser::CallOptimizationResult ByteCodeParser::handleInlining(
                 if (executable->intrinsic() == BoundFunctionCallIntrinsic)
                     return inliningResult;
 
-                if (auto* functionExecutable = jsDynamicCast<FunctionExecutable*>(executable)) {
+                if (auto* functionExecutable = dynamicDowncast<FunctionExecutable>(executable)) {
                     if (callOp == Construct && functionExecutable->constructAbility() == ConstructAbility::CannotConstruct)
                         return inliningResult;
 
@@ -4519,7 +4519,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             JSFunction* function = variant.function();
             if (!function)
                 return CallOptimizationResult::DidNothing;
-            JSBoundFunction* boundFunction = jsDynamicCast<JSBoundFunction*>(function);
+            JSBoundFunction* boundFunction = dynamicDowncast<JSBoundFunction>(function);
             if (!boundFunction)
                 return CallOptimizationResult::DidNothing;
 

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -371,7 +371,7 @@ private:
                 const RegisteredStructureSet& set = node->structureSet();
                 
                 if (value.value()) {
-                    if (Structure* structure = jsDynamicCast<Structure*>(value.value())) {
+                    if (Structure* structure = dynamicDowncast<Structure>(value.value())) {
                         if (set.contains(m_graph.registerStructure(structure))) {
                             m_interpreter.execute(indexInBlock);
                             node->remove(m_graph);
@@ -965,7 +965,7 @@ private:
 
             case CreateThis: {
                 if (JSValue base = m_state.forNode(node->child1()).m_value) {
-                    if (auto* function = jsDynamicCast<JSFunction*>(base)) {
+                    if (auto* function = dynamicDowncast<JSFunction>(base)) {
                         if (FunctionRareData* rareData = function->rareData()) {
                             if (rareData->allocationProfileWatchpointSet().isStillValid() && m_graph.isWatchingStructureCacheClearedWatchpoint(node)) {
                                 Structure* structure = rareData->objectAllocationStructure();
@@ -1007,7 +1007,7 @@ private:
                         changed = true;
                         break;
                     }
-                    if (auto* function = jsDynamicCast<JSFunction*>(base)) {
+                    if (auto* function = dynamicDowncast<JSFunction>(base)) {
                         if (FunctionRareData* rareData = function->rareData()) {
                             if (rareData->allocationProfileWatchpointSet().isStillValid() && m_graph.isWatchingStructureCacheClearedWatchpoint(node)) {
                                 Structure* structure = rareData->internalFunctionAllocationStructure();
@@ -1032,7 +1032,7 @@ private:
                 auto foldConstant = [&] (const ClassInfo* classInfo) {
                     JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
                     if (JSValue base = m_state.forNode(node->child1()).m_value) {
-                        if (auto* function = jsDynamicCast<JSFunction*>(base)) {
+                        if (auto* function = dynamicDowncast<JSFunction>(base)) {
                             if (FunctionRareData* rareData = function->rareData()) {
                                 if (rareData->allocationProfileWatchpointSet().isStillValid() && m_graph.isWatchingStructureCacheClearedWatchpoint(node)) {
                                     Structure* structure = rareData->internalFunctionAllocationStructure();
@@ -1404,7 +1404,7 @@ private:
 
             case GetScope: {
                 if (JSValue base = m_state.forNode(node->child1()).m_value) {
-                    if (JSFunction* function = jsDynamicCast<JSFunction*>(base)) {
+                    if (JSFunction* function = dynamicDowncast<JSFunction>(base)) {
                         m_graph.convertToConstant(node, function->scope());
                         changed = true;
                         break;
@@ -1433,8 +1433,8 @@ private:
                 JSValue calleeValue = m_state.forNode(calleeNode).m_value;
                 JSValue newTargetValue = m_state.forNode(newTargetNode).m_value;
                 if (calleeValue && newTargetValue) {
-                    auto* callee = jsDynamicCast<JSObject*>(calleeValue);
-                    auto* newTarget = jsDynamicCast<JSFunction*>(newTargetValue);
+                    auto* callee = dynamicDowncast<JSObject>(calleeValue);
+                    auto* newTarget = dynamicDowncast<JSFunction>(newTargetValue);
                     if (callee && newTarget) {
                         JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
                         if (callee->realmMayBeNull() == globalObject) {

--- a/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.cpp
@@ -42,14 +42,14 @@ DesiredWeakReferences::~DesiredWeakReferences() = default;
 void DesiredWeakReferences::addLazily(JSCell* cell)
 {
     if (cell) {
-        if (Structure* structure = jsDynamicCast<Structure*>(cell))
+        if (Structure* structure = dynamicDowncast<Structure>(cell))
             m_structures.add(structure->id());
         else {
             // There are weird relationships in how optimized CodeBlocks
             // point to other CodeBlocks. We don't want to have them be
             // part of the weak pointer set. For example, an optimized CodeBlock
             // having a weak pointer to itself will cause it to get collected.
-            RELEASE_ASSERT(!jsDynamicCast<CodeBlock*>(cell));
+            RELEASE_ASSERT(!is<CodeBlock>(cell));
             m_cells.add(cell);
         }
     }
@@ -63,7 +63,7 @@ void DesiredWeakReferences::addLazily(JSValue value)
 
 bool DesiredWeakReferences::contains(JSCell* cell)
 {
-    if (Structure* structure = jsDynamicCast<Structure*>(cell))
+    if (Structure* structure = dynamicDowncast<Structure>(cell))
         return m_structures.contains(structure->id());
     return m_cells.contains(cell);
 }

--- a/Source/JavaScriptCore/dfg/DFGFrozenValue.h
+++ b/Source/JavaScriptCore/dfg/DFGFrozenValue.h
@@ -75,7 +75,7 @@ public:
         JSValue theValue = value();
         if (!theValue)
             return nullptr;
-        return jsDynamicCast<T>(theValue);
+        return dynamicDowncast<std::remove_pointer_t<T>>(theValue);
     }
     template<typename T>
     T cast()

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -298,7 +298,7 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
                 if (ExecutableBase* executable = variant.executable()) {
                     if (executable->isHostFunction())
                         out.print(comma, "<host function>"_s);
-                    else if (FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(executable))
+                    else if (FunctionExecutable* functionExecutable = dynamicDowncast<FunctionExecutable>(executable))
                         out.print(comma, FunctionExecutableDump(functionExecutable));
                     else
                         out.print(comma, "<non-function executable>"_s);
@@ -1459,7 +1459,7 @@ JSValue Graph::tryGetConstantClosureVar(JSValue base, ScopeOffset offset)
     if (!base)
         return JSValue();
     
-    JSLexicalEnvironment* activation = jsDynamicCast<JSLexicalEnvironment*>(base);
+    JSLexicalEnvironment* activation = dynamicDowncast<JSLexicalEnvironment>(base);
     if (!activation)
         return JSValue();
     
@@ -1509,7 +1509,7 @@ JSArrayBufferView* Graph::tryGetFoldableView(JSValue value)
         return nullptr;
     if (!value)
         return nullptr;
-    JSArrayBufferView* view = jsDynamicCast<JSArrayBufferView*>(value);
+    JSArrayBufferView* view = dynamicDowncast<JSArrayBufferView>(value);
     if (!view)
         return nullptr;
     if (!view->length())
@@ -1630,7 +1630,7 @@ FrozenValue* Graph::freeze(JSValue value)
     // point to other CodeBlocks. We don't want to have them be
     // part of the weak pointer set. For example, an optimized CodeBlock
     // having a weak pointer to itself will cause it to get collected.
-    RELEASE_ASSERT(!jsDynamicCast<CodeBlock*>(value));
+    RELEASE_ASSERT(!is<CodeBlock>(value));
     
     auto result = m_frozenValueMap.add(JSValue::encode(value), nullptr);
     if (!result.isNewEntry) [[likely]]
@@ -1932,9 +1932,9 @@ bool Graph::getPrototypeProperty(JSObject* prototype, Structure* prototypeStruct
 
     // We only care about functions and getters at this point. If you want to access other properties
     // you'll have to add code for those types.
-    JSFunction* function = jsDynamicCast<JSFunction*>(value);
+    JSFunction* function = dynamicDowncast<JSFunction>(value);
     if (!function) {
-        GetterSetter* getterSetter = jsDynamicCast<GetterSetter*>(value);
+        GetterSetter* getterSetter = dynamicDowncast<GetterSetter>(value);
 
         if (!getterSetter)
             return false;

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1017,7 +1017,7 @@ public:
     {
         if (!isCellConstant())
             return nullptr;
-        return jsDynamicCast<T>(asCell());
+        return dynamicDowncast<std::remove_pointer_t<T>>(asCell());
     }
     
     bool hasLazyJSValue()

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -311,7 +311,7 @@ JSC_DEFINE_JIT_OPERATION(operationObjectAssignObject, void, (JSGlobalObject* glo
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (auto* targetObject = jsDynamicCast<JSFinalObject*>(target); targetObject && targetObject->canPerformFastPutInlineExcludingProto() && targetObject->isStructureExtensible()) {
+    if (auto* targetObject = dynamicDowncast<JSFinalObject>(target); targetObject && targetObject->canPerformFastPutInlineExcludingProto() && targetObject->isStructureExtensible()) {
         Vector<UniquedStringImpl*, 8> properties;
         MarkedArgumentBuffer values;
         if (!source->staticPropertiesReified()) {
@@ -354,7 +354,7 @@ JSC_DEFINE_JIT_OPERATION(operationObjectAssignUntyped, void, (JSGlobalObject* gl
     JSObject* source = sourceValue.toObject(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope);
 
-    if (auto* targetObject = jsDynamicCast<JSFinalObject*>(target); targetObject && targetObject->canPerformFastPutInlineExcludingProto() && targetObject->isStructureExtensible()) {
+    if (auto* targetObject = dynamicDowncast<JSFinalObject>(target); targetObject && targetObject->canPerformFastPutInlineExcludingProto() && targetObject->isStructureExtensible()) {
         if (!source->staticPropertiesReified()) {
             source->reifyAllStaticProperties(globalObject);
             OPERATION_RETURN_IF_EXCEPTION(scope);
@@ -812,7 +812,7 @@ ALWAYS_INLINE EncodedJSValue getByValCellInt(JSGlobalObject* globalObject, VM& v
     if (index < 0) {
         // When index is negative, -1 is the most common case. Let's handle it separately.
         if (index == -1) [[likely]] {
-            if (auto* array = jsDynamicCast<JSArray*>(base); array && array->definitelyNegativeOneMiss()) [[likely]]
+            if (auto* array = dynamicDowncast<JSArray>(base); array && array->definitelyNegativeOneMiss()) [[likely]]
                 return JSValue::encode(jsUndefined());
             return JSValue::encode(JSValue(base).get(globalObject, vm.propertyNames->negativeOneIdentifier));
         }
@@ -1423,7 +1423,7 @@ JSC_DEFINE_JIT_OPERATION(operationRegExpExecGeneric, EncodedJSValue, (JSGlobalOb
     JSValue base = JSValue::decode(encodedBase);
     JSValue argument = JSValue::decode(encodedArgument);
     
-    auto* regexp = jsDynamicCast<RegExpObject*>(base);
+    auto* regexp = dynamicDowncast<RegExpObject>(base);
     if (!regexp) [[unlikely]]
         OPERATION_RETURN(scope, throwVMTypeError(globalObject, scope, "Builtin RegExp exec can only be called on a RegExp object"_s));
 
@@ -1729,7 +1729,7 @@ JSC_DEFINE_JIT_OPERATION(operationRegExpTestGeneric, size_t, (JSGlobalObject* gl
     JSValue base = JSValue::decode(encodedBase);
     JSValue argument = JSValue::decode(encodedArgument);
 
-    auto* regexp = jsDynamicCast<RegExpObject*>(base);
+    auto* regexp = dynamicDowncast<RegExpObject>(base);
     if (!regexp) [[unlikely]] {
         throwTypeError(globalObject, scope);
         OPERATION_RETURN(scope, false);
@@ -2354,7 +2354,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewArrayBuffer, JSCell*, (VM* vmPointer, Struc
         auto scope = DECLARE_THROW_SCOPE(vm); \
         JSValue firstValue = JSValue::decode(encodedValue); \
         bool isResizableOrGrowableShared = false; \
-        if (auto* arrayBuffer = jsDynamicCast<JSArrayBuffer*>(firstValue)) \
+        if (auto* arrayBuffer = dynamicDowncast<JSArrayBuffer>(firstValue)) \
             isResizableOrGrowableShared = arrayBuffer->isResizableOrGrowableShared(); \
         Structure* structure = globalObject->typedArrayStructure(Type##type, isResizableOrGrowableShared); \
         OPERATION_RETURN(scope, reinterpret_cast<char*>(constructGenericTypedArrayViewWithArguments<JS##type##Array>(globalObject, structure, firstValue, 0, std::nullopt))); \
@@ -2598,7 +2598,7 @@ JSC_DEFINE_JIT_OPERATION(operationTypeOfIsObject, size_t, (JSGlobalObject* globa
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ASSERT(jsDynamicCast<JSObject*>(object));
+    ASSERT(is<JSObject>(object));
     
     OPERATION_RETURN(scope, jsTypeofIsObject(globalObject, object));
 }
@@ -2610,7 +2610,7 @@ JSC_DEFINE_JIT_OPERATION(operationTypeOfIsFunction, size_t, (JSGlobalObject* glo
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ASSERT(jsDynamicCast<JSObject*>(object));
+    ASSERT(is<JSObject>(object));
 
     OPERATION_RETURN(scope, jsTypeofIsFunction(globalObject, object));
 }
@@ -2622,7 +2622,7 @@ JSC_DEFINE_JIT_OPERATION(operationObjectIsCallable, size_t, (JSGlobalObject* glo
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ASSERT(jsDynamicCast<JSObject*>(object));
+    ASSERT(is<JSObject>(object));
     
     OPERATION_RETURN(scope, object->isCallable());
 }
@@ -2656,7 +2656,7 @@ JSC_DEFINE_JIT_OPERATION(operationTypeOfObject, JSCell*, (JSGlobalObject* global
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ASSERT(jsDynamicCast<JSObject*>(object));
+    ASSERT(is<JSObject>(object));
     
     if (object->structure()->masqueradesAsUndefined(globalObject))
         OPERATION_RETURN(scope, vm.smallStrings.undefinedString());
@@ -2802,7 +2802,7 @@ JSC_DEFINE_JIT_OPERATION(operationHasIndexedProperty, size_t, (JSGlobalObject* g
         // When subscript is negative, -1 is the most common case. Let's handle it separately.
         if (subscript == -1) [[likely]] {
             // what?
-            if (auto* array = jsDynamicCast<JSArray*>(object); array && array->definitelyNegativeOneMiss()) [[likely]]
+            if (auto* array = dynamicDowncast<JSArray>(object); array && array->definitelyNegativeOneMiss()) [[likely]]
                 OPERATION_RETURN(scope, false);
             OPERATION_RETURN(scope, object->hasProperty(globalObject, vm.propertyNames->negativeOneIdentifier));
         }
@@ -2823,7 +2823,7 @@ JSC_DEFINE_JIT_OPERATION(operationHasEnumerableIndexedProperty, size_t, (JSGloba
     if (subscript < 0) [[unlikely]] {
         // When subscript is negative, -1 is the most common case. Let's handle it separately.
         if (subscript == -1) [[likely]] {
-            if (auto* array = jsDynamicCast<JSArray*>(baseCell); array && array->definitelyNegativeOneMiss()) [[likely]]
+            if (auto* array = dynamicDowncast<JSArray>(baseCell); array && array->definitelyNegativeOneMiss()) [[likely]]
                 OPERATION_RETURN(scope, false);
             OPERATION_RETURN(scope, object->hasProperty(globalObject, vm.propertyNames->negativeOneIdentifier));
         }
@@ -3036,7 +3036,7 @@ JSC_DEFINE_JIT_OPERATION(operationStringValueOf, JSString*, (JSGlobalObject* glo
     if (argument.isString())
         OPERATION_RETURN(scope,  asString(argument));
 
-    if (auto* stringObject = jsDynamicCast<StringObject*>(argument))
+    if (auto* stringObject = dynamicDowncast<StringObject>(argument))
         OPERATION_RETURN(scope,  stringObject->internalValue());
 
     throwVMTypeError(globalObject, scope);
@@ -3785,7 +3785,7 @@ JSC_DEFINE_JIT_OPERATION(operationFunctionBind, JSBoundFunction*, (JSGlobalObjec
 
     double length = 0;
     JSString* name = nullptr;
-    JSFunction* function = jsDynamicCast<JSFunction*>(target);
+    JSFunction* function = dynamicDowncast<JSFunction>(target);
     if (function && function->canAssumeNameAndLengthAreOriginal(vm)) [[likely]] {
         // Do nothing! 'length' and 'name' computation are lazily done.
         // And this is totally OK since we know that wrapped functions have canAssumeNameAndLengthAreOriginal condition
@@ -4772,7 +4772,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewArrayWithSpreadSlow, JSCell*, (JSGlobalObje
     CheckedUint32 checkedLength = 0;
     for (unsigned i = 0; i < numItems; i++) {
         JSValue value = JSValue::decode(values[i]);
-        if (JSCellButterfly* array = jsDynamicCast<JSCellButterfly*>(value))
+        if (JSCellButterfly* array = dynamicDowncast<JSCellButterfly>(value))
             checkedLength += array->publicLength();
         else
             ++checkedLength;
@@ -4801,7 +4801,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewArrayWithSpreadSlow, JSCell*, (JSGlobalObje
     unsigned index = 0;
     for (unsigned i = 0; i < numItems; i++) {
         JSValue value = JSValue::decode(values[i]);
-        if (JSCellButterfly* array = jsDynamicCast<JSCellButterfly*>(value)) {
+        if (JSCellButterfly* array = dynamicDowncast<JSCellButterfly>(value)) {
             // We are spreading.
             for (unsigned i = 0; i < array->publicLength(); i++) {
                 result->putDirectIndex(globalObject, index, array->get(i));
@@ -4873,7 +4873,7 @@ JSC_DEFINE_JIT_OPERATION(operationSpreadSet, JSCell*, (JSGlobalObject* globalObj
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ASSERT(jsDynamicCast<JSSet*>(cell));
+    ASSERT(is<JSSet>(cell));
     JSSet* set = jsCast<JSSet*>(cell);
 
     OPERATION_RETURN(scope, JSCellButterfly::createFromSet(globalObject, set));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -592,7 +592,7 @@ void SpeculativeJIT::emitCall(Node* node)
     FunctionExecutable* functionExecutable = nullptr;
     if (isDirect) {
         executable = node->castOperand<ExecutableBase*>();
-        functionExecutable = jsDynamicCast<FunctionExecutable*>(executable);
+        functionExecutable = dynamicDowncast<FunctionExecutable>(executable);
     }
     
     unsigned numPassedArgs = 0;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -696,7 +696,7 @@ void SpeculativeJIT::emitCall(Node* node)
     FunctionExecutable* functionExecutable = nullptr;
     if (isDirect) {
         executable = node->castOperand<ExecutableBase*>();
-        functionExecutable = jsDynamicCast<FunctionExecutable*>(executable);
+        functionExecutable = dynamicDowncast<FunctionExecutable>(executable);
     }
     
     unsigned numPassedArgs = 0;
@@ -999,7 +999,7 @@ void SpeculativeJIT::emitCall(Node* node)
         Edge calleeEdge = m_graph.child(node, 0);
         JSGlobalObject* calleeScope = nullptr;
         if (JSValue calleeValue = m_state.forNode(calleeEdge).value()) {
-            if (auto* callee = jsDynamicCast<JSFunction*>(calleeValue)) {
+            if (auto* callee = dynamicDowncast<JSFunction>(calleeValue)) {
                 m_graph.freeze(callee);
                 calleeScope = callee->realm();
             }

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1637,7 +1637,7 @@ private:
                     break;
                 if (!function)
                     break;
-                auto* wasmFunction = jsDynamicCast<WebAssemblyFunction*>(function);
+                auto* wasmFunction = dynamicDowncast<WebAssemblyFunction>(function);
                 if (!wasmFunction)
                     break;
                 const auto& signature = Wasm::TypeInformation::getFunctionSignature(wasmFunction->typeIndex());
@@ -1807,10 +1807,10 @@ private:
             // This also wipes bound-function thunk call which is suboptimal compared to directly calling a wrapped function here.
             if (executable->intrinsic() == BoundFunctionCallIntrinsic && function && (m_node->op() == Call || m_node->op() == TailCall || m_node->op() == TailCallInlinedCaller)) {
                 JSBoundFunction* boundFunction = jsCast<JSBoundFunction*>(function);
-                if (JSFunction* targetFunction = jsDynamicCast<JSFunction*>(boundFunction->targetFunction())) {
+                if (JSFunction* targetFunction = dynamicDowncast<JSFunction>(boundFunction->targetFunction())) {
                     auto* targetExecutable = targetFunction->executable();
                     if ((boundFunction->boundArgsLength() + m_node->numChildren()) <= Options::maximumDirectCallStackSize()) {
-                        if (FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(targetExecutable)) {
+                        if (FunctionExecutable* functionExecutable = dynamicDowncast<FunctionExecutable>(targetExecutable)) {
                             // We need to update m_parameterSlots before we get to the backend, but we don't
                             // want to do too much of this.
                             unsigned numAllocatedArgs = static_cast<unsigned>(functionExecutable->parameterCount()) + 1;
@@ -1842,7 +1842,7 @@ private:
                 }
             }
 
-            if (FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(executable)) {
+            if (FunctionExecutable* functionExecutable = dynamicDowncast<FunctionExecutable>(executable)) {
                 if (m_node->op() == Construct && functionExecutable->constructAbility() == ConstructAbility::CannotConstruct)
                     break;
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -12938,7 +12938,7 @@ IGNORE_CLANG_WARNINGS_END
         bool isConstruct = node->op() == DirectConstruct;
 
         ExecutableBase* executable = node->castOperand<ExecutableBase*>();
-        FunctionExecutable* functionExecutable = jsDynamicCast<FunctionExecutable*>(executable);
+        FunctionExecutable* functionExecutable = dynamicDowncast<FunctionExecutable>(executable);
 
         unsigned numPassedArgs = node->numChildren() - 1;
         unsigned numAllocatedArgs = numPassedArgs;
@@ -13001,7 +13001,7 @@ IGNORE_CLANG_WARNINGS_END
         Edge calleeEdge = m_graph.child(node, 0);
         JSGlobalObject* calleeScope = nullptr;
         if (JSValue calleeValue = m_state.forNode(calleeEdge).value()) {
-            if (auto* callee = jsDynamicCast<JSFunction*>(calleeValue)) {
+            if (auto* callee = dynamicDowncast<JSFunction>(calleeValue)) {
                 m_graph.freeze(callee);
                 calleeScope = callee->realm();
             }

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -766,7 +766,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
             if (property.location().kind() == NewArrayWithSpreadArgumentPLoc) {
                 ++numProperties;
                 JSValue value = JSValue::decode(values[i]);
-                if (JSCellButterfly* immutableButterfly = jsDynamicCast<JSCellButterfly*>(value))
+                if (JSCellButterfly* immutableButterfly = dynamicDowncast<JSCellButterfly>(value))
                     checkedArraySize += immutableButterfly->publicLength();
                 else
                     checkedArraySize += 1;
@@ -808,7 +808,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
 
         unsigned arrayIndex = 0;
         for (JSValue value : arguments) {
-            if (JSCellButterfly* immutableButterfly = jsDynamicCast<JSCellButterfly*>(value)) {
+            if (JSCellButterfly* immutableButterfly = dynamicDowncast<JSCellButterfly>(value)) {
                 for (unsigned i = 0; i < immutableButterfly->publicLength(); i++) {
                     ASSERT(immutableButterfly->get(i));
                     result->putDirectIndex(globalObject, arrayIndex, immutableButterfly->get(i));
@@ -870,7 +870,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationTypeOfObjectAsTypeofType, UCPUStrictI
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
 
-    ASSERT(jsDynamicCast<JSObject*>(object));
+    ASSERT(is<JSObject>(object));
 
     if (object->structure()->masqueradesAsUndefined(globalObject))
         return toUCPUStrictInt32(static_cast<int32_t>(TypeofType::Undefined));

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -416,8 +416,8 @@ void HeapSnapshotBuilder::dumpToStream(PrintStream& out)
                     nodeLabel.append(it->value);
 
                 if (nodeLabel.isEmpty()) {
-                    if (auto* object = jsDynamicCast<JSObject*>(node.cell)) {
-                        if (auto* function = jsDynamicCast<JSFunction*>(object))
+                    if (auto* object = dynamicDowncast<JSObject>(node.cell)) {
+                        if (auto* function = dynamicDowncast<JSFunction>(object))
                             nodeLabel.append(function->calculatedDisplayName(vm));
                     }
                 }

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -156,12 +156,12 @@ JSValue JSInjectedScriptHost::isPromiseRejectedWithNativeGetterTypeError(JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* promise = jsDynamicCast<JSPromise*>(callFrame->argument(0));
+    auto* promise = dynamicDowncast<JSPromise>(callFrame->argument(0));
     if (!promise)
         return throwTypeError(globalObject, scope, "InjectedScriptHost.isPromiseRejectedWithNativeGetterTypeError first argument must be a Promise."_s);
 
     bool result = false;
-    if (auto* errorInstance = jsDynamicCast<ErrorInstance*>(promise->result()))
+    if (auto* errorInstance = dynamicDowncast<ErrorInstance>(promise->result()))
         result = errorInstance->isNativeGetterTypeError();
     return jsBoolean(result);
 }
@@ -182,12 +182,12 @@ JSValue JSInjectedScriptHost::subtype(JSGlobalObject* globalObject, CallFrame* c
     if (value.isSymbol())
         return vm.smallStrings.symbolString();
 
-    if (auto* object = jsDynamicCast<JSObject*>(value)) {
+    if (auto* object = dynamicDowncast<JSObject>(value)) {
         if (object->isErrorInstance())
             return jsNontrivialString(vm, "error"_s);
 
         // Consider class constructor functions class objects.
-        JSFunction* function = jsDynamicCast<JSFunction*>(value);
+        JSFunction* function = dynamicDowncast<JSFunction>(value);
         if (function && function->isClassConstructorFunction())
             return jsNontrivialString(vm, "class"_s);
 
@@ -247,15 +247,15 @@ JSValue JSInjectedScriptHost::functionDetails(JSGlobalObject* globalObject, Call
 
     VM& vm = globalObject->vm();
     JSValue value = callFrame->uncheckedArgument(0);
-    auto* function = jsDynamicCast<JSFunction*>(value);
+    auto* function = dynamicDowncast<JSFunction>(value);
     if (!function)
         return jsUndefined();
 
     // FIXME: <https://webkit.org/b/87192> Web Inspector: Expose function scope / closure data
 
     auto* targetFunction = function;
-    while (auto* boundFunction = jsDynamicCast<JSBoundFunction*>(targetFunction)) {
-        auto* nextTargetFunction = jsDynamicCast<JSFunction*>(boundFunction->targetFunction());
+    while (auto* boundFunction = dynamicDowncast<JSBoundFunction>(targetFunction)) {
+        auto* nextTargetFunction = dynamicDowncast<JSFunction>(boundFunction->targetFunction());
         if (!nextTargetFunction) [[unlikely]]
             break;
         targetFunction = nextTargetFunction;
@@ -314,7 +314,7 @@ JSValue JSInjectedScriptHost::getOwnPrivatePropertySymbols(JSGlobalObject* globa
     JSArray* result = constructEmptyArray(globalObject, nullptr);
     RETURN_IF_EXCEPTION(scope, JSValue());
 
-    JSObject* object = jsDynamicCast<JSObject*>(value);
+    JSObject* object = dynamicDowncast<JSObject>(value);
     if (!object)
         return result;
 
@@ -348,7 +348,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
     if (internalProperties)
         return internalProperties;
 
-    if (JSPromise* promise = jsDynamicCast<JSPromise*>(value)) {
+    if (JSPromise* promise = dynamicDowncast<JSPromise>(value)) {
         unsigned index = 0;
         JSArray* array = constructEmptyArray(globalObject, nullptr);
         RETURN_IF_EXCEPTION(scope, JSValue());
@@ -374,7 +374,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
         RELEASE_ASSERT_NOT_REACHED();
     }
 
-    if (JSBoundFunction* boundFunction = jsDynamicCast<JSBoundFunction*>(value)) {
+    if (JSBoundFunction* boundFunction = dynamicDowncast<JSBoundFunction>(value)) {
         unsigned index = 0;
         JSArray* array = constructEmptyArray(globalObject, nullptr);
         RETURN_IF_EXCEPTION(scope, JSValue());
@@ -389,7 +389,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
         }
         return array;
     }
-    if (JSArrowFunction* arrowFunction = jsDynamicCast<JSArrowFunction*>(value)) {
+    if (JSArrowFunction* arrowFunction = dynamicDowncast<JSArrowFunction>(value)) {
         if (JSScope* jsScope = arrowFunction->scope()) {
             unsigned index = 0;
             JSArray* array = constructEmptyArray(globalObject, nullptr);
@@ -401,7 +401,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
             return array;
         }
     }
-    if (JSRemoteFunction* remoteFunction = jsDynamicCast<JSRemoteFunction*>(value)) {
+    if (JSRemoteFunction* remoteFunction = dynamicDowncast<JSRemoteFunction>(value)) {
         unsigned index = 0;
         JSArray* array = constructEmptyArray(globalObject, nullptr, 1);
         RETURN_IF_EXCEPTION(scope, JSValue());
@@ -411,7 +411,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
         return array;
     }
 
-    if (ProxyObject* proxy = jsDynamicCast<ProxyObject*>(value)) {
+    if (ProxyObject* proxy = dynamicDowncast<ProxyObject>(value)) {
         unsigned index = 0;
         JSArray* array = constructEmptyArray(globalObject, nullptr, 2);
         RETURN_IF_EXCEPTION(scope, JSValue());
@@ -422,7 +422,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
         return array;
     }
 
-    if (JSWeakObjectRef* weakRef = jsDynamicCast<JSWeakObjectRef*>(value)) {
+    if (JSWeakObjectRef* weakRef = dynamicDowncast<JSWeakObjectRef>(value)) {
         unsigned index = 0;
         JSArray* array = constructEmptyArray(globalObject, nullptr, 1);
         RETURN_IF_EXCEPTION(scope, JSValue());
@@ -432,7 +432,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
         return array;
     }
 
-    if (JSFinalizationRegistry* finalizationRegistry = jsDynamicCast<JSFinalizationRegistry*>(value)) {
+    if (JSFinalizationRegistry* finalizationRegistry = dynamicDowncast<JSFinalizationRegistry>(value)) {
         unsigned index = 0;
         JSArray* array = constructEmptyArray(globalObject, nullptr, 2);
         RETURN_IF_EXCEPTION(scope, JSValue());
@@ -485,7 +485,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
         return array;
     }
 
-    if (JSObject* iteratorObject = jsDynamicCast<JSObject*>(value)) {
+    if (JSObject* iteratorObject = dynamicDowncast<JSObject>(value)) {
         auto toString = [&] (IterationKind kind) {
             switch (kind) {
             case IterationKind::Keys:
@@ -498,7 +498,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
             return jsNontrivialString(vm, ""_s);
         };
         
-        if (auto* arrayIterator = jsDynamicCast<JSArrayIterator*>(iteratorObject)) {
+        if (auto* arrayIterator = dynamicDowncast<JSArrayIterator>(iteratorObject)) {
             JSValue iteratedValue = arrayIterator->iteratedObject();
             IterationKind kind = arrayIterator->kind();
 
@@ -512,7 +512,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
             return array;
         }
 
-        if (auto* mapIterator = jsDynamicCast<JSMapIterator*>(iteratorObject)) {
+        if (auto* mapIterator = dynamicDowncast<JSMapIterator>(iteratorObject)) {
             JSValue iteratedValue = mapIterator->iteratedObject();
             IterationKind kind = mapIterator->kind();
 
@@ -526,7 +526,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
             return array;
         }
 
-        if (auto* setIterator = jsDynamicCast<JSSetIterator*>(iteratorObject)) {
+        if (auto* setIterator = dynamicDowncast<JSSetIterator>(iteratorObject)) {
             JSValue iteratedValue = setIterator->iteratedObject();
             IterationKind kind = setIterator->kind();
 
@@ -541,7 +541,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
         }
     }
 
-    if (JSStringIterator* stringIterator = jsDynamicCast<JSStringIterator*>(value)) {
+    if (JSStringIterator* stringIterator = dynamicDowncast<JSStringIterator>(value)) {
         unsigned index = 0;
         JSArray* array = constructEmptyArray(globalObject, nullptr, 1);
         RETURN_IF_EXCEPTION(scope, JSValue());
@@ -559,12 +559,12 @@ JSValue JSInjectedScriptHost::proxyTargetValue(CallFrame* callFrame)
         return jsUndefined();
 
     JSValue value = callFrame->uncheckedArgument(0);
-    ProxyObject* proxy = jsDynamicCast<ProxyObject*>(value);
+    ProxyObject* proxy = dynamicDowncast<ProxyObject>(value);
     if (!proxy)
         return jsUndefined();
 
     JSObject* target = proxy->target();
-    while (ProxyObject* proxy = jsDynamicCast<ProxyObject*>(target))
+    while (ProxyObject* proxy = dynamicDowncast<ProxyObject>(target))
         target = proxy->target();
 
     return target;
@@ -576,13 +576,13 @@ JSValue JSInjectedScriptHost::weakRefTargetValue(JSGlobalObject* globalObject, C
         return jsUndefined();
 
     JSValue value = callFrame->uncheckedArgument(0);
-    JSWeakObjectRef* weakRef = jsDynamicCast<JSWeakObjectRef*>(value);
+    JSWeakObjectRef* weakRef = dynamicDowncast<JSWeakObjectRef>(value);
     if (!weakRef)
         return jsUndefined();
 
     VM& vm = globalObject->vm();
     JSCell* target = weakRef->deref(vm);
-    while (JSWeakObjectRef* weakRef = jsDynamicCast<JSWeakObjectRef*>(target))
+    while (JSWeakObjectRef* weakRef = dynamicDowncast<JSWeakObjectRef>(target))
         target = weakRef->deref(vm);
     return target ? target : jsUndefined();
 }
@@ -593,7 +593,7 @@ JSValue JSInjectedScriptHost::weakMapSize(JSGlobalObject*, CallFrame* callFrame)
         return jsUndefined();
 
     JSValue value = callFrame->uncheckedArgument(0);
-    JSWeakMap* weakMap = jsDynamicCast<JSWeakMap*>(value);
+    JSWeakMap* weakMap = dynamicDowncast<JSWeakMap>(value);
     if (!weakMap)
         return jsUndefined();
 
@@ -607,7 +607,7 @@ JSValue JSInjectedScriptHost::weakMapEntries(JSGlobalObject* globalObject, CallF
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* weakMap = jsDynamicCast<JSWeakMap*>(callFrame->uncheckedArgument(0));
+    auto* weakMap = dynamicDowncast<JSWeakMap>(callFrame->uncheckedArgument(0));
     if (!weakMap)
         return jsUndefined();
 
@@ -636,7 +636,7 @@ JSValue JSInjectedScriptHost::weakSetSize(JSGlobalObject*, CallFrame* callFrame)
         return jsUndefined();
 
     JSValue value = callFrame->uncheckedArgument(0);
-    JSWeakSet* weakSet = jsDynamicCast<JSWeakSet*>(value);
+    JSWeakSet* weakSet = dynamicDowncast<JSWeakSet>(value);
     if (!weakSet)
         return jsUndefined();
 
@@ -650,7 +650,7 @@ JSValue JSInjectedScriptHost::weakSetEntries(JSGlobalObject* globalObject, CallF
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* weakSet = jsDynamicCast<JSWeakSet*>(callFrame->uncheckedArgument(0));
+    auto* weakSet = dynamicDowncast<JSWeakSet>(callFrame->uncheckedArgument(0));
     if (!weakSet)
         return jsUndefined();
 
@@ -703,11 +703,11 @@ JSValue JSInjectedScriptHost::iteratorEntries(JSGlobalObject* globalObject, Call
 
     JSValue iterator;
     JSValue value = callFrame->uncheckedArgument(0);
-    if (JSStringIterator* stringIterator = jsDynamicCast<JSStringIterator*>(value)) {
+    if (JSStringIterator* stringIterator = dynamicDowncast<JSStringIterator>(value)) {
         if (globalObject->isStringPrototypeIteratorProtocolFastAndNonObservable())
             iterator = stringIterator->clone(globalObject);
-    } else if (JSObject* iteratorObject = jsDynamicCast<JSObject*>(value)) {
-        if (auto* arrayIterator = jsDynamicCast<JSArrayIterator*>(iteratorObject)) {
+    } else if (JSObject* iteratorObject = dynamicDowncast<JSObject>(value)) {
+        if (auto* arrayIterator = dynamicDowncast<JSArrayIterator>(iteratorObject)) {
             JSObject* iteratedObject = arrayIterator->iteratedObject();
             if (isJSArray(iteratedObject)) {
                 JSArray* array = jsCast<JSArray*>(iteratedObject);
@@ -717,12 +717,12 @@ JSValue JSInjectedScriptHost::iteratorEntries(JSGlobalObject* globalObject, Call
                 if (globalObject->isArrayPrototypeIteratorProtocolFastAndNonObservable())
                     iterator = cloneArrayIteratorObject(globalObject, vm, arrayIterator);
             }
-        } else if (auto* mapIterator = jsDynamicCast<JSMapIterator*>(iteratorObject)) {
+        } else if (auto* mapIterator = dynamicDowncast<JSMapIterator>(iteratorObject)) {
             if (jsCast<JSMap*>(mapIterator->iteratedObject())->isIteratorProtocolFastAndNonObservable()) {
                 iterator = cloneMapIteratorObject(globalObject, vm, mapIterator);
                 RETURN_IF_EXCEPTION(scope, { });
             }
-        } else if (auto* setIterator = jsDynamicCast<JSSetIterator*>(iteratorObject)) {
+        } else if (auto* setIterator = dynamicDowncast<JSSetIterator>(iteratorObject)) {
             if (jsCast<JSSet*>(setIterator->iteratedObject())->isIteratorProtocolFastAndNonObservable()) {
                 iterator = cloneSetIteratorObject(globalObject, vm, setIterator);
                 RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp
@@ -90,7 +90,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeAttributeEvaluate, (JSGlob
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -103,7 +103,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeAttributeSavedResultAlias,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -116,7 +116,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionInternalConstructo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -129,7 +129,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionIsHTMLAllCollectio
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -142,7 +142,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionIsPromiseRejectedW
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -155,7 +155,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionProxyTargetValue, 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -168,7 +168,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionWeakRefTargetValue
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -181,7 +181,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionWeakMapSize, (JSGl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -194,7 +194,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionWeakMapEntries, (J
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -207,7 +207,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionWeakSetSize, (JSGl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -220,7 +220,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionWeakSetEntries, (J
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -233,7 +233,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionIteratorEntries, (
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -246,7 +246,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionQueryInstances, (J
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -259,7 +259,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionQueryHolders, (JSG
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -272,7 +272,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionEvaluateWithScopeE
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -285,7 +285,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionSubtype, (JSGlobal
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -298,7 +298,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionFunctionDetails, (
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -311,7 +311,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePrope
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -324,7 +324,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetInternalPropert
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    JSInjectedScriptHost* castedThis = dynamicDowncast<JSInjectedScriptHost>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 

--- a/Source/JavaScriptCore/inspector/JSJavaScriptCallFramePrototype.cpp
+++ b/Source/JavaScriptCore/inspector/JSJavaScriptCallFramePrototype.cpp
@@ -75,7 +75,7 @@ JSC_DEFINE_HOST_FUNCTION(jsJavaScriptCallFramePrototypeFunctionEvaluateWithScope
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSJavaScriptCallFrame* castedThis = jsDynamicCast<JSJavaScriptCallFrame*>(thisValue);
+    JSJavaScriptCallFrame* castedThis = dynamicDowncast<JSJavaScriptCallFrame>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -88,7 +88,7 @@ JSC_DEFINE_HOST_FUNCTION(jsJavaScriptCallFramePrototypeFunctionScopeDescriptions
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSJavaScriptCallFrame* castedThis = jsDynamicCast<JSJavaScriptCallFrame*>(thisValue);
+    JSJavaScriptCallFrame* castedThis = dynamicDowncast<JSJavaScriptCallFrame>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -101,7 +101,7 @@ JSC_DEFINE_HOST_FUNCTION(jsJavaScriptCallFrameAttributeCaller, (JSGlobalObject* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSJavaScriptCallFrame* castedThis = jsDynamicCast<JSJavaScriptCallFrame*>(thisValue);
+    JSJavaScriptCallFrame* castedThis = dynamicDowncast<JSJavaScriptCallFrame>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -114,7 +114,7 @@ JSC_DEFINE_HOST_FUNCTION(jsJavaScriptCallFrameAttributeSourceID, (JSGlobalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSJavaScriptCallFrame* castedThis = jsDynamicCast<JSJavaScriptCallFrame*>(thisValue);
+    JSJavaScriptCallFrame* castedThis = dynamicDowncast<JSJavaScriptCallFrame>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -127,7 +127,7 @@ JSC_DEFINE_HOST_FUNCTION(jsJavaScriptCallFrameAttributeLine, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSJavaScriptCallFrame* castedThis = jsDynamicCast<JSJavaScriptCallFrame*>(thisValue);
+    JSJavaScriptCallFrame* castedThis = dynamicDowncast<JSJavaScriptCallFrame>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -140,7 +140,7 @@ JSC_DEFINE_HOST_FUNCTION(jsJavaScriptCallFrameAttributeColumn, (JSGlobalObject* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSJavaScriptCallFrame* castedThis = jsDynamicCast<JSJavaScriptCallFrame*>(thisValue);
+    JSJavaScriptCallFrame* castedThis = dynamicDowncast<JSJavaScriptCallFrame>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -153,7 +153,7 @@ JSC_DEFINE_HOST_FUNCTION(jsJavaScriptCallFrameAttributeFunctionName, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSJavaScriptCallFrame* castedThis = jsDynamicCast<JSJavaScriptCallFrame*>(thisValue);
+    JSJavaScriptCallFrame* castedThis = dynamicDowncast<JSJavaScriptCallFrame>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -166,7 +166,7 @@ JSC_DEFINE_HOST_FUNCTION(jsJavaScriptCallFrameAttributeScopeChain, (JSGlobalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSJavaScriptCallFrame* castedThis = jsDynamicCast<JSJavaScriptCallFrame*>(thisValue);
+    JSJavaScriptCallFrame* castedThis = dynamicDowncast<JSJavaScriptCallFrame>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -179,7 +179,7 @@ JSC_DEFINE_HOST_FUNCTION(jsJavaScriptCallFrameAttributeThisObject, (JSGlobalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSJavaScriptCallFrame* castedThis = jsDynamicCast<JSJavaScriptCallFrame*>(thisValue);
+    JSJavaScriptCallFrame* castedThis = dynamicDowncast<JSJavaScriptCallFrame>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -192,7 +192,7 @@ JSC_DEFINE_HOST_FUNCTION(jsJavaScriptCallFrameAttributeType, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSJavaScriptCallFrame* castedThis = jsDynamicCast<JSJavaScriptCallFrame*>(thisValue);
+    JSJavaScriptCallFrame* castedThis = dynamicDowncast<JSJavaScriptCallFrame>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
@@ -205,7 +205,7 @@ JSC_DEFINE_HOST_FUNCTION(jsJavaScriptCallFrameIsTailDeleted, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    JSJavaScriptCallFrame* castedThis = jsDynamicCast<JSJavaScriptCallFrame*>(thisValue);
+    JSJavaScriptCallFrame* castedThis = dynamicDowncast<JSJavaScriptCallFrame>(thisValue);
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 

--- a/Source/JavaScriptCore/inspector/ScriptArguments.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptArguments.cpp
@@ -42,7 +42,7 @@ namespace Inspector {
 
 static inline String argumentAsString(JSC::JSGlobalObject* globalObject, JSC::JSValue argument)
 {
-    if (JSC::jsDynamicCast<JSC::ProxyObject*>(argument))
+    if (is<JSC::ProxyObject>(argument))
         return "[object Proxy]"_s;
 
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject->vm());

--- a/Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp
@@ -158,7 +158,7 @@ static bool extractSourceInformationFromException(JSC::JSGlobalObject* globalObj
         lineColumn->column = columnValue && columnValue.isNumber() ? int(columnValue.toNumber(globalObject)) : 0;
         *sourceURL = sourceURLValue.toWTFString(globalObject);
         result = true;
-    } else if (ErrorInstance* error = jsDynamicCast<ErrorInstance*>(exceptionObject))
+    } else if (ErrorInstance* error = dynamicDowncast<ErrorInstance>(exceptionObject))
         result = getLineColumnAndSource(vm, error->stackTrace(), *lineColumn, *sourceURL);
 
     if (sourceURL->isEmpty())

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -670,7 +670,7 @@ static String NODELETE functionName(JSC::FunctionExecutable& functionExecutable)
 
 static String NODELETE functionName(JSC::CodeBlock& codeBlock)
 {
-    if (auto* functionExecutable = JSC::jsDynamicCast<JSC::FunctionExecutable*>(codeBlock.ownerExecutable()))
+    if (auto* functionExecutable = dynamicDowncast<JSC::FunctionExecutable>(codeBlock.ownerExecutable()))
         return functionName(*functionExecutable);
 
     return nullString();
@@ -684,8 +684,8 @@ static String NODELETE functionName(JSC::CallFrame* callFrame)
     if (auto* codeBlock = callFrame->codeBlock())
         return functionName(*codeBlock);
 
-    if (auto* jsFunction = JSC::jsDynamicCast<JSC::JSFunction*>(callFrame->jsCallee())) {
-        if (auto* nativeExecutable = JSC::jsDynamicCast<JSC::NativeExecutable*>(jsFunction->executable()))
+    if (auto* jsFunction = dynamicDowncast<JSC::JSFunction>(callFrame->jsCallee())) {
+        if (auto* nativeExecutable = dynamicDowncast<JSC::NativeExecutable>(jsFunction->executable()))
             return functionName(*nativeExecutable);
     }
 
@@ -805,7 +805,7 @@ Protocol::ErrorStringOr<void> InspectorDebuggerAgent::addSymbolicBreakpoint(cons
             JSC::HeapIterationScope iterationScope(m_debugger.vm().heap);
             m_debugger.vm().heap.objectSpace().forEachLiveCell(iterationScope, [&] (JSC::HeapCell* cell, JSC::HeapCell::Kind kind) {
                 if (isJSCellKind(kind)) {
-                    if (auto* nativeExecutable = JSC::jsDynamicCast<JSC::NativeExecutable*>(static_cast<JSC::JSCell*>(cell))) {
+                    if (auto* nativeExecutable = dynamicDowncast<JSC::NativeExecutable>(static_cast<JSC::JSCell*>(cell))) {
                         if (auto existingIndex = existingReplacedThunks.find(nativeExecutable); existingIndex != notFound)
                             ++existingReplacedThunks[existingIndex]->matchCount;
                         else

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -455,7 +455,7 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
         if (promise && promise->status() == JSPromise::Status::Pending) {
             JSValue reactionsValue = promise->internalField(JSPromise::Field::ReactionsOrResult).get();
             if (reactionsValue) {
-                if (auto* reaction = jsDynamicCast<JSPromiseReaction*>(reactionsValue))
+                if (auto* reaction = dynamicDowncast<JSPromiseReaction>(reactionsValue))
                     return reaction->context();
             }
         }
@@ -465,24 +465,24 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
     auto getParentGenerator = [&](JSGenerator* gen) -> JSGenerator* {
         JSValue generatorContext = gen->internalField(static_cast<unsigned>(JSGenerator::Field::Context)).get();
         ASSERT(generatorContext);
-        JSPromise* awaitedPromise = jsDynamicCast<JSPromise*>(generatorContext);
+        JSPromise* awaitedPromise = dynamicDowncast<JSPromise>(generatorContext);
         JSValue promiseContext = getContextValueFromPromise(awaitedPromise);
 
         if (!promiseContext)
             return nullptr;
 
         // handle simple `await`
-        if (auto* generator = jsDynamicCast<JSGenerator*>(promiseContext))
+        if (auto* generator = dynamicDowncast<JSGenerator>(promiseContext))
             return generator;
 
         // handle `Promise.all`, `Promise.allSettled`, and `Promise.any`
-        if (auto* promiseCombinatorsContext = jsDynamicCast<JSPromiseCombinatorsContext*>(promiseContext)) {
-            if (auto* globalContext = jsDynamicCast<JSPromiseCombinatorsGlobalContext*>(promiseCombinatorsContext->globalContext())) {
+        if (auto* promiseCombinatorsContext = dynamicDowncast<JSPromiseCombinatorsContext>(promiseContext)) {
+            if (auto* globalContext = promiseCombinatorsContext->globalContext()) {
                 JSValue promiseValue = globalContext->promise();
                 ASSERT(promiseValue);
-                if (auto* promise = jsDynamicCast<JSPromise*>(promiseValue)) {
+                if (auto* promise = dynamicDowncast<JSPromise>(promiseValue)) {
                     if (JSValue promiseContext = getContextValueFromPromise(promise)) {
-                        if (auto* generator = jsDynamicCast<JSGenerator*>(promiseContext))
+                        if (auto* generator = dynamicDowncast<JSGenerator>(promiseContext))
                             return generator;
                     }
                 }
@@ -490,9 +490,9 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
         }
 
         // handle and `Promise.race`
-        if (auto* contextPromise = jsDynamicCast<JSPromise*>(promiseContext)) {
+        if (auto* contextPromise = dynamicDowncast<JSPromise>(promiseContext)) {
             if (JSValue parentContext = getContextValueFromPromise(contextPromise)) {
-                if (auto* generator = jsDynamicCast<JSGenerator*>(parentContext))
+                if (auto* generator = dynamicDowncast<JSGenerator>(parentContext))
                     return generator;
             }
         }
@@ -520,7 +520,7 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
     JSGenerator* currentGenerator = getParentGenerator(generator);
     while (currentGenerator && results.size() < maxStackSize) {
         JSValue nextValue = currentGenerator->internalField(static_cast<unsigned>(JSGenerator::Field::Next)).get();
-        JSFunction* asyncFunction = jsDynamicCast<JSFunction*>(nextValue);
+        JSFunction* asyncFunction = dynamicDowncast<JSFunction>(nextValue);
         if (asyncFunction && !asyncFunction->isHostOrBuiltinFunction()) {
             if (FunctionExecutable* executable = asyncFunction->jsExecutable()) {
                 // If a CodeBlock doesn't already exist, the stack trace will only show the filename and won't show line column
@@ -569,7 +569,7 @@ void Interpreter::getStackTrace(JSCell* owner, Vector<StackFrame>& results, size
 
     if (!caller && ownerOfCallLinkInfo && callLinkInfo && callLinkInfo->isTailCall()) {
         // Reconstruct the top frame from CallLinkInfo*
-        CodeBlock* codeBlock = jsDynamicCast<CodeBlock*>(ownerOfCallLinkInfo);
+        CodeBlock* codeBlock = dynamicDowncast<CodeBlock>(ownerOfCallLinkInfo);
         if (codeBlock) {
             CodeOrigin codeOrigin = callLinkInfo->codeOrigin();
             if (codeOrigin.inlineCallFrame()) {
@@ -592,7 +592,7 @@ void Interpreter::getStackTrace(JSCell* owner, Vector<StackFrame>& results, size
         ASSERT(Options::useAsyncStackTrace());
         auto* record = vmEntryRecord(previousEntryFrame);
         if (record->m_context) {
-            if (auto* generator = jsDynamicCast<JSGenerator*>(record->m_context)) {
+            if (auto* generator = dynamicDowncast<JSGenerator>(record->m_context)) {
                 asyncStackTraceOriginGenerator = generator;
                 asyncStackTraceInsertPos = previousEntryFrameStackTraceInsertPos;
             }
@@ -776,12 +776,12 @@ public:
     {
 
         if (!m_isTermination) {
-            if (JSWebAssemblyException* wasmException = jsDynamicCast<JSWebAssemblyException*>(thrownValue)) {
+            if (JSWebAssemblyException* wasmException = dynamicDowncast<JSWebAssemblyException>(thrownValue)) {
                 m_catchableFromWasm = true;
                 m_wasmTag = &wasmException->tag();
                 if (m_wasmTag == &Wasm::Tag::jsExceptionTag())
                     m_exception->tryUnwrapValueForJSTag(m_vm);
-            } else if (ErrorInstance* error = jsDynamicCast<ErrorInstance*>(thrownValue))
+            } else if (ErrorInstance* error = dynamicDowncast<ErrorInstance>(thrownValue))
                 m_catchableFromWasm = error->isCatchableFromWasm();
             else
                 m_catchableFromWasm = true;

--- a/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
+++ b/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
@@ -51,7 +51,7 @@ void ShadowChicken::Packet::dump(PrintStream& out) const
     
     if (isPrologue()) {
         String name = "?"_s;
-        if (auto* function = jsDynamicCast<JSFunction*>(callee)) {
+        if (auto* function = dynamicDowncast<JSFunction>(callee)) {
             name = function->name(callee->vm());
             if (name.isEmpty())
                 name = "?"_s;
@@ -75,7 +75,7 @@ void ShadowChicken::Packet::dump(PrintStream& out) const
 void ShadowChicken::Frame::dump(PrintStream& out) const
 {
     String name = "?"_s;
-    if (auto* function = jsDynamicCast<JSFunction*>(callee)) {
+    if (auto* function = dynamicDowncast<JSFunction>(callee)) {
         name = function->name(callee->vm());
         if (name.isEmpty())
             name = "?"_s;
@@ -315,7 +315,7 @@ void ShadowChicken::update(VM& vm, CallFrame* callFrame)
             if (ShadowChickenInternal::verbose) {
                 dataLog("    Examining callFrame:", RawPointer(callFrame), ", callee:", RawPointer(callFrame->jsCallee()), ", callerFrame:", RawPointer(callFrame->callerFrame()), "\n");
                 JSObject* callee = callFrame->jsCallee();
-                if (auto* function = jsDynamicCast<JSFunction*>(callee))
+                if (auto* function = dynamicDowncast<JSFunction>(callee))
                     dataLog("      Function = ", function->name(callee->vm()), "\n");
             }
 

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -544,7 +544,7 @@ bool StackVisitor::Frame::isImplementationVisibilityPrivate() const
 
         if (callee().isCell()) {
             if (auto* callee = this->callee().asCell()) {
-                if (auto* jsFunction = jsDynamicCast<JSFunction*>(callee)) {
+                if (auto* jsFunction = dynamicDowncast<JSFunction>(callee)) {
                     if (auto* executable = jsFunction->executable())
                         return executable->implementationVisibility();
                     return ImplementationVisibility::Public;

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -3496,7 +3496,7 @@ ALWAYS_INLINE static JSValue getByVal(JSGlobalObject* globalObject, CallFrame* c
     } else if (subscript.isNumber() && baseValue.isCell() && arrayProfile) {
         arrayProfile->setOutOfBounds();
         if (subscript == jsNumber(-1)) {
-            if (auto* array = jsDynamicCast<JSArray*>(baseValue.asCell()); array && array->definitelyNegativeOneMiss()) [[likely]]
+            if (auto* array = dynamicDowncast<JSArray>(baseValue.asCell()); array && array->definitelyNegativeOneMiss()) [[likely]]
                 return jsUndefined();
         }
     }
@@ -3638,7 +3638,7 @@ ALWAYS_INLINE static JSValue getByValWithThis(JSGlobalObject* globalObject, Call
     } else if (subscript.isNumber() && baseValue.isCell() && arrayProfile) {
         arrayProfile->setOutOfBounds();
         if (subscript == jsNumber(-1)) {
-            if (auto* array = jsDynamicCast<JSArray*>(baseValue.asCell()); array && array->definitelyNegativeOneMiss()) [[likely]]
+            if (auto* array = dynamicDowncast<JSArray>(baseValue.asCell()); array && array->definitelyNegativeOneMiss()) [[likely]]
                 return jsUndefined();
         }
     }

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -991,7 +991,7 @@ JSC_DEFINE_CUSTOM_SETTER(testCustomAccessorSetter, (JSGlobalObject* lexicalGloba
     RELEASE_ASSERT(JSValue::decode(thisValue).isCell());
     JSCell* thisCell = JSValue::decode(thisValue).asCell();
     RELEASE_ASSERT(thisCell->type() == GlobalProxyType);
-    GlobalObject* thisObject = jsDynamicCast<GlobalObject*>(jsCast<JSGlobalProxy*>(thisCell)->target());
+    GlobalObject* thisObject = dynamicDowncast<GlobalObject>(uncheckedDowncast<JSGlobalProxy>(thisCell)->target());
     RELEASE_ASSERT(thisObject);
     return GlobalObject::testCustomSetterImpl(lexicalGlobalObject, thisObject, encodedValue, "_testCustomAccessorSetter"_s);
 }
@@ -1000,7 +1000,7 @@ JSC_DEFINE_CUSTOM_SETTER(testCustomValueSetter, (JSGlobalObject* lexicalGlobalOb
 {
     RELEASE_ASSERT(JSValue::decode(thisValue).isCell());
     JSCell* thisCell = JSValue::decode(thisValue).asCell();
-    GlobalObject* thisObject = jsDynamicCast<GlobalObject*>(thisCell);
+    GlobalObject* thisObject = dynamicDowncast<GlobalObject>(thisCell);
     RELEASE_ASSERT(thisObject);
     return GlobalObject::testCustomSetterImpl(lexicalGlobalObject, thisObject, encodedValue, "_testCustomValueSetter"_s);
 }
@@ -1486,7 +1486,7 @@ JSPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject, JSModul
     moduleKey = moduleURL.fileSystemPath();
 
     RefPtr<ScriptFetchParameters> attributes;
-    if (auto* value = jsDynamicCast<JSScriptFetchParameters*>(attributesValue))
+    if (auto* value = dynamicDowncast<JSScriptFetchParameters>(attributesValue))
         attributes = &value->parameters();
 
     Vector<uint8_t> buffer;
@@ -1730,7 +1730,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDescribeArray, (JSGlobalObject* globalObject, C
     if (callFrame->argumentCount() < 1)
         return JSValue::encode(jsUndefined());
     VM& vm = globalObject->vm();
-    JSObject* object = jsDynamicCast<JSObject*>(callFrame->argument(0));
+    JSObject* object = dynamicDowncast<JSObject>(callFrame->argument(0));
     if (!object)
         return JSValue::encode(jsNontrivialString(vm, "<not object>"_s));
     return JSValue::encode(jsNontrivialString(vm, toString("<Butterfly: ", RawPointer(object->butterfly()), "; public length: ", object->getArrayLength(), "; vector length: ", object->getVectorLength(), ">")));
@@ -2273,7 +2273,7 @@ JSC_DEFINE_HOST_FUNCTION(functionReadline, (JSGlobalObject* globalObject, CallFr
     int c;
     FILE* descriptor = stdin;
 
-    if (auto* file = jsDynamicCast<JSFileDescriptor*>(callFrame->argument(0)))
+    if (auto* file = dynamicDowncast<JSFileDescriptor>(callFrame->argument(0)))
         descriptor = file->descriptor();
 
     while ((c = getc(descriptor)) != EOF) {
@@ -2483,7 +2483,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarEvalScript, (JSGlobalObject* globalObject
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     while (global.inherits<JSGlobalProxy>())
         global = jsCast<JSGlobalProxy*>(global)->target();
-    GlobalObject* realm = jsDynamicCast<GlobalObject*>(global);
+    GlobalObject* realm = dynamicDowncast<GlobalObject>(global);
     if (!realm)
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Expected global to point to a global object"_s)));
 
@@ -2684,7 +2684,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentBroadcast, (JSGlobalObject* globalOb
     int32_t index = callFrame->argument(1).toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-    JSArrayBuffer* jsBuffer = jsDynamicCast<JSArrayBuffer*>(callFrame->argument(0));
+    JSArrayBuffer* jsBuffer = dynamicDowncast<JSArrayBuffer>(callFrame->argument(0));
     if (jsBuffer && jsBuffer->isShared()) {
         Workers::singleton().broadcast(
             [&] (const AbstractLocker& locker, Worker& worker) {
@@ -2698,7 +2698,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentBroadcast, (JSGlobalObject* globalOb
     }
 
 #if ENABLE(WEBASSEMBLY)
-    JSWebAssemblyMemory* memory = jsDynamicCast<JSWebAssemblyMemory*>(callFrame->argument(0));
+    JSWebAssemblyMemory* memory = dynamicDowncast<JSWebAssemblyMemory>(callFrame->argument(0));
     if (memory && memory->memory().sharingMode() == MemorySharingMode::Shared) {
         Workers::singleton().broadcast(
             [&] (const AbstractLocker& locker, Worker& worker) {
@@ -2843,7 +2843,7 @@ JSC_DEFINE_HOST_FUNCTION(functionTransferArrayBuffer, (JSGlobalObject* globalObj
     if (callFrame->argumentCount() < 1)
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Not enough arguments"_s)));
     
-    JSArrayBuffer* buffer = jsDynamicCast<JSArrayBuffer*>(callFrame->argument(0));
+    JSArrayBuffer* buffer = dynamicDowncast<JSArrayBuffer>(callFrame->argument(0));
     if (!buffer)
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Expected an array buffer"_s)));
     
@@ -2956,7 +2956,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeout, (JSGlobalObject* globalObject, Call
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // FIXME: This means we can't pass any internal function but I don't think that's common for testing.
-    auto callback = jsDynamicCast<JSFunction*>(callFrame->argument(0));
+    auto callback = dynamicDowncast<JSFunction>(callFrame->argument(0));
     if (!callback)
         return throwVMTypeError(globalObject, scope, "First argument is not a JS function"_s);
 
@@ -2990,7 +2990,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFinalizationRegistryLiveCount, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* finalizationRegistry = jsDynamicCast<JSFinalizationRegistry*>(callFrame->argument(0));
+    auto* finalizationRegistry = dynamicDowncast<JSFinalizationRegistry>(callFrame->argument(0));
     if (!finalizationRegistry)
         return throwVMTypeError(globalObject, scope, "first argument is not a finalizationRegistry"_s);
 
@@ -3003,7 +3003,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFinalizationRegistryDeadCount, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* finalizationRegistry = jsDynamicCast<JSFinalizationRegistry*>(callFrame->argument(0));
+    auto* finalizationRegistry = dynamicDowncast<JSFinalizationRegistry>(callFrame->argument(0));
     if (!finalizationRegistry)
         return throwVMTypeError(globalObject, scope, "first argument is not a finalizationRegistry"_s);
 
@@ -3100,7 +3100,7 @@ JSC_DEFINE_HOST_FUNCTION(functionIsHeapBigInt, (JSGlobalObject*, CallFrame* call
 
 JSC_DEFINE_HOST_FUNCTION(functionIs8BitString, (JSGlobalObject*, CallFrame* callFrame))
 {
-    JSString* string = jsDynamicCast<JSString*>(callFrame->argument(0));
+    JSString* string = dynamicDowncast<JSString>(callFrame->argument(0));
     if (!string)
         return JSValue::encode(jsBoolean(false));
     return JSValue::encode(jsBoolean(string->is8Bit()));
@@ -3233,7 +3233,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEnsureArrayStorage, (JSGlobalObject* globalObje
 {
     VM& vm = globalObject->vm();
     for (unsigned i = 0; i < callFrame->argumentCount(); ++i) {
-        if (JSObject* object = jsDynamicCast<JSObject*>(callFrame->argument(i)))
+        if (JSObject* object = dynamicDowncast<JSObject>(callFrame->argument(i)))
             object->ensureArrayStorage(vm);
     }
     return JSValue::encode(jsUndefined());
@@ -3322,9 +3322,9 @@ JSC_DEFINE_HOST_FUNCTION(functionWebAssemblyMemoryMode, (JSGlobalObject* globalO
     };
 
     if (JSObject* object = callFrame->argument(0).getObject()) {
-        if (auto* memory = jsDynamicCast<JSWebAssemblyMemory*>(object))
+        if (auto* memory = dynamicDowncast<JSWebAssemblyMemory>(object))
             return JSValue::encode(jsString(vm, createString(memory->memory().mode())));
-        if (auto* instance = jsDynamicCast<JSWebAssemblyInstance*>(object))
+        if (auto* instance = dynamicDowncast<JSWebAssemblyInstance>(object))
             return JSValue::encode(jsString(vm, createString(instance->memoryMode())));
     }
 
@@ -3339,7 +3339,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWebAssemblyMemoryWithMode, (JSGlobalObjec
     if (!Wasm::isSupported())
         return throwVMTypeError(globalObject, scope, "createWebAssemblyMemoryWithMode should only be called if the useWebAssembly option is set"_s);
 
-    JSObject* memoryDescriptor = jsDynamicCast<JSObject*>(callFrame->argument(0));
+    JSObject* memoryDescriptor = dynamicDowncast<JSObject>(callFrame->argument(0));
     if (!memoryDescriptor)
         return throwVMTypeError(globalObject, scope, "createWebAssemblyMemoryWithMode expects the first argument to be an object"_s);
 
@@ -3800,7 +3800,7 @@ static void checkException(GlobalObject* globalObject, bool isLastFile, bool has
         JSCell* valueCell = value.asCell();
         vm.ensureTerminationException();
         Exception* terminationException = vm.terminationException();
-        Exception* exception = jsDynamicCast<Exception*>(valueCell);
+        Exception* exception = dynamicDowncast<Exception>(valueCell);
         if (exception)
             return vm.isTerminationException(exception);
         JSCell* terminationError = terminationException->value().asCell();

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -1270,7 +1270,7 @@ static ALWAYS_INLINE JSValue getByVal(VM& vm, JSGlobalObject* globalObject, Code
         ArrayProfile* arrayProfile = &metadata.m_arrayProfile;
         arrayProfile->setOutOfBounds();
         if (subscript == jsNumber(-1)) {
-            if (auto* array = jsDynamicCast<JSArray*>(baseValue.asCell()); array && array->definitelyNegativeOneMiss()) [[likely]]
+            if (auto* array = dynamicDowncast<JSArray>(baseValue.asCell()); array && array->definitelyNegativeOneMiss()) [[likely]]
                 return jsUndefined();
         }
     }

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -803,7 +803,7 @@ JSModuleNamespaceObject* AbstractModuleRecord::getModuleNamespace(JSGlobalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
 #if ASSERT_ENABLED
-    if (auto* cyclic = jsDynamicCast<CyclicModuleRecord*>(this))
+    if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(this))
         ASSERT(cyclic->status() != CyclicModuleRecord::Status::New && cyclic->status() != CyclicModuleRecord::Status::Unlinked);
 #endif
 
@@ -883,9 +883,9 @@ void AbstractModuleRecord::setModuleEnvironment(JSGlobalObject* globalObject, JS
 
 void AbstractModuleRecord::link(JSGlobalObject* globalObject, JSValue scriptFetcher)
 {
-    if (auto* cyclicModuleRecord = jsDynamicCast<CyclicModuleRecord*>(this))
+    if (auto* cyclicModuleRecord = dynamicDowncast<CyclicModuleRecord>(this))
         cyclicModuleRecord->link(globalObject, scriptFetcher); // can throw
-    else if (auto* moduleRecord = jsDynamicCast<SyntheticModuleRecord*>(this))
+    else if (auto* moduleRecord = dynamicDowncast<SyntheticModuleRecord>(this))
         moduleRecord->link(globalObject, scriptFetcher);
     else
         RELEASE_ASSERT_NOT_REACHED();
@@ -896,10 +896,10 @@ JS_EXPORT_PRIVATE JSValue AbstractModuleRecord::evaluate(JSGlobalObject* globalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (auto* jsModuleRecord = jsDynamicCast<JSModuleRecord*>(this))
+    if (auto* jsModuleRecord = dynamicDowncast<JSModuleRecord>(this))
         RELEASE_AND_RETURN(scope, jsModuleRecord->evaluate(globalObject, sentValue, resumeMode));
 #if ENABLE(WEBASSEMBLY)
-    if (auto* wasmModuleRecord = jsDynamicCast<WebAssemblyModuleRecord*>(this)) {
+    if (auto* wasmModuleRecord = dynamicDowncast<WebAssemblyModuleRecord>(this)) {
         // WebAssembly imports need to be supplied during evaluation so that, e.g.,
         // JS module exports are actually available to be read and installed as import
         // bindings.
@@ -910,7 +910,7 @@ JS_EXPORT_PRIVATE JSValue AbstractModuleRecord::evaluate(JSGlobalObject* globalO
         RELEASE_AND_RETURN(scope, wasmModuleRecord->evaluate(globalObject));
     }
 #endif
-    if (auto* syntheticRecord = jsDynamicCast<SyntheticModuleRecord*>(this))
+    if (auto* syntheticRecord = dynamicDowncast<SyntheticModuleRecord>(this))
         RELEASE_AND_RETURN(scope, syntheticRecord->evaluate(globalObject));
     RELEASE_ASSERT_NOT_REACHED();
     return jsUndefined();
@@ -923,16 +923,16 @@ JSPromise* AbstractModuleRecord::evaluate(JSGlobalObject* globalObject)
     auto wrap = [&](JSValue value) -> JSPromise* {
         if (!value)
             return nullptr;
-        if (auto* promise = jsDynamicCast<JSPromise*>(value))
+        if (auto* promise = dynamicDowncast<JSPromise>(value))
             return promise;
         auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
         promise->resolve(globalObject, vm, value);
         return promise;
     };
 
-    if (auto* cyclicRecord = jsDynamicCast<CyclicModuleRecord*>(this))
+    if (auto* cyclicRecord = dynamicDowncast<CyclicModuleRecord>(this))
         return wrap(cyclicRecord->evaluate(globalObject));
-    if (auto* syntheticRecord = jsDynamicCast<SyntheticModuleRecord*>(this))
+    if (auto* syntheticRecord = dynamicDowncast<SyntheticModuleRecord>(this))
         return wrap(syntheticRecord->evaluate(globalObject));
     RELEASE_ASSERT_NOT_REACHED();
     return nullptr;
@@ -969,7 +969,7 @@ unsigned AbstractModuleRecord::innerModuleEvaluation(JSGlobalObject* globalObjec
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* module = jsDynamicCast<CyclicModuleRecord*>(this);
+    auto* module = dynamicDowncast<CyclicModuleRecord>(this);
 
     // 1. If module is not a Cyclic Module Record, then
     if (!module) {
@@ -1017,7 +1017,7 @@ unsigned AbstractModuleRecord::innerModuleEvaluation(JSGlobalObject* globalObjec
         RETURN_IF_EXCEPTION(scope, invalid);
         index = result;
         // 11.c. If requiredModule is a Cyclic Module Record, then
-        if (auto* cyclic = jsDynamicCast<CyclicModuleRecord*>(requiredModule)) {
+        if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(requiredModule)) {
             // 11.c.i. Assert: requiredModule.[[Status]] is one of EVALUATING, EVALUATING-ASYNC, or EVALUATED.
             ASSERT(cyclic->status() == Status::Evaluating || cyclic->status() == Status::EvaluatingAsync || cyclic->status() == Status::Evaluated);
             // 11.c.ii. Assert: requiredModule.[[Status]] is EVALUATING if and only if stack contains requiredModule.
@@ -1109,7 +1109,7 @@ unsigned AbstractModuleRecord::innerModuleLinking(JSGlobalObject* globalObject, 
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* module = jsDynamicCast<CyclicModuleRecord*>(this);
+    auto* module = dynamicDowncast<CyclicModuleRecord>(this);
 
     // 1. If module is not a Cyclic Module Record, then
     if (!module) {
@@ -1150,7 +1150,7 @@ unsigned AbstractModuleRecord::innerModuleLinking(JSGlobalObject* globalObject, 
         index = requiredModule->innerModuleLinking(globalObject, stack, index, scriptFetcher);
         RETURN_IF_EXCEPTION(scope, invalid);
         // 9.c. If requiredModule is a Cyclic Module Record, then
-        if (auto* requiredCyclic = jsDynamicCast<CyclicModuleRecord*>(requiredModule)) {
+        if (auto* requiredCyclic = dynamicDowncast<CyclicModuleRecord>(requiredModule)) {
             // 9.c.i. Assert: requiredModule.[[Status]] is one of LINKING, LINKED, EVALUATING-ASYNC, or EVALUATED.
             Status status = requiredCyclic->status();
             ASSERT_UNUSED(status, status == Status::Linking || status == Status::Linked || status == Status::EvaluatingAsync || status == Status::Evaluated);
@@ -1207,12 +1207,12 @@ static String printableName(const Identifier& ident)
 
 ScriptFetchParameters::Type AbstractModuleRecord::moduleType() const
 {
-    if (jsDynamicCast<const JSModuleRecord*>(this))
+    if (is<JSModuleRecord>(this))
         return ScriptFetchParameters::JavaScript;
-    if (jsDynamicCast<const SyntheticModuleRecord*>(this))
+    if (is<SyntheticModuleRecord>(this))
         return ScriptFetchParameters::JSON;
 #if ENABLE(WEBASSEMBLY)
-    if (jsDynamicCast<const WebAssemblyModuleRecord*>(this))
+    if (is<WebAssemblyModuleRecord>(this))
         return ScriptFetchParameters::WebAssembly;
 #endif
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -476,7 +476,7 @@ void ArrayBuffer::notifyDetaching(VM& vm)
 {
     for (size_t i = numberOfIncomingReferences(); i--;) {
         JSCell* cell = incomingReferenceAt(i);
-        if (JSArrayBufferView* view = jsDynamicCast<JSArrayBufferView*>(cell))
+        if (JSArrayBufferView* view = dynamicDowncast<JSArrayBufferView>(cell))
             view->detachFromArrayBuffer();
     }
     m_detachingWatchpointSet.fireAll(vm, "Array buffer was detached");

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -132,7 +132,7 @@ static ALWAYS_INLINE bool isArraySlowInline(JSGlobalObject* globalObject, ProxyO
             auto* callFrame = vm.topJSCallFrame();
             auto* callee = callFrame && !callFrame->isNativeCalleeFrame() ? callFrame->jsCallee() : nullptr;
             ASCIILiteral calleeName = "Array.isArray"_s;
-            auto* function = callee ? jsDynamicCast<JSFunction*>(callee) : nullptr;
+            auto* function = callee ? dynamicDowncast<JSFunction>(callee) : nullptr;
             // If this function is from a different globalObject than the one passed in above,
             // then this test will fail even if function is Object.prototype.toString. The only
             // way this test will be work everytime is if we check against the
@@ -165,7 +165,7 @@ bool isArraySlow(JSGlobalObject* globalObject, ProxyObject* argument)
 // https://tc39.github.io/ecma262/#sec-isarray
 JSC_DEFINE_HOST_FUNCTION(arrayConstructorPrivateFuncIsArraySlow, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ASSERT_UNUSED(globalObject, jsDynamicCast<ProxyObject*>(callFrame->argument(0)));
+    ASSERT_UNUSED(globalObject, is<ProxyObject>(callFrame->argument(0)));
     return JSValue::encode(jsBoolean(isArraySlowInline(globalObject, jsCast<ProxyObject*>(callFrame->uncheckedArgument(0)))));
 }
 

--- a/Source/JavaScriptCore/runtime/AsyncDisposableStackPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/AsyncDisposableStackPrototype.cpp
@@ -60,7 +60,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncDisposableStackProtoDisposedGetter, (JSGlobalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* asyncDisposableStack = jsDynamicCast<JSAsyncDisposableStack*>(thisValue);
+    auto* asyncDisposableStack = dynamicDowncast<JSAsyncDisposableStack>(thisValue);
     if (!asyncDisposableStack) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "AsyncDisposableStack.prototype.disposed getter requires that |this| be a DisposableStack object"_s);
 

--- a/Source/JavaScriptCore/runtime/BigIntPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/BigIntPrototype.cpp
@@ -87,10 +87,10 @@ static ALWAYS_INLINE JSBigInt* toThisBigIntValue(JSGlobalObject* globalObject, J
 #endif
 
     if (thisValue.isCell()) {
-        if (JSBigInt* bigInt = jsDynamicCast<JSBigInt*>(thisValue.asCell()))
+        if (JSBigInt* bigInt = dynamicDowncast<JSBigInt>(thisValue.asCell()))
             return bigInt;
 
-        if (BigIntObject* bigIntObject = jsDynamicCast<BigIntObject*>(thisValue.asCell())) {
+        if (BigIntObject* bigIntObject = dynamicDowncast<BigIntObject>(thisValue.asCell())) {
             JSValue bigInt = bigIntObject->internalValue();
 #if USE(BIGINT32)
             if (bigInt.isBigInt32())

--- a/Source/JavaScriptCore/runtime/BooleanPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/BooleanPrototype.cpp
@@ -73,7 +73,7 @@ JSC_DEFINE_HOST_FUNCTION(booleanProtoFuncToString, (JSGlobalObject* globalObject
     if (thisValue == jsBoolean(true))
         return JSValue::encode(vm.smallStrings.trueString());
 
-    auto* thisObject = jsDynamicCast<BooleanObject*>(thisValue);
+    auto* thisObject = dynamicDowncast<BooleanObject>(thisValue);
     if (!thisObject) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -93,7 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(booleanProtoFuncValueOf, (JSGlobalObject* globalObject,
     if (thisValue.isBoolean())
         return JSValue::encode(thisValue);
 
-    auto* thisObject = jsDynamicCast<BooleanObject*>(thisValue);
+    auto* thisObject = dynamicDowncast<BooleanObject>(thisValue);
     if (!thisObject) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -1420,13 +1420,13 @@ public:
 
         JSCell* cell = v.asCell();
 
-        if (auto* symbolTable = jsDynamicCast<SymbolTable*>(cell)) {
+        if (auto* symbolTable = dynamicDowncast<SymbolTable>(cell)) {
             m_type = EncodedType::SymbolTable;
             this->allocate<CachedSymbolTable>(encoder)->encode(encoder, *symbolTable);
             return;
         }
 
-        if (auto* string = jsDynamicCast<JSString*>(cell)) {
+        if (auto* string = dynamicDowncast<JSString>(cell)) {
             m_type = EncodedType::String;
             // TODO: This seems wrong? What if this fails.
             auto str = string->tryGetValue();
@@ -1434,25 +1434,25 @@ public:
             return;
         }
 
-        if (auto* immutableButterfly = jsDynamicCast<JSCellButterfly*>(cell)) {
+        if (auto* immutableButterfly = dynamicDowncast<JSCellButterfly>(cell)) {
             m_type = EncodedType::ImmutableButterfly;
             this->allocate<CachedImmutableButterfly>(encoder)->encode(encoder, *immutableButterfly);
             return;
         }
 
-        if (auto* regexp = jsDynamicCast<RegExp*>(cell)) {
+        if (auto* regexp = dynamicDowncast<RegExp>(cell)) {
             m_type = EncodedType::RegExp;
             this->allocate<CachedRegExp>(encoder)->encode(encoder, *regexp);
             return;
         }
 
-        if (auto* templateObjectDescriptor = jsDynamicCast<JSTemplateObjectDescriptor*>(cell)) {
+        if (auto* templateObjectDescriptor = dynamicDowncast<JSTemplateObjectDescriptor>(cell)) {
             m_type = EncodedType::TemplateObjectDescriptor;
             this->allocate<CachedTemplateObjectDescriptor>(encoder)->encode(encoder, *templateObjectDescriptor);
             return;
         }
 
-        if (auto* bigInt = jsDynamicCast<JSBigInt*>(cell)) {
+        if (auto* bigInt = dynamicDowncast<JSBigInt>(cell)) {
             m_type = EncodedType::BigInt;
             this->allocate<CachedBigInt>(encoder)->encode(encoder, *bigInt);
             return;

--- a/Source/JavaScriptCore/runtime/CodeCache.cpp
+++ b/Source/JavaScriptCore/runtime/CodeCache.cpp
@@ -279,7 +279,7 @@ void CodeCache::write()
 
 void writeCodeBlock(const SourceCodeKey& key, const SourceCodeValue& value)
 {
-    UnlinkedCodeBlock* codeBlock = jsDynamicCast<UnlinkedCodeBlock*>(value.cell.get());
+    UnlinkedCodeBlock* codeBlock = dynamicDowncast<UnlinkedCodeBlock>(value.cell.get());
     if (!codeBlock)
         return;
 

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -154,7 +154,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_create_this)
     auto bytecode = pc->as<OpCreateThis>();
     JSObject* result;
     JSObject* constructorAsObject = asObject(GET(bytecode.m_callee).jsValue());
-    JSFunction* constructor = jsDynamicCast<JSFunction*>(constructorAsObject);
+    JSFunction* constructor = dynamicDowncast<JSFunction>(constructorAsObject);
     if (constructor && constructor->canUseAllocationProfiles()) {
         WriteBarrier<JSCell>& cachedCallee = bytecode.metadata(codeBlock).m_cachedCallee;
         if (!cachedCallee)
@@ -202,7 +202,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_create_promise)
         result = JSPromise::create(vm, structure);
     }
 
-    JSFunction* constructor = jsDynamicCast<JSFunction*>(constructorAsObject);
+    JSFunction* constructor = dynamicDowncast<JSFunction>(constructorAsObject);
     if (constructor && constructor->canUseAllocationProfiles()) {
         WriteBarrier<JSCell>& cachedCallee = bytecode.metadata(codeBlock).m_cachedCallee;
         if (!cachedCallee)
@@ -230,7 +230,7 @@ static JSClass* createInternalFieldObject(JSGlobalObject* globalObject, VM& vm, 
     RETURN_IF_EXCEPTION(scope, nullptr);
     JSClass* result = JSClass::create(vm, structure);
 
-    JSFunction* constructor = jsDynamicCast<JSFunction*>(constructorAsObject);
+    JSFunction* constructor = dynamicDowncast<JSFunction>(constructorAsObject);
     if (constructor && constructor->canUseAllocationProfiles()) {
         WriteBarrier<JSCell>& cachedCallee = bytecode.metadata(codeBlock).m_cachedCallee;
         if (!cachedCallee)
@@ -847,8 +847,8 @@ ALWAYS_INLINE UGPRPair iteratorNextTryFastImpl(VM& vm, JSGlobalObject* globalObj
     ASSERT(!GET(bytecode.m_next).jsValue());
     JSObject* iterator = jsCast<JSObject*>(GET(bytecode.m_iterator).jsValue());;
     JSCell* iterable = GET(bytecode.m_iterable).jsValue().asCell();
-    if (auto arrayIterator = jsDynamicCast<JSArrayIterator*>(iterator)) {
-        if (auto array = jsDynamicCast<JSArray*>(iterable); array && isJSArray(array)) {
+    if (auto arrayIterator = dynamicDowncast<JSArrayIterator>(iterator)) {
+        if (auto array = dynamicDowncast<JSArray>(iterable); array && isJSArray(array)) {
             metadata.m_iterableProfile.observeStructureID(array->structureID());
 
             metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastArray;

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -301,7 +301,7 @@ UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, String> retrieveImportAttributesF
     if (options.isUndefined())
         return { };
 
-    auto* optionsObject = jsDynamicCast<JSObject*>(options);
+    auto* optionsObject = dynamicDowncast<JSObject>(options);
     if (!optionsObject) [[unlikely]] {
         throwTypeError(globalObject, scope, "dynamic import's options should be an object"_s);
         return { };
@@ -313,7 +313,7 @@ UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, String> retrieveImportAttributesF
     if (attributes.isUndefined())
         return { };
 
-    auto* attributesObject = jsDynamicCast<JSObject*>(attributes);
+    auto* attributesObject = dynamicDowncast<JSObject>(attributes);
     if (!attributesObject) [[unlikely]] {
         throwTypeError(globalObject, scope, "dynamic import's options.with should be an object"_s);
         return { };

--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
@@ -80,7 +80,7 @@ void CyclicModuleRecord::initializeEnvironment(JSGlobalObject* globalObject, JSV
     if (m_initialized)
         return;
 
-    auto* jsModule = jsDynamicCast<JSModuleRecord*>(this);
+    auto* jsModule = dynamicDowncast<JSModuleRecord>(this);
 #if ENABLE(WEBASSEMBLY)
     auto* wasmModule = !jsModule ? jsCast<WebAssemblyModuleRecord*>(this) : nullptr;
 #else
@@ -444,7 +444,7 @@ void CyclicModuleRecord::execute(JSGlobalObject* globalObject, JSPromise* capabi
     auto scope = DECLARE_THROW_SCOPE(vm);
 
 #if ENABLE(WEBASSEMBLY)
-    if (auto* wasmModule = jsDynamicCast<WebAssemblyModuleRecord*>(this)) {
+    if (auto* wasmModule = dynamicDowncast<WebAssemblyModuleRecord>(this)) {
         wasmModule->initializeImports(globalObject, nullptr, Wasm::CreationMode::FromModuleLoader);
         RETURN_IF_EXCEPTION(scope, void());
         wasmModule->initializeExports(globalObject);

--- a/Source/JavaScriptCore/runtime/DateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/DateConstructor.cpp
@@ -110,7 +110,7 @@ JSObject* constructDate(JSGlobalObject* globalObject, JSValue newTarget, const A
         value = jsCurrentTime();
     else if (numArgs == 1) {
         JSValue arg0 = args.at(0);
-        if (auto* dateInstance = jsDynamicCast<DateInstance*>(arg0))
+        if (auto* dateInstance = dynamicDowncast<DateInstance>(arg0))
             value = dateInstance->internalNumber();
         else {
             JSValue primitive = arg0.toPrimitive(globalObject);

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -101,7 +101,7 @@ static EncodedJSValue formateDateInstance(JSGlobalObject* globalObject, CallFram
     auto& cache = vm.dateCache;
 
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -319,7 +319,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToISOString, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -396,7 +396,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetTime, (JSGlobalObject* globalObject, Ca
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -408,7 +408,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetFullYear, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -423,7 +423,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCFullYear, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -438,7 +438,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetMonth, (JSGlobalObject* globalObject, C
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -453,7 +453,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCMonth, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -468,7 +468,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetDate, (JSGlobalObject* globalObject, Ca
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -483,7 +483,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCDate, (JSGlobalObject* globalObject,
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -498,7 +498,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetDay, (JSGlobalObject* globalObject, Cal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -513,7 +513,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCDay, (JSGlobalObject* globalObject, 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -528,7 +528,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetHours, (JSGlobalObject* globalObject, C
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -543,7 +543,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCHours, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -558,7 +558,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetMinutes, (JSGlobalObject* globalObject,
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -573,7 +573,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCMinutes, (JSGlobalObject* globalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -588,7 +588,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetSeconds, (JSGlobalObject* globalObject,
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -603,7 +603,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCSeconds, (JSGlobalObject* globalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -618,7 +618,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetMilliSeconds, (JSGlobalObject* globalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -637,7 +637,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCMilliseconds, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -656,7 +656,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetTimezoneOffset, (JSGlobalObject* global
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -671,7 +671,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetTime, (JSGlobalObject* globalObject, Ca
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -688,7 +688,7 @@ static EncodedJSValue setNewValueFromTimeArgs(JSGlobalObject* globalObject, Call
     auto& cache = vm.dateCache;
 
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -739,7 +739,7 @@ static EncodedJSValue setNewValueFromDateArgs(JSGlobalObject* globalObject, Call
     auto& cache = vm.dateCache;
 
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -857,7 +857,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetYear, (JSGlobalObject* globalObject, Ca
     auto& cache = vm.dateCache;
 
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -900,7 +900,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetYear, (JSGlobalObject* globalObject, Ca
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -942,7 +942,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToTemporalInstant, (JSGlobalObject* global
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -961,7 +961,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToLocaleString, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -987,7 +987,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToLocaleDateString, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -1013,7 +1013,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToLocaleTimeString, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = callFrame->thisValue();
-    auto* thisDateObj = jsDynamicCast<DateInstance*>(thisValue);
+    auto* thisDateObj = dynamicDowncast<DateInstance>(thisValue);
     if (!thisDateObj) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 

--- a/Source/JavaScriptCore/runtime/DisposableStackPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DisposableStackPrototype.cpp
@@ -59,7 +59,7 @@ JSC_DEFINE_HOST_FUNCTION(disposableStackProtoDisposedGetter, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* disposableStack = jsDynamicCast<JSDisposableStack*>(thisValue);
+    auto* disposableStack = dynamicDowncast<JSDisposableStack>(thisValue);
     if (!disposableStack) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "DisposableStack.prototype.disposed getter requires that |this| be a DisposableStack object"_s);
 

--- a/Source/JavaScriptCore/runtime/Error.cpp
+++ b/Source/JavaScriptCore/runtime/Error.cpp
@@ -249,7 +249,7 @@ JSObject* addErrorInfo(VM& vm, JSObject* error, int line, const SourceCode& sour
     // ErrorInstance to materialize whatever it needs to. There's a chance that we get passed some
     // other kind of object, which also has materializable properties. But this code is heuristic-ey
     // enough that if we're wrong in such corner cases, it's not the end of the world.
-    if (ErrorInstance* errorInstance = jsDynamicCast<ErrorInstance*>(error))
+    if (ErrorInstance* errorInstance = dynamicDowncast<ErrorInstance>(error))
         errorInstance->materializeErrorInfoIfNeeded(vm);
     
     // FIXME: This does not modify the column property, which confusingly continues to reflect

--- a/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
@@ -130,7 +130,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorCaptureStackTrace, (JSGlobalObject* glo
 
     object->putDirect(vm, vm.propertyNames->stack, jsString(vm, Interpreter::stackTraceAsString(vm, stackTrace)), static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    if (auto* errorInstance = jsDynamicCast<ErrorInstance*>(object))
+    if (auto* errorInstance = dynamicDowncast<ErrorInstance>(object))
         errorInstance->setStackPropertyAlreadyMaterialized();
 
     return encodedJSUndefined();
@@ -138,7 +138,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorCaptureStackTrace, (JSGlobalObject* glo
 
 JSC_DEFINE_HOST_FUNCTION(errorConstructorIsError, (JSGlobalObject*, CallFrame* callFrame))
 {
-    JSObject* object = jsDynamicCast<JSObject*>(callFrame->argument(0));
+    JSObject* object = dynamicDowncast<JSObject>(callFrame->argument(0));
     return JSValue::encode(jsBoolean(object && object->isErrorInstance()));
 }
 

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -252,7 +252,7 @@ String ErrorInstance::tryGetMessageForDebugging()
     if (JSObject::getOwnNonIndexPropertySlot(vm, structure(), messagePropertName, messageSlot))
         messageValue = messageSlot.getPureResult();
 
-    if (JSString* string = jsDynamicCast<JSString*>(messageValue))
+    if (JSString* string = dynamicDowncast<JSString>(messageValue))
         return string->tryGetValue();
     return emptyString();
 }

--- a/Source/JavaScriptCore/runtime/Exception.cpp
+++ b/Source/JavaScriptCore/runtime/Exception.cpp
@@ -96,7 +96,7 @@ void Exception::tryUnwrapValueForJSTag(VM& vm)
     if (!m_value)
         return;
 
-    if (auto* exception = jsDynamicCast<JSWebAssemblyException*>(m_value.get())) {
+    if (auto* exception = dynamicDowncast<JSWebAssemblyException>(m_value.get())) {
         if (&exception->tag() == &Wasm::Tag::jsExceptionTag()) {
             m_value.set(vm, this, JSValue::decode(exception->payload().at(0)));
             return;

--- a/Source/JavaScriptCore/runtime/ExceptionScope.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionScope.cpp
@@ -65,7 +65,7 @@ CString ExceptionScope::unexpectedExceptionMessage()
     out.println("The exception was thrown from thread ", *m_vm.throwingThread(), " at:");
     out.print(StackTracePrinter { *m_vm.nativeStackTraceOfLastThrow(), "    " });
 
-    if (auto* error = jsDynamicCast<ErrorInstance*>(exception()->value()))
+    if (auto* error = dynamicDowncast<ErrorInstance>(exception()->value()))
         out.println("Error Exception: ", error->tryGetMessageForDebugging());
     else
         out.println("non-Error Exception: ", exception()->value());

--- a/Source/JavaScriptCore/runtime/FinalizationRegistryPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/FinalizationRegistryPrototype.cpp
@@ -58,7 +58,7 @@ ALWAYS_INLINE static JSFinalizationRegistry* getFinalizationRegistry(VM& vm, JSG
         return nullptr;
     }
 
-    auto* group = jsDynamicCast<JSFinalizationRegistry*>(asObject(value));
+    auto* group = dynamicDowncast<JSFinalizationRegistry>(asObject(value));
     if (group) [[likely]]
         return group;
 

--- a/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
@@ -128,7 +128,7 @@ JSC_DEFINE_HOST_FUNCTION(functionProtoFuncBind, (JSGlobalObject* globalObject, C
 
     double length = 0;
     JSString* name = nullptr;
-    JSFunction* function = jsDynamicCast<JSFunction*>(target);
+    JSFunction* function = dynamicDowncast<JSFunction>(target);
     if (function && function->canAssumeNameAndLengthAreOriginal(vm)) [[likely]] {
         // Do nothing! 'length' and 'name' computation are lazily done.
         // And this is totally OK since we know that wrapped functions have canAssumeNameAndLengthAreOriginal condition
@@ -218,7 +218,7 @@ JSC_DEFINE_CUSTOM_GETTER(argumentsGetter, (JSGlobalObject* globalObject, Encoded
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSFunction* thisObj = jsDynamicCast<JSFunction*>(JSValue::decode(thisValue));
+    JSFunction* thisObj = dynamicDowncast<JSFunction>(JSValue::decode(thisValue));
     if (!thisObj || !isAllowedReceiverFunctionForCallerAndArguments(thisObj))
         return throwVMTypeError(globalObject, scope, RestrictedPropertyAccessError);
 
@@ -289,7 +289,7 @@ JSC_DEFINE_CUSTOM_GETTER(callerGetter, (JSGlobalObject* globalObject, EncodedJSV
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSFunction* thisObj = jsDynamicCast<JSFunction*>(JSValue::decode(thisValue));
+    JSFunction* thisObj = dynamicDowncast<JSFunction>(JSValue::decode(thisValue));
     if (!thisObj || !isAllowedReceiverFunctionForCallerAndArguments(thisObj))
         return throwVMTypeError(globalObject, scope, RestrictedPropertyAccessError);
 
@@ -298,7 +298,7 @@ JSC_DEFINE_CUSTOM_GETTER(callerGetter, (JSGlobalObject* globalObject, EncodedJSV
         return JSValue::encode(jsNull());
 
     // 11. If caller is not an ECMAScript function object, return null.
-    JSFunction* function = jsDynamicCast<JSFunction*>(caller);
+    JSFunction* function = dynamicDowncast<JSFunction>(caller);
     if (!function || function->isHostOrBuiltinFunction())
         return JSValue::encode(jsNull());
 
@@ -321,7 +321,7 @@ JSC_DEFINE_CUSTOM_SETTER(callerAndArgumentsSetter, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSFunction* thisObj = jsDynamicCast<JSFunction*>(JSValue::decode(thisValue));
+    JSFunction* thisObj = dynamicDowncast<JSFunction>(JSValue::decode(thisValue));
     if (!thisObj || !isAllowedReceiverFunctionForCallerAndArguments(thisObj))
         throwTypeError(globalObject, scope, RestrictedPropertyAccessError);
 

--- a/Source/JavaScriptCore/runtime/GetterSetter.h
+++ b/Source/JavaScriptCore/runtime/GetterSetter.h
@@ -92,8 +92,8 @@ public:
         return result;
     }
 
-    bool isGetterNull() const { return !!jsDynamicCast<NullGetterFunction*>(m_getter.get()); }
-    bool isSetterNull() const { return !!jsDynamicCast<NullSetterFunction*>(m_setter.get()); }
+    bool isGetterNull() const { return is<NullGetterFunction>(m_getter.get()); }
+    bool isSetterNull() const { return is<NullSetterFunction>(m_setter.get()); }
 
     JSObject* setter() const LIFETIME_BOUND { return m_setter.get(); }
 

--- a/Source/JavaScriptCore/runtime/InternalFunction.cpp
+++ b/Source/JavaScriptCore/runtime/InternalFunction.cpp
@@ -42,7 +42,7 @@ InternalFunction::InternalFunction(VM& vm, Structure* structure, NativeFunction 
     ASSERT_WITH_MESSAGE(m_functionForCall, "[[Call]] must be implemented");
     ASSERT(m_functionForConstruct);
 
-    ASSERT(jsDynamicCast<InternalFunction*>(this));
+    ASSERT(is<InternalFunction>(this));
     // JSCell::{getCallData,getConstructData} relies on the following conditions.
     ASSERT(methodTable()->getCallData == InternalFunction::info()->methodTable.getCallData);
     ASSERT(methodTable()->getConstructData == InternalFunction::info()->methodTable.getConstructData);
@@ -146,7 +146,7 @@ Structure* InternalFunction::createSubclassStructure(JSGlobalObject* globalObjec
     ASSERT(baseClass->hasMonoProto());
 
     // newTarget may be an InternalFunction if we were called from Reflect.construct.
-    JSFunction* targetFunction = jsDynamicCast<JSFunction*>(newTarget);
+    JSFunction* targetFunction = dynamicDowncast<JSFunction>(newTarget);
 
     if (!targetFunction || !targetFunction->canUseAllocationProfiles()) [[unlikely]] {
         JSValue prototypeValue = newTarget->get(globalObject, vm.propertyNames->prototype);
@@ -156,7 +156,7 @@ Structure* InternalFunction::createSubclassStructure(JSGlobalObject* globalObjec
             if (baseGlobalObject->isOriginalArrayStructure(baseClass))
                 baseClass = baseGlobalObject->arrayStructureForIndexingTypeDuringAllocation(baseClass->indexingType());
         }
-        if (JSObject* prototype = jsDynamicCast<JSObject*>(prototypeValue)) {
+        if (JSObject* prototype = dynamicDowncast<JSObject>(prototypeValue)) {
             // This only happens if someone Reflect.constructs our builtin constructor with another builtin constructor or weird .prototype property on a
             // JSFunction as the new.target. Thus, we don't care about the cost of looking up the structure from our hash table every time.
             return baseGlobalObject->structureCache().emptyStructureForPrototypeFromBaseStructure(baseGlobalObject, prototype, baseClass);
@@ -173,7 +173,7 @@ Structure* InternalFunction::createSubclassStructure(JSGlobalObject* globalObjec
     JSValue prototypeValue = targetFunction->get(globalObject, vm.propertyNames->prototype);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    if (JSObject* prototype = jsDynamicCast<JSObject*>(prototypeValue))
+    if (JSObject* prototype = dynamicDowncast<JSObject>(prototypeValue))
         return rareData->createInternalFunctionAllocationStructureFromBase(vm, baseGlobalObject, prototype, baseClass);
 
     return baseClass;

--- a/Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp
@@ -83,7 +83,7 @@ JSC_DEFINE_HOST_FUNCTION(intlCollatorFuncCompare, (JSGlobalObject* globalObject,
     // 10.3.4 Collator Compare Functions (ECMA-402 2.0)
     // 1. Let collator be the this value.
     // 2. Assert: Type(collator) is Object and collator has an [[initializedCollator]] internal slot whose value is true.
-    IntlCollator* collator = jsDynamicCast<IntlCollator*>(callFrame->thisValue());
+    IntlCollator* collator = dynamicDowncast<IntlCollator>(callFrame->thisValue());
     if (!collator) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.Collator.prototype.compare called on value that's not a Collator"_s));
 
@@ -114,7 +114,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlCollatorPrototypeGetterCompare, (JSGlobalObject* gl
 
     // 10.3.3 Intl.Collator.prototype.compare (ECMA-402 2.0)
     // 1. Let collator be this Collator object.
-    IntlCollator* collator = jsDynamicCast<IntlCollator*>(JSValue::decode(thisValue));
+    IntlCollator* collator = dynamicDowncast<IntlCollator>(JSValue::decode(thisValue));
     if (!collator) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.Collator.prototype.compare called on value that's not a Collator"_s));
 
@@ -145,7 +145,7 @@ JSC_DEFINE_HOST_FUNCTION(intlCollatorPrototypeFuncResolvedOptions, (JSGlobalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // 10.3.5 Intl.Collator.prototype.resolvedOptions() (ECMA-402 2.0)
-    IntlCollator* collator = jsDynamicCast<IntlCollator*>(callFrame->thisValue());
+    IntlCollator* collator = dynamicDowncast<IntlCollator>(callFrame->thisValue());
     if (!collator) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.Collator.prototype.resolvedOptions called on value that's not a Collator"_s));
 

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
@@ -101,7 +101,7 @@ static double handleDateTimeValue(JSGlobalObject* globalObject, JSValue x)
     //  - Add all of the other Temporal types
     //  - Work in epoch nanoseconds
     //  - Return UDateFormat and UDateIntervalFormat depending on the type
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(x);
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(x);
     if (instant)
         return instant->exactTime().epochMilliseconds();
 
@@ -115,7 +115,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatFuncFormatDateTime, (JSGlobalObject* 
     // 12.1.7 DateTime Format Functions (ECMA-402)
     // https://tc39.github.io/ecma402/#sec-formatdatetime
 
-    IntlDateTimeFormat* format = jsDynamicCast<IntlDateTimeFormat*>(callFrame->thisValue());
+    IntlDateTimeFormat* format = dynamicDowncast<IntlDateTimeFormat>(callFrame->thisValue());
     if (!format) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.format called on value that's not a DateTimeFormat"_s));
 
@@ -168,7 +168,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatToParts, (JSGlobal
     // https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype.formatToParts
 
     // Do not use unwrapForOldFunctions.
-    auto* dateTimeFormat = jsDynamicCast<IntlDateTimeFormat*>(callFrame->thisValue());
+    auto* dateTimeFormat = dynamicDowncast<IntlDateTimeFormat>(callFrame->thisValue());
     if (!dateTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.formatToParts called on value that's not a DateTimeFormat"_s));
 
@@ -186,7 +186,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatRange, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Do not use unwrapForOldFunctions.
-    auto* dateTimeFormat = jsDynamicCast<IntlDateTimeFormat*>(callFrame->thisValue());
+    auto* dateTimeFormat = dynamicDowncast<IntlDateTimeFormat>(callFrame->thisValue());
     if (!dateTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.formatRange called on value that's not a DateTimeFormat"_s));
 
@@ -211,7 +211,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatRangeToParts, (JSG
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Do not use unwrapForOldFunctions.
-    auto* dateTimeFormat = jsDynamicCast<IntlDateTimeFormat*>(callFrame->thisValue());
+    auto* dateTimeFormat = dynamicDowncast<IntlDateTimeFormat>(callFrame->thisValue());
     if (!dateTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.formatRangeToParts called on value that's not a DateTimeFormat"_s));
 

--- a/Source/JavaScriptCore/runtime/IntlDisplayNamesPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNamesPrototype.cpp
@@ -79,7 +79,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDisplayNamesPrototypeFuncOf, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* displayNames = jsDynamicCast<IntlDisplayNames*>(callFrame->thisValue());
+    auto* displayNames = dynamicDowncast<IntlDisplayNames>(callFrame->thisValue());
     if (!displayNames) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DisplayNames.prototype.of called on value that's not a DisplayNames"_s);
 
@@ -92,7 +92,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDisplayNamesPrototypeFuncResolvedOptions, (JSGlobal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* displayNames = jsDynamicCast<IntlDisplayNames*>(callFrame->thisValue());
+    auto* displayNames = dynamicDowncast<IntlDisplayNames>(callFrame->thisValue());
     if (!displayNames) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DisplayNames.prototype.resolvedOptions called on value that's not a DisplayNames"_s);
 

--- a/Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp
@@ -82,7 +82,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncFormat, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* durationFormat = jsDynamicCast<IntlDurationFormat*>(callFrame->thisValue());
+    auto* durationFormat = dynamicDowncast<IntlDurationFormat>(callFrame->thisValue());
     if (!durationFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.format called on value that's not a DurationFormat"_s);
 
@@ -102,7 +102,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncFormatToParts, (JSGlobal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* durationFormat = jsDynamicCast<IntlDurationFormat*>(callFrame->thisValue());
+    auto* durationFormat = dynamicDowncast<IntlDurationFormat>(callFrame->thisValue());
     if (!durationFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.formatToParts called on value that's not a DurationFormat"_s);
 
@@ -122,7 +122,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncResolvedOptions, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* durationFormat = jsDynamicCast<IntlDurationFormat*>(callFrame->thisValue());
+    auto* durationFormat = dynamicDowncast<IntlDurationFormat>(callFrame->thisValue());
     if (!durationFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.resolvedOptions called on value that's not a DurationFormat"_s);
 

--- a/Source/JavaScriptCore/runtime/IntlListFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlListFormatPrototype.cpp
@@ -81,7 +81,7 @@ JSC_DEFINE_HOST_FUNCTION(intlListFormatPrototypeFuncFormat, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* listFormat = jsDynamicCast<IntlListFormat*>(callFrame->thisValue());
+    auto* listFormat = dynamicDowncast<IntlListFormat>(callFrame->thisValue());
     if (!listFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.ListFormat.prototype.format called on value that's not a ListFormat"_s);
 
@@ -94,7 +94,7 @@ JSC_DEFINE_HOST_FUNCTION(intlListFormatPrototypeFuncFormatToParts, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* listFormat = jsDynamicCast<IntlListFormat*>(callFrame->thisValue());
+    auto* listFormat = dynamicDowncast<IntlListFormat>(callFrame->thisValue());
     if (!listFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.ListFormat.prototype.formatToParts called on value that's not a ListFormat"_s);
 
@@ -107,7 +107,7 @@ JSC_DEFINE_HOST_FUNCTION(intlListFormatPrototypeFuncResolvedOptions, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* listFormat = jsDynamicCast<IntlListFormat*>(callFrame->thisValue());
+    auto* listFormat = dynamicDowncast<IntlListFormat>(callFrame->thisValue());
     if (!listFormat) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.ListFormat.prototype.resolvedOptions called on value that's not a ListFormat"_s);
 

--- a/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
@@ -121,7 +121,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncMaximize, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
+    auto* locale = dynamicDowncast<IntlLocale>(callFrame->thisValue());
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.maximize called on value that's not a Locale"_s);
 
@@ -137,7 +137,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncMinimize, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
+    auto* locale = dynamicDowncast<IntlLocale>(callFrame->thisValue());
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.minimize called on value that's not a Locale"_s);
 
@@ -153,7 +153,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncToString, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
+    auto* locale = dynamicDowncast<IntlLocale>(callFrame->thisValue());
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.toString called on value that's not a Locale"_s);
 
@@ -167,7 +167,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterBaseName, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.baseName called on value that's not a Locale"_s);
 
@@ -181,7 +181,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendar, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.calendar called on value that's not a Locale"_s);
 
@@ -195,7 +195,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetCalendars, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
+    auto* locale = dynamicDowncast<IntlLocale>(callFrame->thisValue());
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getCalendars called on value that's not a Locale"_s);
 
@@ -208,7 +208,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCaseFirst, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.caseFirst called on value that's not a Locale"_s);
 
@@ -222,7 +222,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCollation, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.collation called on value that's not a Locale"_s);
 
@@ -236,7 +236,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetCollations, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
+    auto* locale = dynamicDowncast<IntlLocale>(callFrame->thisValue());
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getCollations called on value that's not a Locale"_s);
 
@@ -249,7 +249,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterFirstDayOfWeek, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.firstDayOfWeek called on value that's not a Locale"_s);
 
@@ -263,7 +263,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycle, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.hourCycle called on value that's not a Locale"_s);
 
@@ -277,7 +277,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetHourCycles, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
+    auto* locale = dynamicDowncast<IntlLocale>(callFrame->thisValue());
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getHourCycles called on value that's not a Locale"_s);
 
@@ -290,7 +290,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterNumeric, (JSGlobalObject* glob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.numeric called on value that's not a Locale"_s);
 
@@ -303,7 +303,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystem, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.numberingSystem called on value that's not a Locale"_s);
 
@@ -317,7 +317,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetNumberingSystems, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
+    auto* locale = dynamicDowncast<IntlLocale>(callFrame->thisValue());
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getNumberingSystems called on value that's not a Locale"_s);
 
@@ -330,7 +330,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterLanguage, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.language called on value that's not a Locale"_s);
 
@@ -344,7 +344,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterScript, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.script called on value that's not a Locale"_s);
 
@@ -358,7 +358,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterRegion, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.region called on value that's not a Locale"_s);
 
@@ -372,7 +372,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterVariants, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = dynamicDowncast<IntlLocale>(JSValue::decode(thisValue));
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.variants called on value that's not a Locale"_s);
 
@@ -386,7 +386,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetTimeZones, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
+    auto* locale = dynamicDowncast<IntlLocale>(callFrame->thisValue());
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getTimeZones called on value that's not a Locale"_s);
 
@@ -399,7 +399,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetTextInfo, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
+    auto* locale = dynamicDowncast<IntlLocale>(callFrame->thisValue());
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getTextInfo called on value that's not a Locale"_s);
 
@@ -412,7 +412,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetWeekInfo, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
+    auto* locale = dynamicDowncast<IntlLocale>(callFrame->thisValue());
     if (!locale) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getWeekInfo called on value that's not a Locale"_s);
 

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp
@@ -89,7 +89,7 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatFuncFormat, (JSGlobalObject* globalObje
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* numberFormat = jsDynamicCast<IntlNumberFormat*>(callFrame->thisValue());
+    auto* numberFormat = dynamicDowncast<IntlNumberFormat>(callFrame->thisValue());
     if (!numberFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.NumberFormat.prototype.format called on value that's not a NumberFormat"_s));
 
@@ -140,7 +140,7 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRange, (JSGlobalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Do not use unwrapForOldFunctions.
-    auto* numberFormat = jsDynamicCast<IntlNumberFormat*>(callFrame->thisValue());
+    auto* numberFormat = dynamicDowncast<IntlNumberFormat>(callFrame->thisValue());
     if (!numberFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.NumberFormat.prototype.formatRange called on value that's not a NumberFormat"_s));
 
@@ -173,7 +173,7 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatToParts, (JSGlobalOb
     // https://tc39.github.io/ecma402/#sec-intl.numberformat.prototype.formattoparts
 
     // Do not use unwrapForOldFunctions.
-    auto* numberFormat = jsDynamicCast<IntlNumberFormat*>(callFrame->thisValue());
+    auto* numberFormat = dynamicDowncast<IntlNumberFormat>(callFrame->thisValue());
     if (!numberFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.NumberFormat.prototype.formatToParts called on value that's not a NumberFormat"_s));
 
@@ -192,7 +192,7 @@ JSC_DEFINE_HOST_FUNCTION(intlNumberFormatPrototypeFuncFormatRangeToParts, (JSGlo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Do not use unwrapForOldFunctions.
-    auto* numberFormat = jsDynamicCast<IntlNumberFormat*>(callFrame->thisValue());
+    auto* numberFormat = dynamicDowncast<IntlNumberFormat>(callFrame->thisValue());
     if (!numberFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.NumberFormat.prototype.formatRangeToParts called on value that's not a NumberFormat"_s));
 

--- a/Source/JavaScriptCore/runtime/IntlObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlObjectInlines.h
@@ -102,11 +102,11 @@ InstanceType* unwrapForLegacyIntlConstructor(JSGlobalObject* globalObject, JSVal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSObject* thisObject = jsDynamicCast<JSObject*>(thisValue);
+    JSObject* thisObject = dynamicDowncast<JSObject>(thisValue);
     if (!thisObject) [[unlikely]]
         return nullptr;
 
-    auto* instance = jsDynamicCast<InstanceType*>(thisObject);
+    auto* instance = dynamicDowncast<InstanceType>(thisObject);
     if (instance) [[likely]]
         return instance;
 
@@ -120,7 +120,7 @@ InstanceType* unwrapForLegacyIntlConstructor(JSGlobalObject* globalObject, JSVal
 
     JSValue value = thisObject->get(globalObject, vm.propertyNames->builtinNames().intlLegacyConstructedSymbol());
     RETURN_IF_EXCEPTION(scope, nullptr);
-    return jsDynamicCast<InstanceType*>(value);
+    return dynamicDowncast<InstanceType>(value);
 }
 
 template<typename ResultType>

--- a/Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp
@@ -84,7 +84,7 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelect, (JSGlobalObject* gl
 
     // 13.4.3 Intl.PluralRules.prototype.select (value)
     // https://tc39.github.io/ecma402/#sec-intl.pluralrules.prototype.select
-    IntlPluralRules* pluralRules = jsDynamicCast<IntlPluralRules*>(callFrame->thisValue());
+    IntlPluralRules* pluralRules = dynamicDowncast<IntlPluralRules>(callFrame->thisValue());
 
     if (!pluralRules) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.PluralRules.prototype.select called on value that's not a PluralRules"_s));
@@ -101,7 +101,7 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelectRange, (JSGlobalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/diff.html#sec-intl.pluralrules.prototype.selectrange
-    IntlPluralRules* pluralRules = jsDynamicCast<IntlPluralRules*>(callFrame->thisValue());
+    IntlPluralRules* pluralRules = dynamicDowncast<IntlPluralRules>(callFrame->thisValue());
     if (!pluralRules) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.PluralRules.prototype.selectRange called on value that's not a PluralRules"_s));
 
@@ -127,7 +127,7 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncResolvedOptions, (JSGlobalO
 
     // 13.4.4 Intl.PluralRules.prototype.resolvedOptions ()
     // https://tc39.github.io/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions
-    IntlPluralRules* pluralRules = jsDynamicCast<IntlPluralRules*>(callFrame->thisValue());
+    IntlPluralRules* pluralRules = dynamicDowncast<IntlPluralRules>(callFrame->thisValue());
 
     if (!pluralRules) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.PluralRules.prototype.resolvedOptions called on value that's not a PluralRules"_s));

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormatPrototype.cpp
@@ -82,7 +82,7 @@ JSC_DEFINE_HOST_FUNCTION(intlRelativeTimeFormatPrototypeFuncFormat, (JSGlobalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* relativeTimeFormat = jsDynamicCast<IntlRelativeTimeFormat*>(callFrame->thisValue());
+    auto* relativeTimeFormat = dynamicDowncast<IntlRelativeTimeFormat>(callFrame->thisValue());
     if (!relativeTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.RelativeTimeFormat.prototype.format called on value that's not a RelativeTimeFormat"_s));
 
@@ -101,7 +101,7 @@ JSC_DEFINE_HOST_FUNCTION(intlRelativeTimeFormatPrototypeFuncFormatToParts, (JSGl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* relativeTimeFormat = jsDynamicCast<IntlRelativeTimeFormat*>(callFrame->thisValue());
+    auto* relativeTimeFormat = dynamicDowncast<IntlRelativeTimeFormat>(callFrame->thisValue());
     if (!relativeTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.RelativeTimeFormat.prototype.formatToParts called on value that's not a RelativeTimeFormat"_s));
 
@@ -120,7 +120,7 @@ JSC_DEFINE_HOST_FUNCTION(intlRelativeTimeFormatPrototypeFuncResolvedOptions, (JS
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* relativeTimeFormat = jsDynamicCast<IntlRelativeTimeFormat*>(callFrame->thisValue());
+    auto* relativeTimeFormat = dynamicDowncast<IntlRelativeTimeFormat>(callFrame->thisValue());
     if (!relativeTimeFormat) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.RelativeTimeFormat.prototype.resolvedOptions called on value that's not a RelativeTimeFormat"_s));
 

--- a/Source/JavaScriptCore/runtime/IntlSegmentIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmentIteratorPrototype.cpp
@@ -77,7 +77,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmentIteratorPrototypeFuncNext, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* segmentIterator = jsDynamicCast<IntlSegmentIterator*>(callFrame->thisValue());
+    auto* segmentIterator = dynamicDowncast<IntlSegmentIterator>(callFrame->thisValue());
     if (!segmentIterator) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.SegmentIterator.prototype.next called on value that's not a SegmentIterator"_s);
 

--- a/Source/JavaScriptCore/runtime/IntlSegmenterPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmenterPrototype.cpp
@@ -79,7 +79,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmenterPrototypeFuncSegment, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* segmenter = jsDynamicCast<IntlSegmenter*>(callFrame->thisValue());
+    auto* segmenter = dynamicDowncast<IntlSegmenter>(callFrame->thisValue());
     if (!segmenter) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Segmenter.prototype.segment called on value that's not a Segmenter"_s);
 
@@ -92,7 +92,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmenterPrototypeFuncResolvedOptions, (JSGlobalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* segmenter = jsDynamicCast<IntlSegmenter*>(callFrame->thisValue());
+    auto* segmenter = dynamicDowncast<IntlSegmenter>(callFrame->thisValue());
     if (!segmenter) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.Segmenter.prototype.resolvedOptions called on value that's not a Segmenter"_s);
 

--- a/Source/JavaScriptCore/runtime/IntlSegmentsPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmentsPrototype.cpp
@@ -79,7 +79,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmentsPrototypeFuncContaining, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* segments = jsDynamicCast<IntlSegments*>(callFrame->thisValue());
+    auto* segments = dynamicDowncast<IntlSegments>(callFrame->thisValue());
     if (!segments) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "%Segments.prototype%.containing called on value that's not a Segments"_s);
 
@@ -92,7 +92,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmentsPrototypeFuncIterator, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* segments = jsDynamicCast<IntlSegments*>(callFrame->thisValue());
+    auto* segments = dynamicDowncast<IntlSegments>(callFrame->thisValue());
     if (!segments) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "%Segments.prototype%[@@iterator] called on value that's not a Segments"_s);
 

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -433,7 +433,7 @@ IterationMode getIterationMode(VM&, JSGlobalObject* globalObject, JSValue iterab
         return IterationMode::Generic;
 
     // This is correct because we just checked the watchpoint is still valid.
-    JSFunction* symbolIteratorFunction = jsDynamicCast<JSFunction*>(symbolIterator);
+    JSFunction* symbolIteratorFunction = dynamicDowncast<JSFunction>(symbolIterator);
     if (!symbolIteratorFunction)
         return IterationMode::Generic;
 

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -223,7 +223,7 @@ void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, NOESCAPE 
         return;
     }
 
-    if (auto* jsMap = jsDynamicCast<JSMap*>(iterable)) {
+    if (auto* jsMap = dynamicDowncast<JSMap>(iterable)) {
         if (jsMap->isIteratorProtocolFastAndNonObservable()) {
             JSCell* storageCell = jsMap->storageOrSentinel(vm);
             if (storageCell != vm.orderedHashTableSentinel()) {
@@ -232,7 +232,7 @@ void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, NOESCAPE 
             }
             return;
         }
-    } else if (auto* jsSet = jsDynamicCast<JSSet*>(iterable)) {
+    } else if (auto* jsSet = dynamicDowncast<JSSet>(iterable)) {
         if (jsSet->isIteratorProtocolFastAndNonObservable()) {
             JSCell* storageCell = jsSet->storageOrSentinel(vm);
             if (storageCell != vm.orderedHashTableSentinel()) {
@@ -322,7 +322,7 @@ void forEachInIteratorProtocol(JSGlobalObject* globalObject, JSValue iterable, N
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (auto* mapIterator = jsDynamicCast<JSMapIterator*>(iterable)) {
+    if (auto* mapIterator = dynamicDowncast<JSMapIterator>(iterable)) {
         if (mapIteratorProtocolIsFastAndNonObservable(vm, mapIterator)) {
             if (JSMap* iteratedMap = jsCast<JSMap*>(mapIterator->iteratedObject())) {
                 JSCell* storageCell = iteratedMap->storageOrSentinel(vm);
@@ -335,7 +335,7 @@ void forEachInIteratorProtocol(JSGlobalObject* globalObject, JSValue iterable, N
                 return;
             }
         }
-    } else if (auto* setIterator = jsDynamicCast<JSSetIterator*>(iterable)) {
+    } else if (auto* setIterator = dynamicDowncast<JSSetIterator>(iterable)) {
         if (setIteratorProtocolIsFastAndNonObservable(vm, setIterator)) {
             if (JSSet* iteratedSet = jsCast<JSSet*>(setIterator->iteratedObject())) {
                 JSCell* storageCell = iteratedSet->storageOrSentinel(vm);

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -179,7 +179,7 @@ protected:
     void finishCreation(VM& vm)
     {
         Base::finishCreation(vm);
-        ASSERT(jsDynamicCast<JSArray*>(this));
+        ASSERT(is<JSArray>(this));
         ASSERT_WITH_MESSAGE(type() == ArrayType || type() == DerivedArrayType, "Instance inheriting JSArray should have either ArrayType or DerivedArrayType");
     }
 #endif

--- a/Source/JavaScriptCore/runtime/JSArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBuffer.h
@@ -71,7 +71,7 @@ private:
 
 inline ArrayBuffer* toPossiblySharedArrayBuffer(VM&, JSValue value)
 {
-    JSArrayBuffer* wrapper = jsDynamicCast<JSArrayBuffer*>(value);
+    JSArrayBuffer* wrapper = dynamicDowncast<JSArrayBuffer>(value);
     if (!wrapper)
         return nullptr;
     return wrapper->impl();

--- a/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
@@ -186,7 +186,7 @@ JSObject* constructArrayBufferWithSize(JSGlobalObject* globalObject, Structure* 
 // ECMA 24.1.3.1
 JSC_DEFINE_HOST_FUNCTION(arrayBufferFuncIsView, (JSGlobalObject*, CallFrame* callFrame))
 {
-    return JSValue::encode(jsBoolean(jsDynamicCast<JSArrayBufferView*>(callFrame->argument(0))));
+    return JSValue::encode(jsBoolean(dynamicDowncast<JSArrayBufferView>(callFrame->argument(0))));
 }
 
 // Instantiate JSGenericArrayBufferConstructors.

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -109,7 +109,7 @@ static ALWAYS_INLINE std::pair<SpeciesConstructResult, JSArrayBuffer*> speciesCo
     RETURN_IF_EXCEPTION(scope, errorResult);
 
     // 17. Perform ? RequireInternalSlot(new, [[ArrayBufferData]]).
-    JSArrayBuffer* result = jsDynamicCast<JSArrayBuffer*>(newObject);
+    JSArrayBuffer* result = dynamicDowncast<JSArrayBuffer>(newObject);
     if (!result) [[unlikely]] {
         throwTypeError(globalObject, scope, "Species construction does not create ArrayBuffer"_s);
         return errorResult;
@@ -160,7 +160,7 @@ static EncodedJSValue arrayBufferSlice(JSGlobalObject* globalObject, JSValue arr
 
     // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
     // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-    JSArrayBuffer* thisObject = jsDynamicCast<JSArrayBuffer*>(arrayBufferValue);
+    JSArrayBuffer* thisObject = dynamicDowncast<JSArrayBuffer>(arrayBufferValue);
     if (!thisObject || (mode != thisObject->impl()->sharingMode()))
         return throwVMTypeError(globalObject, scope, makeString("Receiver must be "_s, mode == ArrayBufferSharingMode::Default ? "ArrayBuffer"_s : "SharedArrayBuffer"_s));
 
@@ -252,7 +252,7 @@ static EncodedJSValue arrayBufferByteLength(JSGlobalObject* globalObject, JSValu
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsDynamicCast<JSArrayBuffer*>(arrayBufferValue);
+    auto* thisObject = dynamicDowncast<JSArrayBuffer>(arrayBufferValue);
     if (!thisObject || (mode != thisObject->impl()->sharingMode()))
         return throwVMTypeError(globalObject, scope, makeString("Receiver must be "_s, mode == ArrayBufferSharingMode::Default ? "ArrayBuffer"_s : "SharedArrayBuffer"_s));
 
@@ -276,7 +276,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayBufferProtoFuncResize, (JSGlobalObject* globalObje
 
     JSValue arrayBufferValue = callFrame->thisValue();
 
-    JSArrayBuffer* thisObject = jsDynamicCast<JSArrayBuffer*>(arrayBufferValue);
+    JSArrayBuffer* thisObject = dynamicDowncast<JSArrayBuffer>(arrayBufferValue);
     if (!thisObject || (ArrayBufferSharingMode::Shared == thisObject->impl()->sharingMode()))
         return throwVMTypeError(globalObject, scope, "Receiver must be ArrayBuffer"_s);
 
@@ -369,7 +369,7 @@ static JSArrayBuffer* arrayBufferProtoFuncTransferImpl(JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSArrayBuffer* thisObject = jsDynamicCast<JSArrayBuffer*>(arrayBufferValue);
+    JSArrayBuffer* thisObject = dynamicDowncast<JSArrayBuffer>(arrayBufferValue);
     if (!thisObject || (ArrayBufferSharingMode::Shared == thisObject->impl()->sharingMode())) {
         throwVMTypeError(globalObject, scope, "Receiver must be ArrayBuffer"_s);
         return nullptr;
@@ -417,7 +417,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayBufferProtoGetterFuncResizable, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsDynamicCast<JSArrayBuffer*>(callFrame->thisValue());
+    auto* thisObject = dynamicDowncast<JSArrayBuffer>(callFrame->thisValue());
     if (!thisObject || (ArrayBufferSharingMode::Shared == thisObject->impl()->sharingMode()))
         return throwVMTypeError(globalObject, scope, "Receiver must be ArrayBuffer"_s);
 
@@ -430,7 +430,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayBufferProtoGetterFuncMaxByteLength, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsDynamicCast<JSArrayBuffer*>(callFrame->thisValue());
+    auto* thisObject = dynamicDowncast<JSArrayBuffer>(callFrame->thisValue());
     if (!thisObject || (ArrayBufferSharingMode::Shared == thisObject->impl()->sharingMode()))
         return throwVMTypeError(globalObject, scope, "Receiver must be ArrayBuffer"_s);
 
@@ -447,7 +447,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayBufferProtoGetterFuncDetached, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsDynamicCast<JSArrayBuffer*>(callFrame->thisValue());
+    auto* thisObject = dynamicDowncast<JSArrayBuffer>(callFrame->thisValue());
     if (!thisObject || (ArrayBufferSharingMode::Shared == thisObject->impl()->sharingMode()))
         return throwVMTypeError(globalObject, scope, "Receiver must be ArrayBuffer"_s);
 
@@ -468,7 +468,7 @@ JSC_DEFINE_HOST_FUNCTION(sharedArrayBufferProtoFuncGrow, (JSGlobalObject* global
 
     JSValue arrayBufferValue = callFrame->thisValue();
 
-    JSArrayBuffer* thisObject = jsDynamicCast<JSArrayBuffer*>(arrayBufferValue);
+    JSArrayBuffer* thisObject = dynamicDowncast<JSArrayBuffer>(arrayBufferValue);
     if (!thisObject || (ArrayBufferSharingMode::Shared != thisObject->impl()->sharingMode()))
         return throwVMTypeError(globalObject, scope, "Receiver must be SharedArrayBuffer"_s);
 
@@ -499,7 +499,7 @@ JSC_DEFINE_HOST_FUNCTION(sharedArrayBufferProtoGetterFuncGrowable, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsDynamicCast<JSArrayBuffer*>(callFrame->thisValue());
+    auto* thisObject = dynamicDowncast<JSArrayBuffer>(callFrame->thisValue());
     if (!thisObject || (ArrayBufferSharingMode::Shared != thisObject->impl()->sharingMode()))
         return throwVMTypeError(globalObject, scope, "Receiver must be SharedArrayBuffer"_s);
 
@@ -512,7 +512,7 @@ JSC_DEFINE_HOST_FUNCTION(sharedArrayBufferProtoGetterFuncMaxByteLength, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsDynamicCast<JSArrayBuffer*>(callFrame->thisValue());
+    auto* thisObject = dynamicDowncast<JSArrayBuffer>(callFrame->thisValue());
     if (!thisObject || (ArrayBufferSharingMode::Shared != thisObject->impl()->sharingMode()))
         return throwVMTypeError(globalObject, scope, "Receiver must be SharedArrayBuffer"_s);
 

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -175,7 +175,7 @@ JSArrayBufferView::JSArrayBufferView(VM& vm, ConstructionContext& context)
 void JSArrayBufferView::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
-    ASSERT(jsDynamicCast<JSArrayBufferView*>(this));
+    ASSERT(is<JSArrayBufferView>(this));
     switch (m_mode) {
     case FastTypedArray:
         return;

--- a/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
@@ -99,7 +99,7 @@ inline RefPtr<ArrayBufferView> JSArrayBufferView::unsharedImpl()
 
 inline RefPtr<ArrayBufferView> JSArrayBufferView::toWrapped(VM&, JSValue value)
 {
-    if (JSArrayBufferView* view = jsDynamicCast<JSArrayBufferView*>(value)) {
+    if (JSArrayBufferView* view = dynamicDowncast<JSArrayBufferView>(value)) {
         if (!view->isShared() && !view->isResizableOrGrowableShared())
             return view->unsharedImpl();
     }
@@ -108,7 +108,7 @@ inline RefPtr<ArrayBufferView> JSArrayBufferView::toWrapped(VM&, JSValue value)
 
 inline RefPtr<ArrayBufferView> JSArrayBufferView::toWrappedAllowResizable(VM&, JSValue value)
 {
-    if (JSArrayBufferView* view = jsDynamicCast<JSArrayBufferView*>(value)) {
+    if (JSArrayBufferView* view = dynamicDowncast<JSArrayBufferView>(value)) {
         if (view->isShared())
             return nullptr;
         return view->unsharedImpl();
@@ -118,7 +118,7 @@ inline RefPtr<ArrayBufferView> JSArrayBufferView::toWrappedAllowResizable(VM&, J
 
 inline RefPtr<ArrayBufferView> JSArrayBufferView::toWrappedAllowShared(VM&, JSValue value)
 {
-    if (JSArrayBufferView* view = jsDynamicCast<JSArrayBufferView*>(value)) {
+    if (JSArrayBufferView* view = dynamicDowncast<JSArrayBufferView>(value)) {
         if (!view->isResizableOrGrowableShared())
             return view->possiblySharedImpl();
     }
@@ -127,7 +127,7 @@ inline RefPtr<ArrayBufferView> JSArrayBufferView::toWrappedAllowShared(VM&, JSVa
 
 inline RefPtr<ArrayBufferView> JSArrayBufferView::toWrappedAllowSharedAndResizable(VM&, JSValue value)
 {
-    if (JSArrayBufferView* view = jsDynamicCast<JSArrayBufferView*>(value))
+    if (JSArrayBufferView* view = dynamicDowncast<JSArrayBufferView>(value))
         return view->possiblySharedImpl();
     return nullptr;
 }

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -139,7 +139,7 @@ JSC_DEFINE_HOST_FUNCTION(boundFunctionConstruct, (JSGlobalObject* globalObject, 
 
 JSC_DEFINE_HOST_FUNCTION(isBoundFunction, (JSGlobalObject*, CallFrame* callFrame))
 {
-    return JSValue::encode(JSValue(static_cast<bool>(jsDynamicCast<JSBoundFunction*>(callFrame->uncheckedArgument(0)))));
+    return JSValue::encode(JSValue(static_cast<bool>(dynamicDowncast<JSBoundFunction>(callFrame->uncheckedArgument(0)))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(hasInstanceBoundFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -152,7 +152,7 @@ JSC_DEFINE_HOST_FUNCTION(hasInstanceBoundFunction, (JSGlobalObject* globalObject
 inline Structure* getBoundFunctionStructure(VM& vm, JSGlobalObject* globalObject, JSObject* targetFunction)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSFunction* targetJSFunction = jsDynamicCast<JSFunction*>(targetFunction);
+    JSFunction* targetJSFunction = dynamicDowncast<JSFunction>(targetFunction);
     if (targetJSFunction && targetJSFunction->getPrototypeDirect() == globalObject->functionPrototype()) [[likely]]
         return globalObject->boundFunctionStructure();
 

--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -447,9 +447,9 @@ WTF::String JSValue::toWTFStringForConsole(JSGlobalObject* globalObject) const
     RETURN_IF_EXCEPTION(scope, { });
     if (isString())
         return tryMakeString('"', result.data, '"');
-    if (jsDynamicCast<JSArray*>(*this))
+    if (is<JSArray>(*this))
         return tryMakeString('[', result.data, ']');
-    if (jsDynamicCast<JSBigInt*>(*this))
+    if (is<JSBigInt>(*this))
         return tryMakeString(result.data, 'n');
     return result;
 }

--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -258,23 +258,6 @@ bool inherits(From* from)
 
 } // namespace JSCastingHelpers
 
-template<typename To, typename From>
-To jsDynamicCast(From* from)
-{
-    using Dispatcher = JSCastingHelpers::InheritsTraits<typename std::remove_cv<typename std::remove_pointer<To>::type>::type>;
-    if (Dispatcher::template inherits<>(from)) [[likely]]
-        return static_cast<To>(from);
-    return nullptr;
-}
-
-template<typename To>
-To jsDynamicCast(JSValue from)
-{
-    if (!from.isCell()) [[unlikely]]
-        return nullptr;
-    return jsDynamicCast<To>(from.asCell());
-}
-
 } // namespace JSC
 
 // Concept that identifies JSCell subclasses without requiring complete types.
@@ -380,7 +363,7 @@ inline To* dynamicDowncast(const JSC::JSValue& value)
         return nullptr;
     JSC::JSCell* cell = value.asCell();
     if (JSC::JSCastingHelpers::InheritsTraits<To>::inherits(cell)) [[likely]]
-        return static_cast<To*>(cell);
+        SUPPRESS_MEMORY_UNSAFE_CAST return static_cast<To*>(cell);
     return nullptr;
 }
 
@@ -391,7 +374,7 @@ inline To* downcast(JSC::JSValue& value)
     RELEASE_ASSERT(value.isCell());
     JSC::JSCell* cell = value.asCell();
     RELEASE_ASSERT(JSC::JSCastingHelpers::InheritsTraits<To>::inherits(cell));
-    return static_cast<To*>(cell);
+    SUPPRESS_MEMORY_UNSAFE_CAST return static_cast<To*>(cell);
 }
 
 template<typename To>

--- a/Source/JavaScriptCore/runtime/JSCell.cpp
+++ b/Source/JavaScriptCore/runtime/JSCell.cpp
@@ -149,22 +149,22 @@ bool JSCell::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject, u
 
 JSValue JSCell::toPrimitive(JSGlobalObject* globalObject, PreferredPrimitiveType preferredType) const
 {
-    if (const auto* string = jsDynamicCast<const JSString*>(this))
+    if (const auto* string = dynamicDowncast<JSString>(this))
         return string->toPrimitive(globalObject, preferredType);
-    if (const auto* symbol = jsDynamicCast<const Symbol*>(this))
+    if (const auto* symbol = dynamicDowncast<Symbol>(this))
         return symbol->toPrimitive(globalObject, preferredType);
-    if (const auto* bigInt = jsDynamicCast<const JSBigInt*>(this))
+    if (const auto* bigInt = dynamicDowncast<JSBigInt>(this))
         return bigInt->toPrimitive(globalObject, preferredType);
     return downcast<JSObject>(this)->toPrimitive(globalObject, preferredType);
 }
 
 double JSCell::toNumber(JSGlobalObject* globalObject) const
 {
-    if (const auto* string = jsDynamicCast<const JSString*>(this))
+    if (const auto* string = dynamicDowncast<JSString>(this))
         return string->toNumber(globalObject);
-    if (const auto* symbol = jsDynamicCast<const Symbol*>(this))
+    if (const auto* symbol = dynamicDowncast<Symbol>(this))
         return symbol->toNumber(globalObject);
-    if (const auto* bigInt = jsDynamicCast<const JSBigInt*>(this))
+    if (const auto* bigInt = dynamicDowncast<JSBigInt>(this))
         return bigInt->toNumber(globalObject);
     return downcast<JSObject>(this)->toNumber(globalObject);
 }
@@ -189,9 +189,9 @@ JSObject* JSCell::toObjectSlow(JSGlobalObject* globalObject) const
 {
     Integrity::auditStructureID(structureID());
     ASSERT(!isObject());
-    if (const auto* string = jsDynamicCast<const JSString*>(this))
+    if (const auto* string = dynamicDowncast<JSString>(this))
         return string->toObject(globalObject);
-    if (const auto* bigInt = jsDynamicCast<const JSBigInt*>(this))
+    if (const auto* bigInt = dynamicDowncast<JSBigInt>(this))
         return bigInt->toObject(globalObject);
     return downcast<Symbol>(this)->toObject(globalObject);
 }
@@ -267,7 +267,7 @@ JSString* JSCell::toStringSlowCase(JSGlobalObject* globalObject) const
 
     ASSERT(isSymbol() || isHeapBigInt());
     auto* emptyString = jsEmptyString(vm);
-    if (auto* bigInt = jsDynamicCast<JSBigInt*>(const_cast<JSCell*>(this))) {
+    if (auto* bigInt = dynamicDowncast<JSBigInt>(const_cast<JSCell*>(this))) {
         // FIXME: we should rather have two cases here: one-character string vs jsNonTrivialString for everything else.
         auto string = bigInt->toString(globalObject, 10);
         RETURN_IF_EXCEPTION(scope, emptyString);

--- a/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
@@ -139,7 +139,7 @@ EncodedJSValue getData(JSGlobalObject* globalObject, CallFrame* callFrame)
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSDataView* dataView = jsDynamicCast<JSDataView*>(callFrame->thisValue());
+    JSDataView* dataView = dynamicDowncast<JSDataView>(callFrame->thisValue());
     if (!dataView)
         return throwVMTypeError(globalObject, scope, "Receiver of DataView method must be a DataView"_s);
     
@@ -183,7 +183,7 @@ EncodedJSValue setData(JSGlobalObject* globalObject, CallFrame* callFrame)
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSDataView* dataView = jsDynamicCast<JSDataView*>(callFrame->thisValue());
+    JSDataView* dataView = dynamicDowncast<JSDataView>(callFrame->thisValue());
     if (!dataView)
         return throwVMTypeError(globalObject, scope, "Receiver of DataView method must be a DataView"_s);
     
@@ -228,7 +228,7 @@ JSC_DEFINE_CUSTOM_GETTER(dataViewProtoGetterBuffer, (JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSDataView* view = jsDynamicCast<JSDataView*>(JSValue::decode(thisValue));
+    JSDataView* view = dynamicDowncast<JSDataView>(JSValue::decode(thisValue));
     if (!view)
         return throwVMTypeError(globalObject, scope, "DataView.prototype.buffer expects |this| to be a DataView object"_s);
 
@@ -240,7 +240,7 @@ JSC_DEFINE_HOST_FUNCTION(dataViewProtoGetterByteLength, (JSGlobalObject* globalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSDataView* view = jsDynamicCast<JSDataView*>(callFrame->thisValue());
+    JSDataView* view = dynamicDowncast<JSDataView>(callFrame->thisValue());
     if (!view) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "DataView.prototype.byteLength expects |this| to be a DataView object"_s);
 
@@ -257,7 +257,7 @@ JSC_DEFINE_CUSTOM_GETTER(dataViewProtoGetterByteOffset, (JSGlobalObject* globalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSDataView* view = jsDynamicCast<JSDataView*>(JSValue::decode(thisValue));
+    JSDataView* view = dynamicDowncast<JSDataView>(JSValue::decode(thisValue));
     if (!view)
         return throwVMTypeError(globalObject, scope, "DataView.prototype.byteOffset expects |this| to be a DataView object"_s);
 

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -117,7 +117,7 @@ JSFunction::JSFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* glo
 void JSFunction::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
-    ASSERT(jsDynamicCast<JSFunction*>(this));
+    ASSERT(is<JSFunction>(this));
     ASSERT(type() == JSFunctionType);
     // JSCell::{getCallData,getConstructData} relies on the following conditions.
     ASSERT(methodTable()->getConstructData == &JSFunction::getConstructData);
@@ -487,7 +487,7 @@ CallData JSFunction::getConstructData(JSCell* cell)
 
 String getCalculatedDisplayName(VM& vm, JSObject* object)
 {
-    if (!jsDynamicCast<JSFunction*>(object) && !jsDynamicCast<InternalFunction*>(object))
+    if (!is<JSFunction>(object) && !is<InternalFunction>(object))
         return emptyString();
 
     Structure* structure = object->structure();
@@ -500,14 +500,14 @@ String getCalculatedDisplayName(VM& vm, JSObject* object)
             return asString(displayName)->tryGetValueWithoutGC();
     }
 
-    if (auto* function = jsDynamicCast<JSFunction*>(object)) {
+    if (auto* function = dynamicDowncast<JSFunction>(object)) {
         String actualName = function->nameWithoutGC(vm);
         if (!actualName.isEmpty() || function->isHostOrBuiltinFunction())
             return actualName;
 
         return function->jsExecutable()->ecmaName().string();
     }
-    if (auto* function = jsDynamicCast<InternalFunction*>(object))
+    if (auto* function = dynamicDowncast<InternalFunction>(object))
         return function->name();
 
     return emptyString();

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
@@ -40,7 +40,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSString* jsString = jsDynamicCast<JSString*>(callFrame->argument(0));
+    JSString* jsString = dynamicDowncast<JSString>(callFrame->argument(0));
     if (!jsString) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.fromBase64 requires a string"_s);
 
@@ -49,14 +49,14 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
 
     JSValue optionsValue = callFrame->argument(1);
     if (!optionsValue.isUndefined()) {
-        JSObject* optionsObject = jsDynamicCast<JSObject*>(optionsValue);
+        JSObject* optionsObject = dynamicDowncast<JSObject>(optionsValue);
         if (!optionsValue.isObject()) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "Uint8Array.fromBase64 requires that options be an object"_s);
 
         JSValue alphabetValue = optionsObject->get(globalObject, vm.propertyNames->alphabet);
         RETURN_IF_EXCEPTION(scope, { });
         if (!alphabetValue.isUndefined()) {
-            JSString* alphabetString = jsDynamicCast<JSString*>(alphabetValue);
+            JSString* alphabetString = dynamicDowncast<JSString>(alphabetValue);
             if (!alphabetString) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "Uint8Array.fromBase64 requires that alphabet be \"base64\" or \"base64url\""_s);
 
@@ -71,7 +71,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
         JSValue lastChunkHandlingValue = optionsObject->get(globalObject, vm.propertyNames->lastChunkHandling);
         RETURN_IF_EXCEPTION(scope, { });
         if (!lastChunkHandlingValue.isUndefined()) {
-            JSString* lastChunkHandlingString = jsDynamicCast<JSString*>(lastChunkHandlingValue);
+            JSString* lastChunkHandlingString = dynamicDowncast<JSString>(lastChunkHandlingValue);
             if (!lastChunkHandlingString) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "Uint8Array.fromBase64 requires that lastChunkHandling be \"loose\", \"strict\", or \"stop-before-partial\""_s);
 
@@ -215,7 +215,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromHex, (JSGlobalObject* globalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSString* jsString = jsDynamicCast<JSString*>(callFrame->argument(0));
+    JSString* jsString = dynamicDowncast<JSString>(callFrame->argument(0));
     if (!jsString) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.fromHex requires a string"_s);
     if (jsString->length() % 2) [[unlikely]]

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -121,7 +121,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // https://tc39.es/proposal-resizablearraybuffer/#sec-initializetypedarrayfromarraybuffer
-    if (JSArrayBuffer* jsBuffer = jsDynamicCast<JSArrayBuffer*>(firstValue)) {
+    if (JSArrayBuffer* jsBuffer = dynamicDowncast<JSArrayBuffer>(firstValue)) {
         RefPtr<ArrayBuffer> buffer = jsBuffer->impl();
         if (buffer->isDetached()) {
             throwTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
@@ -160,7 +160,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
     // - Another array. This creates a copy of the of that array.
     // - A primitive. This creates a new typed array of that length and zero-initializes it.
 
-    if (JSObject* object = jsDynamicCast<JSObject*>(firstValue)) {
+    if (JSObject* object = dynamicDowncast<JSObject>(firstValue)) {
         size_t length;
 
         // https://tc39.es/proposal-resizablearraybuffer/#sec-initializetypedarrayfromtypedarray
@@ -193,7 +193,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
 
         // This getPropertySlot operation should not be observed by the Proxy.
         // So we use VMInquiry. And purge the opaque object cases (proxy and namespace object) by isTaintedByOpaqueObject() guard.
-        if (JSArray* array = jsDynamicCast<JSArray*>(object); array && isJSArray(array) && array->isIteratorProtocolFastAndNonObservable()) [[likely]]
+        if (JSArray* array = dynamicDowncast<JSArray>(object); array && isJSArray(array) && array->isIteratorProtocolFastAndNonObservable()) [[likely]]
             length = array->length();
         else {
             PropertySlot lengthSlot(object, PropertySlot::InternalMethodType::VMInquiry, &vm);
@@ -271,7 +271,7 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
     JSValue firstValue = callFrame->uncheckedArgument(0);
     size_t offset = 0;
     std::optional<size_t> length;
-    if (auto* arrayBuffer = jsDynamicCast<JSArrayBuffer*>(firstValue)) {
+    if (auto* arrayBuffer = dynamicDowncast<JSArrayBuffer>(firstValue)) {
         if (argCount > 1) {
             offset = callFrame->uncheckedArgument(1).toIndex(globalObject, "byteOffset"_s);
             RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -430,7 +430,7 @@ bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalOb
     size_t safeLength = objectOffset <= safeUnadjustedLength ? safeUnadjustedLength - objectOffset : 0;
 
     if constexpr (TypedArrayStorageType != TypeBigInt64 && TypedArrayStorageType != TypeBigUint64) {
-        if (JSArray* array = jsDynamicCast<JSArray*>(object); array && isJSArray(array)) [[likely]] {
+        if (JSArray* array = dynamicDowncast<JSArray>(object); array && isJSArray(array)) [[likely]] {
             if (safeLength == length && (safeLength + objectOffset) <= array->length() && array->isIteratorProtocolFastAndNonObservable()) {
                 IndexingType indexingType = array->indexingType() & IndexingShapeMask;
                 if (indexingType == Int32Shape) {
@@ -474,7 +474,7 @@ bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalOb
         return false;
     }
 
-    if (JSArray* array = jsDynamicCast<JSArray*>(sourceValue); array && isJSArray(array)) [[likely]]
+    if (JSArray* array = dynamicDowncast<JSArray>(sourceValue); array && isJSArray(array)) [[likely]]
         RELEASE_AND_RETURN(scope, setFromArrayLike(globalObject, offset, array, 0, array->length()));
 
     size_t targetLength = this->length();
@@ -526,7 +526,7 @@ RefPtr<typename Adaptor::ViewType> JSGenericTypedArrayView<Adaptor>::unsharedTyp
 
 template<typename Adaptor> inline RefPtr<typename Adaptor::ViewType> toPossiblySharedNativeTypedView(VM&, JSValue value)
 {
-    auto* wrapper = jsDynamicCast<typename Adaptor::JSViewType*>(value);
+    auto* wrapper = dynamicDowncast<typename Adaptor::JSViewType>(value);
     if (!wrapper)
         return nullptr;
     return wrapper->possiblySharedTypedImpl();

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
@@ -42,11 +42,11 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSUint8Array* uint8Array = jsDynamicCast<JSUint8Array*>(callFrame->thisValue());
+    JSUint8Array* uint8Array = dynamicDowncast<JSUint8Array>(callFrame->thisValue());
     if (!uint8Array) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires that |this| be a Uint8Array"_s);
 
-    JSString* jsString = jsDynamicCast<JSString*>(callFrame->argument(0));
+    JSString* jsString = dynamicDowncast<JSString>(callFrame->argument(0));
     if (!jsString) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires a string"_s);
 
@@ -55,14 +55,14 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
 
     JSValue optionsValue = callFrame->argument(1);
     if (!optionsValue.isUndefined()) {
-        JSObject* optionsObject = jsDynamicCast<JSObject*>(optionsValue);
+        JSObject* optionsObject = dynamicDowncast<JSObject>(optionsValue);
         if (!optionsValue.isObject()) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires that options be an object"_s);
 
         JSValue alphabetValue = optionsObject->get(globalObject, vm.propertyNames->alphabet);
         RETURN_IF_EXCEPTION(scope, { });
         if (!alphabetValue.isUndefined()) {
-            JSString* alphabetString = jsDynamicCast<JSString*>(alphabetValue);
+            JSString* alphabetString = dynamicDowncast<JSString>(alphabetValue);
             if (!alphabetString) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires that alphabet be \"base64\" or \"base64url\""_s);
 
@@ -77,7 +77,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64, (JSGlobalObject* glob
         JSValue lastChunkHandlingValue = optionsObject->get(globalObject, vm.propertyNames->lastChunkHandling);
         RETURN_IF_EXCEPTION(scope, { });
         if (!lastChunkHandlingValue.isUndefined()) {
-            JSString* lastChunkHandlingString = jsDynamicCast<JSString*>(lastChunkHandlingValue);
+            JSString* lastChunkHandlingString = dynamicDowncast<JSString>(lastChunkHandlingValue);
             if (!lastChunkHandlingString) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromBase64 requires that lastChunkHandling be \"loose\", \"strict\", or \"stop-before-partial\""_s);
 
@@ -117,7 +117,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromHex, (JSGlobalObject* globalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSUint8Array* uint8Array = jsDynamicCast<JSUint8Array*>(callFrame->thisValue());
+    JSUint8Array* uint8Array = dynamicDowncast<JSUint8Array>(callFrame->thisValue());
     if (!uint8Array) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromHex requires that |this| be a Uint8Array"_s);
 
@@ -125,7 +125,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromHex, (JSGlobalObject* globalO
     if (isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)) [[unlikely]]
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
-    JSString* jsString = jsDynamicCast<JSString*>(callFrame->argument(0));
+    JSString* jsString = dynamicDowncast<JSString>(callFrame->argument(0));
     if (!jsString) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.setFromHex requires a string"_s);
     if (jsString->length() % 2) [[unlikely]]
@@ -160,7 +160,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToBase64, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSUint8Array* uint8Array = jsDynamicCast<JSUint8Array*>(callFrame->thisValue());
+    JSUint8Array* uint8Array = dynamicDowncast<JSUint8Array>(callFrame->thisValue());
     if (!uint8Array) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toBase64 requires that |this| be a Uint8Array"_s);
 
@@ -168,14 +168,14 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToBase64, (JSGlobalObject* globalObj
 
     JSValue optionsValue = callFrame->argument(0);
     if (!optionsValue.isUndefined()) {
-        JSObject* optionsObject = jsDynamicCast<JSObject*>(optionsValue);
+        JSObject* optionsObject = dynamicDowncast<JSObject>(optionsValue);
         if (!optionsObject) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toBase64 requires that options be an object"_s);
 
         JSValue alphabetValue = optionsObject->get(globalObject, vm.propertyNames->alphabet);
         RETURN_IF_EXCEPTION(scope, { });
         if (!alphabetValue.isUndefined()) {
-            JSString* alphabetString = jsDynamicCast<JSString*>(alphabetValue);
+            JSString* alphabetString = dynamicDowncast<JSString>(alphabetValue);
             if (!alphabetString) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toBase64 requires that alphabet be \"base64\" or \"base64url\""_s);
 
@@ -213,7 +213,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToHex, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSUint8Array* uint8Array = jsDynamicCast<JSUint8Array*>(callFrame->thisValue());
+    JSUint8Array* uint8Array = dynamicDowncast<JSUint8Array>(callFrame->thisValue());
     if (!uint8Array) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Uint8Array.prototype.toHex requires that |this| be a Uint8Array"_s);
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -146,7 +146,7 @@ inline JSArrayBufferView* speciesConstruct(JSGlobalObject* globalObject, ViewCla
     JSValue result = construct(globalObject, species, args, "species is not a constructor"_s);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    if (JSArrayBufferView* view = jsDynamicCast<JSArrayBufferView*>(result); view) [[likely]] {
+    if (JSArrayBufferView* view = dynamicDowncast<JSArrayBufferView>(result); view) [[likely]] {
         if (view->type() == DataViewType) [[unlikely]] {
             throwTypeError(globalObject, scope, "species constructor did not return a TypedArray View"_s);
             return nullptr;
@@ -1804,14 +1804,14 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewPrivateFuncFromFast(VM& vm, JS
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue arrayLike = callFrame->uncheckedArgument(1);
-    JSArrayBufferView* items = jsDynamicCast<JSArrayBufferView*>(arrayLike);
+    JSArrayBufferView* items = dynamicDowncast<JSArrayBufferView>(arrayLike);
     if (!items) {
         // Converting Double or Int32 to BigInt throws an error.
         if constexpr (ViewClass::TypedArrayStorageType == TypeBigInt64 || ViewClass::TypedArrayStorageType == TypeBigUint64)
             return JSValue::encode(jsUndefined());
 
         // TypedArray.from(Array) case.
-        JSArray* array = jsDynamicCast<JSArray*>(arrayLike);
+        JSArray* array = dynamicDowncast<JSArray>(arrayLike);
         if (!array)
             return JSValue::encode(jsUndefined());
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -859,7 +859,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorQueueEnqueue, (JSGlobalObject* globalObje
 {
     VM& vm = globalObject->vm();
 
-    JSAsyncGenerator* generator = jsDynamicCast<JSAsyncGenerator*>(callFrame->uncheckedArgument(0));
+    JSAsyncGenerator* generator = dynamicDowncast<JSAsyncGenerator>(callFrame->uncheckedArgument(0));
     JSValue value = callFrame->uncheckedArgument(1);
     int32_t resumeMode = callFrame->uncheckedArgument(2).asInt32();
     JSPromise* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(3));
@@ -973,7 +973,7 @@ static ObjectPropertyCondition setupAdaptiveWatchpoint(JSGlobalObject* globalObj
     RELEASE_ASSERT(slot.isCacheableValue() || slot.isCacheableGetter());
     JSValue functionValue = slot.isCacheableValue() ? slot.getValue(globalObject, ident) : slot.getterSetter();
     catchScope.assertNoException();
-    ASSERT(jsDynamicCast<JSFunction*>(functionValue) || jsDynamicCast<GetterSetter*>(functionValue));
+    ASSERT(is<JSFunction>(functionValue) || is<GetterSetter>(functionValue));
 
     ObjectPropertyCondition condition = generateConditionForSelfEquivalence(vm, nullptr, base, ident.impl());
     RELEASE_ASSERT(condition.requiredValue() == functionValue);
@@ -1849,7 +1849,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     {
         JSValue hasOwnPropertyFunction = jsCast<JSFunction*>(objectPrototype()->get(this, vm.propertyNames->hasOwnProperty));
         catchScope.assertNoException();
-        RELEASE_ASSERT(!!jsDynamicCast<JSFunction*>(hasOwnPropertyFunction));
+        RELEASE_ASSERT(is<JSFunction>(hasOwnPropertyFunction));
         m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::hasOwnPropertyFunction)].set(vm, this, jsCast<JSFunction*>(hasOwnPropertyFunction));
     }
 
@@ -3265,7 +3265,7 @@ void JSGlobalObject::tryInstallSpeciesWatchpoint(JSObject* prototype, JSObject* 
         speciesCondition = ObjectPropertyCondition::equivalence(vm, this, constructor, vm.propertyNames->speciesSymbol.impl(), speciesGetterSetter);
         break;
     case HasSpeciesProperty::No:
-        speciesCondition = ObjectPropertyCondition::absence(vm, this, constructor, vm.propertyNames->speciesSymbol.impl(), jsDynamicCast<JSObject*>(constructor->getPrototypeDirect()));
+        speciesCondition = ObjectPropertyCondition::absence(vm, this, constructor, vm.propertyNames->speciesSymbol.impl(), dynamicDowncast<JSObject>(constructor->getPrototypeDirect()));
         break;
     }
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -740,7 +740,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncProtoSetter, (JSGlobalObject* globalObject, C
 
     JSValue value = callFrame->argument(0);
 
-    JSObject* thisObject = jsDynamicCast<JSObject*>(thisValue);
+    JSObject* thisObject = dynamicDowncast<JSObject>(thisValue);
 
     // Setting __proto__ of a primitive should have no effect.
     if (!thisObject)

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -835,7 +835,7 @@ static void moduleRegistryFetchSettled(JSGlobalObject* globalObject, VM& vm, Thr
         makeModulePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleRegistryModuleSettled, modulePromise, entry);
     } else {
         JSValue errorValue = arguments[1];
-        if (auto* error = jsDynamicCast<ErrorInstance*>(errorValue))
+        if (auto* error = dynamicDowncast<ErrorInstance>(errorValue))
             JSModuleLoader::attachErrorInfo(globalObject, error, nullptr, entry->key(), entry->moduleType(), JSModuleLoader::ModuleFailure::Kind::Instantiation);
         entry->fetchError(globalObject, errorValue);
         modulePromise->reject(vm, globalObject, errorValue);
@@ -870,7 +870,7 @@ static void moduleGraphLoadingError(JSGlobalObject* globalObject, VM& vm, ThrowS
     if (status == JSPromise::Status::Rejected) {
         auto* state = jsCast<ModuleGraphLoadingState*>(arguments[2]);
         JSValue errorValue = arguments[1];
-        if (auto* error = jsDynamicCast<ErrorInstance*>(errorValue)) {
+        if (auto* error = dynamicDowncast<ErrorInstance>(errorValue)) {
             errorValue = JSModuleLoader::maybeDuplicateFetchError(globalObject, error);
             RETURN_IF_EXCEPTION(scope, void());
         }
@@ -916,7 +916,7 @@ static void moduleLoadStep(JSGlobalObject* globalObject, VM& vm, ThrowScope& sco
 
             // setEntryRecord logic
             auto* entry = context->entry();
-            if (auto* cyclic = jsDynamicCast<CyclicModuleRecord*>(module); cyclic && cyclic->status() != CyclicModuleRecord::Status::Unlinked) {
+            if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(module); cyclic && cyclic->status() != CyclicModuleRecord::Status::Unlinked) {
                 ASSERT(cyclic->status() != CyclicModuleRecord::Status::Linking);
                 loadPromise->fulfill(vm, globalObject, entry->record());
             } else {
@@ -1024,7 +1024,7 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
             return;
         }
         JSValue errorValue = arguments[1];
-        if (auto* error = jsDynamicCast<ErrorInstance*>(errorValue)) {
+        if (auto* error = dynamicDowncast<ErrorInstance>(errorValue)) {
             auto failure = JSModuleLoader::getErrorInfo(globalObject, error);
             if (failure.isEvaluationError(specifier, type))
                 entry->evaluationError(globalObject, error);
@@ -1055,7 +1055,7 @@ static void moduleLoadTopRejected(JSGlobalObject* globalObject, VM& vm, ThrowSco
             return;
         }
         if (JSValue fetchErrorValue = entry->fetchError()) {
-            if (ErrorInstance* fetchError = jsDynamicCast<ErrorInstance*>(fetchErrorValue)) {
+            if (ErrorInstance* fetchError = dynamicDowncast<ErrorInstance>(fetchErrorValue)) {
                 ErrorInstance* fetchErrorCopy = JSModuleLoader::maybeDuplicateFetchError(globalObject, fetchError);
                 if (scope.exception()) {
                     resultPromise->rejectWithCaughtException(globalObject, scope);
@@ -1195,7 +1195,7 @@ static void moduleLoadStoreError(JSGlobalObject* globalObject, ThrowScope& scope
         auto type = context->moduleRequest().type();
         ModuleRegistryEntry* entry = globalObject->moduleLoader()->ensureRegistered(globalObject, specifier, type);
         RETURN_IF_EXCEPTION(scope, void());
-        if (auto* error = jsDynamicCast<ErrorInstance*>(errorValue)) {
+        if (auto* error = dynamicDowncast<ErrorInstance>(errorValue)) {
             auto failure = JSModuleLoader::getErrorInfo(globalObject, error);
             if (failure.isEvaluationError(specifier, type))
                 entry->evaluationError(globalObject, error);
@@ -1432,7 +1432,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         }
 
         if (error) {
-            if (auto* promise = jsDynamicCast<JSPromise*>(promiseOrCapability))
+            if (auto* promise = dynamicDowncast<JSPromise>(promiseOrCapability))
                 RELEASE_AND_RETURN(scope, promise->rejectPromise(vm, globalObject, error));
 
             JSValue reject = promiseOrCapability.get(globalObject, vm.propertyNames->reject);
@@ -1446,7 +1446,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
             return;
         }
 
-        if (auto* promise = jsDynamicCast<JSPromise*>(promiseOrCapability))
+        if (auto* promise = dynamicDowncast<JSPromise>(promiseOrCapability))
             RELEASE_AND_RETURN(scope, promise->resolvePromise(globalObject, vm, result));
 
         JSValue resolve = promiseOrCapability.get(globalObject, vm.propertyNames->resolve);

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -199,7 +199,7 @@ JSModuleLoader::ModuleFailure JSModuleLoader::getErrorInfo(JSGlobalObject* globa
     VM& vm = globalObject->vm();
     JSModuleLoader::ModuleFailure failure;
     if (JSValue sourceValue = error->getDirect(vm, vm.propertyNames->builtinNames().moduleFailureModuleRecordPrivateName()))
-        failure.m_source = jsDynamicCast<AbstractModuleRecord*>(sourceValue);
+        failure.m_source = dynamicDowncast<AbstractModuleRecord>(sourceValue);
     if (JSValue keyValue = error->getDirect(vm, vm.propertyNames->builtinNames().moduleFailureModuleKeyPrivateName()))
         failure.m_key = jsValueToSpecifier(globalObject, keyValue);
     if (JSValue typeValue = error->getDirect(vm, vm.propertyNames->builtinNames().moduleFailureModuleTypePrivateName()))
@@ -224,7 +224,7 @@ void JSModuleLoader::attachErrorInfo(JSGlobalObject* globalObject, ErrorInstance
 
 bool JSModuleLoader::attachErrorInfo(JSGlobalObject* globalObject, Exception* exception, AbstractModuleRecord* source, const Identifier& key, ScriptFetchParameters::Type type, ModuleFailure::Kind kind)
 {
-    if (auto* error = jsDynamicCast<ErrorInstance*>(exception->value())) {
+    if (auto* error = dynamicDowncast<ErrorInstance>(exception->value())) {
         attachErrorInfo(globalObject, error, source, key, type, kind);
         return true;
     }
@@ -312,7 +312,7 @@ JSArray* JSModuleLoader::dependencyKeysIfEvaluated(JSGlobalObject* globalObject,
     if (auto status = entry->status(); status != ModuleRegistryEntry::Status::Fetched && status != ModuleRegistryEntry::Status::EvaluationFailed)
         RELEASE_AND_RETURN(scope, nullptr);
 
-    if (auto* cyclic = jsDynamicCast<CyclicModuleRecord*>(record); cyclic && cyclic->status() != CyclicModuleRecord::Status::Evaluated)
+    if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(record); cyclic && cyclic->status() != CyclicModuleRecord::Status::Evaluated)
         RELEASE_AND_RETURN(scope, nullptr);
 
     const Vector<AbstractModuleRecord::ModuleRequest>& requests = record->requestedModules();
@@ -346,7 +346,7 @@ void JSModuleLoader::provideFetch(JSGlobalObject* globalObject, const Identifier
 
 static auto getFetchType(JSValue parameters, ScriptFetchParameters::Type fallback = ScriptFetchParameters::Type::JavaScript)
 {
-    if (auto* jsParameters = jsDynamicCast<JSScriptFetchParameters*>(parameters))
+    if (auto* jsParameters = dynamicDowncast<JSScriptFetchParameters>(parameters))
         return jsParameters->parameters().type();
     return fallback;
 }
@@ -411,7 +411,7 @@ JSPromise* JSModuleLoader::linkAndEvaluateModule(JSGlobalObject* globalObject, c
     if (Exception* exception = scope.exception()) {
         attachErrorInfo(globalObject, scope, record, entry->key(), entry->moduleType(), ModuleFailure::Kind::Instantiation);
         entry->instantiationError(globalObject, exception->value());
-        if (auto* cyclic = jsDynamicCast<CyclicModuleRecord*>(record))
+        if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(record))
             cyclic->evaluationError(vm, exception->value());
         return nullptr;
     }
@@ -530,7 +530,7 @@ JSValue JSModuleLoader::evaluate(JSGlobalObject* globalObject, JSValue key, JSVa
 
 JSValue JSModuleLoader::evaluateNonVirtual(JSGlobalObject* globalObject, JSValue, JSValue moduleRecordValue, JSValue, JSValue sentValue, JSValue resumeMode)
 {
-    if (auto* moduleRecord = jsDynamicCast<AbstractModuleRecord*>(moduleRecordValue))
+    if (auto* moduleRecord = dynamicDowncast<AbstractModuleRecord>(moduleRecordValue))
         return moduleRecord->evaluate(globalObject, sentValue, resumeMode);
     return jsUndefined();
 }
@@ -540,7 +540,7 @@ JSModuleNamespaceObject* JSModuleLoader::getModuleNamespaceObject(JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* moduleRecord = jsDynamicCast<AbstractModuleRecord*>(moduleRecordValue);
+    auto* moduleRecord = dynamicDowncast<AbstractModuleRecord>(moduleRecordValue);
     if (!moduleRecord) {
         throwTypeError(globalObject, scope);
         return nullptr;
@@ -645,7 +645,7 @@ JSPromise* JSModuleLoader::hostLoadImportedModule(JSGlobalObject* globalObject, 
         // This allows fetch errors to propagate first because they're required to have priority.
         // To avoid a race condition, instantiation errors need to be checked later, not here.
         if (JSValue fetchError = mapEntry->fetchError()) {
-            if (auto* errorInstance = jsDynamicCast<ErrorInstance*>(fetchError)) {
+            if (auto* errorInstance = dynamicDowncast<ErrorInstance>(fetchError)) {
                 fetchError = JSModuleLoader::duplicateError(globalObject, errorInstance);
                 RETURN_IF_EXCEPTION(scope, nullptr);
             }
@@ -740,7 +740,7 @@ void JSModuleLoader::innerModuleLoading(JSGlobalObject* globalObject, ModuleGrap
     // 1. Assert: state.[[IsLoading]] is true.
     ASSERT(state->isLoading());
     // 2. If module is a Cyclic Module Record, module.[[Status]] is NEW, and state.[[Visited]] does not contain module, then
-    if (auto* cyclic = jsDynamicCast<CyclicModuleRecord*>(module); cyclic && cyclic->status() == CyclicModuleRecord::Status::New && !state->containsVisited(cyclic)) {
+    if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(module); cyclic && cyclic->status() == CyclicModuleRecord::Status::New && !state->containsVisited(cyclic)) {
         // 2.a. Append module to state.[[Visited]].
         state->appendVisited(vm, cyclic);
         // 2.b. Let requestedModulesCount be the number of elements in module.[[RequestedModules]].

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -514,10 +514,10 @@ String JSObject::calculatedClassName(JSObject* object)
     if (object->getOwnPropertySlot(object, globalObject, vm.propertyNames->constructor, slot)) {
         EXCEPTION_ASSERT(!scope.exception());
         if (slot.isValue()) {
-            if (JSObject* ctorObject = jsDynamicCast<JSObject*>(slot.getValue(globalObject, vm.propertyNames->constructor))) {
-                if (JSFunction* constructorFunction = jsDynamicCast<JSFunction*>(ctorObject))
+            if (JSObject* ctorObject = dynamicDowncast<JSObject>(slot.getValue(globalObject, vm.propertyNames->constructor))) {
+                if (JSFunction* constructorFunction = dynamicDowncast<JSFunction>(ctorObject))
                     constructorFunctionName = constructorFunction->calculatedDisplayName(vm);
-                else if (InternalFunction* constructorFunction = jsDynamicCast<InternalFunction*>(ctorObject))
+                else if (InternalFunction* constructorFunction = dynamicDowncast<InternalFunction>(ctorObject))
                     constructorFunctionName = constructorFunction->calculatedDisplayName(vm);
             }
         }
@@ -538,10 +538,10 @@ String JSObject::calculatedClassName(JSObject* object)
                 if (protoObject->getPropertySlot(globalObject, vm.propertyNames->constructor, slot)) {
                     EXCEPTION_ASSERT(!scope.exception());
                     if (slot.isValue()) {
-                        if (JSObject* ctorObject = jsDynamicCast<JSObject*>(slot.getValue(globalObject, vm.propertyNames->constructor))) {
-                            if (JSFunction* constructorFunction = jsDynamicCast<JSFunction*>(ctorObject))
+                        if (JSObject* ctorObject = dynamicDowncast<JSObject>(slot.getValue(globalObject, vm.propertyNames->constructor))) {
+                            if (JSFunction* constructorFunction = dynamicDowncast<JSFunction>(ctorObject))
                                 constructorFunctionName = constructorFunction->calculatedDisplayName(vm);
-                            else if (InternalFunction* constructorFunction = jsDynamicCast<InternalFunction*>(ctorObject))
+                            else if (InternalFunction* constructorFunction = dynamicDowncast<InternalFunction>(ctorObject))
                                 constructorFunctionName = constructorFunction->calculatedDisplayName(vm);
                         }
                     }
@@ -3000,7 +3000,7 @@ ALWAYS_INLINE static bool canDoFastPutDirectIndex(JSObject* object)
         return false;
 
     return (isJSArray(object) && !isCopyOnWrite(object->indexingMode()))
-        || jsDynamicCast<JSFinalObject*>(object);
+        || is<JSFinalObject>(object);
 }
 
 // https://tc39.es/ecma262/#sec-ordinarydefineownproperty

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -936,7 +936,7 @@ protected:
     void finishCreation(VM& vm)
     {
         Base::finishCreation(vm);
-        ASSERT(jsDynamicCast<JSObject*>(this));
+        ASSERT(is<JSObject>(this));
         ASSERT(structure()->hasPolyProto() || getPrototypeDirect().isNull() || Heap::heap(this) == Heap::heap(getPrototypeDirect()));
         ASSERT(structure()->isObject());
         ASSERT(classInfo());

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -147,9 +147,9 @@ JSPromise::DeferredData JSPromise::createDeferredData(JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto [ promiseCapability, resolveCapability, rejectCapability ] = newPromiseCapability(globalObject, promiseConstructor);
     RETURN_IF_EXCEPTION(scope, { });
-    auto* promise = jsDynamicCast<JSPromise*>(promiseCapability);
-    auto* resolve = jsDynamicCast<JSFunction*>(resolveCapability);
-    auto* reject  = jsDynamicCast<JSFunction*>(rejectCapability);
+    auto* promise = dynamicDowncast<JSPromise>(promiseCapability);
+    auto* resolve = dynamicDowncast<JSFunction>(resolveCapability);
+    auto* reject  = dynamicDowncast<JSFunction>(rejectCapability);
     if (promise && resolve && reject)
         return DeferredData { promise, resolve, reject };
 
@@ -399,7 +399,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionResolve, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* other = jsDynamicCast<JSFunctionWithFields*>(callee->getField(JSFunctionWithFields::Field::ResolvingOther));
+    auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::ResolvingOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -418,7 +418,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionReject, (JSGlobalObject* global
     VM& vm = globalObject->vm();
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* other = jsDynamicCast<JSFunctionWithFields*>(callee->getField(JSFunctionWithFields::Field::ResolvingOther));
+    auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::ResolvingOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -457,7 +457,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionResolveWithInternalMicrotask, (
     VM& vm = globalObject->vm();
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* other = jsDynamicCast<JSFunctionWithFields*>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther));
+    auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -476,7 +476,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionRejectWithInternalMicrotask, (J
     VM& vm = globalObject->vm();
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* other = jsDynamicCast<JSFunctionWithFields*>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther));
+    auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -704,7 +704,7 @@ JSObject* promiseSpeciesConstructor(JSGlobalObject* globalObject, JSObject* this
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (auto* promise = jsDynamicCast<JSPromise*>(thisObject)) [[likely]] {
+    if (auto* promise = dynamicDowncast<JSPromise>(thisObject)) [[likely]] {
         if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]]
             return globalObject->promiseConstructor();
     }

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -554,7 +554,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllFulfillFunction, (JSGlobalObject* globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* context = jsDynamicCast<JSPromiseCombinatorsContext*>(callee->getField(JSFunctionWithFields::Field::PromiseAllContext));
+    auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -589,7 +589,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSlowFulfillFunction, (JSGlobalObject* globalO
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* context = jsDynamicCast<JSPromiseCombinatorsContext*>(callee->getField(JSFunctionWithFields::Field::PromiseAllContext));
+    auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -881,11 +881,11 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledFulfillFunction, (JSGlobalObject* glob
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* context = jsDynamicCast<JSPromiseCombinatorsContext*>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
+    auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
-    auto* other = jsDynamicCast<JSFunctionWithFields*>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledOther));
+    auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -925,11 +925,11 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledRejectFunction, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* context = jsDynamicCast<JSPromiseCombinatorsContext*>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
+    auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
-    auto* other = jsDynamicCast<JSFunctionWithFields*>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledOther));
+    auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -969,11 +969,11 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledSlowFulfillFunction, (JSGlobalObject* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* context = jsDynamicCast<JSPromiseCombinatorsContext*>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
+    auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
-    auto* other = jsDynamicCast<JSFunctionWithFields*>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledOther));
+    auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -1017,11 +1017,11 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledSlowRejectFunction, (JSGlobalObject* g
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* context = jsDynamicCast<JSPromiseCombinatorsContext*>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
+    auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
-    auto* other = jsDynamicCast<JSFunctionWithFields*>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledOther));
+    auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -1356,7 +1356,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnyRejectFunction, (JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* context = jsDynamicCast<JSPromiseCombinatorsContext*>(callee->getField(JSFunctionWithFields::Field::PromiseAnyContext));
+    auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAnyContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -1392,7 +1392,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnySlowRejectFunction, (JSGlobalObject* globalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* context = jsDynamicCast<JSPromiseCombinatorsContext*>(callee->getField(JSFunctionWithFields::Field::PromiseAnyContext));
+    auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAnyContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
 

--- a/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
@@ -121,7 +121,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseProtoFuncThen, (JSGlobalObject* globalObject, Ca
     JSValue onFulfilled = callFrame->argument(0);
     JSValue onRejected = callFrame->argument(1);
 
-    auto* promise = jsDynamicCast<JSPromise*>(thisValue);
+    auto* promise = dynamicDowncast<JSPromise>(thisValue);
     if (!promise) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "|this| is not a Promise");
 
@@ -136,7 +136,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseProtoFuncCatch, (JSGlobalObject* globalObject, C
     JSValue thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
     JSValue onRejected = callFrame->argument(0);
 
-    if (auto* promise = jsDynamicCast<JSPromise*>(thisValue); promise && promise->isThenFastAndNonObservable()) [[likely]]
+    if (auto* promise = dynamicDowncast<JSPromise>(thisValue); promise && promise->isThenFastAndNonObservable()) [[likely]]
         RELEASE_AND_RETURN(scope, JSValue::encode(promise->then(globalObject, jsUndefined(), onRejected)));
 
     JSValue then = thisValue.get(globalObject, vm.propertyNames->then);
@@ -244,7 +244,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseProtoFuncFinally, (JSGlobalObject* globalObject,
     JSValue onFinally = callFrame->argument(0);
 
     if (!onFinally.isCallable()) {
-        if (auto* promise = jsDynamicCast<JSPromise*>(thisValue); promise && promise->isThenFastAndNonObservable()) [[likely]]
+        if (auto* promise = dynamicDowncast<JSPromise>(thisValue); promise && promise->isThenFastAndNonObservable()) [[likely]]
             RELEASE_AND_RETURN(scope, JSValue::encode(promise->then(globalObject, onFinally, onFinally)));
 
         JSValue then = thisValue.get(globalObject, vm.propertyNames->then);
@@ -260,7 +260,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseProtoFuncFinally, (JSGlobalObject* globalObject,
         RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, then, thenCallData, thisValue, thenArguments)));
     }
 
-    auto* promise = jsDynamicCast<JSPromise*>(thisValue);
+    auto* promise = dynamicDowncast<JSPromise>(thisValue);
     if (promise && promise->isThenFastAndNonObservable() && promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]] {
         JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
         auto* context = JSPromiseCombinatorsGlobalContext::create(vm, resultPromise, onFinally, jsUndefined());

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -177,7 +177,7 @@ JSC_DEFINE_HOST_FUNCTION(createRemoteFunction, (JSGlobalObject* globalObject, Ca
     JSObject* targetCallable = jsCast<JSObject*>(targetFunction.asCell());
     JSGlobalObject* destinationGlobalObject = globalObject;
     if (!callFrame->uncheckedArgument(1).isUndefinedOrNull()) {
-        if (auto shadowRealm = jsDynamicCast<ShadowRealmObject*>(callFrame->uncheckedArgument(1)))
+        if (auto shadowRealm = dynamicDowncast<ShadowRealmObject>(callFrame->uncheckedArgument(1)))
             destinationGlobalObject = shadowRealm->globalObject();
         else
             destinationGlobalObject = jsCast<JSGlobalObject*>(callFrame->uncheckedArgument(1));
@@ -195,7 +195,7 @@ inline Structure* getRemoteFunctionStructure(JSGlobalObject* globalObject)
 JSRemoteFunction* JSRemoteFunction::tryCreate(JSGlobalObject* globalObject, VM& vm, JSObject* targetCallable)
 {
     ASSERT(targetCallable && targetCallable->isCallable());
-    if (auto remote = jsDynamicCast<JSRemoteFunction*>(targetCallable)) {
+    if (auto remote = dynamicDowncast<JSRemoteFunction>(targetCallable)) {
         targetCallable = remote->targetFunction();
         ASSERT(!JSC::isRemoteFunction(targetCallable));
     }

--- a/Source/JavaScriptCore/runtime/JSScope.cpp
+++ b/Source/JavaScriptCore/runtime/JSScope.cpp
@@ -283,7 +283,7 @@ JSValue JSScope::resolveScopeForHoistingFuncDeclInEval(JSGlobalObject* globalObj
     RETURN_IF_EXCEPTION(throwScope, { });
 
     bool result = false;
-    if (JSScope* scope = jsDynamicCast<JSScope*>(object)) {
+    if (JSScope* scope = dynamicDowncast<JSScope>(object)) {
         if (SymbolTable* scopeSymbolTable = scope->symbolTable()) {
             result = scope->isGlobalObject() || scopeSymbolTable->scopeType() == SymbolTable::ScopeType::VarScope;
         }
@@ -418,7 +418,7 @@ JSScope* JSScope::constantScopeForCodeBlock(ResolveType type, CodeBlock* codeBlo
 
 SymbolTable* JSScope::symbolTable()
 {
-    if (JSSymbolTableObject* symbolTableObject = jsDynamicCast<JSSymbolTableObject*>(this))
+    if (JSSymbolTableObject* symbolTableObject = dynamicDowncast<JSSymbolTableObject>(this))
         return symbolTableObject->symbolTable();
 
     return nullptr;

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.h
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.h
@@ -147,7 +147,7 @@ ALWAYS_INLINE bool JSStringJoiner::appendWithoutSideEffects(JSGlobalObject* glob
     if (value.isCell()) {
         // FIXME: Support JSBigInt in side-effect-free append.
         // https://bugs.webkit.org/show_bug.cgi?id=211173
-        if (JSString* jsString = jsDynamicCast<JSString*>(value)) {
+        if (JSString* jsString = dynamicDowncast<JSString>(value)) {
             auto view = jsString->view(globalObject);
             RETURN_IF_EXCEPTION(scope, false);
             // Since getting the view didn't OOM, we know that the underlying String exists and isn't

--- a/Source/JavaScriptCore/runtime/MapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/MapConstructor.cpp
@@ -79,7 +79,7 @@ JSC_DEFINE_HOST_FUNCTION(constructMap, (JSGlobalObject* globalObject, CallFrame*
         return JSValue::encode(JSMap::create(vm, mapStructure));
 
     bool canPerformFastSet = JSMap::isSetFastAndNonObservable(mapStructure);
-    if (auto* iterableMap = jsDynamicCast<JSMap*>(iterable)) {
+    if (auto* iterableMap = dynamicDowncast<JSMap>(iterable)) {
         if (canPerformFastSet && iterableMap->isIteratorProtocolFastAndNonObservable())
             RELEASE_AND_RETURN(scope, JSValue::encode(iterableMap->clone(globalObject, vm, mapStructure)));
     }
@@ -181,7 +181,7 @@ JSC_DEFINE_HOST_FUNCTION(mapPrivateFuncMapIterationEntryValue, (JSGlobalObject* 
 
 JSC_DEFINE_HOST_FUNCTION(mapPrivateFuncMapStorage, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ASSERT(jsDynamicCast<JSMap*>(callFrame->argument(0)));
+    ASSERT(is<JSMap>(callFrame->argument(0)));
     JSMap* map = jsCast<JSMap*>(callFrame->uncheckedArgument(0));
     return JSValue::encode(map->storageOrSentinel(getVM(globalObject)));
 }

--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -117,7 +117,7 @@ ALWAYS_INLINE static JSMap* getMap(JSGlobalObject* globalObject, JSValue thisVal
         return nullptr;
     }
 
-    if (auto* map = jsDynamicCast<JSMap*>(thisValue.asCell())) [[likely]]
+    if (auto* map = dynamicDowncast<JSMap>(thisValue.asCell())) [[likely]]
         return map;
     throwTypeError(globalObject, scope, "Map operation called on non-Map object"_s);
     return nullptr;

--- a/Source/JavaScriptCore/runtime/ModuleLoadingContext.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleLoadingContext.cpp
@@ -81,9 +81,9 @@ ModuleLoadingContext* ModuleLoadingContext::create(VM& vm, const AbstractModuleR
 JSModuleLoader::ModuleReferrer ModuleLoadingContext::referrer() const
 {
     JSValue ref = m_referrer.get();
-    if (auto* module = jsDynamicCast<CyclicModuleRecord*>(ref))
+    if (auto* module = dynamicDowncast<CyclicModuleRecord>(ref))
         return module;
-    if (auto* exec = jsDynamicCast<ProgramExecutable*>(ref))
+    if (auto* exec = dynamicDowncast<ProgramExecutable>(ref))
         return exec;
     return jsCast<JSGlobalObject*>(ref);
 }

--- a/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
@@ -147,7 +147,7 @@ JSValue ModuleRegistryEntry::error(JSGlobalObject* globalObject) const
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (JSValue fetchError = m_fetchError.get()) {
-        if (auto* errorInstance = jsDynamicCast<ErrorInstance*>(fetchError))
+        if (auto* errorInstance = dynamicDowncast<ErrorInstance>(fetchError))
             RELEASE_AND_RETURN(scope, JSModuleLoader::duplicateError(globalObject, errorInstance));
         RELEASE_AND_RETURN(scope, fetchError);
     }
@@ -156,7 +156,7 @@ JSValue ModuleRegistryEntry::error(JSGlobalObject* globalObject) const
     if (m_evaluationError)
         RELEASE_AND_RETURN(scope, m_evaluationError.get());
     if (m_record) {
-        if (auto* cyclic = jsDynamicCast<CyclicModuleRecord*>(m_record.get()))
+        if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(m_record.get()))
             RELEASE_AND_RETURN(scope, cyclic->evaluationError());
     }
     return { };

--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -101,7 +101,7 @@ static ALWAYS_INLINE bool NODELETE toThisNumber(JSValue thisValue, double& x)
         return true;
     }
 
-    if (auto* numberObject = jsDynamicCast<NumberObject*>(thisValue)) {
+    if (auto* numberObject = dynamicDowncast<NumberObject>(thisValue)) {
         Integrity::auditStructureID(numberObject->structureID());
         x = numberObject->internalValue().asNumber();
         return true;

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -324,7 +324,7 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorAssign, (JSGlobalObject* globalObject,
 
     // FIXME: Extend this for non JSFinalObject. For example, we would like to use this fast path for function objects too.
     // https://bugs.webkit.org/show_bug.cgi?id=185358
-    JSFinalObject* targetObject = jsDynamicCast<JSFinalObject*>(target);
+    JSFinalObject* targetObject = dynamicDowncast<JSFinalObject>(target);
     bool targetCanPerformFastPut = targetObject && targetObject->canPerformFastPutInlineExcludingProto() && targetObject->isStructureExtensible();
     unsigned argsCount = callFrame->argumentCount();
 
@@ -1130,7 +1130,7 @@ JSObject* objectConstructorSeal(JSGlobalObject* globalObject, JSObject* object)
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (jsDynamicCast<JSFinalObject*>(object) && !hasIndexedProperties(object->indexingType())) {
+    if (is<JSFinalObject>(object) && !hasIndexedProperties(object->indexingType())) {
         object->seal(vm);
         return object;
     }
@@ -1163,7 +1163,7 @@ JSObject* objectConstructorFreeze(JSGlobalObject* globalObject, JSObject* object
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (jsDynamicCast<JSFinalObject*>(object) && !hasIndexedProperties(object->indexingType())) {
+    if (is<JSFinalObject>(object) && !hasIndexedProperties(object->indexingType())) {
         object->freeze(vm);
         return object;
     }
@@ -1217,7 +1217,7 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorIsSealed, (JSGlobalObject* globalObjec
     JSObject* object = asObject(obj);
 
     // Quick check for final objects.
-    if (jsDynamicCast<JSFinalObject*>(object) && !hasIndexedProperties(object->indexingType()))
+    if (is<JSFinalObject>(object) && !hasIndexedProperties(object->indexingType()))
         return JSValue::encode(jsBoolean(object->isSealed(vm)));
 
     // 2. Return ? TestIntegrityLevel(O, "sealed").
@@ -1235,7 +1235,7 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorIsFrozen, (JSGlobalObject* globalObjec
     JSObject* object = asObject(obj);
 
     // Quick check for final objects.
-    if (jsDynamicCast<JSFinalObject*>(object) && !hasIndexedProperties(object->indexingType()))
+    if (is<JSFinalObject>(object) && !hasIndexedProperties(object->indexingType()))
         return JSValue::encode(jsBoolean(object->isFrozen(vm)));
 
     // 2. Return ? TestIntegrityLevel(O, "frozen").

--- a/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
@@ -209,7 +209,7 @@ public:
     {
         JSValue* value = slot(storage, aliveEntryCountIndex());
         if (!value->isInt32()) {
-            ASSERT(jsDynamicCast<Storage*>(*value));
+            ASSERT(is<Storage>(*value));
             return jsCast<Storage*>(*value);
         }
         return nullptr;

--- a/Source/JavaScriptCore/runtime/ReflectObject.cpp
+++ b/Source/JavaScriptCore/runtime/ReflectObject.cpp
@@ -105,7 +105,7 @@ JSC_DEFINE_HOST_FUNCTION(reflectObjectConstruct, (JSGlobalObject* globalObject, 
     }
 
     MarkedArgumentBuffer arguments;
-    JSObject* argumentsObject = jsDynamicCast<JSObject*>(callFrame->argument(1));
+    JSObject* argumentsObject = dynamicDowncast<JSObject>(callFrame->argument(1));
     if (!argumentsObject)
         return JSValue::encode(throwTypeError(globalObject, scope, "Reflect.construct requires the second argument be an object"_s));
 

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -159,7 +159,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncTest, (JSGlobalObject* globalObject, Cal
     RETURN_IF_EXCEPTION(scope, { });
 
     if (regExpExecWatchpointIsValid(vm, thisObject)) [[likely]] {
-        auto* regExp = jsDynamicCast<RegExpObject*>(thisValue);
+        auto* regExp = dynamicDowncast<RegExpObject>(thisValue);
         if (!regExp) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "Builtin RegExp exec can only be called on a RegExp object"_s);
         auto strValue = str->value(globalObject);
@@ -180,7 +180,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncExec, (JSGlobalObject* globalObject, Cal
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
+    auto* regexp = dynamicDowncast<RegExpObject>(thisValue);
     if (!regexp) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Builtin RegExp exec can only be called on a RegExp object"_s);
     JSString* string = callFrame->argument(0).toStringOrNull(globalObject);
@@ -205,7 +205,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncCompile, (JSGlobalObject* globalObject, 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* thisRegExp = jsDynamicCast<RegExpObject*>(thisValue);
+    auto* thisRegExp = dynamicDowncast<RegExpObject>(thisValue);
     if (!thisRegExp) [[unlikely]]
         return throwVMTypeError(globalObject, scope);
 
@@ -219,7 +219,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncCompile, (JSGlobalObject* globalObject, 
     JSValue arg0 = callFrame->argument(0);
     JSValue arg1 = callFrame->argument(1);
     
-    if (auto* regExpObject = jsDynamicCast<RegExpObject*>(arg0)) {
+    if (auto* regExpObject = dynamicDowncast<RegExpObject>(arg0)) {
         if (!arg1.isUndefined())
             return throwVMTypeError(globalObject, scope, "Cannot supply flags when constructing one RegExp from another."_s);
         regExp = regExpObject->regExp();
@@ -304,7 +304,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterGlobal, (JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
+    auto* regexp = dynamicDowncast<RegExpObject>(thisValue);
     if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
@@ -320,7 +320,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterHasIndices, (JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
+    auto* regexp = dynamicDowncast<RegExpObject>(thisValue);
     if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
@@ -336,7 +336,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterIgnoreCase, (JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
+    auto* regexp = dynamicDowncast<RegExpObject>(thisValue);
     if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
@@ -352,7 +352,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterMultiline, (JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
+    auto* regexp = dynamicDowncast<RegExpObject>(thisValue);
     if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
@@ -368,7 +368,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterDotAll, (JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
     
     JSValue thisValue = callFrame->thisValue();
-    auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
+    auto* regexp = dynamicDowncast<RegExpObject>(thisValue);
     if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
@@ -384,7 +384,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterSticky, (JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
+    auto* regexp = dynamicDowncast<RegExpObject>(thisValue);
     if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
@@ -400,7 +400,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterUnicode, (JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
+    auto* regexp = dynamicDowncast<RegExpObject>(thisValue);
     if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
@@ -416,7 +416,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterUnicodeSets, (JSGlobalObject* globalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
+    auto* regexp = dynamicDowncast<RegExpObject>(thisValue);
     if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsUndefined());
@@ -449,7 +449,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterSource, (JSGlobalObject* globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->thisValue();
-    auto* regexp = jsDynamicCast<RegExpObject*>(thisValue);
+    auto* regexp = dynamicDowncast<RegExpObject>(thisValue);
     if (!regexp) [[unlikely]] {
         if (thisValue == globalObject->regExpPrototype())
             return JSValue::encode(jsNontrivialString(vm, "(?:)"_s));
@@ -473,7 +473,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncSearch, (JSGlobalObject* globalObject, C
     RETURN_IF_EXCEPTION(scope, { });
 
     if (regExpExecWatchpointIsValid(vm, thisObject)) [[likely]] {
-        auto* regExp = jsDynamicCast<RegExpObject*>(thisValue);
+        auto* regExp = dynamicDowncast<RegExpObject>(thisValue);
         if (!regExp) [[unlikely]]
             return throwVMTypeError(globalObject, scope, "Builtin RegExp exec can only be called on a RegExp object"_s);
         if (regExp->lastIndexIsWritable() && regExp->getLastIndex().isNumber()) [[likely]] {
@@ -1208,7 +1208,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncMatchAll, (JSGlobalObject* globalObject,
     JSString* string = callFrame->argument(0).toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto* regExpObject = jsDynamicCast<RegExpObject*>(thisObject);
+    auto* regExpObject = dynamicDowncast<RegExpObject>(thisObject);
     if (regExpObject && regExpMatchAllWathpointIsValid(regExpObject)) [[likely]] {
         RegExp* regExp = regExpObject->regExp();
 

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -585,7 +585,7 @@ void SamplingProfiler::processUnverifiedStackTraces()
             };
 
             if (calleeCell->type() != JSFunctionType) {
-                if (JSObject* object = jsDynamicCast<JSObject*>(calleeCell))
+                if (JSObject* object = dynamicDowncast<JSObject>(calleeCell))
                     addCallee(object);
 
                 if (!alreadyHasExecutable)
@@ -1112,7 +1112,7 @@ Ref<JSON::Value> SamplingProfiler::stackTracesAsJSON()
         result->setString("category"_s, tierName(stackFrame));
         uint32_t flags = 0;
         if (stackFrame.frameType == SamplingProfiler::FrameType::Executable && stackFrame.executable) {
-            if (auto* executable = jsDynamicCast<FunctionExecutable*>(stackFrame.executable); executable && executable->isBuiltinFunction())
+            if (auto* executable = dynamicDowncast<FunctionExecutable>(stackFrame.executable); executable && executable->isBuiltinFunction())
                 flags = 1;
         }
         result->setDouble("flags"_s, flags);
@@ -1320,7 +1320,7 @@ void SamplingProfiler::reportTopBytecodes(PrintStream& out)
 
         tierCounts.add(tierName(frame), 0).iterator->value++;
         if (frame.frameType == SamplingProfiler::FrameType::Executable && frame.executable) {
-            if (auto* executable = jsDynamicCast<FunctionExecutable*>(frame.executable)) {
+            if (auto* executable = dynamicDowncast<FunctionExecutable>(frame.executable)) {
                 if (executable->isBuiltinFunction())
                     tierCounts.add(Tiers::builtin, 0).iterator->value++;
             }

--- a/Source/JavaScriptCore/runtime/SetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SetConstructor.cpp
@@ -74,7 +74,7 @@ JSC_DEFINE_HOST_FUNCTION(constructSet, (JSGlobalObject* globalObject, CallFrame*
         return JSValue::encode(JSSet::create(vm, setStructure));
 
     bool canPerformFastAdd = JSSet::isAddFastAndNonObservable(setStructure);
-    if (auto* iterableSet = jsDynamicCast<JSSet*>(iterable)) {
+    if (auto* iterableSet = dynamicDowncast<JSSet>(iterable)) {
         if (canPerformFastAdd && iterableSet->isIteratorProtocolFastAndNonObservable()) 
             RELEASE_AND_RETURN(scope, JSValue::encode(iterableSet->clone(globalObject, vm, setStructure)));
     }
@@ -110,7 +110,7 @@ JSC_DEFINE_HOST_FUNCTION(constructSet, (JSGlobalObject* globalObject, CallFrame*
 
 JSC_DEFINE_HOST_FUNCTION(setPrivateFuncSetStorage, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ASSERT(jsDynamicCast<JSSet*>(callFrame->argument(0)));
+    ASSERT(is<JSSet>(callFrame->argument(0)));
     JSSet* set = jsCast<JSSet*>(callFrame->uncheckedArgument(0));
     return JSValue::encode(set->storageOrSentinel(getVM(globalObject)));
 }

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -121,7 +121,7 @@ ALWAYS_INLINE static JSSet* getSet(JSGlobalObject* globalObject, JSValue thisVal
         throwVMError(globalObject, scope, createNotAnObjectError(globalObject, thisValue));
         return nullptr;
     }
-    if (auto* set = jsDynamicCast<JSSet*>(thisValue.asCell())) [[likely]]
+    if (auto* set = dynamicDowncast<JSSet>(thisValue.asCell())) [[likely]]
         return set;
     throwTypeError(globalObject, scope, "Set operation called on non-Set object"_s);
     return nullptr;
@@ -266,7 +266,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
     JSValue otherValue = callFrame->argument(0);
 
     if (otherValue.isCell()) [[likely]] {
-        if (auto* otherSet = jsDynamicCast<JSSet*>(otherValue.asCell())) [[likely]] {
+        if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
             if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
                 scope.release();
                 return fastSetIntersection(globalObject, thisSet, otherSet);
@@ -397,7 +397,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncUnion, (JSGlobalObject* globalObject, CallF
     JSValue otherValue = callFrame->argument(0);
 
     if (otherValue.isCell()) [[likely]] {
-        if (auto* otherSet = jsDynamicCast<JSSet*>(otherValue.asCell())) [[likely]] {
+        if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
             if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
                 scope.release();
                 return fastSetUnion(globalObject, thisSet, otherSet);
@@ -525,7 +525,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
     JSValue otherValue = callFrame->argument(0);
 
     if (otherValue.isCell()) [[likely]] {
-        if (auto* otherSet = jsDynamicCast<JSSet*>(otherValue.asCell())) [[likely]] {
+        if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
             if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
                 scope.release();
                 return fastSetDifference(globalObject, thisSet, otherSet);
@@ -706,7 +706,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncSymmetricDifference, (JSGlobalObject* globa
     JSValue otherValue = callFrame->argument(0);
 
     if (otherValue.isCell()) [[likely]] {
-        if (auto* otherSet = jsDynamicCast<JSSet*>(otherValue.asCell())) [[likely]] {
+        if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
             if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
                 scope.release();
                 return fastSetSymmetricDifference(globalObject, thisSet, otherSet);
@@ -804,7 +804,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSubsetOf, (JSGlobalObject* globalObject, 
     JSValue otherValue = callFrame->argument(0);
 
     if (otherValue.isCell()) [[likely]] {
-        if (auto* otherSet = jsDynamicCast<JSSet*>(otherValue.asCell())) [[likely]] {
+        if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
             if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
                 scope.release();
                 return fastSetIsSubsetOf(globalObject, thisSet, otherSet);
@@ -923,7 +923,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSupersetOf, (JSGlobalObject* globalObject
     JSValue otherValue = callFrame->argument(0);
 
     if (otherValue.isCell()) [[likely]] {
-        if (auto* otherSet = jsDynamicCast<JSSet*>(otherValue.asCell())) [[likely]] {
+        if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
             if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
                 scope.release();
                 return fastSetIsSupersetOf(globalObject, thisSet, otherSet);
@@ -1057,7 +1057,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
     JSValue otherValue = callFrame->argument(0);
 
     if (otherValue.isCell()) [[likely]] {
-        if (auto* otherSet = jsDynamicCast<JSSet*>(otherValue.asCell())) [[likely]] {
+        if (auto* otherSet = dynamicDowncast<JSSet>(otherValue.asCell())) [[likely]] {
             if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
                 scope.release();
                 return fastSetIsDisjointFrom(globalObject, thisSet, otherSet);

--- a/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
@@ -67,7 +67,7 @@ JSC_DEFINE_HOST_FUNCTION(importInRealm, (JSGlobalObject* globalObject, CallFrame
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->uncheckedArgument(0);
-    ShadowRealmObject* thisRealm = jsDynamicCast<ShadowRealmObject*>(thisValue);
+    ShadowRealmObject* thisRealm = dynamicDowncast<ShadowRealmObject>(thisValue);
     ASSERT(thisRealm);
 
     auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
@@ -91,7 +91,7 @@ JSC_DEFINE_HOST_FUNCTION(evalInRealm, (JSGlobalObject* globalObject, CallFrame* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue thisValue = callFrame->argument(0);
-    ShadowRealmObject* thisRealm = jsDynamicCast<ShadowRealmObject*>(thisValue);
+    ShadowRealmObject* thisRealm = dynamicDowncast<ShadowRealmObject>(thisValue);
     ASSERT(thisRealm);
     JSGlobalObject* realmGlobalObject = thisRealm->globalObject();
 
@@ -107,7 +107,7 @@ JSC_DEFINE_HOST_FUNCTION(evalInRealm, (JSGlobalObject* globalObject, CallFrame* 
     EvalExecutable* eval = IndirectEvalExecutable::create(realmGlobalObject, source, lexicallyScopedFeatures, DerivedContextType::None, false, EvalContextType::None, executableError);
     if (executableError) {
         JSValue error = executableError.get();
-        ErrorInstance* errorInstance = jsDynamicCast<ErrorInstance*>(error);
+        ErrorInstance* errorInstance = dynamicDowncast<ErrorInstance>(error);
         if (errorInstance != nullptr && errorInstance->errorType() == ErrorType::SyntaxError) {
             TRY_CLEAR_EXCEPTION(scope, { });
             const String syntaxErrorMessage = errorInstance->sanitizedMessageString(globalObject);
@@ -139,9 +139,9 @@ JSC_DEFINE_HOST_FUNCTION(moveFunctionToRealm, (JSGlobalObject* globalObject, Cal
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue wrappedFnArg = callFrame->argument(0);
-    JSFunction* wrappedFn = jsDynamicCast<JSFunction*>(wrappedFnArg);
+    JSFunction* wrappedFn = dynamicDowncast<JSFunction>(wrappedFnArg);
     JSValue targetRealmArg = callFrame->argument(1);
-    ShadowRealmObject* targetRealm = jsDynamicCast<ShadowRealmObject*>(targetRealmArg);
+    ShadowRealmObject* targetRealm = dynamicDowncast<ShadowRealmObject>(targetRealmArg);
     ASSERT(targetRealm);
     RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/StackFrame.cpp
+++ b/Source/JavaScriptCore/runtime/StackFrame.cpp
@@ -161,7 +161,7 @@ String StackFrame::sourceURL(VM& vm, AllowURLOverride allowOverride) const
             if (isAsyncFrameWithoutCodeBlock()) {
                 ASSERT(jsFrame.callee);
                 ASSERT(!jsFrame.codeBlock);
-                JSFunction* calleeFn = jsDynamicCast<JSFunction*>(jsFrame.callee.get());
+                JSFunction* calleeFn = dynamicDowncast<JSFunction>(jsFrame.callee.get());
                 return processSourceURL(vm, *this, calleeFn->jsExecutable()->sourceURL(), allowOverride);
             }
 
@@ -185,7 +185,7 @@ String StackFrame::sourceURLStripped(VM& vm) const
             if (isAsyncFrameWithoutCodeBlock()) {
                 ASSERT(jsFrame.callee);
                 ASSERT(!jsFrame.codeBlock);
-                JSFunction* calleeFn = jsDynamicCast<JSFunction*>(jsFrame.callee.get());
+                JSFunction* calleeFn = dynamicDowncast<JSFunction>(jsFrame.callee.get());
                 return processSourceURL(vm, *this, calleeFn->jsExecutable()->sourceURLStripped());
             }
 
@@ -222,7 +222,7 @@ String StackFrame::functionName(VM& vm) const
             if (jsFrame.callee && jsFrame.callee->isObject())
                 name = getCalculatedDisplayName(vm, jsCast<JSObject*>(jsFrame.callee.get())).impl();
             else if (jsFrame.codeBlock) {
-                if (auto* executable = jsDynamicCast<FunctionExecutable*>(jsFrame.codeBlock->ownerExecutable()))
+                if (auto* executable = dynamicDowncast<FunctionExecutable>(jsFrame.codeBlock->ownerExecutable()))
                     name = executable->ecmaName().impl();
             }
 

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -344,7 +344,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncReplace, (JSGlobalObject* globalObject, 
 
     JSValue searchValue = callFrame->argument(0);
     if (searchValue.isObject()) {
-        RegExpObject* regExpObject = jsDynamicCast<RegExpObject*>(searchValue);
+        RegExpObject* regExpObject = dynamicDowncast<RegExpObject>(searchValue);
         if (regExpObject && regExpObject->isSymbolReplaceFastAndNonObservable()) [[likely]] {
             JSString* string = thisValue.toString(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
@@ -403,7 +403,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncReplaceAll, (JSGlobalObject* globalObjec
 
     JSValue searchValue = callFrame->argument(0);
     if (searchValue.isObject()) {
-        RegExpObject* regExpObject = jsDynamicCast<RegExpObject*>(searchValue);
+        RegExpObject* regExpObject = dynamicDowncast<RegExpObject>(searchValue);
         if (regExpObject && regExpObject->isSymbolReplaceFastAndNonObservable()) [[likely]] {
             if (!regExpObject->regExp()->global()) [[unlikely]]
                 return throwVMTypeError(globalObject, scope, "String.prototype.replaceAll argument must not be a non-global regular expression"_s);
@@ -466,7 +466,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToString, (JSGlobalObject* globalObject,
         return JSValue::encode(thisValue);
     }
 
-    auto* stringObject = jsDynamicCast<StringObject*>(thisValue);
+    auto* stringObject = dynamicDowncast<StringObject>(thisValue);
     if (!stringObject)
         return throwVMTypeError(globalObject, scope);
 

--- a/Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp
@@ -103,7 +103,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalCalendarPrototypeFuncDateFromFields, (JSGlobalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* calendar = jsDynamicCast<TemporalCalendar*>(callFrame->thisValue());
+    auto* calendar = dynamicDowncast<TemporalCalendar>(callFrame->thisValue());
     if (!calendar)
         return throwVMTypeError(globalObject, scope, "Temporal.Calendar.prototype.dateFromFields called on value that's not a Calendar"_s);
 
@@ -131,7 +131,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalCalendarPrototypeFuncDateAdd, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* calendar = jsDynamicCast<TemporalCalendar*>(callFrame->thisValue());
+    auto* calendar = dynamicDowncast<TemporalCalendar>(callFrame->thisValue());
     if (!calendar)
         return throwVMTypeError(globalObject, scope, "Temporal.Calendar.prototype.dateAdd called on value that's not a Calendar"_s);
 
@@ -160,7 +160,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalCalendarPrototypeFuncDateUntil, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* calendar = jsDynamicCast<TemporalCalendar*>(callFrame->thisValue());
+    auto* calendar = dynamicDowncast<TemporalCalendar>(callFrame->thisValue());
     if (!calendar)
         return throwVMTypeError(globalObject, scope, "Temporal.Calendar.prototype.dateUntil called on value that's not a Calendar"_s);
 
@@ -202,7 +202,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalCalendarPrototypeFuncFields, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* calendar = jsDynamicCast<TemporalCalendar*>(callFrame->thisValue());
+    auto* calendar = dynamicDowncast<TemporalCalendar>(callFrame->thisValue());
     if (!calendar)
         return throwVMTypeError(globalObject, scope, "Temporal.Calendar.prototype.fields called on value that's not a Calendar"_s);
 
@@ -312,7 +312,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalCalendarPrototypeFuncMergeFields, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* calendar = jsDynamicCast<TemporalCalendar*>(callFrame->thisValue());
+    auto* calendar = dynamicDowncast<TemporalCalendar>(callFrame->thisValue());
     if (!calendar)
         return throwVMTypeError(globalObject, scope, "Temporal.Calendar.prototype.mergeFields called on value that's not a Calendar"_s);
 
@@ -427,7 +427,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalCalendarPrototypeFuncToString, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* calendar = jsDynamicCast<TemporalCalendar*>(callFrame->thisValue());
+    auto* calendar = dynamicDowncast<TemporalCalendar>(callFrame->thisValue());
     if (!calendar)
         return throwVMTypeError(globalObject, scope, "Temporal.Calendar.prototype.toString called on value that's not a Calendar"_s);
 
@@ -440,7 +440,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalCalendarPrototypeFuncToJSON, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* calendar = jsDynamicCast<TemporalCalendar*>(callFrame->thisValue());
+    auto* calendar = dynamicDowncast<TemporalCalendar>(callFrame->thisValue());
     if (!calendar)
         return throwVMTypeError(globalObject, scope, "Temporal.Calendar.prototype.toJSON called on value that's not a Calendar"_s);
 

--- a/Source/JavaScriptCore/runtime/TemporalDurationPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDurationPrototype.cpp
@@ -121,7 +121,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncWith, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(callFrame->thisValue());
+    auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.with called on value that's not a Duration"_s);
     
@@ -140,7 +140,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncNegated, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(callFrame->thisValue());
+    auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.negated called on value that's not a Duration"_s);
 
@@ -152,7 +152,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncAbs, (JSGlobalObject* glob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(callFrame->thisValue());
+    auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.abs called on value that's not a Duration"_s);
 
@@ -164,7 +164,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncAdd, (JSGlobalObject* glob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(callFrame->thisValue());
+    auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.add called on value that's not a Duration"_s);
 
@@ -179,7 +179,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncSubtract, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(callFrame->thisValue());
+    auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.subtract called on value that's not a Duration"_s);
 
@@ -194,7 +194,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncRound, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(callFrame->thisValue());
+    auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.round called on value that's not a Duration"_s);
 
@@ -213,7 +213,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncTotal, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(callFrame->thisValue());
+    auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.total called on value that's not a Duration"_s);
 
@@ -229,7 +229,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncToString, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(callFrame->thisValue());
+    auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.toString called on value that's not a Duration"_s);
 
@@ -241,7 +241,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncToJSON, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(callFrame->thisValue());
+    auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.toJSON called on value that's not a Duration"_s);
 
@@ -254,7 +254,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncToLocaleString, (JSGlobalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(callFrame->thisValue());
+    auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.toLocaleString called on value that's not a Duration"_s);
 
@@ -274,7 +274,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterYears, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.years called on value that's not a Duration"_s);
 
@@ -286,7 +286,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterMonths, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.months called on value that's not a Duration"_s);
 
@@ -298,7 +298,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterWeeks, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.weeks called on value that's not a Duration"_s);
 
@@ -310,7 +310,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterDays, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.days called on value that's not a Duration"_s);
 
@@ -322,7 +322,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterHours, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.hours called on value that's not a Duration"_s);
 
@@ -334,7 +334,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterMinutes, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.minutes called on value that's not a Duration"_s);
 
@@ -346,7 +346,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterSeconds, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.seconds called on value that's not a Duration"_s);
 
@@ -358,7 +358,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterMilliseconds, (JSGlobalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.milliseconds called on value that's not a Duration"_s);
 
@@ -370,7 +370,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterMicroseconds, (JSGlobalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.microseconds called on value that's not a Duration"_s);
 
@@ -382,7 +382,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterNanoseconds, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.nanoseconds called on value that's not a Duration"_s);
 
@@ -394,7 +394,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterSign, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.sign called on value that's not a Duration"_s);
 
@@ -406,7 +406,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterBlank, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* duration = jsDynamicCast<TemporalDuration*>(JSValue::decode(thisValue));
+    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.blank called on value that's not a Duration"_s);
 

--- a/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
@@ -108,7 +108,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncAdd, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(callFrame->thisValue());
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.add called on value that's not a Instant"_s);
 
@@ -129,7 +129,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncSubtract, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(callFrame->thisValue());
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.subtract called on value that's not a Instant"_s);
 
@@ -150,7 +150,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncUntil, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(callFrame->thisValue());
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.until called on value that's not a Instant"_s);
 
@@ -169,7 +169,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncSince, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(callFrame->thisValue());
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.since called on value that's not a Instant"_s);
 
@@ -188,7 +188,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncRound, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(callFrame->thisValue());
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.round called on value that's not a Instant"_s);
 
@@ -207,7 +207,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncEquals, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(callFrame->thisValue());
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.equals called on value that's not a Instant"_s);
 
@@ -224,7 +224,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncToString, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(callFrame->thisValue());
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.toString called on value that's not a Instant"_s);
 
@@ -236,7 +236,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncToJSON, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(callFrame->thisValue());
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.toJSON called on value that's not a Instant"_s);
 
@@ -249,7 +249,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncToLocaleString, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(callFrame->thisValue());
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.toLocaleString called on value that's not a Instant"_s);
 
@@ -276,7 +276,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochMilliseconds, (JSGlo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(JSValue::decode(thisValue));
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(JSValue::decode(thisValue));
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.epochMilliseconds called on value that's not a Instant"_s);
 
@@ -288,7 +288,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochNanoseconds, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    TemporalInstant* instant = jsDynamicCast<TemporalInstant*>(JSValue::decode(thisValue));
+    TemporalInstant* instant = dynamicDowncast<TemporalInstant>(JSValue::decode(thisValue));
     if (!instant)
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.epochNanoseconds called on value that's not a Instant"_s);
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -139,7 +139,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncGetISOFields, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.getISOFields called on value that's not a PlainDate"_s);
 
@@ -157,7 +157,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainMonthDay, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* temporalDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* temporalDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!temporalDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toPlainMonthDay called on value that's not a PlainDate"_s);
 
@@ -174,7 +174,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainYearMonth, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* temporalDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* temporalDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!temporalDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toPlainYearMonth called on value that's not a PlainDate"_s);
 
@@ -191,7 +191,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncAdd, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.add called on value that's not a PlainDate"_s);
 
@@ -213,7 +213,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncSubtract, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.subtract called on value that's not a PlainDate"_s);
 
@@ -235,7 +235,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncWith, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.with called on value that's not a PlainDate"_s);
 
@@ -255,7 +255,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncUntil, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.until called on value that's not a PlainDate"_s);
 
@@ -274,7 +274,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncSince, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.since called on value that's not a PlainDate"_s);
 
@@ -293,7 +293,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncEquals, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.equals called on value that's not a PlainDate"_s);
 
@@ -312,7 +312,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainDateTime, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toPlainDateTime called on value that's not a PlainDate"_s);
 
@@ -332,7 +332,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToString, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toString called on value that's not a PlainDate"_s);
 
@@ -345,7 +345,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToJSON, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toJSON called on value that's not a PlainDate"_s);
 
@@ -358,7 +358,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToLocaleString, (JSGlobal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(callFrame->thisValue());
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toLocaleString called on value that's not a PlainDate"_s);
 
@@ -379,7 +379,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterCalendar, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.calendar called on value that's not a PlainDate"_s);
 
@@ -391,7 +391,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterCalendarId, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.calendarId called on value that's not a PlainDate"_s);
 
@@ -404,7 +404,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterYear, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.year called on value that's not a PlainDate"_s);
 
@@ -416,7 +416,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterMonth, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.month called on value that's not a PlainDate"_s);
 
@@ -428,7 +428,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterMonthCode, (JSGlobalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.monthCode called on value that's not a PlainDate"_s);
 
@@ -440,7 +440,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterDay, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.day called on value that's not a PlainDate"_s);
 
@@ -452,7 +452,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterDayOfWeek, (JSGlobalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.dayOfWeek called on value that's not a PlainDate"_s);
 
@@ -464,7 +464,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterDayOfYear, (JSGlobalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.dayOfYear called on value that's not a PlainDate"_s);
 
@@ -476,7 +476,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterWeekOfYear, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.weekOfYear called on value that's not a PlainDate"_s);
 
@@ -488,7 +488,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterDaysInWeek, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.daysInWeek called on value that's not a PlainDate"_s);
 
@@ -500,7 +500,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterDaysInMonth, (JSGlobalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.daysInMonth called on value that's not a PlainDate"_s);
 
@@ -512,7 +512,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterDaysInYear, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.daysInYear called on value that's not a PlainDate"_s);
 
@@ -524,7 +524,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterMonthsInYear, (JSGlobal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.monthsInYear called on value that's not a PlainDate"_s);
 
@@ -536,7 +536,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterInLeapYear, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDate*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDate>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.inLeapYear called on value that's not a PlainDate"_s);
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -146,7 +146,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncGetISOFields, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.getISOFields called on value that's not a PlainDateTime"_s);
 
@@ -170,7 +170,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncAdd, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.add called on value that's not a PlainDateTime"_s);
 
@@ -201,7 +201,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncSubtract, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.subtract called on value that's not a PlainDateTime"_s);
 
@@ -232,7 +232,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.with called on value that's not a PlainDateTime"_s);
 
@@ -249,7 +249,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWithPlainTime, (JSGlo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.withPlainTime called on value that's not a PlainDateTime"_s);
 
@@ -269,7 +269,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncRound, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.round called on value that's not a PlainDateTime"_s);
 
@@ -286,7 +286,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncEquals, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.equals called on value that's not a PlainDateTime"_s);
 
@@ -305,7 +305,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncToPlainDate, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.toPlainDate called on value that's not a PlainDateTime"_s);
 
@@ -318,7 +318,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncToPlainTime, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.toPlainTime called on value that's not a PlainDateTime"_s);
 
@@ -331,7 +331,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncToString, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.toString called on value that's not a PlainDateTime"_s);
 
@@ -344,7 +344,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncToJSON, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.toJSON called on value that's not a PlainDateTime"_s);
 
@@ -357,7 +357,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncToLocaleString, (JSGl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(callFrame->thisValue());
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.toLocaleString called on value that's not a PlainDateTime"_s);
 
@@ -378,7 +378,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterCalendar, (JSGlobal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.calendar called on value that's not a PlainDateTime"_s);
 
@@ -390,7 +390,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterCalendarId, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDate = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDate = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.calendarId called on value that's not a PlainDateTime"_s);
 
@@ -403,7 +403,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterYear, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.year called on value that's not a PlainDateTime"_s);
 
@@ -415,7 +415,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterMonth, (JSGlobalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.month called on value that's not a PlainDateTime"_s);
 
@@ -427,7 +427,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterMonthCode, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.monthCode called on value that's not a PlainDateTime"_s);
 
@@ -439,7 +439,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterDay, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.day called on value that's not a PlainDateTime"_s);
 
@@ -451,7 +451,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterHour, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.hour called on value that's not a PlainDateTime"_s);
 
@@ -463,7 +463,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterMinute, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.minute called on value that's not a PlainDateTime"_s);
 
@@ -475,7 +475,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterSecond, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.second called on value that's not a PlainDateTime"_s);
 
@@ -487,7 +487,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterMillisecond, (JSGlo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.millisecond called on value that's not a PlainDateTime"_s);
 
@@ -499,7 +499,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterMicrosecond, (JSGlo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.microsecond called on value that's not a PlainDateTime"_s);
 
@@ -511,7 +511,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterNanosecond, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.nanosecond called on value that's not a PlainDateTime"_s);
 
@@ -523,7 +523,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterDayOfWeek, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.dayOfWeek called on value that's not a PlainDateTime"_s);
 
@@ -535,7 +535,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterDayOfYear, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.dayOfYear called on value that's not a PlainDateTime"_s);
 
@@ -547,7 +547,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterWeekOfYear, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.weekOfYear called on value that's not a PlainDateTime"_s);
 
@@ -559,7 +559,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterDaysInWeek, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.daysInWeek called on value that's not a PlainDateTime"_s);
 
@@ -571,7 +571,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterDaysInMonth, (JSGlo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.daysInMonth called on value that's not a PlainDateTime"_s);
 
@@ -583,7 +583,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterDaysInYear, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.daysInYear called on value that's not a PlainDateTime"_s);
 
@@ -595,7 +595,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterMonthsInYear, (JSGl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.monthsInYear called on value that's not a PlainDateTime"_s);
 
@@ -607,7 +607,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterInLeapYear, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainDateTime = jsDynamicCast<TemporalPlainDateTime*>(JSValue::decode(thisValue));
+    auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(JSValue::decode(thisValue));
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.inLeapYear called on value that's not a PlainDateTime"_s);
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -101,7 +101,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToString, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(callFrame->thisValue());
+    auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(callFrame->thisValue());
     if (!monthDay)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toString called on value that's not a PlainMonthDay"_s);
 
@@ -114,7 +114,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToJSON, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(callFrame->thisValue());
+    auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(callFrame->thisValue());
     if (!monthDay)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toJSON called on value that's not a PlainMonthDay"_s);
 
@@ -127,7 +127,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToLocaleString, (JSGl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(callFrame->thisValue());
+    auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(callFrame->thisValue());
     if (!monthDay)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toLocaleString called on value that's not a PlainMonthDay"_s);
 
@@ -140,7 +140,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncWith, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(callFrame->thisValue());
+    auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(callFrame->thisValue());
     if (!monthDay) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.with called on value that's not a PlainMonthDay"_s);
 
@@ -162,7 +162,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncEquals, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(callFrame->thisValue());
+    auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(callFrame->thisValue());
     if (!monthDay) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.equals called on value that's not a PlainMonthDay"_s);
 
@@ -181,7 +181,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToPlainDate, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(callFrame->thisValue());
+    auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(callFrame->thisValue());
     if (!monthDay) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toPlainDate called on value that's not a PlainMonthDay"_s);
 
@@ -224,7 +224,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterCalendarId, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(JSValue::decode(thisValue));
+    auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(JSValue::decode(thisValue));
     if (!monthDay)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.calendar called on value that's not a PlainMonthDay"_s);
 
@@ -238,7 +238,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterDay, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(JSValue::decode(thisValue));
+    auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(JSValue::decode(thisValue));
     if (!monthDay)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.day called on value that's not a PlainMonthDay"_s);
 
@@ -251,7 +251,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainMonthDayPrototypeGetterMonthCode, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* monthDay = jsDynamicCast<TemporalPlainMonthDay*>(JSValue::decode(thisValue));
+    auto* monthDay = dynamicDowncast<TemporalPlainMonthDay>(JSValue::decode(thisValue));
     if (!monthDay)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.monthCode called on value that's not a PlainMonthDay"_s);
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
@@ -117,7 +117,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncAdd, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.add called on value that's not a PlainTime"_s);
 
@@ -136,7 +136,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncSubtract, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.subtract called on value that's not a PlainTime"_s);
 
@@ -155,7 +155,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncWith, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.with called on value that's not a PlainTime"_s);
 
@@ -175,7 +175,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncUntil, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.until called on value that's not a PlainTime"_s);
 
@@ -194,7 +194,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncSince, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.since called on value that's not a PlainTime"_s);
 
@@ -213,7 +213,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncRound, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.round called on value that's not a PlainTime"_s);
 
@@ -233,7 +233,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncEquals, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.equals called on value that's not a PlainTime"_s);
 
@@ -249,7 +249,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncGetISOFields, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.getISOFields called on value that's not a PlainTime"_s);
 
@@ -270,7 +270,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToString, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.toString called on value that's not a PlainTime"_s);
 
@@ -283,7 +283,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToJSON, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.toJSON called on value that's not a PlainTime"_s);
 
@@ -296,7 +296,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToLocaleString, (JSGlobal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(callFrame->thisValue());
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.toLocaleString called on value that's not a PlainTime"_s);
 
@@ -317,7 +317,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterHour, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(JSValue::decode(thisValue));
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(JSValue::decode(thisValue));
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.hour called on value that's not a PlainTime"_s);
 
@@ -329,7 +329,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterMinute, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(JSValue::decode(thisValue));
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(JSValue::decode(thisValue));
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.minute called on value that's not a PlainTime"_s);
 
@@ -341,7 +341,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterSecond, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(JSValue::decode(thisValue));
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(JSValue::decode(thisValue));
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.second called on value that's not a PlainTime"_s);
 
@@ -353,7 +353,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterMillisecond, (JSGlobalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(JSValue::decode(thisValue));
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(JSValue::decode(thisValue));
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.millisecond called on value that's not a PlainTime"_s);
 
@@ -365,7 +365,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterMicrosecond, (JSGlobalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(JSValue::decode(thisValue));
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(JSValue::decode(thisValue));
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.microsecond called on value that's not a PlainTime"_s);
 
@@ -377,7 +377,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterNanosecond, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(JSValue::decode(thisValue));
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(JSValue::decode(thisValue));
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.nanosecond called on value that's not a PlainTime"_s);
 
@@ -389,7 +389,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterCalendar, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* plainTime = jsDynamicCast<TemporalPlainTime*>(JSValue::decode(thisValue));
+    auto* plainTime = dynamicDowncast<TemporalPlainTime>(JSValue::decode(thisValue));
     if (!plainTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.calendar called on value that's not a PlainTime"_s);
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
@@ -120,7 +120,7 @@ static JSC::EncodedJSValue temporalPlainYearMonthPrototypeAddOrSubtract(JSGlobal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(callFrame->thisValue());
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(callFrame->thisValue());
     if (!yearMonth) [[unlikely]] {
         if constexpr (op == AddOrSubtract::Add)
             return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.add called on value that's not a PlainYearMonth"_s);
@@ -159,7 +159,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncWith, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(callFrame->thisValue());
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(callFrame->thisValue());
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.with called on value that's not a PlainYearMonth"_s);
 
@@ -179,7 +179,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncUntil, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(callFrame->thisValue());
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(callFrame->thisValue());
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.until called on value that's not a PlainYearMonth"_s);
 
@@ -198,7 +198,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncSince, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(callFrame->thisValue());
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(callFrame->thisValue());
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.since called on value that's not a PlainYearMonth"_s);
 
@@ -217,7 +217,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncEquals, (JSGlobalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(callFrame->thisValue());
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(callFrame->thisValue());
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.equals called on value that's not a PlainYearMonth"_s);
 
@@ -236,7 +236,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToPlainDate, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(callFrame->thisValue());
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(callFrame->thisValue());
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.toPlainDate called on value that's not a PlainYearMonth"_s);
 
@@ -270,7 +270,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToString, (JSGlobalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(callFrame->thisValue());
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(callFrame->thisValue());
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.toString called on value that's not a PlainYearMonth"_s);
 
@@ -283,7 +283,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToJSON, (JSGlobalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(callFrame->thisValue());
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(callFrame->thisValue());
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.toJSON called on value that's not a PlainYearMonth"_s);
 
@@ -296,7 +296,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToLocaleString, (JSG
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(callFrame->thisValue());
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(callFrame->thisValue());
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.toLocaleString called on value that's not a PlainYearMonth"_s);
 
@@ -317,7 +317,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainYearMonthPrototypeGetterCalendarId, (JSGlo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(JSValue::decode(thisValue));
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(JSValue::decode(thisValue));
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.calendar called on value that's not a PlainYearMonth"_s);
 
@@ -330,7 +330,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainYearMonthPrototypeGetterYear, (JSGlobalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(JSValue::decode(thisValue));
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(JSValue::decode(thisValue));
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.year called on value that's not a PlainYearMonth"_s);
 
@@ -342,7 +342,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainYearMonthPrototypeGetterMonth, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(JSValue::decode(thisValue));
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(JSValue::decode(thisValue));
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.month called on value that's not a PlainYearMonth"_s);
 
@@ -354,7 +354,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainYearMonthPrototypeGetterMonthCode, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(JSValue::decode(thisValue));
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(JSValue::decode(thisValue));
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.monthCode called on value that's not a PlainYearMonth"_s);
 
@@ -366,7 +366,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainYearMonthPrototypeGetterDaysInMonth, (JSGl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(JSValue::decode(thisValue));
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(JSValue::decode(thisValue));
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.daysInMonth called on value that's not a PlainYearMonth"_s);
 
@@ -378,7 +378,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainYearMonthPrototypeGetterDaysInYear, (JSGlo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(JSValue::decode(thisValue));
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(JSValue::decode(thisValue));
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.daysInYear called on value that's not a PlainYearMonth"_s);
 
@@ -390,7 +390,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainYearMonthPrototypeGetterMonthsInYear, (JSG
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(JSValue::decode(thisValue));
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(JSValue::decode(thisValue));
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.monthsInYear called on value that's not a PlainYearMonth"_s);
 
@@ -402,7 +402,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainYearMonthPrototypeGetterInLeapYear, (JSGlo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* yearMonth = jsDynamicCast<TemporalPlainYearMonth*>(JSValue::decode(thisValue));
+    auto* yearMonth = dynamicDowncast<TemporalPlainYearMonth>(JSValue::decode(thisValue));
     if (!yearMonth) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.inLeapYear called on value that's not a PlainYearMonth"_s);
 

--- a/Source/JavaScriptCore/runtime/TemporalTimeZonePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZonePrototype.cpp
@@ -89,7 +89,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalTimeZonePrototypeFuncToString, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* timeZone = jsDynamicCast<TemporalTimeZone*>(callFrame->thisValue());
+    auto* timeZone = dynamicDowncast<TemporalTimeZone>(callFrame->thisValue());
     if (!timeZone)
         return throwVMTypeError(globalObject, scope, "Temporal.TimeZone.prototype.toString called on value that's not a TimeZone"_s);
 

--- a/Source/JavaScriptCore/runtime/TestRunnerUtils.cpp
+++ b/Source/JavaScriptCore/runtime/TestRunnerUtils.cpp
@@ -37,11 +37,11 @@ FunctionExecutable* getExecutableForFunction(JSValue theFunctionValue)
     if (!theFunctionValue.isCell())
         return nullptr;
 
-    JSFunction* theFunction = jsDynamicCast<JSFunction*>(theFunctionValue);
+    JSFunction* theFunction = dynamicDowncast<JSFunction>(theFunctionValue);
     if (!theFunction)
         return nullptr;
     
-    FunctionExecutable* executable = jsDynamicCast<FunctionExecutable*>(
+    FunctionExecutable* executable = dynamicDowncast<FunctionExecutable>(
         theFunction->executable());
     return executable;
 }

--- a/Source/JavaScriptCore/runtime/ThrowScope.cpp
+++ b/Source/JavaScriptCore/runtime/ThrowScope.cpp
@@ -81,7 +81,7 @@ Exception* ThrowScope::throwException(JSGlobalObject* globalObject, Exception* e
 
 Exception* ThrowScope::throwException(JSGlobalObject* globalObject, JSValue error)
 {
-    if (!error.isCell() || error.isObject() || !jsDynamicCast<Exception*>(error.asCell()))
+    if (!error.isCell() || error.isObject() || !is<Exception>(error.asCell()))
         m_vm.verifyExceptionCheckNeedIsSatisfied(m_recursionDepth, m_location);
     
     return m_vm.throwException(globalObject, error);

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1078,7 +1078,7 @@ Exception* VM::throwException(JSGlobalObject* globalObject, Exception* exception
 
 Exception* VM::throwException(JSGlobalObject* globalObject, JSValue thrownValue)
 {
-    Exception* exception = jsDynamicCast<Exception*>(thrownValue);
+    Exception* exception = dynamicDowncast<Exception>(thrownValue);
     if (!exception)
         exception = Exception::create(*this, thrownValue);
 

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
@@ -66,7 +66,7 @@ ALWAYS_INLINE static JSWeakMap* getWeakMap(JSGlobalObject* globalObject, JSValue
         return nullptr;
     }
 
-    if (auto* map = jsDynamicCast<JSWeakMap*>(asObject(value))) [[likely]]
+    if (auto* map = dynamicDowncast<JSWeakMap>(asObject(value))) [[likely]]
         return map;
 
     throwTypeError(globalObject, scope, "Called WeakMap function on a non-WeakMap object"_s);

--- a/Source/JavaScriptCore/runtime/WeakObjectRefPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakObjectRefPrototype.cpp
@@ -56,7 +56,7 @@ ALWAYS_INLINE static JSWeakObjectRef* getWeakRef(JSGlobalObject* globalObject, J
         return nullptr;
     }
 
-    if (auto* ref = jsDynamicCast<JSWeakObjectRef*>(asObject(value))) [[likely]]
+    if (auto* ref = dynamicDowncast<JSWeakObjectRef>(asObject(value))) [[likely]]
         return ref;
 
     throwTypeError(globalObject, scope, "Called WeakRef function on a non-WeakRef object"_s);

--- a/Source/JavaScriptCore/runtime/WeakSetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakSetPrototype.cpp
@@ -60,7 +60,7 @@ ALWAYS_INLINE static JSWeakSet* getWeakSet(JSGlobalObject* globalObject, JSValue
         return nullptr;
     }
 
-    if (auto* set = jsDynamicCast<JSWeakSet*>(asObject(value))) [[likely]]
+    if (auto* set = dynamicDowncast<JSWeakSet>(asObject(value))) [[likely]]
         return set;
 
     throwTypeError(globalObject, scope, "Called WeakSet function on a non-WeakSet object"_s);

--- a/Source/JavaScriptCore/tools/HeapVerifier.cpp
+++ b/Source/JavaScriptCore/tools/HeapVerifier.cpp
@@ -326,7 +326,7 @@ bool HeapVerifier::validateJSCell(VM* expectedVM, JSCell* cell, CellProfile* pro
             }
         }
         
-        CodeBlock* codeBlock = jsDynamicCast<CodeBlock*>(cell);
+        CodeBlock* codeBlock = dynamicDowncast<CodeBlock>(cell);
         if (codeBlock) [[unlikely]] {
             bool success = true;
             codeBlock->forEachValueProfile([&](auto& valueProfile, bool) {

--- a/Source/JavaScriptCore/tools/Integrity.cpp
+++ b/Source/JavaScriptCore/tools/Integrity.cpp
@@ -301,7 +301,7 @@ bool Analyzer::analyzeCell(VM& vm, JSCell* cell, Analyzer::Action action)
     }
 
     if (cell->isObject()) {
-        AUDIT_VERIFY(jsDynamicCast<JSObject*>(cell),
+        AUDIT_VERIFY(dynamicDowncast<JSObject>(cell),
             "cell %p cell.type %d", cell, cell->type());
     }
 

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -575,7 +575,7 @@ JSC_DEFINE_CUSTOM_GETTER(customGetterValueGetter, (JSGlobalObject* globalObject,
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    CustomGetter* thisObject = jsDynamicCast<CustomGetter*>(JSValue::decode(thisValue));
+    CustomGetter* thisObject = dynamicDowncast<CustomGetter>(JSValue::decode(thisValue));
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
     bool shouldThrow = thisObject->get(globalObject, PropertyName(Identifier::fromString(vm, "shouldThrow"_s))).toBoolean(globalObject);
@@ -591,7 +591,7 @@ JSC_DEFINE_CUSTOM_GETTER(customGetterAcessorGetter, (JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSObject* thisObject = jsDynamicCast<JSObject*>(JSValue::decode(thisValue));
+    JSObject* thisObject = dynamicDowncast<JSObject>(JSValue::decode(thisValue));
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
     bool shouldThrow = thisObject->get(globalObject, PropertyName(Identifier::fromString(vm, "shouldThrow"_s))).toBoolean(globalObject);
@@ -722,7 +722,7 @@ JSC_DEFINE_CUSTOM_GETTER(runtimeArrayLengthGetter, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    RuntimeArray* thisObject = jsDynamicCast<RuntimeArray*>(JSValue::decode(thisValue));
+    RuntimeArray* thisObject = dynamicDowncast<RuntimeArray>(JSValue::decode(thisValue));
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
     return JSValue::encode(jsNumber(thisObject->getLength()));
@@ -737,7 +737,7 @@ JSC_DEFINE_CUSTOM_GETTER(testStaticAccessorGetter, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     
-    JSObject* thisObject = jsDynamicCast<JSObject*>(JSValue::decode(thisValue));
+    JSObject* thisObject = dynamicDowncast<JSObject>(JSValue::decode(thisValue));
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
 
@@ -837,7 +837,7 @@ JSC_DEFINE_CUSTOM_SETTER(testStaticValuePutter, (JSGlobalObject* globalObject, E
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     
-    JSObject* thisObject = jsDynamicCast<JSObject*>(JSValue::decode(thisValue));
+    JSObject* thisObject = dynamicDowncast<JSObject>(JSValue::decode(thisValue));
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
 
@@ -850,7 +850,7 @@ JSC_DEFINE_CUSTOM_SETTER(testStaticValuePutterSetFlag, (JSGlobalObject* globalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSObject* thisObject = jsDynamicCast<JSObject*>(JSValue::decode(thisValue));
+    JSObject* thisObject = dynamicDowncast<JSObject>(JSValue::decode(thisValue));
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
 
@@ -1159,7 +1159,7 @@ JSC_DEFINE_CUSTOM_GETTER(domJITGetterCustomGetter, (JSGlobalObject* globalObject
     DollarVMAssertScope assertScope;
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    DOMJITNode* thisObject = jsDynamicCast<DOMJITNode*>(JSValue::decode(thisValue));
+    DOMJITNode* thisObject = dynamicDowncast<DOMJITNode>(JSValue::decode(thisValue));
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
     return JSValue::encode(jsNumber(thisObject->value()));
@@ -1260,7 +1260,7 @@ JSC_DEFINE_CUSTOM_GETTER(domJITGetterNoEffectCustomGetter, (JSGlobalObject* glob
     DollarVMAssertScope assertScope;
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    DOMJITNode* thisObject = jsDynamicCast<DOMJITNode*>(JSValue::decode(thisValue));
+    DOMJITNode* thisObject = dynamicDowncast<DOMJITNode>(JSValue::decode(thisValue));
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
     return JSValue::encode(jsNumber(thisObject->value()));
@@ -1353,7 +1353,7 @@ public:
 JSC_DEFINE_HOST_FUNCTION(functionDOMJITGetterComplexEnableException, (JSGlobalObject*, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
-    auto* object = jsDynamicCast<DOMJITGetterComplex*>(callFrame->thisValue());
+    auto* object = dynamicDowncast<DOMJITGetterComplex>(callFrame->thisValue());
     if (object)
         object->m_enableException = true;
     return JSValue::encode(jsUndefined());
@@ -1365,7 +1365,7 @@ JSC_DEFINE_CUSTOM_GETTER(domJITGetterComplexCustomGetter, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsDynamicCast<DOMJITGetterComplex*>(JSValue::decode(thisValue));
+    auto* thisObject = dynamicDowncast<DOMJITGetterComplex>(JSValue::decode(thisValue));
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
     if (thisObject->m_enableException)
@@ -1381,7 +1381,7 @@ JSC_DEFINE_JIT_OPERATION(domJITGetterComplexSlowCall, EncodedJSValue, (JSGlobalO
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* object = static_cast<DOMJITNode*>(pointer);
-    auto* domjitGetterComplex = jsDynamicCast<DOMJITGetterComplex*>(object);
+    auto* domjitGetterComplex = dynamicDowncast<DOMJITGetterComplex>(object);
     if (domjitGetterComplex) {
         if (domjitGetterComplex->m_enableException)
             OPERATION_RETURN(scope, JSValue::encode(throwException(globalObject, scope, createError(globalObject, "DOMJITGetterComplex slow call exception"_s))));
@@ -1458,7 +1458,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDOMJITFunctionObjectWithTypeCheck, (JSGlobalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    DOMJITNode* thisObject = jsDynamicCast<DOMJITNode*>(callFrame->thisValue());
+    DOMJITNode* thisObject = dynamicDowncast<DOMJITNode>(callFrame->thisValue());
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
     return JSValue::encode(jsNumber(thisObject->value()));
@@ -1521,7 +1521,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDOMJITCheckJSCastObjectWithTypeCheck, (JSGlobal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsDynamicCast<DOMJITCheckJSCastObject*>(callFrame->thisValue());
+    auto* thisObject = dynamicDowncast<DOMJITCheckJSCastObject>(callFrame->thisValue());
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
     return JSValue::encode(jsNumber(thisObject->value()));
@@ -1629,7 +1629,7 @@ JSC_DEFINE_CUSTOM_GETTER(domJITGetterBaseJSObjectCustomGetter, (JSGlobalObject* 
     DollarVMAssertScope assertScope;
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSObject* thisObject = jsDynamicCast<JSObject*>(JSValue::decode(thisValue));
+    JSObject* thisObject = dynamicDowncast<JSObject>(JSValue::decode(thisValue));
     if (!thisObject)
         return throwVMTypeError(globalObject, scope);
     return JSValue::encode(thisObject->getPrototypeDirect());
@@ -1828,7 +1828,7 @@ JSC_DEFINE_CUSTOM_SETTER(customFunctionSetter, (JSGlobalObject* globalObject, En
     DollarVMAssertScope assertScope;
 
     JSValue value = JSValue::decode(encodedValue);
-    JSFunction* function = jsDynamicCast<JSFunction*>(value);
+    JSFunction* function = dynamicDowncast<JSFunction>(value);
     if (!function)
         return false;
 
@@ -1988,13 +1988,13 @@ JSC_DEFINE_HOST_FUNCTION(functionWasmStreamingParserAddBytes, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsDynamicCast<WasmStreamingParser*>(callFrame->thisValue());
+    auto* thisObject = dynamicDowncast<WasmStreamingParser>(callFrame->thisValue());
     if (!thisObject)
         RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(false)));
 
     JSValue value = callFrame->argument(0);
     BaseWebAssemblySourceProvider* provider = nullptr;
-    if (auto* source = jsDynamicCast<JSSourceCode*>(value))
+    if (auto* source = dynamicDowncast<JSSourceCode>(value))
         provider = static_cast<BaseWebAssemblySourceProvider*>(source->sourceCode().provider());
     SourceProviderBufferGuard guard(provider);
 
@@ -2006,7 +2006,7 @@ JSC_DEFINE_HOST_FUNCTION(functionWasmStreamingParserAddBytes, (JSGlobalObject* g
 JSC_DEFINE_HOST_FUNCTION(functionWasmStreamingParserFinalize, (JSGlobalObject*, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
-    auto* thisObject = jsDynamicCast<WasmStreamingParser*>(callFrame->thisValue());
+    auto* thisObject = dynamicDowncast<WasmStreamingParser>(callFrame->thisValue());
     if (!thisObject)
         return JSValue::encode(jsBoolean(false));
     return JSValue::encode(jsNumber(static_cast<int32_t>(thisObject->streamingParser().finalize())));
@@ -2089,13 +2089,13 @@ JSC_DEFINE_HOST_FUNCTION(functionWasmStreamingCompilerAddBytes, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsDynamicCast<WasmStreamingCompiler*>(callFrame->thisValue());
+    auto* thisObject = dynamicDowncast<WasmStreamingCompiler>(callFrame->thisValue());
     if (!thisObject)
         RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(false)));
 
     JSValue value = callFrame->argument(0);
     BaseWebAssemblySourceProvider* provider = nullptr;
-    if (auto* source = jsDynamicCast<JSSourceCode*>(value))
+    if (auto* source = dynamicDowncast<JSSourceCode>(value))
         provider = static_cast<BaseWebAssemblySourceProvider*>(source->sourceCode().provider());
     SourceProviderBufferGuard guard(provider);
 
@@ -2491,9 +2491,9 @@ JSC_DEFINE_HOST_FUNCTION(functionCpuClflush, (JSGlobalObject*, CallFrame* callFr
 
     uint32_t offset = callFrame->argument(1).asUInt32();
 
-    if (JSArrayBufferView* view = jsDynamicCast<JSArrayBufferView*>(callFrame->argument(0)))
+    if (JSArrayBufferView* view = dynamicDowncast<JSArrayBufferView>(callFrame->argument(0)))
         toFlush.append(std::bit_cast<char*>(view->vector()) + offset);
-    else if (JSObject* object = jsDynamicCast<JSObject*>(callFrame->argument(0))) {
+    else if (JSObject* object = dynamicDowncast<JSObject>(callFrame->argument(0))) {
         switch (object->indexingType()) {
         case ALL_INT32_INDEXING_TYPES:
         case ALL_CONTIGUOUS_INDEXING_TYPES:
@@ -2549,11 +2549,11 @@ static FunctionExecutable* NODELETE getExecutableForFunction(JSValue theFunction
     if (!theFunctionValue.isCell())
         return nullptr;
     
-    JSFunction* theFunction = jsDynamicCast<JSFunction*>(theFunctionValue);
+    JSFunction* theFunction = dynamicDowncast<JSFunction>(theFunctionValue);
     if (!theFunction)
         return nullptr;
     
-    FunctionExecutable* executable = jsDynamicCast<FunctionExecutable*>(theFunction->executable());
+    FunctionExecutable* executable = dynamicDowncast<FunctionExecutable>(theFunction->executable());
 
     return executable;
 }
@@ -2724,7 +2724,7 @@ static CodeBlock* codeBlockFromArg(JSGlobalObject* globalObject, CallFrame* call
     JSValue value = callFrame->uncheckedArgument(0);
     CodeBlock* candidateCodeBlock = nullptr;
     if (value.isCell()) {
-        JSFunction* func = jsDynamicCast<JSFunction*>(value.asCell());
+        JSFunction* func = dynamicDowncast<JSFunction>(value.asCell());
         if (func) {
             if (func->isHostFunction())
                 candidateCodeBlock = nullptr;
@@ -2907,7 +2907,7 @@ JSC_DEFINE_HOST_FUNCTION(functionIndexingMode, (JSGlobalObject* globalObject, Ca
 JSC_DEFINE_HOST_FUNCTION(functionInlineCapacity, (JSGlobalObject*, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
-    if (auto* object = jsDynamicCast<JSObject*>(callFrame->argument(0)))
+    if (auto* object = dynamicDowncast<JSObject>(callFrame->argument(0)))
         return JSValue::encode(jsNumber(object->structure()->inlineCapacity()));
 
     return encodedJSUndefined();
@@ -3142,7 +3142,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateGlobalObject, (JSGlobalObject* globalObje
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     JSValue prototype = jsNull();
-    if (JSObject* object = jsDynamicCast<JSObject*>(callFrame->argument(0)))
+    if (JSObject* object = dynamicDowncast<JSObject>(callFrame->argument(0)))
         prototype = object;
     return JSValue::encode(JSGlobalObject::create(vm, JSGlobalObject::createStructure(vm, prototype)));
 }
@@ -3152,7 +3152,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateProxy, (JSGlobalObject* globalObject, Cal
     DollarVMAssertScope assertScope;
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    JSGlobalObject* target = jsDynamicCast<JSGlobalObject*>(callFrame->argument(0));
+    JSGlobalObject* target = dynamicDowncast<JSGlobalObject>(callFrame->argument(0));
     if (!target) [[unlikely]]
         return JSValue::encode(jsUndefined());
     Structure* structure = JSGlobalProxy::createStructure(vm, target, target->getPrototypeDirect());
@@ -3280,7 +3280,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForCompile, (JSGloba
     auto [taintedness, url] = sourceTaintedOriginFromStack(vm, callFrame);
     auto source = makeSource("[wasm code]"_s, SourceOrigin(url), taintedness);
 
-    auto callback = jsDynamicCast<JSFunction*>(callFrame->argument(0));
+    auto callback = dynamicDowncast<JSFunction>(callFrame->argument(0));
     if (!callback)
         return throwVMTypeError(globalObject, scope, "First argument is not a JS function"_s);
 
@@ -3305,7 +3305,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiate, (JSG
     auto [taintedness, url] = sourceTaintedOriginFromStack(vm, callFrame);
     auto source = makeSource("[wasm code]"_s, SourceOrigin(url), taintedness);
 
-    auto callback = jsDynamicCast<JSFunction*>(callFrame->argument(0));
+    auto callback = dynamicDowncast<JSFunction>(callFrame->argument(0));
     if (!callback)
         return throwVMTypeError(globalObject, scope, "First argument is not a JS function"_s);
 
@@ -3340,7 +3340,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiateWithUR
     String wasmSourceURL = urlArgument.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto callback = jsDynamicCast<JSFunction*>(callFrame->argument(1));
+    auto callback = dynamicDowncast<JSFunction>(callFrame->argument(1));
     if (!callback)
         return throwVMTypeError(globalObject, scope, "Second argument is not a JS function"_s);
 
@@ -3400,7 +3400,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateObjectDoingSideEffectPutWithoutCorrectSlo
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
 
-    auto* dollarVM = jsDynamicCast<JSDollarVM*>(callFrame->thisValue());
+    auto* dollarVM = dynamicDowncast<JSDollarVM>(callFrame->thisValue());
     RELEASE_ASSERT(dollarVM);
     auto* result = ObjectDoingSideEffectPutWithoutCorrectSlotStatus::create(vm, dollarVM->objectDoingSideEffectPutWithoutCorrectSlotStatusStructure());
     return JSValue::encode(result);
@@ -3432,7 +3432,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetImpureGetterDelegate, (JSGlobalObject* globa
     JSValue delegate = callFrame->argument(1);
     if (!delegate.isObject())
         return JSValue::encode(jsUndefined());
-    ImpureGetter* impureGetter = jsDynamicCast<ImpureGetter*>(asObject(base.asCell()));
+    ImpureGetter* impureGetter = dynamicDowncast<ImpureGetter>(asObject(base.asCell()));
     if (!impureGetter) [[unlikely]] {
         throwTypeError(globalObject, scope, "argument is not an ImpureGetter"_s);
         return encodedJSValue();
@@ -3523,7 +3523,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateElement, (JSGlobalObject* globalObject, C
     JSLockHolder lock(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    Root* root = jsDynamicCast<Root*>(callFrame->argument(0));
+    Root* root = dynamicDowncast<Root>(callFrame->argument(0));
     if (!root)
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Cannot create Element without a Root."_s)));
     return JSValue::encode(Element::create(vm, globalObject, root));
@@ -3534,7 +3534,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGetElement, (JSGlobalObject* globalObject, Call
     DollarVMAssertScope assertScope;
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    Root* root = jsDynamicCast<Root*>(callFrame->argument(0));
+    Root* root = dynamicDowncast<Root>(callFrame->argument(0));
     if (!root)
         return JSValue::encode(jsUndefined());
     Element* result = root->element();
@@ -3556,7 +3556,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGetHiddenValue, (JSGlobalObject* globalObject, 
     JSLockHolder lock(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    SimpleObject* simpleObject = jsDynamicCast<SimpleObject*>(callFrame->argument(0));
+    SimpleObject* simpleObject = dynamicDowncast<SimpleObject>(callFrame->argument(0));
     if (!simpleObject) [[unlikely]] {
         throwTypeError(globalObject, scope, "Invalid use of getHiddenValue test function"_s);
         return encodedJSValue();
@@ -3571,7 +3571,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetHiddenValue, (JSGlobalObject* globalObject, 
     JSLockHolder lock(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    SimpleObject* simpleObject = jsDynamicCast<SimpleObject*>(callFrame->argument(0));
+    SimpleObject* simpleObject = dynamicDowncast<SimpleObject>(callFrame->argument(0));
     if (!simpleObject) [[unlikely]] {
         throwTypeError(globalObject, scope, "Invalid use of setHiddenValue test function"_s);
         return encodedJSValue();
@@ -3625,7 +3625,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFindTypeForExpression, (JSGlobalObject* globalO
 
     JSValue functionValue = callFrame->argument(0);
     RELEASE_ASSERT(functionValue.isCallable());
-    FunctionExecutable* executable = (jsDynamicCast<JSFunction*>(functionValue.asCell()->getObject()))->jsExecutable();
+    FunctionExecutable* executable = (dynamicDowncast<JSFunction>(functionValue.asCell()->getObject()))->jsExecutable();
 
     RELEASE_ASSERT(callFrame->argument(1).isString());
     auto substring = asString(callFrame->argument(1))->value(globalObject);
@@ -3645,7 +3645,7 @@ JSC_DEFINE_HOST_FUNCTION(functionReturnTypeFor, (JSGlobalObject* globalObject, C
 
     JSValue functionValue = callFrame->argument(0);
     RELEASE_ASSERT(functionValue.isCallable());
-    FunctionExecutable* executable = (jsDynamicCast<JSFunction*>(functionValue.asCell()->getObject()))->jsExecutable();
+    FunctionExecutable* executable = (dynamicDowncast<JSFunction>(functionValue.asCell()->getObject()))->jsExecutable();
 
     unsigned offset = executable->functionStart();
     String jsonString = vm.typeProfiler()->typeInformationForExpressionAtOffset(TypeProfilerSearchDescriptorFunctionReturn, offset, executable->sourceID(), vm);
@@ -3679,7 +3679,7 @@ JSC_DEFINE_HOST_FUNCTION(functionHasBasicBlockExecuted, (JSGlobalObject* globalO
 
     JSValue functionValue = callFrame->argument(0);
     RELEASE_ASSERT(functionValue.isCallable());
-    FunctionExecutable* executable = (jsDynamicCast<JSFunction*>(functionValue.asCell()->getObject()))->jsExecutable();
+    FunctionExecutable* executable = (dynamicDowncast<JSFunction>(functionValue.asCell()->getObject()))->jsExecutable();
 
     RELEASE_ASSERT(callFrame->argument(1).isString());
     auto substring = asString(callFrame->argument(1))->value(globalObject);
@@ -3699,7 +3699,7 @@ JSC_DEFINE_HOST_FUNCTION(functionBasicBlockExecutionCount, (JSGlobalObject* glob
 
     JSValue functionValue = callFrame->argument(0);
     RELEASE_ASSERT(functionValue.isCallable());
-    FunctionExecutable* executable = (jsDynamicCast<JSFunction*>(functionValue.asCell()->getObject()))->jsExecutable();
+    FunctionExecutable* executable = (dynamicDowncast<JSFunction>(functionValue.asCell()->getObject()))->jsExecutable();
 
     RELEASE_ASSERT(callFrame->argument(1).isString());
     auto substring = asString(callFrame->argument(1))->value(globalObject);
@@ -3832,7 +3832,7 @@ JSC_DEFINE_HOST_FUNCTION(functionLoadGetterFromGetterSetter, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    GetterSetter* getterSetter = jsDynamicCast<GetterSetter*>(callFrame->argument(0));
+    GetterSetter* getterSetter = dynamicDowncast<GetterSetter>(callFrame->argument(0));
     if (!getterSetter) [[unlikely]] {
         throwTypeError(globalObject, scope, "Invalid use of loadGetterFromGetterSetter test function: argument is not a GetterSetter"_s);
         return encodedJSValue();
@@ -3853,8 +3853,8 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateCustomTestGetterSetter, (JSGlobalObject* 
 JSC_DEFINE_HOST_FUNCTION(functionDeltaBetweenButterflies, (JSGlobalObject*, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
-    JSObject* a = jsDynamicCast<JSObject*>(callFrame->argument(0));
-    JSObject* b = jsDynamicCast<JSObject*>(callFrame->argument(1));
+    JSObject* a = dynamicDowncast<JSObject>(callFrame->argument(0));
+    JSObject* b = dynamicDowncast<JSObject>(callFrame->argument(1));
     if (!a || !b)
         return JSValue::encode(jsNumber(PNaN));
 
@@ -3965,7 +3965,7 @@ JSC_DEFINE_HOST_FUNCTION(functionHasOwnLengthProperty, (JSGlobalObject* globalOb
     VM& vm = globalObject->vm();
 
     JSObject* target = asObject(callFrame->uncheckedArgument(0));
-    JSFunction* function = jsDynamicCast<JSFunction*>(target);
+    JSFunction* function = dynamicDowncast<JSFunction>(target);
     return JSValue::encode(jsBoolean(function->canAssumeNameAndLengthAreOriginal(vm)));
 }
 
@@ -3984,7 +3984,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetUserPreferredLanguages, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSArray* array = jsDynamicCast<JSArray*>(callFrame->argument(0));
+    JSArray* array = dynamicDowncast<JSArray>(callFrame->argument(0));
     if (!array)
         return throwVMTypeError(globalObject, scope, "Expected first argument to be an array"_s);
 
@@ -4099,7 +4099,7 @@ JSC_DEFINE_HOST_FUNCTION(functionToCacheableDictionary, (JSGlobalObject* globalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSObject* object = jsDynamicCast<JSObject*>(callFrame->argument(0));
+    JSObject* object = dynamicDowncast<JSObject>(callFrame->argument(0));
     if (!object)
         return throwVMTypeError(globalObject, scope, "Expected first argument to be an object"_s);
     if (!object->structure()->isUncacheableDictionary())
@@ -4113,7 +4113,7 @@ JSC_DEFINE_HOST_FUNCTION(functionToUncacheableDictionary, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSObject* object = jsDynamicCast<JSObject*>(callFrame->argument(0));
+    JSObject* object = dynamicDowncast<JSObject>(callFrame->argument(0));
     if (!object)
         return throwVMTypeError(globalObject, scope, "Expected first argument to be an object"_s);
     object->convertToUncacheableDictionary(vm);

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -365,7 +365,7 @@ SUPPRESS_ASAN void VMInspector::dumpRegisters(CallFrame* callFrame)
 
     // Dumping from low memory to high memory.
     JSCell* owner = callFrame->codeOwnerCell();
-    CodeBlock* codeBlock = jsDynamicCast<CodeBlock*>(owner);
+    CodeBlock* codeBlock = dynamicDowncast<CodeBlock>(owner);
     unsigned numCalleeLocals = codeBlock ? codeBlock->numCalleeLocals() : 0;
     unsigned numVars = codeBlock ? codeBlock->numVars() : 0;
     bool isWasm = false;

--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -82,15 +82,15 @@ void validateWasmValue(uint64_t wasmValue, Type expectedType)
             ASSERT(value.isInt32());
 
         if (isStructref(expectedType))
-            ASSERT(jsDynamicCast<JSWebAssemblyStruct*>(value));
+            ASSERT(is<JSWebAssemblyStruct>(value));
 
         if (isArrayref(expectedType))
-            ASSERT(jsDynamicCast<JSWebAssemblyArray*>(value));
+            ASSERT(is<JSWebAssemblyArray>(value));
 
         if (isRefWithTypeIndex(expectedType)) {
             auto expectedRTT = Wasm::TypeInformation::getCanonicalRTT(expectedType.index);
             if (expectedRTT->kind() == RTTKind::Function) {
-                ASSERT(jsDynamicCast<JSFunction*>(value));
+                ASSERT(is<JSFunction>(value));
                 return;
             }
             auto objectPtr = jsCast<WebAssemblyGCObjectBase*>(value);

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -176,7 +176,7 @@ static inline void SYSV_ABI buildEntryBufferForCatch(Probe::Context& context)
 
     JSValue thrownValue = JSValue::decode(exception);
     void* payload = nullptr;
-    if (JSWebAssemblyException* wasmException = jsDynamicCast<JSWebAssemblyException*>(thrownValue))
+    if (JSWebAssemblyException* wasmException = dynamicDowncast<JSWebAssemblyException>(thrownValue))
         payload = std::bit_cast<void*>(wasmException->payload().span().data());
 
     context.gpr(GPRInfo::argumentGPR0) = std::bit_cast<uintptr_t>(buffer);

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -1109,12 +1109,12 @@ bool TypeInformation::isReferenceValueAssignable(JSValue refValue, bool allowNul
             // Casts to these types cannot fail as any value can be an externref/hostref.
             return true;
         case TypeKind::Funcref:
-            return jsDynamicCast<WebAssemblyFunctionBase*>(refValue);
+            return dynamicDowncast<WebAssemblyFunctionBase>(refValue);
         case TypeKind::Eqref:
-            return (refValue.isInt32() && refValue.asInt32() <= maxI31ref && refValue.asInt32() >= minI31ref) || jsDynamicCast<JSWebAssemblyArray*>(refValue) || jsDynamicCast<JSWebAssemblyStruct*>(refValue);
+            return (refValue.isInt32() && refValue.asInt32() <= maxI31ref && refValue.asInt32() >= minI31ref) || is<JSWebAssemblyArray>(refValue) || is<JSWebAssemblyStruct>(refValue);
         case TypeKind::Exnref:
             // Exnref and Noexnref are in a different heap hierarchy
-            return jsDynamicCast<JSWebAssemblyException*>(refValue);
+            return dynamicDowncast<JSWebAssemblyException>(refValue);
         case TypeKind::Noexnref:
         case TypeKind::Noneref:
         case TypeKind::Nofuncref:
@@ -1123,9 +1123,9 @@ bool TypeInformation::isReferenceValueAssignable(JSValue refValue, bool allowNul
         case TypeKind::I31ref:
             return refValue.isInt32() && refValue.asInt32() <= maxI31ref && refValue.asInt32() >= minI31ref;
         case TypeKind::Arrayref:
-            return jsDynamicCast<JSWebAssemblyArray*>(refValue);
+            return dynamicDowncast<JSWebAssemblyArray>(refValue);
         case TypeKind::Structref:
-            return jsDynamicCast<JSWebAssemblyStruct*>(refValue);
+            return dynamicDowncast<JSWebAssemblyStruct>(refValue);
         default:
             RELEASE_ASSERT_NOT_REACHED();
         }
@@ -1140,14 +1140,14 @@ bool TypeInformation::isReferenceValueAssignable(JSValue refValue, bool allowNul
 
     switch (rtt->kind()) {
     case RTTKind::Function: {
-        WebAssemblyFunctionBase* funcRef = jsDynamicCast<WebAssemblyFunctionBase*>(refValue);
+        WebAssemblyFunctionBase* funcRef = dynamicDowncast<WebAssemblyFunctionBase>(refValue);
         if (!funcRef)
             return false;
         return funcRef->rtt()->isSubRTT(*rtt);
     }
     case RTTKind::Array:
     case RTTKind::Struct: {
-        auto* object = jsDynamicCast<WebAssemblyGCObjectBase*>(refValue);
+        auto* object = dynamicDowncast<WebAssemblyGCObjectBase>(refValue);
         if (!object)
             return false;
         return object->rtt().isSubRTT(*rtt);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -388,7 +388,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyPromisingFunc, (JSGlobalObject* globalObject
 
     JSValue arg = callFrame->argument(0);
 
-    auto* wrapped = jsDynamicCast<WebAssemblyFunctionBase*>(arg);
+    auto* wrapped = dynamicDowncast<WebAssemblyFunctionBase>(arg);
     if (!wrapped) [[unlikely]]
         return JSValue::encode(throwTypeError(globalObject, scope, "Argument 0 must be a WebAssembly exported function"_s));
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -105,14 +105,14 @@ ALWAYS_INLINE std::span<const uint8_t> getWasmBufferFromValue(JSGlobalObject* gl
     VM& vm = getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    if (auto* source = jsDynamicCast<JSSourceCode*>(value)) {
+    if (auto* source = dynamicDowncast<JSSourceCode>(value)) {
         auto* provider = static_cast<BaseWebAssemblySourceProvider*>(source->sourceCode().provider());
         return { provider->data(), provider->size() };
     }
 
     // If the given bytes argument is not a BufferSource, a TypeError exception is thrown.
-    JSArrayBuffer* arrayBuffer = value.getObject() ? jsDynamicCast<JSArrayBuffer*>(value.getObject()) : nullptr;
-    JSArrayBufferView* arrayBufferView = value.getObject() ? jsDynamicCast<JSArrayBufferView*>(value.getObject()) : nullptr;
+    JSArrayBuffer* arrayBuffer = value.getObject() ? dynamicDowncast<JSArrayBuffer>(value.getObject()) : nullptr;
+    JSArrayBufferView* arrayBufferView = value.getObject() ? dynamicDowncast<JSArrayBufferView>(value.getObject()) : nullptr;
     if (!(arrayBuffer || arrayBufferView)) {
         throwException(globalObject, throwScope, createTypeError(globalObject,
             "first argument must be an ArrayBufferView or an ArrayBuffer"_s, defaultSourceAppender, runtimeTypeForValue(value)));
@@ -145,7 +145,7 @@ ALWAYS_INLINE Vector<uint8_t> createSourceBufferFromValue(VM& vm, JSGlobalObject
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     BaseWebAssemblySourceProvider* provider = nullptr;
-    if (auto* source = jsDynamicCast<JSSourceCode*>(value))
+    if (auto* source = dynamicDowncast<JSSourceCode>(value))
         provider = static_cast<BaseWebAssemblySourceProvider*>(source->sourceCode().provider());
     SourceProviderBufferGuard bufferGuard(provider);
 
@@ -250,7 +250,7 @@ ALWAYS_INLINE uint64_t toWebAssemblyValue(JSGlobalObject* globalObject, const Wa
             if (type.isNullable() && value.isNull())
                 break;
 
-            auto* wasmFunction = jsDynamicCast<WebAssemblyFunctionBase*>(value);
+            auto* wasmFunction = dynamicDowncast<WebAssemblyFunctionBase>(value);
             if (!wasmFunction)
                 return throwVMTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -610,7 +610,7 @@ void JSWebAssemblyInstance::initElementSegment(uint32_t tableIndex, const Elemen
         if (jsTable->table()->isFuncrefTable()) {
             // Validation should guarantee that the table is for funcs, and the value is a func as well.
             if (initValue.isObject())
-                ASSERT(jsDynamicCast<WebAssemblyFunctionBase*>(asObject(initValue)));
+                ASSERT(is<WebAssemblyFunctionBase>(asObject(initValue)));
             else
                 ASSERT(initValue.isNull());
         } else

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
@@ -250,7 +250,7 @@ static bool isMutI16Array(const JSWebAssemblyArray* array)
 // Expands into code that verifies that the variable contains a (non-null) array of mutable i16s.
 #define ENSURE_ARRAY_MUT_I16(var) \
     { \
-        auto* tmpArray = jsDynamicCast<JSWebAssemblyArray*>(var); \
+        auto* tmpArray = dynamicDowncast<JSWebAssemblyArray>(var); \
         if (!tmpArray || !isMutI16Array(tmpArray)) [[unlikely]] \
             THROW_ILLEGAL_ARGUMENT_EXCEPTION; \
     }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
@@ -50,7 +50,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
     JSValue tagValue = callFrame->argument(0);
     JSValue tagParameters = callFrame->argument(1);
 
-    auto tag = jsDynamicCast<JSWebAssemblyTag*>(tagValue);
+    auto tag = dynamicDowncast<JSWebAssemblyTag>(tagValue);
     if (!tag)
         return throwVMTypeError(globalObject, scope, "WebAssembly.Exception constructor expects the first argument to be a WebAssembly.Tag"_s);
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
@@ -86,7 +86,7 @@ ALWAYS_INLINE static JSWebAssemblyException* getException(JSGlobalObject* global
         throwVMError(globalObject, scope, createNotAnObjectError(globalObject, thisValue));
         return nullptr;
     }
-    auto* tag = jsDynamicCast<JSWebAssemblyException*>(thisValue.asCell());
+    auto* tag = dynamicDowncast<JSWebAssemblyException>(thisValue.asCell());
     if (tag) [[likely]]
         return tag;
     throwTypeError(globalObject, scope, "WebAssembly.Exception operation called on non-Exception object"_s);
@@ -108,7 +108,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyExceptionProtoFuncGetArg, (JSGlobalObject* g
     if (callFrame->argumentCount() < 2) [[unlikely]]
         return JSValue::encode(throwException(globalObject, throwScope, createNotEnoughArgumentsError(globalObject)));
 
-    JSWebAssemblyTag* tag = jsDynamicCast<JSWebAssemblyTag*>(callFrame->argument(0));
+    JSWebAssemblyTag* tag = dynamicDowncast<JSWebAssemblyTag>(callFrame->argument(0));
     if (!tag) [[unlikely]]
         return throwVMTypeError(globalObject, throwScope, formatMessage("First argument must be a WebAssembly.Tag"_s));
 
@@ -135,7 +135,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyExceptionProtoFuncIs, (JSGlobalObject* globa
     if (callFrame->argumentCount() < 1) [[unlikely]]
         return JSValue::encode(throwException(globalObject, throwScope, createNotEnoughArgumentsError(globalObject)));
 
-    JSWebAssemblyTag* tag = jsDynamicCast<JSWebAssemblyTag*>(callFrame->argument(0));
+    JSWebAssemblyTag* tag = dynamicDowncast<JSWebAssemblyTag>(callFrame->argument(0));
     if (!tag)
         return throwVMTypeError(globalObject, throwScope, "WebAssembly.Exception.is(): First argument must be a WebAssembly.Tag"_s);
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
@@ -58,7 +58,7 @@ const ClassInfo WebAssemblyGlobalPrototype::s_info = { "WebAssembly.Global"_s, &
 static ALWAYS_INLINE JSWebAssemblyGlobal* getGlobal(JSGlobalObject* globalObject, VM& vm, JSValue v)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    JSWebAssemblyGlobal* result = jsDynamicCast<JSWebAssemblyGlobal*>(v);
+    JSWebAssemblyGlobal* result = dynamicDowncast<JSWebAssemblyGlobal>(v);
     if (!result) {
         throwException(globalObject, throwScope,
             createTypeError(globalObject, "expected |this| value to be an instance of WebAssembly.Global"_s));

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyInstanceConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyInstanceConstructor.cpp
@@ -51,7 +51,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyInstance, (JSGlobalObject* global
     RefPtr<SourceProvider> provider = StringSourceProvider::create("[wasm code]"_s, SourceOrigin(url), String(), taintedness, TextPosition(), SourceProviderSourceType::Program);
 
     // If moduleObject is not a WebAssembly.Module instance, a TypeError is thrown.
-    JSWebAssemblyModule* module = jsDynamicCast<JSWebAssemblyModule*>(callFrame->argument(0));
+    JSWebAssemblyModule* module = dynamicDowncast<JSWebAssemblyModule>(callFrame->argument(0));
     if (!module)
         return JSValue::encode(throwException(globalObject, scope, createTypeError(globalObject, "first argument to WebAssembly.Instance must be a WebAssembly.Module"_s, defaultSourceAppender, runtimeTypeForValue(callFrame->argument(0)))));
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyInstancePrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyInstancePrototype.cpp
@@ -42,7 +42,7 @@ const ClassInfo WebAssemblyInstancePrototype::s_info = { "WebAssembly.Instance"_
 static ALWAYS_INLINE JSWebAssemblyInstance* getInstance(JSGlobalObject* globalObject, VM& vm, JSValue v)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    JSWebAssemblyInstance* result = jsDynamicCast<JSWebAssemblyInstance*>(v);
+    JSWebAssemblyInstance* result = dynamicDowncast<JSWebAssemblyInstance>(v);
     if (!result) {
         throwException(globalObject, throwScope, 
             createTypeError(globalObject, "expected |this| value to be an instance of WebAssembly.Instance"_s));

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp
@@ -65,7 +65,7 @@ ALWAYS_INLINE JSWebAssemblyMemory* getMemory(JSGlobalObject* globalObject, VM& v
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    JSWebAssemblyMemory* memory = jsDynamicCast<JSWebAssemblyMemory*>(value); 
+    JSWebAssemblyMemory* memory = dynamicDowncast<JSWebAssemblyMemory>(value);
     if (!memory) {
         throwException(globalObject, throwScope, 
             createTypeError(globalObject, "WebAssembly.Memory.prototype.buffer getter called with non WebAssembly.Memory |this| value"_s));

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
@@ -77,7 +77,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyModuleCustomSections, (JSGlobalObject* globa
     if (callFrame->argumentCount() < 2) [[unlikely]]
         return JSValue::encode(throwException(globalObject, throwScope, createNotEnoughArgumentsError(globalObject)));
 
-    JSWebAssemblyModule* module = jsDynamicCast<JSWebAssemblyModule*>(callFrame->uncheckedArgument(0));
+    JSWebAssemblyModule* module = dynamicDowncast<JSWebAssemblyModule>(callFrame->uncheckedArgument(0));
     if (!module)
         return JSValue::encode(throwException(globalObject, throwScope, createTypeError(globalObject, "WebAssembly.Module.customSections called with non WebAssembly.Module argument"_s)));
 
@@ -211,7 +211,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyModuleImports, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    JSWebAssemblyModule* module = jsDynamicCast<JSWebAssemblyModule*>(callFrame->argument(0));
+    JSWebAssemblyModule* module = dynamicDowncast<JSWebAssemblyModule>(callFrame->argument(0));
     if (!module)
         return JSValue::encode(throwException(globalObject, throwScope, createTypeError(globalObject, "WebAssembly.Module.imports called with non WebAssembly.Module argument"_s)));
 
@@ -254,7 +254,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyModuleExports, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    JSWebAssemblyModule* module = jsDynamicCast<JSWebAssemblyModule*>(callFrame->argument(0));
+    JSWebAssemblyModule* module = dynamicDowncast<JSWebAssemblyModule>(callFrame->argument(0));
     if (!module)
         return JSValue::encode(throwException(globalObject, throwScope, createTypeError(globalObject, "WebAssembly.Module.exports called with non WebAssembly.Module argument"_s)));
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -431,7 +431,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
 
         case Wasm::ExternalKind::Table: {
             // 7. If i is a table import:
-            JSWebAssemblyTable* table = jsDynamicCast<JSWebAssemblyTable*>(value);
+            JSWebAssemblyTable* table = dynamicDowncast<JSWebAssemblyTable>(value);
             // i. If v is not a WebAssembly.Table object, throw a WebAssembly.LinkError.
             if (!table)
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Table import"_s, "is not an instance of WebAssembly.Table"_s)));
@@ -462,7 +462,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
         }
 
         case Wasm::ExternalKind::Exception: {
-            JSWebAssemblyTag* tag = jsDynamicCast<JSWebAssemblyTag*>(value);
+            JSWebAssemblyTag* tag = dynamicDowncast<JSWebAssemblyTag>(value);
             if (!tag)
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Tag import"_s, "is not an instance of WebAssembly.Tag"_s)));
 
@@ -477,7 +477,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
         }
 
         case Wasm::ExternalKind::Memory:
-            JSWebAssemblyMemory* memory = jsDynamicCast<JSWebAssemblyMemory*>(value);
+            JSWebAssemblyMemory* memory = dynamicDowncast<JSWebAssemblyMemory>(value);
             // i. If v is not a WebAssembly.Memory object, throw a WebAssembly.LinkError.
             if (!memory)
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Memory import"_s, "is not an instance of WebAssembly.Memory"_s)));

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
@@ -136,7 +136,7 @@ void* runWebAssemblySuspendingFunction(JSGlobalObject* globalObject, CallFrame* 
     JSValue result = call(globalObject, callable, callData, jsUndefined(), args);
     RETURN_IF_EXCEPTION(scope, { });
 
-    JSPromise* promise = jsDynamicCast<JSPromise*>(result);
+    JSPromise* promise = dynamicDowncast<JSPromise>(result);
     if (!promise) {
         // The spec requires us to suspend even if the wrapped function returned a real value.
         promise = JSPromise::create(vm, globalObject->promiseStructure());

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
@@ -64,7 +64,7 @@ const ClassInfo WebAssemblyTablePrototype::s_info = { "WebAssembly.Table"_s, &Ba
 static ALWAYS_INLINE JSWebAssemblyTable* getTable(JSGlobalObject* globalObject, VM& vm, JSValue v)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    JSWebAssemblyTable* result = jsDynamicCast<JSWebAssemblyTable*>(v);
+    JSWebAssemblyTable* result = dynamicDowncast<JSWebAssemblyTable>(v);
     if (!result) {
         throwException(globalObject, throwScope, 
             createTypeError(globalObject, "expected |this| value to be an instance of WebAssembly.Table"_s));

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagPrototype.cpp
@@ -85,7 +85,7 @@ ALWAYS_INLINE static JSWebAssemblyTag* getTag(JSGlobalObject* globalObject, JSVa
         throwVMError(globalObject, scope, createNotAnObjectError(globalObject, thisValue));
         return nullptr;
     }
-    auto* tag = jsDynamicCast<JSWebAssemblyTag*>(thisValue.asCell());
+    auto* tag = dynamicDowncast<JSWebAssemblyTag>(thisValue.asCell());
     if (tag) [[likely]]
         return tag;
     throwTypeError(globalObject, scope, "WebAssembly.Tag operation called on non-Tag object"_s);

--- a/Source/WebCore/dom/AsyncNodeDeletionQueueInlines.h
+++ b/Source/WebCore/dom/AsyncNodeDeletionQueueInlines.h
@@ -56,7 +56,7 @@ ALWAYS_INLINE void AsyncNodeDeletionQueue::deleteNodesNow()
 
 ALWAYS_INLINE ContainerNode::CanDelayNodeDeletion AsyncNodeDeletionQueue::canNodeBeDeletedAsync(const Node& node)
 {
-    if (!dynamicDowncast<HTMLElement>(node))
+    if (!is<HTMLElement>(node))
         return ContainerNode::CanDelayNodeDeletion::Yes;
     if (isNodeLikelyLarge(node))
         return ContainerNode::CanDelayNodeDeletion::No;

--- a/Source/WebCore/dom/ComposedTreeIterator.h
+++ b/Source/WebCore/dom/ComposedTreeIterator.h
@@ -415,7 +415,7 @@ inline void ComposedTreeIterator<ContextInlineCapacity>::traverseNextInShadowTre
             context().slotNodeIndex = 0;
             RefPtr assignedNode = assignedNodes->at(0).get();
             ASSERT(assignedNode);
-            ASSERT(dynamicDowncast<Element>(assignedNode->parentNode()));
+            ASSERT(is<Element>(assignedNode->parentNode()));
             m_contextStack.append(Context(*dynamicDowncast<Element>(assignedNode->parentNode()), *assignedNode, Context::Slotted));
             return;
         }
@@ -453,7 +453,7 @@ inline bool ComposedTreeIterator<ContextInlineCapacity>::advanceInSlot(int direc
 
     RefPtr slotNode = assignedNodes.at(context().slotNodeIndex).get();
     ASSERT(slotNode);
-    ASSERT(dynamicDowncast<Element>(slotNode->parentNode()));
+    ASSERT(is<Element>(slotNode->parentNode()));
     m_contextStack.append(Context(*dynamicDowncast<Element>(slotNode->parentNode()), *slotNode, Context::Slotted));
     return true;
 }

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -1049,7 +1049,7 @@ bool Position::isCandidate() const
 
 bool Position::isRenderedCharacter() const
 {
-    if (!dynamicDowncast<Text>(deprecatedNode()))
+    if (!is<Text>(deprecatedNode()))
         return false;
     auto [renderText, offset] = resolvedTextRendererAndOffset();
     return renderText && renderText->containsRenderedCharacterOffset(offset);

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -381,7 +381,7 @@ auto JavaScriptEvaluationResult::JSExtractor::jsValueToExtractedValue(JSGlobalCo
     JSC::JSGlobalObject* globalObject = ::toJS(context);
     JSC::JSObject* jsObject = ::toJS(globalObject, object).toObject(globalObject);
 
-    if (auto* info = jsDynamicCast<JSWebKitJSHandle*>(jsObject)) {
+    if (auto* info = dynamicDowncast<JSWebKitJSHandle>(jsObject)) {
         RELEASE_ASSERT(globalObject->template inherits<WebCore::JSDOMGlobalObject>());
         auto* domGlobalObject = jsCast<WebCore::JSDOMGlobalObject*>(globalObject);
         RefPtr document = dynamicDowncast<Document>(domGlobalObject->scriptExecutionContext());
@@ -392,7 +392,7 @@ auto JavaScriptEvaluationResult::JSExtractor::jsValueToExtractedValue(JSGlobalCo
         return makeUniqueRef<JSHandleInfo>(ref->identifier(), world->identifier(), frame->info(), ref->windowFrameIdentifier());
     }
 
-    if (auto* node = jsDynamicCast<JSWebKitSerializedNode*>(jsObject)) {
+    if (auto* node = dynamicDowncast<JSWebKitSerializedNode>(jsObject)) {
         Ref serializedNode { node->wrapped() };
         return makeUniqueRef<SerializedNode>(serializedNode->serializedNode());
     }

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -336,7 +336,7 @@ WebCore::Element* WebAutomationSessionProxy::elementForNodeHandle(WebFrame& fram
     if (!element)
         return nullptr;
 
-    auto elementWrapper = JSC::jsDynamicCast<WebCore::JSElement*>(toJS(element));
+    auto elementWrapper = dynamicDowncast<WebCore::JSElement>(toJS(element));
     if (!elementWrapper)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -100,7 +100,7 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
         SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     }
 
-    if (auto* domGlobalObject = JSC::jsDynamicCast<JSDOMGlobalObject*>(toJS(context))) {
+    if (auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(toJS(context))) {
         domGlobalObject->addScriptErrorCallback([extension = Ref { *extension }, contentWorldType](const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber) {
             extension->didEncounterScriptError(message, sourceURL, lineNumber, columnNumber, contentWorldType);
         });
@@ -138,7 +138,7 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
         SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     }
 
-    if (auto* domGlobalObject = JSC::jsDynamicCast<JSDOMGlobalObject*>(toJS(context))) {
+    if (auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(toJS(context))) {
         domGlobalObject->addScriptErrorCallback([extension = Ref { *extension }](const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber) {
             extension->didEncounterScriptError(message, sourceURL, lineNumber, columnNumber, WebExtensionContentWorldType::Main);
         });
@@ -158,7 +158,7 @@ void WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary(WebFrame&
     SUPPRESS_UNCOUNTED_ARG auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
     bool browserAlreadySet = namespaceObject && JSValueIsObject(context, namespaceObject);
 
-    auto* domGlobalObject = JSC::jsDynamicCast<JSDOMGlobalObject*>(toJS(context));
+    auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(toJS(context));
     bool callbacksAlreadyRegistered = !domGlobalObject || domGlobalObject->hasScriptErrorCallbacks();
 
     // If both browser and callbacks are already set up, nothing to do.

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
@@ -88,7 +88,7 @@
     JSC::JSGlobalObject* globalObject = ::toJS(context.JSGlobalContextRef);
     JSC::JSObject* jsObject = ::toJS(globalObject, object).toObject(globalObject);
 
-    if (auto* info = jsDynamicCast<WebCore::JSWebKitJSHandle*>(jsObject)) {
+    if (auto* info = dynamicDowncast<WebCore::JSWebKitJSHandle>(jsObject)) {
         RELEASE_ASSERT(globalObject->template inherits<WebCore::JSDOMGlobalObject>());
         auto* domGlobalObject = jsCast<WebCore::JSDOMGlobalObject*>(globalObject);
         RefPtr document = dynamicDowncast<WebCore::Document>(domGlobalObject->scriptExecutionContext());

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1286,7 +1286,7 @@ void WebPage::willBeginWritingToolsSession(const std::optional<WebCore::WritingT
         if (!object)
             continue;
 
-        if (auto* jsNode = JSC::jsDynamicCast<JSNode*>(object))
+        if (auto* jsNode = dynamicDowncast<JSNode>(object))
             preservedNodes.add(protect(jsNode->wrapped()));
     }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -228,7 +228,7 @@ RefPtr<WebCore::GraphicsLayerAsyncContentsDisplayDelegate> GraphicsLayerCARemote
 
 bool GraphicsLayerCARemote::shouldDirectlyCompositeImageBuffer(ImageBuffer* image) const
 {
-    return !!dynamicDowncast<ImageBufferBackendHandleSharing>(image->toBackendSharing());
+    return is<ImageBufferBackendHandleSharing>(image->toBackendSharing());
 }
 
 class ImageBufferFlusherFence final : public WebCore::PlatformCALayerDelegatedContentsFence {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1659,7 +1659,7 @@ static RefPtr<Node> NODELETE nodeFromJSHandleIdentifier(JSHandleIdentifier ident
     if (!object)
         return { };
 
-    auto* jsNode = jsDynamicCast<JSNode*>(object);
+    auto* jsNode = dynamicDowncast<JSNode>(object);
     if (!jsNode)
         return { };
 

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -2108,7 +2108,7 @@ static WebFrameLoadType NODELETE toWebFrameLoadType(WebCore::FrameLoadType frame
     // The global object is probably a proxy object? - if so, we know how to use this!
     JSC::JSObject* globalObjectObj = toJS(globalObjectRef);
     if (!strcmp(globalObjectObj->classInfo()->className, "JSWindowProxy"))
-        anyWorldGlobalObject = JSC::jsDynamicCast<WebCore::JSDOMWindow*>(static_cast<WebCore::JSWindowProxy*>(globalObjectObj)->window());
+        anyWorldGlobalObject = dynamicDowncast<WebCore::JSDOMWindow>(static_cast<WebCore::JSWindowProxy*>(globalObjectObj)->window());
 
     if (!anyWorldGlobalObject)
         return @"";

--- a/Tools/DumpRenderTree/TestRunner.cpp
+++ b/Tools/DumpRenderTree/TestRunner.cpp
@@ -309,7 +309,7 @@ static JSValueRef setAudioResultCallback(JSContextRef context, JSObjectRef funct
     JSC::VM& vm = toJS(context)->vm();
     JSC::JSLockHolder lock(vm);
 
-    JSC::JSArrayBufferView* jsBufferView = JSC::jsDynamicCast<JSC::JSArrayBufferView*>(toJS(toJS(context), arguments[0]));
+    JSC::JSArrayBufferView* jsBufferView = dynamicDowncast<JSC::JSArrayBufferView>(toJS(toJS(context), arguments[0]));
     ASSERT(jsBufferView);
     RefPtr<JSC::ArrayBufferView> bufferView = jsBufferView->unsharedImpl();
     auto buffer = static_cast<const uint8_t*>(bufferView->baseAddress());
@@ -2354,7 +2354,7 @@ void TestRunner::setOpenPanelFilesMediaIcon(JSContextRef context, JSValueRef med
     JSC::VM& vm = toJS(context)->vm();
     JSC::JSLockHolder lock(vm);
     
-    JSC::JSArrayBufferView* jsBufferView = JSC::jsDynamicCast<JSC::JSArrayBufferView*>(toJS(toJS(context), mediaIcon));
+    JSC::JSArrayBufferView* jsBufferView = dynamicDowncast<JSC::JSArrayBufferView>(toJS(toJS(context), mediaIcon));
     ASSERT(jsBufferView);
     RefPtr<JSC::ArrayBufferView> bufferView = jsBufferView->unsharedImpl();
     auto buffer = static_cast<const uint8_t*>(bufferView->baseAddress());

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2860,26 +2860,6 @@ def check_wtf_move(clean_lines, line_number, file_state, error):
         error(line_number, 'runtime/wtf_move', 4, "Use 'WTF::move()' instead of 'WTFMove()'.")
 
 
-def check_js_dynamic_cast(clean_lines, line_number, file_state, error):
-    """Looks for use of 'jsDynamicCast' which should be replaced with 'dynamicDowncast'.
-
-    Args:
-      clean_lines: A CleansedLines instance containing the file.
-      line_number: The number of the line to check.
-      file_state: A _FileState instance which maintains information about
-                  the state of things in the file.
-      error: The function to call with any errors found.
-    """
-
-    if file_state.is_c():
-        return
-
-    line = clean_lines.elided[line_number]
-
-    if search(r'\bjsDynamicCast\b', line):
-        error(line_number, 'runtime/js_dynamic_cast', 4, "Use 'dynamicDowncast<T>()' instead of 'jsDynamicCast<T*>()'.")
-
-
 def check_js_cast(clean_lines, line_number, file_state, error):
     """Looks for use of 'jsCast' which should be replaced with 'downcast' or 'uncheckedDowncast'.
 
@@ -3959,7 +3939,6 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
     check_max_min_macros(clean_lines, line_number, file_state, error)
     check_wtf_checked_size(clean_lines, line_number, file_state, error)
     check_wtf_move(clean_lines, line_number, file_state, error)
-    check_js_dynamic_cast(clean_lines, line_number, file_state, error)
     check_js_cast(clean_lines, line_number, file_state, error)
     check_unsafe_get(clean_lines, line_number, file_state, error)
     check_wtf_make_unique(clean_lines, line_number, file_state, error)

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6210,18 +6210,6 @@ class WebKitStyleTest(CppStyleTestBase):
             '',
             'foo.h')
 
-    def test_js_dynamic_cast(self):
-        self.assert_lint(
-            'auto* foo = dynamicDowncast<JSFoo>(bar);',
-            '',
-            'foo.cpp')
-
-        self.assert_lint(
-            'auto* foo = jsDynamicCast<JSFoo*>(bar);',
-            "Use 'dynamicDowncast<T>()' instead of 'jsDynamicCast<T*>()'."
-            "  [runtime/js_dynamic_cast] [4]",
-            'foo.cpp')
-
     def test_js_cast(self):
         self.assert_lint(
             'auto* foo = uncheckedDowncast<JSFoo>(bar);',


### PR DESCRIPTION
#### a6df2880b331293ee2f3e3d6f67093ff4ef77015
<pre>
Drop jsDynamicCast&lt;&gt;() in favor of dynamicDowncast&lt;&gt;()
<a href="https://bugs.webkit.org/show_bug.cgi?id=312710">https://bugs.webkit.org/show_bug.cgi?id=312710</a>

Reviewed by Anne van Kesteren.

Drop jsDynamicCast&lt;&gt;() in favor of dynamicDowncast&lt;&gt;() for casting
consistency throughout the codebase.

Canonical link: <a href="https://commits.webkit.org/311547@main">https://commits.webkit.org/311547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fb18cd6ea86da7ece5cb697f4cbe71750226ff0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166122 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111380 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a0bc811-edb9-4be5-80c7-7ca64fe12e00) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121824 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85540 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/847fb238-6841-4e30-ad57-0949957ee67f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102492 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/518e9dea-53b5-439d-8cd0-bcc209319be7) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/156620 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23125 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21373 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13893 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149349 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168607 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18133 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12765 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129958 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130065 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35233 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140869 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88033 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24888 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17674 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189317 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29870 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93884 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48575 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29392 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29622 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->