### PR TITLE
[GStreamer] Flaky media test failures due to video frame map failures in avviddec with buffers allocated by the GL buffer pool

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1907,7 +1907,7 @@ media/modern-media-controls/scrubber/scrubber-has-correct-ax-label.html [ Timeou
 media/modern-media-controls/volume-support/volume-support-click.html [ Timeout ]
 media/modern-media-controls/audio/audio-controls-styles.html [ Failure ]
 media/modern-media-controls/media-controller/media-controller-auto-hide-mouse-enter-over-controls-bar.html [ Failure ]
-# media/modern-media-controls/media-controller/media-controller-auto-hide-mouse-leave-after-play.html [ Failure ]
+media/modern-media-controls/media-controller/media-controller-auto-hide-mouse-leave-after-play.html [ Failure ]
 media/modern-media-controls/media-controller/media-controller-video-with-only-audio.html [ Failure ]
 media/modern-media-controls/time-label/time-label.html [ Failure ]
 media/modern-media-controls/volume-support/volume-support-drag.html [ Failure ]
@@ -4354,38 +4354,7 @@ webkit.org/b/229062 fast/forms/caps-lock-indicator-width.html [ Skip ]
 # Test is a flaky timeout. The test is also skipped in iOS and Windows.
 media/video-remote-control-playpause.html [ Skip ]
 
-# Timeouts due to gstreamer allocation error
-webkit.org/b/309438 compositing/video/video-clip-change-src.html [ Pass Timeout ]
-webkit.org/b/309438 media/media-controller-timeupdate.html [ Pass Timeout ]
-webkit.org/b/309438 media/media-source/media-source-reopen.html [ Pass Failure ]
-webkit.org/b/309438 media/media-source/media-source-webm-configuration-framerate.html [ Pass Timeout ]
-webkit.org/b/309438 media/modern-media-controls/media-controller/media-controller-auto-hide-mouse-leave-after-play.html [ Failure Timeout ]
-webkit.org/b/309438 media/modern-media-controls/media-controller/media-controller-click-on-video-controls-should-not-pause.html [ Pass Timeout ]
-webkit.org/b/309438 media/modern-media-controls/tracks-support/no-tracks.html [ Pass Timeout ]
-webkit.org/b/309438 media/playlist-inherits-user-gesture.html [ Pass Timeout ]
-webkit.org/b/309438 media/remote-control-command-scrubbing.html [ Pass Timeout ]
-webkit.org/b/309438 media/remote-control-command-seek.html [ Pass Timeout ]
-webkit.org/b/309438 media/remove-from-document-with-text-track.html [ Pass Timeout ]
-webkit.org/b/309438 media/track/track-cue-missing.html [ Pass Timeout ]
-webkit.org/b/309438 media/track/track-long-captions-file.html [ Pass Timeout ]
-webkit.org/b/309438 media/track/webvtt-inline.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-concurrent-playback.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-currentTime-duration.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-currenttime-monotonic.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-currentTime-set2.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-isplayingtoautomotiveheadunit.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-load-preload-metadata.html [ Pass Failure ]
-webkit.org/b/309438 media/video-main-content-allow-then-scroll.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-main-content-autoplay.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-main-content-deny-display-none.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-main-content-deny-too-small.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-paused-0-rate.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-pause-empty-events.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-replaces-poster.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-seek-by-small-increment.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-seeking.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-seek-pause.html [ Pass Timeout ]
-webkit.org/b/309438 media/video-webkit-playsinline.html [ Pass Timeout ]
+webkit.org/b/312714 media/media-source/media-source-webm-configuration-framerate.html [ Pass Timeout ]
 
 # Failure Pass Crash Timeout
 webkit.org/b/207062 webkit.org/b/244776 imported/w3c/web-platform-tests/media-source/mediasource-replay.html [ Skip ]
@@ -5316,7 +5285,6 @@ webkit.org/b/306468 http/wpt/service-workers/fetch-service-worker-preload-changi
 webkit.org/b/306468 http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https.html [ Pass Failure Timeout ]
 
 webkit.org/b/116277 media/video-buffered.html [ Pass Failure Timeout ]
-webkit.org/b/306471 media/video-poster-not-found.html [ Pass Timeout ]
 
 webkit.org/b/306472 fast/repaint/selection-gap-absolute-child.html [ Pass Failure ]
 webkit.org/b/306474 imported/w3c/web-platform-tests/fetch/range/sw-416.https.window.html [ Pass Failure ]
@@ -5353,10 +5321,6 @@ webkit.org/b/307292 imported/w3c/web-platform-tests/resource-timing/buffered-fla
 webkit.org/b/307293 imported/w3c/web-platform-tests/event-timing/keyup.html [ Pass Failure ]
 webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup.html [ Pass Failure ]
 
-webkit.org/b/307294 media/video-pause-immediately.html [ Pass Timeout ]
-webkit.org/b/307294 media/video-playbackrate.html [ Pass Timeout ]
-webkit.org/b/307294 media/video-seek-past-end-paused.html [ Timeout Pass ]
-
 webkit.org/b/294295 fullscreen/full-screen-request-removed-with-raf.html [ Pass Timeout ]
 
 webkit.org/b/307368 fast/repaint/iframe-from-display-none-repaint.html [ Pass ImageOnlyFailure ]
@@ -5365,8 +5329,6 @@ webkit.org/b/307368 fast/repaint/iframe-from-display-none-repaint.html [ Pass Im
 webkit.org/b/307597 imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html [ Crash Pass ]
 
 webkit.org/b/307657 imported/w3c/web-platform-tests/resource-timing/status-codes-create-entry.html [ Pass Failure ]
-
-webkit.org/b/307666 media/modern-media-controls/status-support/status-support-playing.html [ Pass Timeout ]
 
 webkit.org/b/307989 imported/w3c/web-platform-tests/cookies/path/default.html [ Pass Failure ]
 
@@ -5382,8 +5344,6 @@ webkit.org/b/288005 imported/w3c/web-platform-tests/css/selectors/invalidation/n
 
 webkit.org/b/308971 fast/canvas/canvas-strokePath-round-lineCap.html [ Pass ImageOnlyFailure ]
 webkit.org/b/308972 fast/repaint/search-field-cancel.html [ Pass ImageOnlyFailure Failure ]
-
-webkit.org/b/308146 media/video-size.html [ Pass Failure Timeout ]
 
 webkit.org/b/308262 fast/css/view-transitions-hide-under-page-background-color.html [ Pass ImageOnlyFailure ]
 
@@ -5421,10 +5381,6 @@ webkit.org/b/310215 fast/loader/submit-form-while-parsing-2.html [ Pass Failure 
 
 webkit.org/b/310268 fast/css/anchor-position-media-query-viewport-units.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/310274 media/media-controller-time.html [ Pass Timeout ]
-
-webkit.org/b/310278 media/video-pause-play-resolve.html [ Pass Timeout ]
-
 webkit.org/b/310543 fast/css/outline-auto-zoom-canvas.html [ Failure ]
 webkit.org/b/310543 fast/images/imagemap-focus-ring-zoom-style.html [ ImageOnlyFailure ]
 webkit.org/b/310543 fast/images/image-map-outline-with-scale-transform.html [ ImageOnlyFailure ]
@@ -5457,8 +5413,6 @@ webkit.org/b/309872 imported/w3c/web-platform-tests/permissions-policy/reporting
 
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root.html [ ImageOnlyFailure Pass ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-root-both-edges.html [ ImageOnlyFailure ]
-
-webkit.org/b/311093 media/video-src-blob-replay.html [ Pass Timeout ]
 
 webkit.org/b/195466 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/ready-states/autoplay.html [ Failure Pass ]
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1294,7 +1294,7 @@ webgl/2.0.y/conformance/context/context-no-alpha-fbo-with-alpha.html [ Skip ]
 
 # Flaky tests on Aug-2023
 webkit.org/b/261024 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-return-value-handling-dynamic.html [ Failure Pass ]
-webkit.org/b/261024 imported/w3c/web-platform-tests/media-source/mediasource-play.html [ Failure Pass Timeout ]
+webkit.org/b/261024 imported/w3c/web-platform-tests/media-source/mediasource-play.html [ Failure Pass ]
 webkit.org/b/261024 inspector/canvas/recording-webgl-full.html [ Failure ]
 
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-plus-filter.html [ ImageOnlyFailure ]
@@ -1303,6 +1303,8 @@ imported/w3c/web-platform-tests/css/filter-effects/filtered-inline-is-container.
 
 http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html [ Skip ]
 
+media/video-concurrent-playback.html [ Pass Failure ]
+
 # Flaky tests Nov2023
 webkit.org/b/264680 fast/media/mq-prefers-contrast-live-update-for-listener.html [ Failure Pass ]
 webkit.org/b/264680 fast/scrolling/gtk/user-scroll-snapping-interaction.html [ Timeout ]
@@ -1310,8 +1312,6 @@ webkit.org/b/264680 http/wpt/service-workers/controlled-sharedworker.https.html 
 webkit.org/b/264680 imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251.html?include=loading [ Failure Pass ]
 webkit.org/b/264680 imported/w3c/web-platform-tests/media-source/mediasource-seek-during-pending-seek.html [ Crash Failure Pass Timeout ]
 webkit.org/b/264680 inspector/heap/getPreview.html [ Failure Pass ]
-webkit.org/b/264680 media/no-fullscreen-when-hidden.html [ Timeout Pass ]
-webkit.org/b/264680 media/video-background-tab-playback.html [ Timeout Pass ]
 webkit.org/b/264680 scrollbars/scrollbar-selectors.html [ Pass Timeout ]
 
 fast/dom/no-scroll-when-command-click-fragment-URL.html [ Skip ]
@@ -1467,9 +1467,7 @@ webkit.org/b/310751 imported/w3c/web-platform-tests/webrtc/protocol/h264-profile
 webkit.org/b/310752 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter.html [ Pass Failure ]
 webkit.org/b/310753 imported/w3c/web-platform-tests/webrtc/protocol/split.https.html [ Pass Failure ]
 webkit.org/b/310754 inspector/controller/runtime-controller-import.html [ Pass Failure ]
-webkit.org/b/310755 media/modern-media-controls/time-labels-support/remaining-time.html [ Pass Timeout ]
-webkit.org/b/310756 media/video-currentTime-set.html [ Pass Timeout ]
-webkit.org/b/310757 media/video-main-content-allow-then-scroll.html [ Pass Timeout ]
+media/video-currentTime-set.html [ Pass Failure ]
 
 inspector/unit-tests/retryuntil.html [ Pass Failure ]
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -173,8 +173,10 @@ webkit.org/b/298588 fast/media/mq-pointer-styling.html [ Skip ]
 webkit.org/b/298588 fast/media/mq-pointer.html [ Skip ]
 
 # Pending to create bug.
-media/video-background-tab-playback.html [ Failure ]
 svg/hixie/viewbox/002.xml [ Failure ]
+
+webkit.org/b/264680 media/video-background-tab-playback.html [ Failure ]
+webkit.org/b/264680 media/no-fullscreen-when-hidden.html [ Pass Failure ]
 
 webkit.org/b/298919 imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-reportValidity-delegatesFocus.html [ Skip ]
 
@@ -1262,9 +1264,6 @@ webkit.org/b/310739 imported/w3c/web-platform-tests/editing/other/copy-elements-
 webkit.org/b/310741 imported/w3c/web-platform-tests/navigation-api/navigate-event/defer/tentative/defer-restore-callback-abort.html [ Pass Timeout ]
 webkit.org/b/310743 imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-right.html [ Pass ImageOnlyFailure ]
 webkit.org/b/310744 imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-014.html [ Pass ImageOnlyFailure ]
-webkit.org/b/310745 media/modern-media-controls/time-label/time-label-white-space-nowrap.html [ Pass Timeout ]
-webkit.org/b/310746 media/video-seek-double.html [ Pass Timeout ]
-webkit.org/b/310747 media/video-seekable.html [ Pass Timeout ]
 
 webkit.org/b/310543 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-082.html [ ImageOnlyFailure ]
 webkit.org/b/310543 imported/w3c/web-platform-tests/css/css-contain/content-visibility/scrollIntoView-with-focus-target-with-contents-hidden.html [ ImageOnlyFailure ]
@@ -1275,7 +1274,6 @@ webkit.org/b/311857 [ arm64 ] imported/w3c/web-platform-tests/css/css-position/s
 webkit.org/b/311858 [ arm64 ] imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-001.html [ Pass ImageOnlyFailure ]
 webkit.org/b/311859 [ arm64 ] http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction-timeout.html [ Pass Failure ]
 webkit.org/b/311861 [ arm64 ] media/video-played-ranges-1.html [ Pass Failure Timeout Crash ]
-webkit.org/b/311863 [ arm64 ] media/video-interruption-with-resume-not-allowing-play.html [ Pass Failure Timeout ]
 webkit.org/b/311864 [ arm64 ] fast/events/monotonic-event-time-real-gap.html [ Pass Failure ]
 webkit.org/b/311865 [ arm64 ] imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-blob.window.html [ Pass Failure ]
 


### PR DESCRIPTION
#### ea60ea79a3be81301927471653e1026bb9a3d9c6
<pre>
[GStreamer] Flaky media test failures due to video frame map failures in avviddec with buffers allocated by the GL buffer pool
<a href="https://bugs.webkit.org/show_bug.cgi?id=309438">https://bugs.webkit.org/show_bug.cgi?id=309438</a>

Unreviewed, un-flag most media flaky/timeout tests that are now passing since the SDK was updated to
GStreamer 1.28 (on April 13th 2026) where decoded video frames are exported as DMABuf, thus using a
code path not triggering the previous video frame map failures anymore.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/311541@main">https://commits.webkit.org/311541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87f7825ec3e4709581dbaa0ac55a0f0dac5129dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157300 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/30637 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/23830 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/166124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111382 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/30772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/30639 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/166124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111382 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/160258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/30772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/23830 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/166124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/30772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/30639 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/13895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/30772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/23830 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/168609 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/23830 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/168609 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30238 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/30639 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/168609 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30161 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/23830 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88037 "Failed to checkout and rebase branch from PR 63065") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23922 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30161 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/23830 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/29872 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/29394 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29624 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29521 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->