### PR TITLE
Address WebVTT settings line parsing failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/support/regions-lines.test
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/support/regions-lines.test
@@ -1,7 +1,7 @@
 regions, lines
 <link rel="help" href="https://w3c.github.io/webvtt/#collect-webvtt-region-settings">
 
-assert_equals(cues.length, 13);
+assert_equals(cues.length, 11);
 
 var regions = Array.from(cues).map(function(cue) {
     return cue.region;
@@ -13,9 +13,7 @@ var valid_lines = [
     100,
     101,
     65536,
-    4294967296,
-    18446744073709552000,
-    10000000000000000000000000000000000,
+    4294967295,
     2,
 ];
 valid_lines.forEach(function(valid, index) {
@@ -55,37 +53,29 @@ lines:65536
 
 REGION
 id:6
-lines:4294967296
+lines:4294967295
 
 REGION
 id:7
-lines:18446744073709552000
-
-REGION
-id:8
-lines:10000000000000000000000000000000000
-
-REGION
-id:9
 lines:1 lines:3
 lines:2
 
 NOTE invalid
 
 REGION
-id:10
+id:8
 lines:-0
 
 REGION
-id:11
+id:9
 lines:1.5
 
 REGION
-id:12
+id:10
 lines:-1
 
 REGION
-id:13
+id:11
 lines: 1
 lines :1
 
@@ -120,10 +110,4 @@ text
 text
 
 00:00:00.000 --> 00:00:01.000 region:11
-text
-
-00:00:00.000 --> 00:00:01.000 region:12
-text
-
-00:00:00.000 --> 00:00:01.000 region:13
 text

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/comment-in-cue-text.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/comment-in-cue-text.html
@@ -3,7 +3,7 @@
 <!-- See /webvtt/parsing/file-parsing/README.md -->
 <meta charset=utf-8>
 <title>WebVTT parser test: comment-in-cue-text</title>
-<link rel="help" href="https://www.w3.org/TR/webvtt1/#webvtt-comment-block">
+<link rel="help" href="https://www.w3.org/TR/webvtt1/#introduction-comments">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-lines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-lines-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL regions, lines assert_equals: Failed with region 5 expected 4294967296 but got 4294967295
+PASS regions, lines
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-lines.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/regions-lines.html
@@ -27,7 +27,7 @@ function trackLoaded(event) {
     var video = track.parentNode;
     var cues = video.textTracks[0].cues;
     {
-assert_equals(cues.length, 13);
+assert_equals(cues.length, 11);
 
 var regions = Array.from(cues).map(function(cue) {
     return cue.region;
@@ -39,9 +39,7 @@ var valid_lines = [
     100,
     101,
     65536,
-    4294967296,
-    18446744073709552000,
-    10000000000000000000000000000000000,
+    4294967295,
     2,
 ];
 valid_lines.forEach(function(valid, index) {

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/settings-line-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/settings-line-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL settings, line assert_equals: Failed with cue 2 expected 0 but got -0
+PASS settings, line
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/support/regions-lines.vtt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tests/support/regions-lines.vtt
@@ -24,37 +24,29 @@ lines:65536
 
 REGION
 id:6
-lines:4294967296
+lines:4294967295
 
 REGION
 id:7
-lines:18446744073709552000
-
-REGION
-id:8
-lines:10000000000000000000000000000000000
-
-REGION
-id:9
 lines:1 lines:3
 lines:2
 
 NOTE invalid
 
 REGION
-id:10
+id:8
 lines:-0
 
 REGION
-id:11
+id:9
 lines:1.5
 
 REGION
-id:12
+id:10
 lines:-1
 
 REGION
-id:13
+id:11
 lines: 1
 lines :1
 
@@ -89,10 +81,4 @@ text
 text
 
 00:00:00.000 --> 00:00:01.000 region:11
-text
-
-00:00:00.000 --> 00:00:01.000 region:12
-text
-
-00:00:00.000 --> 00:00:01.000 region:13
 text

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tools/build.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/tools/build.py
@@ -108,8 +108,14 @@ def main():
 
     tests_pattern = path.join(file_parsing_path, TEST_FILE_PATTERN)
 
-    # Clean test directory
-    shutil.rmtree(test_output_path)
+    # Clean generated files
+    for file in glob.glob(tests_pattern):
+        test_basefilename = path.splitext(path.basename(file))[0]
+        html_file = path.join(test_output_path, test_basefilename + '.html')
+        vtt_file = path.join(test_output_path, 'support', test_basefilename + '.vtt')
+        for f in [html_file, vtt_file]:
+            if path.exists(f):
+                os.remove(f)
 
     # Generate tests
     for file in glob.glob(tests_pattern):

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1197,13 +1197,9 @@ void VTTCue::setCueSettings(const String& inputString)
         case Line: {
             bool isValid = false;
             do {
-                // 1-2 - Collect chars that are either '-', '%', or a digit.
-                // 1. If value contains any characters other than U+002D HYPHEN-MINUS characters (-), U+0025 PERCENT SIGN
-                //    characters (%), and characters in the range U+0030 DIGIT ZERO (0) to U+0039 DIGIT NINE (9), then jump
-                //    to the step labeled next setting.
-                float linePosition;
+                double linePosition;
                 bool isNegative;
-                if (!input.scanFloat(linePosition, &isNegative))
+                if (!input.scanDouble(linePosition, &isNegative))
                     break;
 
                 LineAlignSetting alignment { LineAlignSetting::Start };
@@ -1224,37 +1220,17 @@ void VTTCue::setCueSettings(const String& inputString)
                     }
                 }
 
-                // 2. If value does not contain at least one character in the range U+0030 DIGIT ZERO (0) to U+0039 DIGIT
-                //    NINE (9), then jump to the step labeled next setting.
-                // 3. If any character in value other than the first character is a U+002D HYPHEN-MINUS character (-), then
-                //    jump to the step labeled next setting.
-                // 4. If any character in value other than the last character is a U+0025 PERCENT SIGN character (%), then
-                //    jump to the step labeled next setting.
-                // 5. If the first character in value is a U+002D HYPHEN-MINUS character (-) and the last character in value is a
-                //    U+0025 PERCENT SIGN character (%), then jump to the step labeled next setting.
                 if (isPercentage && isNegative)
                     break;
 
-                // 6. Ignoring the trailing percent sign, if any, interpret value as a (potentially signed) integer, and
-                //    let number be that number.
-                // 7. If the last character in value is a U+0025 PERCENT SIGN character (%), but number is not in the range
-                //    0 ≤ number ≤ 100, then jump to the step labeled next setting.
-                // 8. Let cue's text track cue line position be number.
-                // 9. If the last character in value is a U+0025 PERCENT SIGN character (%), then let cue's text track cue
-                //    snap-to-lines flag be false. Otherwise, let it be true.
                 if (isPercentage) {
                     if (linePosition < 0 || linePosition > 100)
                         break;
 
-                    // 10 - If '%' then set snap-to-lines flag to false.
                     m_snapToLines = false;
-                } else {
-                    if (linePosition - static_cast<int>(linePosition))
-                        break;
-
+                } else
                     m_snapToLines = true;
-                }
-                
+
                 m_linePosition = linePosition;
                 m_lineAlignment = alignment;
                 isValid = true;
@@ -1266,10 +1242,10 @@ void VTTCue::setCueSettings(const String& inputString)
             break;
         }
         case Position: {
-            float position;
+            double position;
             PositionAlignSetting alignment { PositionAlignSetting::Auto };
 
-            auto parsePosition = [&] (VTTScanner& input, auto end, float& position, auto& alignment) -> bool {
+            auto parsePosition = [&](VTTScanner& input, auto end, double& position, auto& alignment) -> bool {
                 // 1. a position value consisting of: a WebVTT percentage.
                 if (!WebVTTParser::parseFloatPercentageValue(input, position)) {
                     ALWAYS_LOG(identifier, "Invalid position percentage");
@@ -1307,7 +1283,7 @@ void VTTCue::setCueSettings(const String& inputString)
             break;
         }
         case Size: {
-            float cueSize;
+            double cueSize;
             if (WebVTTParser::parseFloatPercentageValue(input, cueSize) && input.isAt(valueRun.end()))
                 m_cueSize = cueSize;
             else

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -199,7 +199,7 @@ void VTTRegion::parseSettingValue(RegionSetting setting, VTTScanner& input)
         break;
     }
     case Width: {
-        float floatWidth;
+        double floatWidth;
         if (WebVTTParser::parseFloatPercentageValue(input, floatWidth) && parsedEntireRun(input, valueRun))
             m_width = floatWidth;
         else

--- a/Source/WebCore/html/track/VTTScanner.cpp
+++ b/Source/WebCore/html/track/VTTScanner.cpp
@@ -137,20 +137,22 @@ unsigned VTTScanner::scanDigits(unsigned& number)
     return numDigits;
 }
 
-bool VTTScanner::scanFloat(float& number, bool* isNegative)
+bool VTTScanner::scanDouble(double& number, bool* isNegative)
 {
     bool negative = scan('-');
     Run integerRun = collectWhile<isASCIIDigit>();
 
     advance(integerRun.length());
     Run decimalRun = createRun(position(), position());
-    if (scan('.')) {
+    bool hasDot = scan('.');
+    if (hasDot) {
         decimalRun = collectWhile<isASCIIDigit>();
         advance(decimalRun.length());
     }
 
-    // At least one digit required.
-    if (integerRun.isEmpty() && decimalRun.isEmpty()) {
+    // At least one digit required, and if there is a dot it must have
+    // digits on both sides.
+    if (integerRun.isEmpty() || (hasDot && decimalRun.isEmpty())) {
         // Restore to starting position.
         seekTo(integerRun.start());
         return false;
@@ -159,13 +161,16 @@ bool VTTScanner::scanFloat(float& number, bool* isNegative)
     Run floatRun = createRun(integerRun.start(), position());
     bool validNumber;
     if (m_is8Bit)
-        number = charactersToFloat(floatRun.span8(), &validNumber);
+        number = charactersToDouble(floatRun.span8(), &validNumber);
     else
-        number = charactersToFloat(floatRun.span16(), &validNumber);
+        number = charactersToDouble(floatRun.span16(), &validNumber);
 
-    if (!validNumber)
-        number = std::numeric_limits<float>::max();
-    else if (negative)
+    if (!validNumber || !std::isfinite(number)) {
+        seekTo(integerRun.start());
+        return false;
+    }
+
+    if (negative && number)
         number = -number;
 
     if (isNegative)

--- a/Source/WebCore/html/track/VTTScanner.h
+++ b/Source/WebCore/html/track/VTTScanner.h
@@ -148,8 +148,8 @@ public:
     // Note: Does not handle sign.
     unsigned scanDigits(unsigned& number);
 
-    // Scan a floating point value on one of the forms: \d+\.? \d+\.\d+ \.\d+
-    bool scanFloat(float& number, bool* isNegative = nullptr);
+    // Scan a double of the form: \d+\.\d+ or \d+
+    bool scanDouble(double& number, bool* isNegative = nullptr);
 
 protected:
     Run NODELETE createRun(Position start, Position end) const;

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -62,11 +62,11 @@ constexpr unsigned fileIdentifierLength = 6;
 constexpr unsigned regionIdentifierLength = 6;
 constexpr unsigned styleIdentifierLength = 5;
 
-bool WebVTTParser::parseFloatPercentageValue(VTTScanner& valueScanner, float& percentage)
+bool WebVTTParser::parseFloatPercentageValue(VTTScanner& valueScanner, double& percentage)
 {
-    float number;
+    double number;
     bool isNegative = false;
-    if (!valueScanner.scanFloat(number, &isNegative))
+    if (!valueScanner.scanDouble(number, &isNegative))
         return false;
     // '%' must be present and at the end of the setting value.
     if (!valueScanner.scan('%'))
@@ -81,14 +81,14 @@ bool WebVTTParser::parseFloatPercentageValue(VTTScanner& valueScanner, float& pe
 
 bool WebVTTParser::parseFloatPercentageValuePair(VTTScanner& valueScanner, char delimiter, FloatPoint& valuePair)
 {
-    float firstCoord;
+    double firstCoord;
     if (!parseFloatPercentageValue(valueScanner, firstCoord))
         return false;
 
     if (!valueScanner.scan(delimiter))
         return false;
 
-    float secondCoord;
+    double secondCoord;
     if (!parseFloatPercentageValue(valueScanner, secondCoord))
         return false;
 

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -126,7 +126,7 @@ public:
     static bool collectTimeStamp(const String&, MediaTime&);
 
     // Useful functions for parsing percentage settings.
-    static bool parseFloatPercentageValue(VTTScanner& valueScanner, float&);
+    static bool parseFloatPercentageValue(VTTScanner& valueScanner, double&);
     static bool parseFloatPercentageValuePair(VTTScanner& valueScanner, char, FloatPoint&);
 
     // Input data to the parser to parse.


### PR DESCRIPTION
#### b57d6ca3ffb338d47ab7414d97182dc287064c48
<pre>
Address WebVTT settings line parsing failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=312720">https://bugs.webkit.org/show_bug.cgi?id=312720</a>

Reviewed by Chris Dumez.

When parsing the settings line number we should use a double, require a
digit on both sides of the dot (if any), not cast to int, and not allow
-0 through.

We also update the regions line test here as it was incorrect
(VTTRegion uses unsigned long for its lines member).

We also remove comments that are no longer aligned with the current
specification and did not seem particularly helpful.

Upstream changes:

    <a href="https://github.com/web-platform-tests/wpt/pull/59335">https://github.com/web-platform-tests/wpt/pull/59335</a>

Canonical link: <a href="https://commits.webkit.org/311729@main">https://commits.webkit.org/311729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58170ed54dafd4d3d4b6bafcc9e20449b4078959

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166616 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122185 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102854 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14387 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19511 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169105 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13824 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130352 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130469 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141305 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88661 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24001 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25223 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18111 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95158 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29886 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30116 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->