### PR TITLE
Refactor InputStreamPreprocessor

### DIFF
--- a/Source/WebCore/html/parser/HTMLTokenizer.cpp
+++ b/Source/WebCore/html/parser/HTMLTokenizer.cpp
@@ -100,8 +100,7 @@ inline bool HTMLTokenizer::inEndTagBufferingState() const
 }
 
 HTMLTokenizer::HTMLTokenizer(const HTMLParserOptions& options)
-    : m_preprocessor(*this)
-    , m_options(options)
+    : m_options(options)
 {
 }
 
@@ -235,7 +234,7 @@ bool HTMLTokenizer::processToken(SegmentedString& source)
             return true;
     }
 
-    if (!m_preprocessor.peek(source, isNullCharacterSkippingState(m_state)))
+    if (!m_preprocessor.peek(source, isNullCharacterSkippingState(m_state) && !m_forceNullCharacterReplacement))
         return haveBufferedCharacterToken();
     char16_t character = m_preprocessor.nextInputCharacter();
 

--- a/Source/WebCore/html/parser/HTMLTokenizer.h
+++ b/Source/WebCore/html/parser/HTMLTokenizer.h
@@ -74,8 +74,6 @@ public:
     void setRCDATAState();
     void setScriptDataState();
 
-    bool neverSkipNullCharacters() const;
-
 private:
     enum State {
         DataState,
@@ -195,7 +193,7 @@ private:
     char16_t m_additionalAllowedCharacter { 0 };
 
     // https://html.spec.whatwg.org/#preprocessing-the-input-stream
-    InputStreamPreprocessor<HTMLTokenizer> m_preprocessor;
+    InputStreamPreprocessor m_preprocessor;
 
     Vector<char16_t, 32> m_appropriateEndTagName;
 
@@ -339,11 +337,6 @@ inline void HTMLTokenizer::setScriptDataState()
 inline bool HTMLTokenizer::isNullCharacterSkippingState(State state)
 {
     return state == DataState || state == RCDATAState || state == RAWTEXTState;
-}
-
-inline bool HTMLTokenizer::neverSkipNullCharacters() const
-{
-    return m_forceNullCharacterReplacement;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/InputStreamPreprocessor.h
+++ b/Source/WebCore/html/parser/InputStreamPreprocessor.h
@@ -32,14 +32,9 @@
 
 namespace WebCore {
 
-// http://www.whatwg.org/specs/web-apps/current-work/#preprocessing-the-input-stream
-template <typename Tokenizer>
+// https://html.spec.whatwg.org/#preprocessing-the-input-stream
 class InputStreamPreprocessor {
 public:
-    explicit InputStreamPreprocessor(Tokenizer& tokenizer)
-        : m_tokenizer(tokenizer)
-    {
-    }
 
     ALWAYS_INLINE char16_t nextInputCharacter() const { return m_nextInputCharacter; }
     ALWAYS_INLINE bool skipNextNewLine() const { return m_skipNextNewLine; }
@@ -99,7 +94,7 @@ private:
         m_skipNextNewLine = false;
         if (m_nextInputCharacter || isAtEndOfFile(source))
             return true;
-        if (skipNullCharacters && !m_tokenizer.neverSkipNullCharacters()) {
+        if (skipNullCharacters) {
             source.advancePastNonNewline();
             if (source.isEmpty())
                 return false;
@@ -115,9 +110,7 @@ private:
         return source.isClosed() && source.length() == 1;
     }
 
-    Tokenizer& m_tokenizer;
-
-    // http://www.whatwg.org/specs/web-apps/current-work/#next-input-character
+    // https://html.spec.whatwg.org/#next-input-character
     char16_t m_nextInputCharacter { 0 };
     bool m_skipNextNewLine { false };
 };

--- a/Source/WebCore/html/parser/MarkupTokenizerInlines.h
+++ b/Source/WebCore/html/parser/MarkupTokenizerInlines.h
@@ -60,7 +60,7 @@ inline bool isTokenizerWhitespace(char16_t character)
 // We use this macro when the HTML spec says "consume the next input character ... and switch to the <mumble> state."
 #define ADVANCE_TO(newState)                                    \
     do {                                                        \
-        if (!m_preprocessor.advance(source, isNullCharacterSkippingState(newState))) { \
+        if (!m_preprocessor.advance(source, isNullCharacterSkippingState(newState) && !m_forceNullCharacterReplacement)) { \
             m_state = newState;                                 \
             return haveBufferedCharacterToken();                \
         }                                                       \
@@ -69,7 +69,7 @@ inline bool isTokenizerWhitespace(char16_t character)
     } while (false)
 #define ADVANCE_PAST_NON_NEWLINE_TO(newState)                   \
     do {                                                        \
-        if (!m_preprocessor.advancePastNonNewline(source, isNullCharacterSkippingState(newState))) { \
+        if (!m_preprocessor.advancePastNonNewline(source, isNullCharacterSkippingState(newState) && !m_forceNullCharacterReplacement)) { \
             m_state = newState;                                 \
             return haveBufferedCharacterToken();                \
         }                                                       \
@@ -80,7 +80,7 @@ inline bool isTokenizerWhitespace(char16_t character)
 // For more complex cases, caller consumes the characters first and then uses this macro.
 #define SWITCH_TO(newState)                                     \
     do {                                                        \
-        if (!m_preprocessor.peek(source, isNullCharacterSkippingState(newState))) { \
+        if (!m_preprocessor.peek(source, isNullCharacterSkippingState(newState) && !m_forceNullCharacterReplacement)) { \
             m_state = newState;                                 \
             return haveBufferedCharacterToken();                \
         }                                                       \


### PR DESCRIPTION
#### fce5870fc8ccb96a2f18523d7c2cd9dd30989e6c
<pre>
Refactor InputStreamPreprocessor
<a href="https://bugs.webkit.org/show_bug.cgi?id=312713">https://bugs.webkit.org/show_bug.cgi?id=312713</a>

Reviewed by Chris Dumez.

As of 311539@main WebVTTTokenizer no longer uses this class so
HTMLTokenizer is the sole consumer. It also appears however that
neverSkipNullCharacters() does not need to be called on the Tokenizer
class and can instead be made the responsibility of the Tokenizer
class.

We also move MarkupTokenizerInlines to a more appropriate directory as
it&apos;s never used by XML.

Canonical link: <a href="https://commits.webkit.org/311558@main">https://commits.webkit.org/311558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2e70ee1b91f331c62fbfdf4b178d693b34c3089

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157296 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111378 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d246fa8-aff8-4e89-85ea-44e38697a243) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121822 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85538 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8997bd1f-8c60-4523-ab06-8946aa29f301) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102490 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2fabbd3a-51df-4ab1-87fd-e2cab76a6eca) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23124 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21371 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13891 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168605 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12763 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129956 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30234 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130063 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140865 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88029 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23930 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17670 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93882 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29390 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29517 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->