### PR TITLE
Reduce use of jsCast<>() in favor of uncheckedDowncast<>()

### DIFF
--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -86,7 +86,7 @@ void AbstractModuleRecord::finishCreation(JSGlobalObject*, VM& vm)
 template<typename Visitor>
 void AbstractModuleRecord::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    AbstractModuleRecord* thisObject = jsCast<AbstractModuleRecord*>(cell);
+    AbstractModuleRecord* thisObject = uncheckedDowncast<AbstractModuleRecord>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_moduleEnvironment);
@@ -1080,7 +1080,7 @@ unsigned AbstractModuleRecord::innerModuleEvaluation(JSGlobalObject* globalObjec
             // 16.b.ii. Remove the last element of stack.
             AbstractModuleRecord* requiredModule = stack.takeLast();
             // 16.b.iii. Assert: requiredModule is a Cyclic Module Record.
-            auto* cyclic = jsCast<CyclicModuleRecord*>(requiredModule); // cyclic is a downcasted alias of requiredModule.
+            auto* cyclic = uncheckedDowncast<CyclicModuleRecord>(requiredModule); // cyclic is a downcasted alias of requiredModule.
             // 16.b.iv. Assert: requiredModule.[[AsyncEvaluationOrder]] is either an integer or UNSET.
             ASSERT(cyclic->asyncEvaluationOrder().hasOrder() || cyclic->asyncEvaluationOrder().isUnset());
             // 16.b.v. If requiredModule.[[AsyncEvaluationOrder]] is UNSET, set requiredModule.[[Status]] to EVALUATED.
@@ -1182,7 +1182,7 @@ unsigned AbstractModuleRecord::innerModuleLinking(JSGlobalObject* globalObject, 
             // 13.b.ii. Remove the last element of stack.
             AbstractModuleRecord* requiredModule = stack.takeLast();
             // 13.b.iii. Assert: requiredModule is a Cyclic Module Record.
-            auto* cyclic = jsCast<CyclicModuleRecord*>(requiredModule);
+            auto* cyclic = uncheckedDowncast<CyclicModuleRecord>(requiredModule);
             // 13.b.iv. Set requiredModule.[[Status]] to LINKED.
             cyclic->status(Status::Linked);
             // 13.b.v. If requiredModule and module are the same Module Record, set done to true.

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -150,7 +150,7 @@ static ALWAYS_INLINE bool isArraySlowInline(JSGlobalObject* globalObject, ProxyO
         if (argument->type() != ProxyObjectType)
             return false;
 
-        proxy = jsCast<ProxyObject*>(argument);
+        proxy = uncheckedDowncast<ProxyObject>(argument);
     }
 
     ASSERT_NOT_REACHED();
@@ -166,7 +166,7 @@ bool isArraySlow(JSGlobalObject* globalObject, ProxyObject* argument)
 JSC_DEFINE_HOST_FUNCTION(arrayConstructorPrivateFuncIsArraySlow, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     ASSERT_UNUSED(globalObject, is<ProxyObject>(callFrame->argument(0)));
-    return JSValue::encode(jsBoolean(isArraySlowInline(globalObject, jsCast<ProxyObject*>(callFrame->uncheckedArgument(0)))));
+    return JSValue::encode(jsBoolean(isArraySlowInline(globalObject, uncheckedDowncast<ProxyObject>(callFrame->uncheckedArgument(0)))));
 }
 
 ALWAYS_INLINE JSArray* fastArrayOf(JSGlobalObject* globalObject, CallFrame* callFrame, size_t length)
@@ -375,7 +375,7 @@ static JSArray* tryCreateArrayFromSet(JSGlobalObject* globalObject, JSSet* set)
     if (storageCell == vm.orderedHashTableSentinel())
         RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
 
-    auto* storage = jsCast<JSSet::Storage*>(storageCell);
+    auto* storage = uncheckedDowncast<JSSet::Storage>(storageCell);
 
     // First pass: determine indexing type
     IndexingType indexingType = IsArray;
@@ -386,7 +386,7 @@ static JSArray* tryCreateArrayFromSet(JSGlobalObject* globalObject, JSSet* set)
         if (storageCell == vm.orderedHashTableSentinel())
             break;
 
-        auto* currentStorage = jsCast<JSSet::Storage*>(storageCell);
+        auto* currentStorage = uncheckedDowncast<JSSet::Storage>(storageCell);
         entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
         JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -417,7 +417,7 @@ static JSArray* tryCreateArrayFromSet(JSGlobalObject* globalObject, JSSet* set)
     storageCell = set->storageOrSentinel(vm);
     if (storageCell == vm.orderedHashTableSentinel()) [[unlikely]]
         return nullptr;
-    storage = jsCast<JSSet::Storage*>(storageCell);
+    storage = uncheckedDowncast<JSSet::Storage>(storageCell);
 
     entry = 0;
     size_t i = 0;
@@ -428,7 +428,7 @@ static JSArray* tryCreateArrayFromSet(JSGlobalObject* globalObject, JSSet* set)
             if (storageCell == vm.orderedHashTableSentinel())
                 break;
 
-            auto* currentStorage = jsCast<JSSet::Storage*>(storageCell);
+            auto* currentStorage = uncheckedDowncast<JSSet::Storage>(storageCell);
             entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
             JSValue value = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -443,7 +443,7 @@ static JSArray* tryCreateArrayFromSet(JSGlobalObject* globalObject, JSSet* set)
             if (storageCell == vm.orderedHashTableSentinel())
                 break;
 
-            auto* currentStorage = jsCast<JSSet::Storage*>(storageCell);
+            auto* currentStorage = uncheckedDowncast<JSSet::Storage>(storageCell);
             entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
             JSValue value = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -478,7 +478,7 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
     if (storageCell == vm.orderedHashTableSentinel())
         RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
 
-    auto* storage = jsCast<JSMap::Storage*>(storageCell);
+    auto* storage = uncheckedDowncast<JSMap::Storage>(storageCell);
 
     IndexingType indexingType = IsArray;
     JSMap::Helper::Entry entry = 0;
@@ -488,7 +488,7 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
         if (storageCell == vm.orderedHashTableSentinel())
             break;
 
-        auto* currentStorage = jsCast<JSMap::Storage*>(storageCell);
+        auto* currentStorage = uncheckedDowncast<JSMap::Storage>(storageCell);
         entry = JSMap::Helper::iterationEntry(*currentStorage) + 1;
 
         JSValue entryValue;
@@ -523,7 +523,7 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
     storageCell = map->storageOrSentinel(vm);
     if (storageCell == vm.orderedHashTableSentinel()) [[unlikely]]
         return nullptr;
-    storage = jsCast<JSMap::Storage*>(storageCell);
+    storage = uncheckedDowncast<JSMap::Storage>(storageCell);
 
     entry = 0;
     size_t i = 0;
@@ -534,7 +534,7 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
             if (storageCell == vm.orderedHashTableSentinel())
                 break;
 
-            auto* currentStorage = jsCast<JSMap::Storage*>(storageCell);
+            auto* currentStorage = uncheckedDowncast<JSMap::Storage>(storageCell);
             entry = JSMap::Helper::iterationEntry(*currentStorage) + 1;
 
             JSValue value;
@@ -554,7 +554,7 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
             if (storageCell == vm.orderedHashTableSentinel())
                 break;
 
-            auto* currentStorage = jsCast<JSMap::Storage*>(storageCell);
+            auto* currentStorage = uncheckedDowncast<JSMap::Storage>(storageCell);
             entry = JSMap::Helper::iterationEntry(*currentStorage) + 1;
 
             JSValue value;
@@ -595,7 +595,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayConstructorPrivateFromFastWithoutMapFn, (JSGlobalO
         // For `Array.from(arguments)`
         switch (items.asCell()->type()) {
         case DirectArgumentsType: {
-            auto* arguments = jsCast<DirectArguments*>(items.asCell());
+            auto* arguments = uncheckedDowncast<DirectArguments>(items.asCell());
             if (arguments->isIteratorProtocolFastAndNonObservable()) [[likely]] {
                 result = tryCreateArrayFromDirectArguments(globalObject, arguments);
                 RETURN_IF_EXCEPTION(scope, { });
@@ -603,7 +603,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayConstructorPrivateFromFastWithoutMapFn, (JSGlobalO
             break;
         }
         case ScopedArgumentsType: {
-            auto* arguments = jsCast<ScopedArguments*>(items.asCell());
+            auto* arguments = uncheckedDowncast<ScopedArguments>(items.asCell());
             if (arguments->isIteratorProtocolFastAndNonObservable()) [[likely]] {
                 result = tryCreateArrayFromScopedArguments(globalObject, arguments);
                 RETURN_IF_EXCEPTION(scope, { });
@@ -611,7 +611,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayConstructorPrivateFromFastWithoutMapFn, (JSGlobalO
             break;
         }
         case ClonedArgumentsType: {
-            auto* arguments = jsCast<ClonedArguments*>(items.asCell());
+            auto* arguments = uncheckedDowncast<ClonedArguments>(items.asCell());
             if (arguments->isIteratorProtocolFastAndNonObservable()) [[likely]] {
                 result = tryCreateArrayFromClonedArguments(globalObject, arguments);
                 RETURN_IF_EXCEPTION(scope, { });
@@ -624,14 +624,14 @@ JSC_DEFINE_HOST_FUNCTION(arrayConstructorPrivateFromFastWithoutMapFn, (JSGlobalO
         }
     } else if (items && items.isCell() && items.asCell()->type() == JSSetType) {
         // For `Array.from(set)`
-        auto* set = jsCast<JSSet*>(items.asCell());
+        auto* set = uncheckedDowncast<JSSet>(items.asCell());
         if (set->isIteratorProtocolFastAndNonObservable()) [[likely]] {
             result = tryCreateArrayFromSet(globalObject, set);
             RETURN_IF_EXCEPTION(scope, { });
         }
     } else if (items && items.isCell() && items.asCell()->type() == JSMapIteratorType) {
         // For `Array.from(map.keys())`, `Array.from(map.values())`
-        auto* mapIterator = jsCast<JSMapIterator*>(items.asCell());
+        auto* mapIterator = uncheckedDowncast<JSMapIterator>(items.asCell());
         if (mapIterator->kind() != IterationKind::Entries && mapIteratorProtocolIsFastAndNonObservable(vm, mapIterator)) [[likely]] {
             result = tryCreateArrayFromMapIterator(globalObject, mapIterator);
             RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.h
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.h
@@ -68,13 +68,13 @@ inline bool isArray(JSGlobalObject* globalObject, JSValue argumentValue)
     if (!argumentValue.isObject())
         return false;
 
-    JSObject* argument = jsCast<JSObject*>(argumentValue);
+    JSObject* argument = uncheckedDowncast<JSObject>(argumentValue);
     if (argument->type() == ArrayType || argument->type() == DerivedArrayType)
         return true;
 
     if (argument->type() != ProxyObjectType)
         return false;
-    return isArraySlow(globalObject, jsCast<ProxyObject*>(argument));
+    return isArraySlow(globalObject, uncheckedDowncast<ProxyObject>(argument));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -909,7 +909,7 @@ static ALWAYS_INLINE std::span<EncodedJSValue> sortStableSort(JSGlobalObject* gl
     ASSERT(callData.type != CallData::Type::None);
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(comparator), 2);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(comparator), 2);
         RETURN_IF_EXCEPTION(scope, compacted);
         RELEASE_AND_RETURN(scope, arrayStableSort(vm, compacted, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
             auto scope = DECLARE_THROW_SCOPE(vm);
@@ -950,7 +950,7 @@ static ALWAYS_INLINE void sortCommit(JSGlobalObject* globalObject, JSObject* thi
 
     bool appended = false;
     if (isJSArray(thisObject)) [[likely]] {
-        appended = jsCast<JSArray*>(thisObject)->appendMemcpy(globalObject, vm, 0, indexingType, sorted);
+        appended = uncheckedDowncast<JSArray>(thisObject)->appendMemcpy(globalObject, vm, 0, indexingType, sorted);
         RETURN_IF_EXCEPTION(scope, void());
     }
 
@@ -1588,7 +1588,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, Ca
 
     if (!callFrame->argumentCount()) {
         if (isJSArray(thisValue)) [[likely]] {
-            auto* array = jsCast<JSArray*>(thisValue);
+            auto* array = uncheckedDowncast<JSArray>(thisValue);
             if (arrayMissingIsConcatSpreadable(vm, array) && arraySpeciesWatchpointIsValid(vm, array)) [[likely]] {
                 JSArray* result = tryCloneArrayFromFast<ArrayFillMode::Empty>(globalObject, array);
                 RETURN_IF_EXCEPTION(scope, { });
@@ -1599,7 +1599,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, Ca
     } else if (callFrame->argumentCount() == 1) {
         JSValue argumentValue = callFrame->uncheckedArgument(0);
         if (isJSArray(thisValue)) [[likely]] {
-            auto* firstArray = jsCast<JSArray*>(thisValue);
+            auto* firstArray = uncheckedDowncast<JSArray>(thisValue);
             if (arrayMissingIsConcatSpreadable(vm, firstArray) && arraySpeciesWatchpointIsValid(vm, firstArray)) [[likely]] {
                 // This code assumes that neither array has set Symbol.isConcatSpreadable. If the first array
                 // has indexed accessors then one of those accessors might change the value of Symbol.isConcatSpreadable
@@ -1611,7 +1611,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, Ca
                         if (result) [[likely]]
                             return JSValue::encode(result);
                     } else {
-                        auto* argumentObject = jsCast<JSObject*>(argumentValue);
+                        auto* argumentObject = uncheckedDowncast<JSObject>(argumentValue);
                         if (arrayMissingIsConcatSpreadable(vm, argumentObject)) [[likely]] {
                             if (!isJSArray(argumentObject)) {
                                 auto* result = concatAppendOne(globalObject, vm, firstArray, argumentValue);
@@ -1619,7 +1619,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, Ca
                                 if (result) [[likely]]
                                     return JSValue::encode(result);
                             } else {
-                                auto* result = concatAppendArray(globalObject, vm, firstArray, jsCast<JSArray*>(argumentValue));
+                                auto* result = concatAppendArray(globalObject, vm, firstArray, uncheckedDowncast<JSArray>(argumentValue));
                                 RETURN_IF_EXCEPTION(scope, { });
                                 if (result) [[likely]]
                                     return JSValue::encode(result);
@@ -1689,8 +1689,8 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, Ca
             uint64_t resultSize = checkedResultSize.value();
 
             if (isJSArray(result) && isJSArray(object) && resultSize <= MAX_ARRAY_INDEX) {
-                JSArray* resultArray = jsCast<JSArray*>(result);
-                JSArray* otherArray = jsCast<JSArray*>(object);
+                JSArray* resultArray = uncheckedDowncast<JSArray>(result);
+                JSArray* otherArray = uncheckedDowncast<JSArray>(object);
                 unsigned startIndex = resultIndex;
                 bool success = resultArray->appendMemcpy(globalObject, vm, resultIndex, otherArray);
                 RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -1759,7 +1759,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncFill, (JSGlobalObject* globalObject, Call
 
     JSValue value = callFrame->argument(0);
     if (isJSArray(thisValue)) [[likely]] {
-        auto* array = jsCast<JSArray*>(thisValue);
+        auto* array = uncheckedDowncast<JSArray>(thisValue);
         if (array->fastFill(vm, k, finalIndex, value))
             return JSValue::encode(array);
     }
@@ -1793,7 +1793,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncToReversed, (JSGlobalObject* globalObject
     }
 
     if (isJSArray(thisObject)) [[likely]] {
-        JSArray* thisArray = jsCast<JSArray*>(thisObject);
+        JSArray* thisArray = uncheckedDowncast<JSArray>(thisObject);
         if (auto fastResult = thisArray->fastToReversed(globalObject, length))
             return JSValue::encode(fastResult);
     }
@@ -1894,7 +1894,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncWith, (JSGlobalObject* globalObject, Call
     }
     JSValue value = callFrame->argument(1);
     if (isJSArray(thisObject)) [[likely]] {
-        JSArray* thisArray = jsCast<JSArray*>(thisObject);
+        JSArray* thisArray = uncheckedDowncast<JSArray>(thisObject);
         if (auto fastResult = thisArray->fastWith(globalObject, actualIndex, value, length))
             return JSValue::encode(fastResult);
     }
@@ -1950,7 +1950,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncIncludes, (JSGlobalObject* globalObject, 
     JSValue searchElement = callFrame->argument(0);
 
     if (isJSArray(thisObject)) [[likely]] {
-        JSArray* thisArray = jsCast<JSArray*>(thisObject);
+        JSArray* thisArray = uncheckedDowncast<JSArray>(thisObject);
         auto fastResult = thisArray->fastIncludes(globalObject, searchElement, index, length);
         RETURN_IF_EXCEPTION(scope, { });
         if (fastResult)
@@ -2197,7 +2197,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncFlat, (JSGlobalObject* globalObject, Call
     }
 
     if (isJSArray(thisObject) && arraySpeciesWatchpointIsValid(vm, thisObject)) [[likely]] {
-        JSArray* thisArray = jsCast<JSArray*>(thisObject);
+        JSArray* thisArray = uncheckedDowncast<JSArray>(thisObject);
         auto fastResult = thisArray->fastFlat(globalObject, depthNum, length);
         RETURN_IF_EXCEPTION(scope, { });
         if (fastResult) [[likely]]

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -113,7 +113,7 @@ ALWAYS_INLINE std::pair<SpeciesConstructResult, JSObject*> speciesConstructArray
         constructor = thisObject->get(globalObject, vm.propertyNames->constructor);
         RETURN_IF_EXCEPTION(scope, exceptionResult);
         if (constructor.isConstructor()) {
-            JSObject* constructorObject = jsCast<JSObject*>(constructor);
+            JSObject* constructorObject = uncheckedDowncast<JSObject>(constructor);
             bool isArrayConstructorFromAnotherRealm = globalObject != constructorObject->realm()
                 && constructorObject->inherits<ArrayConstructor>();
             if (isArrayConstructorFromAnotherRealm)
@@ -151,7 +151,7 @@ ALWAYS_INLINE void setLength(JSGlobalObject* globalObject, VM& vm, JSObject* obj
             return;
         }
         scope.release();
-        jsCast<JSArray*>(obj)->setLength(globalObject, static_cast<uint32_t>(value), throwException);
+        uncheckedDowncast<JSArray>(obj)->setLength(globalObject, static_cast<uint32_t>(value), throwException);
         return;
     }
     scope.release();

--- a/Source/JavaScriptCore/runtime/AsyncDisposableStackConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/AsyncDisposableStackConstructor.cpp
@@ -59,7 +59,7 @@ void AsyncDisposableStackConstructor::finishCreation(VM& vm, JSGlobalObject*, As
 template<typename Visitor>
 void AsyncDisposableStackConstructor::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<AsyncDisposableStackConstructor*>(cell);
+    auto* thisObject = uncheckedDowncast<AsyncDisposableStackConstructor>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -105,7 +105,7 @@ EncodedJSValue atomicReadModifyWriteCase(JSGlobalObject* globalObject, VM& vm, c
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSGenericTypedArrayView<Adaptor>* typedArray = jsCast<JSGenericTypedArrayView<Adaptor>*>(typedArrayView);
+    JSGenericTypedArrayView<Adaptor>* typedArray = uncheckedDowncast<JSGenericTypedArrayView<Adaptor>>(typedArrayView);
     
     typename Adaptor::Type extraArgs[Func::numExtraArgs + 1]; // Add 1 to avoid 0 size array error in VS.
     for (unsigned i = 0; i < Func::numExtraArgs; ++i) {
@@ -333,7 +333,7 @@ EncodedJSValue atomicStoreCase(JSGlobalObject* globalObject, VM& vm, JSValue ope
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSGenericTypedArrayView<Adaptor>* typedArray = jsCast<JSGenericTypedArrayView<Adaptor>*>(typedArrayView);
+    JSGenericTypedArrayView<Adaptor>* typedArray = uncheckedDowncast<JSGenericTypedArrayView<Adaptor>>(typedArrayView);
 
     typename Adaptor::Type extraArg;
     JSValue value;
@@ -496,12 +496,12 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncWait, (JSGlobalObject* globalObject, CallFra
     case Int32ArrayType: {
         int32_t expectedValue = callFrame->argument(2).toInt32(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int32_t>(globalObject, jsCast<JSInt32Array*>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Sync)));
+        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int32_t>(globalObject, uncheckedDowncast<JSInt32Array>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Sync)));
     }
     case BigInt64ArrayType: {
         int64_t expectedValue = callFrame->argument(2).toBigInt64(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int64_t>(globalObject, jsCast<JSBigInt64Array*>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Sync)));
+        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int64_t>(globalObject, uncheckedDowncast<JSBigInt64Array>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Sync)));
     }
     default:
         RELEASE_ASSERT_NOT_REACHED();
@@ -528,12 +528,12 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncWaitAsync, (JSGlobalObject* globalObject, Ca
     case Int32ArrayType: {
         int32_t expectedValue = callFrame->argument(2).toInt32(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int32_t>(globalObject, jsCast<JSInt32Array*>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Async)));
+        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int32_t>(globalObject, uncheckedDowncast<JSInt32Array>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Async)));
     }
     case BigInt64ArrayType: {
         int64_t expectedValue = callFrame->argument(2).toBigInt64(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int64_t>(globalObject, jsCast<JSBigInt64Array*>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Async)));
+        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int64_t>(globalObject, uncheckedDowncast<JSBigInt64Array>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Async)));
     }
     default:
         RELEASE_ASSERT_NOT_REACHED();
@@ -577,11 +577,11 @@ EncodedJSValue getWaiterListSize(JSGlobalObject* globalObject, CallFrame* callFr
 
     switch (typedArrayView->type()) {
     case Int32ArrayType: {
-        auto ptr = jsCast<JSInt32Array*>(typedArrayView)->typedVector() + accessIndex;
+        auto ptr = uncheckedDowncast<JSInt32Array>(typedArrayView)->typedVector() + accessIndex;
         RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(WaiterListManager::singleton().waiterListSize(ptr))));
     }
     case BigInt64ArrayType: {
-        auto ptr = jsCast<JSBigInt64Array*>(typedArrayView)->typedVector() + accessIndex;
+        auto ptr = uncheckedDowncast<JSBigInt64Array>(typedArrayView)->typedVector() + accessIndex;
         RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(WaiterListManager::singleton().waiterListSize(ptr))));
     }
     default:
@@ -618,11 +618,11 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncNotify, (JSGlobalObject* globalObject, CallF
 
     switch (typedArrayView->type()) {
     case Int32ArrayType: {
-        int32_t* ptr = jsCast<JSInt32Array*>(typedArrayView)->typedVector() + accessIndex;
+        int32_t* ptr = uncheckedDowncast<JSInt32Array>(typedArrayView)->typedVector() + accessIndex;
         return JSValue::encode(jsNumber(WaiterListManager::singleton().notifyWaiter(ptr, count)));
     }
     case BigInt64ArrayType: {
-        int64_t* ptr = jsCast<JSBigInt64Array*>(typedArrayView)->typedVector() + accessIndex;
+        int64_t* ptr = uncheckedDowncast<JSBigInt64Array>(typedArrayView)->typedVector() + accessIndex;
         return JSValue::encode(jsNumber(WaiterListManager::singleton().notifyWaiter(ptr, count)));
     }
     default:

--- a/Source/JavaScriptCore/runtime/BrandedStructure.h
+++ b/Source/JavaScriptCore/runtime/BrandedStructure.h
@@ -53,7 +53,7 @@ public:
     ALWAYS_INLINE bool checkBrand(Symbol* brand)
     {
         UniquedStringImpl* brandUid = &brand->uid();
-        for (BrandedStructure* currentStructure = this; currentStructure; currentStructure = jsCast<BrandedStructure*>(currentStructure->m_parentBrand.get())) {
+        for (BrandedStructure* currentStructure = this; currentStructure; currentStructure = uncheckedDowncast<BrandedStructure>(currentStructure->m_parentBrand.get())) {
             if (brandUid == currentStructure->m_brand)
                 return true;
         }
@@ -63,7 +63,7 @@ public:
     template<typename Visitor>
     static void visitAdditionalChildren(JSCell* cell, Visitor& visitor)
     {
-        BrandedStructure* thisObject = jsCast<BrandedStructure*>(cell);
+        BrandedStructure* thisObject = uncheckedDowncast<BrandedStructure>(cell);
         visitor.append(thisObject->m_parentBrand);
     }
 

--- a/Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h
@@ -87,9 +87,9 @@ inline UniquedStringImpl* CacheableIdentifier::uid() const
     if (isUid())
         return std::bit_cast<UniquedStringImpl*>(m_bits & ~s_uidTag);
     if (isSymbolCell())
-        return &jsCast<Symbol*>(cell())->uid();
+        return &uncheckedDowncast<Symbol>(cell())->uid();
     ASSERT(isStringCell());
-    JSString* string = jsCast<JSString*>(cell());
+    JSString* string = uncheckedDowncast<JSString>(cell());
     return std::bit_cast<UniquedStringImpl*>(string->getValueImpl());
 }
 
@@ -99,7 +99,7 @@ inline bool CacheableIdentifier::isCacheableIdentifierCell(JSCell* cell)
         return true;
     if (!cell->isString())
         return false;
-    JSString* string = jsCast<JSString*>(cell);
+    JSString* string = uncheckedDowncast<JSString>(cell);
     if (const StringImpl* impl = string->tryGetValueImpl())
         return impl->isAtom();
     return false;
@@ -118,7 +118,7 @@ inline GCOwnedDataScope<const UniquedStringImpl*> CacheableIdentifier::getCachea
         return { cell, &asSymbol(cell)->uid() };
     if (!cell->isString())
         return { };
-    JSString* string = jsCast<JSString*>(cell);
+    JSString* string = uncheckedDowncast<JSString>(cell);
     if (const StringImpl* impl = string->tryGetValueImpl(); impl && impl->isAtom())
         return { cell, static_cast<const AtomStringImpl*>(impl) };
     return { };

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -2635,7 +2635,7 @@ template<typename UnlinkedCodeBlockType>
 void encodeCodeBlock(Encoder& encoder, const SourceCodeKey& key, const UnlinkedCodeBlock* codeBlock)
 {
     auto* entry = encoder.template malloc<CacheEntry<UnlinkedCodeBlockType>>(encoder);
-    entry->encode(encoder, { key, jsCast<const UnlinkedCodeBlockType*>(codeBlock) });
+    entry->encode(encoder, { key, uncheckedDowncast<UnlinkedCodeBlockType>(codeBlock) });
 }
 
 RefPtr<CachedBytecode> encodeCodeBlock(VM& vm, const SourceCodeKey& key, const UnlinkedCodeBlock* codeBlock, FileSystem::FileHandle& fileHandle, BytecodeCacheError& error)

--- a/Source/JavaScriptCore/runtime/CachedTypes.h
+++ b/Source/JavaScriptCore/runtime/CachedTypes.h
@@ -119,7 +119,7 @@ UnlinkedCodeBlock* decodeCodeBlockImpl(VM&, const SourceCodeKey&, Ref<CachedByte
 template<typename UnlinkedCodeBlockType>
 UnlinkedCodeBlockType* decodeCodeBlock(VM& vm, const SourceCodeKey& key, Ref<CachedBytecode> cachedBytecode)
 {
-    return jsCast<UnlinkedCodeBlockType*>(decodeCodeBlockImpl(vm, key, WTF::move(cachedBytecode)));
+    return uncheckedDowncast<UnlinkedCodeBlockType>(decodeCodeBlockImpl(vm, key, WTF::move(cachedBytecode)));
 }
 
 JS_EXPORT_PRIVATE RefPtr<CachedBytecode> encodeFunctionCodeBlock(VM&, const UnlinkedFunctionCodeBlock*, BytecodeCacheError&);

--- a/Source/JavaScriptCore/runtime/CellSize.h
+++ b/Source/JavaScriptCore/runtime/CellSize.h
@@ -51,17 +51,17 @@ inline size_t cellSize(JSCell* cell)
     if (isDynamicallySizedType(cellType)) {
         switch (cellType) {
         case DirectArgumentsType: {
-            auto* args = jsCast<DirectArguments*>(cell);
+            auto* args = uncheckedDowncast<DirectArguments>(cell);
             return DirectArguments::allocationSize(args->m_minCapacity);
         }
         case FinalObjectType:
             return JSFinalObject::allocationSize(structure->inlineCapacity());
         case LexicalEnvironmentType: {
-            auto* env = jsCast<JSLexicalEnvironment*>(cell);
+            auto* env = uncheckedDowncast<JSLexicalEnvironment>(cell);
             return JSLexicalEnvironment::allocationSize(env->symbolTable());
         }
         case ModuleEnvironmentType: {
-            auto* env = jsCast<JSModuleEnvironment*>(cell);
+            auto* env = uncheckedDowncast<JSModuleEnvironment>(cell);
             return JSModuleEnvironment::allocationSize(env->symbolTable());
         }
         default:

--- a/Source/JavaScriptCore/runtime/ClonedArguments.cpp
+++ b/Source/JavaScriptCore/runtime/ClonedArguments.cpp
@@ -111,9 +111,9 @@ ClonedArguments* ClonedArguments::createWithInlineFrame(JSGlobalObject* globalOb
     JSFunction* callee;
     
     if (inlineCallFrame)
-        callee = jsCast<JSFunction*>(inlineCallFrame->calleeRecovery.recover(targetFrame));
+        callee = uncheckedDowncast<JSFunction>(inlineCallFrame->calleeRecovery.recover(targetFrame));
     else
-        callee = jsCast<JSFunction*>(targetFrame->jsCallee());
+        callee = uncheckedDowncast<JSFunction>(targetFrame->jsCallee());
 
     ClonedArguments* result = nullptr;
 
@@ -208,11 +208,11 @@ Structure* ClonedArguments::createSlowPutStructure(VM& vm, JSGlobalObject* globa
 
 bool ClonedArguments::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObject, PropertyName ident, PropertySlot& slot)
 {
-    ClonedArguments* thisObject = jsCast<ClonedArguments*>(object);
+    ClonedArguments* thisObject = uncheckedDowncast<ClonedArguments>(object);
     VM& vm = globalObject->vm();
 
     if (!thisObject->specialsMaterialized()) {
-        FunctionExecutable* executable = jsCast<FunctionExecutable*>(thisObject->m_callee->executable());
+        FunctionExecutable* executable = uncheckedDowncast<FunctionExecutable>(thisObject->m_callee->executable());
         bool isStrictMode = executable->isInStrictContext();
 
         if (ident == vm.propertyNames->callee) {
@@ -236,14 +236,14 @@ bool ClonedArguments::getOwnPropertySlot(JSObject* object, JSGlobalObject* globa
 
 void ClonedArguments::getOwnSpecialPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder&, DontEnumPropertiesMode mode)
 {
-    ClonedArguments* thisObject = jsCast<ClonedArguments*>(object);
+    ClonedArguments* thisObject = uncheckedDowncast<ClonedArguments>(object);
     if (mode == DontEnumPropertiesMode::Include)
         thisObject->materializeSpecialsIfNecessary(globalObject);
 }
 
 bool ClonedArguments::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName ident, JSValue value, PutPropertySlot& slot)
 {
-    ClonedArguments* thisObject = jsCast<ClonedArguments*>(cell);
+    ClonedArguments* thisObject = uncheckedDowncast<ClonedArguments>(cell);
     VM& vm = globalObject->vm();
     
     if (ident == vm.propertyNames->callee
@@ -258,7 +258,7 @@ bool ClonedArguments::put(JSCell* cell, JSGlobalObject* globalObject, PropertyNa
 
 bool ClonedArguments::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName ident, DeletePropertySlot& slot)
 {
-    ClonedArguments* thisObject = jsCast<ClonedArguments*>(cell);
+    ClonedArguments* thisObject = uncheckedDowncast<ClonedArguments>(cell);
     VM& vm = globalObject->vm();
     
     if (ident == vm.propertyNames->callee
@@ -270,7 +270,7 @@ bool ClonedArguments::deleteProperty(JSCell* cell, JSGlobalObject* globalObject,
 
 bool ClonedArguments::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, PropertyName ident, const PropertyDescriptor& descriptor, bool shouldThrow)
 {
-    ClonedArguments* thisObject = jsCast<ClonedArguments*>(object);
+    ClonedArguments* thisObject = uncheckedDowncast<ClonedArguments>(object);
     VM& vm = globalObject->vm();
     
     if (ident == vm.propertyNames->callee
@@ -285,7 +285,7 @@ void ClonedArguments::materializeSpecials(JSGlobalObject* globalObject)
     RELEASE_ASSERT(!specialsMaterialized());
     VM& vm = globalObject->vm();
     
-    FunctionExecutable* executable = jsCast<FunctionExecutable*>(m_callee->executable());
+    FunctionExecutable* executable = uncheckedDowncast<FunctionExecutable>(m_callee->executable());
     bool isStrictMode = executable->isInStrictContext();
     
     if (isStrictMode || executable->usesNonSimpleParameterList())
@@ -307,7 +307,7 @@ void ClonedArguments::materializeSpecialsIfNecessary(JSGlobalObject* globalObjec
 template<typename Visitor>
 void ClonedArguments::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    ClonedArguments* thisObject = jsCast<ClonedArguments*>(cell);
+    ClonedArguments* thisObject = uncheckedDowncast<ClonedArguments>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_callee);

--- a/Source/JavaScriptCore/runtime/CodeCache.h
+++ b/Source/JavaScriptCore/runtime/CodeCache.h
@@ -121,7 +121,7 @@ public:
         findResult->value.age = m_age;
         m_age += key.length();
 
-        return jsCast<UnlinkedCodeBlockType*>(findResult->value.cell.get());
+        return uncheckedDowncast<UnlinkedCodeBlockType>(findResult->value.cell.get());
     }
 
     AddResult addCache(const SourceCodeKey& key, const SourceCodeValue& value)

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -803,7 +803,7 @@ ALWAYS_INLINE UGPRPair iteratorOpenTryFastImpl(VM& vm, JSGlobalObject* globalObj
         // We should be good to go.
         metadata.m_iterationMetadata.seenModes = metadata.m_iterationMetadata.seenModes | IterationMode::FastArray;
         GET(bytecode.m_next) = JSValue();
-        auto* iteratedObject = jsCast<JSObject*>(iterable);
+        auto* iteratedObject = uncheckedDowncast<JSObject>(iterable);
         iterator = JSArrayIterator::create(vm, globalObject->arrayIteratorStructure(), iteratedObject, IterationKind::Values);
         PROFILE_VALUE_IN(iterator.jsValue(), m_iteratorValueProfile);
         return encodeResult(pc, reinterpret_cast<void*>(static_cast<uintptr_t>(IterationMode::FastArray)));
@@ -845,7 +845,7 @@ ALWAYS_INLINE UGPRPair iteratorNextTryFastImpl(VM& vm, JSGlobalObject* globalObj
     auto& metadata = bytecode.metadata(codeBlock);
 
     ASSERT(!GET(bytecode.m_next).jsValue());
-    JSObject* iterator = jsCast<JSObject*>(GET(bytecode.m_iterator).jsValue());;
+    JSObject* iterator = uncheckedDowncast<JSObject>(GET(bytecode.m_iterator).jsValue());;
     JSCell* iterable = GET(bytecode.m_iterable).jsValue().asCell();
     if (auto arrayIterator = dynamicDowncast<JSArrayIterator>(iterator)) {
         if (auto array = dynamicDowncast<JSArray>(iterable); array && isJSArray(array)) {
@@ -914,7 +914,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_enter)
 {
     BEGIN();
     Heap::heap(codeBlock)->writeBarrier(codeBlock);
-    GET(codeBlock->scopeRegister()) = jsCast<JSCallee*>(callFrame->jsCallee())->scope();
+    GET(codeBlock->scopeRegister()) = uncheckedDowncast<JSCallee>(callFrame->jsCallee())->scope();
     if (codeBlock->couldBeTainted()) [[unlikely]]
         vm.setMightBeExecutingTaintedCode();
     END();
@@ -961,7 +961,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_enumerator_next)
     auto mode = static_cast<JSPropertyNameEnumerator::Flag>(modeRegister.jsValue().asUInt32());
     uint32_t index = indexRegister.jsValue().asUInt32();
 
-    JSPropertyNameEnumerator* enumerator = jsCast<JSPropertyNameEnumerator*>(GET(bytecode.m_enumerator).jsValue());
+    JSPropertyNameEnumerator* enumerator = uncheckedDowncast<JSPropertyNameEnumerator>(GET(bytecode.m_enumerator).jsValue());
     JSValue baseValue = GET(bytecode.m_base).jsValue();
     ASSERT(!baseValue.isUndefinedOrNull());
     JSObject* base = baseValue.toObject(globalObject);
@@ -987,7 +987,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_enumerator_get_by_val)
     auto& metadata = bytecode.metadata(codeBlock);
     auto mode = static_cast<JSPropertyNameEnumerator::Flag>(GET(bytecode.m_mode).jsValue().asUInt32());
     metadata.m_enumeratorMetadata |= static_cast<uint8_t>(mode);
-    JSPropertyNameEnumerator* enumerator = jsCast<JSPropertyNameEnumerator*>(GET(bytecode.m_enumerator).jsValue());
+    JSPropertyNameEnumerator* enumerator = uncheckedDowncast<JSPropertyNameEnumerator>(GET(bytecode.m_enumerator).jsValue());
     unsigned index = GET(bytecode.m_index).jsValue().asInt32();
 
     RETURN_PROFILED(CommonSlowPaths::opEnumeratorGetByVal(globalObject, baseValue, propertyName, index, mode, enumerator, &metadata.m_arrayProfile, &metadata.m_enumeratorMetadata));
@@ -1003,7 +1003,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_enumerator_in_by_val)
     metadata.m_enumeratorMetadata |= static_cast<uint8_t>(mode);
 
     CHECK_EXCEPTION();
-    JSPropertyNameEnumerator* enumerator = jsCast<JSPropertyNameEnumerator*>(GET(bytecode.m_enumerator).jsValue());
+    JSPropertyNameEnumerator* enumerator = uncheckedDowncast<JSPropertyNameEnumerator>(GET(bytecode.m_enumerator).jsValue());
     if (auto* base = baseValue.getObject()) {
         if (mode == JSPropertyNameEnumerator::OwnStructureMode && base->structureID() == enumerator->cachedStructureID())
             RETURN(jsBoolean(true));
@@ -1026,7 +1026,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_enumerator_put_by_val)
     auto& metadata = bytecode.metadata(codeBlock);
     auto mode = static_cast<JSPropertyNameEnumerator::Flag>(GET(bytecode.m_mode).jsValue().asUInt32());
     metadata.m_enumeratorMetadata |= static_cast<uint8_t>(mode);
-    JSPropertyNameEnumerator* enumerator = jsCast<JSPropertyNameEnumerator*>(GET(bytecode.m_enumerator).jsValue());
+    JSPropertyNameEnumerator* enumerator = uncheckedDowncast<JSPropertyNameEnumerator>(GET(bytecode.m_enumerator).jsValue());
     unsigned index = GET(bytecode.m_index).jsValue().asInt32();
 
     CommonSlowPaths::opEnumeratorPutByVal(globalObject, baseValue, propertyName, value, bytecode.m_ecmaMode, index, mode, enumerator, &metadata.m_arrayProfile, &metadata.m_enumeratorMetadata);
@@ -1042,7 +1042,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_enumerator_has_own_property)
     auto mode = static_cast<JSPropertyNameEnumerator::Flag>(GET(bytecode.m_mode).jsValue().asUInt32());
     metadata.m_enumeratorMetadata |= static_cast<uint8_t>(mode);
 
-    JSPropertyNameEnumerator* enumerator = jsCast<JSPropertyNameEnumerator*>(GET(bytecode.m_enumerator).jsValue());
+    JSPropertyNameEnumerator* enumerator = uncheckedDowncast<JSPropertyNameEnumerator>(GET(bytecode.m_enumerator).jsValue());
     if (auto* base = baseValue.getObject()) {
         if (mode == JSPropertyNameEnumerator::OwnStructureMode && base->structureID() == enumerator->cachedStructureID())
             RETURN(jsBoolean(true));
@@ -1119,7 +1119,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_resolve_scope)
     case UnresolvedProperty:
     case UnresolvedPropertyWithVarInjectionChecks: {
         if (resolvedScope->isGlobalObject()) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(resolvedScope);
+            JSGlobalObject* globalObject = uncheckedDowncast<JSGlobalObject>(resolvedScope);
             bool hasProperty = globalObject->hasProperty(globalObject, ident);
             CHECK_EXCEPTION();
             if (hasProperty) {
@@ -1129,7 +1129,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_resolve_scope)
                 metadata.m_globalLexicalBindingEpoch = globalObject->globalLexicalBindingEpoch();
             }
         } else if (resolvedScope->isGlobalLexicalEnvironment()) {
-            JSGlobalLexicalEnvironment* globalLexicalEnvironment = jsCast<JSGlobalLexicalEnvironment*>(resolvedScope);
+            JSGlobalLexicalEnvironment* globalLexicalEnvironment = uncheckedDowncast<JSGlobalLexicalEnvironment>(resolvedScope);
             ConcurrentJSLocker locker(codeBlock->m_lock);
             metadata.m_resolveType = needsVarInjectionChecks(resolveType) ? GlobalLexicalVarWithVarInjectionChecks : GlobalLexicalVar;
             metadata.m_globalLexicalEnvironment.set(vm, codeBlock, globalLexicalEnvironment);
@@ -1289,7 +1289,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_new_array_with_spread)
     if (numItems == 1 && bitVector.get(0)) {
         Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(CopyOnWriteArrayWithContiguous);
         if (isCopyOnWrite(structure->indexingMode())) {
-            JSArray* result = CommonSlowPaths::allocateNewArrayBuffer(vm, structure, jsCast<JSCellButterfly*>(values[0]));
+            JSArray* result = CommonSlowPaths::allocateNewArrayBuffer(vm, structure, uncheckedDowncast<JSCellButterfly>(values[0]));
             RETURN(result);
         }
     }
@@ -1298,7 +1298,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_new_array_with_spread)
     for (int i = 0; i < numItems; i++) {
         if (bitVector.get(i)) {
             JSValue value = values[-i];
-            JSCellButterfly* array = jsCast<JSCellButterfly*>(value);
+            JSCellButterfly* array = uncheckedDowncast<JSCellButterfly>(value);
             checkedArraySize += array->publicLength();
         } else
             checkedArraySize += 1;
@@ -1322,7 +1322,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_new_array_with_spread)
         JSValue value = values[-i];
         if (bitVector.get(i)) {
             // We are spreading.
-            JSCellButterfly* array = jsCast<JSCellButterfly*>(value);
+            JSCellButterfly* array = uncheckedDowncast<JSCellButterfly>(value);
             for (unsigned i = 0; i < array->publicLength(); i++) {
                 RELEASE_ASSERT(array->get(i));
                 result->putDirectIndex(globalObject, index, array->get(i));
@@ -1429,7 +1429,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_spread)
         ASSERT(!arguments.hasOverflowed());
         JSValue arrayResult = call(globalObject, iterationFunction, callData, jsNull(), arguments);
         CHECK_EXCEPTION();
-        array = jsCast<JSArray*>(arrayResult);
+        array = uncheckedDowncast<JSArray>(arrayResult);
     }
 
     RETURN(JSCellButterfly::createFromArray(globalObject, vm, array));

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.h
@@ -127,14 +127,14 @@ inline bool canAccessArgumentIndexQuickly(JSObject& object, uint32_t index)
 {
     switch (object.type()) {
     case DirectArgumentsType: {
-        DirectArguments* directArguments = jsCast<DirectArguments*>(&object);
-        if (directArguments->isMappedArgumentInDFG(index))
+        auto& directArguments = uncheckedDowncast<DirectArguments>(object);
+        if (directArguments.isMappedArgumentInDFG(index))
             return true;
         break;
     }
     case ScopedArgumentsType: {
-        ScopedArguments* scopedArguments = jsCast<ScopedArguments*>(&object);
-        if (scopedArguments->isMappedArgumentInDFG(index))
+        auto& scopedArguments = uncheckedDowncast<ScopedArguments>(object);
+        if (scopedArguments.isMappedArgumentInDFG(index))
             return true;
         break;
     }
@@ -147,7 +147,7 @@ inline bool canAccessArgumentIndexQuickly(JSObject& object, uint32_t index)
 ALWAYS_INLINE Structure* originalStructureBeforePut(JSCell* cell)
 {
     if (cell->type() == GlobalProxyType)
-        return jsCast<JSGlobalProxy*>(cell)->target()->structure();
+        return uncheckedDowncast<JSGlobalProxy>(cell)->target()->structure();
     return cell->structure();
 }
 
@@ -183,7 +183,7 @@ static ALWAYS_INLINE void putDirectWithReify(VM& vm, JSGlobalObject* globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     bool isJSFunction = baseObject->inherits<JSFunction>();
     if (isJSFunction) {
-        JSFunction* jsFunction = jsCast<JSFunction*>(baseObject);
+        JSFunction* jsFunction = uncheckedDowncast<JSFunction>(baseObject);
 
         if (propertyName == vm.propertyNames->prototype) {
             slot.disableCaching();
@@ -220,7 +220,7 @@ static ALWAYS_INLINE void putDirectAccessorWithReify(VM& vm, JSGlobalObject* glo
     bool isJSFunction = baseObject->inherits<JSFunction>();
     if (isJSFunction) {
         ASSERT(propertyName != vm.propertyNames->prototype);
-        jsCast<JSFunction*>(baseObject)->reifyLazyPropertyIfNeeded<>(vm, globalObject, propertyName);
+        uncheckedDowncast<JSFunction>(baseObject)->reifyLazyPropertyIfNeeded<>(vm, globalObject, propertyName);
         RETURN_IF_EXCEPTION(scope, void());
     }
 

--- a/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
@@ -60,7 +60,7 @@ inline void tryCachePutToScopeGlobal(
     case GlobalPropertyWithVarInjectionChecks: {
         // Global Lexical Binding Epoch is changed. Update op_get_from_scope from GlobalProperty to GlobalLexicalVar.
         if (scope->isGlobalLexicalEnvironment()) {
-            JSGlobalLexicalEnvironment* globalLexicalEnvironment = jsCast<JSGlobalLexicalEnvironment*>(scope);
+            JSGlobalLexicalEnvironment* globalLexicalEnvironment = uncheckedDowncast<JSGlobalLexicalEnvironment>(scope);
             ResolveType newResolveType = needsVarInjectionChecks(resolveType) ? GlobalLexicalVarWithVarInjectionChecks : GlobalLexicalVar;
             SymbolTableEntry entry = globalLexicalEnvironment->symbolTable()->get(ident.impl());
             ASSERT(!entry.isNull());
@@ -126,7 +126,7 @@ inline void tryCacheGetFromScopeGlobal(
     case GlobalPropertyWithVarInjectionChecks: {
         // Global Lexical Binding Epoch is changed. Update op_get_from_scope from GlobalProperty to GlobalLexicalVar.
         if (scope->isGlobalLexicalEnvironment()) {
-            JSGlobalLexicalEnvironment* globalLexicalEnvironment = jsCast<JSGlobalLexicalEnvironment*>(scope);
+            JSGlobalLexicalEnvironment* globalLexicalEnvironment = uncheckedDowncast<JSGlobalLexicalEnvironment>(scope);
             ResolveType newResolveType = needsVarInjectionChecks(resolveType) ? GlobalLexicalVarWithVarInjectionChecks : GlobalLexicalVar;
             SymbolTableEntry entry = globalLexicalEnvironment->symbolTable()->get(ident.impl());
             ASSERT(!entry.isNull());
@@ -161,7 +161,7 @@ inline void tryCacheGetFromScopeGlobal(
 ALWAYS_INLINE JSCellButterfly* trySpreadFast(JSGlobalObject* globalObject, JSCell* iterable)
 {
     if (isJSArray(iterable)) {
-        JSArray* array = jsCast<JSArray*>(iterable);
+        JSArray* array = uncheckedDowncast<JSArray>(iterable);
         if (array->isIteratorProtocolFastAndNonObservable()) {
             // JSCellButterfly::createFromArray does not consult the prototype chain,
             // so we must be sure that not consulting the prototype chain would
@@ -174,29 +174,29 @@ ALWAYS_INLINE JSCellButterfly* trySpreadFast(JSGlobalObject* globalObject, JSCel
     switch (iterable->type()) {
     case StringType: {
         if (globalObject->isStringPrototypeIteratorProtocolFastAndNonObservable()) [[likely]]
-            return JSCellButterfly::createFromString(globalObject, jsCast<JSString*>(iterable));
+            return JSCellButterfly::createFromString(globalObject, uncheckedDowncast<JSString>(iterable));
         return nullptr;
     }
     case ClonedArgumentsType: {
-        auto* arguments = jsCast<ClonedArguments*>(iterable);
+        auto* arguments = uncheckedDowncast<ClonedArguments>(iterable);
         if (arguments->isIteratorProtocolFastAndNonObservable()) [[likely]]
             return JSCellButterfly::createFromClonedArguments(globalObject, arguments);
         return nullptr;
     }
     case DirectArgumentsType: {
-        auto* arguments = jsCast<DirectArguments*>(iterable);
+        auto* arguments = uncheckedDowncast<DirectArguments>(iterable);
         if (arguments->isIteratorProtocolFastAndNonObservable()) [[likely]]
             return JSCellButterfly::createFromDirectArguments(globalObject, arguments);
         return nullptr;
     }
     case ScopedArgumentsType: {
-        auto* arguments = jsCast<ScopedArguments*>(iterable);
+        auto* arguments = uncheckedDowncast<ScopedArguments>(iterable);
         if (arguments->isIteratorProtocolFastAndNonObservable()) [[likely]]
             return JSCellButterfly::createFromScopedArguments(globalObject, arguments);
         return nullptr;
     }
     case JSSetType: {
-        auto* set = jsCast<JSSet*>(iterable);
+        auto* set = uncheckedDowncast<JSSet>(iterable);
         if (set->isIteratorProtocolFastAndNonObservable()) [[likely]]
             return JSCellButterfly::createFromSet(globalObject, set);
         return nullptr;

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -142,7 +142,7 @@ JSValue evaluate(JSGlobalObject* globalObject, const SourceCode& source, JSValue
 
     if (!thisValue || thisValue.isUndefinedOrNull())
         thisValue = globalObject;
-    JSObject* thisObj = jsCast<JSObject*>(thisValue.toThis(globalObject, ECMAMode::sloppy()));
+    JSObject* thisObj = uncheckedDowncast<JSObject>(thisValue.toThis(globalObject, ECMAMode::sloppy()));
     JSValue result = vm.interpreter.executeProgram(source, globalObject, thisObj);
 
     if (scope.exception()) [[unlikely]] {

--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
@@ -61,7 +61,7 @@ void CyclicModuleRecord::finishCreation(JSGlobalObject* globalObject, VM& vm)
 template<typename Visitor>
 void CyclicModuleRecord::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    CyclicModuleRecord* thisObject = jsCast<CyclicModuleRecord*>(cell);
+    CyclicModuleRecord* thisObject = uncheckedDowncast<CyclicModuleRecord>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_evaluationError);
@@ -82,7 +82,7 @@ void CyclicModuleRecord::initializeEnvironment(JSGlobalObject* globalObject, JSV
 
     auto* jsModule = dynamicDowncast<JSModuleRecord>(this);
 #if ENABLE(WEBASSEMBLY)
-    auto* wasmModule = !jsModule ? jsCast<WebAssemblyModuleRecord*>(this) : nullptr;
+    auto* wasmModule = !jsModule ? uncheckedDowncast<WebAssemblyModuleRecord>(this) : nullptr;
 #else
     ASSERT(jsModule);
 #endif
@@ -404,7 +404,7 @@ JSPromise* CyclicModuleRecord::evaluate(JSGlobalObject* globalObject)
         // 9.a. For each Cyclic Module Record m of stack, do
         for (AbstractModuleRecord* abstractRecord : stack) {
             // 9.a.i. Assert: m.[[Status]] is EVALUATING.
-            auto* cyclic = jsCast<CyclicModuleRecord*>(abstractRecord);
+            auto* cyclic = uncheckedDowncast<CyclicModuleRecord>(abstractRecord);
             ASSERT(cyclic->status() == Status::Evaluating);
             // 9.a.ii. Set m.[[Status]] to EVALUATED.
             cyclic->status(Status::Evaluated);
@@ -461,7 +461,7 @@ void CyclicModuleRecord::execute(JSGlobalObject* globalObject, JSPromise* capabi
         RELEASE_AND_RETURN(scope, void());
     }
 #endif
-    RELEASE_AND_RETURN(scope, jsCast<JSModuleRecord*>(this)->execute(globalObject, capability));
+    RELEASE_AND_RETURN(scope, uncheckedDowncast<JSModuleRecord>(this)->execute(globalObject, capability));
 }
 
 void CyclicModuleRecord::executeAsync(JSGlobalObject* globalObject)
@@ -504,7 +504,7 @@ static void gatherAvailableAncestors(CyclicModuleRecord* module, Vector<CyclicMo
 
     // 1. For each Cyclic Module Record m of module.[[AsyncParentModules]], do
     for (const WriteBarrier<AbstractModuleRecord>& barrier : module->asyncParentModules()) {
-        auto* m = jsCast<CyclicModuleRecord*>(barrier.get());
+        auto* m = uncheckedDowncast<CyclicModuleRecord>(barrier.get());
         // 1.a. If execList does not contain m and m.[[CycleRoot]].[[EvaluationError]] is empty, then
         // (Probable spec bug (https://github.com/tc39/ecma262/issues/3766). We need an additional check here that m.[[CycleRoot]] isn't empty.)
         ASSERT_IMPLIES(!m->cycleRoot(), m->evaluationError());
@@ -570,7 +570,7 @@ void CyclicModuleRecord::asyncExecutionRejected(JSGlobalObject* globalObject, JS
     // 10. For each Cyclic Module Record m of module.[[AsyncParentModules]], do
     for (const WriteBarrier<AbstractModuleRecord>& m : asyncParentModules()) {
         // 10.a. Perform AsyncModuleExecutionRejected(m, error).
-        jsCast<CyclicModuleRecord*>(m.get())->asyncExecutionRejected(globalObject, error);
+        uncheckedDowncast<CyclicModuleRecord>(m.get())->asyncExecutionRejected(globalObject, error);
     }
     // 11. Return UNUSED.
 }

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -375,7 +375,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToPrimitiveSymbol, (JSGlobalObject* global
     JSValue thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
     if (!thisValue.isObject())
         return throwVMTypeError(globalObject, scope, "Date.prototype[Symbol.toPrimitive] expected |this| to be an object."_s);
-    JSObject* thisObject = jsCast<JSObject*>(thisValue);
+    JSObject* thisObject = uncheckedDowncast<JSObject>(thisValue);
     Integrity::auditStructureID(thisObject->structureID());
 
     if (!callFrame->argumentCount())

--- a/Source/JavaScriptCore/runtime/DirectArguments.cpp
+++ b/Source/JavaScriptCore/runtime/DirectArguments.cpp
@@ -91,14 +91,14 @@ DirectArguments* DirectArguments::createByCopying(JSGlobalObject* globalObject, 
     for (unsigned i = capacity; i--;)
         result->storage()[i].set(vm, result, callFrame->getArgumentUnsafe(i));
     
-    result->setCallee(vm, jsCast<JSFunction*>(callFrame->jsCallee()));
+    result->setCallee(vm, uncheckedDowncast<JSFunction>(callFrame->jsCallee()));
     
     return result;
 }
 
 size_t DirectArguments::estimatedSize(JSCell* cell, VM& vm)
 {
-    DirectArguments* thisObject = jsCast<DirectArguments*>(cell);
+    DirectArguments* thisObject = uncheckedDowncast<DirectArguments>(cell);
     size_t mappedArgumentsSize = thisObject->m_mappedArguments ? thisObject->mappedArgumentsSize() * sizeof(bool) : 0;
     size_t modifiedArgumentsSize = thisObject->m_modifiedArgumentsDescriptor ? thisObject->m_length * sizeof(bool) : 0;
     return Base::estimatedSize(cell, vm) + mappedArgumentsSize + modifiedArgumentsSize;

--- a/Source/JavaScriptCore/runtime/DisposableStackConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/DisposableStackConstructor.cpp
@@ -59,7 +59,7 @@ void DisposableStackConstructor::finishCreation(VM& vm, JSGlobalObject*, Disposa
 template<typename Visitor>
 void DisposableStackConstructor::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<DisposableStackConstructor*>(cell);
+    auto* thisObject = uncheckedDowncast<DisposableStackConstructor>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/Error.cpp
+++ b/Source/JavaScriptCore/runtime/Error.cpp
@@ -396,7 +396,7 @@ JSObject* createURIError(JSGlobalObject* globalObject, const String& message)
 JSObject* createOutOfMemoryError(JSGlobalObject* globalObject)
 {
     auto* error = createRangeError(globalObject, "Out of memory"_s, nullptr);
-    jsCast<ErrorInstance*>(error)->setOutOfMemoryError();
+    uncheckedDowncast<ErrorInstance>(error)->setOutOfMemoryError();
     return error;
 }
 
@@ -405,7 +405,7 @@ JSObject* createOutOfMemoryError(JSGlobalObject* globalObject, const String& mes
     if (message.isEmpty())
         return createOutOfMemoryError(globalObject);
     auto* error = createRangeError(globalObject, makeString("Out of memory: "_s, message), nullptr);
-    jsCast<ErrorInstance*>(error)->setOutOfMemoryError();
+    uncheckedDowncast<ErrorInstance>(error)->setOutOfMemoryError();
     return error;
 }
 

--- a/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
@@ -82,7 +82,7 @@ JSC_DEFINE_HOST_FUNCTION(callErrorConstructor, (JSGlobalObject* globalObject, Ca
 bool ErrorConstructor::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
     VM& vm = globalObject->vm();
-    ErrorConstructor* thisObject = jsCast<ErrorConstructor*>(cell);
+    ErrorConstructor* thisObject = uncheckedDowncast<ErrorConstructor>(cell);
 
     if (propertyName == vm.propertyNames->stackTraceLimit) {
         if (value.isNumber()) {
@@ -100,7 +100,7 @@ bool ErrorConstructor::put(JSCell* cell, JSGlobalObject* globalObject, PropertyN
 bool ErrorConstructor::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
     VM& vm = globalObject->vm();
-    ErrorConstructor* thisObject = jsCast<ErrorConstructor*>(cell);
+    ErrorConstructor* thisObject = uncheckedDowncast<ErrorConstructor>(cell);
 
     if (propertyName == vm.propertyNames->stackTraceLimit)
         thisObject->globalObject()->setStackTraceLimit(std::nullopt);

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -213,7 +213,7 @@ String ErrorInstance::sanitizedNameString(JSGlobalObject* globalObject)
     // Error objects may have a name property, and if not, its prototype should have
     // a name property for the type of error e.g. "SyntaxError".
     while (currentObj.isCell() && prototypeDepth++ < 2) {
-        JSObject* obj = jsCast<JSObject*>(currentObj);
+        JSObject* obj = uncheckedDowncast<JSObject>(currentObj);
         if (JSObject::getOwnPropertySlot(obj, globalObject, namePropertName, nameSlot) && nameSlot.isValue()) {
             nameValue = nameSlot.getValue(globalObject, namePropertName);
             break;
@@ -329,7 +329,7 @@ bool ErrorInstance::materializeErrorInfoIfNeeded(VM& vm, PropertyName propertyNa
 bool ErrorInstance::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
     VM& vm = globalObject->vm();
-    ErrorInstance* thisObject = jsCast<ErrorInstance*>(object);
+    ErrorInstance* thisObject = uncheckedDowncast<ErrorInstance>(object);
     thisObject->materializeErrorInfoIfNeeded(vm, propertyName);
     return Base::getOwnPropertySlot(thisObject, globalObject, propertyName, slot);
 }
@@ -337,7 +337,7 @@ bool ErrorInstance::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalO
 void ErrorInstance::getOwnSpecialPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder&, DontEnumPropertiesMode mode)
 {
     VM& vm = globalObject->vm();
-    ErrorInstance* thisObject = jsCast<ErrorInstance*>(object);
+    ErrorInstance* thisObject = uncheckedDowncast<ErrorInstance>(object);
     if (mode == DontEnumPropertiesMode::Include)
         thisObject->materializeErrorInfoIfNeeded(vm);
 }
@@ -345,7 +345,7 @@ void ErrorInstance::getOwnSpecialPropertyNames(JSObject* object, JSGlobalObject*
 bool ErrorInstance::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, const PropertyDescriptor& descriptor, bool shouldThrow)
 {
     VM& vm = globalObject->vm();
-    ErrorInstance* thisObject = jsCast<ErrorInstance*>(object);
+    ErrorInstance* thisObject = uncheckedDowncast<ErrorInstance>(object);
     thisObject->materializeErrorInfoIfNeeded(vm, propertyName);
     return Base::defineOwnProperty(thisObject, globalObject, propertyName, descriptor, shouldThrow);
 }
@@ -353,7 +353,7 @@ bool ErrorInstance::defineOwnProperty(JSObject* object, JSGlobalObject* globalOb
 bool ErrorInstance::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
     VM& vm = globalObject->vm();
-    ErrorInstance* thisObject = jsCast<ErrorInstance*>(cell);
+    ErrorInstance* thisObject = uncheckedDowncast<ErrorInstance>(cell);
     bool materializedProperties = thisObject->materializeErrorInfoIfNeeded(vm, propertyName);
     if (materializedProperties)
         slot.disableCaching();
@@ -363,7 +363,7 @@ bool ErrorInstance::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName
 bool ErrorInstance::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
     VM& vm = globalObject->vm();
-    ErrorInstance* thisObject = jsCast<ErrorInstance*>(cell);
+    ErrorInstance* thisObject = uncheckedDowncast<ErrorInstance>(cell);
     bool materializedProperties = thisObject->materializeErrorInfoIfNeeded(vm, propertyName);
     if (materializedProperties)
         slot.disableCaching();

--- a/Source/JavaScriptCore/runtime/EvalExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/EvalExecutable.cpp
@@ -53,7 +53,7 @@ auto EvalExecutable::ensureTemplateObjectMap(VM&) -> TemplateObjectMap&
 template<typename Visitor>
 void EvalExecutable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    EvalExecutable* thisObject = jsCast<EvalExecutable*>(cell);
+    EvalExecutable* thisObject = uncheckedDowncast<EvalExecutable>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     if (TemplateObjectMap* map = thisObject->m_templateObjectMap.get()) {

--- a/Source/JavaScriptCore/runtime/Exception.cpp
+++ b/Source/JavaScriptCore/runtime/Exception.cpp
@@ -58,7 +58,7 @@ Structure* Exception::createStructure(VM& vm, JSGlobalObject* globalObject, JSVa
 template<typename Visitor>
 void Exception::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    Exception* thisObject = jsCast<Exception*>(cell);
+    Exception* thisObject = uncheckedDowncast<Exception>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -43,7 +43,7 @@ namespace JSC {
 JSObject* createStackOverflowError(JSGlobalObject* globalObject)
 {
     auto* error = createRangeError(globalObject, "Maximum call stack size exceeded."_s);
-    jsCast<ErrorInstance*>(error)->setStackOverflowError();
+    uncheckedDowncast<ErrorInstance>(error)->setStackOverflowError();
     return error;
 }
 

--- a/Source/JavaScriptCore/runtime/ExecutableBase.cpp
+++ b/Source/JavaScriptCore/runtime/ExecutableBase.cpp
@@ -48,12 +48,12 @@ void ExecutableBase::dump(PrintStream& out) const
 
     switch (type()) {
     case NativeExecutableType: {
-        NativeExecutable* native = jsCast<NativeExecutable*>(realThis);
+        NativeExecutable* native = uncheckedDowncast<NativeExecutable>(realThis);
         out.print("NativeExecutable:"_s, RawPointer(native->function().taggedPtr()), "/"_s, RawPointer(native->constructor().taggedPtr()));
         return;
     }
     case EvalExecutableType: {
-        EvalExecutable* eval = jsCast<EvalExecutable*>(realThis);
+        EvalExecutable* eval = uncheckedDowncast<EvalExecutable>(realThis);
         if (CodeBlock* codeBlock = eval->codeBlock())
             out.print(*codeBlock);
         else
@@ -61,7 +61,7 @@ void ExecutableBase::dump(PrintStream& out) const
         return;
     }
     case ProgramExecutableType: {
-        ProgramExecutable* eval = jsCast<ProgramExecutable*>(realThis);
+        ProgramExecutable* eval = uncheckedDowncast<ProgramExecutable>(realThis);
         if (CodeBlock* codeBlock = eval->codeBlock())
             out.print(*codeBlock);
         else
@@ -69,7 +69,7 @@ void ExecutableBase::dump(PrintStream& out) const
         return;
     }
     case ModuleProgramExecutableType: {
-        ModuleProgramExecutable* executable = jsCast<ModuleProgramExecutable*>(realThis);
+        ModuleProgramExecutable* executable = uncheckedDowncast<ModuleProgramExecutable>(realThis);
         if (CodeBlock* codeBlock = executable->codeBlock())
             out.print(*codeBlock);
         else
@@ -77,7 +77,7 @@ void ExecutableBase::dump(PrintStream& out) const
         return;
     }
     case FunctionExecutableType: {
-        FunctionExecutable* function = jsCast<FunctionExecutable*>(realThis);
+        FunctionExecutable* function = uncheckedDowncast<FunctionExecutable>(realThis);
         if (!function->eitherCodeBlock())
             out.print("FunctionExecutable w/o CodeBlock"_s);
         else {
@@ -97,9 +97,9 @@ void ExecutableBase::dump(PrintStream& out) const
 CodeBlockHash ExecutableBase::hashFor(CodeSpecializationKind kind) const
 {
     if (type() == NativeExecutableType)
-        return jsCast<const NativeExecutable*>(this)->hashFor(kind);
+        return uncheckedDowncast<NativeExecutable>(this)->hashFor(kind);
     
-    return jsCast<const ScriptExecutable*>(this)->hashFor(kind);
+    return uncheckedDowncast<ScriptExecutable>(this)->hashFor(kind);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ExecutableBaseInlines.h
+++ b/Source/JavaScriptCore/runtime/ExecutableBaseInlines.h
@@ -42,8 +42,8 @@ inline Structure* ExecutableBase::createStructure(VM& vm, JSGlobalObject* global
 inline Intrinsic ExecutableBase::intrinsic() const
 {
     if (isHostFunction())
-        return jsCast<const NativeExecutable*>(this)->intrinsic();
-    return jsCast<const ScriptExecutable*>(this)->intrinsic();
+        return uncheckedDowncast<NativeExecutable>(this)->intrinsic();
+    return uncheckedDowncast<ScriptExecutable>(this)->intrinsic();
 }
 
 inline Intrinsic ExecutableBase::intrinsicFor(CodeSpecializationKind kind) const
@@ -56,16 +56,16 @@ inline Intrinsic ExecutableBase::intrinsicFor(CodeSpecializationKind kind) const
 inline ImplementationVisibility ExecutableBase::implementationVisibility() const
 {
     if (isFunctionExecutable())
-        return jsCast<const FunctionExecutable*>(this)->implementationVisibility();
+        return uncheckedDowncast<FunctionExecutable>(this)->implementationVisibility();
     if (isHostFunction())
-        return jsCast<const NativeExecutable*>(this)->implementationVisibility();
+        return uncheckedDowncast<NativeExecutable>(this)->implementationVisibility();
     return ImplementationVisibility::Public;
 }
 
 inline InlineAttribute ExecutableBase::inlineAttribute() const
 {
     if (isFunctionExecutable())
-        return jsCast<const FunctionExecutable*>(this)->inlineAttribute();
+        return uncheckedDowncast<FunctionExecutable>(this)->inlineAttribute();
     return InlineAttribute::None;
 }
 
@@ -73,14 +73,14 @@ inline bool ExecutableBase::hasJITCodeForCall() const
 {
     if (isHostFunction())
         return true;
-    return jsCast<const ScriptExecutable*>(this)->hasJITCodeForCall();
+    return uncheckedDowncast<ScriptExecutable>(this)->hasJITCodeForCall();
 }
 
 inline bool ExecutableBase::hasJITCodeForConstruct() const
 {
     if (isHostFunction())
         return true;
-    return jsCast<const ScriptExecutable*>(this)->hasJITCodeForConstruct();
+    return uncheckedDowncast<ScriptExecutable>(this)->hasJITCodeForConstruct();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
@@ -78,7 +78,7 @@ template<typename Visitor>
 void FunctionExecutable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     VM& vm = visitor.vm();
-    FunctionExecutable* thisObject = jsCast<FunctionExecutable*>(cell);
+    FunctionExecutable* thisObject = uncheckedDowncast<FunctionExecutable>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_topLevelExecutable);
@@ -111,7 +111,7 @@ template<typename Visitor>
 void FunctionExecutable::visitOutputConstraintsImpl(JSCell* cell, Visitor& visitor)
 {
     VM& vm = visitor.vm();
-    auto* executable = jsCast<FunctionExecutable*>(cell);
+    auto* executable = uncheckedDowncast<FunctionExecutable>(cell);
     auto* codeBlockForCall = executable->m_codeBlockForCall.get();
     if (codeBlockForCall) {
         if (!visitor.isMarked(codeBlockForCall))

--- a/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
@@ -82,13 +82,13 @@ JSC_DEFINE_HOST_FUNCTION(functionProtoFuncToString, (JSGlobalObject* globalObjec
 
     JSValue thisValue = callFrame->thisValue();
     if (thisValue.inherits<JSFunction>()) {
-        JSFunction* function = jsCast<JSFunction*>(thisValue);
+        JSFunction* function = uncheckedDowncast<JSFunction>(thisValue);
         Integrity::auditStructureID(function->structureID());
         RELEASE_AND_RETURN(scope, JSValue::encode(function->toString(globalObject)));
     }
 
     if (thisValue.inherits<InternalFunction>()) {
-        InternalFunction* function = jsCast<InternalFunction*>(thisValue);
+        InternalFunction* function = uncheckedDowncast<InternalFunction>(thisValue);
         Integrity::auditStructureID(function->structureID());
         RELEASE_AND_RETURN(scope, JSValue::encode(jsMakeNontrivialString(globalObject, "function "_s, function->name(), "() {\n    [native code]\n}"_s)));
     }
@@ -259,7 +259,7 @@ public:
             if (callee->inherits<JSBoundFunction>() || callee->inherits<JSRemoteFunction>() || callee->type() == ProxyObjectType)
                 return IterationStatus::Continue;
             if (callee->inherits<JSFunction>()) {
-                if (jsCast<JSFunction*>(callee)->executable()->implementationVisibility() != ImplementationVisibility::Public)
+                if (uncheckedDowncast<JSFunction>(callee)->executable()->implementationVisibility() != ImplementationVisibility::Public)
                     return IterationStatus::Continue;
             }
 

--- a/Source/JavaScriptCore/runtime/FunctionRareData.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionRareData.cpp
@@ -54,7 +54,7 @@ Structure* FunctionRareData::createStructure(VM& vm, JSGlobalObject* globalObjec
 template<typename Visitor>
 void FunctionRareData::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    FunctionRareData* rareData = jsCast<FunctionRareData*>(cell);
+    FunctionRareData* rareData = uncheckedDowncast<FunctionRareData>(cell);
     ASSERT_GC_OBJECT_INHERITS(cell, info());
     Base::visitChildren(cell, visitor);
 

--- a/Source/JavaScriptCore/runtime/GenericArgumentsImplInlines.h
+++ b/Source/JavaScriptCore/runtime/GenericArgumentsImplInlines.h
@@ -49,7 +49,7 @@ DEFINE_VISIT_CHILDREN_WITH_MODIFIER(template<typename Type>, GenericArgumentsImp
 template<typename Type>
 bool GenericArgumentsImpl<Type>::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObject, PropertyName ident, PropertySlot& slot)
 {
-    Type* thisObject = jsCast<Type*>(object);
+    Type* thisObject = uncheckedDowncast<Type>(object);
     VM& vm = globalObject->vm();
 
     if (!thisObject->overrodeThings()) {
@@ -76,7 +76,7 @@ bool GenericArgumentsImpl<Type>::getOwnPropertySlot(JSObject* object, JSGlobalOb
 template<typename Type>
 bool GenericArgumentsImpl<Type>::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* globalObject, unsigned index, PropertySlot& slot)
 {
-    Type* thisObject = jsCast<Type*>(object);
+    Type* thisObject = uncheckedDowncast<Type>(object);
 
     if (!thisObject->isModifiedArgumentDescriptor(index) && thisObject->isMappedArgument(index)) {
         slot.setValue(thisObject, static_cast<unsigned>(PropertyAttribute::None), thisObject->getIndexQuickly(index));
@@ -98,7 +98,7 @@ template<typename Type>
 void GenericArgumentsImpl<Type>::getOwnPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder& array, DontEnumPropertiesMode mode)
 {
     VM& vm = globalObject->vm();
-    Type* thisObject = jsCast<Type*>(object);
+    Type* thisObject = uncheckedDowncast<Type>(object);
 
     if (array.includeStringProperties()) {
         for (unsigned i = 0; i < thisObject->internalLength(); ++i) {
@@ -120,7 +120,7 @@ void GenericArgumentsImpl<Type>::getOwnPropertyNames(JSObject* object, JSGlobalO
 template<typename Type>
 bool GenericArgumentsImpl<Type>::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName ident, JSValue value, PutPropertySlot& slot)
 {
-    Type* thisObject = jsCast<Type*>(cell);
+    Type* thisObject = uncheckedDowncast<Type>(cell);
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -151,7 +151,7 @@ bool GenericArgumentsImpl<Type>::put(JSCell* cell, JSGlobalObject* globalObject,
 template<typename Type>
 bool GenericArgumentsImpl<Type>::putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned index, JSValue value, bool shouldThrow)
 {
-    Type* thisObject = jsCast<Type*>(cell);
+    Type* thisObject = uncheckedDowncast<Type>(cell);
     VM& vm = globalObject->vm();
 
     if (thisObject->isMappedArgument(index)) {
@@ -165,7 +165,7 @@ bool GenericArgumentsImpl<Type>::putByIndex(JSCell* cell, JSGlobalObject* global
 template<typename Type>
 bool GenericArgumentsImpl<Type>::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName ident, DeletePropertySlot& slot)
 {
-    Type* thisObject = jsCast<Type*>(cell);
+    Type* thisObject = uncheckedDowncast<Type>(cell);
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -189,7 +189,7 @@ bool GenericArgumentsImpl<Type>::deletePropertyByIndex(JSCell* cell, JSGlobalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    Type* thisObject = jsCast<Type*>(cell);
+    Type* thisObject = uncheckedDowncast<Type>(cell);
 
     bool propertyMightBeInJSObjectStorage = thisObject->isModifiedArgumentDescriptor(index) || !thisObject->isMappedArgument(index);
     bool deletedProperty = true;
@@ -216,7 +216,7 @@ bool GenericArgumentsImpl<Type>::deletePropertyByIndex(JSCell* cell, JSGlobalObj
 template<typename Type>
 bool GenericArgumentsImpl<Type>::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, PropertyName ident, const PropertyDescriptor& descriptor, bool shouldThrow)
 {
-    Type* thisObject = jsCast<Type*>(object);
+    Type* thisObject = uncheckedDowncast<Type>(object);
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 

--- a/Source/JavaScriptCore/runtime/GetterSetter.cpp
+++ b/Source/JavaScriptCore/runtime/GetterSetter.cpp
@@ -36,7 +36,7 @@ const ClassInfo GetterSetter::s_info = { "GetterSetter"_s, nullptr, nullptr, nul
 template<typename Visitor>
 void GetterSetter::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    GetterSetter* thisObject = jsCast<GetterSetter*>(cell);
+    GetterSetter* thisObject = uncheckedDowncast<GetterSetter>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 

--- a/Source/JavaScriptCore/runtime/GlobalExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/GlobalExecutable.cpp
@@ -37,7 +37,7 @@ const ClassInfo GlobalExecutable::s_info = { "GlobalExecutable"_s, &Base::s_info
 template<typename Visitor>
 void GlobalExecutable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* executable = jsCast<GlobalExecutable*>(cell);
+    auto* executable = uncheckedDowncast<GlobalExecutable>(cell);
     ASSERT_GC_OBJECT_INHERITS(executable, info());
     Base::visitChildren(executable, visitor);
     visitor.append(executable->m_unlinkedCodeBlock);
@@ -59,7 +59,7 @@ DEFINE_VISIT_CHILDREN(GlobalExecutable);
 template<typename Visitor>
 void GlobalExecutable::visitOutputConstraintsImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* executable = jsCast<GlobalExecutable*>(cell);
+    auto* executable = uncheckedDowncast<GlobalExecutable>(cell);
     if (CodeBlock* codeBlock = executable->codeBlock()) {
         if (!visitor.isMarked(codeBlock))
             runConstraint(NoLockingNecessary, visitor, codeBlock);

--- a/Source/JavaScriptCore/runtime/InternalFunction.cpp
+++ b/Source/JavaScriptCore/runtime/InternalFunction.cpp
@@ -68,7 +68,7 @@ void InternalFunction::finishCreation(VM& vm, unsigned length, const String& nam
 template<typename Visitor>
 void InternalFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    InternalFunction* thisObject = jsCast<InternalFunction*>(cell);
+    InternalFunction* thisObject = uncheckedDowncast<InternalFunction>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     
@@ -102,7 +102,7 @@ String InternalFunction::displayName(VM& vm)
 CallData InternalFunction::getCallData(JSCell* cell)
 {
     // Keep this function OK for invocation from concurrent compilers.
-    auto* function = jsCast<InternalFunction*>(cell);
+    auto* function = uncheckedDowncast<InternalFunction>(cell);
     ASSERT(function->m_functionForCall);
 
     CallData callData;
@@ -117,7 +117,7 @@ CallData InternalFunction::getConstructData(JSCell* cell)
 {
     // Keep this function OK for invocation from concurrent compilers.
     CallData constructData;
-    auto* function = jsCast<InternalFunction*>(cell);
+    auto* function = uncheckedDowncast<InternalFunction>(cell);
     if (function->m_functionForConstruct != callHostFunctionAsConstructor) {
         constructData.type = CallData::Type::Native;
         constructData.native.function = function->m_functionForConstruct;
@@ -198,16 +198,16 @@ JSGlobalObject* getFunctionRealm(JSGlobalObject* globalObject, JSObject* object)
 
     while (true) {
         if (object->inherits<JSBoundFunction>()) {
-            object = jsCast<JSBoundFunction*>(object)->targetFunction();
+            object = uncheckedDowncast<JSBoundFunction>(object)->targetFunction();
             continue;
         }
         if (object->inherits<JSRemoteFunction>()) {
-            object = jsCast<JSRemoteFunction*>(object)->targetFunction();
+            object = uncheckedDowncast<JSRemoteFunction>(object)->targetFunction();
             continue;
         }
 
         if (object->type() == ProxyObjectType) {
-            auto* proxy = jsCast<ProxyObject*>(object);
+            auto* proxy = uncheckedDowncast<ProxyObject>(object);
             if (proxy->isRevoked()) {
                 throwTypeError(globalObject, scope, "Cannot get function realm from revoked Proxy"_s);
                 return nullptr;

--- a/Source/JavaScriptCore/runtime/IntlCollator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollator.cpp
@@ -63,7 +63,7 @@ IntlCollator::IntlCollator(VM& vm, Structure* structure)
 template<typename Visitor>
 void IntlCollator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    IntlCollator* thisObject = jsCast<IntlCollator*>(cell);
+    IntlCollator* thisObject = uncheckedDowncast<IntlCollator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -92,7 +92,7 @@ IntlDateTimeFormat::IntlDateTimeFormat(VM& vm, Structure* structure)
 template<typename Visitor>
 void IntlDateTimeFormat::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    IntlDateTimeFormat* thisObject = jsCast<IntlDateTimeFormat*>(cell);
+    IntlDateTimeFormat* thisObject = uncheckedDowncast<IntlDateTimeFormat>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -68,7 +68,7 @@ IntlLocale::IntlLocale(VM& vm, Structure* structure)
 template<typename Visitor>
 void IntlLocale::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<IntlLocale*>(cell);
+    auto* thisObject = uncheckedDowncast<IntlLocale>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);
@@ -306,7 +306,7 @@ void IntlLocale::initializeLocale(JSGlobalObject* globalObject, JSValue tagValue
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    String tag = tagValue.inherits<IntlLocale>() ? jsCast<IntlLocale*>(tagValue)->toString() : tagValue.toWTFString(globalObject);
+    String tag = tagValue.inherits<IntlLocale>() ? uncheckedDowncast<IntlLocale>(tagValue)->toString() : tagValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, void());
     scope.release();
     initializeLocale(globalObject, tag, optionsValue);

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -90,7 +90,7 @@ IntlNumberFormat::IntlNumberFormat(VM& vm, Structure* structure)
 template<typename Visitor>
 void IntlNumberFormat::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    IntlNumberFormat* thisObject = jsCast<IntlNumberFormat*>(cell);
+    IntlNumberFormat* thisObject = uncheckedDowncast<IntlNumberFormat>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -88,72 +88,72 @@ static JSC_DECLARE_HOST_FUNCTION(intlObjectFuncSupportedValuesOf);
 
 static JSValue createCollatorConstructor(VM& vm, JSObject* object)
 {
-    IntlObject* intlObject = jsCast<IntlObject*>(object);
+    IntlObject* intlObject = uncheckedDowncast<IntlObject>(object);
     JSGlobalObject* globalObject = intlObject->realm();
-    return IntlCollatorConstructor::create(vm, IntlCollatorConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<IntlCollatorPrototype*>(globalObject->collatorStructure()->storedPrototypeObject()));
+    return IntlCollatorConstructor::create(vm, IntlCollatorConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<IntlCollatorPrototype>(globalObject->collatorStructure()->storedPrototypeObject()));
 }
 
 static JSValue createDateTimeFormatConstructor(VM&, JSObject* object)
 {
-    IntlObject* intlObject = jsCast<IntlObject*>(object);
+    IntlObject* intlObject = uncheckedDowncast<IntlObject>(object);
     JSGlobalObject* globalObject = intlObject->realm();
     return globalObject->dateTimeFormatConstructor();
 }
 
 static JSValue createDisplayNamesConstructor(VM& vm, JSObject* object)
 {
-    IntlObject* intlObject = jsCast<IntlObject*>(object);
+    IntlObject* intlObject = uncheckedDowncast<IntlObject>(object);
     JSGlobalObject* globalObject = intlObject->realm();
-    return IntlDisplayNamesConstructor::create(vm, IntlDisplayNamesConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<IntlDisplayNamesPrototype*>(globalObject->displayNamesStructure()->storedPrototypeObject()));
+    return IntlDisplayNamesConstructor::create(vm, IntlDisplayNamesConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<IntlDisplayNamesPrototype>(globalObject->displayNamesStructure()->storedPrototypeObject()));
 }
 
 static JSValue createDurationFormatConstructor(VM& vm, JSObject* object)
 {
-    IntlObject* intlObject = jsCast<IntlObject*>(object);
+    IntlObject* intlObject = uncheckedDowncast<IntlObject>(object);
     JSGlobalObject* globalObject = intlObject->realm();
-    return IntlDurationFormatConstructor::create(vm, IntlDurationFormatConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<IntlDurationFormatPrototype*>(globalObject->durationFormatStructure()->storedPrototypeObject()));
+    return IntlDurationFormatConstructor::create(vm, IntlDurationFormatConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<IntlDurationFormatPrototype>(globalObject->durationFormatStructure()->storedPrototypeObject()));
 }
 
 static JSValue createListFormatConstructor(VM& vm, JSObject* object)
 {
-    IntlObject* intlObject = jsCast<IntlObject*>(object);
+    IntlObject* intlObject = uncheckedDowncast<IntlObject>(object);
     JSGlobalObject* globalObject = intlObject->realm();
-    return IntlListFormatConstructor::create(vm, IntlListFormatConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<IntlListFormatPrototype*>(globalObject->listFormatStructure()->storedPrototypeObject()));
+    return IntlListFormatConstructor::create(vm, IntlListFormatConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<IntlListFormatPrototype>(globalObject->listFormatStructure()->storedPrototypeObject()));
 }
 
 static JSValue createLocaleConstructor(VM& vm, JSObject* object)
 {
-    IntlObject* intlObject = jsCast<IntlObject*>(object);
+    IntlObject* intlObject = uncheckedDowncast<IntlObject>(object);
     JSGlobalObject* globalObject = intlObject->realm();
-    return IntlLocaleConstructor::create(vm, IntlLocaleConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<IntlLocalePrototype*>(globalObject->localeStructure()->storedPrototypeObject()));
+    return IntlLocaleConstructor::create(vm, IntlLocaleConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<IntlLocalePrototype>(globalObject->localeStructure()->storedPrototypeObject()));
 }
 
 static JSValue createNumberFormatConstructor(VM&, JSObject* object)
 {
-    IntlObject* intlObject = jsCast<IntlObject*>(object);
+    IntlObject* intlObject = uncheckedDowncast<IntlObject>(object);
     JSGlobalObject* globalObject = intlObject->realm();
     return globalObject->numberFormatConstructor();
 }
 
 static JSValue createPluralRulesConstructor(VM& vm, JSObject* object)
 {
-    IntlObject* intlObject = jsCast<IntlObject*>(object);
+    IntlObject* intlObject = uncheckedDowncast<IntlObject>(object);
     JSGlobalObject* globalObject = intlObject->realm();
-    return IntlPluralRulesConstructor::create(vm, IntlPluralRulesConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<IntlPluralRulesPrototype*>(globalObject->pluralRulesStructure()->storedPrototypeObject()));
+    return IntlPluralRulesConstructor::create(vm, IntlPluralRulesConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<IntlPluralRulesPrototype>(globalObject->pluralRulesStructure()->storedPrototypeObject()));
 }
 
 static JSValue createRelativeTimeFormatConstructor(VM& vm, JSObject* object)
 {
-    IntlObject* intlObject = jsCast<IntlObject*>(object);
+    IntlObject* intlObject = uncheckedDowncast<IntlObject>(object);
     JSGlobalObject* globalObject = intlObject->realm();
-    return IntlRelativeTimeFormatConstructor::create(vm, IntlRelativeTimeFormatConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<IntlRelativeTimeFormatPrototype*>(globalObject->relativeTimeFormatStructure()->storedPrototypeObject()));
+    return IntlRelativeTimeFormatConstructor::create(vm, IntlRelativeTimeFormatConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<IntlRelativeTimeFormatPrototype>(globalObject->relativeTimeFormatStructure()->storedPrototypeObject()));
 }
 
 static JSValue createSegmenterConstructor(VM& vm, JSObject* object)
 {
-    IntlObject* intlObject = jsCast<IntlObject*>(object);
+    IntlObject* intlObject = uncheckedDowncast<IntlObject>(object);
     JSGlobalObject* globalObject = intlObject->realm();
-    return IntlSegmenterConstructor::create(vm, IntlSegmenterConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<IntlSegmenterPrototype*>(globalObject->segmenterStructure()->storedPrototypeObject()));
+    return IntlSegmenterConstructor::create(vm, IntlSegmenterConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<IntlSegmenterPrototype>(globalObject->segmenterStructure()->storedPrototypeObject()));
 }
 
 }
@@ -789,7 +789,7 @@ Vector<String> canonicalizeLocaleList(JSGlobalObject* globalObject, JSValue loca
 
             String tag;
             if (kValue.inherits<IntlLocale>())
-                tag = jsCast<IntlLocale*>(kValue)->toString();
+                tag = uncheckedDowncast<IntlLocale>(kValue)->toString();
             else {
                 JSString* string = kValue.toString(globalObject);
                 RETURN_IF_EXCEPTION(scope, Vector<String>());

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -72,7 +72,7 @@ IntlPluralRules::IntlPluralRules(VM& vm, Structure* structure)
 template<typename Visitor>
 void IntlPluralRules::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    IntlPluralRules* thisObject = jsCast<IntlPluralRules*>(cell);
+    IntlPluralRules* thisObject = uncheckedDowncast<IntlPluralRules>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
@@ -63,7 +63,7 @@ IntlRelativeTimeFormat::IntlRelativeTimeFormat(VM& vm, Structure* structure)
 template<typename Visitor>
 void IntlRelativeTimeFormat::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<IntlRelativeTimeFormat*>(cell);
+    auto* thisObject = uncheckedDowncast<IntlRelativeTimeFormat>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/runtime/IntlSegmentIterator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmentIterator.cpp
@@ -62,7 +62,7 @@ IntlSegmentIterator::IntlSegmentIterator(VM& vm, Structure* structure, std::uniq
 template<typename Visitor>
 void IntlSegmentIterator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<IntlSegmentIterator*>(cell);
+    auto* thisObject = uncheckedDowncast<IntlSegmentIterator>(cell);
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_string);
 }

--- a/Source/JavaScriptCore/runtime/IntlSegments.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegments.cpp
@@ -108,7 +108,7 @@ JSObject* IntlSegments::createSegmentIterator(JSGlobalObject* globalObject)
 template<typename Visitor>
 void IntlSegments::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<IntlSegments*>(cell);
+    auto* thisObject = uncheckedDowncast<IntlSegments>(cell);
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_string);
 }

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -450,7 +450,7 @@ IterationMode getIterationMode(VM&, JSGlobalObject* globalObject, JSValue iterab
     if (!isJSArray(iterable))
         return IterationMode::Generic;
 
-    JSArray* array = jsCast<JSArray*>(iterable);
+    JSArray* array = uncheckedDowncast<JSArray>(iterable);
     Structure* structure = array->structure();
     // FIXME: We want to support broader JSArrays as long as array[@@iterator] is not defined.
     if (!globalObject->isOriginalArrayStructure(structure))

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -92,7 +92,7 @@ static ALWAYS_INLINE void forEachInMapStorage(VM& vm, JSGlobalObject* globalObje
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* storage = jsCast<JSMap::Storage*>(storageCell);
+    auto* storage = uncheckedDowncast<JSMap::Storage>(storageCell);
     JSMap::Helper::Entry entry = startEntry;
 
     while (true) {
@@ -100,7 +100,7 @@ static ALWAYS_INLINE void forEachInMapStorage(VM& vm, JSGlobalObject* globalObje
         if (storageCell == vm.orderedHashTableSentinel())
             break;
 
-        storage = jsCast<JSMap::Storage*>(storageCell);
+        storage = uncheckedDowncast<JSMap::Storage>(storageCell);
         entry = JSMap::Helper::iterationEntry(*storage) + 1;
 
         JSValue value;
@@ -130,7 +130,7 @@ static ALWAYS_INLINE void forEachInSetStorage(VM& vm, JSGlobalObject* globalObje
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* storage = jsCast<JSSet::Storage*>(storageCell);
+    auto* storage = uncheckedDowncast<JSSet::Storage>(storageCell);
     JSSet::Helper::Entry entry = startEntry;
 
     while (true) {
@@ -138,7 +138,7 @@ static ALWAYS_INLINE void forEachInSetStorage(VM& vm, JSGlobalObject* globalObje
         if (storageCell == vm.orderedHashTableSentinel())
             break;
 
-        storage = jsCast<JSSet::Storage*>(storageCell);
+        storage = uncheckedDowncast<JSSet::Storage>(storageCell);
         entry = JSSet::Helper::iterationEntry(*storage) + 1;
         JSValue entryKey = JSSet::Helper::getIterationEntryKey(*storage);
 
@@ -181,7 +181,7 @@ ALWAYS_INLINE void forEachInIterationRecord(JSGlobalObject* globalObject, Iterat
     std::optional<CachedCall> cachedCallHolder;
     CachedCall* cachedCall = nullptr;
     if (callData.type == CallData::Type::JS) [[likely]] {
-        cachedCallHolder.emplace(globalObject, jsCast<JSFunction*>(nextMethod), 0);
+        cachedCallHolder.emplace(globalObject, uncheckedDowncast<JSFunction>(nextMethod), 0);
         if (scope.exception()) [[unlikely]]
             return;
         cachedCall = &cachedCallHolder.value();
@@ -217,7 +217,7 @@ void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, NOESCAPE 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (getIterationMode(vm, globalObject, iterable) == IterationMode::FastArray) {
-        auto* array = jsCast<JSArray*>(iterable);
+        auto* array = uncheckedDowncast<JSArray>(iterable);
         forEachInFastArray(globalObject, iterable, array, callback);
         RETURN_IF_EXCEPTION(scope, void());
         return;
@@ -256,7 +256,7 @@ void forEachInIterable(JSGlobalObject& globalObject, JSObject* iterable, JSValue
 
     auto iterationMode = getIterationMode(vm, &globalObject, iterable, iteratorMethod);
     if (iterationMode == IterationMode::FastArray) {
-        auto* array = jsCast<JSArray*>(iterable);
+        auto* array = uncheckedDowncast<JSArray>(iterable);
         for (unsigned index = 0; index < array->length(); ++index) {
             JSValue nextValue = array->getIndex(&globalObject, index);
             RETURN_IF_EXCEPTION(scope, void());
@@ -287,7 +287,7 @@ void forEachInIterable(JSGlobalObject& globalObject, JSObject* iterable, JSValue
     std::optional<CachedCall> cachedCallHolder;
     CachedCall* cachedCall = nullptr;
     if (callData.type == CallData::Type::JS) [[likely]] {
-        cachedCallHolder.emplace(&globalObject, jsCast<JSFunction*>(nextMethod), 0);
+        cachedCallHolder.emplace(&globalObject, uncheckedDowncast<JSFunction>(nextMethod), 0);
         if (scope.exception()) [[unlikely]]
             return;
         cachedCall = &cachedCallHolder.value();
@@ -324,7 +324,7 @@ void forEachInIteratorProtocol(JSGlobalObject* globalObject, JSValue iterable, N
 
     if (auto* mapIterator = dynamicDowncast<JSMapIterator>(iterable)) {
         if (mapIteratorProtocolIsFastAndNonObservable(vm, mapIterator)) {
-            if (JSMap* iteratedMap = jsCast<JSMap*>(mapIterator->iteratedObject())) {
+            if (JSMap* iteratedMap = mapIterator->iteratedObject()) {
                 JSCell* storageCell = iteratedMap->storageOrSentinel(vm);
                 if (storageCell != vm.orderedHashTableSentinel()) {
                     JSMap::Helper::Entry startEntry = mapIterator->entry();
@@ -337,7 +337,7 @@ void forEachInIteratorProtocol(JSGlobalObject* globalObject, JSValue iterable, N
         }
     } else if (auto* setIterator = dynamicDowncast<JSSetIterator>(iterable)) {
         if (setIteratorProtocolIsFastAndNonObservable(vm, setIterator)) {
-            if (JSSet* iteratedSet = jsCast<JSSet*>(setIterator->iteratedObject())) {
+            if (JSSet* iteratedSet = setIterator->iteratedObject()) {
                 JSCell* storageCell = iteratedSet->storageOrSentinel(vm);
                 if (storageCell != vm.orderedHashTableSentinel()) {
                     JSSet::Helper::Entry startEntry = setIterator->entry();

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -149,7 +149,7 @@ bool JSArray::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSArray* array = jsCast<JSArray*>(object);
+    JSArray* array = uncheckedDowncast<JSArray>(object);
 
     // 2. If P is "length", then
     // https://tc39.es/ecma262/#sec-arraysetlength
@@ -226,7 +226,7 @@ bool JSArray::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, 
 bool JSArray::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
     VM& vm = globalObject->vm();
-    JSArray* thisObject = jsCast<JSArray*>(object);
+    JSArray* thisObject = uncheckedDowncast<JSArray>(object);
     if (propertyName == vm.propertyNames->length) {
         unsigned attributes = thisObject->isLengthWritable() ? PropertyAttribute::DontDelete | PropertyAttribute::DontEnum : PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly;
         slot.setValue(thisObject, attributes, jsNumber(thisObject->length()));
@@ -242,7 +242,7 @@ bool JSArray::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName prope
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSArray* thisObject = jsCast<JSArray*>(cell);
+    JSArray* thisObject = uncheckedDowncast<JSArray>(cell);
     thisObject->ensureWritable(vm);
 
     if (propertyName == vm.propertyNames->length) {
@@ -272,7 +272,7 @@ bool JSArray::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName prope
 bool JSArray::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
     VM& vm = globalObject->vm();
-    JSArray* thisObject = jsCast<JSArray*>(cell);
+    JSArray* thisObject = uncheckedDowncast<JSArray>(cell);
 
     if (propertyName == vm.propertyNames->length)
         return false;
@@ -1020,7 +1020,7 @@ JSString* JSArray::fastToString(JSGlobalObject* globalObject)
 
         if (!sawHoles && !genericCase && result && isCoW) {
             ASSERT(JSCellButterfly::fromButterfly(this->butterfly()) == immutableButterfly);
-            vm.heap.immutableButterflyToStringCache.add(immutableButterfly, jsCast<JSString*>(result));
+            vm.heap.immutableButterflyToStringCache.add(immutableButterfly, result);
         }
 
         return result;
@@ -1369,9 +1369,9 @@ JSArray* JSArray::fastSlice(JSGlobalObject* globalObject, JSObject* source, uint
         // We do not need to have ClonedArgumentsType here since it does not have interceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero.
         switch (source->type()) {
         case DirectArgumentsType:
-            return DirectArguments::fastSlice(globalObject, jsCast<DirectArguments*>(source), startIndex, count);
+            return DirectArguments::fastSlice(globalObject, uncheckedDowncast<DirectArguments>(source), startIndex, count);
         case ScopedArgumentsType:
-            return ScopedArguments::fastSlice(globalObject, jsCast<ScopedArguments*>(source), startIndex, count);
+            return ScopedArguments::fastSlice(globalObject, uncheckedDowncast<ScopedArguments>(source), startIndex, count);
         default:
             return nullptr;
         }
@@ -2113,7 +2113,7 @@ JSArray* tryCloneArrayFromFast(JSGlobalObject* globalObject, JSValue arrayValue)
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* array = jsCast<JSArray*>(arrayValue);
+    auto* array = uncheckedDowncast<JSArray>(arrayValue);
     if (!array->isIteratorProtocolFastAndNonObservable()) [[unlikely]]
         return nullptr;
 
@@ -2255,7 +2255,7 @@ static uint64_t calculateFlattenedLength(JSGlobalObject* globalObject, JSArray* 
             if (!element) [[unlikely]]
                 continue;
             if (depth > 0 && isJSArray(element)) {
-                JSArray* elementArray = jsCast<JSArray*>(element);
+                JSArray* elementArray = uncheckedDowncast<JSArray>(element);
                 uint64_t newDepth = (depth == std::numeric_limits<uint64_t>::max()) ? depth : depth - 1;
                 uint64_t flatLength = calculateFlattenedLength(globalObject, elementArray, elementArray->length(), newDepth);
                 RETURN_IF_EXCEPTION(scope, flatLength);
@@ -2341,7 +2341,7 @@ static uint64_t fastFlatIntoBuffer(JSGlobalObject* globalObject, T* resultBuffer
             if (!element) [[unlikely]]
                 continue;
             if (depth > 0 && isJSArray(element)) {
-                JSArray* elementArray = jsCast<JSArray*>(element);
+                JSArray* elementArray = uncheckedDowncast<JSArray>(element);
                 uint64_t newDepth = (depth == std::numeric_limits<uint64_t>::max()) ? depth : depth - 1;
                 resultIndex = fastFlatIntoBuffer(globalObject, resultBuffer, resultIndex, elementArray, elementArray->length(), newDepth, vectorLength);
                 RETURN_IF_EXCEPTION(scope, resultIndex);

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -351,7 +351,7 @@ JSArray* asArray(JSValue);
 inline JSArray* asArray(JSCell* cell)
 {
     ASSERT(cell->inherits<JSArray>());
-    return jsCast<JSArray*>(cell);
+    return uncheckedDowncast<JSArray>(cell);
 }
 
 inline JSArray* asArray(JSValue value)

--- a/Source/JavaScriptCore/runtime/JSArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBuffer.cpp
@@ -77,7 +77,7 @@ ArrayBufferSharingMode JSArrayBuffer::sharingMode() const
 
 size_t JSArrayBuffer::estimatedSize(JSCell* cell, VM& vm)
 {
-    JSArrayBuffer* thisObject = jsCast<JSArrayBuffer*>(cell);
+    JSArrayBuffer* thisObject = uncheckedDowncast<JSArrayBuffer>(cell);
     size_t bufferEstimatedSize = thisObject->impl()->gcSizeEstimateInBytes();
     return Base::estimatedSize(cell, vm) + bufferEstimatedSize;
 }

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -63,7 +63,7 @@ std::optional<JSValue> arrayBufferSpeciesConstructorSlow(JSGlobalObject* globalO
     JSValue constructor = thisObject->get(globalObject, vm.propertyNames->constructor);
     RETURN_IF_EXCEPTION(scope, std::nullopt);
     if (constructor.isConstructor()) {
-        JSObject* constructorObject = jsCast<JSObject*>(constructor);
+        JSObject* constructorObject = uncheckedDowncast<JSObject>(constructor);
         JSGlobalObject* globalObjectFromConstructor = constructorObject->realm();
         bool isAnyArrayBufferConstructor = constructorObject == globalObjectFromConstructor->arrayBufferConstructor(mode);
         if (isAnyArrayBufferConstructor)

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -195,7 +195,7 @@ void JSArrayBufferView::finishCreation(VM& vm)
     case GrowableSharedDataViewMode:
     case GrowableSharedAutoLengthDataViewMode:
         ASSERT(!butterfly());
-        vm.heap.addReference(this, jsCast<JSDataView*>(this)->possiblySharedBuffer());
+        vm.heap.addReference(this, uncheckedDowncast<JSDataView>(this)->possiblySharedBuffer());
         return;
     }
     RELEASE_ASSERT_NOT_REACHED();
@@ -204,7 +204,7 @@ void JSArrayBufferView::finishCreation(VM& vm)
 template<typename Visitor>
 void JSArrayBufferView::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSArrayBufferView* thisObject = jsCast<JSArrayBufferView*>(cell);
+    JSArrayBufferView* thisObject = uncheckedDowncast<JSArrayBufferView>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(cell, visitor);
 

--- a/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
@@ -52,7 +52,7 @@ inline bool JSArrayBufferView::isShared()
     case ResizableNonSharedAutoLengthDataViewMode:
     case GrowableSharedDataViewMode:
     case GrowableSharedAutoLengthDataViewMode:
-        return jsCast<JSDataView*>(this)->possiblySharedBuffer()->isShared();
+        return uncheckedDowncast<JSDataView>(this)->possiblySharedBuffer()->isShared();
     default:
         return false;
     }
@@ -76,7 +76,7 @@ inline ArrayBuffer* JSArrayBufferView::possiblySharedBufferImpl()
     case ResizableNonSharedAutoLengthDataViewMode:
     case GrowableSharedDataViewMode:
     case GrowableSharedAutoLengthDataViewMode:
-        return jsCast<JSDataView*>(this)->possiblySharedBuffer();
+        return uncheckedDowncast<JSDataView>(this)->possiblySharedBuffer();
     case FastTypedArray:
     case OversizeTypedArray:
         return slowDownAndWasteMemory();
@@ -237,7 +237,7 @@ inline JSArrayBufferView* validateTypedArray(JSGlobalObject* globalObject, JSVal
         return nullptr;
     }
 
-    RELEASE_AND_RETURN(scope, validateTypedArray(globalObject, jsCast<JSArrayBufferView*>(typedArrayCell)));
+    RELEASE_AND_RETURN(scope, validateTypedArray(globalObject, uncheckedDowncast<JSArrayBufferView>(typedArrayCell)));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -209,15 +209,15 @@ ALWAYS_INLINE uint64_t toLength(JSGlobalObject* globalObject, JSObject* object)
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (isJSArray(object)) [[likely]]
-        return jsCast<JSArray*>(object)->length();
+        return uncheckedDowncast<JSArray>(object)->length();
 
     switch (object->type()) {
     case DirectArgumentsType:
-        RELEASE_AND_RETURN(scope, jsCast<DirectArguments*>(object)->length(globalObject));
+        RELEASE_AND_RETURN(scope, uncheckedDowncast<DirectArguments>(object)->length(globalObject));
     case ScopedArgumentsType:
-        RELEASE_AND_RETURN(scope, jsCast<ScopedArguments*>(object)->length(globalObject));
+        RELEASE_AND_RETURN(scope, uncheckedDowncast<ScopedArguments>(object)->length(globalObject));
     case ClonedArgumentsType:
-        RELEASE_AND_RETURN(scope, jsCast<ClonedArguments*>(object)->length(globalObject));
+        RELEASE_AND_RETURN(scope, uncheckedDowncast<ClonedArguments>(object)->length(globalObject));
     default:
         break;
     }

--- a/Source/JavaScriptCore/runtime/JSArrayIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayIterator.cpp
@@ -71,7 +71,7 @@ void JSArrayIterator::finishCreation(VM& vm)
 template<typename Visitor>
 void JSArrayIterator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSArrayIterator*>(cell);
+    auto* thisObject = uncheckedDowncast<JSArrayIterator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/JSArrayIterator.h
+++ b/Source/JavaScriptCore/runtime/JSArrayIterator.h
@@ -66,7 +66,7 @@ public:
     WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
 
     IterationKind kind() const { return static_cast<IterationKind>(internalField(Field::Kind).get().asUInt32AsAnyInt()); }
-    JSObject* iteratedObject() const { return jsCast<JSObject*>(internalField(Field::IteratedObject).get()); }
+    JSObject* iteratedObject() const { return uncheckedDowncast<JSObject>(internalField(Field::IteratedObject).get()); }
 
     JS_EXPORT_PRIVATE static JSArrayIterator* create(VM&, Structure*, JSObject* iteratedObject, JSValue kind);
     static JSArrayIterator* create(VM& vm, Structure* structure, JSObject* iteratedObject, IterationKind kind)

--- a/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.cpp
+++ b/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.cpp
@@ -52,7 +52,7 @@ void JSAsyncDisposableStack::finishCreation(VM& vm)
 template<typename Visitor>
 void JSAsyncDisposableStack::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSAsyncDisposableStack*>(cell);
+    auto* thisObject = uncheckedDowncast<JSAsyncDisposableStack>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.cpp
@@ -59,7 +59,7 @@ JSAsyncFromSyncIterator* JSAsyncFromSyncIterator::create(VM& vm, Structure* stru
 template<typename Visitor>
 void JSAsyncFromSyncIterator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSAsyncFromSyncIterator*>(cell);
+    auto* thisObject = uncheckedDowncast<JSAsyncFromSyncIterator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/JSAsyncGenerator.cpp
+++ b/Source/JavaScriptCore/runtime/JSAsyncGenerator.cpp
@@ -72,7 +72,7 @@ void JSAsyncGenerator::finishCreation(VM& vm)
 template<typename Visitor>
 void JSAsyncGenerator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSAsyncGenerator*>(cell);
+    auto* thisObject = uncheckedDowncast<JSAsyncGenerator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }
@@ -100,7 +100,7 @@ void JSAsyncGenerator::enqueue(VM& vm, JSValue value, int32_t mode, JSPromise* p
             item->setContext(vm, item);
             setQueue(vm, item);
         } else {
-            JSPromiseReaction* tail = jsCast<JSPromiseReaction*>(last);
+            JSPromiseReaction* tail = uncheckedDowncast<JSPromiseReaction>(last);
             JSPromiseReaction* head = tail->next();
             JSPromiseReaction* item = JSPromiseReaction::create(
                 vm,
@@ -123,7 +123,7 @@ std::tuple<JSValue, int32_t, JSPromise*> JSAsyncGenerator::dequeue(VM& vm)
 
     JSValue value = resumeValue();
     int32_t mode = resumeMode();
-    JSPromise* promise = jsCast<JSPromise*>(resumePromise());
+    JSPromise* promise = uncheckedDowncast<JSPromise>(resumePromise());
 
     JSValue last = queue();
     if (last.isNull()) {
@@ -131,7 +131,7 @@ std::tuple<JSValue, int32_t, JSPromise*> JSAsyncGenerator::dequeue(VM& vm)
         setResumeValue(vm, jsUndefined());
         setResumePromise(vm, jsUndefined());
     } else {
-        JSPromiseReaction* tail = jsCast<JSPromiseReaction*>(last);
+        JSPromiseReaction* tail = uncheckedDowncast<JSPromiseReaction>(last);
         JSPromiseReaction* head = tail->next();
 
         setResumePromise(vm, head->promise());

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -639,7 +639,7 @@ private:
 inline JSBigInt* asHeapBigInt(JSValue value)
 {
     ASSERT(value.asCell()->isHeapBigInt());
-    return jsCast<JSBigInt*>(value.asCell());
+    return uncheckedDowncast<JSBigInt>(value.asCell());
 }
 
 inline JSBigInt::Digit JSBigInt::digit(unsigned n)

--- a/Source/JavaScriptCore/runtime/JSBigIntInlines.h
+++ b/Source/JavaScriptCore/runtime/JSBigIntInlines.h
@@ -37,7 +37,7 @@ inline JSValue JSBigInt::toNumber(JSValue bigInt)
     if (bigInt.isBigInt32())
         return jsNumber(bigInt.bigInt32AsInt32());
 #endif
-    return toNumberHeap(jsCast<JSBigInt*>(bigInt));
+    return toNumberHeap(uncheckedDowncast<JSBigInt>(bigInt));
 }
 
 uint64_t JSBigInt::toBigUInt64(JSValue bigInt)

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -41,7 +41,7 @@ const ClassInfo JSBoundFunction::s_info = { "Function"_s, &Base::s_info, nullptr
 
 JSC_DEFINE_HOST_FUNCTION(boundThisNoArgsFunctionCall, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    JSBoundFunction* boundFunction = jsCast<JSBoundFunction*>(callFrame->jsCallee());
+    JSBoundFunction* boundFunction = uncheckedDowncast<JSBoundFunction>(callFrame->jsCallee());
 
     MarkedArgumentBuffer args;
     unsigned boundArgsLength = boundFunction->boundArgsLength();
@@ -59,7 +59,7 @@ JSC_DEFINE_HOST_FUNCTION(boundThisNoArgsFunctionCall, (JSGlobalObject* globalObj
         RELEASE_ASSERT(!args.hasOverflowed());
     }
 
-    JSFunction* targetFunction = jsCast<JSFunction*>(boundFunction->targetFunction());
+    JSFunction* targetFunction = uncheckedDowncast<JSFunction>(boundFunction->targetFunction());
     ExecutableBase* executable = targetFunction->executable();
     if (executable->hasJITCodeForCall()) {
         // Force the executable to cache its arity entrypoint.
@@ -74,7 +74,7 @@ JSC_DEFINE_HOST_FUNCTION(boundFunctionCall, (JSGlobalObject* globalObject, CallF
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSBoundFunction* boundFunction = jsCast<JSBoundFunction*>(callFrame->jsCallee());
+    JSBoundFunction* boundFunction = uncheckedDowncast<JSBoundFunction>(callFrame->jsCallee());
 
     MarkedArgumentBuffer args;
     unsigned boundArgsLength = boundFunction->boundArgsLength();
@@ -105,7 +105,7 @@ JSC_DEFINE_HOST_FUNCTION(boundFunctionConstruct, (JSGlobalObject* globalObject, 
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSBoundFunction* boundFunction = jsCast<JSBoundFunction*>(callFrame->jsCallee());
+    JSBoundFunction* boundFunction = uncheckedDowncast<JSBoundFunction>(callFrame->jsCallee());
 
     JSObject* targetFunction = boundFunction->targetFunction();
     auto constructData = JSC::getConstructDataInline(targetFunction);
@@ -144,7 +144,7 @@ JSC_DEFINE_HOST_FUNCTION(isBoundFunction, (JSGlobalObject*, CallFrame* callFrame
 
 JSC_DEFINE_HOST_FUNCTION(hasInstanceBoundFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    JSBoundFunction* boundObject = jsCast<JSBoundFunction*>(callFrame->uncheckedArgument(0));
+    JSBoundFunction* boundObject = uncheckedDowncast<JSBoundFunction>(callFrame->uncheckedArgument(0));
     JSValue value = callFrame->uncheckedArgument(1);
     return JSValue::encode(jsBoolean(boundObject->targetFunction()->hasInstance(globalObject, value)));
 }
@@ -230,7 +230,7 @@ JSBoundFunction* JSBoundFunction::createRaw(VM& vm, JSGlobalObject* globalObject
 
 bool JSBoundFunction::customHasInstance(JSObject* object, JSGlobalObject* globalObject, JSValue value)
 {
-    return jsCast<JSBoundFunction*>(object)->m_targetFunction->hasInstance(globalObject, value);
+    return uncheckedDowncast<JSBoundFunction>(object)->m_targetFunction->hasInstance(globalObject, value);
 }
 
 JSBoundFunction::JSBoundFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSObject* targetFunction, JSValue boundThis, unsigned boundArgsLength, JSValue arg0, JSValue arg1, JSValue arg2, JSString* nameMayBeNull, double length, const SourceCode& source)
@@ -275,7 +275,7 @@ JSString* JSBoundFunction::nameSlow(VM& vm)
     while (true) {
         ASSERT(cursor->inherits<JSFunction>()); // If this is not JSFunction, we eagerly materialized the name.
         if (!cursor->inherits<JSBoundFunction>()) {
-            terminal = jsCast<JSFunction*>(cursor)->originalName(globalObject);
+            terminal = uncheckedDowncast<JSFunction>(cursor)->originalName(globalObject);
             if (scope.exception()) [[unlikely]] {
                 scope.clearException();
                 terminal = jsEmptyString(vm);
@@ -283,7 +283,7 @@ JSString* JSBoundFunction::nameSlow(VM& vm)
             break;
         }
         ++nestingCount;
-        JSBoundFunction* boundFunction = jsCast<JSBoundFunction*>(cursor);
+        JSBoundFunction* boundFunction = uncheckedDowncast<JSBoundFunction>(cursor);
         terminal = boundFunction->nameMayBeNull();
         if (terminal)
             break;
@@ -328,11 +328,11 @@ String JSBoundFunction::nameStringWithoutGCSlow(VM& vm)
     while (true) {
         ASSERT(cursor->inherits<JSFunction>()); // If this is not JSFunction, we eagerly materialized the name.
         if (!cursor->inherits<JSBoundFunction>()) {
-            terminal = jsCast<JSFunction*>(cursor)->nameWithoutGC(vm);
+            terminal = uncheckedDowncast<JSFunction>(cursor)->nameWithoutGC(vm);
             break;
         }
         ++nestingCount;
-        JSBoundFunction* boundFunction = jsCast<JSBoundFunction*>(cursor);
+        JSBoundFunction* boundFunction = uncheckedDowncast<JSBoundFunction>(cursor);
         if (boundFunction->nameMayBeNull()) {
             terminal = boundFunction->nameStringWithoutGC(vm);
             break;
@@ -360,10 +360,10 @@ double JSBoundFunction::lengthSlow(VM& vm)
     while (true) {
         ASSERT(cursor->inherits<JSFunction>()); // If this is not JSFunction, we eagerly materialized the length already.
         if (!cursor->inherits<JSBoundFunction>()) {
-            length = jsCast<JSFunction*>(cursor)->originalLength(vm);
+            length = uncheckedDowncast<JSFunction>(cursor)->originalLength(vm);
             break;
         }
-        JSBoundFunction* boundFunction = jsCast<JSBoundFunction*>(cursor);
+        JSBoundFunction* boundFunction = uncheckedDowncast<JSBoundFunction>(cursor);
         if (!std::isnan(boundFunction->m_length)) {
             length = boundFunction->m_length;
             break;
@@ -389,7 +389,7 @@ bool JSBoundFunction::canConstructSlow()
             m_canConstruct = constructData.type == CallData::Type::None ? TriState::False : TriState::True;
             return m_canConstruct == TriState::True;
         }
-        JSBoundFunction* boundFunction = jsCast<JSBoundFunction*>(cursor);
+        JSBoundFunction* boundFunction = uncheckedDowncast<JSBoundFunction>(cursor);
         if (boundFunction->m_canConstruct != TriState::Indeterminate) {
             m_canConstruct = boundFunction->m_canConstruct;
             return m_canConstruct == TriState::True;
@@ -424,7 +424,7 @@ bool JSBoundFunction::canSkipNameAndLengthMaterialization(JSGlobalObject* global
 template<typename Visitor>
 void JSBoundFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSBoundFunction* thisObject = jsCast<JSBoundFunction*>(cell);
+    JSBoundFunction* thisObject = uncheckedDowncast<JSBoundFunction>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 

--- a/Source/JavaScriptCore/runtime/JSBoundFunctionInlines.h
+++ b/Source/JavaScriptCore/runtime/JSBoundFunctionInlines.h
@@ -49,7 +49,7 @@ inline void JSBoundFunction::forEachBoundArg(const Invocable<IterationStatus(JSV
         return;
     }
     for (unsigned index = 0; index < length; ++index) {
-        if (func(jsCast<JSCellButterfly*>(m_boundArgs[0].get())->get(index)) == IterationStatus::Done)
+        if (func(uncheckedDowncast<JSCellButterfly>(m_boundArgs[0].get())->get(index)) == IterationStatus::Done)
             return;
     }
 }

--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -307,13 +307,13 @@ void JSValue::dumpInContextAssumingStructure(
             out.print(",length:(", string->length(), ")");
             out.print(": ", impl);
         } else if (structure->classInfoForCells()->isSubClassOf(RegExp::info()))
-            out.print("RegExp: ", *jsCast<RegExp*>(asCell()));
+            out.print("RegExp: ", *uncheckedDowncast<RegExp>(asCell()));
         else if (structure->classInfoForCells()->isSubClassOf(Symbol::info()))
             out.print("Symbol: ", RawPointer(asCell()));
         else if (structure->classInfoForCells()->isSubClassOf(Structure::info()))
-            out.print("Structure: ", inContext(*jsCast<Structure*>(asCell()), context));
+            out.print("Structure: ", inContext(*uncheckedDowncast<Structure>(asCell()), context));
         else if (isHeapBigInt())
-            out.print("BigInt[heap-allocated]: addr=", RawPointer(asCell()), ", length=", jsCast<JSBigInt*>(asCell())->length(), ", sign=", jsCast<JSBigInt*>(asCell())->sign());
+            out.print("BigInt[heap-allocated]: addr=", RawPointer(asCell()), ", length=", uncheckedDowncast<JSBigInt>(asCell())->length(), ", sign=", uncheckedDowncast<JSBigInt>(asCell())->sign());
         else if (structure->classInfoForCells()->isSubClassOf(JSObject::info())) {
             out.print("Object: ", RawPointer(asCell()));
             auto* butterfly = asObject(asCell())->butterfly();

--- a/Source/JavaScriptCore/runtime/JSCJSValuePropertyInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValuePropertyInlines.h
@@ -158,7 +158,7 @@ ALWAYS_INLINE T JSValue::getAs(JSGlobalObject* globalObject, PropertyNameType pr
     if (vm.exceptionForInspection())
         return nullptr;
 #endif
-    return jsCast<T>(value);
+    return uncheckedDowncast<std::remove_pointer_t<T>>(value);
 }
 
 inline JSString* JSValue::toString(JSGlobalObject* globalObject) const

--- a/Source/JavaScriptCore/runtime/JSCallee.cpp
+++ b/Source/JavaScriptCore/runtime/JSCallee.cpp
@@ -47,7 +47,7 @@ JSCallee::JSCallee(VM& vm, JSScope* scope, Structure* structure)
 template<typename Visitor>
 void JSCallee::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSCallee* thisObject = jsCast<JSCallee*>(cell);
+    JSCallee* thisObject = uncheckedDowncast<JSCallee>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 

--- a/Source/JavaScriptCore/runtime/JSCellButterfly.cpp
+++ b/Source/JavaScriptCore/runtime/JSCellButterfly.cpp
@@ -50,7 +50,7 @@ void JSCellButterfly::visitChildrenImpl(JSCell* cell, Visitor& visitor)
         return;
     }
 
-    Butterfly* butterfly = jsCast<JSCellButterfly*>(cell)->toButterfly();
+    Butterfly* butterfly = uncheckedDowncast<JSCellButterfly>(cell)->toButterfly();
     visitor.appendValuesHidden(butterfly->contiguous().data(), butterfly->publicLength());
 }
 

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -362,7 +362,7 @@ inline void JSCell::setPerCellBit(bool value)
 inline JSObject* JSCell::toObject(JSGlobalObject* globalObject) const
 {
     if (isObject())
-        return jsCast<JSObject*>(const_cast<JSCell*>(this));
+        return uncheckedDowncast<JSObject>(const_cast<JSCell*>(this));
     return toObjectSlow(globalObject);
 }
 

--- a/Source/JavaScriptCore/runtime/JSCustomGetterFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSCustomGetterFunction.cpp
@@ -40,7 +40,7 @@ JSC_DEFINE_HOST_FUNCTION(customGetterFunctionCall, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSCustomGetterFunction* customGetterFunction = jsCast<JSCustomGetterFunction*>(callFrame->jsCallee());
+    JSCustomGetterFunction* customGetterFunction = uncheckedDowncast<JSCustomGetterFunction>(callFrame->jsCallee());
     JSValue thisValue = callFrame->thisValue();
     auto getter = customGetterFunction->getter();
 

--- a/Source/JavaScriptCore/runtime/JSCustomSetterFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSCustomSetterFunction.cpp
@@ -37,7 +37,7 @@ static JSC_DECLARE_HOST_FUNCTION(customSetterFunctionCall);
 
 JSC_DEFINE_HOST_FUNCTION(customSetterFunctionCall, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    auto customSetterFunction = jsCast<JSCustomSetterFunction*>(callFrame->jsCallee());
+    auto customSetterFunction = uncheckedDowncast<JSCustomSetterFunction>(callFrame->jsCallee());
     auto setter = customSetterFunction->setter();
     setter(globalObject, JSValue::encode(callFrame->thisValue()), JSValue::encode(callFrame->argument(0)), customSetterFunction->propertyName());
     return JSValue::encode(jsUndefined());

--- a/Source/JavaScriptCore/runtime/JSDisposableStack.cpp
+++ b/Source/JavaScriptCore/runtime/JSDisposableStack.cpp
@@ -52,7 +52,7 @@ void JSDisposableStack::finishCreation(VM& vm)
 template<typename Visitor>
 void JSDisposableStack::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSDisposableStack*>(cell);
+    auto* thisObject = uncheckedDowncast<JSDisposableStack>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
@@ -67,7 +67,7 @@ void JSFinalizationRegistry::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     Base::visitChildren(cell, visitor);
 
-    auto* thisObject = jsCast<JSFinalizationRegistry*>(cell);
+    auto* thisObject = uncheckedDowncast<JSFinalizationRegistry>(cell);
 
     Locker locker { thisObject->cellLock() };
     for (const auto& iter : thisObject->m_liveRegistrations) {

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
@@ -59,7 +59,7 @@ public:
     const WriteBarrier<Unknown>& internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
     WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
 
-    JSObject* callback() const { return jsCast<JSObject*>(internalField(Field::Callback).get()); }
+    JSObject* callback() const { return uncheckedDowncast<JSObject>(internalField(Field::Callback).get()); }
 
     static JSFinalizationRegistry* create(VM&, Structure*, JSObject* callback);
     static JSFinalizationRegistry* createWithInitialValues(VM&, Structure*);

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -220,8 +220,8 @@ String JSFunction::name(VM& vm)
 {
     if (isHostFunction()) {
         if (this->inherits<JSBoundFunction>())
-            return jsCast<JSBoundFunction*>(this)->nameString(vm);
-        NativeExecutable* executable = jsCast<NativeExecutable*>(this->executable());
+            return uncheckedDowncast<JSBoundFunction>(this)->nameString(vm);
+        NativeExecutable* executable = uncheckedDowncast<NativeExecutable>(this->executable());
         return executable->name();
     }
     const Identifier identifier = jsExecutable()->name();
@@ -235,8 +235,8 @@ String JSFunction::nameWithoutGC(VM& vm)
     AssertNoGC assertNoGC;
     if (isHostFunction()) {
         if (this->inherits<JSBoundFunction>())
-            return jsCast<JSBoundFunction*>(this)->nameStringWithoutGC(vm);
-        NativeExecutable* executable = jsCast<NativeExecutable*>(this->executable());
+            return uncheckedDowncast<JSBoundFunction>(this)->nameStringWithoutGC(vm);
+        NativeExecutable* executable = uncheckedDowncast<NativeExecutable>(this->executable());
         return executable->name();
     }
     const Identifier identifier = jsExecutable()->name();
@@ -273,13 +273,13 @@ JSString* JSFunction::toString(JSGlobalObject* globalObject)
 {
     VM& vm = getVM(globalObject);
     if (inherits<JSBoundFunction>()) {
-        JSBoundFunction* function = jsCast<JSBoundFunction*>(this);
+        JSBoundFunction* function = uncheckedDowncast<JSBoundFunction>(this);
         auto scope = DECLARE_THROW_SCOPE(vm);
         JSValue string = jsMakeNontrivialString(globalObject, "function "_s, function->nameString(vm), "() {\n    [native code]\n}"_s);
         RETURN_IF_EXCEPTION(scope, nullptr);
         return asString(string);
     } else if (inherits<JSRemoteFunction>()) {
-        JSRemoteFunction* function = jsCast<JSRemoteFunction*>(this);
+        JSRemoteFunction* function = uncheckedDowncast<JSRemoteFunction>(this);
         auto scope = DECLARE_THROW_SCOPE(vm);
         JSValue string = jsMakeNontrivialString(globalObject, "function "_s, function->nameString(), "() {\n    [native code]\n}"_s);
         RETURN_IF_EXCEPTION(scope, nullptr);
@@ -301,7 +301,7 @@ const SourceCode* JSFunction::sourceCode() const
 template<typename Visitor>
 void JSFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSFunction* thisObject = jsCast<JSFunction*>(cell);
+    JSFunction* thisObject = uncheckedDowncast<JSFunction>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
@@ -340,7 +340,7 @@ bool JSFunction::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSFunction* thisObject = jsCast<JSFunction*>(object);
+    JSFunction* thisObject = uncheckedDowncast<JSFunction>(object);
 
     if (propertyName == vm.propertyNames->prototype) {
         if (thisObject->mayHaveNonReifiedPrototype()) {
@@ -366,7 +366,7 @@ bool JSFunction::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObje
 
 void JSFunction::getOwnSpecialPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder& propertyNames, DontEnumPropertiesMode mode)
 {
-    JSFunction* thisObject = jsCast<JSFunction*>(object);
+    JSFunction* thisObject = uncheckedDowncast<JSFunction>(object);
     VM& vm = globalObject->vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
@@ -409,7 +409,7 @@ bool JSFunction::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName pr
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSFunction* thisObject = jsCast<JSFunction*>(cell);
+    JSFunction* thisObject = uncheckedDowncast<JSFunction>(cell);
 
     if (propertyName == vm.propertyNames->prototype) {
         slot.disableCaching();
@@ -439,7 +439,7 @@ bool JSFunction::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, Prop
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSFunction* thisObject = jsCast<JSFunction*>(cell);
+    JSFunction* thisObject = uncheckedDowncast<JSFunction>(cell);
 
     PropertyStatus propertyType = thisObject->reifyLazyPropertyIfNeeded<>(vm, globalObject, propertyName);
     RETURN_IF_EXCEPTION(scope, false);
@@ -453,7 +453,7 @@ bool JSFunction::defineOwnProperty(JSObject* object, JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSFunction* thisObject = jsCast<JSFunction*>(object);
+    JSFunction* thisObject = uncheckedDowncast<JSFunction>(object);
 
 
     if (propertyName == vm.propertyNames->prototype) {
@@ -685,7 +685,7 @@ JSFunction::PropertyStatus JSFunction::reifyLazyBoundNameIfNeeded(VM& vm, JSGlob
         RELEASE_AND_RETURN(scope, reifyName(vm, globalObject));
     else if (this->inherits<JSBoundFunction>()) {
         FunctionRareData* rareData = this->ensureRareData(vm);
-        JSString* name = jsCast<JSBoundFunction*>(this)->name(vm);
+        JSString* name = uncheckedDowncast<JSBoundFunction>(this)->name(vm);
         JSString* string = jsString(globalObject, vm.smallStrings.boundPrefixString(), name);
         RETURN_IF_EXCEPTION(scope, PropertyStatus::Lazy);
         unsigned initialAttributes = PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly;
@@ -693,7 +693,7 @@ JSFunction::PropertyStatus JSFunction::reifyLazyBoundNameIfNeeded(VM& vm, JSGlob
         putDirect(vm, nameIdent, string, initialAttributes);
     } else if (this->inherits<JSRemoteFunction>()) {
         FunctionRareData* rareData = this->ensureRareData(vm);
-        JSString* name = jsCast<JSRemoteFunction*>(this)->nameMayBeNull();
+        JSString* name = uncheckedDowncast<JSRemoteFunction>(this)->nameMayBeNull();
         if (!name)
             name = jsEmptyString(vm);
         unsigned initialAttributes = PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly;

--- a/Source/JavaScriptCore/runtime/JSFunctionInlines.h
+++ b/Source/JavaScriptCore/runtime/JSFunctionInlines.h
@@ -154,9 +154,9 @@ inline bool JSFunction::hasReifiedName() const
 inline double JSFunction::originalLength(VM& vm)
 {
     if (inherits<JSBoundFunction>())
-        return jsCast<JSBoundFunction*>(this)->length(vm);
+        return uncheckedDowncast<JSBoundFunction>(this)->length(vm);
     if (inherits<JSRemoteFunction>())
-        return jsCast<JSRemoteFunction*>(this)->length(vm);
+        return uncheckedDowncast<JSRemoteFunction>(this)->length(vm);
     ASSERT(!isHostFunction());
     return jsExecutable()->parameterCount();
 }
@@ -178,14 +178,14 @@ inline JSString* JSFunction::originalName(JSGlobalObject* globalObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (this->inherits<JSBoundFunction>()) {
-        JSString* nameMayBeNull = jsCast<JSBoundFunction*>(this)->nameMayBeNull();
+        JSString* nameMayBeNull = uncheckedDowncast<JSBoundFunction>(this)->nameMayBeNull();
         if (nameMayBeNull)
             RELEASE_AND_RETURN(scope, jsString(globalObject, vm.smallStrings.boundPrefixString(), nameMayBeNull));
         return jsEmptyString(vm);
     }
 
     if (this->inherits<JSRemoteFunction>()) {
-        JSString* nameMayBeNull = jsCast<JSRemoteFunction*>(this)->nameMayBeNull();
+        JSString* nameMayBeNull = uncheckedDowncast<JSRemoteFunction>(this)->nameMayBeNull();
         if (nameMayBeNull)
             return nameMayBeNull;
         return jsEmptyString(vm);
@@ -278,7 +278,7 @@ inline CallData JSFunction::getCallDataInline(JSCell* cell)
     // Keep this function OK for invocation from concurrent compilers.
     CallData callData;
 
-    JSFunction* thisObject = jsCast<JSFunction*>(cell);
+    JSFunction* thisObject = uncheckedDowncast<JSFunction>(cell);
     if (thisObject->isHostFunction()) {
         callData.type = CallData::Type::Native;
         callData.native.function = thisObject->nativeFunction();
@@ -301,10 +301,10 @@ inline CallData JSFunction::getConstructDataInline(JSCell* cell)
     // Keep this function OK for invocation from concurrent compilers.
     CallData constructData;
 
-    JSFunction* thisObject = jsCast<JSFunction*>(cell);
+    JSFunction* thisObject = uncheckedDowncast<JSFunction>(cell);
     if (thisObject->isHostFunction()) {
         if (thisObject->inherits<JSBoundFunction>()) {
-            if (jsCast<JSBoundFunction*>(thisObject)->canConstruct()) {
+            if (uncheckedDowncast<JSBoundFunction>(thisObject)->canConstruct()) {
                 constructData.type = CallData::Type::Native;
                 constructData.native.function = thisObject->nativeConstructor();
                 constructData.native.isBoundFunction = true;

--- a/Source/JavaScriptCore/runtime/JSFunctionWithFields.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunctionWithFields.cpp
@@ -51,7 +51,7 @@ JSFunctionWithFields* JSFunctionWithFields::create(VM& vm, JSGlobalObject* globa
 template<typename Visitor>
 void JSFunctionWithFields::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSFunctionWithFields* thisObject = jsCast<JSFunctionWithFields*>(cell);
+    JSFunctionWithFields* thisObject = uncheckedDowncast<JSFunctionWithFields>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.appendValues(thisObject->m_internalFields, numberOfInternalFields);

--- a/Source/JavaScriptCore/runtime/JSGenerator.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenerator.cpp
@@ -69,7 +69,7 @@ void JSGenerator::finishCreation(VM& vm)
 template<typename Visitor>
 void JSGenerator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSGenerator*>(cell);
+    auto* thisObject = uncheckedDowncast<JSGenerator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -165,7 +165,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
 
         // https://tc39.es/proposal-resizablearraybuffer/#sec-initializetypedarrayfromtypedarray
         if (isTypedView(object->type())) {
-            auto* view = jsCast<JSArrayBufferView*>(object);
+            auto* view = uncheckedDowncast<JSArrayBufferView>(object);
 
             length = view->length();
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -305,51 +305,51 @@ bool JSGenericTypedArrayView<Adaptor>::setFromTypedArray(JSGlobalObject* globalO
 
     TypedArrayType typedArrayType = JSC::typedArrayType(object->type());
     if (typedArrayType == Adaptor::typeValue)
-        return memmoveFastPath(jsCast<JSArrayBufferView*>(object));
+        return memmoveFastPath(object);
 
     if (isSomeUint8(typedArrayType) && isSomeUint8(Adaptor::typeValue))
-        return memmoveFastPath(jsCast<JSArrayBufferView*>(object));
+        return memmoveFastPath(object);
 
     if (isInt(Adaptor::typeValue) && isInt(typedArrayType) && !isClamped(Adaptor::typeValue) && JSC::elementSize(Adaptor::typeValue) == JSC::elementSize(typedArrayType))
-        return memmoveFastPath(jsCast<JSArrayBufferView*>(object));
+        return memmoveFastPath(object);
 
     switch (typedArrayType) {
     case TypeInt8:
         RELEASE_AND_RETURN(scope, setWithSpecificType<Int8Adaptor>(
-            globalObject, offset, jsCast<JSInt8Array*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSInt8Array>(object), objectOffset, length, type));
     case TypeInt16:
         RELEASE_AND_RETURN(scope, setWithSpecificType<Int16Adaptor>(
-            globalObject, offset, jsCast<JSInt16Array*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSInt16Array>(object), objectOffset, length, type));
     case TypeInt32:
         RELEASE_AND_RETURN(scope, setWithSpecificType<Int32Adaptor>(
-            globalObject, offset, jsCast<JSInt32Array*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSInt32Array>(object), objectOffset, length, type));
     case TypeUint8:
         RELEASE_AND_RETURN(scope, setWithSpecificType<Uint8Adaptor>(
-            globalObject, offset, jsCast<JSUint8Array*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSUint8Array>(object), objectOffset, length, type));
     case TypeUint8Clamped:
         RELEASE_AND_RETURN(scope, setWithSpecificType<Uint8ClampedAdaptor>(
-            globalObject, offset, jsCast<JSUint8ClampedArray*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSUint8ClampedArray>(object), objectOffset, length, type));
     case TypeUint16:
         RELEASE_AND_RETURN(scope, setWithSpecificType<Uint16Adaptor>(
-            globalObject, offset, jsCast<JSUint16Array*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSUint16Array>(object), objectOffset, length, type));
     case TypeUint32:
         RELEASE_AND_RETURN(scope, setWithSpecificType<Uint32Adaptor>(
-            globalObject, offset, jsCast<JSUint32Array*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSUint32Array>(object), objectOffset, length, type));
     case TypeFloat16:
         RELEASE_AND_RETURN(scope, setWithSpecificType<Float16Adaptor>(
-            globalObject, offset, jsCast<JSFloat16Array*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSFloat16Array>(object), objectOffset, length, type));
     case TypeFloat32:
         RELEASE_AND_RETURN(scope, setWithSpecificType<Float32Adaptor>(
-            globalObject, offset, jsCast<JSFloat32Array*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSFloat32Array>(object), objectOffset, length, type));
     case TypeFloat64:
         RELEASE_AND_RETURN(scope, setWithSpecificType<Float64Adaptor>(
-            globalObject, offset, jsCast<JSFloat64Array*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSFloat64Array>(object), objectOffset, length, type));
     case TypeBigInt64:
         RELEASE_AND_RETURN(scope, setWithSpecificType<BigInt64Adaptor>(
-            globalObject, offset, jsCast<JSBigInt64Array*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSBigInt64Array>(object), objectOffset, length, type));
     case TypeBigUint64:
         RELEASE_AND_RETURN(scope, setWithSpecificType<BigUint64Adaptor>(
-            globalObject, offset, jsCast<JSBigUint64Array*>(object), objectOffset, length, type));
+            globalObject, offset, uncheckedDowncast<JSBigUint64Array>(object), objectOffset, length, type));
     case NotTypedArray:
     case TypeDataView: {
         RELEASE_ASSERT_NOT_REACHED();
@@ -550,7 +550,7 @@ template<typename Adaptor>
 bool JSGenericTypedArrayView<Adaptor>::getOwnPropertySlot(
     JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
-    JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(object);
+    JSGenericTypedArrayView* thisObject = uncheckedDowncast<JSGenericTypedArrayView>(object);
 
     if (std::optional<uint32_t> index = parseIndex(propertyName))
         return getOwnPropertySlotByIndex(thisObject, globalObject, index.value(), slot);
@@ -566,7 +566,7 @@ bool JSGenericTypedArrayView<Adaptor>::put(
     JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value,
     PutPropertySlot& slot)
 {
-    JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(cell);
+    JSGenericTypedArrayView* thisObject = uncheckedDowncast<JSGenericTypedArrayView>(cell);
 
     // https://tc39.es/ecma262/#sec-typedarray-set
     if (std::optional<uint32_t> index = parseIndex(propertyName)) {
@@ -596,7 +596,7 @@ bool JSGenericTypedArrayView<Adaptor>::defineOwnProperty(
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(object);
+    JSGenericTypedArrayView* thisObject = uncheckedDowncast<JSGenericTypedArrayView>(object);
 
     if (std::optional<uint32_t> index = parseIndex(propertyName)) {
         auto throwTypeErrorIfNeeded = [&] (ASCIILiteral errorMessage) -> bool {
@@ -640,7 +640,7 @@ template<typename Adaptor>
 bool JSGenericTypedArrayView<Adaptor>::deleteProperty(
     JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
-    JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(cell);
+    JSGenericTypedArrayView* thisObject = uncheckedDowncast<JSGenericTypedArrayView>(cell);
 
     if (std::optional<uint32_t> index = parseIndex(propertyName))
         return deletePropertyByIndex(thisObject, globalObject, index.value());
@@ -657,7 +657,7 @@ bool JSGenericTypedArrayView<Adaptor>::getOwnPropertySlotByIndex(
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(object);
+    JSGenericTypedArrayView* thisObject = uncheckedDowncast<JSGenericTypedArrayView>(object);
 
     if (thisObject->isDetached() || !thisObject->inBounds(propertyName))
         return false;
@@ -679,7 +679,7 @@ template<typename Adaptor>
 bool JSGenericTypedArrayView<Adaptor>::putByIndex(
     JSCell* cell, JSGlobalObject* globalObject, unsigned propertyName, JSValue value, bool)
 {
-    JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(cell);
+    JSGenericTypedArrayView* thisObject = uncheckedDowncast<JSGenericTypedArrayView>(cell);
     thisObject->setIndex(globalObject, propertyName, value);
     return true;
 }
@@ -689,7 +689,7 @@ bool JSGenericTypedArrayView<Adaptor>::deletePropertyByIndex(
     JSCell* cell, JSGlobalObject*, unsigned propertyName)
 {
     // Integer-indexed elements can't be deleted, so we must return false when the index is valid.
-    JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(cell);
+    JSGenericTypedArrayView* thisObject = uncheckedDowncast<JSGenericTypedArrayView>(cell);
     return thisObject->isDetached() || !thisObject->inBounds(propertyName);
 }
 
@@ -698,7 +698,7 @@ void JSGenericTypedArrayView<Adaptor>::getOwnPropertyNames(
     JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder& array, DontEnumPropertiesMode mode)
 {
     VM& vm = globalObject->vm();
-    JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(object);
+    JSGenericTypedArrayView* thisObject = uncheckedDowncast<JSGenericTypedArrayView>(object);
 
     if (array.includeStringProperties()) {
         uint64_t length = thisObject->length();
@@ -712,7 +712,7 @@ void JSGenericTypedArrayView<Adaptor>::getOwnPropertyNames(
 template<typename Adaptor>
 size_t JSGenericTypedArrayView<Adaptor>::estimatedSize(JSCell* cell, VM& vm)
 {
-    JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(cell);
+    JSGenericTypedArrayView* thisObject = uncheckedDowncast<JSGenericTypedArrayView>(cell);
 
     if (thisObject->m_mode == OversizeTypedArray)
         return Base::estimatedSize(thisObject, vm) + thisObject->byteLengthRaw();
@@ -726,7 +726,7 @@ template<typename Adaptor>
 template<typename Visitor>
 void JSGenericTypedArrayView<Adaptor>::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(cell);
+    JSGenericTypedArrayView* thisObject = uncheckedDowncast<JSGenericTypedArrayView>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
@@ -1041,7 +1041,7 @@ template<typename PassedAdaptor> inline Structure* JSGenericResizableOrGrowableS
 template<typename PassedAdaptor> inline bool JSGenericResizableOrGrowableSharedTypedArrayView<PassedAdaptor>::preventExtensions(JSObject* cell, JSGlobalObject* globalObject)
 {
     // https://tc39.es/ecma262/#sec-typedarray-preventextensions
-    auto* object = jsCast<JSGenericResizableOrGrowableSharedTypedArrayView<PassedAdaptor>*>(cell);
+    auto* object = uncheckedDowncast<JSGenericResizableOrGrowableSharedTypedArrayView<PassedAdaptor>>(cell);
     if (object->isAutoLength())
         return false;
     if (object->isResizableNonShared())

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -123,7 +123,7 @@ inline JSArrayBufferView* speciesConstruct(JSGlobalObject* globalObject, ViewCla
 
     // Even though exemplar is extended, still we can try to use watchpoints to avoid @@species lookup if the obtained constructor is ViewClass's constructor.
     JSObject* viewClassConstructor = globalObject->typedArrayConstructor(ViewClass::TypedArrayStorageType);
-    JSObject* constructor = jsCast<JSObject*>(constructorValue);
+    JSObject* constructor = uncheckedDowncast<JSObject>(constructorValue);
     if (constructor == viewClassConstructor) [[likely]] {
         if (inSameRealm && globalObject->typedArraySpeciesWatchpointSet(ViewClass::TypedArrayStorageType).state() == IsWatched && globalObject->typedArrayConstructorSpeciesWatchpointSet().state() == IsWatched) [[likely]]
             RELEASE_AND_RETURN(scope, defaultConstructor());
@@ -278,7 +278,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSet(VM& vm, JSGlobalO
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // 22.2.3.22
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
 
     if (!callFrame->argumentCount()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Expected at least one argument"_s);
@@ -302,7 +302,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSet(VM& vm, JSGlobalO
     JSValue source = callFrame->uncheckedArgument(0);
 
     if (source.isObject() && isTypedView(asObject(source)->type())) {
-        JSArrayBufferView* sourceView = jsCast<JSArrayBufferView*>(source);
+        JSArrayBufferView* sourceView = uncheckedDowncast<JSArrayBufferView>(source);
         IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
         auto lengthValue = integerIndexedObjectLength(sourceView, getter);
         if (!lengthValue) [[unlikely]]
@@ -323,7 +323,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncCopyWithin(VM& vm, JS
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // 22.2.3.5
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -435,7 +435,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncIncludes(VM& vm, JSGl
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -501,7 +501,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncIndexOf(VM& vm, JSGlo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // 22.2.3.13
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -545,7 +545,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncJoin(VM& vm, JSGlobal
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -605,7 +605,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFill(VM& vm, JSGlobal
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.fill
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -667,7 +667,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncLastIndexOf(VM& vm, J
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // 22.2.3.16
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -728,7 +728,7 @@ template<typename ViewClass>
 ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoGetterFuncBuffer(VM&, JSGlobalObject* globalObject, CallFrame* callFrame)
 {
     // 22.2.3.3
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
 
     return JSValue::encode(thisObject->possiblySharedJSBuffer(globalObject));
 }
@@ -737,7 +737,7 @@ template<typename ViewClass>
 ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoGetterFuncLength(VM&, JSGlobalObject*, CallFrame* callFrame)
 {
     // 22.2.3.17
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
 
     return JSValue::encode(jsNumber(thisObject->length()));
 }
@@ -746,7 +746,7 @@ template<typename ViewClass>
 ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoGetterFuncByteLength(VM&, JSGlobalObject*, CallFrame* callFrame)
 {
     // 22.2.3.2
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
 
     return JSValue::encode(jsNumber(thisObject->byteLength()));
 }
@@ -755,7 +755,7 @@ template<typename ViewClass>
 ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoGetterFuncByteOffset(VM&, JSGlobalObject*, CallFrame* callFrame)
 {
     // 22.2.3.3
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
 
     return JSValue::encode(jsNumber(thisObject->byteOffset()));
 }
@@ -766,7 +766,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncForEach(VM& vm, JSGlo
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.foreach
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -780,7 +780,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncForEach(VM& vm, JSGlo
     JSValue thisArg = callFrame->argument(1);
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(functorValue), 3);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(functorValue), 3);
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
@@ -816,7 +816,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncForEach(VM& vm, JSGlo
 
 #define JSC_DISPATCH_TYPED_ARRAY(name) \
     case name##ArrayType: { \
-        jsCast<JS##name##Array*>(result)->setIndex(globalObject, index, mapped); \
+        uncheckedDowncast<JS##name##Array>(result)->setIndex(globalObject, index, mapped); \
         break; \
     }
 
@@ -826,7 +826,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncMap(VM& vm, JSGlobalO
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.map
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -850,7 +850,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncMap(VM& vm, JSGlobalO
     RETURN_IF_EXCEPTION(scope, { });
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(functorValue), 3);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(functorValue), 3);
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
@@ -909,7 +909,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncMap(VM& vm, JSGlobalO
 #define JSC_DISPATCH_TYPED_ARRAY(name) \
     case name##ArrayType: { \
         if constexpr (contentType(name##ArrayType) == ViewClass::contentType) { \
-            auto to = jsCast<JS##name##Array*>(result)->typedSpan(); \
+            auto to = uncheckedDowncast<JS##name##Array>(result)->typedSpan(); \
             if constexpr (name##ArrayType == Uint8ClampedArrayType) { \
                 if constexpr (std::is_same_v<typename decltype(from)::value_type, uint8_t>) { \
                     WTF::copyElements(to, from); \
@@ -933,7 +933,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFilter(VM& vm, JSGlob
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.filter
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -952,7 +952,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFilter(VM& vm, JSGlob
     }
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(functorValue), 3);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(functorValue), 3);
         RETURN_IF_EXCEPTION(scope, { });
 
         typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto nativeValue) ALWAYS_INLINE_LAMBDA {
@@ -1026,7 +1026,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFind(VM& vm, JSGlobal
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.find
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1040,7 +1040,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFind(VM& vm, JSGlobal
     JSValue thisArg = callFrame->argument(1);
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(functorValue), 3);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(functorValue), 3);
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
@@ -1099,7 +1099,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindIndex(VM& vm, JSG
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.findindex
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1113,7 +1113,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindIndex(VM& vm, JSG
     JSValue thisArg = callFrame->argument(1);
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(functorValue), 3);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(functorValue), 3);
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
@@ -1172,7 +1172,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindLast(VM& vm, JSGl
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.findlast
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1186,7 +1186,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindLast(VM& vm, JSGl
     JSValue thisArg = callFrame->argument(1);
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(functorValue), 3);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(functorValue), 3);
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
@@ -1245,7 +1245,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindLastIndex(VM& vm,
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.findlastindex
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1259,7 +1259,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncFindLastIndex(VM& vm,
     JSValue thisArg = callFrame->argument(1);
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(functorValue), 3);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(functorValue), 3);
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
@@ -1318,7 +1318,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncEvery(VM& vm, JSGloba
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.every
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1332,7 +1332,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncEvery(VM& vm, JSGloba
     JSValue thisArg = callFrame->argument(1);
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(functorValue), 3);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(functorValue), 3);
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
@@ -1391,7 +1391,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSome(VM& vm, JSGlobal
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.some
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1405,7 +1405,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSome(VM& vm, JSGlobal
     JSValue thisArg = callFrame->argument(1);
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(functorValue), 3);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(functorValue), 3);
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
@@ -1464,7 +1464,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduce(VM& vm, JSGlob
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduce
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    auto* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1484,7 +1484,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduce(VM& vm, JSGlob
 
     bool initialized = hasInitialValue;
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(callback), 4);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(callback), 4);
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
@@ -1539,7 +1539,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduceRight(VM& vm, J
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduceright
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    auto* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1559,7 +1559,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduceRight(VM& vm, J
 
     bool initialized = hasInitialValue;
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(callback), 4);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(callback), 4);
         RETURN_IF_EXCEPTION(scope, { });
 
         scope.release();
@@ -1615,7 +1615,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReverse(VM& vm, JSGlo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // 22.2.3.21
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1632,7 +1632,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncToReversed(VM& vm, JS
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1697,7 +1697,7 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
     auto result = src;
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(comparatorValue), 2);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(comparatorValue), 2);
         RETURN_IF_EXCEPTION(scope, { });
         result = arrayStableSort(vm, src, workingSet, [&](auto left, auto right) ALWAYS_INLINE_LAMBDA {
             auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1760,7 +1760,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSort(VM& vm, JSGlobal
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.sort requires the comparator argument to be a function or undefined"_s);
 
     // https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1778,7 +1778,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncToSorted(VM& vm, JSGl
     if (!comparatorValue.isUndefined() && !comparatorValue.isCallable()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.toSorted requires the comparator argument to be a function or undefined"_s);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1868,7 +1868,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSlice(VM& vm, JSGloba
 
     // 22.2.3.26
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1934,51 +1934,51 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSlice(VM& vm, JSGloba
     switch (result->type()) {
     case Int8ArrayType:
         scope.release();
-        jsCast<JSInt8Array*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSInt8Array>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     case Int16ArrayType:
         scope.release();
-        jsCast<JSInt16Array*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSInt16Array>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     case Int32ArrayType:
         scope.release();
-        jsCast<JSInt32Array*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSInt32Array>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     case Uint8ArrayType:
         scope.release();
-        jsCast<JSUint8Array*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSUint8Array>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     case Uint8ClampedArrayType:
         scope.release();
-        jsCast<JSUint8ClampedArray*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSUint8ClampedArray>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     case Uint16ArrayType:
         scope.release();
-        jsCast<JSUint16Array*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSUint16Array>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     case Uint32ArrayType:
         scope.release();
-        jsCast<JSUint32Array*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSUint32Array>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     case Float16ArrayType:
         scope.release();
-        jsCast<JSFloat16Array*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSFloat16Array>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     case Float32ArrayType:
         scope.release();
-        jsCast<JSFloat32Array*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSFloat32Array>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     case Float64ArrayType:
         scope.release();
-        jsCast<JSFloat64Array*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSFloat64Array>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     case BigInt64ArrayType:
         scope.release();
-        jsCast<JSBigInt64Array*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSBigInt64Array>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     case BigUint64ArrayType:
         scope.release();
-        jsCast<JSBigUint64Array*>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
+        uncheckedDowncast<JSBigUint64Array>(result)->setFromTypedArray(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
     default:
         RELEASE_ASSERT_NOT_REACHED();
@@ -1992,7 +1992,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSubarray(VM& vm, JSGl
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
 
     size_t thisLength = thisObject->length();
     size_t srcByteOffset = thisObject->byteOffsetRaw();
@@ -2079,7 +2079,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncWith(VM& vm, JSGlobal
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    ViewClass* thisObject = uncheckedDowncast<ViewClass>(callFrame->thisValue());
     IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
     auto length = integerIndexedObjectLength(thisObject, getter);
     if (!length) [[unlikely]]

--- a/Source/JavaScriptCore/runtime/JSGlobalLexicalEnvironment.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalLexicalEnvironment.cpp
@@ -39,13 +39,13 @@ void JSGlobalLexicalEnvironment::destroy(JSCell* cell)
 
 bool JSGlobalLexicalEnvironment::getOwnPropertySlot(JSObject* object, JSGlobalObject*, PropertyName propertyName, PropertySlot& slot)
 {
-    JSGlobalLexicalEnvironment* thisObject = jsCast<JSGlobalLexicalEnvironment*>(object);
+    JSGlobalLexicalEnvironment* thisObject = uncheckedDowncast<JSGlobalLexicalEnvironment>(object);
     return symbolTableGet(thisObject, propertyName, slot);
 }
 
 bool JSGlobalLexicalEnvironment::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
-    JSGlobalLexicalEnvironment* thisObject = jsCast<JSGlobalLexicalEnvironment*>(cell);
+    JSGlobalLexicalEnvironment* thisObject = uncheckedDowncast<JSGlobalLexicalEnvironment>(cell);
     ASSERT(!Heap::heap(value) || Heap::heap(value) == Heap::heap(thisObject));
     bool alwaysThrowWhenAssigningToConstProperty = true;
     bool ignoreConstAssignmentError = slot.isInitialization();

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -387,42 +387,42 @@ static JSC_DECLARE_HOST_FUNCTION(signpostStop);
 
 static JSValue initializeEvalFunction(VM&, JSObject* object)
 {
-    return jsCast<JSGlobalObject*>(object)->evalFunction();
+    return uncheckedDowncast<JSGlobalObject>(object)->evalFunction();
 }
 
 static JSValue createProxyProperty(VM& vm, JSObject* object)
 {
-    JSGlobalObject* global = jsCast<JSGlobalObject*>(object);
+    JSGlobalObject* global = uncheckedDowncast<JSGlobalObject>(object);
     return ProxyConstructor::create(vm, ProxyConstructor::createStructure(vm, global, global->functionPrototype()));
 }
 
 static JSValue createJSONProperty(VM& vm, JSObject* object)
 {
-    JSGlobalObject* global = jsCast<JSGlobalObject*>(object);
+    JSGlobalObject* global = uncheckedDowncast<JSGlobalObject>(object);
     return JSONObject::create(vm, global, JSONObject::createStructure(vm, global, global->objectPrototype()));
 }
 
 static JSValue createMathProperty(VM& vm, JSObject* object)
 {
-    JSGlobalObject* global = jsCast<JSGlobalObject*>(object);
+    JSGlobalObject* global = uncheckedDowncast<JSGlobalObject>(object);
     return MathObject::create(vm, global, MathObject::createStructure(vm, global, global->objectPrototype()));
 }
 
 static JSValue createReflectProperty(VM& vm, JSObject* object)
 {
-    JSGlobalObject* global = jsCast<JSGlobalObject*>(object);
+    JSGlobalObject* global = uncheckedDowncast<JSGlobalObject>(object);
     return ReflectObject::create(vm, global, ReflectObject::createStructure(vm, global, global->objectPrototype()));
 }
 
 static JSValue createAtomicsProperty(VM& vm, JSObject *object)
 {
-    JSGlobalObject* global = jsCast<JSGlobalObject*>(object);
+    JSGlobalObject* global = uncheckedDowncast<JSGlobalObject>(object);
     return AtomicsObject::create(vm, global, AtomicsObject::createStructure(vm, global, global->objectPrototype()));
 }
 
 static JSValue createConsoleProperty(VM& vm, JSObject* object)
 {
-    JSGlobalObject* global = jsCast<JSGlobalObject*>(object);
+    JSGlobalObject* global = uncheckedDowncast<JSGlobalObject>(object);
     return ConsoleObject::create(vm, global, ConsoleObject::createStructure(vm, global, constructEmptyObject(global)));
 }
 
@@ -742,7 +742,7 @@ const GlobalObjectMethodTable* JSGlobalObject::baseGlobalObjectMethodTable()
 
 JSC_DEFINE_HOST_FUNCTION(resolvePromise, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    auto* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(0));
+    auto* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
     promise->resolvePromise(globalObject, globalObject->vm(), argument);
     return encodedJSUndefined();
@@ -750,7 +750,7 @@ JSC_DEFINE_HOST_FUNCTION(resolvePromise, (JSGlobalObject* globalObject, CallFram
 
 JSC_DEFINE_HOST_FUNCTION(rejectPromise, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    auto* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(0));
+    auto* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
     promise->rejectPromise(globalObject->vm(), globalObject, argument);
     return encodedJSUndefined();
@@ -758,7 +758,7 @@ JSC_DEFINE_HOST_FUNCTION(rejectPromise, (JSGlobalObject* globalObject, CallFrame
 
 JSC_DEFINE_HOST_FUNCTION(fulfillPromise, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    auto* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(0));
+    auto* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
     promise->fulfillPromise(globalObject->vm(), globalObject, argument);
     return encodedJSUndefined();
@@ -766,7 +766,7 @@ JSC_DEFINE_HOST_FUNCTION(fulfillPromise, (JSGlobalObject* globalObject, CallFram
 
 JSC_DEFINE_HOST_FUNCTION(resolvePromiseWithFirstResolvingFunctionCallCheck, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    auto* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(0));
+    auto* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
     promise->resolve(globalObject, globalObject->vm(), argument);
     return encodedJSUndefined();
@@ -774,7 +774,7 @@ JSC_DEFINE_HOST_FUNCTION(resolvePromiseWithFirstResolvingFunctionCallCheck, (JSG
 
 JSC_DEFINE_HOST_FUNCTION(rejectPromiseWithFirstResolvingFunctionCallCheck, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    auto* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(0));
+    auto* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
     promise->reject(globalObject->vm(), globalObject, argument);
     return encodedJSUndefined();
@@ -782,7 +782,7 @@ JSC_DEFINE_HOST_FUNCTION(rejectPromiseWithFirstResolvingFunctionCallCheck, (JSGl
 
 JSC_DEFINE_HOST_FUNCTION(fulfillPromiseWithFirstResolvingFunctionCallCheck, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    auto* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(0));
+    auto* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
     promise->fulfill(globalObject->vm(), globalObject, argument);
     return encodedJSUndefined();
@@ -832,7 +832,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseEmptyOnRejected, (JSGlobalObject* globalObject, 
 JSC_DEFINE_HOST_FUNCTION(promiseResolve, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     ASSERT(callFrame->argumentCount() == 2);
-    JSObject* constructor = jsCast<JSObject*>(callFrame->uncheckedArgument(0));
+    JSObject* constructor = uncheckedDowncast<JSObject>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
     return JSValue::encode(JSPromise::promiseResolve(globalObject, constructor, argument));
 }
@@ -840,14 +840,14 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolve, (JSGlobalObject* globalObject, CallFram
 JSC_DEFINE_HOST_FUNCTION(promiseReject, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     ASSERT(callFrame->argumentCount() == 2);
-    JSObject* constructor = jsCast<JSObject*>(callFrame->uncheckedArgument(0));
+    JSObject* constructor = uncheckedDowncast<JSObject>(callFrame->uncheckedArgument(0));
     JSValue argument = callFrame->uncheckedArgument(1);
     return JSValue::encode(JSPromise::promiseReject(globalObject, constructor, argument));
 }
 
 JSC_DEFINE_HOST_FUNCTION(performPromiseThen, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    auto* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(0));
+    auto* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue onFulfilled = callFrame->uncheckedArgument(1);
     JSValue onRejected = callFrame->uncheckedArgument(2);
     JSValue promiseOrCapability = callFrame->uncheckedArgument(3);
@@ -862,7 +862,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorQueueEnqueue, (JSGlobalObject* globalObje
     JSAsyncGenerator* generator = dynamicDowncast<JSAsyncGenerator>(callFrame->uncheckedArgument(0));
     JSValue value = callFrame->uncheckedArgument(1);
     int32_t resumeMode = callFrame->uncheckedArgument(2).asInt32();
-    JSPromise* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(3));
+    JSPromise* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(3));
 
     if (!generator) [[unlikely]] {
         promise->reject(vm, globalObject, createTypeError(globalObject, "|this| should be an async generator"_s));
@@ -880,7 +880,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorQueueDequeueResolve, (JSGlobalObject* glo
 {
     VM& vm = globalObject->vm();
 
-    JSAsyncGenerator* generator = jsCast<JSAsyncGenerator*>(callFrame->uncheckedArgument(0));
+    JSAsyncGenerator* generator = uncheckedDowncast<JSAsyncGenerator>(callFrame->uncheckedArgument(0));
     JSValue resolution = callFrame->uncheckedArgument(1);
 
     auto [value, resumeMode, promise] = generator->dequeue(vm);
@@ -894,7 +894,7 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorQueueDequeueReject, (JSGlobalObject* glob
 {
     VM& vm = globalObject->vm();
 
-    JSAsyncGenerator* generator = jsCast<JSAsyncGenerator*>(callFrame->uncheckedArgument(0));
+    JSAsyncGenerator* generator = uncheckedDowncast<JSAsyncGenerator>(callFrame->uncheckedArgument(0));
     JSValue error = callFrame->uncheckedArgument(1);
 
     auto [value, resumeMode, promise] = generator->dequeue(vm);
@@ -957,7 +957,7 @@ static GetterSetter* getGetterById(JSGlobalObject* globalObject, JSObject* base,
     JSValue baseValue = JSValue(base);
     PropertySlot slot(baseValue, PropertySlot::InternalMethodType::VMInquiry, &vm);
     baseValue.getPropertySlot(globalObject, ident, slot);
-    return jsCast<GetterSetter*>(slot.getPureResult());
+    return uncheckedDowncast<GetterSetter>(slot.getPureResult());
 }
 
 static ObjectPropertyCondition setupAdaptiveWatchpoint(JSGlobalObject* globalObject, JSObject* base, const Identifier& ident)
@@ -1009,21 +1009,21 @@ void JSGlobalObject::initializeErrorConstructor(LazyClassStructure::Initializer&
 {
     init.setPrototype(NativeErrorPrototype::create(init.vm, NativeErrorPrototype::createStructure(init.vm, this, m_errorStructure.prototype(this)), errorTypeName(errorType)));
     init.setStructure(ErrorInstance::createStructure(init.vm, this, init.prototype));
-    init.setConstructor(NativeErrorConstructor<errorType>::create(init.vm, NativeErrorConstructor<errorType>::createStructure(init.vm, this, m_errorStructure.constructor(this)), jsCast<NativeErrorPrototype*>(init.prototype)));
+    init.setConstructor(NativeErrorConstructor<errorType>::create(init.vm, NativeErrorConstructor<errorType>::createStructure(init.vm, this, m_errorStructure.constructor(this)), uncheckedDowncast<NativeErrorPrototype>(init.prototype)));
 }
 
 void JSGlobalObject::initializeAggregateErrorConstructor(LazyClassStructure::Initializer& init)
 {
     init.setPrototype(AggregateErrorPrototype::create(init.vm, AggregateErrorPrototype::createStructure(init.vm, this, m_errorStructure.prototype(this))));
     init.setStructure(ErrorInstance::createStructure(init.vm, this, init.prototype));
-    init.setConstructor(AggregateErrorConstructor::create(init.vm, AggregateErrorConstructor::createStructure(init.vm, this, m_errorStructure.constructor(this)), jsCast<AggregateErrorPrototype*>(init.prototype)));
+    init.setConstructor(AggregateErrorConstructor::create(init.vm, AggregateErrorConstructor::createStructure(init.vm, this, m_errorStructure.constructor(this)), uncheckedDowncast<AggregateErrorPrototype>(init.prototype)));
 }
 
 void JSGlobalObject::initializeSuppressedErrorConstructor(LazyClassStructure::Initializer& init)
 {
     init.setPrototype(SuppressedErrorPrototype::create(init.vm, SuppressedErrorPrototype::createStructure(init.vm, this, m_errorStructure.prototype(this))));
     init.setStructure(ErrorInstance::createStructure(init.vm, this, init.prototype));
-    init.setConstructor(SuppressedErrorConstructor::create(init.vm, SuppressedErrorConstructor::createStructure(init.vm, this, m_errorStructure.constructor(this)), jsCast<SuppressedErrorPrototype*>(init.prototype)));
+    init.setConstructor(SuppressedErrorConstructor::create(init.vm, SuppressedErrorConstructor::createStructure(init.vm, this, m_errorStructure.constructor(this)), uncheckedDowncast<SuppressedErrorPrototype>(init.prototype)));
 }
 
 SUPPRESS_ASAN inline void JSGlobalObject::initStaticGlobals(VM& vm)
@@ -1120,11 +1120,11 @@ void JSGlobalObject::init(VM& vm)
 
     m_numberProtoToStringFunction.initLater(
         [] (const Initializer<JSFunction>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, init.vm.propertyNames->toString.string(), numberProtoFuncToString, ImplementationVisibility::Public, NumberPrototypeToStringIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 1, init.vm.propertyNames->toString.string(), numberProtoFuncToString, ImplementationVisibility::Public, NumberPrototypeToStringIntrinsic));
         });
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringSubstring)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "substring"_s, stringProtoFuncSubstring, ImplementationVisibility::Public, StringPrototypeSubstringIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "substring"_s, stringProtoFuncSubstring, ImplementationVisibility::Public, StringPrototypeSubstringIntrinsic));
         });
 
     m_functionProtoHasInstanceSymbolFunction.set(vm, this, hasInstanceSymbolFunction);
@@ -1141,7 +1141,7 @@ void JSGlobalObject::init(VM& vm)
     m_objectPrototype->putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->underscoreProto, protoAccessor, PropertyAttribute::Accessor | PropertyAttribute::DontEnum);
     m_functionPrototype->structure()->setPrototypeWithoutTransition(vm, m_objectPrototype.get());
     m_objectStructureForObjectConstructor.set(vm, this, m_structureCache.emptyObjectStructureForPrototype(this, m_objectPrototype.get(), JSFinalObject::defaultInlineCapacity));
-    m_objectProtoValueOfFunction.set(vm, this, jsCast<JSFunction*>(objectPrototype()->getDirect(vm, vm.propertyNames->valueOf)));
+    m_objectProtoValueOfFunction.set(vm, this, uncheckedDowncast<JSFunction>(objectPrototype()->getDirect(vm, vm.propertyNames->valueOf)));
 
     JS_GLOBAL_OBJECT_ADDITIONS_3;
 
@@ -1186,7 +1186,7 @@ void JSGlobalObject::init(VM& vm)
             init.owner->typedArrayStructure(Type##type, /* isResizableOrGrowableShared */ false); /* Initialize non-resizable Structure too */ \
         }); \
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::type##Array)].initLater([](const Initializer<JSCell>& init) { \
-            init.set(jsCast<JSGlobalObject*>(init.owner)->typedArrayConstructor(TypedArrayType::Type##type)); \
+            init.set(init.owner->typedArrayConstructor(TypedArrayType::Type##type)); \
         });
     FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(INIT_TYPED_ARRAY_LATER)
 #undef INIT_TYPED_ARRAY_LATER
@@ -1337,20 +1337,20 @@ void JSGlobalObject::init(VM& vm)
         [] (LazyClassStructure::Initializer& init) {
             init.setPrototype(JSArrayBufferPrototype::create(init.vm, init.global, JSArrayBufferPrototype::createStructure(init.vm, init.global, init.global->m_objectPrototype.get()), ArrayBufferSharingMode::Shared));
             init.setStructure(JSArrayBuffer::createStructure(init.vm, init.global, init.prototype));
-            init.setConstructor(JSSharedArrayBufferConstructor::create(init.vm, JSSharedArrayBufferConstructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), jsCast<JSArrayBufferPrototype*>(init.prototype)));
+            init.setConstructor(JSSharedArrayBufferConstructor::create(init.vm, JSSharedArrayBufferConstructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), uncheckedDowncast<JSArrayBufferPrototype>(init.prototype)));
         });
 
     m_disposableStackStructure.initLater(
         [] (LazyClassStructure::Initializer& init) -> void {
             init.setPrototype(DisposableStackPrototype::create(init.vm, init.global, DisposableStackPrototype::createStructure(init.vm, init.global, init.global->m_objectPrototype.get())));
             init.setStructure(JSDisposableStack::createStructure(init.vm, init.global, init.prototype));
-            init.setConstructor(DisposableStackConstructor::create(init.vm, init.global, DisposableStackConstructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), jsCast<DisposableStackPrototype*>(init.prototype)));
+            init.setConstructor(DisposableStackConstructor::create(init.vm, init.global, DisposableStackConstructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), uncheckedDowncast<DisposableStackPrototype>(init.prototype)));
         });
     m_asyncDisposableStackStructure.initLater(
         [] (LazyClassStructure::Initializer& init) -> void {
             init.setPrototype(AsyncDisposableStackPrototype::create(init.vm, init.global, AsyncDisposableStackPrototype::createStructure(init.vm, init.global, init.global->m_objectPrototype.get())));
             init.setStructure(JSAsyncDisposableStack::createStructure(init.vm, init.global, init.prototype));
-            init.setConstructor(AsyncDisposableStackConstructor::create(init.vm, init.global, AsyncDisposableStackConstructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), jsCast<AsyncDisposableStackPrototype*>(init.prototype)));
+            init.setConstructor(AsyncDisposableStackConstructor::create(init.vm, init.global, AsyncDisposableStackConstructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), uncheckedDowncast<AsyncDisposableStackPrototype>(init.prototype)));
         });
 
     m_iteratorPrototype.set(vm, this, JSIteratorPrototype::create(vm, this, JSIteratorPrototype::createStructure(vm, this, m_objectPrototype.get())));
@@ -1406,7 +1406,7 @@ void JSGlobalObject::init(VM& vm)
         [] (LazyClassStructure::Initializer& init) { \
             init.setPrototype(capitalName##Prototype::create(init.vm, init.global, capitalName##Prototype::createStructure(init.vm, init.global, init.global->m_ ## prototypeBase ## Prototype.get()))); \
             init.setStructure(instanceType::createStructure(init.vm, init.global, init.prototype)); \
-            init.setConstructor(capitalName ## Constructor::create(init.vm, capitalName ## Constructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), jsCast<capitalName ## Prototype*>(init.prototype))); \
+            init.setConstructor(capitalName ## Constructor::create(init.vm, capitalName ## Constructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), uncheckedDowncast<capitalName ## Prototype>(init.prototype))); \
         }); \
     }
     
@@ -1571,61 +1571,61 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
 
     m_collatorStructure.initLater(
         [] (const Initializer<Structure>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             IntlCollatorPrototype* collatorPrototype = IntlCollatorPrototype::create(init.vm, globalObject, IntlCollatorPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
             init.set(IntlCollator::createStructure(init.vm, globalObject, collatorPrototype));
         });
     m_displayNamesStructure.initLater(
         [] (const Initializer<Structure>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             IntlDisplayNamesPrototype* displayNamesPrototype = IntlDisplayNamesPrototype::create(init.vm, IntlDisplayNamesPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
             init.set(IntlDisplayNames::createStructure(init.vm, globalObject, displayNamesPrototype));
         });
     m_durationFormatStructure.initLater(
         [] (const Initializer<Structure>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             IntlDurationFormatPrototype* durationFormatPrototype = IntlDurationFormatPrototype::create(init.vm, IntlDurationFormatPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
             init.set(IntlDurationFormat::createStructure(init.vm, globalObject, durationFormatPrototype));
         });
     m_listFormatStructure.initLater(
         [] (const Initializer<Structure>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             IntlListFormatPrototype* listFormatPrototype = IntlListFormatPrototype::create(init.vm, IntlListFormatPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
             init.set(IntlListFormat::createStructure(init.vm, globalObject, listFormatPrototype));
         });
     m_localeStructure.initLater(
         [] (const Initializer<Structure>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             IntlLocalePrototype* localePrototype = IntlLocalePrototype::create(init.vm, IntlLocalePrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
             init.set(IntlLocale::createStructure(init.vm, globalObject, localePrototype));
         });
     m_pluralRulesStructure.initLater(
         [] (const Initializer<Structure>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             IntlPluralRulesPrototype* pluralRulesPrototype = IntlPluralRulesPrototype::create(init.vm, globalObject, IntlPluralRulesPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
             init.set(IntlPluralRules::createStructure(init.vm, globalObject, pluralRulesPrototype));
         });
     m_relativeTimeFormatStructure.initLater(
         [] (const Initializer<Structure>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             IntlRelativeTimeFormatPrototype* relativeTimeFormatPrototype = IntlRelativeTimeFormatPrototype::create(init.vm, IntlRelativeTimeFormatPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
             init.set(IntlRelativeTimeFormat::createStructure(init.vm, globalObject, relativeTimeFormatPrototype));
         });
     m_segmentIteratorStructure.initLater(
         [] (const Initializer<Structure>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             IntlSegmentIteratorPrototype* segmentIteratorPrototype = IntlSegmentIteratorPrototype::create(init.vm, IntlSegmentIteratorPrototype::createStructure(init.vm, globalObject, globalObject->iteratorPrototype()));
             init.set(IntlSegmentIterator::createStructure(init.vm, globalObject, segmentIteratorPrototype));
         });
     m_segmenterStructure.initLater(
         [] (const Initializer<Structure>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             IntlSegmenterPrototype* segmenterPrototype = IntlSegmenterPrototype::create(init.vm, IntlSegmenterPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
             init.set(IntlSegmenter::createStructure(init.vm, globalObject, segmenterPrototype));
         });
     m_segmentsStructure.initLater(
         [] (const Initializer<Structure>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             IntlSegmentsPrototype* segmentsPrototype = IntlSegmentsPrototype::create(init.vm, globalObject, IntlSegmentsPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
             init.set(IntlSegments::createStructure(init.vm, globalObject, segmentsPrototype));
         });
@@ -1658,18 +1658,18 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         [] (LazyClassStructure::Initializer& init) {
             init.setPrototype(IntlDateTimeFormatPrototype::create(init.vm, init.global, IntlDateTimeFormatPrototype::createStructure(init.vm, init.global, init.global->objectPrototype())));
             init.setStructure(IntlDateTimeFormat::createStructure(init.vm, init.global, init.prototype));
-            init.setConstructor(IntlDateTimeFormatConstructor::create(init.vm, IntlDateTimeFormatConstructor::createStructure(init.vm, init.global, init.global->functionPrototype()), jsCast<IntlDateTimeFormatPrototype*>(init.prototype)));
+            init.setConstructor(IntlDateTimeFormatConstructor::create(init.vm, IntlDateTimeFormatConstructor::createStructure(init.vm, init.global, init.global->functionPrototype()), uncheckedDowncast<IntlDateTimeFormatPrototype>(init.prototype)));
         });
     m_numberFormatStructure.initLater(
         [] (LazyClassStructure::Initializer& init) {
             init.setPrototype(IntlNumberFormatPrototype::create(init.vm, init.global, IntlNumberFormatPrototype::createStructure(init.vm, init.global, init.global->objectPrototype())));
             init.setStructure(IntlNumberFormat::createStructure(init.vm, init.global, init.prototype));
-            init.setConstructor(IntlNumberFormatConstructor::create(init.vm, IntlNumberFormatConstructor::createStructure(init.vm, init.global, init.global->functionPrototype()), jsCast<IntlNumberFormatPrototype*>(init.prototype)));
+            init.setConstructor(IntlNumberFormatConstructor::create(init.vm, IntlNumberFormatConstructor::createStructure(init.vm, init.global, init.global->functionPrototype()), uncheckedDowncast<IntlNumberFormatPrototype>(init.prototype)));
         });
 
     m_defaultCollator.initLater(
         [] (const Initializer<IntlCollator>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             VM& vm = init.vm;
             auto scope = DECLARE_THROW_SCOPE(vm);
             IntlCollator* collator = IntlCollator::create(vm, globalObject->collatorStructure());
@@ -1680,7 +1680,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
 
     m_defaultDateTimeFormat.initLater(
         [] (const Initializer<IntlDateTimeFormat>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             VM& vm = init.vm;
             auto scope = DECLARE_THROW_SCOPE(vm);
             auto* dateTimeFormat = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
@@ -1691,7 +1691,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
 
     m_defaultDateFormat.initLater(
         [] (const Initializer<IntlDateTimeFormat>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             VM& vm = init.vm;
             auto scope = DECLARE_THROW_SCOPE(vm);
             auto* dateTimeFormat = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
@@ -1702,7 +1702,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
 
     m_defaultTimeFormat.initLater(
         [] (const Initializer<IntlDateTimeFormat>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             VM& vm = init.vm;
             auto scope = DECLARE_THROW_SCOPE(vm);
             auto* dateTimeFormat = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
@@ -1713,7 +1713,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
 
     m_defaultNumberFormat.initLater(
         [] (const Initializer<IntlNumberFormat>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             VM& vm = init.vm;
             auto scope = DECLARE_THROW_SCOPE(vm);
             auto* numberFormat = IntlNumberFormat::create(vm, globalObject->numberFormatStructure());
@@ -1728,63 +1728,63 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     if (Options::useTemporal()) {
         m_calendarStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+                JSGlobalObject* globalObject = init.owner;
                 TemporalCalendarPrototype* calendarPrototype = TemporalCalendarPrototype::create(init.vm, globalObject, TemporalCalendarPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
                 init.set(TemporalCalendar::createStructure(init.vm, globalObject, calendarPrototype));
             });
 
         m_durationStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+                JSGlobalObject* globalObject = init.owner;
                 TemporalDurationPrototype* durationPrototype = TemporalDurationPrototype::create(init.vm, TemporalDurationPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
                 init.set(TemporalDuration::createStructure(init.vm, globalObject, durationPrototype));
             });
 
         m_instantStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+                JSGlobalObject* globalObject = init.owner;
                 TemporalInstantPrototype* instantPrototype = TemporalInstantPrototype::create(init.vm, TemporalInstantPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
                 init.set(TemporalInstant::createStructure(init.vm, globalObject, instantPrototype));
             });
 
         m_plainDateStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                auto* globalObject = jsCast<JSGlobalObject*>(init.owner);
+                auto* globalObject = init.owner;
                 auto* plainDatePrototype = TemporalPlainDatePrototype::create(init.vm, globalObject, TemporalPlainDatePrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
                 init.set(TemporalPlainDate::createStructure(init.vm, globalObject, plainDatePrototype));
             });
 
         m_plainDateTimeStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                auto* globalObject = jsCast<JSGlobalObject*>(init.owner);
+                auto* globalObject = init.owner;
                 auto* plainDateTimePrototype = TemporalPlainDateTimePrototype::create(init.vm, globalObject, TemporalPlainDateTimePrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
                 init.set(TemporalPlainDateTime::createStructure(init.vm, globalObject, plainDateTimePrototype));
             });
 
         m_plainMonthDayStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                auto* globalObject = jsCast<JSGlobalObject*>(init.owner);
+                auto* globalObject = init.owner;
                 auto* plainMonthDayPrototype = TemporalPlainMonthDayPrototype::create(init.vm, globalObject, TemporalPlainMonthDayPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
                 init.set(TemporalPlainMonthDay::createStructure(init.vm, globalObject, plainMonthDayPrototype));
             });
 
         m_plainTimeStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                auto* globalObject = jsCast<JSGlobalObject*>(init.owner);
+                auto* globalObject = init.owner;
                 auto* plainTimePrototype = TemporalPlainTimePrototype::create(init.vm, globalObject, TemporalPlainTimePrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
                 init.set(TemporalPlainTime::createStructure(init.vm, globalObject, plainTimePrototype));
             });
 
         m_plainYearMonthStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                auto* globalObject = jsCast<JSGlobalObject*>(init.owner);
+                auto* globalObject = init.owner;
                 auto* plainYearMonthPrototype = TemporalPlainYearMonthPrototype::create(init.vm, globalObject, TemporalPlainYearMonthPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
                 init.set(TemporalPlainYearMonth::createStructure(init.vm, globalObject, plainYearMonthPrototype));
             });
 
         m_timeZoneStructure.initLater(
             [] (const Initializer<Structure>& init) {
-                JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+                JSGlobalObject* globalObject = init.owner;
                 TemporalTimeZonePrototype* timeZonePrototype = TemporalTimeZonePrototype::create(init.vm, globalObject, TemporalTimeZonePrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
                 init.set(TemporalTimeZone::createStructure(init.vm, globalObject, timeZonePrototype));
             });
@@ -1834,28 +1834,28 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     GetterSetter* regExpProtoUnicodeSetsGetter = getGetterById(this, m_regExpPrototype.get(), vm.propertyNames->unicodeSets);
     catchScope.assertNoException();
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpProtoUnicodeSetsGetter)].set(vm, this, regExpProtoUnicodeSetsGetter);
-    JSFunction* regExpSymbolReplace = jsCast<JSFunction*>(m_regExpPrototype->getDirect(vm, vm.propertyNames->replaceSymbol));
+    JSFunction* regExpSymbolReplace = uncheckedDowncast<JSFunction>(m_regExpPrototype->getDirect(vm, vm.propertyNames->replaceSymbol));
     m_regExpProtoSymbolReplace.set(vm, this, regExpSymbolReplace);
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpBuiltinExec)].set(vm, this, jsCast<JSFunction*>(m_regExpPrototype->getDirect(vm, vm.propertyNames->exec)));
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpBuiltinExec)].set(vm, this, uncheckedDowncast<JSFunction>(m_regExpPrototype->getDirect(vm, vm.propertyNames->exec)));
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpPrototypeSymbolMatch)].set(vm, this, m_regExpPrototype->getDirect(vm, vm.propertyNames->matchSymbol).asCell());
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpPrototypeSymbolReplace)].set(vm, this, m_regExpPrototype->getDirect(vm, vm.propertyNames->replaceSymbol).asCell());
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isArray)].initLater([] (const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "isArray"_s, arrayConstructorIsArray, ImplementationVisibility::Public, ArrayIsArrayIntrinsic));
+        init.set(JSFunction::create(init.vm, init.owner, 1, "isArray"_s, arrayConstructorIsArray, ImplementationVisibility::Public, ArrayIsArrayIntrinsic));
     });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::callFunction)].set(vm, this, callFunction);
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::applyFunction)].set(vm, this, applyFunction);
 
     {
-        JSValue hasOwnPropertyFunction = jsCast<JSFunction*>(objectPrototype()->get(this, vm.propertyNames->hasOwnProperty));
+        JSValue hasOwnPropertyFunction = uncheckedDowncast<JSFunction>(objectPrototype()->get(this, vm.propertyNames->hasOwnProperty));
         catchScope.assertNoException();
         RELEASE_ASSERT(is<JSFunction>(hasOwnPropertyFunction));
-        m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::hasOwnPropertyFunction)].set(vm, this, jsCast<JSFunction*>(hasOwnPropertyFunction));
+        m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::hasOwnPropertyFunction)].set(vm, this, uncheckedDowncast<JSFunction>(hasOwnPropertyFunction));
     }
 
 #define INIT_PRIVATE_GLOBAL(funcName, code) \
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::funcName)].initLater([] (const Initializer<JSCell>& init) { \
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner); \
+            JSGlobalObject* globalObject = init.owner; \
             init.set(JSFunction::create(init.vm, globalObject, code ## CodeGenerator(init.vm), globalObject)); \
         });
     JSC_FOREACH_BUILTIN_LINK_TIME_CONSTANT(INIT_PRIVATE_GLOBAL)
@@ -1863,302 +1863,302 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
 
     // AsyncFromSyncIterator Helpers
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncFromSyncIteratorCreate)].initLater([](const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "asyncFromSyncIteratorCreate"_s, asyncFromSyncIteratorPrivateFuncCreate, ImplementationVisibility::Private, AsyncFromSyncIteratorCreateIntrinsic));
+        init.set(JSFunction::create(init.vm, init.owner, 2, "asyncFromSyncIteratorCreate"_s, asyncFromSyncIteratorPrivateFuncCreate, ImplementationVisibility::Private, AsyncFromSyncIteratorCreateIntrinsic));
     });
 
     // RegExpStringIteratorHelpers
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpStringIteratorCreate)].initLater([](const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "regExpStringIteratorCreate"_s, regExpStringIteratorPrivateFuncCreate, ImplementationVisibility::Private, RegExpStringIteratorCreateIntrinsic));
+        init.set(JSFunction::create(init.vm, init.owner, 4, "regExpStringIteratorCreate"_s, regExpStringIteratorPrivateFuncCreate, ImplementationVisibility::Private, RegExpStringIteratorCreateIntrinsic));
     });
 
     // WrapForValidIterator Helpers
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::wrapForValidIteratorCreate)].initLater([](const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "wrapForValidIteratorCreate"_s, wrapForValidIteratorPrivateFuncCreate, ImplementationVisibility::Private, WrapForValidIteratorCreateIntrinsic));
+        init.set(JSFunction::create(init.vm, init.owner, 2, "wrapForValidIteratorCreate"_s, wrapForValidIteratorPrivateFuncCreate, ImplementationVisibility::Private, WrapForValidIteratorCreateIntrinsic));
     });
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::iteratorHelperCreate)].initLater([](const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "iteratorHelperCreate"_s, iteratorHelperPrivateFuncCreate, ImplementationVisibility::Private, IteratorHelperCreateIntrinsic));
+        init.set(JSFunction::create(init.vm, init.owner, 2, "iteratorHelperCreate"_s, iteratorHelperPrivateFuncCreate, ImplementationVisibility::Private, IteratorHelperCreateIntrinsic));
     });
 
     // Global object and function helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isFinite)].initLater([] (const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "isFinite"_s, globalFuncIsFinite, ImplementationVisibility::Private, GlobalIsFiniteIntrinsic));
+        init.set(JSFunction::create(init.vm, init.owner, 1, "isFinite"_s, globalFuncIsFinite, ImplementationVisibility::Private, GlobalIsFiniteIntrinsic));
     });
 
     // Map and Set helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::Set)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(jsCast<JSGlobalObject*>(init.owner)->setConstructor());
+            init.set(init.owner->setConstructor());
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::Map)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(jsCast<JSGlobalObject*>(init.owner)->mapConstructor());
+            init.set(init.owner->mapConstructor());
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::mapIterationNext)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "mapIterationNext"_s, mapPrivateFuncMapIterationNext, ImplementationVisibility::Private, JSMapIterationNextIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "mapIterationNext"_s, mapPrivateFuncMapIterationNext, ImplementationVisibility::Private, JSMapIterationNextIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::mapIterationEntry)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "mapIterationEntry"_s, mapPrivateFuncMapIterationEntry, ImplementationVisibility::Private, JSMapIterationEntryIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "mapIterationEntry"_s, mapPrivateFuncMapIterationEntry, ImplementationVisibility::Private, JSMapIterationEntryIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::mapStorage)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "mapStorage"_s, mapPrivateFuncMapStorage, ImplementationVisibility::Private, JSMapStorageIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "mapStorage"_s, mapPrivateFuncMapStorage, ImplementationVisibility::Private, JSMapStorageIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::mapIteratorNext)].initLater([](const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "mapIteratorNext"_s, mapIteratorPrivateFuncMapIteratorNext, ImplementationVisibility::Private, JSMapIteratorNextIntrinsic));
+        init.set(JSFunction::create(init.vm, init.owner, 0, "mapIteratorNext"_s, mapIteratorPrivateFuncMapIteratorNext, ImplementationVisibility::Private, JSMapIteratorNextIntrinsic));
     });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::mapIteratorKey)].initLater([](const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "mapIteratorKey"_s, mapIteratorPrivateFuncMapIteratorKey, ImplementationVisibility::Private, JSMapIteratorKeyIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "mapIteratorKey"_s, mapIteratorPrivateFuncMapIteratorKey, ImplementationVisibility::Private, JSMapIteratorKeyIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::mapIteratorValue)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "mapIteratorValue"_s, mapIteratorPrivateFuncMapIteratorValue, ImplementationVisibility::Private, JSMapIteratorValueIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "mapIteratorValue"_s, mapIteratorPrivateFuncMapIteratorValue, ImplementationVisibility::Private, JSMapIteratorValueIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::mapIterationEntryKey)].initLater([](const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "mapIterationEntryKey"_s, mapPrivateFuncMapIterationEntryKey, ImplementationVisibility::Private, JSMapIterationEntryKeyIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "mapIterationEntryKey"_s, mapPrivateFuncMapIterationEntryKey, ImplementationVisibility::Private, JSMapIterationEntryKeyIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::mapIterationEntryValue)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "mapIterationEntryValue"_s, mapPrivateFuncMapIterationEntryValue, ImplementationVisibility::Private, JSMapIterationEntryValueIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "mapIterationEntryValue"_s, mapPrivateFuncMapIterationEntryValue, ImplementationVisibility::Private, JSMapIterationEntryValueIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::setIterationNext)].initLater([](const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "setIterationNext"_s, setPrivateFuncSetIterationNext, ImplementationVisibility::Private, JSSetIterationNextIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "setIterationNext"_s, setPrivateFuncSetIterationNext, ImplementationVisibility::Private, JSSetIterationNextIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::setIterationEntry)].initLater([](const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "setIterationEntry"_s, setPrivateFuncSetIterationEntry, ImplementationVisibility::Private, JSSetIterationEntryIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "setIterationEntry"_s, setPrivateFuncSetIterationEntry, ImplementationVisibility::Private, JSSetIterationEntryIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::setIterationEntryKey)].initLater([](const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "setIterationEntryKey"_s, setPrivateFuncSetIterationEntryKey, ImplementationVisibility::Private, JSSetIterationEntryKeyIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "setIterationEntryKey"_s, setPrivateFuncSetIterationEntryKey, ImplementationVisibility::Private, JSSetIterationEntryKeyIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::setIteratorNext)].initLater([](const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "setIteratorNext"_s, setIteratorPrivateFuncSetIteratorNext, ImplementationVisibility::Private, JSSetIteratorNextIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "setIteratorNext"_s, setIteratorPrivateFuncSetIteratorNext, ImplementationVisibility::Private, JSSetIteratorNextIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::setIteratorKey)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "setIteratorKey"_s, setIteratorPrivateFuncSetIteratorKey, ImplementationVisibility::Private, JSSetIteratorKeyIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "setIteratorKey"_s, setIteratorPrivateFuncSetIteratorKey, ImplementationVisibility::Private, JSSetIteratorKeyIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::setStorage)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "setStorage"_s, setPrivateFuncSetStorage, ImplementationVisibility::Private, JSSetStorageIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "setStorage"_s, setPrivateFuncSetStorage, ImplementationVisibility::Private, JSSetStorageIntrinsic));
         });
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::importModule)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "importModule"_s, globalFuncImportModule, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "importModule"_s, globalFuncImportModule, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::copyDataProperties)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "copyDataProperties"_s, globalFuncCopyDataProperties, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "copyDataProperties"_s, globalFuncCopyDataProperties, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::cloneObject)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "cloneObject"_s, globalFuncCloneObject, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "cloneObject"_s, globalFuncCloneObject, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::resolvePromise)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "resolvePromise"_s, resolvePromise, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "resolvePromise"_s, resolvePromise, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::rejectPromise)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "rejectPromise"_s, rejectPromise, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "rejectPromise"_s, rejectPromise, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::fulfillPromise)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "fulfillPromise"_s, fulfillPromise, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "fulfillPromise"_s, fulfillPromise, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::resolvePromiseWithFirstResolvingFunctionCallCheck)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "resolvePromiseWithFirstResolvingFunctionCallCheck"_s, resolvePromiseWithFirstResolvingFunctionCallCheck, ImplementationVisibility::Private, ResolvePromiseWithFirstResolvingFunctionCallCheckIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "resolvePromiseWithFirstResolvingFunctionCallCheck"_s, resolvePromiseWithFirstResolvingFunctionCallCheck, ImplementationVisibility::Private, ResolvePromiseWithFirstResolvingFunctionCallCheckIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::rejectPromiseWithFirstResolvingFunctionCallCheck)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "rejectPromiseWithFirstResolvingFunctionCallCheck"_s, rejectPromiseWithFirstResolvingFunctionCallCheck, ImplementationVisibility::Private, RejectPromiseWithFirstResolvingFunctionCallCheckIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "rejectPromiseWithFirstResolvingFunctionCallCheck"_s, rejectPromiseWithFirstResolvingFunctionCallCheck, ImplementationVisibility::Private, RejectPromiseWithFirstResolvingFunctionCallCheckIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::fulfillPromiseWithFirstResolvingFunctionCallCheck)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "fulfillPromiseWithFirstResolvingFunctionCallCheck"_s, fulfillPromiseWithFirstResolvingFunctionCallCheck, ImplementationVisibility::Private, FulfillPromiseWithFirstResolvingFunctionCallCheckIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "fulfillPromiseWithFirstResolvingFunctionCallCheck"_s, fulfillPromiseWithFirstResolvingFunctionCallCheck, ImplementationVisibility::Private, FulfillPromiseWithFirstResolvingFunctionCallCheckIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::resolveWithInternalMicrotaskForAsyncAwait)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 3, "resolveWithInternalMicrotaskForAsyncAwait"_s, resolveWithInternalMicrotaskForAsyncAwait, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 3, "resolveWithInternalMicrotaskForAsyncAwait"_s, resolveWithInternalMicrotaskForAsyncAwait, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncGeneratorQueueEnqueue)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "asyncGeneratorQueueEnqueue"_s, asyncGeneratorQueueEnqueue, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 4, "asyncGeneratorQueueEnqueue"_s, asyncGeneratorQueueEnqueue, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncGeneratorQueueDequeueResolve)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "asyncGeneratorQueueDequeueResolve"_s, asyncGeneratorQueueDequeueResolve, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "asyncGeneratorQueueDequeueResolve"_s, asyncGeneratorQueueDequeueResolve, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::asyncGeneratorQueueDequeueReject)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "asyncGeneratorQueueDequeueReject"_s, asyncGeneratorQueueDequeueReject, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "asyncGeneratorQueueDequeueReject"_s, asyncGeneratorQueueDequeueReject, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::driveAsyncFunction)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "driveAsyncFunction"_s, driveAsyncFunction, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "driveAsyncFunction"_s, driveAsyncFunction, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::newHandledRejectedPromise)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "newHandledRejectedPromise"_s, newHandledRejectedPromise, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "newHandledRejectedPromise"_s, newHandledRejectedPromise, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::promiseEmptyOnFulfilled)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "promiseEmptyOnFulfilled"_s, promiseEmptyOnFulfilled, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "promiseEmptyOnFulfilled"_s, promiseEmptyOnFulfilled, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::promiseEmptyOnRejected)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "promiseEmptyOnRejected"_s, promiseEmptyOnRejected, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "promiseEmptyOnRejected"_s, promiseEmptyOnRejected, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::promiseResolve)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "promiseResolve"_s, promiseResolve, ImplementationVisibility::Private, PromiseResolveIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "promiseResolve"_s, promiseResolve, ImplementationVisibility::Private, PromiseResolveIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::promiseReject)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "promiseReject"_s, promiseReject, ImplementationVisibility::Private, PromiseRejectIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "promiseReject"_s, promiseReject, ImplementationVisibility::Private, PromiseRejectIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::performPromiseThen)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "performPromiseThen"_s, performPromiseThen, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 4, "performPromiseThen"_s, performPromiseThen, ImplementationVisibility::Private));
         });
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::makeTypeError)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "makeTypeError"_s, globalFuncMakeTypeError, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "makeTypeError"_s, globalFuncMakeTypeError, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::AggregateError)].initLater([] (const Initializer<JSCell>& init) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+            JSGlobalObject* globalObject = init.owner;
             init.set(globalObject->m_aggregateErrorStructure.constructor(globalObject));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::ReferenceError)].initLater([] (const Initializer<JSCell>& init) {
-        JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+        JSGlobalObject* globalObject = init.owner;
         init.set(globalObject->m_referenceErrorStructure.constructor(globalObject));
     });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::SuppressedError)].initLater([] (const Initializer<JSCell>& init) {
-        JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+        JSGlobalObject* globalObject = init.owner;
         init.set(globalObject->m_suppressedErrorStructure.constructor(globalObject));
     });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::DisposableStack)].initLater([] (const Initializer<JSCell>& init) {
-        JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+        JSGlobalObject* globalObject = init.owner;
         init.set(globalObject->m_disposableStackStructure.constructor(globalObject));
     });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::AsyncDisposableStack)].initLater([] (const Initializer<JSCell>& init) {
-        JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+        JSGlobalObject* globalObject = init.owner;
         init.set(globalObject->m_asyncDisposableStackStructure.constructor(globalObject));
     });
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArrayLength)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "typedArrayViewLength"_s, typedArrayViewPrivateFuncLength, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "typedArrayViewLength"_s, typedArrayViewPrivateFuncLength, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isTypedArrayView)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "typedArrayViewIsTypedArrayView"_s, typedArrayViewPrivateFuncIsTypedArrayView, ImplementationVisibility::Private, IsTypedArrayViewIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "typedArrayViewIsTypedArrayView"_s, typedArrayViewPrivateFuncIsTypedArrayView, ImplementationVisibility::Private, IsTypedArrayViewIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isSharedTypedArrayView)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "typedArrayViewIsSharedTypedArrayView"_s, typedArrayViewPrivateFuncIsSharedTypedArrayView, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "typedArrayViewIsSharedTypedArrayView"_s, typedArrayViewPrivateFuncIsSharedTypedArrayView, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isResizableOrGrowableSharedTypedArrayView)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "typedArrayViewPrivateFuncIsResizableOrGrowableSharedTypedArrayView"_s, typedArrayViewPrivateFuncIsResizableOrGrowableSharedTypedArrayView, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "typedArrayViewPrivateFuncIsResizableOrGrowableSharedTypedArrayView"_s, typedArrayViewPrivateFuncIsResizableOrGrowableSharedTypedArrayView, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArrayFromFast)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "typedArrayViewTypedArrayFromFast"_s, typedArrayViewPrivateFuncTypedArrayFromFast, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "typedArrayViewTypedArrayFromFast"_s, typedArrayViewPrivateFuncTypedArrayFromFast, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::arrayFromFastWithoutMapFn)].initLater([] (const Initializer<JSCell>& init) {
-        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "arrayFromFastWithoutMapFn"_s, arrayConstructorPrivateFromFastWithoutMapFn, ImplementationVisibility::Private));
+        init.set(JSFunction::create(init.vm, init.owner, 2, "arrayFromFastWithoutMapFn"_s, arrayConstructorPrivateFromFastWithoutMapFn, ImplementationVisibility::Private));
     });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isDetached)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "typedArrayViewIsDetached"_s, typedArrayViewPrivateFuncIsDetached, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "typedArrayViewIsDetached"_s, typedArrayViewPrivateFuncIsDetached, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isBoundFunction)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "isBound"_s, isBoundFunction, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "isBound"_s, isBoundFunction, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::hasInstanceBoundFunction)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "hasInstanceBound"_s, hasInstanceBoundFunction, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "hasInstanceBound"_s, hasInstanceBoundFunction, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::instanceOf)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "instanceOf"_s, objectPrivateFuncInstanceOf, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "instanceOf"_s, objectPrivateFuncInstanceOf, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::BuiltinLog)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "BuiltinLog"_s, globalFuncBuiltinLog, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "BuiltinLog"_s, globalFuncBuiltinLog, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::BuiltinDescribe)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "BuiltinDescribe"_s, globalFuncBuiltinDescribe, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "BuiltinDescribe"_s, globalFuncBuiltinDescribe, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::min)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "min"_s, mathProtoFuncMin, ImplementationVisibility::Private, MinIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "min"_s, mathProtoFuncMin, ImplementationVisibility::Private, MinIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::repeatCharacter)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "repeatCharacter"_s, stringProtoFuncRepeatCharacter, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "repeatCharacter"_s, stringProtoFuncRepeatCharacter, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isArraySlow)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "isArraySlow"_s, arrayConstructorPrivateFuncIsArraySlow, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "isArraySlow"_s, arrayConstructorPrivateFuncIsArraySlow, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::importInRealm)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "importInRealm"_s, importInRealm, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "importInRealm"_s, importInRealm, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::evalFunction)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, init.vm.propertyNames->eval.string(), globalFuncEval, ImplementationVisibility::Public));
+            init.set(JSFunction::create(init.vm, init.owner, 1, init.vm.propertyNames->eval.string(), globalFuncEval, ImplementationVisibility::Public));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::evalInRealm)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "evalInRealm"_s, evalInRealm, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "evalInRealm"_s, evalInRealm, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::moveFunctionToRealm)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "moveFunctionToRealm"_s, moveFunctionToRealm, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "moveFunctionToRealm"_s, moveFunctionToRealm, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::sameValue)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "is"_s, objectConstructorIs, ImplementationVisibility::Private, ObjectIsIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "is"_s, objectConstructorIs, ImplementationVisibility::Private, ObjectIsIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::setPrototypeDirect)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "setPrototypeDirect"_s, globalFuncSetPrototypeDirect, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "setPrototypeDirect"_s, globalFuncSetPrototypeDirect, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::setPrototypeDirectOrThrow)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "setPrototypeDirectOrThrow"_s, globalFuncSetPrototypeDirectOrThrow, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "setPrototypeDirectOrThrow"_s, globalFuncSetPrototypeDirectOrThrow, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::toIntegerOrInfinity)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "toIntegerOrInfinity"_s, globalFuncToIntegerOrInfinity, ImplementationVisibility::Private, ToIntegerOrInfinityIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "toIntegerOrInfinity"_s, globalFuncToIntegerOrInfinity, ImplementationVisibility::Private, ToIntegerOrInfinityIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::toLength)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "toLength"_s, globalFuncToLength, ImplementationVisibility::Private, ToLengthIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "toLength"_s, globalFuncToLength, ImplementationVisibility::Private, ToLengthIntrinsic));
         });
 
     // RegExp.prototype helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpCreate)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "esSpecRegExpCreate"_s, esSpecRegExpCreate, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "esSpecRegExpCreate"_s, esSpecRegExpCreate, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isRegExp)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "esSpecIsRegExp"_s, esSpecIsRegExp, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "esSpecIsRegExp"_s, esSpecIsRegExp, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpMatchFast)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "regExpMatchFast"_s, regExpProtoFuncMatchFast, ImplementationVisibility::Private, RegExpMatchFastIntrinsic));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "regExpMatchFast"_s, regExpProtoFuncMatchFast, ImplementationVisibility::Private, RegExpMatchFastIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpSplitFast)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "regExpSplitFast"_s, regExpProtoFuncSplitFast, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "regExpSplitFast"_s, regExpProtoFuncSplitFast, ImplementationVisibility::Private));
         });
 
     // String.prototype helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringIncludesInternal)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "stringIncludesInternal"_s, builtinStringIncludesInternal, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "stringIncludesInternal"_s, builtinStringIncludesInternal, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringIndexOfInternal)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "stringIndexOfInternal"_s, builtinStringIndexOfInternal, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "stringIndexOfInternal"_s, builtinStringIndexOfInternal, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringSplitFast)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "stringSplitFast"_s, stringProtoFuncSplitFast, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "stringSplitFast"_s, stringProtoFuncSplitFast, ImplementationVisibility::Private));
         });
 
     // Proxy helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::handleNegativeProxyHasTrapResult)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "handleNegativeProxyHasTrapResult"_s, globalFuncHandleNegativeProxyHasTrapResult, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "handleNegativeProxyHasTrapResult"_s, globalFuncHandleNegativeProxyHasTrapResult, ImplementationVisibility::Private));
         });
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::handleProxyGetTrapResult)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 3, "handleProxyGetTrapResult"_s, globalFuncHandleProxyGetTrapResult, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 3, "handleProxyGetTrapResult"_s, globalFuncHandleProxyGetTrapResult, ImplementationVisibility::Private));
         });
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::handlePositiveProxySetTrapResult)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 3, "handlePositiveProxySetTrapResult"_s, globalFuncHandlePositiveProxySetTrapResult, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 3, "handlePositiveProxySetTrapResult"_s, globalFuncHandlePositiveProxySetTrapResult, ImplementationVisibility::Private));
         });
 
     // PrivateSymbols / PrivateNames
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::createPrivateSymbol)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "createPrivateSymbol"_s, createPrivateSymbol, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "createPrivateSymbol"_s, createPrivateSymbol, ImplementationVisibility::Private));
         });
 
     // JSON helpers
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::jsonParse)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "parse"_s, jsonParse, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "parse"_s, jsonParse, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::jsonStringify)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "stringify"_s, jsonStringify, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 2, "stringify"_s, jsonStringify, ImplementationVisibility::Private));
         });
 
     // ShadowRealms
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::createRemoteFunction)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "createRemoteFunction"_s, createRemoteFunction, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "createRemoteFunction"_s, createRemoteFunction, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isRemoteFunction)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "isRemoteFunction"_s, isRemoteFunction, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 0, "isRemoteFunction"_s, isRemoteFunction, ImplementationVisibility::Private));
         });
 
 #if ENABLE(WEBASSEMBLY)
     // WebAssembly Streaming API
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::webAssemblyCompileStreamingInternal)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "compileStreamingInternal"_s, webAssemblyCompileStreamingInternal, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "compileStreamingInternal"_s, webAssemblyCompileStreamingInternal, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::webAssemblyInstantiateStreamingInternal)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "instantiateStreamingInternal"_s, webAssemblyInstantiateStreamingInternal, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, init.owner, 1, "instantiateStreamingInternal"_s, webAssemblyInstantiateStreamingInternal, ImplementationVisibility::Private));
         });
 #endif
 
@@ -2166,14 +2166,14 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         init.set(init.vm.emptyPropertyNameEnumerator());
     });
 
-    m_performProxyObjectHasFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectHas)));
-    m_performProxyObjectHasByValFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectHasByVal)));
-    m_performProxyObjectGetFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectGet)));
-    m_performProxyObjectGetByValFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectGetByVal)));
-    m_performProxyObjectSetStrictFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetStrict)));
-    m_performProxyObjectSetSloppyFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetSloppy)));
-    m_performProxyObjectSetByValStrictFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetByValStrict)));
-    m_performProxyObjectSetByValSloppyFunction.set(vm, this, jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetByValSloppy)));
+    m_performProxyObjectHasFunction.set(vm, this, uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::performProxyObjectHas)));
+    m_performProxyObjectHasByValFunction.set(vm, this, uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::performProxyObjectHasByVal)));
+    m_performProxyObjectGetFunction.set(vm, this, uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::performProxyObjectGet)));
+    m_performProxyObjectGetByValFunction.set(vm, this, uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::performProxyObjectGetByVal)));
+    m_performProxyObjectSetStrictFunction.set(vm, this, uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetStrict)));
+    m_performProxyObjectSetSloppyFunction.set(vm, this, uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetSloppy)));
+    m_performProxyObjectSetByValStrictFunction.set(vm, this, uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetByValStrict)));
+    m_performProxyObjectSetByValSloppyFunction.set(vm, this, uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetByValSloppy)));
 
     if (Options::exposeProfilersOnGlobalObject()) {
 #if ENABLE(SAMPLING_PROFILER)
@@ -2223,7 +2223,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
                 init.setPrototype(capitalName##Prototype::create(init.vm, init.global, capitalName##Prototype::createStructure(init.vm, init.global, init.global->prototypeBase ## Prototype()))); \
                 init.setStructure(instanceType::createStructure(init.vm, init.global, init.prototype)); \
                 auto* constructorPrototype = strcmp(#prototypeBase, "error") == 0 ? init.global->m_errorStructure.constructor(init.global) : init.global->functionPrototype(); \
-                init.setConstructor(capitalName ## Constructor::create(init.vm, capitalName ## Constructor::createStructure(init.vm, init.global, constructorPrototype), jsCast<capitalName ## Prototype*>(init.prototype))); \
+                init.setConstructor(capitalName ## Constructor::create(init.vm, capitalName ## Constructor::createStructure(init.vm, init.global, constructorPrototype), uncheckedDowncast<capitalName ## Prototype>(init.prototype))); \
             }); \
     }
 
@@ -2312,7 +2312,7 @@ bool JSGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, PropertyNam
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSGlobalObject* thisObject = jsCast<JSGlobalObject*>(cell);
+    JSGlobalObject* thisObject = uncheckedDowncast<JSGlobalObject>(cell);
     ASSERT(!Heap::heap(value) || Heap::heap(value) == Heap::heap(thisObject));
 
     if (isThisValueAltered(slot, thisObject)) [[unlikely]] {
@@ -2339,7 +2339,7 @@ bool JSGlobalObject::defineOwnProperty(JSObject* object, JSGlobalObject* globalO
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSGlobalObject* thisObject = jsCast<JSGlobalObject*>(object);
+    JSGlobalObject* thisObject = uncheckedDowncast<JSGlobalObject>(object);
 
     SymbolTableEntry entry;
     PropertyDescriptor currentDescriptor;
@@ -2519,7 +2519,7 @@ IterationStatus GlobalObjectDependencyFinder::operator()(HeapCell* cell, HeapCel
     if (isJSCellKind(kind) && static_cast<JSCell*>(cell)->isObject()) {
         // FIXME: This const_cast exists because this isn't a C++ lambda.
         // https://bugs.webkit.org/show_bug.cgi?id=159644
-        const_cast<GlobalObjectDependencyFinder*>(this)->visit(jsCast<JSObject*>(static_cast<JSCell*>(cell)));
+        const_cast<GlobalObjectDependencyFinder*>(this)->visit(uncheckedDowncast<JSObject>(static_cast<JSCell*>(cell)));
     }
     return IterationStatus::Continue;
 }
@@ -2623,7 +2623,7 @@ inline IterationStatus ObjectsWithBrokenIndexingFinder<mode>::visit(JSObject* ob
     };
 
     if (object->inherits<JSFunction>()) {
-        JSFunction* function = jsCast<JSFunction*>(object);
+        JSFunction* function = uncheckedDowncast<JSFunction>(object);
         if (FunctionRareData* rareData = function->rareData()) {
             // We only use this to cache JSFinalObjects. They do not start off with a broken indexing type.
             ASSERT(!(rareData->objectAllocationStructure() && hasBrokenIndexing(rareData->objectAllocationStructure()->indexingType())));
@@ -2639,7 +2639,7 @@ inline IterationStatus ObjectsWithBrokenIndexingFinder<mode>::visit(JSObject* ob
     }
 
     if (object->inherits<JSGlobalObject>()) {
-        JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(object);
+        JSGlobalObject* globalObject = uncheckedDowncast<JSGlobalObject>(object);
         // If this globalObject is already having a bad time, then structures in its StructureCache
         // does not affect on this new JSGlobalObject's haveABadTime since they are already slow mode.
         if (!globalObject->isHavingABadTime()) {
@@ -2683,7 +2683,7 @@ IterationStatus ObjectsWithBrokenIndexingFinder<mode>::operator()(HeapCell* cell
     if (isJSCellKind(kind) && static_cast<JSCell*>(cell)->isObject()) {
         // FIXME: This const_cast exists because this isn't a C++ lambda.
         // https://bugs.webkit.org/show_bug.cgi?id=159644
-        return const_cast<ObjectsWithBrokenIndexingFinder*>(this)->visit(jsCast<JSObject*>(static_cast<JSCell*>(cell)));
+        return const_cast<ObjectsWithBrokenIndexingFinder*>(this)->visit(uncheckedDowncast<JSObject>(static_cast<JSCell*>(cell)));
     }
     return IterationStatus::Continue;
 }
@@ -2883,7 +2883,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 template<typename Visitor>
 void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 { 
-    JSGlobalObject* thisObject = jsCast<JSGlobalObject*>(cell);
+    JSGlobalObject* thisObject = uncheckedDowncast<JSGlobalObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
@@ -3180,12 +3180,12 @@ bool JSGlobalObject::getOwnPropertySlot(JSObject* object, JSGlobalObject* global
 {
     if (Base::getOwnPropertySlot(object, globalObject, propertyName, slot))
         return true;
-    return symbolTableGet(jsCast<JSGlobalObject*>(object), propertyName, slot);
+    return symbolTableGet(uncheckedDowncast<JSGlobalObject>(object), propertyName, slot);
 }
 
 void JSGlobalObject::clearRareData(JSCell* cell)
 {
-    jsCast<JSGlobalObject*>(cell)->m_rareData = nullptr;
+    uncheckedDowncast<JSGlobalObject>(cell)->m_rareData = nullptr;
 }
 
 template<typename SpeciesWatchpoint>

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -846,7 +846,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncCopyDataProperties, (JSGlobalObject* globalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSFinalObject* target = jsCast<JSFinalObject*>(callFrame->thisValue());
+    JSFinalObject* target = uncheckedDowncast<JSFinalObject>(callFrame->thisValue());
     ASSERT(target->isStructureExtensible());
 
     JSValue sourceValue = callFrame->uncheckedArgument(0);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -213,14 +213,14 @@ ALWAYS_INLINE Structure* JSGlobalObject::arrayStructureForIndexingTypeDuringAllo
     RELEASE_AND_RETURN(scope, InternalFunction::createSubclassStructure(globalObject, asObject(newTarget), functionGlobalObject->arrayStructureForIndexingTypeDuringAllocation(indexingType)));
 }
 
-inline JSFunction* JSGlobalObject::evalFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::evalFunction)); }
-inline JSFunction* JSGlobalObject::throwTypeErrorFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::throwTypeErrorFunction)); }
-inline JSFunction* JSGlobalObject::iteratorProtocolFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performIteration)); }
-inline JSFunction* JSGlobalObject::promiseProtoThenFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::defaultPromiseThen)); }
-inline JSFunction* JSGlobalObject::promiseEmptyOnFulfilledFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::promiseEmptyOnFulfilled)); }
-inline JSFunction* JSGlobalObject::promiseEmptyOnRejectedFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::promiseEmptyOnRejected)); }
-inline JSFunction* JSGlobalObject::regExpProtoExecFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::regExpBuiltinExec)); }
-inline JSFunction* JSGlobalObject::stringProtoSubstringFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::stringSubstring)); }
+inline JSFunction* JSGlobalObject::evalFunction() const { return uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::evalFunction)); }
+inline JSFunction* JSGlobalObject::throwTypeErrorFunction() const { return uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::throwTypeErrorFunction)); }
+inline JSFunction* JSGlobalObject::iteratorProtocolFunction() const { return uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::performIteration)); }
+inline JSFunction* JSGlobalObject::promiseProtoThenFunction() const { return uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::defaultPromiseThen)); }
+inline JSFunction* JSGlobalObject::promiseEmptyOnFulfilledFunction() const { return uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::promiseEmptyOnFulfilled)); }
+inline JSFunction* JSGlobalObject::promiseEmptyOnRejectedFunction() const { return uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::promiseEmptyOnRejected)); }
+inline JSFunction* JSGlobalObject::regExpProtoExecFunction() const { return uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::regExpBuiltinExec)); }
+inline JSFunction* JSGlobalObject::stringProtoSubstringFunction() const { return uncheckedDowncast<JSFunction>(linkTimeConstant(LinkTimeConstant::stringSubstring)); }
 inline JSFunction* JSGlobalObject::performProxyObjectHasFunction() const { return m_performProxyObjectHasFunction.get(); }
 inline JSFunction* JSGlobalObject::performProxyObjectHasFunctionConcurrently() const { return performProxyObjectHasFunction(); }
 inline JSFunction* JSGlobalObject::performProxyObjectHasByValFunction() const { return m_performProxyObjectHasByValFunction.get(); }
@@ -697,7 +697,7 @@ template<typename Type> inline Type JSGlobalObject::linkTimeConstantConcurrently
     JSCell* result = m_linkTimeConstants[static_cast<unsigned>(value)].getConcurrently();
     if (!result)
         return nullptr;
-    return jsCast<Type>(result);
+    return uncheckedDowncast<std::remove_pointer_t<Type>>(result);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalProxy.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalProxy.cpp
@@ -37,7 +37,7 @@ const ClassInfo JSGlobalProxy::s_info = { "JSGlobalProxy"_s, &Base::s_info, null
 template<typename Visitor>
 void JSGlobalProxy::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(cell);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_target);
@@ -57,73 +57,73 @@ void JSGlobalProxy::setTarget(VM& vm, JSGlobalObject* globalObject)
 
 bool JSGlobalProxy::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(object);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(object);
     return thisObject->target()->methodTable()->getOwnPropertySlot(thisObject->target(), globalObject, propertyName, slot);
 }
 
 bool JSGlobalProxy::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* globalObject, unsigned propertyName, PropertySlot& slot)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(object);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(object);
     return thisObject->target()->methodTable()->getOwnPropertySlotByIndex(thisObject->target(), globalObject, propertyName, slot);
 }
 
 bool JSGlobalProxy::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(cell);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(cell);
     return thisObject->target()->methodTable()->put(thisObject->target(), globalObject, propertyName, value, slot);
 }
 
 bool JSGlobalProxy::putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned propertyName, JSValue value, bool shouldThrow)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(cell);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(cell);
     return thisObject->target()->methodTable()->putByIndex(thisObject->target(), globalObject, propertyName, value, shouldThrow);
 }
 
 bool JSGlobalProxy::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, const PropertyDescriptor& descriptor, bool shouldThrow)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(object);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(object);
     return thisObject->target()->methodTable()->defineOwnProperty(thisObject->target(), globalObject, propertyName, descriptor, shouldThrow);
 }
 
 bool JSGlobalProxy::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(cell);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(cell);
     return thisObject->target()->methodTable()->deleteProperty(thisObject->target(), globalObject, propertyName, slot);
 }
 
 bool JSGlobalProxy::isExtensible(JSObject* object, JSGlobalObject* globalObject)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(object);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(object);
     return thisObject->target()->methodTable()->isExtensible(thisObject->target(), globalObject);
 }
 
 bool JSGlobalProxy::preventExtensions(JSObject* object, JSGlobalObject* globalObject)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(object);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(object);
     return thisObject->target()->methodTable()->preventExtensions(thisObject->target(), globalObject);
 }
 
 bool JSGlobalProxy::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned propertyName)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(cell);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(cell);
     return thisObject->target()->methodTable()->deletePropertyByIndex(thisObject->target(), globalObject, propertyName);
 }
 
 void JSGlobalProxy::getOwnPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder& propertyNames, DontEnumPropertiesMode mode)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(object);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(object);
     thisObject->target()->methodTable()->getOwnPropertyNames(thisObject->target(), globalObject, propertyNames, mode);
 }
 
 bool JSGlobalProxy::setPrototype(JSObject* object, JSGlobalObject* globalObject, JSValue prototype, bool shouldThrowIfCantSet)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(object);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(object);
     return thisObject->target()->methodTable()->setPrototype(thisObject->target(), globalObject, prototype, shouldThrowIfCantSet);
 }
 
 JSValue JSGlobalProxy::getPrototype(JSObject* object, JSGlobalObject* globalObject)
 {
-    JSGlobalProxy* thisObject = jsCast<JSGlobalProxy*>(object);
+    JSGlobalProxy* thisObject = uncheckedDowncast<JSGlobalProxy>(object);
     return thisObject->target()->methodTable()->getPrototype(thisObject->target(), globalObject);
 }
 

--- a/Source/JavaScriptCore/runtime/JSGlobalProxy.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalProxy.h
@@ -104,7 +104,7 @@ ALWAYS_INLINE bool isThisValueAltered(const PutPropertySlot& slot, JSObject* bas
         return true;
     JSObject* thisObject = asObject(thisValue);
     // Only GlobalProxyType can be seen as the same to the original target object.
-    if (thisObject->type() == GlobalProxyType && static_cast<void*>(jsCast<JSGlobalProxy*>(thisObject)->target()) == static_cast<void*>(baseObject))
+    if (thisObject->type() == GlobalProxyType && static_cast<void*>(uncheckedDowncast<JSGlobalProxy>(thisObject)->target()) == static_cast<void*>(baseObject))
         return false;
     return true;
 }

--- a/Source/JavaScriptCore/runtime/JSInternalFieldObjectImplInlines.h
+++ b/Source/JavaScriptCore/runtime/JSInternalFieldObjectImplInlines.h
@@ -33,7 +33,7 @@ template<unsigned passedNumberOfInternalFields>
 template<typename Visitor>
 void JSInternalFieldObjectImpl<passedNumberOfInternalFields>::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSInternalFieldObjectImpl*>(cell);
+    auto* thisObject = uncheckedDowncast<JSInternalFieldObjectImpl>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.appendValues(thisObject->m_internalFields, numberOfInternalFields);

--- a/Source/JavaScriptCore/runtime/JSIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSIterator.cpp
@@ -51,7 +51,7 @@ JSIterator* JSIterator::create(VM& vm, Structure* structure)
 template<typename Visitor>
 void JSIterator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSIterator*>(cell);
+    auto* thisObject = uncheckedDowncast<JSIterator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorConstructor.cpp
@@ -64,7 +64,7 @@ void JSIteratorConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject,
 template<typename Visitor>
 void JSIteratorConstructor::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSIteratorConstructor*>(cell);
+    auto* thisObject = uncheckedDowncast<JSIteratorConstructor>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }
@@ -93,7 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(constructIterator, (JSGlobalObject* globalObject, CallF
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSObject* newTarget = asObject(callFrame->newTarget());
-    JSIteratorConstructor* iteratorConstructor = jsCast<JSIteratorConstructor*>(callFrame->jsCallee());
+    JSIteratorConstructor* iteratorConstructor = uncheckedDowncast<JSIteratorConstructor>(callFrame->jsCallee());
     if (newTarget == iteratorConstructor)
         return JSValue::encode(throwTypeError(globalObject, scope, "Iterator cannot be constructed directly"_s));
 

--- a/Source/JavaScriptCore/runtime/JSIteratorHelper.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorHelper.cpp
@@ -69,7 +69,7 @@ JSIteratorHelper::JSIteratorHelper(VM& vm, Structure* structure)
 template<typename Visitor>
 void JSIteratorHelper::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSIteratorHelper*>(cell);
+    auto* thisObject = uncheckedDowncast<JSIteratorHelper>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -197,7 +197,7 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncForEach, (JSGlobalObject* globalObject
     uint64_t counter = 0;
 
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(callbackArg), 2);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(callbackArg), 2);
         RETURN_IF_EXCEPTION(scope, { });
 
         forEachInIteratorProtocol(globalObject, thisValue, [&](VM&, JSGlobalObject*, JSValue nextItem) ALWAYS_INLINE_LAMBDA {
@@ -275,7 +275,7 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncIncludes, (JSGlobalObject* globalObjec
     std::optional<CachedCall> cachedCallHolder;
     CachedCall* cachedCall = nullptr;
     if (callData.type == CallData::Type::JS) [[likely]] {
-        cachedCallHolder.emplace(globalObject, jsCast<JSFunction*>(nextMethod), 0);
+        cachedCallHolder.emplace(globalObject, uncheckedDowncast<JSFunction>(nextMethod), 0);
         RETURN_IF_EXCEPTION(scope, { });
 
         cachedCall = &cachedCallHolder.value();
@@ -356,7 +356,7 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncJoin, (JSGlobalObject* globalObject, C
     std::optional<CachedCall> cachedCallHolder;
     CachedCall* cachedCall = nullptr;
     if (callData.type == CallData::Type::JS) [[likely]] {
-        cachedCallHolder.emplace(globalObject, jsCast<JSFunction*>(nextMethod), 0);
+        cachedCallHolder.emplace(globalObject, uncheckedDowncast<JSFunction>(nextMethod), 0);
         RETURN_IF_EXCEPTION(scope, { });
 
         cachedCall = &cachedCallHolder.value();

--- a/Source/JavaScriptCore/runtime/JSLexicalEnvironment.cpp
+++ b/Source/JavaScriptCore/runtime/JSLexicalEnvironment.cpp
@@ -39,7 +39,7 @@ const ClassInfo JSLexicalEnvironment::s_info = { "JSLexicalEnvironment"_s, &Base
 template<typename Visitor>
 void JSLexicalEnvironment::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSLexicalEnvironment*>(cell);
+    auto* thisObject = uncheckedDowncast<JSLexicalEnvironment>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.appendValuesHidden(thisObject->variables(), thisObject->symbolTable()->scopeSize());
@@ -49,7 +49,7 @@ DEFINE_VISIT_CHILDREN(JSLexicalEnvironment);
 
 void JSLexicalEnvironment::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
-    auto* thisObject = jsCast<JSLexicalEnvironment*>(cell);
+    auto* thisObject = uncheckedDowncast<JSLexicalEnvironment>(cell);
     Base::analyzeHeap(cell, analyzer);
 
     ConcurrentJSLocker locker(thisObject->symbolTable()->m_lock);
@@ -69,7 +69,7 @@ void JSLexicalEnvironment::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 
 void JSLexicalEnvironment::getOwnSpecialPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder& propertyNames, DontEnumPropertiesMode mode)
 {
-    JSLexicalEnvironment* thisObject = jsCast<JSLexicalEnvironment*>(object);
+    JSLexicalEnvironment* thisObject = uncheckedDowncast<JSLexicalEnvironment>(object);
     SymbolTable* symbolTable = thisObject->symbolTable();
 
     {
@@ -92,7 +92,7 @@ void JSLexicalEnvironment::getOwnSpecialPropertyNames(JSObject* object, JSGlobal
 
 bool JSLexicalEnvironment::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
-    JSLexicalEnvironment* thisObject = jsCast<JSLexicalEnvironment*>(object);
+    JSLexicalEnvironment* thisObject = uncheckedDowncast<JSLexicalEnvironment>(object);
 
     if (symbolTableGet(thisObject, propertyName, slot))
         return true;
@@ -114,7 +114,7 @@ bool JSLexicalEnvironment::getOwnPropertySlot(JSObject* object, JSGlobalObject* 
 
 bool JSLexicalEnvironment::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
-    JSLexicalEnvironment* thisObject = jsCast<JSLexicalEnvironment*>(cell);
+    JSLexicalEnvironment* thisObject = uncheckedDowncast<JSLexicalEnvironment>(cell);
     ASSERT(!Heap::heap(value) || Heap::heap(value) == Heap::heap(thisObject));
 
     bool shouldThrowReadOnlyError = slot.isStrictMode() || thisObject->isLexicalScope();

--- a/Source/JavaScriptCore/runtime/JSMapIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSMapIterator.cpp
@@ -61,7 +61,7 @@ void JSMapIterator::finishCreation(VM& vm)
 template<typename Visitor>
 void JSMapIterator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSMapIterator*>(cell);
+    auto* thisObject = uncheckedDowncast<JSMapIterator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }
@@ -77,7 +77,7 @@ JSC_DEFINE_HOST_FUNCTION(mapIteratorPrivateFuncMapIteratorNext, (JSGlobalObject 
     JSCell* cell = callFrame->uncheckedArgument(0).asCell();
     if (cell == vm.orderedHashTableSentinel())
         return JSValue::encode(cell);
-    return JSValue::encode(jsCast<JSMapIterator*>(cell)->next(vm));
+    return JSValue::encode(uncheckedDowncast<JSMapIterator>(cell)->next(vm));
 }
 
 JSC_DEFINE_HOST_FUNCTION(mapIteratorPrivateFuncMapIteratorKey, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -88,7 +88,7 @@ JSC_DEFINE_HOST_FUNCTION(mapIteratorPrivateFuncMapIteratorKey, (JSGlobalObject *
     JSCell* cell = callFrame->uncheckedArgument(0).asCell();
     if (cell == vm.orderedHashTableSentinel())
         return JSValue::encode(cell);
-    return JSValue::encode(jsCast<JSMapIterator*>(cell)->peekKey(vm));
+    return JSValue::encode(uncheckedDowncast<JSMapIterator>(cell)->peekKey(vm));
 }
 
 JSC_DEFINE_HOST_FUNCTION(mapIteratorPrivateFuncMapIteratorValue, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -99,7 +99,7 @@ JSC_DEFINE_HOST_FUNCTION(mapIteratorPrivateFuncMapIteratorValue, (JSGlobalObject
     JSCell* cell = callFrame->uncheckedArgument(0).asCell();
     if (cell == vm.orderedHashTableSentinel())
         return JSValue::encode(cell);
-    return JSValue::encode(jsCast<JSMapIterator*>(cell)->peekValue(vm));
+    return JSValue::encode(uncheckedDowncast<JSMapIterator>(cell)->peekValue(vm));
 }
 
 }

--- a/Source/JavaScriptCore/runtime/JSMapIterator.h
+++ b/Source/JavaScriptCore/runtime/JSMapIterator.h
@@ -103,7 +103,7 @@ public:
             setStorage(vm, storage);
         }
 
-        JSMap::Storage& storageRef = *jsCast<JSMap::Storage*>(storage);
+        JSMap::Storage& storageRef = *uncheckedDowncast<JSMap::Storage>(storage);
         auto result = JSMap::Helper::transitAndNext(vm, storageRef, entry());
         if (!result.storage) {
             markClosed(sentinel);
@@ -157,7 +157,7 @@ public:
         JSCell* storage = this->tryGetStorage();
         ASSERT(storage);
         ASSERT_UNUSED(vm, storage != vm.orderedHashTableSentinel());
-        JSMap::Storage& storageRef = *jsCast<JSMap::Storage*>(storage);
+        JSMap::Storage& storageRef = *uncheckedDowncast<JSMap::Storage>(storage);
         return JSMap::Helper::getKey(storageRef, entry);
     }
 
@@ -167,12 +167,12 @@ public:
         JSCell* storage = this->tryGetStorage();
         ASSERT(storage);
         ASSERT_UNUSED(vm, storage != vm.orderedHashTableSentinel());
-        JSMap::Storage& storageRef = *jsCast<JSMap::Storage*>(storage);
+        JSMap::Storage& storageRef = *uncheckedDowncast<JSMap::Storage>(storage);
         return JSMap::Helper::getValue(storageRef, entry);
     }
 
     IterationKind kind() const { return static_cast<IterationKind>(internalField(Field::Kind).get().asUInt32AsAnyInt()); }
-    JSMap* iteratedObject() const { return jsCast<JSMap*>(internalField(Field::IteratedObject).get()); }
+    JSMap* iteratedObject() const { return uncheckedDowncast<JSMap>(internalField(Field::IteratedObject).get()); }
     JSCell* tryGetStorage() const
     {
         JSValue value = internalField(Field::Storage).get();

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -87,7 +87,7 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
     if (microtaskCall && microtaskCall->canUseCall(functionObject)) [[likely]] {
         if (!vm.isSafeToRecurseSoft()) [[unlikely]]
             return throwStackOverflowError(globalObject, scope);
-        auto* jsFunction = jsCast<JSFunction*>(functionObject.asCell());
+        auto* jsFunction = uncheckedDowncast<JSFunction>(functionObject.asCell());
         if (auto result = microtaskCall->tryCallWithArguments(vm, jsFunction, thisValue, context, args...)) [[likely]] {
             scope.release();
             return result;
@@ -124,14 +124,14 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
             DeferTraps deferTraps(vm); // We can't jettison this code if we're about to run it.
 
             // Compile the callee:
-            functionExecutable->prepareForExecution<FunctionExecutable>(vm, jsCast<JSFunction*>(functionObject.asCell()), functionScope, CodeSpecializationKind::CodeForCall, newCodeBlock);
+            functionExecutable->prepareForExecution<FunctionExecutable>(vm, uncheckedDowncast<JSFunction>(functionObject.asCell()), functionScope, CodeSpecializationKind::CodeForCall, newCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
             ASSERT(newCodeBlock);
             newCodeBlock->m_shouldAlwaysBeInlined = false;
         }
 
         if (microtaskCall) {
-            auto* jsFunction = jsCast<JSFunction*>(functionObject.asCell());
+            auto* jsFunction = uncheckedDowncast<JSFunction>(functionObject.asCell());
             microtaskCall->initialize(vm, jsFunction);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
 
@@ -191,7 +191,7 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
 
 #if ENABLE(WEBASSEMBLY)
     if (callData.native.isWasm)
-        return JSValue::decode(vmEntryToWasm(jsCast<WebAssemblyFunction*>(functionObject)->jsToWasm(ArityCheckMode::MustCheckArity).taggedPtr(), &vm, &protoCallFrame));
+        return JSValue::decode(vmEntryToWasm(uncheckedDowncast<WebAssemblyFunction>(functionObject)->jsToWasm(ArityCheckMode::MustCheckArity).taggedPtr(), &vm, &protoCallFrame));
 #endif
 
     return JSValue::decode(vmEntryToNative(nativeFunction.taggedPtr(), &vm, &protoCallFrame));
@@ -307,7 +307,7 @@ static void asyncFromSyncIteratorContinueOrDone(JSGlobalObject* globalObject, VM
                 }
             }
             if (error) [[unlikely]] {
-                jsCast<JSPromise*>(promise)->reject(vm, globalObject, error);
+                uncheckedDowncast<JSPromise>(promise)->reject(vm, globalObject, error);
                 return;
             }
             if (returnMethod.isCallable()) {
@@ -317,13 +317,13 @@ static void asyncFromSyncIteratorContinueOrDone(JSGlobalObject* globalObject, VM
             }
         }
         scope.release();
-        jsCast<JSPromise*>(promise)->reject(vm, globalObject, result);
+        uncheckedDowncast<JSPromise>(promise)->reject(vm, globalObject, result);
         break;
     }
     case JSPromise::Status::Fulfilled: {
         auto* resultObject = createIteratorResultObject(globalObject, result, done);
         scope.release();
-        jsCast<JSPromise*>(promise)->resolve(globalObject, vm, resultObject);
+        uncheckedDowncast<JSPromise>(promise)->resolve(globalObject, vm, resultObject);
         break;
     }
     }
@@ -358,14 +358,14 @@ static void promiseAllResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* globalContext = jsCast<JSPromiseCombinatorsGlobalContext*>(context->globalContext());
+    auto* globalContext = context->globalContext();
     switch (status) {
     case JSPromise::Status::Pending: {
         RELEASE_ASSERT_NOT_REACHED();
         break;
     }
     case JSPromise::Status::Fulfilled: {
-        auto* values = jsCast<JSArray*>(globalContext->values());
+        auto* values = uncheckedDowncast<JSArray>(globalContext->values());
         uint64_t index = context->index();
 
         values->putDirectIndex(globalObject, index, resolution);
@@ -394,8 +394,8 @@ static void promiseAllSettledResolveJob(JSGlobalObject* globalObject, VM& vm, JS
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* globalContext = jsCast<JSPromiseCombinatorsGlobalContext*>(context->globalContext());
-    auto* values = jsCast<JSArray*>(globalContext->values());
+    auto* globalContext = context->globalContext();
+    auto* values = uncheckedDowncast<JSArray>(globalContext->values());
     uint64_t index = context->index();
 
     JSObject* resultObject = nullptr;
@@ -432,7 +432,7 @@ static void promiseAnyResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* globalContext = jsCast<JSPromiseCombinatorsGlobalContext*>(context->globalContext());
+    auto* globalContext = context->globalContext();
 
     switch (status) {
     case JSPromise::Status::Pending: {
@@ -445,7 +445,7 @@ static void promiseAnyResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
         break;
     }
     case JSPromise::Status::Rejected: {
-        auto* errors = jsCast<JSArray*>(globalContext->values());
+        auto* errors = uncheckedDowncast<JSArray>(globalContext->values());
         uint64_t index = context->index();
 
         errors->putDirectIndex(globalObject, index, resolution);
@@ -686,7 +686,7 @@ static void asyncGeneratorResumeNextReturn(JSGlobalObject* globalObject, JSAsync
 
 static void promiseFinallyAwaitJob(JSGlobalObject* globalObject, VM& vm, JSValue settledValue, JSPromiseCombinatorsGlobalContext* context, JSPromise::Status status)
 {
-    auto* resultPromise = jsCast<JSPromise*>(context->promise());
+    auto* resultPromise = uncheckedDowncast<JSPromise>(context->promise());
     JSValue originalValue = context->values();
     bool wasFulfilled = context->remainingElementsCount().asBoolean();
 
@@ -730,7 +730,7 @@ static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPr
     context->setRemainingElementsCount(vm, jsBoolean(status == JSPromise::Status::Fulfilled));
 
     if (result.inherits<JSPromise>()) {
-        auto* promise = jsCast<JSPromise*>(result);
+        auto* promise = uncheckedDowncast<JSPromise>(result);
         if (promise->isThenFastAndNonObservable()) {
             scope.release();
             promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseFinallyAwaitJob, resultPromise, context);
@@ -783,7 +783,7 @@ static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPr
 static void asyncModuleExecutionDone(JSGlobalObject* globalObject, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
 {
     scope.release();
-    auto* module = jsCast<JSModuleRecord*>(arguments[2]);
+    auto* module = uncheckedDowncast<JSModuleRecord>(arguments[2]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled)
         module->asyncExecutionFulfilled(globalObject);
@@ -795,7 +795,7 @@ static void asyncModuleExecutionDone(JSGlobalObject* globalObject, ThrowScope& s
 
 static void asyncModuleExecutionResume(JSGlobalObject* globalObject, VM& vm, ThrowScope& scope, std::span<const JSValue, maxMicrotaskArguments> arguments, uint8_t payload)
 {
-    auto* module = jsCast<JSModuleRecord*>(arguments[2]);
+    auto* module = uncheckedDowncast<JSModuleRecord>(arguments[2]);
     JSValue resolution = arguments[1];
     auto status = static_cast<JSPromise::Status>(payload);
     auto* capability = module->asyncCapability();
@@ -822,8 +822,8 @@ static void moduleRegistryFetchSettled(JSGlobalObject* globalObject, VM& vm, Thr
     // arguments[0] = pre-created modulePromise
     // arguments[1] = resolution (JSSourceCode*) or rejection (error)
     // arguments[2] = ModuleRegistryEntry*
-    auto* entry = jsCast<ModuleRegistryEntry*>(arguments[2]);
-    auto* modulePromise = jsCast<JSPromise*>(arguments[0]);
+    auto* entry = uncheckedDowncast<ModuleRegistryEntry>(arguments[2]);
+    auto* modulePromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
         auto* jsSourceCode = downcast<JSSourceCode>(arguments[1]);
@@ -847,8 +847,8 @@ static void moduleRegistryModuleSettled(JSGlobalObject* globalObject, VM& vm, st
     // arguments[0] = pre-created modulePromise
     // arguments[1] = resolution (AbstractModuleRecord*) or rejection (error)
     // arguments[2] = ModuleRegistryEntry*
-    auto* entry = jsCast<ModuleRegistryEntry*>(arguments[2]);
-    auto* modulePromise = jsCast<JSPromise*>(arguments[0]);
+    auto* entry = uncheckedDowncast<ModuleRegistryEntry>(arguments[2]);
+    auto* modulePromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
         auto* moduleRecord = downcast<AbstractModuleRecord>(arguments[1]);
@@ -868,7 +868,7 @@ static void moduleGraphLoadingError(JSGlobalObject* globalObject, VM& vm, ThrowS
     // arguments[2] = ModuleGraphLoadingState*
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Rejected) {
-        auto* state = jsCast<ModuleGraphLoadingState*>(arguments[2]);
+        auto* state = uncheckedDowncast<ModuleGraphLoadingState>(arguments[2]);
         JSValue errorValue = arguments[1];
         if (auto* error = dynamicDowncast<ErrorInstance>(errorValue)) {
             errorValue = JSModuleLoader::maybeDuplicateFetchError(globalObject, error);
@@ -883,8 +883,8 @@ static void moduleLoadStep(JSGlobalObject* globalObject, VM& vm, ThrowScope& sco
     // arguments[0] = pre-created loadPromise
     // arguments[1] = resolution value or error
     // arguments[2] = ModuleLoadingContext*
-    auto* context = jsCast<ModuleLoadingContext*>(arguments[2]);
-    auto* loadPromise = jsCast<JSPromise*>(arguments[0]);
+    auto* context = uncheckedDowncast<ModuleLoadingContext>(arguments[2]);
+    auto* loadPromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
 
     switch (context->step()) {
@@ -962,8 +962,8 @@ static void moduleLoadTopSettled(JSGlobalObject* globalObject, VM& vm, ThrowScop
     // arguments[0] = pre-created intermediatePromise
     // arguments[1] = resolution (JSSourceCode*) or error
     // arguments[2] = ModuleLoadingContext*
-    auto* context = jsCast<ModuleLoadingContext*>(arguments[2]);
-    auto* intermediatePromise = jsCast<JSPromise*>(arguments[0]);
+    auto* context = uncheckedDowncast<ModuleLoadingContext>(arguments[2]);
+    auto* intermediatePromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
         auto* jsSourceCode = downcast<JSSourceCode>(arguments[1]);
@@ -1041,8 +1041,8 @@ static void moduleLoadTopRejected(JSGlobalObject* globalObject, VM& vm, ThrowSco
     // arguments[0] = pre-created resultPromise
     // arguments[1] = resolution or error
     // arguments[2] = ModuleLoadingContext*
-    auto* context = jsCast<ModuleLoadingContext*>(arguments[2]);
-    auto* resultPromise = jsCast<JSPromise*>(arguments[0]);
+    auto* context = uncheckedDowncast<ModuleLoadingContext>(arguments[2]);
+    auto* resultPromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled)
         resultPromise->fulfill(vm, globalObject, arguments[1]);
@@ -1078,10 +1078,10 @@ static void moduleLoadSpecifierTransform(JSGlobalObject* globalObject, VM& vm, T
     // arguments[0] = pre-created transformedStatePromise
     // arguments[1] = resolution
     // arguments[2] = ModuleLoadingContext*
-    auto* transformedPromise = jsCast<JSPromise*>(arguments[0]);
+    auto* transformedPromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
-        auto* context = jsCast<ModuleLoadingContext*>(arguments[2]);
+        auto* context = uncheckedDowncast<ModuleLoadingContext>(arguments[2]);
         scope.release();
         transformedPromise->fulfill(vm, globalObject, identifierToJSValue(vm, context->moduleRequest().m_specifier));
     } else
@@ -1094,8 +1094,8 @@ static void moduleLoadCombinedLoadSettled(JSGlobalObject* globalObject, VM& vm, 
     // arguments[0] = combinedPromise
     // arguments[1] = resolution or error
     // arguments[2] = ModuleLoaderPayload*
-    auto* combinedPromise = jsCast<JSPromise*>(arguments[0]);
-    auto* modulePayload = jsCast<ModuleLoaderPayload*>(arguments[2]);
+    auto* combinedPromise = uncheckedDowncast<JSPromise>(arguments[0]);
+    auto* modulePayload = uncheckedDowncast<ModuleLoaderPayload>(arguments[2]);
     auto status = static_cast<JSPromise::Status>(payload);
     scope.release();
     if (status == JSPromise::Status::Fulfilled) {
@@ -1117,8 +1117,8 @@ static void moduleLoadCombinedStateSettled(JSGlobalObject* globalObject, VM& vm,
     // arguments[0] = combinedPromise
     // arguments[1] = resolution or error
     // arguments[2] = ModuleLoaderPayload*
-    auto* combinedPromise = jsCast<JSPromise*>(arguments[0]);
-    auto* modulePayload = jsCast<ModuleLoaderPayload*>(arguments[2]);
+    auto* combinedPromise = uncheckedDowncast<JSPromise>(arguments[0]);
+    auto* modulePayload = uncheckedDowncast<ModuleLoaderPayload>(arguments[2]);
     auto status = static_cast<JSPromise::Status>(payload);
     scope.release();
     if (status == JSPromise::Status::Fulfilled) {
@@ -1140,8 +1140,8 @@ static void moduleLoadLinkEvaluateSettled(JSGlobalObject* globalObject, VM& vm, 
     // arguments[0] = pre-created resultPromise
     // arguments[1] = resolution (AbstractModuleRecord*) or error
     // arguments[2] = ModuleLoadingContext*
-    auto* context = jsCast<ModuleLoadingContext*>(arguments[2]);
-    auto* resultPromise = jsCast<JSPromise*>(arguments[0]);
+    auto* context = uncheckedDowncast<ModuleLoadingContext>(arguments[2]);
+    auto* resultPromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
         auto* record = downcast<AbstractModuleRecord>(arguments[1]);
@@ -1172,7 +1172,7 @@ static void moduleLoadReturnRecord(JSGlobalObject* globalObject, VM& vm, ThrowSc
     // arguments[0] = resultPromise
     // arguments[1] = resolution or error
     // arguments[2] = AbstractModuleRecord*
-    auto* resultPromise = jsCast<JSPromise*>(arguments[0]);
+    auto* resultPromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     scope.release();
     if (status == JSPromise::Status::Fulfilled)
@@ -1189,7 +1189,7 @@ static void moduleLoadStoreError(JSGlobalObject* globalObject, ThrowScope& scope
     // arguments[2] = ModuleLoadingContext*
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Rejected) {
-        auto* context = jsCast<ModuleLoadingContext*>(arguments[2]);
+        auto* context = uncheckedDowncast<ModuleLoadingContext>(arguments[2]);
         JSValue errorValue = arguments[1];
         const Identifier& specifier = context->moduleRequest().m_specifier;
         auto type = context->moduleRequest().type();
@@ -1214,8 +1214,8 @@ static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, Throw
     // arguments[0] = capabilityPromise
     // arguments[1] = resolution or error
     // arguments[2] = AbstractModuleRecord*
-    auto* capabilityPromise = jsCast<JSPromise*>(arguments[0]);
-    auto* module = jsCast<AbstractModuleRecord*>(arguments[2]);
+    auto* capabilityPromise = uncheckedDowncast<JSPromise>(arguments[0]);
+    auto* module = uncheckedDowncast<AbstractModuleRecord>(arguments[2]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
         // linkAndEvaluate logic
@@ -1241,8 +1241,8 @@ static void dynamicImportEvaluateSettled(JSGlobalObject* globalObject, VM& vm, T
     // arguments[0] = capabilityPromise
     // arguments[1] = resolution or error
     // arguments[2] = AbstractModuleRecord*
-    auto* capabilityPromise = jsCast<JSPromise*>(arguments[0]);
-    auto* module = jsCast<AbstractModuleRecord*>(arguments[2]);
+    auto* capabilityPromise = uncheckedDowncast<JSPromise>(arguments[0]);
+    auto* module = uncheckedDowncast<AbstractModuleRecord>(arguments[2]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
         JSModuleNamespaceObject* moduleNamespace = module->getModuleNamespace(globalObject);
@@ -1267,7 +1267,7 @@ static void importModuleNamespace(JSGlobalObject* globalObject, VM& vm, ThrowSco
     // arguments[0] = resultPromise
     // arguments[1] = module namespace (from dynamic import pipeline) or error
     // arguments[2] = unused
-    auto* resultPromise = jsCast<JSPromise*>(arguments[0]);
+    auto* resultPromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto status = static_cast<JSPromise::Status>(payload);
     if (status == JSPromise::Status::Fulfilled) {
         // The value is a JSModuleNamespaceObject forwarded from the internal
@@ -1289,8 +1289,8 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
 
     switch (task) {
     case InternalMicrotask::PromiseResolveThenableJobFast: {
-        auto* promise = jsCast<JSPromise*>(arguments[0]);
-        auto* promiseToResolve = jsCast<JSPromise*>(arguments[1]);
+        auto* promise = uncheckedDowncast<JSPromise>(arguments[0]);
+        auto* promiseToResolve = uncheckedDowncast<JSPromise>(arguments[1]);
 
         if (!promiseSpeciesWatchpointIsValid(vm, promise)) [[unlikely]]
             RELEASE_AND_RETURN(scope, promiseResolveThenableJobFastSlow(globalObject, promise, promiseToResolve));
@@ -1301,7 +1301,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
     }
 
     case InternalMicrotask::PromiseResolveThenableJobWithInternalMicrotaskFast: {
-        auto* promise = jsCast<JSPromise*>(arguments[0]);
+        auto* promise = uncheckedDowncast<JSPromise>(arguments[0]);
         JSValue context = arguments[1];
         auto task = static_cast<InternalMicrotask>(payload);
 
@@ -1312,7 +1312,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         switch (promise->status()) {
         case JSPromise::Status::Pending: {
             JSValue encodedTask = jsNumber(static_cast<int32_t>(task));
-            auto* reaction = JSPromiseReaction::create(vm, jsUndefined(), encodedTask, encodedTask, context, reactionsOrResult ? jsCast<JSPromiseReaction*>(reactionsOrResult) : nullptr);
+            auto* reaction = JSPromiseReaction::create(vm, jsUndefined(), encodedTask, encodedTask, context, reactionsOrResult ? uncheckedDowncast<JSPromiseReaction>(reactionsOrResult) : nullptr);
             promise->setReactionsOrResult(vm, reaction);
             promise->markAsHandled();
             break;
@@ -1335,7 +1335,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
     case InternalMicrotask::PromiseResolveThenableJob: {
         JSValue promise = arguments[0];
         JSValue then = arguments[1];
-        JSPromise* promiseToResolve = jsCast<JSPromise*>(arguments[2]);
+        JSPromise* promiseToResolve = uncheckedDowncast<JSPromise>(arguments[2]);
         auto [resolve, reject] = promiseToResolve->createResolvingFunctions(vm, globalObject);
         RELEASE_AND_RETURN(scope, promiseResolveThenableJob(globalObject, promise, then, resolve, reject));
     }
@@ -1350,7 +1350,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
     }
 
     case InternalMicrotask::PromiseResolveWithoutHandlerJob: {
-        auto* promise = jsCast<JSPromise*>(arguments[0]);
+        auto* promise = uncheckedDowncast<JSPromise>(arguments[0]);
         JSValue resolution = arguments[1];
         switch (static_cast<JSPromise::Status>(payload)) {
         case JSPromise::Status::Pending: {
@@ -1372,7 +1372,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
     }
 
     case InternalMicrotask::PromiseFulfillWithoutHandlerJob: {
-        auto* promise = jsCast<JSPromise*>(arguments[0]);
+        auto* promise = uncheckedDowncast<JSPromise>(arguments[0]);
         JSValue resolution = arguments[1];
         switch (static_cast<JSPromise::Status>(payload)) {
         case JSPromise::Status::Pending:
@@ -1391,16 +1391,16 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
     }
 
     case InternalMicrotask::PromiseRaceResolveJob:
-        RELEASE_AND_RETURN(scope, promiseRaceResolveJob(globalObject, vm, jsCast<JSPromise*>(arguments[0]), arguments[1], static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, promiseRaceResolveJob(globalObject, vm, uncheckedDowncast<JSPromise>(arguments[0]), arguments[1], static_cast<JSPromise::Status>(payload)));
 
     case InternalMicrotask::PromiseAllResolveJob:
-        RELEASE_AND_RETURN(scope, promiseAllResolveJob(globalObject, vm, jsCast<JSPromise*>(arguments[0]), arguments[1], jsCast<JSPromiseCombinatorsContext*>(arguments[2]), static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, promiseAllResolveJob(globalObject, vm, uncheckedDowncast<JSPromise>(arguments[0]), arguments[1], uncheckedDowncast<JSPromiseCombinatorsContext>(arguments[2]), static_cast<JSPromise::Status>(payload)));
 
     case InternalMicrotask::PromiseAllSettledResolveJob:
-        RELEASE_AND_RETURN(scope, promiseAllSettledResolveJob(globalObject, vm, jsCast<JSPromise*>(arguments[0]), arguments[1], jsCast<JSPromiseCombinatorsContext*>(arguments[2]), static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, promiseAllSettledResolveJob(globalObject, vm, uncheckedDowncast<JSPromise>(arguments[0]), arguments[1], uncheckedDowncast<JSPromiseCombinatorsContext>(arguments[2]), static_cast<JSPromise::Status>(payload)));
 
     case InternalMicrotask::PromiseAnyResolveJob:
-        RELEASE_AND_RETURN(scope, promiseAnyResolveJob(globalObject, vm, jsCast<JSPromise*>(arguments[0]), arguments[1], jsCast<JSPromiseCombinatorsContext*>(arguments[2]), static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, promiseAnyResolveJob(globalObject, vm, uncheckedDowncast<JSPromise>(arguments[0]), arguments[1], uncheckedDowncast<JSPromiseCombinatorsContext>(arguments[2]), static_cast<JSPromise::Status>(payload)));
 
     case InternalMicrotask::PromiseReactionJob: {
         JSValue promiseOrCapability = arguments[0];
@@ -1469,7 +1469,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
 
     case InternalMicrotask::AsyncFunctionResume: {
         JSValue resolution = arguments[1];
-        auto* generator = jsCast<JSGenerator*>(arguments[2]);
+        auto* generator = uncheckedDowncast<JSGenerator>(arguments[2]);
         JSGenerator::ResumeMode resumeMode = JSGenerator::ResumeMode::NormalMode;
         switch (static_cast<JSPromise::Status>(payload)) {
         case JSPromise::Status::Pending: {
@@ -1507,14 +1507,14 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         }
 
         if (error) {
-            auto* promise = jsCast<JSPromise*>(generator->context());
+            auto* promise = uncheckedDowncast<JSPromise>(generator->context());
             scope.release();
             promise->reject(vm, globalObject, error);
             return;
         }
 
         if (generator->state() == static_cast<int32_t>(JSGenerator::State::Executing)) {
-            auto* promise = jsCast<JSPromise*>(generator->context());
+            auto* promise = uncheckedDowncast<JSPromise>(generator->context());
             scope.release();
             promise->resolve(globalObject, vm, value);
             return;
@@ -1530,19 +1530,19 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         RELEASE_AND_RETURN(scope, asyncFromSyncIteratorContinueOrDone(globalObject, vm, arguments[2], arguments[1], static_cast<JSPromise::Status>(payload), task == InternalMicrotask::AsyncFromSyncIteratorDone));
 
     case InternalMicrotask::AsyncGeneratorYieldAwaited: {
-        RELEASE_AND_RETURN(scope, asyncGeneratorYieldAwaited(globalObject, jsCast<JSAsyncGenerator*>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, asyncGeneratorYieldAwaited(globalObject, uncheckedDowncast<JSAsyncGenerator>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
     case InternalMicrotask::AsyncGeneratorBodyCallNormal: {
-        RELEASE_AND_RETURN(scope, asyncGeneratorBodyCallNormal(globalObject, jsCast<JSAsyncGenerator*>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, asyncGeneratorBodyCallNormal(globalObject, uncheckedDowncast<JSAsyncGenerator>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
     case InternalMicrotask::AsyncGeneratorBodyCallReturn: {
-        RELEASE_AND_RETURN(scope, asyncGeneratorBodyCallReturn(globalObject, jsCast<JSAsyncGenerator*>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, asyncGeneratorBodyCallReturn(globalObject, uncheckedDowncast<JSAsyncGenerator>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
     case InternalMicrotask::AsyncGeneratorResumeNext: {
-        RELEASE_AND_RETURN(scope, asyncGeneratorResumeNextReturn(globalObject, jsCast<JSAsyncGenerator*>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, asyncGeneratorResumeNextReturn(globalObject, uncheckedDowncast<JSAsyncGenerator>(arguments[2]), arguments[1], static_cast<JSPromise::Status>(payload)));
     }
 
     case InternalMicrotask::PromiseFinallyReactionJob: {
@@ -1553,9 +1553,9 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         // payload = Fulfilled/Rejected status
         scope.release();
         promiseFinallyReactionJob(globalObject, vm,
-            jsCast<JSPromise*>(arguments[0]),
+            uncheckedDowncast<JSPromise>(arguments[0]),
             arguments[1],
-            jsCast<JSPromiseCombinatorsGlobalContext*>(arguments[2]),
+            uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[2]),
             static_cast<JSPromise::Status>(payload));
         return;
     }
@@ -1569,7 +1569,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         scope.release();
         promiseFinallyAwaitJob(globalObject, vm,
             arguments[1],
-            jsCast<JSPromiseCombinatorsGlobalContext*>(arguments[2]),
+            uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[2]),
             static_cast<JSPromise::Status>(payload));
         return;
     }
@@ -1643,7 +1643,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         // loadAndEvaluateModule: extract module key from AbstractModuleRecord
         // arguments[0] = resultPromise
         // arguments[1] = resolution (AbstractModuleRecord*) or error
-        auto* resultPromise = jsCast<JSPromise*>(arguments[0]);
+        auto* resultPromise = uncheckedDowncast<JSPromise>(arguments[0]);
         auto status = static_cast<JSPromise::Status>(payload);
         scope.release();
         if (status == JSPromise::Status::Fulfilled) {

--- a/Source/JavaScriptCore/runtime/JSMicrotaskDispatcher.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotaskDispatcher.cpp
@@ -61,7 +61,7 @@ JSMicrotaskDispatcher::JSMicrotaskDispatcher(VM& vm, Structure* structure, Ref<M
 template<typename Visitor>
 void JSMicrotaskDispatcher::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSMicrotaskDispatcher*>(cell);
+    auto* thisObject = uncheckedDowncast<JSMicrotaskDispatcher>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_globalObject);

--- a/Source/JavaScriptCore/runtime/JSModuleEnvironment.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleEnvironment.cpp
@@ -62,7 +62,7 @@ JSModuleEnvironment* JSModuleEnvironment::create(
 template<typename Visitor>
 void JSModuleEnvironment::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSModuleEnvironment* thisObject = jsCast<JSModuleEnvironment*>(cell);
+    JSModuleEnvironment* thisObject = uncheckedDowncast<JSModuleEnvironment>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.appendValues(thisObject->variables(), thisObject->symbolTable()->scopeSize());
@@ -75,7 +75,7 @@ bool JSModuleEnvironment::getOwnPropertySlot(JSObject* cell, JSGlobalObject* glo
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSModuleEnvironment* thisObject = jsCast<JSModuleEnvironment*>(cell);
+    JSModuleEnvironment* thisObject = uncheckedDowncast<JSModuleEnvironment>(cell);
     AbstractModuleRecord::Resolution resolution = thisObject->moduleRecord()->resolveImport(globalObject, Identifier::fromUid(vm, propertyName.uid()));
     RETURN_IF_EXCEPTION(scope, false);
     if (resolution.type == AbstractModuleRecord::Resolution::Type::Resolved) {
@@ -95,7 +95,7 @@ bool JSModuleEnvironment::getOwnPropertySlot(JSObject* cell, JSGlobalObject* glo
 
 void JSModuleEnvironment::getOwnSpecialPropertyNames(JSObject* cell, JSGlobalObject*, PropertyNameArrayBuilder& propertyNamesArray, DontEnumPropertiesMode)
 {
-    JSModuleEnvironment* thisObject = jsCast<JSModuleEnvironment*>(cell);
+    JSModuleEnvironment* thisObject = uncheckedDowncast<JSModuleEnvironment>(cell);
     if (propertyNamesArray.includeStringProperties()) {
         for (const auto& pair : thisObject->moduleRecord()->importEntries()) {
             const AbstractModuleRecord::ImportEntry& importEntry = pair.value;
@@ -110,7 +110,7 @@ bool JSModuleEnvironment::put(JSCell* cell, JSGlobalObject* globalObject, Proper
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSModuleEnvironment* thisObject = jsCast<JSModuleEnvironment*>(cell);
+    JSModuleEnvironment* thisObject = uncheckedDowncast<JSModuleEnvironment>(cell);
     // All imported bindings are immutable.
     AbstractModuleRecord::Resolution resolution = thisObject->moduleRecord()->resolveImport(globalObject, Identifier::fromUid(vm, propertyName.uid()));
     RETURN_IF_EXCEPTION(scope, false);
@@ -126,7 +126,7 @@ bool JSModuleEnvironment::deleteProperty(JSCell* cell, JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSModuleEnvironment* thisObject = jsCast<JSModuleEnvironment*>(cell);
+    JSModuleEnvironment* thisObject = uncheckedDowncast<JSModuleEnvironment>(cell);
     // All imported bindings are immutable.
     AbstractModuleRecord::Resolution resolution = thisObject->moduleRecord()->resolveImport(globalObject, Identifier::fromUid(vm, propertyName.uid()));
     RETURN_IF_EXCEPTION(scope, false);

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -59,7 +59,7 @@ static constexpr unsigned maximumResolutionFailures = 128;
 static Identifier jsValueToSpecifier(JSGlobalObject* globalObject, JSValue value)
 {
     if (value.isSymbol())
-        return Identifier::fromUid(jsCast<Symbol*>(value)->privateName());
+        return Identifier::fromUid(uncheckedDowncast<Symbol>(value)->privateName());
     ASSERT(value.isString());
     return asString(value)->toIdentifier(globalObject);
 }
@@ -79,7 +79,7 @@ ErrorInstance* JSModuleLoader::duplicateTypeError(JSGlobalObject* globalObject, 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* copy = jsCast<ErrorInstance*>(createTypeErrorCopy(globalObject, error));
+    auto* copy = uncheckedDowncast<ErrorInstance>(createTypeErrorCopy(globalObject, error));
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     auto copyField = [&](const Identifier& name) -> bool {
@@ -260,7 +260,7 @@ void JSModuleLoader::finishCreation(JSGlobalObject*, VM& vm)
 template<typename Visitor>
 void JSModuleLoader::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSModuleLoader* thisObject = jsCast<JSModuleLoader*>(cell);
+    JSModuleLoader* thisObject = uncheckedDowncast<JSModuleLoader>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     Locker locker { thisObject->cellLock() };
@@ -1012,7 +1012,7 @@ JSPromise* JSModuleLoader::makeModule(JSGlobalObject* globalObject, const Identi
 
 #if ENABLE(WEBASSEMBLY)
     if (sourceCode.provider()->sourceType() == SourceProviderSourceType::WebAssembly)
-        RELEASE_AND_RETURN(scope, jsCast<JSPromise*>(JSWebAssembly::instantiate(globalObject, promise, sourceCode.provider(), moduleKey, jsSourceCode)));
+        RELEASE_AND_RETURN(scope, uncheckedDowncast<JSPromise>(JSWebAssembly::instantiate(globalObject, promise, sourceCode.provider(), moduleKey, jsSourceCode)));
 #endif
 
     // https://tc39.es/proposal-json-modules/#sec-parse-json-module
@@ -1030,7 +1030,7 @@ JSPromise* JSModuleLoader::makeModule(JSGlobalObject* globalObject, const Identi
         vm, sourceCode, ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
         StrictModeLexicallyScopedFeature, JSParserScriptMode::Module, SourceParseMode::ModuleAnalyzeMode, error);
     if (error.isValid()) {
-        auto* errorInstance = jsCast<ErrorInstance*>(error.toErrorObject(globalObject, sourceCode));
+        auto* errorInstance = uncheckedDowncast<ErrorInstance>(error.toErrorObject(globalObject, sourceCode));
         attachErrorInfo(globalObject, errorInstance, nullptr, moduleKey, ScriptFetchParameters::JavaScript, ModuleFailure::Kind::Evaluation);
         promise->reject(vm, globalObject, errorInstance);
         RELEASE_AND_RETURN(scope, promise);
@@ -1043,7 +1043,7 @@ JSPromise* JSModuleLoader::makeModule(JSGlobalObject* globalObject, const Identi
     auto result = moduleAnalyzer.analyze(*moduleProgramNode);
     if (!result) {
         auto [errorType, message] = WTF::move(result.error());
-        auto* errorInstance = jsCast<ErrorInstance*>(createError(globalObject, errorType, message));
+        auto* errorInstance = uncheckedDowncast<ErrorInstance>(createError(globalObject, errorType, message));
         attachErrorInfo(globalObject, errorInstance, nullptr, moduleKey, ScriptFetchParameters::JavaScript, ModuleFailure::Kind::Evaluation);
         promise->reject(vm, globalObject, errorInstance);
         RELEASE_AND_RETURN(scope, promise);

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
@@ -90,7 +90,7 @@ void JSModuleNamespaceObject::destroy(JSCell* cell)
 template<typename Visitor>
 void JSModuleNamespaceObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSModuleNamespaceObject* thisObject = jsCast<JSModuleNamespaceObject*>(cell);
+    JSModuleNamespaceObject* thisObject = uncheckedDowncast<JSModuleNamespaceObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_moduleRecord);
@@ -181,14 +181,14 @@ bool JSModuleNamespaceObject::getOwnPropertySlotCommon(JSGlobalObject* globalObj
 
 bool JSModuleNamespaceObject::getOwnPropertySlot(JSObject* cell, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
-    JSModuleNamespaceObject* thisObject = jsCast<JSModuleNamespaceObject*>(cell);
+    JSModuleNamespaceObject* thisObject = uncheckedDowncast<JSModuleNamespaceObject>(cell);
     return thisObject->getOwnPropertySlotCommon(globalObject, propertyName, slot);
 }
 
 bool JSModuleNamespaceObject::getOwnPropertySlotByIndex(JSObject* cell, JSGlobalObject* globalObject, unsigned propertyName, PropertySlot& slot)
 {
     VM& vm = globalObject->vm();
-    JSModuleNamespaceObject* thisObject = jsCast<JSModuleNamespaceObject*>(cell);
+    JSModuleNamespaceObject* thisObject = uncheckedDowncast<JSModuleNamespaceObject>(cell);
     return thisObject->getOwnPropertySlotCommon(globalObject, Identifier::from(vm, propertyName), slot);
 }
 
@@ -216,7 +216,7 @@ bool JSModuleNamespaceObject::putByIndex(JSCell*, JSGlobalObject* globalObject, 
 bool JSModuleNamespaceObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
     // https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-delete-p
-    JSModuleNamespaceObject* thisObject = jsCast<JSModuleNamespaceObject*>(cell);
+    JSModuleNamespaceObject* thisObject = uncheckedDowncast<JSModuleNamespaceObject>(cell);
     if (propertyName.isSymbol())
         return Base::deleteProperty(thisObject, globalObject, propertyName, slot);
 
@@ -226,7 +226,7 @@ bool JSModuleNamespaceObject::deleteProperty(JSCell* cell, JSGlobalObject* globa
 bool JSModuleNamespaceObject::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned propertyName)
 {
     VM& vm = globalObject->vm();
-    JSModuleNamespaceObject* thisObject = jsCast<JSModuleNamespaceObject*>(cell);
+    JSModuleNamespaceObject* thisObject = uncheckedDowncast<JSModuleNamespaceObject>(cell);
     return !thisObject->m_exports.contains(Identifier::from(vm, propertyName).impl());
 }
 
@@ -236,7 +236,7 @@ void JSModuleNamespaceObject::getOwnPropertyNames(JSObject* cell, JSGlobalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys
-    JSModuleNamespaceObject* thisObject = jsCast<JSModuleNamespaceObject*>(cell);
+    JSModuleNamespaceObject* thisObject = uncheckedDowncast<JSModuleNamespaceObject>(cell);
     for (const auto& name : thisObject->m_names) {
         if (mode == DontEnumPropertiesMode::Exclude) {
             // Perform [[GetOwnProperty]] to throw ReferenceError if binding is uninitialized.
@@ -259,7 +259,7 @@ bool JSModuleNamespaceObject::defineOwnProperty(JSObject* cell, JSGlobalObject* 
 
     // https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-defineownproperty-p-desc
 
-    JSModuleNamespaceObject* thisObject = jsCast<JSModuleNamespaceObject*>(cell);
+    JSModuleNamespaceObject* thisObject = uncheckedDowncast<JSModuleNamespaceObject>(cell);
 
     // 1. If Type(P) is Symbol, return OrdinaryDefineOwnProperty(O, P, Desc).
     if (propertyName.isSymbol())

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
@@ -75,7 +75,7 @@ void JSModuleRecord::finishCreation(JSGlobalObject* globalObject, VM& vm)
 template<typename Visitor>
 void JSModuleRecord::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSModuleRecord* thisObject = jsCast<JSModuleRecord*>(cell);
+    JSModuleRecord* thisObject = uncheckedDowncast<JSModuleRecord>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_moduleProgramExecutable);

--- a/Source/JavaScriptCore/runtime/JSNativeStdFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSNativeStdFunction.cpp
@@ -38,7 +38,7 @@ static JSC_DECLARE_HOST_FUNCTION(runStdFunction);
 template<typename Visitor>
 void JSNativeStdFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSNativeStdFunction* thisObject = jsCast<JSNativeStdFunction*>(cell);
+    JSNativeStdFunction* thisObject = uncheckedDowncast<JSNativeStdFunction>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_captures.begin(), thisObject->m_captures.end());
@@ -59,7 +59,7 @@ NativeExecutable* JSNativeStdFunction::getHostFunction(VM& vm, Intrinsic intrins
 
 JSC_DEFINE_HOST_FUNCTION(runStdFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    JSNativeStdFunction* function = jsCast<JSNativeStdFunction*>(callFrame->jsCallee());
+    JSNativeStdFunction* function = uncheckedDowncast<JSNativeStdFunction>(callFrame->jsCallee());
     ASSERT(function);
     return function->function()(globalObject, callFrame);
 }

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -166,7 +166,7 @@ static inline JSValue unwrapBoxedPrimitive(JSGlobalObject* globalObject, JSObjec
     if (object->inherits<StringObject>())
         return object->toString(globalObject);
     if (object->inherits<BooleanObject>() || object->inherits<BigIntObject>())
-        return jsCast<JSWrapperObject*>(object)->internalValue();
+        return uncheckedDowncast<JSWrapperObject>(object)->internalValue();
 
     // Do not unwrap SymbolObject to Symbol. It is not performed in the spec.
     // http://www.ecma-international.org/ecma-262/6.0/#sec-serializejsonproperty
@@ -259,7 +259,7 @@ Stringifier::Stringifier(JSGlobalObject* globalObject, JSValue replacer, JSValue
                 m_usingArrayReplacer = true;
                 forEachInArrayLike(globalObject, replacerObject, [&] (JSValue name) -> bool {
                     if (name.isObject()) {
-                        auto* nameObject = jsCast<JSObject*>(name);
+                        auto* nameObject = uncheckedDowncast<JSObject>(name);
                         if (!nameObject->inherits<NumberObject>() && !nameObject->inherits<StringObject>())
                             return true;
                     } else if (!name.isNumber() && !name.isString())
@@ -381,7 +381,7 @@ Stringifier::StringifyResult Stringifier::appendStringifiedValue(StringBuilder& 
     if (value.isObject()) {
         JSObject* object = asObject(value);
         if (object->inherits<JSRawJSONObject>()) {
-            String string = jsCast<JSRawJSONObject*>(object)->rawJSON(vm)->value(m_globalObject);
+            String string = uncheckedDowncast<JSRawJSONObject>(object)->rawJSON(vm)->value(m_globalObject);
             RETURN_IF_EXCEPTION(scope, StringifyFailed);
             builder.append(WTF::move(string));
             return StringifySucceeded;
@@ -625,7 +625,7 @@ bool Stringifier::Holder::appendNextProperty(Stringifier& stringifier, StringBui
                     unsigned offset = std::get<1>(m_propertiesAndOffsets[index]);
                     value = m_object->getDirect(offset);
                     if (value.isGetterSetter()) {
-                        value = jsCast<GetterSetter*>(value)->callGetter(globalObject, m_object);
+                        value = uncheckedDowncast<GetterSetter>(value)->callGetter(globalObject, m_object);
                         RETURN_IF_EXCEPTION(scope, false);
                     } else if (value.isCustomGetterSetter()) {
                         value = m_object->get(globalObject, propertyName);
@@ -1771,7 +1771,7 @@ NEVER_INLINE JSValue Walker::walk(JSValue unfiltered)
             objectStartVisitMember:
             [[fallthrough]];
             case ObjectStartVisitMember: {
-                JSObject* object = jsCast<JSObject*>(markedStack.last());
+                JSObject* object = uncheckedDowncast<JSObject>(markedStack.last());
                 uint32_t index = indexStack.last();
                 PropertyNameArrayBuilder& properties = propertyStack.last();
                 if (index == properties.size()) {
@@ -1812,7 +1812,7 @@ NEVER_INLINE JSValue Walker::walk(JSValue unfiltered)
                 [[fallthrough]];
             }
             case ObjectEndVisitMember: {
-                JSObject* object = jsCast<JSObject*>(markedStack.last());
+                JSObject* object = uncheckedDowncast<JSObject>(markedStack.last());
                 Identifier prop = propertyStack.last()[indexStack.last()];
                 JSValue filteredValue = callReviver(object, jsString(vm, prop.string()), outValue, outValueRange);
                 RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -413,7 +413,7 @@ ALWAYS_INLINE Structure* JSObjectWithButterfly::visitButterflyImpl(Visitor& visi
 
 size_t JSObject::estimatedSize(JSCell* cell, VM& vm)
 {
-    JSObject* thisObject = jsCast<JSObject*>(cell);
+    JSObject* thisObject = uncheckedDowncast<JSObject>(cell);
     size_t butterflyOutOfLineSize = thisObject->butterfly() ? thisObject->structure()->outOfLineSize() : 0;
     return Base::estimatedSize(cell, vm) + butterflyOutOfLineSize;
 }
@@ -421,7 +421,7 @@ size_t JSObject::estimatedSize(JSCell* cell, VM& vm)
 template<typename Visitor>
 void JSObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSObject* thisObject = jsCast<JSObject*>(cell);
+    JSObject* thisObject = uncheckedDowncast<JSObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     typename Visitor::DefaultMarkingViolationAssertionScope assertionScope(visitor);
 
@@ -433,7 +433,7 @@ DEFINE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE, JSObject);
 template<typename Visitor>
 void JSObjectWithButterfly::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSObjectWithButterfly* thisObject = jsCast<JSObjectWithButterfly*>(cell);
+    JSObjectWithButterfly* thisObject = uncheckedDowncast<JSObjectWithButterfly>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     typename Visitor::DefaultMarkingViolationAssertionScope assertionScope(visitor);
 
@@ -446,7 +446,7 @@ DEFINE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE, JSObjectWithButterfly);
 
 void JSObject::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
-    JSObject* thisObject = jsCast<JSObject*>(cell);
+    JSObject* thisObject = uncheckedDowncast<JSObject>(cell);
     Base::analyzeHeap(cell, analyzer);
 
     Structure* structure = thisObject->structure();
@@ -485,7 +485,7 @@ void JSObject::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 template<typename Visitor>
 void JSFinalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSFinalObject* thisObject = jsCast<JSFinalObject*>(cell);
+    JSFinalObject* thisObject = uncheckedDowncast<JSFinalObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     typename Visitor::DefaultMarkingViolationAssertionScope assertionScope(visitor);
     
@@ -694,7 +694,7 @@ bool ordinarySetWithOwnDescriptor(JSGlobalObject* globalObject, JSObject* object
     JSObject* current = object;
     while (true) {
         if (current->type() == ProxyObjectType) {
-            auto* proxy = jsCast<ProxyObject*>(current);
+            auto* proxy = uncheckedDowncast<ProxyObject>(current);
             PutPropertySlot slot(receiver, shouldThrow);
             RELEASE_AND_RETURN(scope, proxy->ProxyObject::put(proxy, globalObject, propertyName, value, slot));
         }
@@ -852,7 +852,7 @@ bool JSObject::putInlineSlow(JSGlobalObject* globalObject, PropertyName property
         if (isValidOffset(offset)) {
             hasProperty = true;
             if (attributes & PropertyAttribute::CustomAccessorOrValue)
-                customSetter = jsCast<CustomGetterSetter*>(obj->getDirect(offset))->setter();
+                customSetter = uncheckedDowncast<CustomGetterSetter>(obj->getDirect(offset))->setter();
         } else if (structure->hasNonReifiedStaticProperties()) {
             if (auto entry = structure->findPropertyHashEntry(propertyName)) {
                 hasProperty = true;
@@ -875,7 +875,7 @@ bool JSObject::putInlineSlow(JSGlobalObject* globalObject, PropertyName property
                 // We need to make sure that we decide to cache this property before we potentially execute aribitrary JS.
                 if (!this->structure()->isUncacheableDictionary())
                     slot.setCacheableSetter(obj, offset);
-                RELEASE_AND_RETURN(scope, jsCast<GetterSetter*>(obj->getDirect(offset))->callSetter(globalObject, slot.thisValue(), value, slot.isStrictMode()));
+                RELEASE_AND_RETURN(scope, uncheckedDowncast<GetterSetter>(obj->getDirect(offset))->callSetter(globalObject, slot.thisValue(), value, slot.isStrictMode()));
             }
             if (attributes & PropertyAttribute::CustomAccessor) {
                 // FIXME: Remove this after WebIDL generator is fixed to set ReadOnly for [RuntimeConditionallyReadWrite] attributes.
@@ -982,7 +982,7 @@ bool JSObject::definePropertyOnReceiver(JSGlobalObject* globalObject, PropertyNa
         return typeError(globalObject, scope, slot.isStrictMode(), ReadonlyPropertyWriteError);
     scope.release();
     if (receiver->type() == GlobalProxyType)
-        receiver = jsCast<JSGlobalProxy*>(receiver)->target();
+        receiver = uncheckedDowncast<JSGlobalProxy>(receiver)->target();
 
     if (slot.isTaintedByOpaqueObject() || receiver->methodTable()->defineOwnProperty != JSObject::defineOwnProperty) {
         if (mightBeSpecialProperty(vm, receiver->type(), propertyName.uid()))
@@ -1032,7 +1032,7 @@ bool JSObject::putInlineFastReplacingStaticPropertyIfNeeded(JSGlobalObject* glob
 bool JSObject::putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned propertyName, JSValue value, bool shouldThrow)
 {
     VM& vm = globalObject->vm();
-    JSObject* thisObject = jsCast<JSObject*>(cell);
+    JSObject* thisObject = uncheckedDowncast<JSObject>(cell);
 
     if (propertyName > MAX_ARRAY_INDEX) {
         PutPropertySlot slot(cell, shouldThrow);
@@ -1215,7 +1215,7 @@ void JSObject::enterDictionaryIndexingMode(VM& vm)
 void JSObject::notifyPresenceOfIndexedAccessors(VM& vm)
 {
     if (isGlobalObject()) [[unlikely]] {
-        jsCast<JSGlobalObject*>(this)->globalThis()->notifyPresenceOfIndexedAccessors(vm);
+        uncheckedDowncast<JSGlobalObject>(this)->globalThis()->notifyPresenceOfIndexedAccessors(vm);
         return;
     }
 
@@ -2354,7 +2354,7 @@ bool JSObject::hasEnumerableProperty(JSGlobalObject* globalObject, unsigned prop
 // ECMA 8.6.2.5
 bool JSObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
-    JSObject* thisObject = jsCast<JSObject*>(cell);
+    JSObject* thisObject = uncheckedDowncast<JSObject>(cell);
     VM& vm = globalObject->vm();
     
     if (std::optional<uint32_t> index = parseIndex(propertyName))
@@ -2411,7 +2411,7 @@ bool JSObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, Proper
 bool JSObject::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned i)
 {
     VM& vm = globalObject->vm();
-    JSObject* thisObject = jsCast<JSObject*>(cell);
+    JSObject* thisObject = uncheckedDowncast<JSObject>(cell);
     
     if (i > MAX_ARRAY_INDEX)
         return JSCell::deleteProperty(thisObject, globalObject, Identifier::from(vm, i));
@@ -2599,7 +2599,7 @@ JSValue JSObject::toPrimitive(JSGlobalObject* globalObject, PreferredPrimitiveTy
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (isJSArray(this)) {
-        auto* array = jsCast<JSArray*>(const_cast<JSObject*>(this));
+        auto* array = uncheckedDowncast<JSArray>(const_cast<JSObject*>(this));
         if (array->isToPrimitiveFastAndNonObservable()) [[likely]]
             RELEASE_AND_RETURN(scope, array->fastToString(globalObject));
     }
@@ -2842,7 +2842,7 @@ JSString* JSObject::toString(JSGlobalObject* globalObject) const
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (isJSArray(this)) {
-        auto* array = jsCast<JSArray*>(const_cast<JSObject*>(this));
+        auto* array = uncheckedDowncast<JSArray>(const_cast<JSObject*>(this));
         if (array->isToPrimitiveFastAndNonObservable()) [[likely]]
             RELEASE_AND_RETURN(scope, array->fastToString(globalObject));
     }
@@ -2945,13 +2945,13 @@ void JSObject::reifyAllStaticProperties(JSGlobalObject* globalObject)
 NEVER_INLINE void JSObject::fillGetterPropertySlot(VM&, PropertySlot& slot, JSCell* getterSetter, unsigned attributes, PropertyOffset offset)
 {
     if (structure()->isUncacheableDictionary()) {
-        slot.setGetterSlot(this, attributes, jsCast<GetterSetter*>(getterSetter));
+        slot.setGetterSlot(this, attributes, uncheckedDowncast<GetterSetter>(getterSetter));
         return;
     }
 
     // This access is cacheable because Structure requires an attributeChangedTransition
     // if this property stops being an accessor.
-    slot.setCacheableGetterSlot(this, attributes, jsCast<GetterSetter*>(getterSetter), offset);
+    slot.setCacheableGetterSlot(this, attributes, uncheckedDowncast<GetterSetter>(getterSetter), offset);
 }
 
 static bool putIndexedDescriptor(JSGlobalObject* globalObject, SparseArrayValueMap* map, SparseArrayEntry* entryInMap, const PropertyDescriptor& descriptor, PropertyDescriptor& oldDescriptor)
@@ -3181,13 +3181,13 @@ bool JSObject::attemptToInterceptPutByIndexOnHoleForPrototype(JSGlobalObject* gl
 
         if (current->type() == ProxyObjectType) {
             scope.release();
-            auto* proxy = jsCast<ProxyObject*>(current);
+            auto* proxy = uncheckedDowncast<ProxyObject>(current);
             putResult = proxy->putByIndexCommon(globalObject, thisValue, i, value, shouldThrow);
             return true;
         }
 
         if (isTypedArrayType(current->type())) {
-            auto* typedArray = jsCast<JSArrayBufferView*>(current);
+            auto* typedArray = uncheckedDowncast<JSArrayBufferView>(current);
             if (typedArray->isOutOfBounds() || i >= typedArray->length()) {
                 putResult = true;
                 return true;

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -1336,7 +1336,7 @@ inline JSObject* asObject(JSCell* cell)
 {
     ASSERT(cell);
     ASSERT(cell->isObjectSlow());
-    return jsCast<JSObject*>(cell);
+    return uncheckedDowncast<JSObject>(cell);
 }
 
 inline JSObject* asObject(JSValue value)
@@ -1416,7 +1416,7 @@ ALWAYS_INLINE bool JSObject::getOwnNonIndexPropertySlot(VM& vm, Structure* struc
             return true;
         case CustomGetterSetterType:
             ASSERT(attributes & PropertyAttribute::CustomAccessorOrValue);
-            fillCustomGetterPropertySlot(slot, jsCast<CustomGetterSetter*>(cell), attributes, structure);
+            fillCustomGetterPropertySlot(slot, uncheckedDowncast<CustomGetterSetter>(cell), attributes, structure);
             return true;
         default:
             break;
@@ -1431,7 +1431,7 @@ ALWAYS_INLINE void JSObject::fillCustomGetterPropertySlot(PropertySlot& slot, Cu
 {
     ASSERT(attributes & PropertyAttribute::CustomAccessorOrValue);
     if (customGetterSetter->inherits<DOMAttributeGetterSetter>()) {
-        auto* domAttribute = jsCast<DOMAttributeGetterSetter*>(customGetterSetter);
+        auto* domAttribute = uncheckedDowncast<DOMAttributeGetterSetter>(customGetterSetter);
         if (structure->isUncacheableDictionary())
             slot.setCustom(this, attributes, domAttribute->getter(), domAttribute->setter(), domAttribute->domAttribute());
         else

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -133,7 +133,7 @@ inline T JSObject::getAs(JSGlobalObject* globalObject, PropertyNameType property
     if (vm.exceptionForInspection())
         return nullptr;
 #endif
-    return jsCast<T>(value);
+    return uncheckedDowncast<std::remove_pointer_t<T>>(value);
 }
 
 template<typename CellType, SubspaceAccess>
@@ -220,7 +220,7 @@ ALWAYS_INLINE bool JSObject::getPropertySlot(JSGlobalObject* globalObject, unsig
             return false;
         if (object->type() == ProxyObjectType && slot.internalMethodType() == PropertySlot::InternalMethodType::HasProperty)
             return false;
-        if (isTypedArrayType(object->type()) && propertyName >= jsCast<JSArrayBufferView*>(object)->length())
+        if (isTypedArrayType(object->type()) && propertyName >= uncheckedDowncast<JSArrayBufferView>(object)->length())
             return false;
         JSValue prototype;
         if (!structure->typeInfo().overridesGetPrototype() || slot.internalMethodType() == PropertySlot::InternalMethodType::VMInquiry) [[likely]]
@@ -380,7 +380,7 @@ ALWAYS_INLINE bool JSObject::putInlineForJSObject(JSCell* cell, JSGlobalObject* 
 {
     VM& vm = getVM(globalObject);
 
-    JSObject* thisObject = jsCast<JSObject*>(cell);
+    JSObject* thisObject = uncheckedDowncast<JSObject>(cell);
     ASSERT(value);
     ASSERT(!Heap::heap(value) || Heap::heap(value) == Heap::heap(thisObject));
 
@@ -604,7 +604,7 @@ inline bool JSObject::canGetIndexQuicklyForTypedArray(unsigned i) const
     switch (type()) {
 #define CASE_TYPED_ARRAY_TYPE(name) \
     case name ## ArrayType :\
-        return jsCast<const JS ## name ## Array *>(this)->canGetIndexQuickly(i);
+        return uncheckedDowncast<JS ## name ## Array>(this)->canGetIndexQuickly(i);
         FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(CASE_TYPED_ARRAY_TYPE)
 #undef CASE_TYPED_ARRAY_TYPE
     default:
@@ -624,7 +624,7 @@ inline JSValue JSObject::getIndexQuicklyForTypedArray(unsigned i, ArrayProfile* 
     switch (type()) {
 #define CASE_TYPED_ARRAY_TYPE(name) \
     case name ## ArrayType : {\
-        auto* typedArray = jsCast<const JS ## name ## Array *>(this);\
+        auto* typedArray = uncheckedDowncast<JS ## name ## Array>(this);\
         RELEASE_ASSERT(typedArray->canGetIndexQuickly(i));\
         return typedArray->getIndexQuickly(i);\
     }
@@ -641,7 +641,7 @@ inline void JSObject::setIndexQuicklyForTypedArray(unsigned i, JSValue value)
     switch (type()) {
 #define CASE_TYPED_ARRAY_TYPE(name) \
     case name ## ArrayType : {\
-        auto* typedArray = jsCast<JS ## name ## Array *>(this);\
+        auto* typedArray = uncheckedDowncast<JS ## name ## Array>(this);\
         RELEASE_ASSERT(typedArray->canSetIndexQuickly(i, value));\
         typedArray->setIndexQuickly(i, value);\
         break;\
@@ -682,7 +682,7 @@ inline bool JSObject::trySetIndexQuicklyForTypedArray(unsigned i, JSValue v, Arr
 #endif
 #define CASE_TYPED_ARRAY_TYPE(name) \
     case name ## ArrayType : { \
-        auto* typedArray = jsCast<JS ## name ## Array *>(this);\
+        auto* typedArray = uncheckedDowncast<JS ## name ## Array>(this);\
         if (!typedArray->canSetIndexQuickly(i, v))\
             return false;\
         typedArray->setIndexQuickly(i, v);\
@@ -935,7 +935,7 @@ inline bool JSObject::hasPrivateBrand(JSGlobalObject*, JSValue brand)
 {
     ASSERT(brand.isSymbol() && asSymbol(brand)->uid().isPrivate());
     Structure* structure = this->structure();
-    return structure->isBrandedStructure() && jsCast<BrandedStructure*>(structure)->checkBrand(asSymbol(brand));
+    return structure->isBrandedStructure() && uncheckedDowncast<BrandedStructure>(structure)->checkBrand(asSymbol(brand));
 }
 
 inline void JSObject::checkPrivateBrand(JSGlobalObject* globalObject, JSValue brand)
@@ -945,7 +945,7 @@ inline void JSObject::checkPrivateBrand(JSGlobalObject* globalObject, JSValue br
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     Structure* structure = this->structure();
-    if (!structure->isBrandedStructure() || !jsCast<BrandedStructure*>(structure)->checkBrand(asSymbol(brand)))
+    if (!structure->isBrandedStructure() || !uncheckedDowncast<BrandedStructure>(structure)->checkBrand(asSymbol(brand)))
         throwException(globalObject, scope, createPrivateMethodAccessError(globalObject));
 }
 
@@ -956,7 +956,7 @@ inline void JSObject::setPrivateBrand(JSGlobalObject* globalObject, JSValue bran
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     Structure* structure = this->structure();
-    if (structure->isBrandedStructure() && jsCast<BrandedStructure*>(structure)->checkBrand(asSymbol(brand))) {
+    if (structure->isBrandedStructure() && uncheckedDowncast<BrandedStructure>(structure)->checkBrand(asSymbol(brand))) {
         throwException(globalObject, scope, createReinstallPrivateMethodError(globalObject));
         RELEASE_AND_RETURN(scope, void());
     }

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -79,7 +79,7 @@ void JSPromise::finishCreation(VM& vm)
 template<typename Visitor>
 void JSPromise::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSPromise*>(cell);
+    auto* thisObject = uncheckedDowncast<JSPromise>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }
@@ -159,7 +159,7 @@ JSPromise::DeferredData JSPromise::createDeferredData(JSGlobalObject* globalObje
 
 JSPromise* JSPromise::resolvedPromise(JSGlobalObject* globalObject, JSValue value)
 {
-    return jsCast<JSPromise*>(promiseResolve(globalObject, globalObject->promiseConstructor(), value));
+    return uncheckedDowncast<JSPromise>(promiseResolve(globalObject, globalObject->promiseConstructor(), value));
 }
 
 JSPromise* JSPromise::rejectedPromise(JSGlobalObject* globalObject, JSValue value)
@@ -257,7 +257,7 @@ void JSPromise::performPromiseThen(VM& vm, JSGlobalObject* globalObject, JSValue
     JSValue reactionsOrResult = this->reactionsOrResult();
     switch (status()) {
     case JSPromise::Status::Pending: {
-        auto* reaction = JSPromiseReaction::create(vm, promiseOrCapability, onFulfilled, onRejected, jsUndefined(), reactionsOrResult ? jsCast<JSPromiseReaction*>(reactionsOrResult) : nullptr);
+        auto* reaction = JSPromiseReaction::create(vm, promiseOrCapability, onFulfilled, onRejected, jsUndefined(), reactionsOrResult ? uncheckedDowncast<JSPromiseReaction>(reactionsOrResult) : nullptr);
         setReactionsOrResult(vm, reaction);
         markAsHandled();
         break;
@@ -282,7 +282,7 @@ void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* 
     switch (status()) {
     case JSPromise::Status::Pending: {
         JSValue encodedTask = jsNumber(static_cast<int32_t>(task));
-        auto* reaction = JSPromiseReaction::create(vm, promise, encodedTask, encodedTask, context, reactionsOrResult ? jsCast<JSPromiseReaction*>(reactionsOrResult) : nullptr);
+        auto* reaction = JSPromiseReaction::create(vm, promise, encodedTask, encodedTask, context, reactionsOrResult ? uncheckedDowncast<JSPromiseReaction>(reactionsOrResult) : nullptr);
         setReactionsOrResult(vm, reaction);
         markAsHandled();
         break;
@@ -337,7 +337,7 @@ void JSPromise::rejectPromise(VM& vm, JSGlobalObject* globalObject, JSValue argu
 
     if (!reactions)
         return;
-    triggerPromiseReactions(vm, globalObject, Status::Rejected, jsCast<JSPromiseReaction*>(reactions), argument);
+    triggerPromiseReactions(vm, globalObject, Status::Rejected, uncheckedDowncast<JSPromiseReaction>(reactions), argument);
 }
 
 void JSPromise::fulfillPromise(VM& vm, JSGlobalObject* globalObject, JSValue argument)
@@ -350,7 +350,7 @@ void JSPromise::fulfillPromise(VM& vm, JSGlobalObject* globalObject, JSValue arg
 
     if (!reactions)
         return;
-    triggerPromiseReactions(vm, globalObject, Status::Fulfilled, jsCast<JSPromiseReaction*>(reactions), argument);
+    triggerPromiseReactions(vm, globalObject, Status::Fulfilled, uncheckedDowncast<JSPromiseReaction>(reactions), argument);
 }
 
 void JSPromise::resolvePromise(JSGlobalObject* globalObject, VM& vm, JSValue resolution)
@@ -366,7 +366,7 @@ void JSPromise::resolvePromise(JSGlobalObject* globalObject, VM& vm, JSValue res
 
     auto* resolutionObject = asObject(resolution);
     if (resolutionObject->inherits<JSPromise>()) {
-        auto* promise = jsCast<JSPromise*>(resolutionObject);
+        auto* promise = uncheckedDowncast<JSPromise>(resolutionObject);
         if (promise->isThenFastAndNonObservable())
             return globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveThenableJobFast, 0, resolutionObject, this, jsUndefined());
     }
@@ -398,7 +398,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionResolve, (JSGlobalObject* globa
 {
     VM& vm = globalObject->vm();
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::ResolvingOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -406,7 +406,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionResolve, (JSGlobalObject* globa
     callee->setField(vm, JSFunctionWithFields::Field::ResolvingOther, jsNull());
     other->setField(vm, JSFunctionWithFields::Field::ResolvingOther, jsNull());
 
-    auto* promise = jsCast<JSPromise*>(callee->getField(JSFunctionWithFields::Field::ResolvingPromise));
+    auto* promise = uncheckedDowncast<JSPromise>(callee->getField(JSFunctionWithFields::Field::ResolvingPromise));
     JSValue argument = callFrame->argument(0);
 
     promise->resolvePromise(globalObject, vm, argument);
@@ -417,7 +417,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionReject, (JSGlobalObject* global
 {
     VM& vm = globalObject->vm();
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::ResolvingOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -425,7 +425,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionReject, (JSGlobalObject* global
     callee->setField(vm, JSFunctionWithFields::Field::ResolvingOther, jsNull());
     other->setField(vm, JSFunctionWithFields::Field::ResolvingOther, jsNull());
 
-    auto* promise = jsCast<JSPromise*>(callee->getField(JSFunctionWithFields::Field::ResolvingPromise));
+    auto* promise = uncheckedDowncast<JSPromise>(callee->getField(JSFunctionWithFields::Field::ResolvingPromise));
     JSValue argument = callFrame->argument(0);
 
     promise->rejectPromise(vm, globalObject, argument);
@@ -434,8 +434,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionReject, (JSGlobalObject* global
 
 JSC_DEFINE_HOST_FUNCTION(promiseFirstResolvingFunctionResolve, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* promise = jsCast<JSPromise*>(callee->getField(JSFunctionWithFields::Field::FirstResolvingPromise));
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
+    auto* promise = uncheckedDowncast<JSPromise>(callee->getField(JSFunctionWithFields::Field::FirstResolvingPromise));
     JSValue argument = callFrame->argument(0);
 
     promise->resolve(globalObject, globalObject->vm(), argument);
@@ -444,8 +444,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseFirstResolvingFunctionResolve, (JSGlobalObject* 
 
 JSC_DEFINE_HOST_FUNCTION(promiseFirstResolvingFunctionReject, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    auto* promise = jsCast<JSPromise*>(callee->getField(JSFunctionWithFields::Field::FirstResolvingPromise));
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
+    auto* promise = uncheckedDowncast<JSPromise>(callee->getField(JSFunctionWithFields::Field::FirstResolvingPromise));
     JSValue argument = callFrame->argument(0);
 
     promise->reject(globalObject->vm(), globalObject, argument);
@@ -456,7 +456,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionResolveWithInternalMicrotask, (
 {
     VM& vm = globalObject->vm();
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -464,7 +464,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionResolveWithInternalMicrotask, (
     callee->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther, jsNull());
     other->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther, jsNull());
 
-    auto* context = jsCast<JSPromiseCombinatorsGlobalContext*>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext));
+    auto* context = uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext));
     JSValue argument = callFrame->argument(0);
     JSValue onFulfilled = context->promise();
     JSPromise::resolveWithInternalMicrotask(globalObject, vm, argument, static_cast<InternalMicrotask>(onFulfilled.asInt32()), context->remainingElementsCount());
@@ -475,7 +475,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionRejectWithInternalMicrotask, (J
 {
     VM& vm = globalObject->vm();
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* other = dynamicDowncast<JSFunctionWithFields>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther));
     if (!other) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -483,7 +483,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionRejectWithInternalMicrotask, (J
     callee->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther, jsNull());
     other->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther, jsNull());
 
-    auto* context = jsCast<JSPromiseCombinatorsGlobalContext*>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext));
+    auto* context = uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext));
     JSValue argument = callFrame->argument(0);
     JSValue onFulfilled = context->promise();
     JSPromise::rejectWithInternalMicrotask(vm, globalObject, argument, static_cast<InternalMicrotask>(onFulfilled.asInt32()), context->remainingElementsCount());
@@ -495,7 +495,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseCapabilityExecutor, (JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     JSValue resolve = callee->getField(JSFunctionWithFields::Field::ExecutorResolve);
     if (!resolve.isUndefined()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "resolve function is already set"_s);
@@ -602,7 +602,7 @@ void JSPromise::triggerPromiseReactions(VM& vm, JSGlobalObject* globalObject, St
 void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* globalObject, VM& vm, JSValue resolution, InternalMicrotask task, JSValue context)
 {
     if (resolution.inherits<JSPromise>()) {
-        auto* promise = jsCast<JSPromise*>(resolution);
+        auto* promise = uncheckedDowncast<JSPromise>(resolution);
         if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]]
             return promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, jsUndefined(), context);
 
@@ -641,7 +641,7 @@ void JSPromise::resolveWithInternalMicrotask(JSGlobalObject* globalObject, VM& v
 
     auto* resolutionObject = asObject(resolution);
     if (resolutionObject->inherits<JSPromise>()) {
-        auto* promise = jsCast<JSPromise*>(resolutionObject);
+        auto* promise = uncheckedDowncast<JSPromise>(resolutionObject);
         if (promise->isThenFastAndNonObservable())
             return globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveThenableJobWithInternalMicrotaskFast, static_cast<uint8_t>(task), resolutionObject, context, jsUndefined());
     }
@@ -778,7 +778,7 @@ JSObject* JSPromise::promiseResolve(JSGlobalObject* globalObject, JSObject* cons
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (argument.inherits<JSPromise>()) {
-        auto* promise = jsCast<JSPromise*>(argument);
+        auto* promise = uncheckedDowncast<JSPromise>(argument);
         if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]] {
             if (constructor == promise->realm()->promiseConstructor())
                 return promise;

--- a/Source/JavaScriptCore/runtime/JSPromiseCombinatorsContext.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseCombinatorsContext.cpp
@@ -45,7 +45,7 @@ JSPromiseCombinatorsContext* JSPromiseCombinatorsContext::create(VM& vm, JSPromi
 template<typename Visitor>
 void JSPromiseCombinatorsContext::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSPromiseCombinatorsContext*>(cell);
+    auto* thisObject = uncheckedDowncast<JSPromiseCombinatorsContext>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_globalContext);

--- a/Source/JavaScriptCore/runtime/JSPromiseCombinatorsGlobalContext.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseCombinatorsGlobalContext.cpp
@@ -48,7 +48,7 @@ Structure* JSPromiseCombinatorsGlobalContext::createStructure(VM& vm, JSGlobalOb
 template<typename Visitor>
 void JSPromiseCombinatorsGlobalContext::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSPromiseCombinatorsGlobalContext*>(cell);
+    auto* thisObject = uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_promise);

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -193,7 +193,7 @@ static JSObject* promiseRaceSlow(JSGlobalObject* globalObject, CallFrame* callFr
     std::optional<CachedCall> cachedCallHolder;
     CachedCall* cachedCall = nullptr;
     if (promiseResolveCallData.type == CallData::Type::JS) [[likely]] {
-        cachedCallHolder.emplace(globalObject, jsCast<JSFunction*>(promiseResolveValue), 1);
+        cachedCallHolder.emplace(globalObject, uncheckedDowncast<JSFunction>(promiseResolveValue), 1);
         if (scope.exception()) [[unlikely]] {
             callRejectWithScopeException();
             return promise;
@@ -342,7 +342,7 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
     std::optional<CachedCall> cachedCallHolder;
     CachedCall* cachedCall = nullptr;
     if (promiseResolveCallData.type == CallData::Type::JS) [[likely]] {
-        cachedCallHolder.emplace(globalObject, jsCast<JSFunction*>(promiseResolveValue), 1);
+        cachedCallHolder.emplace(globalObject, uncheckedDowncast<JSFunction>(promiseResolveValue), 1);
         if (scope.exception()) [[unlikely]] {
             callRejectWithScopeException();
             return promise;
@@ -553,16 +553,16 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllFulfillFunction, (JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
     callee->setField(vm, JSFunctionWithFields::Field::PromiseAllContext, jsNull());
 
-    auto* globalContext = jsCast<JSPromiseCombinatorsGlobalContext*>(context->globalContext());
-    auto* promise = jsCast<JSPromise*>(globalContext->promise());
-    auto* values = jsCast<JSArray*>(globalContext->values());
+    auto* globalContext = context->globalContext();
+    auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
+    auto* values = uncheckedDowncast<JSArray>(globalContext->values());
 
     JSValue value = callFrame->argument(0);
     uint64_t index = context->index();
@@ -588,7 +588,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSlowFulfillFunction, (JSGlobalObject* globalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -598,8 +598,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSlowFulfillFunction, (JSGlobalObject* globalO
     callee->setField(vm, JSFunctionWithFields::Field::PromiseAllContext, jsNull());
     callee->setField(vm, JSFunctionWithFields::Field::PromiseAllResolve, jsNull());
 
-    auto* globalContext = jsCast<JSPromiseCombinatorsGlobalContext*>(context->globalContext());
-    auto* values = jsCast<JSArray*>(globalContext->values());
+    auto* globalContext = context->globalContext();
+    auto* values = uncheckedDowncast<JSArray>(globalContext->values());
 
     JSValue value = callFrame->argument(0);
     uint64_t index = context->index();
@@ -663,7 +663,7 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
     std::optional<CachedCall> cachedCallHolder;
     CachedCall* cachedCall = nullptr;
     if (promiseResolveCallData.type == CallData::Type::JS) [[likely]] {
-        cachedCallHolder.emplace(globalObject, jsCast<JSFunction*>(promiseResolveValue), 1);
+        cachedCallHolder.emplace(globalObject, uncheckedDowncast<JSFunction>(promiseResolveValue), 1);
         if (scope.exception()) [[unlikely]] {
             callRejectWithScopeException();
             return promise;
@@ -880,7 +880,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledFulfillFunction, (JSGlobalObject* glob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -894,9 +894,9 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledFulfillFunction, (JSGlobalObject* glob
     other->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledContext, jsNull());
     other->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledOther, jsNull());
 
-    auto* globalContext = jsCast<JSPromiseCombinatorsGlobalContext*>(context->globalContext());
-    auto* promise = jsCast<JSPromise*>(globalContext->promise());
-    auto* values = jsCast<JSArray*>(globalContext->values());
+    auto* globalContext = context->globalContext();
+    auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
+    auto* values = uncheckedDowncast<JSArray>(globalContext->values());
 
     JSValue value = callFrame->argument(0);
     uint64_t index = context->index();
@@ -924,7 +924,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledRejectFunction, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -938,9 +938,9 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledRejectFunction, (JSGlobalObject* globa
     other->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledContext, jsNull());
     other->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledOther, jsNull());
 
-    auto* globalContext = jsCast<JSPromiseCombinatorsGlobalContext*>(context->globalContext());
-    auto* promise = jsCast<JSPromise*>(globalContext->promise());
-    auto* values = jsCast<JSArray*>(globalContext->values());
+    auto* globalContext = context->globalContext();
+    auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
+    auto* values = uncheckedDowncast<JSArray>(globalContext->values());
 
     JSValue reason = callFrame->argument(0);
     uint64_t index = context->index();
@@ -968,7 +968,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledSlowFulfillFunction, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -982,8 +982,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledSlowFulfillFunction, (JSGlobalObject* 
     other->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledContext, jsNull());
     other->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledOther, jsNull());
 
-    auto* globalContext = jsCast<JSPromiseCombinatorsGlobalContext*>(context->globalContext());
-    auto* values = jsCast<JSArray*>(globalContext->values());
+    auto* globalContext = context->globalContext();
+    auto* values = uncheckedDowncast<JSArray>(globalContext->values());
     JSValue resolve = globalContext->promise();
 
     JSValue value = callFrame->argument(0);
@@ -1016,7 +1016,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledSlowRejectFunction, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAllSettledContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -1030,8 +1030,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledSlowRejectFunction, (JSGlobalObject* g
     other->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledContext, jsNull());
     other->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledOther, jsNull());
 
-    auto* globalContext = jsCast<JSPromiseCombinatorsGlobalContext*>(context->globalContext());
-    auto* values = jsCast<JSArray*>(globalContext->values());
+    auto* globalContext = context->globalContext();
+    auto* values = uncheckedDowncast<JSArray>(globalContext->values());
     JSValue resolve = globalContext->promise();
 
     JSValue reason = callFrame->argument(0);
@@ -1146,7 +1146,7 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
     std::optional<CachedCall> cachedCallHolder;
     CachedCall* cachedCall = nullptr;
     if (promiseResolveCallData.type == CallData::Type::JS) [[likely]] {
-        cachedCallHolder.emplace(globalObject, jsCast<JSFunction*>(promiseResolveValue), 1);
+        cachedCallHolder.emplace(globalObject, uncheckedDowncast<JSFunction>(promiseResolveValue), 1);
         if (scope.exception()) [[unlikely]] {
             callRejectWithScopeException();
             return promise;
@@ -1355,16 +1355,16 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnyRejectFunction, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAnyContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
     callee->setField(vm, JSFunctionWithFields::Field::PromiseAnyContext, jsNull());
 
-    auto* globalContext = jsCast<JSPromiseCombinatorsGlobalContext*>(context->globalContext());
-    auto* promise = jsCast<JSPromise*>(globalContext->promise());
-    auto* errors = jsCast<JSArray*>(globalContext->values());
+    auto* globalContext = context->globalContext();
+    auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
+    auto* errors = uncheckedDowncast<JSArray>(globalContext->values());
 
     JSValue reason = callFrame->argument(0);
     uint64_t index = context->index();
@@ -1391,7 +1391,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnySlowRejectFunction, (JSGlobalObject* globalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     auto* context = dynamicDowncast<JSPromiseCombinatorsContext>(callee->getField(JSFunctionWithFields::Field::PromiseAnyContext));
     if (!context) [[unlikely]]
         return JSValue::encode(jsUndefined());
@@ -1401,8 +1401,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnySlowRejectFunction, (JSGlobalObject* globalOb
     callee->setField(vm, JSFunctionWithFields::Field::PromiseAnyContext, jsNull());
     callee->setField(vm, JSFunctionWithFields::Field::PromiseAnyReject, jsNull());
 
-    auto* globalContext = jsCast<JSPromiseCombinatorsGlobalContext*>(context->globalContext());
-    auto* errors = jsCast<JSArray*>(globalContext->values());
+    auto* globalContext = context->globalContext();
+    auto* errors = uncheckedDowncast<JSArray>(globalContext->values());
 
     JSValue reason = callFrame->argument(0);
     uint64_t index = context->index();

--- a/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
@@ -154,7 +154,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseProtoFuncCatch, (JSGlobalObject* globalObject, C
 
 JSC_DEFINE_HOST_FUNCTION(promiseFinallyValueThunkFunc, (JSGlobalObject*, CallFrame* callFrame))
 {
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     JSValue value = callee->getField(JSFunctionWithFields::Field::ResolvingPromise);
     return JSValue::encode(value);
 }
@@ -163,7 +163,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseFinallyThrowerFunc, (JSGlobalObject* globalObjec
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     JSValue reason = callee->getField(JSFunctionWithFields::Field::ResolvingPromise);
     return throwVMError(globalObject, scope, reason);
 }
@@ -173,9 +173,9 @@ JSC_DEFINE_HOST_FUNCTION(promiseFinallyThenFinallyFunc, (JSGlobalObject* globalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     JSValue onFinally = callee->getField(JSFunctionWithFields::Field::ResolvingPromise);
-    JSObject* constructor = jsCast<JSObject*>(callee->getField(JSFunctionWithFields::Field::ResolvingOther));
+    JSObject* constructor = uncheckedDowncast<JSObject>(callee->getField(JSFunctionWithFields::Field::ResolvingOther));
     JSValue value = callFrame->argument(0);
 
     JSValue result = call(globalObject, onFinally, jsUndefined(), ArgList { }, "onFinally is not a function"_s);
@@ -205,9 +205,9 @@ JSC_DEFINE_HOST_FUNCTION(promiseFinallyCatchFinallyFunc, (JSGlobalObject* global
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* callee = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    auto* callee = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
     JSValue onFinally = callee->getField(JSFunctionWithFields::Field::ResolvingPromise);
-    JSObject* constructor = jsCast<JSObject*>(callee->getField(JSFunctionWithFields::Field::ResolvingOther));
+    JSObject* constructor = uncheckedDowncast<JSObject>(callee->getField(JSFunctionWithFields::Field::ResolvingOther));
     JSValue reason = callFrame->argument(0);
 
     JSValue result = call(globalObject, onFinally, jsUndefined(), ArgList { }, "onFinally is not a function"_s);

--- a/Source/JavaScriptCore/runtime/JSPromiseReaction.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseReaction.cpp
@@ -43,7 +43,7 @@ JSPromiseReaction* JSPromiseReaction::create(VM& vm, JSValue promise, JSValue on
 template<typename Visitor>
 void JSPromiseReaction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSPromiseReaction*>(cell);
+    auto* thisObject = uncheckedDowncast<JSPromiseReaction>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_promise);

--- a/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp
+++ b/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.cpp
@@ -88,7 +88,7 @@ void JSPropertyNameEnumerator::finishCreation(VM& vm, RefPtr<PropertyNameArray>&
 template<typename Visitor>
 void JSPropertyNameEnumerator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSPropertyNameEnumerator* thisObject = jsCast<JSPropertyNameEnumerator*>(cell);
+    JSPropertyNameEnumerator* thisObject = uncheckedDowncast<JSPropertyNameEnumerator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(cell, visitor);
     if (auto* propertyNames = thisObject->m_propertyNames.get()) {

--- a/Source/JavaScriptCore/runtime/JSRawJSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSRawJSONObject.cpp
@@ -64,8 +64,8 @@ Structure* JSRawJSONObject::createStructure(VM& vm, JSGlobalObject* globalObject
 JSString* JSRawJSONObject::rawJSON(VM& vm)
 {
     if (!structure()->didTransition()) [[likely]]
-        return jsCast<JSString*>(getDirect(rawJSONObjectRawJSONPropertyOffset));
-    return jsCast<JSString*>(getDirect(vm, vm.propertyNames->rawJSON));
+        return uncheckedDowncast<JSString>(getDirect(rawJSONObjectRawJSONPropertyOffset));
+    return uncheckedDowncast<JSString>(getDirect(vm, vm.propertyNames->rawJSON));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSRegExpStringIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSRegExpStringIterator.cpp
@@ -53,7 +53,7 @@ void JSRegExpStringIterator::finishCreation(VM& vm)
 template<typename Visitor>
 void JSRegExpStringIterator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSRegExpStringIterator*>(cell);
+    auto* thisObject = uncheckedDowncast<JSRegExpStringIterator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -85,9 +85,9 @@ JSC_DEFINE_HOST_FUNCTION(remoteFunctionCallForJSFunction, (JSGlobalObject* globa
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSRemoteFunction* remoteFunction = jsCast<JSRemoteFunction*>(callFrame->jsCallee());
+    JSRemoteFunction* remoteFunction = uncheckedDowncast<JSRemoteFunction>(callFrame->jsCallee());
     ASSERT(remoteFunction->isRemoteFunction());
-    JSFunction* targetFunction = jsCast<JSFunction*>(remoteFunction->targetFunction());
+    JSFunction* targetFunction = uncheckedDowncast<JSFunction>(remoteFunction->targetFunction());
     JSGlobalObject* targetGlobalObject = targetFunction->realm();
 
     MarkedArgumentBuffer args;
@@ -126,7 +126,7 @@ JSC_DEFINE_HOST_FUNCTION(remoteFunctionCallGeneric, (JSGlobalObject* globalObjec
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSRemoteFunction* remoteFunction = jsCast<JSRemoteFunction*>(callFrame->jsCallee());
+    JSRemoteFunction* remoteFunction = uncheckedDowncast<JSRemoteFunction>(callFrame->jsCallee());
     ASSERT(remoteFunction->isRemoteFunction());
     JSObject* targetFunction = remoteFunction->targetFunction();
     JSGlobalObject* targetGlobalObject = targetFunction->realm();
@@ -174,13 +174,13 @@ JSC_DEFINE_HOST_FUNCTION(createRemoteFunction, (JSGlobalObject* globalObject, Ca
     JSValue targetFunction = callFrame->uncheckedArgument(0);
     ASSERT(targetFunction.isCallable());
 
-    JSObject* targetCallable = jsCast<JSObject*>(targetFunction.asCell());
+    JSObject* targetCallable = uncheckedDowncast<JSObject>(targetFunction.asCell());
     JSGlobalObject* destinationGlobalObject = globalObject;
     if (!callFrame->uncheckedArgument(1).isUndefinedOrNull()) {
         if (auto shadowRealm = dynamicDowncast<ShadowRealmObject>(callFrame->uncheckedArgument(1)))
             destinationGlobalObject = shadowRealm->globalObject();
         else
-            destinationGlobalObject = jsCast<JSGlobalObject*>(callFrame->uncheckedArgument(1));
+            destinationGlobalObject = uncheckedDowncast<JSGlobalObject>(callFrame->uncheckedArgument(1));
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(JSRemoteFunction::tryCreate(destinationGlobalObject, vm, targetCallable)));
@@ -259,7 +259,7 @@ void JSRemoteFunction::finishCreation(JSGlobalObject* globalObject, VM& vm)
 template<typename Visitor>
 void JSRemoteFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSRemoteFunction* thisObject = jsCast<JSRemoteFunction*>(cell);
+    JSRemoteFunction* thisObject = uncheckedDowncast<JSRemoteFunction>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 

--- a/Source/JavaScriptCore/runtime/JSScope.cpp
+++ b/Source/JavaScriptCore/runtime/JSScope.cpp
@@ -44,7 +44,7 @@ const ClassInfo JSScope::s_info = { "Scope"_s, &Base::s_info, nullptr, nullptr, 
 template<typename Visitor>
 void JSScope::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSScope* thisObject = jsCast<JSScope*>(cell);
+    JSScope* thisObject = uncheckedDowncast<JSScope>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_next);
@@ -59,7 +59,7 @@ static inline bool abstractAccess(JSGlobalObject* globalObject, JSScope* scope, 
     DeferTerminationForAWhile deferScope(vm);
 
     if (scope->isJSLexicalEnvironment()) {
-        JSLexicalEnvironment* lexicalEnvironment = jsCast<JSLexicalEnvironment*>(scope);
+        JSLexicalEnvironment* lexicalEnvironment = uncheckedDowncast<JSLexicalEnvironment>(scope);
 
         SymbolTable* symbolTable = lexicalEnvironment->symbolTable();
         {
@@ -80,7 +80,7 @@ static inline bool abstractAccess(JSGlobalObject* globalObject, JSScope* scope, 
         }
 
         if (scope->type() == ModuleEnvironmentType) {
-            JSModuleEnvironment* moduleEnvironment = jsCast<JSModuleEnvironment*>(scope);
+            JSModuleEnvironment* moduleEnvironment = uncheckedDowncast<JSModuleEnvironment>(scope);
             AbstractModuleRecord* moduleRecord = moduleEnvironment->moduleRecord();
             auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
             AbstractModuleRecord::Resolution resolution = moduleRecord->resolveImport(globalObject, ident);
@@ -105,7 +105,7 @@ static inline bool abstractAccess(JSGlobalObject* globalObject, JSScope* scope, 
     }
 
     if (scope->isGlobalLexicalEnvironment()) {
-        JSGlobalLexicalEnvironment* globalLexicalEnvironment = jsCast<JSGlobalLexicalEnvironment*>(scope);
+        JSGlobalLexicalEnvironment* globalLexicalEnvironment = uncheckedDowncast<JSGlobalLexicalEnvironment>(scope);
         SymbolTable* symbolTable = globalLexicalEnvironment->symbolTable();
         ConcurrentJSLocker locker(symbolTable->m_lock);
         auto iter = symbolTable->find(locker, ident.impl());
@@ -137,7 +137,7 @@ static inline bool abstractAccess(JSGlobalObject* globalObject, JSScope* scope, 
     }
 
     if (scope->isGlobalObject()) {
-        JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(scope);
+        JSGlobalObject* globalObject = uncheckedDowncast<JSGlobalObject>(scope);
         {
             SymbolTable* symbolTable = globalObject->symbolTable();
             ConcurrentJSLocker locker(symbolTable->m_lock);
@@ -200,7 +200,7 @@ JSObject* JSScope::objectAtScope(JSScope* scope)
 {
     JSObject* object = scope;
     if (object->type() == WithScopeType)
-        return jsCast<JSWithScope*>(object)->object();
+        return uncheckedDowncast<JSWithScope>(object)->object();
 
     return object;
 }
@@ -217,7 +217,7 @@ static inline bool isUnscopable(JSGlobalObject* globalObject, JSScope* scope, JS
     RETURN_IF_EXCEPTION(throwScope, false);
     if (!unscopables.isObject())
         return false;
-    JSValue blocked = jsCast<JSObject*>(unscopables)->get(globalObject, ident);
+    JSValue blocked = uncheckedDowncast<JSObject>(unscopables)->get(globalObject, ident);
     RETURN_IF_EXCEPTION(throwScope, false);
 
     return blocked.toBoolean(globalObject);
@@ -328,12 +328,12 @@ void JSScope::collectClosureVariablesUnderTDZ(JSScope* scope, TDZEnvironment& re
             continue;
 
         if (scope->isModuleScope()) {
-            AbstractModuleRecord* moduleRecord = jsCast<JSModuleEnvironment*>(scope)->moduleRecord();
+            AbstractModuleRecord* moduleRecord = uncheckedDowncast<JSModuleEnvironment>(scope)->moduleRecord();
             for (const auto& pair : moduleRecord->importEntries())
                 result.add(pair.key);
         }
 
-        SymbolTable* symbolTable = jsCast<JSSymbolTableObject*>(scope)->symbolTable();
+        SymbolTable* symbolTable = uncheckedDowncast<JSSymbolTableObject>(scope)->symbolTable();
         ASSERT(symbolTable->scopeType() == SymbolTable::ScopeType::LexicalScope || symbolTable->scopeType() == SymbolTable::ScopeType::CatchScope || symbolTable->scopeType() == SymbolTable::ScopeType::CatchScopeWithSimpleParameter);
         ConcurrentJSLocker locker(symbolTable->m_lock);
         for (auto end = symbolTable->end(locker), iter = symbolTable->begin(locker); iter != end; ++iter)
@@ -351,14 +351,14 @@ bool JSScope::isVarScope()
 {
     if (type() != LexicalEnvironmentType)
         return false;
-    return jsCast<JSLexicalEnvironment*>(this)->symbolTable()->scopeType() == SymbolTable::ScopeType::VarScope;
+    return uncheckedDowncast<JSLexicalEnvironment>(this)->symbolTable()->scopeType() == SymbolTable::ScopeType::VarScope;
 }
 
 bool JSScope::isLexicalScope()
 {
     if (!isJSLexicalEnvironment())
         return false;
-    return jsCast<JSLexicalEnvironment*>(this)->symbolTable()->scopeType() == SymbolTable::ScopeType::LexicalScope;
+    return uncheckedDowncast<JSLexicalEnvironment>(this)->symbolTable()->scopeType() == SymbolTable::ScopeType::LexicalScope;
 }
 
 bool JSScope::isModuleScope()
@@ -371,7 +371,7 @@ bool JSScope::isCatchScope()
     if (type() != LexicalEnvironmentType)
         return false;
 
-    auto scopeType = jsCast<JSLexicalEnvironment*>(this)->symbolTable()->scopeType();
+    auto scopeType = uncheckedDowncast<JSLexicalEnvironment>(this)->symbolTable()->scopeType();
     return scopeType == SymbolTable::ScopeType::CatchScope
         || scopeType == SymbolTable::ScopeType::CatchScopeWithSimpleParameter;
 }
@@ -380,21 +380,21 @@ bool JSScope::isCatchScopeWithSimpleParameter()
 {
     if (type() != LexicalEnvironmentType)
         return false;
-    return jsCast<JSLexicalEnvironment*>(this)->symbolTable()->scopeType() == SymbolTable::ScopeType::CatchScopeWithSimpleParameter;
+    return uncheckedDowncast<JSLexicalEnvironment>(this)->symbolTable()->scopeType() == SymbolTable::ScopeType::CatchScopeWithSimpleParameter;
 }
 
 bool JSScope::isFunctionNameScopeObject()
 {
     if (type() != LexicalEnvironmentType)
         return false;
-    return jsCast<JSLexicalEnvironment*>(this)->symbolTable()->scopeType() == SymbolTable::ScopeType::FunctionNameScope;
+    return uncheckedDowncast<JSLexicalEnvironment>(this)->symbolTable()->scopeType() == SymbolTable::ScopeType::FunctionNameScope;
 }
 
 bool JSScope::isNestedLexicalScope()
 {
     if (!isJSLexicalEnvironment())
         return false;
-    return jsCast<JSLexicalEnvironment*>(this)->symbolTable()->isNestedLexicalScope();
+    return uncheckedDowncast<JSLexicalEnvironment>(this)->symbolTable()->isNestedLexicalScope();
 }
 
 JSScope* JSScope::constantScopeForCodeBlock(ResolveType type, CodeBlock* codeBlock)

--- a/Source/JavaScriptCore/runtime/JSSegmentedVariableObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSSegmentedVariableObject.cpp
@@ -65,7 +65,7 @@ ScopeOffset JSSegmentedVariableObject::addVariables(unsigned numberOfVariablesTo
 template<typename Visitor>
 void JSSegmentedVariableObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSSegmentedVariableObject* thisObject = jsCast<JSSegmentedVariableObject*>(cell);
+    JSSegmentedVariableObject* thisObject = uncheckedDowncast<JSSegmentedVariableObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     
@@ -80,7 +80,7 @@ DEFINE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE, JSSegmentedVariableObject
 
 void JSSegmentedVariableObject::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
-    JSSegmentedVariableObject* thisObject = jsCast<JSSegmentedVariableObject*>(cell);
+    JSSegmentedVariableObject* thisObject = uncheckedDowncast<JSSegmentedVariableObject>(cell);
     Base::analyzeHeap(cell, analyzer);
 
     ConcurrentJSLocker locker(thisObject->symbolTable()->m_lock);

--- a/Source/JavaScriptCore/runtime/JSSetIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSSetIterator.cpp
@@ -61,7 +61,7 @@ void JSSetIterator::finishCreation(VM& vm)
 template<typename Visitor>
 void JSSetIterator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSSetIterator*>(cell);
+    auto* thisObject = uncheckedDowncast<JSSetIterator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }
@@ -77,7 +77,7 @@ JSC_DEFINE_HOST_FUNCTION(setIteratorPrivateFuncSetIteratorNext, (JSGlobalObject 
     if (cell == vm.orderedHashTableSentinel())
         return JSValue::encode(cell);
 
-    JSSetIterator* iterator = jsCast<JSSetIterator*>(cell);
+    JSSetIterator* iterator = uncheckedDowncast<JSSetIterator>(cell);
     return JSValue::encode(iterator->next(vm));
 }
 
@@ -90,7 +90,7 @@ JSC_DEFINE_HOST_FUNCTION(setIteratorPrivateFuncSetIteratorKey, (JSGlobalObject *
     if (cell == vm.orderedHashTableSentinel())
         return JSValue::encode(cell);
 
-    JSSetIterator* iterator = jsCast<JSSetIterator*>(cell);
+    JSSetIterator* iterator = uncheckedDowncast<JSSetIterator>(cell);
     return JSValue::encode(iterator->peekKey(vm));
 }
 

--- a/Source/JavaScriptCore/runtime/JSSetIterator.h
+++ b/Source/JavaScriptCore/runtime/JSSetIterator.h
@@ -99,7 +99,7 @@ public:
             setStorage(vm, storage);
         }
 
-        JSSet::Storage& storageRef = *jsCast<JSSet::Storage*>(storage);
+        JSSet::Storage& storageRef = *uncheckedDowncast<JSSet::Storage>(storage);
         auto result = JSSet::Helper::transitAndNext(vm, storageRef, entry());
         if (!result.storage) {
             markClosed(sentinel);
@@ -142,12 +142,12 @@ public:
         JSCell* storage = this->tryGetStorage();
         ASSERT(storage);
         ASSERT_UNUSED(vm, storage != vm.orderedHashTableSentinel());
-        JSSet::Storage& storageRef = *jsCast<JSSet::Storage*>(storage);
+        JSSet::Storage& storageRef = *uncheckedDowncast<JSSet::Storage>(storage);
         return JSSet::Helper::getKey(storageRef, entry);
     }
 
     IterationKind kind() const { return static_cast<IterationKind>(internalField(Field::Kind).get().asUInt32AsAnyInt()); }
-    JSSet* iteratedObject() const { return jsCast<JSSet*>(internalField(Field::IteratedObject).get()); }
+    JSSet* iteratedObject() const { return uncheckedDowncast<JSSet>(internalField(Field::IteratedObject).get()); }
     JSCell* tryGetStorage() const
     {
         JSValue value = internalField(Field::Storage).get();

--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -67,7 +67,7 @@ void JSRopeString::RopeBuilder<RecordOverflow>::expand()
 
 void JSString::dumpToStream(const JSCell* cell, PrintStream& out)
 {
-    const JSString* thisObject = jsCast<const JSString*>(cell);
+    const JSString* thisObject = uncheckedDowncast<JSString>(cell);
     out.printf("<%p, %s, [%u], ", thisObject, thisObject->className().characters(), thisObject->length());
     uintptr_t pointer = thisObject->fiberConcurrently();
     if (pointer & isRopeInPointer) {

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -796,7 +796,7 @@ inline StringImpl* JSString::tryGetValueImpl() const
 inline JSString* asString(JSValue value)
 {
     ASSERT(value.isStringSlow());
-    return jsCast<JSString*>(value.asCell());
+    return uncheckedDowncast<JSString>(value.asCell());
 }
 
 // This MUST NOT GC.

--- a/Source/JavaScriptCore/runtime/JSStringIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSStringIterator.cpp
@@ -60,7 +60,7 @@ void JSStringIterator::finishCreation(VM& vm)
 JSStringIterator* JSStringIterator::clone(JSGlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
-    JSString* iteratedString = jsCast<JSString*>(this->iteratedString());
+    JSString* iteratedString = uncheckedDowncast<JSString>(this->iteratedString());
     auto* clone = JSStringIterator::create(vm, globalObject->stringIteratorStructure(), iteratedString);
     clone->internalField(Field::Index).set(vm, clone, this->index());
     return clone;
@@ -69,7 +69,7 @@ JSStringIterator* JSStringIterator::clone(JSGlobalObject* globalObject)
 template<typename Visitor>
 void JSStringIterator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSStringIterator*>(cell);
+    auto* thisObject = uncheckedDowncast<JSStringIterator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.h
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.h
@@ -153,7 +153,7 @@ ALWAYS_INLINE bool JSStringJoiner::appendWithoutSideEffects(JSGlobalObject* glob
             // Since getting the view didn't OOM, we know that the underlying String exists and isn't
             // a rope. Thus, `tryGetValue` on the owner JSString will succeed. Since jsString could be
             // a substring we make sure to get the owner's String not jsString's.
-            append(jsString, StringViewWithUnderlyingString(view, jsCast<const JSString*>(view.owner)->tryGetValue()));
+            append(jsString, StringViewWithUnderlyingString(view, uncheckedDowncast<JSString>(view.owner)->tryGetValue()));
             return true;
         }
         return false;
@@ -203,7 +203,7 @@ ALWAYS_INLINE bool JSStringJoiner::append(JSGlobalObject* globalObject, JSValue 
         auto view = jsString->view(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
         scope.release();
-        append(jsString, StringViewWithUnderlyingString(view, jsCast<const JSString*>(view.owner)->tryGetValue()));
+        append(jsString, StringViewWithUnderlyingString(view, uncheckedDowncast<JSString>(view.owner)->tryGetValue()));
         return false;
     }
     return true;

--- a/Source/JavaScriptCore/runtime/JSSymbolTableObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSSymbolTableObject.cpp
@@ -39,7 +39,7 @@ const ClassInfo JSSymbolTableObject::s_info = { "SymbolTableObject"_s, &Base::s_
 template<typename Visitor>
 void JSSymbolTableObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSSymbolTableObject* thisObject = jsCast<JSSymbolTableObject*>(cell);
+    JSSymbolTableObject* thisObject = uncheckedDowncast<JSSymbolTableObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_symbolTable);
@@ -49,7 +49,7 @@ DEFINE_VISIT_CHILDREN(JSSymbolTableObject);
 
 bool JSSymbolTableObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
-    JSSymbolTableObject* thisObject = jsCast<JSSymbolTableObject*>(cell);
+    JSSymbolTableObject* thisObject = uncheckedDowncast<JSSymbolTableObject>(cell);
     if (thisObject->symbolTable()->contains(propertyName.uid()))
         return false;
 
@@ -59,7 +59,7 @@ bool JSSymbolTableObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObj
 void JSSymbolTableObject::getOwnSpecialPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder& propertyNames, DontEnumPropertiesMode mode)
 {
     VM& vm = globalObject->vm();
-    JSSymbolTableObject* thisObject = jsCast<JSSymbolTableObject*>(object);
+    JSSymbolTableObject* thisObject = uncheckedDowncast<JSSymbolTableObject>(object);
     SymbolTable* symbolTable = thisObject->symbolTable();
     {
         ConcurrentJSLocker locker(symbolTable->m_lock);

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
@@ -122,7 +122,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncIsSharedTypedArrayView, (JSGlo
         return JSValue::encode(jsBoolean(false));
     if (!isTypedView(value.asCell()->type()))
         return JSValue::encode(jsBoolean(false));
-    return JSValue::encode(jsBoolean(jsCast<JSArrayBufferView*>(value)->isShared()));
+    return JSValue::encode(jsBoolean(uncheckedDowncast<JSArrayBufferView>(value)->isShared()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncIsResizableOrGrowableSharedTypedArrayView, (JSGlobalObject*, CallFrame* callFrame))
@@ -132,7 +132,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncIsResizableOrGrowableSharedTyp
         return JSValue::encode(jsBoolean(false));
     if (!isTypedView(value.asCell()->type()))
         return JSValue::encode(jsBoolean(false));
-    return JSValue::encode(jsBoolean(jsCast<JSArrayBufferView*>(value)->isResizableOrGrowableShared()));
+    return JSValue::encode(jsBoolean(uncheckedDowncast<JSArrayBufferView>(value)->isResizableOrGrowableShared()));
 }
 
 static inline std::optional<JSType> NODELETE isTypedArrayViewConstructor(JSValue value)
@@ -160,7 +160,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncTypedArrayFromFast, (JSGlobalO
     if (!type)
         return JSValue::encode(jsUndefined());
 
-    if (jsCast<JSObject*>(constructor)->realm() != globalObject)
+    if (uncheckedDowncast<JSObject>(constructor)->realm() != globalObject)
         return JSValue::encode(jsUndefined());
 
     scope.release();
@@ -171,7 +171,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncIsDetached, (JSGlobalObject*, 
 {
     JSValue argument = callFrame->uncheckedArgument(0);
     ASSERT(argument.isCell() && isTypedView(argument.asCell()->type()));
-    return JSValue::encode(jsBoolean(jsCast<JSArrayBufferView*>(argument)->isDetached()));
+    return JSValue::encode(jsBoolean(uncheckedDowncast<JSArrayBufferView>(argument)->isDetached()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncLength, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -182,7 +182,7 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncLength, (JSGlobalObject* globa
     if (!argument.isCell() || !isTypedView(argument.asCell()->type())) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view"_s);
 
-    JSArrayBufferView* thisObject = jsCast<JSArrayBufferView*>(argument);
+    JSArrayBufferView* thisObject = uncheckedDowncast<JSArrayBufferView>(argument);
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -197,7 +197,7 @@ inline EncodedJSValue createTypedArrayIteratorObject(JSGlobalObject* globalObjec
     if (!callFrame->thisValue().isCell() || !isTypedArrayType(callFrame->thisValue().asCell()->type())) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view"_s);
 
-    JSArrayBufferView* thisObject = jsCast<JSArrayBufferView*>(callFrame->thisValue());
+    JSArrayBufferView* thisObject = uncheckedDowncast<JSArrayBufferView>(callFrame->thisValue());
     validateTypedArray(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/JavaScriptCore/runtime/JSWeakObjectRef.cpp
+++ b/Source/JavaScriptCore/runtime/JSWeakObjectRef.cpp
@@ -42,7 +42,7 @@ void JSWeakObjectRef::finishCreation(VM& vm, JSCell* value)
 template<typename Visitor>
 void JSWeakObjectRef::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSWeakObjectRef*>(cell);
+    auto* thisObject = uncheckedDowncast<JSWeakObjectRef>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     // This doesn't need to be atomic because if we are out of date we will get write barriered and revisit ourselves.

--- a/Source/JavaScriptCore/runtime/JSWithScope.cpp
+++ b/Source/JavaScriptCore/runtime/JSWithScope.cpp
@@ -44,7 +44,7 @@ JSWithScope* JSWithScope::create(
 template<typename Visitor>
 void JSWithScope::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSWithScope* thisObject = jsCast<JSWithScope*>(cell);
+    JSWithScope* thisObject = uncheckedDowncast<JSWithScope>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_object);

--- a/Source/JavaScriptCore/runtime/JSWrapForValidIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSWrapForValidIterator.cpp
@@ -59,7 +59,7 @@ void JSWrapForValidIterator::finishCreation(VM& vm, JSValue iterator, JSValue ne
 template<typename Visitor>
 void JSWrapForValidIterator::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSWrapForValidIterator*>(cell);
+    auto* thisObject = uncheckedDowncast<JSWrapForValidIterator>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
+++ b/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
@@ -68,8 +68,8 @@ public:
     static JSWrapForValidIterator* createWithInitialValues(VM&, Structure*);
     static JSWrapForValidIterator* create(VM&, Structure*, JSValue iterator, JSValue nextMethod);
 
-    JSObject* iteratedIterator() const { return jsCast<JSObject*>(internalField(Field::IteratedIterator).get()); }
-    JSObject* iteratedNextMethod() const { return jsCast<JSObject*>(internalField(Field::IteratedNextMethod).get()); }
+    JSObject* iteratedIterator() const { return uncheckedDowncast<JSObject>(internalField(Field::IteratedIterator).get()); }
+    JSObject* iteratedNextMethod() const { return uncheckedDowncast<JSObject>(internalField(Field::IteratedNextMethod).get()); }
 
     void setIteratedIterator(VM& vm, JSValue iterator) { internalField(Field::IteratedIterator).set(vm, this, iterator); }
     void setIteratedNextMethod(VM& vm, JSValue nextMethod) { internalField(Field::IteratedNextMethod).set(vm, this, nextMethod); }

--- a/Source/JavaScriptCore/runtime/JSWrapperObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSWrapperObject.cpp
@@ -32,7 +32,7 @@ STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSWrapperObject);
 template<typename Visitor>
 void JSWrapperObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSWrapperObject*>(cell);
+    auto* thisObject = uncheckedDowncast<JSWrapperObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/Lookup.cpp
+++ b/Source/JavaScriptCore/runtime/Lookup.cpp
@@ -67,7 +67,7 @@ bool setUpStaticFunctionSlot(VM& vm, const ClassInfo* classInfo, const HashTable
     }
 
     if (isAccessor)
-        slot.setCacheableGetterSlot(thisObject, attributes, jsCast<GetterSetter*>(thisObject->getDirect(offset)), offset);
+        slot.setCacheableGetterSlot(thisObject, attributes, uncheckedDowncast<GetterSetter>(thisObject->getDirect(offset)), offset);
     else
         slot.setValue(thisObject, attributes, thisObject->getDirect(offset), offset);
     return true;

--- a/Source/JavaScriptCore/runtime/Lookup.h
+++ b/Source/JavaScriptCore/runtime/Lookup.h
@@ -523,7 +523,7 @@ inline void reifyStaticProperty(VM& vm, const ClassInfo* classInfo, const Proper
     if (value.attributes() & PropertyAttribute::ClassStructure) {
         LazyClassStructure* lazyStructure = std::bit_cast<LazyClassStructure*>(
             std::bit_cast<char*>(&thisObj) + value.lazyClassStructureOffset());
-        JSObject* constructor = lazyStructure->constructor(jsCast<JSGlobalObject*>(&thisObj));
+        JSObject* constructor = lazyStructure->constructor(&uncheckedDowncast<JSGlobalObject>(thisObj));
         thisObj.putDirect(vm, propertyName, constructor, attributesForStructure(value.attributes()));
         return;
     }

--- a/Source/JavaScriptCore/runtime/MapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/MapConstructor.cpp
@@ -138,7 +138,7 @@ JSC_DEFINE_HOST_FUNCTION(mapPrivateFuncMapIterationNext, (JSGlobalObject* global
     if (cell == vm.orderedHashTableSentinel())
         return JSValue::encode(vm.orderedHashTableSentinel());
 
-    JSMap::Storage& storage = *jsCast<JSMap::Storage*>(cell);
+    JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
     JSMap::Helper::Entry entry = JSMap::Helper::toNumber(callFrame->uncheckedArgument(1));
     return JSValue::encode(JSMap::Helper::nextAndUpdateIterationEntry(vm, storage, entry));
 }
@@ -151,7 +151,7 @@ JSC_DEFINE_HOST_FUNCTION(mapPrivateFuncMapIterationEntry, (JSGlobalObject* globa
     JSCell* cell = callFrame->uncheckedArgument(0).asCell();
     ASSERT_UNUSED(vm, cell != vm.orderedHashTableSentinel());
 
-    JSMap::Storage& storage = *jsCast<JSMap::Storage*>(cell);
+    JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
     return JSValue::encode(JSMap::Helper::getIterationEntry(storage));
 }
 
@@ -163,7 +163,7 @@ JSC_DEFINE_HOST_FUNCTION(mapPrivateFuncMapIterationEntryKey, (JSGlobalObject* gl
     JSCell* cell = callFrame->uncheckedArgument(0).asCell();
     ASSERT_UNUSED(vm, cell != vm.orderedHashTableSentinel());
 
-    JSMap::Storage& storage = *jsCast<JSMap::Storage*>(cell);
+    JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
     return JSValue::encode(JSMap::Helper::getIterationEntryKey(storage));
 }
 
@@ -175,14 +175,14 @@ JSC_DEFINE_HOST_FUNCTION(mapPrivateFuncMapIterationEntryValue, (JSGlobalObject* 
     JSCell* cell = callFrame->uncheckedArgument(0).asCell();
     ASSERT_UNUSED(vm, cell != vm.orderedHashTableSentinel());
 
-    JSMap::Storage& storage = *jsCast<JSMap::Storage*>(cell);
+    JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
     return JSValue::encode(JSMap::Helper::getIterationEntryValue(storage));
 }
 
 JSC_DEFINE_HOST_FUNCTION(mapPrivateFuncMapStorage, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     ASSERT(is<JSMap>(callFrame->argument(0)));
-    JSMap* map = jsCast<JSMap*>(callFrame->uncheckedArgument(0));
+    JSMap* map = uncheckedDowncast<JSMap>(callFrame->uncheckedArgument(0));
     return JSValue::encode(map->storageOrSentinel(getVM(globalObject)));
 }
 

--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -221,7 +221,7 @@ JSC_DEFINE_HOST_FUNCTION(mapProtoFuncGetOrInsertComputed, (JSGlobalObject* globa
         ASSERT(callData.type != CallData::Type::None);
 
         if (callData.type == CallData::Type::JS) [[likely]] {
-            CachedCall cachedCall(globalObject, jsCast<JSFunction*>(valueCallback), 1);
+            CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(valueCallback), 1);
             RETURN_IF_EXCEPTION(scope, JSValue());
 
             return cachedCall.callWithArguments(globalObject, jsUndefined(), key);

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -461,7 +461,7 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncSumPrecise, (JSGlobalObject* globalObject,
     scope.release();
 
     const std::optional<uint64_t> length = isJSArray(iterable) ?
-        std::make_optional(static_cast<uint64_t>(jsCast<JSArray*>(iterable)->length()))
+        std::make_optional(static_cast<uint64_t>(uncheckedDowncast<JSArray>(iterable)->length()))
         : std::nullopt;
 
     auto calculatePreciseSum = [&](auto& sum) {

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -52,8 +52,8 @@ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(DebuggableMicrotaskDispatcher);
 bool QueuedTask::isRunnable() const
 {
     if (isJSMicrotaskDispatcher()) [[unlikely]]
-        return jsCast<JSMicrotaskDispatcher*>(dispatcher())->dispatcher()->isRunnable();
-    return jsCast<JSGlobalObject*>(dispatcher())->microtaskRunnability() == QueuedTaskResult::Executed;
+        return uncheckedDowncast<JSMicrotaskDispatcher>(dispatcher())->dispatcher()->isRunnable();
+    return uncheckedDowncast<JSGlobalObject>(dispatcher())->microtaskRunnability() == QueuedTaskResult::Executed;
 }
 
 static bool runMicrotask(JSGlobalObject* globalObject, TopExceptionScope& catchScope, VM& vm, QueuedTask& task, MicrotaskCall* microtaskCall)
@@ -177,7 +177,7 @@ ALWAYS_INLINE std::pair<JSGlobalObject*, bool> MicrotaskQueue::drainImpl(JSGloba
         auto& front = m_queue.front();
 
         if (!front.isJSMicrotaskDispatcher()) [[likely]] {
-            auto* globalObject = jsCast<JSGlobalObject*>(front.dispatcher());
+            auto* globalObject = uncheckedDowncast<JSGlobalObject>(front.dispatcher());
             auto result = globalObject->microtaskRunnability();
             if (result != QueuedTask::Result::Executed) [[unlikely]] {
                 auto task = m_queue.dequeue();
@@ -195,7 +195,7 @@ ALWAYS_INLINE std::pair<JSGlobalObject*, bool> MicrotaskQueue::drainImpl(JSGloba
                 return { nullptr, true };
             }
         } else {
-            auto* jsMicrotaskDispatcher = jsCast<JSMicrotaskDispatcher*>(front.dispatcher());
+            auto* jsMicrotaskDispatcher = uncheckedDowncast<JSMicrotaskDispatcher>(front.dispatcher());
             auto* globalObject = front.globalObject();
 
             if (globalObject != currentGlobalObject) [[unlikely]]

--- a/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
@@ -42,14 +42,14 @@ inline JSCell* QueuedTask::dispatcher() const
 inline JSGlobalObject* QueuedTask::globalObject() const
 {
     if (isJSMicrotaskDispatcher()) [[unlikely]]
-        return jsCast<JSMicrotaskDispatcher*>(dispatcher())->globalObject();
-    return jsCast<JSGlobalObject*>(dispatcher());
+        return uncheckedDowncast<JSMicrotaskDispatcher>(dispatcher())->globalObject();
+    return uncheckedDowncast<JSGlobalObject>(dispatcher());
 }
 
 inline JSMicrotaskDispatcher* QueuedTask::jsMicrotaskDispatcher() const
 {
     if (isJSMicrotaskDispatcher()) [[unlikely]]
-        return jsCast<JSMicrotaskDispatcher*>(dispatcher());
+        return uncheckedDowncast<JSMicrotaskDispatcher>(dispatcher());
     return nullptr;
 }
 

--- a/Source/JavaScriptCore/runtime/ModuleGraphLoadingState.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleGraphLoadingState.cpp
@@ -55,7 +55,7 @@ void ModuleGraphLoadingState::finishCreation(VM& vm)
 template<typename Visitor>
 void ModuleGraphLoadingState::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<ModuleGraphLoadingState*>(cell);
+    auto* thisObject = uncheckedDowncast<ModuleGraphLoadingState>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_promise);

--- a/Source/JavaScriptCore/runtime/ModuleLoaderPayload.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleLoaderPayload.cpp
@@ -60,7 +60,7 @@ void ModuleLoaderPayload::finishCreation(VM& vm)
 template<typename Visitor>
 void ModuleLoaderPayload::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<ModuleLoaderPayload*>(cell);
+    auto* thisObject = uncheckedDowncast<ModuleLoaderPayload>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_fulfillment);

--- a/Source/JavaScriptCore/runtime/ModuleLoadingContext.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleLoadingContext.cpp
@@ -85,13 +85,13 @@ JSModuleLoader::ModuleReferrer ModuleLoadingContext::referrer() const
         return module;
     if (auto* exec = dynamicDowncast<ProgramExecutable>(ref))
         return exec;
-    return jsCast<JSGlobalObject*>(ref);
+    return uncheckedDowncast<JSGlobalObject>(ref);
 }
 
 template<typename Visitor>
 void ModuleLoadingContext::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<ModuleLoadingContext*>(cell);
+    auto* thisObject = uncheckedDowncast<ModuleLoadingContext>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_scriptFetcher);

--- a/Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp
@@ -65,7 +65,7 @@ UnlinkedModuleProgramCodeBlock* ModuleProgramExecutable::getUnlinkedCodeBlock(JS
 
     m_unlinkedCodeBlock.set(vm, this, unlinkedModuleProgramCode);
     VirtualRegister symbolTableReg = VirtualRegister(unlinkedModuleProgramCode->moduleEnvironmentSymbolTableConstantRegisterOffset());
-    SymbolTable* symbolTable = jsCast<SymbolTable*>(unlinkedModuleProgramCode->getConstant(symbolTableReg));
+    SymbolTable* symbolTable = uncheckedDowncast<SymbolTable>(unlinkedModuleProgramCode->getConstant(symbolTableReg));
     m_moduleEnvironmentSymbolTable.set(vm, this, symbolTable->cloneScopePart(vm));
     RELEASE_AND_RETURN(throwScope, unlinkedModuleProgramCode);
 }
@@ -95,7 +95,7 @@ auto ModuleProgramExecutable::ensureTemplateObjectMap(VM&) -> TemplateObjectMap&
 template<typename Visitor>
 void ModuleProgramExecutable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    ModuleProgramExecutable* thisObject = jsCast<ModuleProgramExecutable*>(cell);
+    ModuleProgramExecutable* thisObject = uncheckedDowncast<ModuleProgramExecutable>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_moduleEnvironmentSymbolTable);

--- a/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
@@ -59,7 +59,7 @@ void ModuleRegistryEntry::finishCreation(VM& vm)
 template<typename Visitor>
 void ModuleRegistryEntry::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<ModuleRegistryEntry*>(cell);
+    auto* thisObject = uncheckedDowncast<ModuleRegistryEntry>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_scriptFetcher);

--- a/Source/JavaScriptCore/runtime/NativeExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/NativeExecutable.cpp
@@ -120,7 +120,7 @@ JSString* NativeExecutable::toStringSlow(JSGlobalObject *globalObject)
 template<typename Visitor>
 void NativeExecutable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    NativeExecutable* thisObject = jsCast<NativeExecutable*>(cell);
+    NativeExecutable* thisObject = uncheckedDowncast<NativeExecutable>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_asString);

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -118,7 +118,7 @@ void ObjectConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject, Obj
 static ALWAYS_INLINE JSObject* constructObjectWithNewTarget(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newTarget)
 {
     VM& vm = globalObject->vm();
-    ObjectConstructor* objectConstructor = jsCast<ObjectConstructor*>(callFrame->jsCallee());
+    ObjectConstructor* objectConstructor = uncheckedDowncast<ObjectConstructor>(callFrame->jsCallee());
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // We need to check newTarget condition in this caller side instead of InternalFunction::createSubclassStructure side.
@@ -1283,7 +1283,7 @@ JSArray* ownPropertyKeys(JSGlobalObject* globalObject, JSObject* object, Propert
     auto kind = inferCachedPropertyNamesKind(propertyNameMode, dontEnumPropertiesMode);
 
     if (object->inherits<ProxyObject>()) {
-        ProxyObject* proxy = jsCast<ProxyObject*>(object);
+        ProxyObject* proxy = uncheckedDowncast<ProxyObject>(object);
         if (proxy->forwardsGetOwnPropertyNamesToTarget(dontEnumPropertiesMode))
             object = proxy->target();
     }

--- a/Source/JavaScriptCore/runtime/OrderedHashTable.cpp
+++ b/Source/JavaScriptCore/runtime/OrderedHashTable.cpp
@@ -32,7 +32,7 @@ template<typename Traits>
 template<typename Visitor>
 void OrderedHashTable<Traits>::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    OrderedHashTable<Traits>* thisObject = jsCast<OrderedHashTable<Traits>*>(cell);
+    OrderedHashTable<Traits>* thisObject = uncheckedDowncast<OrderedHashTable<Traits>>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 

--- a/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
@@ -210,7 +210,7 @@ public:
         JSValue* value = slot(storage, aliveEntryCountIndex());
         if (!value->isInt32()) {
             ASSERT(is<Storage>(*value));
-            return jsCast<Storage*>(*value);
+            return uncheckedDowncast<Storage>(*value);
         }
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/PinballCompletion.cpp
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.cpp
@@ -99,7 +99,7 @@ void PinballCompletion::assimilate(PinballCompletion* other)
 template<typename Visitor>
 void PinballCompletion::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<PinballCompletion*>(cell);
+    auto* thisObject = uncheckedDowncast<PinballCompletion>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
@@ -153,10 +153,10 @@ extern "C" void pinballHandlerFinishReject(PinballHandlerContext*);
 static void pinballHandlerInitContext(JSGlobalObject* globalObject, CallFrame* callFrame, PinballHandlerContext* context)
 {
     VM& vm = globalObject->vm();
-    JSFunctionWithFields* self = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
+    JSFunctionWithFields* self = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
 
     ASSERT(callFrame->argumentCount() == 1);
-    PinballCompletion* pinball = jsCast<PinballCompletion*>(self->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
+    PinballCompletion* pinball = uncheckedDowncast<PinballCompletion>(self->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
     ASSERT(pinball->hasSlices());
 #if ASSERT_ENABLED
     context->magic = 0xBA11FEED;
@@ -184,8 +184,8 @@ void pinballHandlerInitContextForFulfill(JSGlobalObject* globalObject, CallFrame
 void pinballHandlerInitContextForReject(JSGlobalObject* globalObject, CallFrame* callFrame, PinballHandlerContext* context)
 {
 #if ASSERT_ENABLED
-    JSFunctionWithFields* self = jsCast<JSFunctionWithFields*>(callFrame->jsCallee());
-    PinballCompletion* pinball = jsCast<PinballCompletion*>(self->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
+    JSFunctionWithFields* self = uncheckedDowncast<JSFunctionWithFields>(callFrame->jsCallee());
+    PinballCompletion* pinball = uncheckedDowncast<PinballCompletion>(self->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
     ASSERT(pinball->slices().size() == 1); // exceptions are only supported with slab slicing, expecting 1 slice
 #endif
 
@@ -200,7 +200,7 @@ void pinballHandlerImplantSlice(PinballHandlerContext* context, Register *base, 
 {
     ASSERT(context->magic == 0xBA11FEED);
     VM& vm = context->globalObject->vm();
-    PinballCompletion* pinball = jsCast<PinballCompletion*>(context->handler->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
+    PinballCompletion* pinball = uncheckedDowncast<PinballCompletion>(context->handler->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
 
     auto* slice = context->slice.get();
     CallFrame* bottommostImplantedFrame = slice->implant(base, sentinelFrame);
@@ -227,7 +227,7 @@ UCPURegister pinballHandlerFulfillFunctionContinue(PinballHandlerContext* contex
     VM& vm = *context->vm;
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSPIContext& jspiContext = context->jspiContext;
-    PinballCompletion* pinball = jsCast<PinballCompletion*>(context->handler->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
+    PinballCompletion* pinball = uncheckedDowncast<PinballCompletion>(context->handler->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
 
     if (jspiContext.completion) {
         // Computation was suspended again; the remainder of this completion should be added to the new one.
@@ -269,7 +269,7 @@ void pinballHandlerFinishReject(PinballHandlerContext* context)
     VM& vm = *context->vm;
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSPIContext& jspiContext = context->jspiContext;
-    PinballCompletion* pinball = jsCast<PinballCompletion*>(context->handler->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
+    PinballCompletion* pinball = uncheckedDowncast<PinballCompletion>(context->handler->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
     ASSERT(!pinball->hasSlices());
 
     if (jspiContext.completion) {

--- a/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
@@ -284,7 +284,7 @@ auto ProgramExecutable::ensureTemplateObjectMap(VM&) -> TemplateObjectMap&
 template<typename Visitor>
 void ProgramExecutable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    ProgramExecutable* thisObject = jsCast<ProgramExecutable*>(cell);
+    ProgramExecutable* thisObject = uncheckedDowncast<ProgramExecutable>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     if (TemplateObjectMap* map = thisObject->m_templateObjectMap.get()) {

--- a/Source/JavaScriptCore/runtime/PropertyDescriptor.cpp
+++ b/Source/JavaScriptCore/runtime/PropertyDescriptor.cpp
@@ -121,8 +121,8 @@ void PropertyDescriptor::setUndefined()
 GetterSetter* PropertyDescriptor::slowGetterSetter(JSGlobalObject* globalObject) const
 {
     VM& vm = globalObject->vm();
-    JSValue getter = m_getter && !m_getter.isUndefined() ? jsCast<JSObject*>(m_getter) : jsUndefined();
-    JSValue setter = m_setter && !m_setter.isUndefined() ? jsCast<JSObject*>(m_setter) : jsUndefined();
+    JSValue getter = m_getter && !m_getter.isUndefined() ? uncheckedDowncast<JSObject>(m_getter) : jsUndefined();
+    JSValue setter = m_setter && !m_setter.isUndefined() ? uncheckedDowncast<JSObject>(m_setter) : jsUndefined();
     return GetterSetter::create(vm, globalObject, getter, setter);
 }
 
@@ -164,7 +164,7 @@ void PropertyDescriptor::setDescriptor(JSValue value, unsigned attributes)
     if (value.isGetterSetter()) {
         m_attributes &= ~PropertyAttribute::ReadOnly; // FIXME: we should be able to ASSERT this!
 
-        GetterSetter* accessor = jsCast<GetterSetter*>(value);
+        GetterSetter* accessor = uncheckedDowncast<GetterSetter>(value);
         m_getter = !accessor->isGetterNull() ? accessor->getter() : jsUndefined();
         m_setter = !accessor->isSetterNull() ? accessor->setter() : jsUndefined();
         m_seenAttributes = EnumerablePresent | ConfigurablePresent;

--- a/Source/JavaScriptCore/runtime/PropertyTable.cpp
+++ b/Source/JavaScriptCore/runtime/PropertyTable.cpp
@@ -134,7 +134,7 @@ void PropertyTable::finishCreation(VM& vm)
 template<typename Visitor>
 void PropertyTable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<PropertyTable*>(cell);
+    auto* thisObject = uncheckedDowncast<PropertyTable>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(cell, visitor);
     visitor.reportExtraMemoryVisited(thisObject->dataSize(thisObject->isCompact()));

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -76,7 +76,7 @@ void ProxyObject::finishCreation(VM& vm, JSGlobalObject* globalObject, JSValue t
         return;
     }
 
-    JSObject* targetAsObject = jsCast<JSObject*>(target);
+    JSObject* targetAsObject = uncheckedDowncast<JSObject>(target);
 
     m_isCallable = targetAsObject->isCallable();
     if (m_isCallable) {
@@ -181,7 +181,7 @@ static JSValue performProxyGet(JSGlobalObject* globalObject, ProxyObject* proxyO
     if (handlerValue.isNull())
         return throwTypeError(globalObject, scope, s_proxyAlreadyRevokedErrorMessage);
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSObject* getHandler = proxyObject->getHandlerTrap(globalObject, handler, callData, vm.propertyNames->get, ProxyObject::HandlerTrap::Get);
     RETURN_IF_EXCEPTION(scope, { });
@@ -287,7 +287,7 @@ bool ProxyObject::performInternalMethodGetOwnProperty(JSGlobalObject* globalObje
         return false;
     }
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSObject* getOwnPropertyDescriptorMethod = getHandlerTrap(globalObject, handler, callData, vm.propertyNames->getOwnPropertyDescriptor, HandlerTrap::GetOwnPropertyDescriptor);
     RETURN_IF_EXCEPTION(scope, false);
@@ -394,7 +394,7 @@ bool ProxyObject::performHasProperty(JSGlobalObject* globalObject, PropertyName 
         return false;
     }
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSObject* hasMethod = getHandlerTrap(globalObject, handler, callData, vm.propertyNames->has, HandlerTrap::Has);
     RETURN_IF_EXCEPTION(scope, false);
@@ -476,14 +476,14 @@ bool ProxyObject::getOwnPropertySlotCommon(JSGlobalObject* globalObject, Propert
 
 bool ProxyObject::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
-    ProxyObject* thisObject = jsCast<ProxyObject*>(object);
+    ProxyObject* thisObject = uncheckedDowncast<ProxyObject>(object);
     return thisObject->getOwnPropertySlotCommon(globalObject, propertyName, slot);
 }
 
 bool ProxyObject::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* globalObject, unsigned propertyName, PropertySlot& slot)
 {
     VM& vm = globalObject->vm();
-    ProxyObject* thisObject = jsCast<ProxyObject*>(object);
+    ProxyObject* thisObject = uncheckedDowncast<ProxyObject>(object);
     Identifier ident = Identifier::from(vm, propertyName);
     return thisObject->getOwnPropertySlotCommon(globalObject, ident.impl(), slot);
 }
@@ -509,7 +509,7 @@ bool ProxyObject::performPut(JSGlobalObject* globalObject, JSValue putValue, JSV
         return false;
     }
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSObject* setMethod = getHandlerTrap(globalObject, handler, callData, vm.propertyNames->set, HandlerTrap::Set);
     RETURN_IF_EXCEPTION(scope, false);
@@ -570,9 +570,9 @@ bool ProxyObject::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName p
     slot.disableCaching();
     slot.setIsTaintedByOpaqueObject();
 
-    ProxyObject* thisObject = jsCast<ProxyObject*>(cell);
+    ProxyObject* thisObject = uncheckedDowncast<ProxyObject>(cell);
     auto performDefaultPut = [&] () {
-        JSObject* target = jsCast<JSObject*>(thisObject->target());
+        JSObject* target = thisObject->target();
         return target->methodTable()->put(target, globalObject, propertyName, value, slot);
     };
     return thisObject->performPut(globalObject, value, slot.thisValue(), propertyName, performDefaultPut, slot.isStrictMode());
@@ -595,7 +595,7 @@ bool ProxyObject::putByIndexCommon(JSGlobalObject* globalObject, JSValue thisVal
 
 bool ProxyObject::putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned propertyName, JSValue value, bool shouldThrow)
 {
-    ProxyObject* thisObject = jsCast<ProxyObject*>(cell);
+    ProxyObject* thisObject = uncheckedDowncast<ProxyObject>(cell);
     return thisObject->putByIndexCommon(globalObject, thisObject, propertyName, value, shouldThrow);
 }
 
@@ -609,12 +609,12 @@ JSC_DEFINE_HOST_FUNCTION(performProxyCall, (JSGlobalObject* globalObject, CallFr
         throwStackOverflowError(globalObject, scope);
         return encodedJSValue();
     }
-    ProxyObject* proxy = jsCast<ProxyObject*>(callFrame->jsCallee());
+    ProxyObject* proxy = uncheckedDowncast<ProxyObject>(callFrame->jsCallee());
     JSValue handlerValue = proxy->handler();
     if (handlerValue.isNull())
         return throwVMTypeError(globalObject, scope, s_proxyAlreadyRevokedErrorMessage);
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSValue applyMethod = handler->getMethod(globalObject, callData, makeIdentifier(vm, "apply"_s), "'apply' property of a Proxy's handler should be callable"_s);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -638,7 +638,7 @@ JSC_DEFINE_HOST_FUNCTION(performProxyCall, (JSGlobalObject* globalObject, CallFr
 CallData ProxyObject::getCallData(JSCell* cell)
 {
     CallData callData;
-    ProxyObject* proxy = jsCast<ProxyObject*>(cell);
+    ProxyObject* proxy = uncheckedDowncast<ProxyObject>(cell);
     if (proxy->m_isCallable) {
         callData.type = CallData::Type::Native;
         callData.native.function = performProxyCall;
@@ -658,12 +658,12 @@ JSC_DEFINE_HOST_FUNCTION(performProxyConstruct, (JSGlobalObject* globalObject, C
         throwStackOverflowError(globalObject, scope);
         return encodedJSValue();
     }
-    ProxyObject* proxy = jsCast<ProxyObject*>(callFrame->jsCallee());
+    ProxyObject* proxy = uncheckedDowncast<ProxyObject>(callFrame->jsCallee());
     JSValue handlerValue = proxy->handler();
     if (handlerValue.isNull())
         return throwVMTypeError(globalObject, scope, s_proxyAlreadyRevokedErrorMessage);
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSValue constructMethod = handler->getMethod(globalObject, callData, makeIdentifier(vm, "construct"_s), "'construct' property of a Proxy's handler should be callable"_s);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -691,7 +691,7 @@ JSC_DEFINE_HOST_FUNCTION(performProxyConstruct, (JSGlobalObject* globalObject, C
 CallData ProxyObject::getConstructData(JSCell* cell)
 {
     CallData constructData;
-    ProxyObject* proxy = jsCast<ProxyObject*>(cell);
+    ProxyObject* proxy = uncheckedDowncast<ProxyObject>(cell);
     if (proxy->m_isConstructible) {
         constructData.type = CallData::Type::Native;
         constructData.native.function = performProxyConstruct;
@@ -722,7 +722,7 @@ bool ProxyObject::performDelete(JSGlobalObject* globalObject, PropertyName prope
         return false;
     }
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSValue deletePropertyMethod = handler->getMethod(globalObject, callData, makeIdentifier(vm, "deleteProperty"_s), "'deleteProperty' property of a Proxy's handler should be callable"_s);
     RETURN_IF_EXCEPTION(scope, false);
@@ -769,7 +769,7 @@ bool ProxyObject::performDelete(JSGlobalObject* globalObject, PropertyName prope
 
 bool ProxyObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
-    ProxyObject* thisObject = jsCast<ProxyObject*>(cell);
+    ProxyObject* thisObject = uncheckedDowncast<ProxyObject>(cell);
     auto performDefaultDelete = [&] () -> bool {
         JSObject* target = thisObject->target();
         return target->methodTable()->deleteProperty(target, globalObject, propertyName, slot);
@@ -780,7 +780,7 @@ bool ProxyObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, Pro
 bool ProxyObject::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned propertyName)
 {
     VM& vm = globalObject->vm();
-    ProxyObject* thisObject = jsCast<ProxyObject*>(cell);
+    ProxyObject* thisObject = uncheckedDowncast<ProxyObject>(cell);
     Identifier ident = Identifier::from(vm, propertyName);
     auto performDefaultDelete = [&] () -> bool {
         JSObject* target = thisObject->target();
@@ -806,7 +806,7 @@ bool ProxyObject::performPreventExtensions(JSGlobalObject* globalObject)
         return false;
     }
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSValue preventExtensionsMethod = handler->getMethod(globalObject, callData, makeIdentifier(vm, "preventExtensions"_s), "'preventExtensions' property of a Proxy's handler should be callable"_s);
     RETURN_IF_EXCEPTION(scope, false);
@@ -837,7 +837,7 @@ bool ProxyObject::performPreventExtensions(JSGlobalObject* globalObject)
 
 bool ProxyObject::preventExtensions(JSObject* object, JSGlobalObject* globalObject)
 {
-    return jsCast<ProxyObject*>(object)->performPreventExtensions(globalObject);
+    return uncheckedDowncast<ProxyObject>(object)->performPreventExtensions(globalObject);
 }
 
 bool ProxyObject::performIsExtensible(JSGlobalObject* globalObject)
@@ -857,7 +857,7 @@ bool ProxyObject::performIsExtensible(JSGlobalObject* globalObject)
         return false;
     }
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSValue isExtensibleMethod = handler->getMethod(globalObject, callData, makeIdentifier(vm, "isExtensible"_s), "'isExtensible' property of a Proxy's handler should be callable"_s);
     RETURN_IF_EXCEPTION(scope, false);
@@ -894,7 +894,7 @@ bool ProxyObject::performIsExtensible(JSGlobalObject* globalObject)
 
 bool ProxyObject::isExtensible(JSObject* object, JSGlobalObject* globalObject)
 {
-    return jsCast<ProxyObject*>(object)->performIsExtensible(globalObject);
+    return uncheckedDowncast<ProxyObject>(object)->performIsExtensible(globalObject);
 }
 
 bool ProxyObject::performDefineOwnProperty(JSGlobalObject* globalObject, PropertyName propertyName, const PropertyDescriptor& descriptor, bool shouldThrow)
@@ -922,7 +922,7 @@ bool ProxyObject::performDefineOwnProperty(JSGlobalObject* globalObject, Propert
         return false;
     }
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSValue definePropertyMethod = handler->getMethod(globalObject, callData, vm.propertyNames->defineProperty, "'defineProperty' property of a Proxy's handler should be callable"_s);
     RETURN_IF_EXCEPTION(scope, false);
@@ -1001,7 +1001,7 @@ bool ProxyObject::performDefineOwnProperty(JSGlobalObject* globalObject, Propert
 
 bool ProxyObject::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, const PropertyDescriptor& descriptor, bool shouldThrow)
 {
-    ProxyObject* thisObject = jsCast<ProxyObject*>(object);
+    ProxyObject* thisObject = uncheckedDowncast<ProxyObject>(object);
     return thisObject->performDefineOwnProperty(globalObject, propertyName, descriptor, shouldThrow);
 }
 
@@ -1041,7 +1041,7 @@ void ProxyObject::performGetOwnPropertyNames(JSGlobalObject* globalObject, Prope
         return;
     }
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSObject* ownKeysMethod = getHandlerTrap(globalObject, handler, callData, vm.propertyNames->ownKeys, HandlerTrap::OwnKeys);
     RETURN_IF_EXCEPTION(scope, void());
@@ -1149,7 +1149,7 @@ void ProxyObject::performGetOwnEnumerablePropertyNames(JSGlobalObject* globalObj
 
 void ProxyObject::getOwnPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder& propertyNameArray, DontEnumPropertiesMode mode)
 {
-    ProxyObject* thisObject = jsCast<ProxyObject*>(object);
+    ProxyObject* thisObject = uncheckedDowncast<ProxyObject>(object);
     if (mode == DontEnumPropertiesMode::Include)
         thisObject->performGetOwnPropertyNames(globalObject, propertyNameArray);
     else
@@ -1175,7 +1175,7 @@ bool ProxyObject::performSetPrototype(JSGlobalObject* globalObject, JSValue prot
         return false;
     }
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSValue setPrototypeOfMethod = handler->getMethod(globalObject, callData, makeIdentifier(vm, "setPrototypeOf"_s), "'setPrototypeOf' property of a Proxy's handler should be callable"_s);
     RETURN_IF_EXCEPTION(scope, false);
@@ -1219,7 +1219,7 @@ bool ProxyObject::performSetPrototype(JSGlobalObject* globalObject, JSValue prot
 
 bool ProxyObject::setPrototype(JSObject* object, JSGlobalObject* globalObject, JSValue prototype, bool shouldThrowIfCantSet)
 {
-    return jsCast<ProxyObject*>(object)->performSetPrototype(globalObject, prototype, shouldThrowIfCantSet);
+    return uncheckedDowncast<ProxyObject>(object)->performSetPrototype(globalObject, prototype, shouldThrowIfCantSet);
 }
 
 JSValue ProxyObject::performGetPrototype(JSGlobalObject* globalObject)
@@ -1239,7 +1239,7 @@ JSValue ProxyObject::performGetPrototype(JSGlobalObject* globalObject)
         return { };
     }
 
-    JSObject* handler = jsCast<JSObject*>(handlerValue);
+    JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
     JSValue getPrototypeOfMethod = handler->getMethod(globalObject, callData, makeIdentifier(vm, "getPrototypeOf"_s), "'getPrototypeOf' property of a Proxy's handler should be callable"_s);
     RETURN_IF_EXCEPTION(scope, { });
@@ -1278,7 +1278,7 @@ JSValue ProxyObject::performGetPrototype(JSGlobalObject* globalObject)
 
 JSValue ProxyObject::getPrototype(JSObject* object, JSGlobalObject* globalObject)
 {
-    return jsCast<ProxyObject*>(object)->performGetPrototype(globalObject);
+    return uncheckedDowncast<ProxyObject>(object)->performGetPrototype(globalObject);
 }
 
 void ProxyObject::revoke(VM& vm)
@@ -1296,7 +1296,7 @@ bool ProxyObject::isRevoked() const
 template<typename Visitor>
 void ProxyObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<ProxyObject*>(cell);
+    auto* thisObject = uncheckedDowncast<ProxyObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_handlerStructureID);

--- a/Source/JavaScriptCore/runtime/ProxyObject.h
+++ b/Source/JavaScriptCore/runtime/ProxyObject.h
@@ -79,7 +79,7 @@ public:
 
     DECLARE_VISIT_CHILDREN;
 
-    JSObject* target() const { return jsCast<JSObject*>(internalField(Field::Target).get()); }
+    JSObject* target() const { return uncheckedDowncast<JSObject>(internalField(Field::Target).get()); }
     JSValue handler() const { return internalField(Field::Handler).get(); }
 
     static void validateNegativeHasTrapResult(JSGlobalObject*, JSObject*, PropertyName);

--- a/Source/JavaScriptCore/runtime/ProxyRevoke.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyRevoke.cpp
@@ -57,12 +57,12 @@ void ProxyRevoke::finishCreation(VM& vm)
 
 JSC_DEFINE_HOST_FUNCTION(performProxyRevoke, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ProxyRevoke* proxyRevoke = jsCast<ProxyRevoke*>(callFrame->jsCallee());
+    ProxyRevoke* proxyRevoke = uncheckedDowncast<ProxyRevoke>(callFrame->jsCallee());
     JSValue proxyValue = proxyRevoke->proxy();
     if (proxyValue.isNull())
         return JSValue::encode(jsUndefined());
 
-    ProxyObject* proxy = jsCast<ProxyObject*>(proxyValue);
+    ProxyObject* proxy = uncheckedDowncast<ProxyObject>(proxyValue);
     VM& vm = globalObject->vm();
     proxy->revoke(vm);
     proxyRevoke->setProxyToNull(vm);
@@ -72,7 +72,7 @@ JSC_DEFINE_HOST_FUNCTION(performProxyRevoke, (JSGlobalObject* globalObject, Call
 template<typename Visitor>
 void ProxyRevoke::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    ProxyRevoke* thisObject = jsCast<ProxyRevoke*>(cell);
+    ProxyRevoke* thisObject = uncheckedDowncast<ProxyRevoke>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -579,7 +579,7 @@ void RegExp::printTraceData()
 void RegExp::dumpToStream(const JSCell* cell, PrintStream& out)
 {
     // This function can be called concurrently. So we must not ref m_pattern.
-    auto* regExp = jsCast<const RegExp*>(cell);
+    auto* regExp = uncheckedDowncast<RegExp>(cell);
     out.print(toCString("/", regExp->pattern().impl(), "/", Yarr::flagsString(regExp->flags()).data()));
 }
 

--- a/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
@@ -351,7 +351,7 @@ JSObject* constructRegExp(JSGlobalObject* globalObject, const ArgList& args,  JS
     }
 
     if (isPatternRegExp) {
-        RegExp* regExp = jsCast<RegExpObject*>(patternArg)->regExp();
+        RegExp* regExp = uncheckedDowncast<RegExpObject>(patternArg)->regExp();
         Structure* structure = getRegExpStructure(globalObject, newTarget);
         RETURN_IF_EXCEPTION(scope, nullptr);
 

--- a/Source/JavaScriptCore/runtime/RegExpObject.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpObject.cpp
@@ -51,7 +51,7 @@ void RegExpObject::finishCreation(VM& vm)
 template<typename Visitor>
 void RegExpObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    RegExpObject* thisObject = jsCast<RegExpObject*>(cell);
+    RegExpObject* thisObject = uncheckedDowncast<RegExpObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.appendUnbarriered(thisObject->regExp());
@@ -64,7 +64,7 @@ bool RegExpObject::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalOb
 {
     VM& vm = globalObject->vm();
     if (propertyName == vm.propertyNames->lastIndex) {
-        RegExpObject* regExp = jsCast<RegExpObject*>(object);
+        RegExpObject* regExp = uncheckedDowncast<RegExpObject>(object);
         unsigned attributes = regExp->lastIndexIsWritable() ? PropertyAttribute::DontDelete | PropertyAttribute::DontEnum : PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly;
         slot.setValue(regExp, attributes, regExp->getLastIndex());
         return true;
@@ -93,7 +93,7 @@ bool RegExpObject::defineOwnProperty(JSObject* object, JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (propertyName == vm.propertyNames->lastIndex) {
-        RegExpObject* regExp = jsCast<RegExpObject*>(object);
+        RegExpObject* regExp = uncheckedDowncast<RegExpObject>(object);
         if (descriptor.configurablePresent() && descriptor.configurable())
             return typeError(globalObject, scope, shouldThrow, UnconfigurablePropertyChangeConfigurabilityError);
         if (descriptor.enumerablePresent() && descriptor.enumerable())
@@ -125,19 +125,19 @@ bool RegExpObject::defineOwnProperty(JSObject* object, JSGlobalObject* globalObj
 
 JSC_DEFINE_CUSTOM_SETTER(regExpObjectSetLastIndexStrict, (JSGlobalObject* globalObject, EncodedJSValue thisValue, EncodedJSValue value, PropertyName))
 {
-    return jsCast<RegExpObject*>(JSValue::decode(thisValue))->setLastIndex(globalObject, JSValue::decode(value), true);
+    return uncheckedDowncast<RegExpObject>(JSValue::decode(thisValue))->setLastIndex(globalObject, JSValue::decode(value), true);
 }
 
 JSC_DEFINE_CUSTOM_SETTER(regExpObjectSetLastIndexSloppy, (JSGlobalObject* globalObject, EncodedJSValue thisValue, EncodedJSValue value, PropertyName))
 {
-    return jsCast<RegExpObject*>(JSValue::decode(thisValue))->setLastIndex(globalObject, JSValue::decode(value), false);
+    return uncheckedDowncast<RegExpObject>(JSValue::decode(thisValue))->setLastIndex(globalObject, JSValue::decode(value), false);
 }
 
 bool RegExpObject::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    RegExpObject* thisObject = jsCast<RegExpObject*>(cell);
+    RegExpObject* thisObject = uncheckedDowncast<RegExpObject>(cell);
 
     if (propertyName == vm.propertyNames->lastIndex) {
         if (!thisObject->lastIndexIsWritable())

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -118,7 +118,7 @@ static inline JSValue regExpExec(JSGlobalObject* globalObject, JSValue thisValue
         auto callData = JSC::getCallDataInline(regExpExec);
         ASSERT(callData.type != CallData::Type::None);
         if (callData.type == CallData::Type::JS) [[likely]] {
-            CachedCall cachedCall(globalObject, jsCast<JSFunction*>(regExpExec), 1);
+            CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(regExpExec), 1);
             RETURN_IF_EXCEPTION(scope, { });
             match = cachedCall.callWithArguments(globalObject, thisValue, str);
             RETURN_IF_EXCEPTION(scope, { });
@@ -192,8 +192,8 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncExec, (JSGlobalObject* globalObject, Cal
 
 JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncMatchFast, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    RegExpObject* thisObject = jsCast<RegExpObject*>(callFrame->thisValue());
-    JSString* string = jsCast<JSString*>(callFrame->uncheckedArgument(0));
+    RegExpObject* thisObject = uncheckedDowncast<RegExpObject>(callFrame->thisValue());
+    JSString* string = uncheckedDowncast<JSString>(callFrame->uncheckedArgument(0));
     if (!thisObject->regExp()->global())
         return JSValue::encode(thisObject->exec(globalObject, string));
     return JSValue::encode(thisObject->matchGlobal(globalObject, string));
@@ -625,7 +625,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncSplitFast, (JSGlobalObject* globalObject
     // 1. [handled by JS builtin] Let rx be the this value.
     // 2. [handled by JS builtin] If Type(rx) is not Object, throw a TypeError exception.
     JSValue thisValue = callFrame->thisValue();
-    RegExp* regexp = jsCast<RegExpObject*>(thisValue)->regExp();
+    RegExp* regexp = uncheckedDowncast<RegExpObject>(thisValue)->regExp();
 
     // 3. [handled by JS builtin] Let S be ? ToString(string).
     JSString* inputString = callFrame->argument(0).toString(globalObject);

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -594,12 +594,12 @@ void SamplingProfiler::processUnverifiedStackTraces()
                 return;
             }
 
-            addCallee(jsCast<JSFunction*>(calleeCell));
+            addCallee(uncheckedDowncast<JSFunction>(calleeCell));
 
             if (alreadyHasExecutable)
                 return;
 
-            ExecutableBase* executable = jsCast<JSFunction*>(calleeCell)->executable();
+            ExecutableBase* executable = uncheckedDowncast<JSFunction>(calleeCell)->executable();
             if (!executable) {
                 setFallbackFrameType();
                 return;

--- a/Source/JavaScriptCore/runtime/ScopedArguments.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.cpp
@@ -92,7 +92,7 @@ ScopedArguments* ScopedArguments::createByCopying(JSGlobalObject* globalObject, 
     return createByCopyingFrom(
         globalObject->vm(), globalObject->scopedArgumentsStructure(),
         callFrame->registers() + CallFrame::argumentOffset(0), callFrame->argumentCount(),
-        jsCast<JSFunction*>(callFrame->jsCallee()), table, scope);
+        uncheckedDowncast<JSFunction>(callFrame->jsCallee()), table, scope);
 }
 
 ScopedArguments* ScopedArguments::createByCopyingFrom(VM& vm, Structure* structure, Register* argumentsStart, unsigned totalLength, JSFunction* callee, ScopedArgumentsTable* table, JSLexicalEnvironment* scope)

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
@@ -138,7 +138,7 @@ void ScriptExecutable::installCode(VM& vm, CodeBlock* genericCodeBlock, CodeType
     
     switch (codeType) {
     case GlobalCode: {
-        ProgramExecutable* executable = jsCast<ProgramExecutable*>(this);
+        ProgramExecutable* executable = uncheckedDowncast<ProgramExecutable>(this);
         ProgramCodeBlock* codeBlock = static_cast<ProgramCodeBlock*>(genericCodeBlock);
         
         ASSERT(kind == CodeSpecializationKind::CodeForCall);
@@ -148,7 +148,7 @@ void ScriptExecutable::installCode(VM& vm, CodeBlock* genericCodeBlock, CodeType
     }
 
     case ModuleCode: {
-        ModuleProgramExecutable* executable = jsCast<ModuleProgramExecutable*>(this);
+        ModuleProgramExecutable* executable = uncheckedDowncast<ModuleProgramExecutable>(this);
         ModuleProgramCodeBlock* codeBlock = static_cast<ModuleProgramCodeBlock*>(genericCodeBlock);
 
         ASSERT(kind == CodeSpecializationKind::CodeForCall);
@@ -158,7 +158,7 @@ void ScriptExecutable::installCode(VM& vm, CodeBlock* genericCodeBlock, CodeType
     }
 
     case EvalCode: {
-        EvalExecutable* executable = jsCast<EvalExecutable*>(this);
+        EvalExecutable* executable = uncheckedDowncast<EvalExecutable>(this);
         EvalCodeBlock* codeBlock = static_cast<EvalCodeBlock*>(genericCodeBlock);
         
         ASSERT(kind == CodeSpecializationKind::CodeForCall);
@@ -168,7 +168,7 @@ void ScriptExecutable::installCode(VM& vm, CodeBlock* genericCodeBlock, CodeType
     }
         
     case FunctionCode: {
-        FunctionExecutable* executable = jsCast<FunctionExecutable*>(this);
+        FunctionExecutable* executable = uncheckedDowncast<FunctionExecutable>(this);
         FunctionCodeBlock* codeBlock = static_cast<FunctionCodeBlock*>(genericCodeBlock);
         
         oldCodeBlock = executable->replaceCodeBlockWith(vm, kind, codeBlock);
@@ -259,7 +259,7 @@ CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunc
     JSGlobalObject* globalObject = scope->realm();
 
     if (classInfo() == EvalExecutable::info()) {
-        EvalExecutable* executable = jsCast<EvalExecutable*>(this);
+        EvalExecutable* executable = uncheckedDowncast<EvalExecutable>(this);
         RELEASE_ASSERT(kind == CodeSpecializationKind::CodeForCall);
         RELEASE_ASSERT(!executable->m_codeBlock);
         RELEASE_ASSERT(!function);
@@ -272,7 +272,7 @@ CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunc
     }
 
     if (classInfo() == ProgramExecutable::info()) {
-        ProgramExecutable* executable = jsCast<ProgramExecutable*>(this);
+        ProgramExecutable* executable = uncheckedDowncast<ProgramExecutable>(this);
         RELEASE_ASSERT(kind == CodeSpecializationKind::CodeForCall);
         RELEASE_ASSERT(!executable->m_codeBlock);
         RELEASE_ASSERT(!function);
@@ -280,7 +280,7 @@ CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunc
     }
 
     if (classInfo() == ModuleProgramExecutable::info()) {
-        ModuleProgramExecutable* executable = jsCast<ModuleProgramExecutable*>(this);
+        ModuleProgramExecutable* executable = uncheckedDowncast<ModuleProgramExecutable>(this);
         RELEASE_ASSERT(kind == CodeSpecializationKind::CodeForCall);
         RELEASE_ASSERT(!executable->m_codeBlock);
         RELEASE_ASSERT(!function);
@@ -293,7 +293,7 @@ CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunc
 
     RELEASE_ASSERT(classInfo() == FunctionExecutable::info());
     RELEASE_ASSERT(function);
-    FunctionExecutable* executable = jsCast<FunctionExecutable*>(this);
+    FunctionExecutable* executable = uncheckedDowncast<FunctionExecutable>(this);
     RELEASE_ASSERT(!executable->codeBlockFor(kind));
     ParserError error;
     OptionSet<CodeGenerationMode> codeGenerationMode = globalObject->defaultCodeGenerationMode();
@@ -328,7 +328,7 @@ CodeBlock* ScriptExecutable::newReplacementCodeBlockFor(
     VM& vm = this->vm();
     if (classInfo() == EvalExecutable::info()) {
         RELEASE_ASSERT(kind == CodeSpecializationKind::CodeForCall);
-        EvalExecutable* executable = jsCast<EvalExecutable*>(this);
+        EvalExecutable* executable = uncheckedDowncast<EvalExecutable>(this);
         EvalCodeBlock* baseline = static_cast<EvalCodeBlock*>(
             executable->codeBlock()->baselineVersion());
         EvalCodeBlock* result = EvalCodeBlock::create(vm,
@@ -339,7 +339,7 @@ CodeBlock* ScriptExecutable::newReplacementCodeBlockFor(
     
     if (classInfo() == ProgramExecutable::info()) {
         RELEASE_ASSERT(kind == CodeSpecializationKind::CodeForCall);
-        ProgramExecutable* executable = jsCast<ProgramExecutable*>(this);
+        ProgramExecutable* executable = uncheckedDowncast<ProgramExecutable>(this);
         ProgramCodeBlock* baseline = static_cast<ProgramCodeBlock*>(
             executable->codeBlock()->baselineVersion());
         ProgramCodeBlock* result = ProgramCodeBlock::create(vm,
@@ -350,7 +350,7 @@ CodeBlock* ScriptExecutable::newReplacementCodeBlockFor(
 
     if (classInfo() == ModuleProgramExecutable::info()) {
         RELEASE_ASSERT(kind == CodeSpecializationKind::CodeForCall);
-        ModuleProgramExecutable* executable = jsCast<ModuleProgramExecutable*>(this);
+        ModuleProgramExecutable* executable = uncheckedDowncast<ModuleProgramExecutable>(this);
         ModuleProgramCodeBlock* baseline = static_cast<ModuleProgramCodeBlock*>(
             executable->codeBlock()->baselineVersion());
         ModuleProgramCodeBlock* result = ModuleProgramCodeBlock::create(vm,
@@ -360,7 +360,7 @@ CodeBlock* ScriptExecutable::newReplacementCodeBlockFor(
     }
 
     RELEASE_ASSERT(classInfo() == FunctionExecutable::info());
-    FunctionExecutable* executable = jsCast<FunctionExecutable*>(this);
+    FunctionExecutable* executable = uncheckedDowncast<FunctionExecutable>(this);
     FunctionCodeBlock* baseline = static_cast<FunctionCodeBlock*>(
         executable->codeBlockFor(kind)->baselineVersion());
     FunctionCodeBlock* result = FunctionCodeBlock::create(vm,
@@ -427,7 +427,7 @@ ScriptExecutable* ScriptExecutable::topLevelExecutable()
 {
     switch (type()) {
     case FunctionExecutableType:
-        return jsCast<FunctionExecutable*>(this)->topLevelExecutable();
+        return uncheckedDowncast<FunctionExecutable>(this)->topLevelExecutable();
     default:
         return this;
     }
@@ -486,14 +486,14 @@ CodeBlockHash ScriptExecutable::hashFor(CodeSpecializationKind kind) const
 std::optional<int> ScriptExecutable::overrideLineNumber(VM&) const
 {
     if (inherits<FunctionExecutable>())
-        return jsCast<const FunctionExecutable*>(this)->overrideLineNumber();
+        return uncheckedDowncast<FunctionExecutable>(this)->overrideLineNumber();
     return std::nullopt;
 }
 
 unsigned ScriptExecutable::typeProfilingStartOffset() const
 {
     if (inherits<FunctionExecutable>())
-        return jsCast<const FunctionExecutable*>(this)->functionStart();
+        return uncheckedDowncast<FunctionExecutable>(this)->functionStart();
     if (inherits<EvalExecutable>())
         return UINT_MAX;
     return 0;
@@ -502,7 +502,7 @@ unsigned ScriptExecutable::typeProfilingStartOffset() const
 unsigned ScriptExecutable::typeProfilingEndOffset() const
 {
     if (inherits<FunctionExecutable>())
-        return jsCast<const FunctionExecutable*>(this)->functionEnd();
+        return uncheckedDowncast<FunctionExecutable>(this)->functionEnd();
     if (inherits<EvalExecutable>())
         return UINT_MAX;
     return source().length() - 1;
@@ -513,10 +513,10 @@ void ScriptExecutable::recordParse(CodeFeatures features, LexicallyScopedFeature
     switch (type()) {
     case FunctionExecutableType:
         // Since UnlinkedFunctionExecutable holds the information to calculate lastLine and endColumn, we do not need to remember them in ScriptExecutable's fields.
-        jsCast<FunctionExecutable*>(this)->recordParse(features, lexicallyScopedFeatures, hasCapturedVariables);
+        uncheckedDowncast<FunctionExecutable>(this)->recordParse(features, lexicallyScopedFeatures, hasCapturedVariables);
         return;
     default:
-        jsCast<GlobalExecutable*>(this)->recordParse(features, lexicallyScopedFeatures, hasCapturedVariables, lastLine, endColumn);
+        uncheckedDowncast<GlobalExecutable>(this)->recordParse(features, lexicallyScopedFeatures, hasCapturedVariables, lastLine, endColumn);
         return;
     }
 }
@@ -525,9 +525,9 @@ int ScriptExecutable::lastLine() const
 {
     switch (type()) {
     case FunctionExecutableType:
-        return jsCast<const FunctionExecutable*>(this)->lastLine();
+        return uncheckedDowncast<FunctionExecutable>(this)->lastLine();
     default:
-        return jsCast<const GlobalExecutable*>(this)->lastLine();
+        return uncheckedDowncast<GlobalExecutable>(this)->lastLine();
     }
     return 0;
 }
@@ -536,9 +536,9 @@ unsigned ScriptExecutable::endColumn() const
 {
     switch (type()) {
     case FunctionExecutableType:
-        return jsCast<const FunctionExecutable*>(this)->endColumn();
+        return uncheckedDowncast<FunctionExecutable>(this)->endColumn();
     default:
-        return jsCast<const GlobalExecutable*>(this)->endColumn();
+        return uncheckedDowncast<GlobalExecutable>(this)->endColumn();
     }
     return 0;
 }

--- a/Source/JavaScriptCore/runtime/SetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SetConstructor.cpp
@@ -111,7 +111,7 @@ JSC_DEFINE_HOST_FUNCTION(constructSet, (JSGlobalObject* globalObject, CallFrame*
 JSC_DEFINE_HOST_FUNCTION(setPrivateFuncSetStorage, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     ASSERT(is<JSSet>(callFrame->argument(0)));
-    JSSet* set = jsCast<JSSet*>(callFrame->uncheckedArgument(0));
+    JSSet* set = uncheckedDowncast<JSSet>(callFrame->uncheckedArgument(0));
     return JSValue::encode(set->storageOrSentinel(getVM(globalObject)));
 }
 
@@ -124,7 +124,7 @@ JSC_DEFINE_HOST_FUNCTION(setPrivateFuncSetIterationNext, (JSGlobalObject* global
     if (cell == vm.orderedHashTableSentinel())
         return JSValue::encode(vm.orderedHashTableSentinel());
 
-    JSSet::Storage& storage = *jsCast<JSSet::Storage*>(cell);
+    JSSet::Storage& storage = *uncheckedDowncast<JSSet::Storage>(cell);
     JSSet::Helper::Entry entry = JSSet::Helper::toNumber(callFrame->uncheckedArgument(1));
     return JSValue::encode(JSSet::Helper::nextAndUpdateIterationEntry(vm, storage, entry));
 }
@@ -137,7 +137,7 @@ JSC_DEFINE_HOST_FUNCTION(setPrivateFuncSetIterationEntry, (JSGlobalObject* globa
     JSCell* cell = callFrame->uncheckedArgument(0).asCell();
     ASSERT_UNUSED(vm, cell != vm.orderedHashTableSentinel());
 
-    JSSet::Storage& storage = *jsCast<JSSet::Storage*>(cell);
+    JSSet::Storage& storage = *uncheckedDowncast<JSSet::Storage>(cell);
     return JSValue::encode(JSSet::Helper::getIterationEntry(storage));
 }
 
@@ -149,7 +149,7 @@ JSC_DEFINE_HOST_FUNCTION(setPrivateFuncSetIterationEntryKey, (JSGlobalObject* gl
     JSCell* cell = callFrame->uncheckedArgument(0).asCell();
     ASSERT_UNUSED(vm, cell != vm.orderedHashTableSentinel());
 
-    JSSet::Storage& storage = *jsCast<JSSet::Storage*>(cell);
+    JSSet::Storage& storage = *uncheckedDowncast<JSSet::Storage>(cell);
     return JSValue::encode(JSSet::Helper::getIterationEntryKey(storage));
 }
 

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -231,7 +231,7 @@ static EncodedJSValue fastSetIntersection(JSGlobalObject* globalObject, JSSet* t
     if (sourceStorageCell == vm.orderedHashTableSentinel())
         return JSValue::encode(result);
 
-    auto* sourceStorage = jsCast<JSSet::Storage*>(sourceStorageCell);
+    auto* sourceStorage = uncheckedDowncast<JSSet::Storage>(sourceStorageCell);
     JSSet::Helper::Entry entry = 0;
 
     while (true) {
@@ -239,7 +239,7 @@ static EncodedJSValue fastSetIntersection(JSGlobalObject* globalObject, JSSet* t
         if (sourceStorageCell == vm.orderedHashTableSentinel())
             break;
 
-        auto* currentStorage = jsCast<JSSet::Storage*>(sourceStorageCell);
+        auto* currentStorage = uncheckedDowncast<JSSet::Storage>(sourceStorageCell);
         entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
         JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -296,13 +296,13 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
         if (storageCell == vm.orderedHashTableSentinel())
             return JSValue::encode(result);
 
-        auto* storage = jsCast<JSSet::Storage*>(storageCell);
+        auto* storage = uncheckedDowncast<JSSet::Storage>(storageCell);
         JSSet::Helper::Entry entry = 0;
         CallData hasCallData = JSC::getCallDataInline(has);
 
         std::optional<CachedCall> cachedHasCall;
         if (hasCallData.type == CallData::Type::JS) [[likely]] {
-            cachedHasCall.emplace(globalObject, jsCast<JSFunction*>(has), 1);
+            cachedHasCall.emplace(globalObject, uncheckedDowncast<JSFunction>(has), 1);
             RETURN_IF_EXCEPTION(scope, { });
         }
 
@@ -311,7 +311,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
             if (storageCell == vm.orderedHashTableSentinel())
                 break;
 
-            storage = jsCast<JSSet::Storage*>(storageCell);
+            storage = uncheckedDowncast<JSSet::Storage>(storageCell);
             entry = JSSet::Helper::iterationEntry(*storage) + 1;
             JSValue entryKey = JSSet::Helper::getIterationEntryKey(*storage);
 
@@ -364,7 +364,7 @@ static EncodedJSValue fastSetUnion(JSGlobalObject* globalObject, JSSet* thisSet,
 
     JSCell* otherStorageCell = otherSet->storageOrSentinel(vm);
     if (otherStorageCell != vm.orderedHashTableSentinel()) {
-        auto* otherStorage = jsCast<JSSet::Storage*>(otherStorageCell);
+        auto* otherStorage = uncheckedDowncast<JSSet::Storage>(otherStorageCell);
         JSSet::Helper::Entry entry = 0;
 
         while (true) {
@@ -372,7 +372,7 @@ static EncodedJSValue fastSetUnion(JSGlobalObject* globalObject, JSSet* thisSet,
             if (otherStorageCell == vm.orderedHashTableSentinel())
                 break;
 
-            auto* currentStorage = jsCast<JSSet::Storage*>(otherStorageCell);
+            auto* currentStorage = uncheckedDowncast<JSSet::Storage>(otherStorageCell);
             entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
             JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -455,7 +455,7 @@ static EncodedJSValue fastSetIsSubsetOf(JSGlobalObject* globalObject, JSSet* thi
     if (thisStorageCell == vm.orderedHashTableSentinel())
         return JSValue::encode(jsBoolean(true));
 
-    auto* thisStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+    auto* thisStorage = uncheckedDowncast<JSSet::Storage>(thisStorageCell);
     JSSet::Helper::Entry entry = 0;
 
     while (true) {
@@ -463,7 +463,7 @@ static EncodedJSValue fastSetIsSubsetOf(JSGlobalObject* globalObject, JSSet* thi
         if (thisStorageCell == vm.orderedHashTableSentinel())
             break;
 
-        auto* currentStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+        auto* currentStorage = uncheckedDowncast<JSSet::Storage>(thisStorageCell);
         entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
         JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -489,7 +489,7 @@ static EncodedJSValue fastSetDifference(JSGlobalObject* globalObject, JSSet* thi
     if (thisStorageCell == vm.orderedHashTableSentinel())
         return JSValue::encode(result);
 
-    auto* thisStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+    auto* thisStorage = uncheckedDowncast<JSSet::Storage>(thisStorageCell);
     JSSet::Helper::Entry entry = 0;
 
     while (true) {
@@ -497,7 +497,7 @@ static EncodedJSValue fastSetDifference(JSGlobalObject* globalObject, JSSet* thi
         if (thisStorageCell == vm.orderedHashTableSentinel())
             break;
 
-        auto* currentStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+        auto* currentStorage = uncheckedDowncast<JSSet::Storage>(thisStorageCell);
         entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
         JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -560,11 +560,11 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
         CallData hasCallData = JSC::getCallDataInline(has);
         std::optional<CachedCall> cachedHasCall;
         if (hasCallData.type == CallData::Type::JS) [[likely]] {
-            cachedHasCall.emplace(globalObject, jsCast<JSFunction*>(has), 1);
+            cachedHasCall.emplace(globalObject, uncheckedDowncast<JSFunction>(has), 1);
             RETURN_IF_EXCEPTION(scope, { });
         }
 
-        auto* resultStorage = jsCast<JSSet::Storage*>(resultStorageCell);
+        auto* resultStorage = uncheckedDowncast<JSSet::Storage>(resultStorageCell);
         JSSet::Helper::Entry entry = 0;
 
         while (true) {
@@ -572,7 +572,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
             if (resultStorageCell == vm.orderedHashTableSentinel())
                 break;
 
-            auto* currentStorage = jsCast<JSSet::Storage*>(resultStorageCell);
+            auto* currentStorage = uncheckedDowncast<JSSet::Storage>(resultStorageCell);
             entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
             JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -613,7 +613,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
 
         std::optional<CachedCall> cachedNextCall;
         if (nextCallData.type == CallData::Type::JS) [[likely]] {
-            cachedNextCall.emplace(globalObject, jsCast<JSFunction*>(nextMethod), 0);
+            cachedNextCall.emplace(globalObject, uncheckedDowncast<JSFunction>(nextMethod), 0);
             RETURN_IF_EXCEPTION(scope, { });
         }
 
@@ -665,7 +665,7 @@ static EncodedJSValue fastSetSymmetricDifference(JSGlobalObject* globalObject, J
 
     JSCell* otherStorageCell = otherSet->storageOrSentinel(vm);
     if (otherStorageCell != vm.orderedHashTableSentinel()) {
-        auto* otherStorage = jsCast<JSSet::Storage*>(otherStorageCell);
+        auto* otherStorage = uncheckedDowncast<JSSet::Storage>(otherStorageCell);
         JSSet::Helper::Entry entry = 0;
 
         while (true) {
@@ -673,7 +673,7 @@ static EncodedJSValue fastSetSymmetricDifference(JSGlobalObject* globalObject, J
             if (otherStorageCell == vm.orderedHashTableSentinel())
                 break;
 
-            auto* currentStorage = jsCast<JSSet::Storage*>(otherStorageCell);
+            auto* currentStorage = uncheckedDowncast<JSSet::Storage>(otherStorageCell);
             entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
             JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -748,7 +748,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncSymmetricDifference, (JSGlobalObject* globa
 
     std::optional<CachedCall> cachedNextCall;
     if (nextCallData.type == CallData::Type::JS) [[likely]] {
-        cachedNextCall.emplace(globalObject, jsCast<JSFunction*>(nextMethod), 0);
+        cachedNextCall.emplace(globalObject, uncheckedDowncast<JSFunction>(nextMethod), 0);
         RETURN_IF_EXCEPTION(scope, { });
     }
 
@@ -836,12 +836,12 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSubsetOf, (JSGlobalObject* globalObject, 
     if (thisStorageCell == vm.orderedHashTableSentinel())
         return JSValue::encode(jsBoolean(true));
 
-    auto* thisStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+    auto* thisStorage = uncheckedDowncast<JSSet::Storage>(thisStorageCell);
     JSSet::Helper::Entry entry = 0;
 
     std::optional<CachedCall> cachedHasCall;
     if (hasCallData.type == CallData::Type::JS) [[likely]] {
-        cachedHasCall.emplace(globalObject, jsCast<JSFunction*>(has), 1);
+        cachedHasCall.emplace(globalObject, uncheckedDowncast<JSFunction>(has), 1);
         RETURN_IF_EXCEPTION(scope, { });
     }
 
@@ -850,7 +850,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSubsetOf, (JSGlobalObject* globalObject, 
         if (thisStorageCell == vm.orderedHashTableSentinel())
             break;
 
-        auto* currentStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+        auto* currentStorage = uncheckedDowncast<JSSet::Storage>(thisStorageCell);
         entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
         JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -889,7 +889,7 @@ static EncodedJSValue fastSetIsSupersetOf(JSGlobalObject* globalObject, JSSet* t
     if (otherStorageCell == vm.orderedHashTableSentinel())
         return JSValue::encode(jsBoolean(true));
 
-    auto* otherStorage = jsCast<JSSet::Storage*>(otherStorageCell);
+    auto* otherStorage = uncheckedDowncast<JSSet::Storage>(otherStorageCell);
     JSSet::Helper::Entry entry = 0;
 
     while (true) {
@@ -897,7 +897,7 @@ static EncodedJSValue fastSetIsSupersetOf(JSGlobalObject* globalObject, JSSet* t
         if (otherStorageCell == vm.orderedHashTableSentinel())
             break;
 
-        auto* currentStorage = jsCast<JSSet::Storage*>(otherStorageCell);
+        auto* currentStorage = uncheckedDowncast<JSSet::Storage>(otherStorageCell);
         entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
         JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -965,7 +965,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSupersetOf, (JSGlobalObject* globalObject
 
     std::optional<CachedCall> cachedNextCall;
     if (nextCallData.type == CallData::Type::JS) [[likely]] {
-        cachedNextCall.emplace(globalObject, jsCast<JSFunction*>(nextMethod), 0);
+        cachedNextCall.emplace(globalObject, uncheckedDowncast<JSFunction>(nextMethod), 0);
         RETURN_IF_EXCEPTION(scope, { });
     }
 
@@ -1023,7 +1023,7 @@ static EncodedJSValue fastSetIsDisjointFrom(JSGlobalObject* globalObject, JSSet*
     if (smallerStorageCell == vm.orderedHashTableSentinel())
         return JSValue::encode(jsBoolean(true));
 
-    auto* smallerStorage = jsCast<JSSet::Storage*>(smallerStorageCell);
+    auto* smallerStorage = uncheckedDowncast<JSSet::Storage>(smallerStorageCell);
     JSSet::Helper::Entry entry = 0;
 
     while (true) {
@@ -1031,7 +1031,7 @@ static EncodedJSValue fastSetIsDisjointFrom(JSGlobalObject* globalObject, JSSet*
         if (smallerStorageCell == vm.orderedHashTableSentinel())
             break;
 
-        auto* currentStorage = jsCast<JSSet::Storage*>(smallerStorageCell);
+        auto* currentStorage = uncheckedDowncast<JSSet::Storage>(smallerStorageCell);
         entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
         JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -1086,13 +1086,13 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
         if (thisStorageCell == vm.orderedHashTableSentinel())
             return JSValue::encode(jsBoolean(true));
 
-        auto* thisStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+        auto* thisStorage = uncheckedDowncast<JSSet::Storage>(thisStorageCell);
         JSSet::Helper::Entry entry = 0;
 
         CallData hasCallData = JSC::getCallDataInline(has);
         std::optional<CachedCall> cachedHasCall;
         if (hasCallData.type == CallData::Type::JS) [[likely]] {
-            cachedHasCall.emplace(globalObject, jsCast<JSFunction*>(has), 1);
+            cachedHasCall.emplace(globalObject, uncheckedDowncast<JSFunction>(has), 1);
             RETURN_IF_EXCEPTION(scope, { });
         }
 
@@ -1101,7 +1101,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
             if (thisStorageCell == vm.orderedHashTableSentinel())
                 break;
 
-            auto* currentStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+            auto* currentStorage = uncheckedDowncast<JSSet::Storage>(thisStorageCell);
             entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
             JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
@@ -1140,7 +1140,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
 
         std::optional<CachedCall> cachedNextCall;
         if (nextCallData.type == CallData::Type::JS) [[likely]] {
-            cachedNextCall.emplace(globalObject, jsCast<JSFunction*>(nextMethod), 0);
+            cachedNextCall.emplace(globalObject, uncheckedDowncast<JSFunction>(nextMethod), 0);
             RETURN_IF_EXCEPTION(scope, { });
         }
 

--- a/Source/JavaScriptCore/runtime/ShadowRealmObject.cpp
+++ b/Source/JavaScriptCore/runtime/ShadowRealmObject.cpp
@@ -49,7 +49,7 @@ ShadowRealmObject::ShadowRealmObject(VM& vm, Structure* structure)
 template<typename Visitor>
 void ShadowRealmObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    ShadowRealmObject* thisObject = jsCast<ShadowRealmObject*>(cell);
+    ShadowRealmObject* thisObject = uncheckedDowncast<ShadowRealmObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 

--- a/Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp
+++ b/Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp
@@ -65,7 +65,7 @@ bool SimpleTypedArrayController::JSArrayBufferOwner::isReachableFromOpaqueRoots(
 {
     if (reason) [[unlikely]]
         *reason = "JSArrayBuffer is opaque root"_s;
-    auto& wrapper = *JSC::jsCast<JSC::JSArrayBuffer*>(handle.slot()->asCell());
+    auto& wrapper = uncheckedDowncast<JSArrayBuffer>(*handle.slot()->asCell());
     return visitor.containsOpaqueRoot(wrapper.impl());
 }
 

--- a/Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp
+++ b/Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp
@@ -154,7 +154,7 @@ void SparseArrayEntry::get(JSObject* thisObject, PropertySlot& slot) const
         return;
     }
 
-    slot.setGetterSlot(thisObject, m_attributes, jsCast<GetterSetter*>(value));
+    slot.setGetterSlot(thisObject, m_attributes, uncheckedDowncast<GetterSetter>(value));
 }
 
 void SparseArrayEntry::get(PropertyDescriptor& descriptor) const
@@ -196,7 +196,7 @@ bool SparseArrayEntry::put(JSGlobalObject* globalObject, JSValue thisValue, Spar
         return true;
     }
 
-    RELEASE_AND_RETURN(scope, jsCast<GetterSetter*>(Base::get())->callSetter(globalObject, thisValue, value, shouldThrow));
+    RELEASE_AND_RETURN(scope, uncheckedDowncast<GetterSetter>(Base::get())->callSetter(globalObject, thisValue, value, shouldThrow));
 }
 
 JSValue SparseArrayEntry::getNonSparseMode() const
@@ -213,7 +213,7 @@ JSValue SparseArrayEntry::get() const
 template<typename Visitor>
 void SparseArrayValueMap::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    SparseArrayValueMap* thisObject = jsCast<SparseArrayValueMap*>(cell);
+    SparseArrayValueMap* thisObject = uncheckedDowncast<SparseArrayValueMap>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(cell, visitor);
     {

--- a/Source/JavaScriptCore/runtime/StackFrame.cpp
+++ b/Source/JavaScriptCore/runtime/StackFrame.cpp
@@ -220,7 +220,7 @@ String StackFrame::functionName(VM& vm) const
             }
             String name;
             if (jsFrame.callee && jsFrame.callee->isObject())
-                name = getCalculatedDisplayName(vm, jsCast<JSObject*>(jsFrame.callee.get())).impl();
+                name = getCalculatedDisplayName(vm, uncheckedDowncast<JSObject>(jsFrame.callee.get())).impl();
             else if (jsFrame.codeBlock) {
                 if (auto* executable = dynamicDowncast<FunctionExecutable>(jsFrame.codeBlock->ownerExecutable()))
                     name = executable->ecmaName().impl();

--- a/Source/JavaScriptCore/runtime/StringObject.cpp
+++ b/Source/JavaScriptCore/runtime/StringObject.cpp
@@ -46,7 +46,7 @@ void StringObject::finishCreation(VM& vm, JSString* string)
 
 bool StringObject::getOwnPropertySlot(JSObject* cell, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
-    StringObject* thisObject = jsCast<StringObject*>(cell);
+    StringObject* thisObject = uncheckedDowncast<StringObject>(cell);
     if (thisObject->internalValue()->getStringPropertySlot(globalObject, propertyName, slot))
         return true;
     return JSObject::getOwnPropertySlot(thisObject, globalObject, propertyName, slot);
@@ -54,7 +54,7 @@ bool StringObject::getOwnPropertySlot(JSObject* cell, JSGlobalObject* globalObje
     
 bool StringObject::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* globalObject, unsigned propertyName, PropertySlot& slot)
 {
-    StringObject* thisObject = jsCast<StringObject*>(object);
+    StringObject* thisObject = uncheckedDowncast<StringObject>(object);
     if (thisObject->internalValue()->getStringPropertySlot(globalObject, propertyName, slot))
         return true;    
     VM& vm = globalObject->vm();
@@ -66,7 +66,7 @@ bool StringObject::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    StringObject* thisObject = jsCast<StringObject*>(cell);
+    StringObject* thisObject = uncheckedDowncast<StringObject>(cell);
 
     if (propertyName == vm.propertyNames->length)
         return typeError(globalObject, scope, slot.isStrictMode(), ReadonlyPropertyWriteError);
@@ -82,7 +82,7 @@ bool StringObject::putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsign
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    StringObject* thisObject = jsCast<StringObject*>(cell);
+    StringObject* thisObject = uncheckedDowncast<StringObject>(cell);
     if (thisObject->internalValue()->canGetIndex(propertyName))
         return typeError(globalObject, scope, shouldThrow, ReadonlyPropertyWriteError);
     RELEASE_AND_RETURN(scope, JSObject::putByIndex(cell, globalObject, propertyName, value, shouldThrow));
@@ -104,7 +104,7 @@ bool StringObject::defineOwnProperty(JSObject* object, JSGlobalObject* globalObj
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    StringObject* thisObject = jsCast<StringObject*>(object);
+    StringObject* thisObject = uncheckedDowncast<StringObject>(object);
 
     if (isStringOwnProperty(globalObject, thisObject, propertyName)) {
         // The current PropertyDescriptor is always
@@ -127,7 +127,7 @@ bool StringObject::defineOwnProperty(JSObject* object, JSGlobalObject* globalObj
 bool StringObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
     VM& vm = globalObject->vm();
-    StringObject* thisObject = jsCast<StringObject*>(cell);
+    StringObject* thisObject = uncheckedDowncast<StringObject>(cell);
     if (propertyName == vm.propertyNames->length)
         return false;
     std::optional<uint32_t> index = parseIndex(propertyName);
@@ -138,7 +138,7 @@ bool StringObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, Pr
 
 bool StringObject::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned i)
 {
-    StringObject* thisObject = jsCast<StringObject*>(cell);
+    StringObject* thisObject = uncheckedDowncast<StringObject>(cell);
     if (thisObject->internalValue()->canGetIndex(i))
         return false;
     return JSObject::deletePropertyByIndex(thisObject, globalObject, i);
@@ -147,7 +147,7 @@ bool StringObject::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObj
 void StringObject::getOwnPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder& propertyNames, DontEnumPropertiesMode mode)
 {
     VM& vm = globalObject->vm();
-    StringObject* thisObject = jsCast<StringObject*>(object);
+    StringObject* thisObject = uncheckedDowncast<StringObject>(object);
     if (propertyNames.includeStringProperties()) {
         int size = thisObject->internalValue()->length();
         for (int i = 0; i < size; ++i)

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -461,7 +461,7 @@ inline JSString* replaceUsingStringSearch(VM& vm, JSGlobalObject* globalObject, 
 
     std::optional<CachedCall> cachedCall;
     if (callData.type == CallData::Type::JS) {
-        cachedCall.emplace(globalObject, jsCast<JSFunction*>(replaceValue), 3);
+        cachedCall.emplace(globalObject, uncheckedDowncast<JSFunction>(replaceValue), 3);
         RETURN_IF_EXCEPTION(scope, nullptr);
     }
 
@@ -1300,7 +1300,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     unsigned sourceLen = source->length();
-    RegExpObject* regExpObject = jsCast<RegExpObject*>(searchValue);
+    RegExpObject* regExpObject = uncheckedDowncast<RegExpObject>(searchValue);
     RegExp* regExp = regExpObject->regExp();
     bool global = regExp->global();
     bool hasNamedCaptures = regExp->hasNamedCaptures();
@@ -1314,7 +1314,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
             RELEASE_AND_RETURN(scope, removeAllUsingRegExpSearch(vm, globalObject, string, source, regExp));
 
         if (callData.type == CallData::Type::JS && !hasNamedCaptures && sourceLen >= Options::thresholdForStringReplaceCache())
-            RELEASE_AND_RETURN(scope, replaceAllWithCacheUsingRegExpSearch(vm, globalObject, string, source, regExp, jsCast<JSFunction*>(replaceValue)));
+            RELEASE_AND_RETURN(scope, replaceAllWithCacheUsingRegExpSearch(vm, globalObject, string, source, regExp, uncheckedDowncast<JSFunction>(replaceValue)));
     }
 
     if (callData.type == CallData::Type::None) {
@@ -1354,7 +1354,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
         int argCount = regExp->numSubpatterns() + 1 + 2;
         if (hasNamedCaptures)
             ++argCount;
-        JSFunction* func = jsCast<JSFunction*>(replaceValue);
+        JSFunction* func = uncheckedDowncast<JSFunction>(replaceValue);
         std::optional<CachedCall> cachedCallHolder;
         CachedCall* cachedCall = nullptr;
         while (true) {

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1396,7 +1396,7 @@ void Structure::didTransitionFromThisStructure(DeferredStructureTransitionWatchp
 template<typename Visitor>
 void Structure::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    Structure* thisObject = jsCast<Structure*>(cell);
+    Structure* thisObject = uncheckedDowncast<Structure>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/runtime/StructureChain.cpp
+++ b/Source/JavaScriptCore/runtime/StructureChain.cpp
@@ -72,7 +72,7 @@ void StructureChain::finishCreation(VM& vm, JSObject* head)
 template<typename Visitor>
 void StructureChain::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    StructureChain* thisObject = jsCast<StructureChain*>(cell);
+    StructureChain* thisObject = uncheckedDowncast<StructureChain>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.markAuxiliary(thisObject->m_vector.get());

--- a/Source/JavaScriptCore/runtime/StructureCreateInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureCreateInlines.h
@@ -48,7 +48,7 @@ inline void JSObject::didBecomePrototype(VM& vm)
     }
 
     if (type() == GlobalProxyType) [[unlikely]]
-        jsCast<JSGlobalProxy*>(this)->target()->didBecomePrototype(vm);
+        uncheckedDowncast<JSGlobalProxy>(this)->target()->didBecomePrototype(vm);
 }
 
 template<typename CellType, SubspaceAccess>

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -55,7 +55,7 @@ inline Structure* Structure::create(VM& vm, Structure* previous, DeferredStructu
         return result;
     }
     case StructureVariant::Branded: {
-        auto* result = new (NotNull, allocateCell<BrandedStructure>(vm)) BrandedStructure(vm, jsCast<BrandedStructure*>(previous));
+        auto* result = new (NotNull, allocateCell<BrandedStructure>(vm)) BrandedStructure(vm, uncheckedDowncast<BrandedStructure>(previous));
         result->finishCreation(vm, previous, deferred);
         return result;
     }
@@ -210,7 +210,7 @@ inline bool Structure::hasIndexingHeader(const JSCell* cell) const
     if (!isTypedView(m_blob.type()))
         return false;
 
-    TypedArrayMode mode = jsCast<const JSArrayBufferView*>(cell)->mode();
+    TypedArrayMode mode = uncheckedDowncast<JSArrayBufferView>(cell)->mode();
     return isWastefulTypedArray(mode);
 }
 

--- a/Source/JavaScriptCore/runtime/StructureRareData.cpp
+++ b/Source/JavaScriptCore/runtime/StructureRareData.cpp
@@ -74,7 +74,7 @@ StructureRareData::StructureRareData(VM& vm, Structure* previous)
 template<typename Visitor>
 void StructureRareData::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    StructureRareData* thisObject = jsCast<StructureRareData*>(cell);
+    StructureRareData* thisObject = uncheckedDowncast<StructureRareData>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/runtime/Symbol.h
+++ b/Source/JavaScriptCore/runtime/Symbol.h
@@ -86,7 +86,7 @@ Symbol* asSymbol(JSValue);
 inline Symbol* asSymbol(JSValue value)
 {
     ASSERT(value.asCell()->isSymbol());
-    return jsCast<Symbol*>(value.asCell());
+    return uncheckedDowncast<Symbol>(value.asCell());
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/SymbolPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolPrototype.cpp
@@ -85,7 +85,7 @@ inline Symbol* NODELETE tryExtractSymbol(JSValue thisValue)
     JSObject* thisObject = asObject(thisValue);
     if (!thisObject->inherits<SymbolObject>())
         return nullptr;
-    return asSymbol(jsCast<SymbolObject*>(thisObject)->internalValue());
+    return asSymbol(uncheckedDowncast<SymbolObject>(thisObject)->internalValue());
 }
 
 JSC_DEFINE_CUSTOM_GETTER(symbolProtoGetterDescription, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))

--- a/Source/JavaScriptCore/runtime/SymbolTable.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolTable.cpp
@@ -95,7 +95,7 @@ SymbolTable::~SymbolTable() = default;
 template<typename Visitor>
 void SymbolTable::visitChildrenImpl(JSCell* thisCell, Visitor& visitor)
 {
-    SymbolTable* thisSymbolTable = jsCast<SymbolTable*>(thisCell);
+    SymbolTable* thisSymbolTable = uncheckedDowncast<SymbolTable>(thisCell);
     ASSERT_GC_OBJECT_INHERITS(thisSymbolTable, info());
     Base::visitChildren(thisSymbolTable, visitor);
 

--- a/Source/JavaScriptCore/runtime/SyntheticModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/SyntheticModuleRecord.cpp
@@ -70,7 +70,7 @@ void SyntheticModuleRecord::finishCreation(JSGlobalObject* globalObject, VM& vm)
 template<typename Visitor>
 void SyntheticModuleRecord::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    SyntheticModuleRecord* thisObject = jsCast<SyntheticModuleRecord*>(cell);
+    SyntheticModuleRecord* thisObject = uncheckedDowncast<SyntheticModuleRecord>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -70,13 +70,13 @@ JSObject* TemporalCalendar::getTemporalCalendarWithISODefault(JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (itemValue.inherits<TemporalPlainDate>())
-        return jsCast<TemporalPlainDate*>(itemValue)->calendar();
+        return uncheckedDowncast<TemporalPlainDate>(itemValue)->calendar();
 
     if (itemValue.inherits<TemporalPlainDateTime>())
-        return jsCast<TemporalPlainDateTime*>(itemValue)->calendar();
+        return uncheckedDowncast<TemporalPlainDateTime>(itemValue)->calendar();
 
     if (itemValue.inherits<TemporalPlainTime>())
-        return jsCast<TemporalPlainTime*>(itemValue)->calendar();
+        return uncheckedDowncast<TemporalPlainTime>(itemValue)->calendar();
 
     JSValue calendar = itemValue.get(globalObject, vm.propertyNames->calendar);
     RETURN_IF_EXCEPTION(scope, { });
@@ -112,26 +112,26 @@ JSObject* TemporalCalendar::from(JSGlobalObject* globalObject, JSValue calendarL
     if (calendarLike.isObject()) {
         // FIXME: Also support PlainMonthDay, PlainYearMonth, ZonedDateTime.
         if (calendarLike.inherits<TemporalPlainDate>())
-            return jsCast<TemporalPlainDate*>(calendarLike)->calendar();
+            return uncheckedDowncast<TemporalPlainDate>(calendarLike)->calendar();
 
         if (calendarLike.inherits<TemporalPlainDateTime>())
-            return jsCast<TemporalPlainDateTime*>(calendarLike)->calendar();
+            return uncheckedDowncast<TemporalPlainDateTime>(calendarLike)->calendar();
 
         if (calendarLike.inherits<TemporalPlainTime>())
-            return jsCast<TemporalPlainTime*>(calendarLike)->calendar();
+            return uncheckedDowncast<TemporalPlainTime>(calendarLike)->calendar();
 
-        JSObject* calendarLikeObject = jsCast<JSObject*>(calendarLike);
+        JSObject* calendarLikeObject = uncheckedDowncast<JSObject>(calendarLike);
         bool hasProperty = calendarLikeObject->hasProperty(globalObject, vm.propertyNames->calendar);
         RETURN_IF_EXCEPTION(scope, { });
         if (!hasProperty)
-            return jsCast<JSObject*>(calendarLike);
+            return uncheckedDowncast<JSObject>(calendarLike);
 
         calendarLike = calendarLikeObject->get(globalObject, vm.propertyNames->calendar);
         if (calendarLike.isObject()) {
-            bool hasProperty = jsCast<JSObject*>(calendarLike)->hasProperty(globalObject, vm.propertyNames->calendar);
+            bool hasProperty = uncheckedDowncast<JSObject>(calendarLike)->hasProperty(globalObject, vm.propertyNames->calendar);
             RETURN_IF_EXCEPTION(scope, { });
             if (!hasProperty)
-                return jsCast<JSObject*>(calendarLike);
+                return uncheckedDowncast<JSObject>(calendarLike);
         }
     }
 

--- a/Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendarPrototype.cpp
@@ -216,7 +216,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalCalendarPrototypeFuncFields, (JSGlobalObject* g
             return;
         }
         if (!isISO8601 && !shouldAddEraAndEraYear) {
-            auto string = jsCast<JSString*>(value)->value(globalObject);
+            auto string = uncheckedDowncast<JSString>(value)->value(globalObject);
             RETURN_IF_EXCEPTION(scope, void());
             if (string.data == "year"_s)
                 shouldAddEraAndEraYear = true;

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -81,7 +81,7 @@ ISO8601::Duration TemporalDuration::fromDurationLike(JSGlobalObject* globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (durationLike->inherits<TemporalDuration>())
-        return jsCast<TemporalDuration*>(durationLike)->m_duration;
+        return uncheckedDowncast<TemporalDuration>(durationLike)->m_duration;
 
     ISO8601::Duration result;
     auto hasRelevantProperty = false;
@@ -156,7 +156,7 @@ TemporalDuration* TemporalDuration::toTemporalDuration(JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (itemValue.inherits<TemporalDuration>())
-        return jsCast<TemporalDuration*>(itemValue);
+        return uncheckedDowncast<TemporalDuration>(itemValue);
 
     auto result = toISO8601Duration(globalObject, itemValue);
     RETURN_IF_EXCEPTION(scope, nullptr);
@@ -194,7 +194,7 @@ TemporalDuration* TemporalDuration::from(JSGlobalObject* globalObject, JSValue i
     VM& vm = globalObject->vm();
 
     if (itemValue.inherits<TemporalDuration>()) {
-        ISO8601::Duration cloned = jsCast<TemporalDuration*>(itemValue)->m_duration;
+        ISO8601::Duration cloned = uncheckedDowncast<TemporalDuration>(itemValue)->m_duration;
         return TemporalDuration::create(vm, globalObject->durationStructure(), WTF::move(cloned));
     }
 

--- a/Source/JavaScriptCore/runtime/TemporalInstant.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.cpp
@@ -148,11 +148,11 @@ TemporalInstant* TemporalInstant::toInstant(JSGlobalObject* globalObject, JSValu
     }
 
     if (itemValue.inherits<TemporalInstant>())
-        return jsCast<TemporalInstant*>(itemValue);
+        return uncheckedDowncast<TemporalInstant>(itemValue);
 
     // FIXME: when Temporal.ZonedDateTime lands
     // if (itemValue.inherits<TemporalZonedDateTime>())
-    //    return TemporalInstant::create(vm, globalObject->instantStructure(), jsCast<TemporalZonedDateTime*>(itemValue)->epochTime());
+    //    return TemporalInstant::create(vm, globalObject->instantStructure(), uncheckedDowncast<TemporalZonedDateTime>(itemValue)->epochTime());
 
     String string = itemValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
@@ -173,7 +173,7 @@ TemporalInstant* TemporalInstant::from(JSGlobalObject* globalObject, JSValue ite
     VM& vm = globalObject->vm();
 
     if (itemValue.inherits<TemporalInstant>()) {
-        ISO8601::ExactTime exactTime = jsCast<TemporalInstant*>(itemValue)->exactTime();
+        ISO8601::ExactTime exactTime = uncheckedDowncast<TemporalInstant>(itemValue)->exactTime();
         return TemporalInstant::create(vm, globalObject->instantStructure(), exactTime);
     }
 

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -64,72 +64,72 @@ STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(TemporalObject);
 
 static JSValue createCalendarConstructor(VM& vm, JSObject* object)
 {
-    TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
+    TemporalObject* temporalObject = uncheckedDowncast<TemporalObject>(object);
     JSGlobalObject* globalObject = temporalObject->realm();
-    return TemporalCalendarConstructor::create(vm, TemporalCalendarConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<TemporalCalendarPrototype*>(globalObject->calendarStructure()->storedPrototypeObject()));
+    return TemporalCalendarConstructor::create(vm, TemporalCalendarConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<TemporalCalendarPrototype>(globalObject->calendarStructure()->storedPrototypeObject()));
 }
 
 static JSValue createNowObject(VM& vm, JSObject* object)
 {
-    TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
+    TemporalObject* temporalObject = uncheckedDowncast<TemporalObject>(object);
     JSGlobalObject* globalObject = temporalObject->realm();
     return TemporalNow::create(vm, TemporalNow::createStructure(vm, globalObject));
 }
 
 static JSValue createDurationConstructor(VM& vm, JSObject* object)
 {
-    TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
+    TemporalObject* temporalObject = uncheckedDowncast<TemporalObject>(object);
     JSGlobalObject* globalObject = temporalObject->realm();
-    return TemporalDurationConstructor::create(vm, TemporalDurationConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<TemporalDurationPrototype*>(globalObject->durationStructure()->storedPrototypeObject()));
+    return TemporalDurationConstructor::create(vm, TemporalDurationConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<TemporalDurationPrototype>(globalObject->durationStructure()->storedPrototypeObject()));
 }
 
 static JSValue createInstantConstructor(VM& vm, JSObject* object)
 {
-    TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
+    TemporalObject* temporalObject = uncheckedDowncast<TemporalObject>(object);
     JSGlobalObject* globalObject = temporalObject->realm();
-    return TemporalInstantConstructor::create(vm, TemporalInstantConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<TemporalInstantPrototype*>(globalObject->instantStructure()->storedPrototypeObject()));
+    return TemporalInstantConstructor::create(vm, TemporalInstantConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<TemporalInstantPrototype>(globalObject->instantStructure()->storedPrototypeObject()));
 }
 
 static JSValue createPlainDateConstructor(VM& vm, JSObject* object)
 {
-    TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
+    TemporalObject* temporalObject = uncheckedDowncast<TemporalObject>(object);
     auto* globalObject = temporalObject->realm();
-    return TemporalPlainDateConstructor::create(vm, TemporalPlainDateConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<TemporalPlainDatePrototype*>(globalObject->plainDateStructure()->storedPrototypeObject()));
+    return TemporalPlainDateConstructor::create(vm, TemporalPlainDateConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<TemporalPlainDatePrototype>(globalObject->plainDateStructure()->storedPrototypeObject()));
 }
 
 static JSValue createPlainDateTimeConstructor(VM& vm, JSObject* object)
 {
-    TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
+    TemporalObject* temporalObject = uncheckedDowncast<TemporalObject>(object);
     auto* globalObject = temporalObject->realm();
-    return TemporalPlainDateTimeConstructor::create(vm, TemporalPlainDateTimeConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<TemporalPlainDateTimePrototype*>(globalObject->plainDateTimeStructure()->storedPrototypeObject()));
+    return TemporalPlainDateTimeConstructor::create(vm, TemporalPlainDateTimeConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<TemporalPlainDateTimePrototype>(globalObject->plainDateTimeStructure()->storedPrototypeObject()));
 }
 
 static JSValue createPlainMonthDayConstructor(VM& vm, JSObject* object)
 {
-    TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
+    TemporalObject* temporalObject = uncheckedDowncast<TemporalObject>(object);
     auto* globalObject = temporalObject->realm();
-    return TemporalPlainMonthDayConstructor::create(vm, TemporalPlainMonthDayConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<TemporalPlainMonthDayPrototype*>(globalObject->plainMonthDayStructure()->storedPrototypeObject()));
+    return TemporalPlainMonthDayConstructor::create(vm, TemporalPlainMonthDayConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<TemporalPlainMonthDayPrototype>(globalObject->plainMonthDayStructure()->storedPrototypeObject()));
 }
 
 static JSValue createPlainTimeConstructor(VM& vm, JSObject* object)
 {
-    TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
+    TemporalObject* temporalObject = uncheckedDowncast<TemporalObject>(object);
     auto* globalObject = temporalObject->realm();
-    return TemporalPlainTimeConstructor::create(vm, TemporalPlainTimeConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<TemporalPlainTimePrototype*>(globalObject->plainTimeStructure()->storedPrototypeObject()));
+    return TemporalPlainTimeConstructor::create(vm, TemporalPlainTimeConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<TemporalPlainTimePrototype>(globalObject->plainTimeStructure()->storedPrototypeObject()));
 }
 
 static JSValue createPlainYearMonthConstructor(VM& vm, JSObject* object)
 {
-    TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
+    TemporalObject* temporalObject = uncheckedDowncast<TemporalObject>(object);
     auto* globalObject = temporalObject->realm();
-    return TemporalPlainYearMonthConstructor::create(vm, TemporalPlainYearMonthConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<TemporalPlainYearMonthPrototype*>(globalObject->plainYearMonthStructure()->storedPrototypeObject()));
+    return TemporalPlainYearMonthConstructor::create(vm, TemporalPlainYearMonthConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<TemporalPlainYearMonthPrototype>(globalObject->plainYearMonthStructure()->storedPrototypeObject()));
 }
 
 static JSValue createTimeZoneConstructor(VM& vm, JSObject* object)
 {
-    TemporalObject* temporalObject = jsCast<TemporalObject*>(object);
+    TemporalObject* temporalObject = uncheckedDowncast<TemporalObject>(object);
     JSGlobalObject* globalObject = temporalObject->realm();
-    return TemporalTimeZoneConstructor::create(vm, TemporalTimeZoneConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), jsCast<TemporalTimeZonePrototype*>(globalObject->timeZoneStructure()->storedPrototypeObject()));
+    return TemporalTimeZoneConstructor::create(vm, TemporalTimeZoneConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), uncheckedDowncast<TemporalTimeZonePrototype>(globalObject->timeZoneStructure()->storedPrototypeObject()));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -64,7 +64,7 @@ void TemporalPlainDate::finishCreation(VM& vm)
     m_calendar.initLater(
         [] (const auto& init) {
             VM& vm = init.vm;
-            auto* plainDate = jsCast<TemporalPlainDate*>(init.owner);
+            auto* plainDate = init.owner;
             auto* globalObject = plainDate->realm();
             auto* calendar = TemporalCalendar::create(vm, globalObject->calendarStructure(), iso8601CalendarID());
             init.set(calendar);
@@ -76,7 +76,7 @@ void TemporalPlainDate::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     Base::visitChildren(cell, visitor);
 
-    auto* thisObject = jsCast<TemporalPlainDate*>(cell);
+    auto* thisObject = uncheckedDowncast<TemporalPlainDate>(cell);
     thisObject->m_calendar.visit(visitor);
 }
 
@@ -161,16 +161,16 @@ TemporalPlainDate* TemporalPlainDate::from(JSGlobalObject* globalObject, JSValue
 
     if (itemValue.isObject()) {
         if (itemValue.inherits<TemporalPlainDate>())
-            return jsCast<TemporalPlainDate*>(itemValue);
+            return uncheckedDowncast<TemporalPlainDate>(itemValue);
 
         if (itemValue.inherits<TemporalPlainDateTime>())
-            return TemporalPlainDate::create(vm, globalObject->plainDateStructure(), jsCast<TemporalPlainDateTime*>(itemValue)->plainDate());
+            return TemporalPlainDate::create(vm, globalObject->plainDateStructure(), uncheckedDowncast<TemporalPlainDateTime>(itemValue)->plainDate());
 
         JSObject* calendar = TemporalCalendar::getTemporalCalendarWithISODefault(globalObject, itemValue);
         RETURN_IF_EXCEPTION(scope, { });
 
         // FIXME: Implement after fleshing out Temporal.Calendar.
-        if (!calendar->inherits<TemporalCalendar>() || !jsCast<TemporalCalendar*>(calendar)->isISO8601()) {
+        if (!calendar->inherits<TemporalCalendar>() || !uncheckedDowncast<TemporalCalendar>(calendar)->isISO8601()) {
             throwRangeError(globalObject, scope, "unimplemented: from non-ISO8601 calendar"_s);
             return { };
         }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
@@ -140,7 +140,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateConstructorFuncFrom, (JSGlobalObject* 
     RETURN_IF_EXCEPTION(scope, { });
 
     if (itemValue.inherits<TemporalPlainDate>())
-        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::create(vm, globalObject->plainDateStructure(), jsCast<TemporalPlainDate*>(itemValue)->plainDate())));
+        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::create(vm, globalObject->plainDateStructure(), uncheckedDowncast<TemporalPlainDate>(itemValue)->plainDate())));
 
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::from(globalObject, itemValue, overflow)));
 }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -63,7 +63,7 @@ void TemporalPlainDateTime::finishCreation(VM& vm)
     m_calendar.initLater(
         [] (const auto& init) {
             VM& vm = init.vm;
-            auto* globalObject = jsCast<TemporalPlainDateTime*>(init.owner)->realm();
+            auto* globalObject = init.owner->realm();
             auto* calendar = TemporalCalendar::create(vm, globalObject->calendarStructure(), iso8601CalendarID());
             init.set(calendar);
         });
@@ -74,7 +74,7 @@ void TemporalPlainDateTime::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     Base::visitChildren(cell, visitor);
 
-    auto* thisObject = jsCast<TemporalPlainDateTime*>(cell);
+    auto* thisObject = uncheckedDowncast<TemporalPlainDateTime>(cell);
     thisObject->m_calendar.visit(visitor);
 }
 
@@ -116,16 +116,16 @@ TemporalPlainDateTime* TemporalPlainDateTime::from(JSGlobalObject* globalObject,
 
     if (itemValue.isObject()) {
         if (itemValue.inherits<TemporalPlainDateTime>())
-            return jsCast<TemporalPlainDateTime*>(itemValue);
+            return uncheckedDowncast<TemporalPlainDateTime>(itemValue);
 
         if (itemValue.inherits<TemporalPlainDate>())
-            return TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), jsCast<TemporalPlainDate*>(itemValue)->plainDate(), { });
+            return TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), uncheckedDowncast<TemporalPlainDate>(itemValue)->plainDate(), { });
 
         JSObject* calendar = TemporalCalendar::getTemporalCalendarWithISODefault(globalObject, itemValue);
         RETURN_IF_EXCEPTION(scope, { });
 
         // FIXME: Implement after fleshing out Temporal.Calendar.
-        if (!calendar->inherits<TemporalCalendar>() || !jsCast<TemporalCalendar*>(calendar)->isISO8601()) {
+        if (!calendar->inherits<TemporalCalendar>() || !uncheckedDowncast<TemporalCalendar>(calendar)->isISO8601()) {
             throwRangeError(globalObject, scope, "unimplemented: from non-ISO8601 calendar"_s);
             return { };
         }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
@@ -126,7 +126,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimeConstructorFuncFrom, (JSGlobalObje
         toTemporalOverflow(globalObject, options);
         RETURN_IF_EXCEPTION(scope, { });
 
-        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), jsCast<TemporalPlainDateTime*>(itemValue)->plainDate(), jsCast<TemporalPlainDateTime*>(itemValue)->plainTime())));
+        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), uncheckedDowncast<TemporalPlainDateTime>(itemValue)->plainDate(), uncheckedDowncast<TemporalPlainDateTime>(itemValue)->plainTime())));
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDateTime::from(globalObject, itemValue, options)));

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
@@ -63,7 +63,7 @@ void TemporalPlainMonthDay::finishCreation(VM& vm)
     m_calendar.initLater(
         [] (const auto& init) {
             VM& vm = init.vm;
-            auto* plainMonthDay = jsCast<TemporalPlainMonthDay*>(init.owner);
+            auto* plainMonthDay = init.owner;
             auto* globalObject = plainMonthDay->realm();
             auto* calendar = TemporalCalendar::create(vm, globalObject->calendarStructure(), iso8601CalendarID());
             init.set(calendar);
@@ -75,7 +75,7 @@ void TemporalPlainMonthDay::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     Base::visitChildren(cell, visitor);
 
-    auto* thisObject = jsCast<TemporalPlainMonthDay*>(cell);
+    auto* thisObject = uncheckedDowncast<TemporalPlainMonthDay>(cell);
     thisObject->m_calendar.visit(visitor);
 }
 
@@ -150,16 +150,16 @@ TemporalPlainMonthDay* TemporalPlainMonthDay::from(JSGlobalObject* globalObject,
 
     if (itemValue.isObject()) {
         if (itemValue.inherits<TemporalPlainMonthDay>())
-            return jsCast<TemporalPlainMonthDay*>(itemValue);
+            return uncheckedDowncast<TemporalPlainMonthDay>(itemValue);
 
         if (itemValue.inherits<TemporalPlainMonthDay>())
-            return TemporalPlainMonthDay::create(vm, globalObject->plainMonthDayStructure(), jsCast<TemporalPlainMonthDay*>(itemValue)->plainMonthDay());
+            return TemporalPlainMonthDay::create(vm, globalObject->plainMonthDayStructure(), uncheckedDowncast<TemporalPlainMonthDay>(itemValue)->plainMonthDay());
 
         JSObject* calendar = TemporalCalendar::getTemporalCalendarWithISODefault(globalObject, itemValue);
         RETURN_IF_EXCEPTION(scope, { });
 
         // FIXME: Implement after fleshing out Temporal.Calendar.
-        if (!calendar->inherits<TemporalCalendar>() || !jsCast<TemporalCalendar*>(calendar)->isISO8601()) [[unlikely]] {
+        if (!calendar->inherits<TemporalCalendar>() || !uncheckedDowncast<TemporalCalendar>(calendar)->isISO8601()) [[unlikely]] {
             throwRangeError(globalObject, scope, "unimplemented: from non-ISO8601 calendar"_s);
             return { };
         }

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
@@ -145,7 +145,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayConstructorFuncFrom, (JSGlobalObje
         toTemporalOverflow(globalObject, callFrame->argument(1));
         RETURN_IF_EXCEPTION(scope, { });
 
-        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainMonthDay::create(vm, globalObject->plainMonthDayStructure(), jsCast<TemporalPlainMonthDay*>(itemValue)->plainMonthDay())));
+        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainMonthDay::create(vm, globalObject->plainMonthDayStructure(), uncheckedDowncast<TemporalPlainMonthDay>(itemValue)->plainMonthDay())));
     }
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainMonthDay::from(globalObject, itemValue, callFrame->argument(1))));
 }

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -66,7 +66,7 @@ void TemporalPlainTime::finishCreation(VM& vm)
     m_calendar.initLater(
         [] (const auto& init) {
             VM& vm = init.vm;
-            auto* plainTime = jsCast<TemporalPlainTime*>(init.owner);
+            auto* plainTime = init.owner;
             auto* globalObject = plainTime->realm();
             auto* calendar = TemporalCalendar::create(vm, globalObject->calendarStructure(), iso8601CalendarID());
             init.set(calendar);
@@ -78,7 +78,7 @@ void TemporalPlainTime::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     Base::visitChildren(cell, visitor);
 
-    auto* thisObject = jsCast<TemporalPlainTime*>(cell);
+    auto* thisObject = uncheckedDowncast<TemporalPlainTime>(cell);
     thisObject->m_calendar.visit(visitor);
 }
 
@@ -434,7 +434,7 @@ TemporalPlainTime* TemporalPlainTime::from(JSGlobalObject* globalObject, JSValue
 
     if (itemValue.isObject()) {
         if (itemValue.inherits<TemporalPlainTime>())
-            return jsCast<TemporalPlainTime*>(itemValue);
+            return uncheckedDowncast<TemporalPlainTime>(itemValue);
 
         if (itemValue.inherits<TemporalPlainDateTime>()) {
             // Validate overflow -- see step 2(a)(ii) of ToTemporalTime
@@ -442,9 +442,9 @@ TemporalPlainTime* TemporalPlainTime::from(JSGlobalObject* globalObject, JSValue
                 toTemporalOverflow(globalObject, options);
                 RETURN_IF_EXCEPTION(scope, { });
             }
-            return TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), jsCast<TemporalPlainDateTime*>(itemValue)->plainTime());
+            return TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), uncheckedDowncast<TemporalPlainDateTime>(itemValue)->plainTime());
         }
-        auto duration = toTemporalTimeRecord(globalObject, jsCast<JSObject*>(itemValue));
+        auto duration = toTemporalTimeRecord(globalObject, uncheckedDowncast<JSObject>(itemValue));
         RETURN_IF_EXCEPTION(scope, { });
 
         TemporalOverflow overflow = TemporalOverflow::Constrain;

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
@@ -126,7 +126,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimeConstructorFuncFrom, (JSGlobalObject* 
             toTemporalOverflow(globalObject, options);
         RETURN_IF_EXCEPTION(scope, { });
         return JSValue::encode(TemporalPlainTime::create(vm, globalObject->plainTimeStructure(),
-            jsCast<TemporalPlainTime*>(itemValue)->plainTime()));
+            uncheckedDowncast<TemporalPlainTime>(itemValue)->plainTime()));
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainTime::from(globalObject, itemValue, options)));

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
@@ -64,7 +64,7 @@ void TemporalPlainYearMonth::finishCreation(VM& vm)
     m_calendar.initLater(
         [] (const auto& init) {
             VM& vm = init.vm;
-            auto* plainYearMonth = jsCast<TemporalPlainYearMonth*>(init.owner);
+            auto* plainYearMonth = init.owner;
             auto* globalObject = plainYearMonth->realm();
             auto* calendar = TemporalCalendar::create(vm, globalObject->calendarStructure(), iso8601CalendarID());
             init.set(calendar);
@@ -76,7 +76,7 @@ void TemporalPlainYearMonth::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     Base::visitChildren(cell, visitor);
 
-    auto* thisObject = jsCast<TemporalPlainYearMonth*>(cell);
+    auto* thisObject = uncheckedDowncast<TemporalPlainYearMonth>(cell);
     thisObject->m_calendar.visit(visitor);
 }
 
@@ -148,13 +148,13 @@ TemporalPlainYearMonth* TemporalPlainYearMonth::from(JSGlobalObject* globalObjec
 
     if (item.isObject()) {
         if (item.inherits<TemporalPlainYearMonth>())
-            return jsCast<TemporalPlainYearMonth*>(item);
+            return uncheckedDowncast<TemporalPlainYearMonth>(item);
 
         JSObject* calendar = TemporalCalendar::getTemporalCalendarWithISODefault(globalObject, item);
         RETURN_IF_EXCEPTION(scope, { });
 
         // FIXME: Implement after fleshing out Temporal.Calendar.
-        if (!calendar->inherits<TemporalCalendar>() || !jsCast<TemporalCalendar*>(calendar)->isISO8601()) [[unlikely]] {
+        if (!calendar->inherits<TemporalCalendar>() || !uncheckedDowncast<TemporalCalendar>(calendar)->isISO8601()) [[unlikely]] {
             throwRangeError(globalObject, scope, "unimplemented: from non-ISO8601 calendar"_s);
             return { };
         }

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthConstructor.cpp
@@ -162,7 +162,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthConstructorFuncFrom, (JSGlobalObj
         toTemporalOverflow(globalObject, callFrame->argument(1));
         RETURN_IF_EXCEPTION(scope, { });
 
-        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainYearMonth::create(vm, globalObject->plainYearMonthStructure(), jsCast<TemporalPlainYearMonth*>(itemValue)->plainYearMonth())));
+        RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainYearMonth::create(vm, globalObject->plainYearMonthStructure(), uncheckedDowncast<TemporalPlainYearMonth>(itemValue)->plainYearMonth())));
     }
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainYearMonth::from(globalObject, itemValue, callFrame->argument(1))));
 }

--- a/Source/JavaScriptCore/runtime/TemporalTimeZone.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZone.cpp
@@ -73,7 +73,7 @@ JSObject* TemporalTimeZone::from(JSGlobalObject* globalObject, JSValue timeZoneL
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (timeZoneLike.isObject()) {
-        JSObject* timeZoneLikeObject = jsCast<JSObject*>(timeZoneLike);
+        JSObject* timeZoneLikeObject = uncheckedDowncast<JSObject>(timeZoneLike);
 
         // FIXME: We need to implement code retrieving TimeZone from Temporal Date Like objects. But
         // currently they are not implemented yet.
@@ -85,7 +85,7 @@ JSObject* TemporalTimeZone::from(JSGlobalObject* globalObject, JSValue timeZoneL
 
         timeZoneLike = timeZoneLikeObject->get(globalObject, vm.propertyNames->timeZone);
         if (timeZoneLike.isObject()) {
-            JSObject* timeZoneLikeObject = jsCast<JSObject*>(timeZoneLike);
+            JSObject* timeZoneLikeObject = uncheckedDowncast<JSObject>(timeZoneLike);
             bool hasProperty = timeZoneLikeObject->hasProperty(globalObject, vm.propertyNames->timeZone);
             RETURN_IF_EXCEPTION(scope, { });
             if (!hasProperty)

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -205,7 +205,7 @@ void WaiterListManager::notifyWaiterImpl(const AbstractLocker& listLocker, Ref<W
 
     if (waiter->isAsync()) {
         waiter->scheduleWorkAndClear(listLocker, [resolveResult](DeferredWorkTimer::Ticket ticket) {
-            JSPromise* promise = jsCast<JSPromise*>(ticket->target());
+            JSPromise* promise = uncheckedDowncast<JSPromise>(ticket->target());
             JSGlobalObject* globalObject = promise->realm();
             VM& vm = promise->vm();
             JSValue result = resolveResult == ResolveResult::Ok ? vm.smallStrings.okString() : vm.smallStrings.timedOutString();
@@ -376,7 +376,7 @@ void Waiter::dump(PrintStream& out) const
     out.print(", ticket=", RawPointer(ticket.get()));
     if (ticket && !ticket->isCancelled()) {
         out.print(", m_ticket->globalObject=", RawPointer(ticket->target()->realm()));
-        out.print(", m_ticket->target=", RawPointer(jsCast<JSObject*>(ticket->dependencies().last())));
+        out.print(", m_ticket->target=", RawPointer(uncheckedDowncast<JSObject>(ticket->dependencies().last())));
         out.print(", m_ticket->scriptExecutionOwner=", RawPointer(ticket->scriptExecutionOwner()));
     }
 

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.cpp
@@ -45,7 +45,7 @@ template<typename WeakMapBucket>
 template<typename Visitor>
 void WeakMapImpl<WeakMapBucket>::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    WeakMapImpl* thisObject = jsCast<WeakMapImpl*>(cell);
+    WeakMapImpl* thisObject = uncheckedDowncast<WeakMapImpl>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.reportExtraMemoryVisited(thisObject->m_capacity * sizeof(WeakMapBucket));
@@ -80,7 +80,7 @@ ALWAYS_INLINE void WeakMapImpl<BucketType>::visitOutputConstraints(JSCell* cell,
 {
     static_assert(std::is_same<BucketType, WeakMapBucket<WeakMapBucketDataKeyValue>>::value);
 
-    auto* thisObject = jsCast<WeakMapImpl*>(cell);
+    auto* thisObject = uncheckedDowncast<WeakMapImpl>(cell);
     auto* buffer = thisObject->buffer();
     for (uint32_t index = 0; index < thisObject->m_capacity; ++index) {
         auto* bucket = buffer + index;

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
@@ -188,7 +188,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapGetOrInsertComputed, (JSGlobalObject* g
 
     JSValue value;
     if (callData.type == CallData::Type::JS) [[likely]] {
-        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(valueCallback), 1);
+        CachedCall cachedCall(globalObject, uncheckedDowncast<JSFunction>(valueCallback), 1);
         RETURN_IF_EXCEPTION(scope, { });
 
         value = cachedCall.callWithArguments(globalObject, jsUndefined(), key);


### PR DESCRIPTION
#### b8ef260b13ef485d0397e02152f1a4571d5ded96
<pre>
Reduce use of jsCast&lt;&gt;() in favor of uncheckedDowncast&lt;&gt;()
<a href="https://bugs.webkit.org/show_bug.cgi?id=312711">https://bugs.webkit.org/show_bug.cgi?id=312711</a>

Reviewed by Anne van Kesteren.

Reduce use of jsCast&lt;&gt;() in favor of uncheckedDowncast&lt;&gt;(), for casting
consistency throughout the codebase.

Canonical link: <a href="https://commits.webkit.org/311557@main">https://commits.webkit.org/311557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de53188e39de67fc0939ff8f48e82c4f85834987

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157357 "81 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111439 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54dd3312-1f5b-4388-8364-765e5c683e2e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85585 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3b426c2-67f9-4086-809f-3b1de47686ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102544 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/228dbe03-6529-4d59-a348-9cdb251d3c25) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23176 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21422 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13952 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149408 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168666 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18192 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12824 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130009 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35240 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140918 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88149 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24938 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17723 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/189376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29929 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93943 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/189376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29451 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29681 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29578 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->