### PR TITLE
Import WPT test for sticky user activation across same-origin navigations

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -817,6 +817,7 @@ imported/w3c/web-platform-tests/html/user-activation/activation-trigger-keyboard
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-keyboard-escape.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-mouse-left.html [ Skip ]
 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-mouse-right.html [ Skip ]
+webkit.org/b/312719 imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html [ Skip ]
 imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/allow-crossorigin.html [ Skip ]
 imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/disallow-crossorigin.html [ Skip ]
 imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<title>User activation propagation across a same-origin navigation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="resources/utils.js"></script>
+
+<body>
+  <p>Placeholder</p>
+</body>
+
+<script>
+  'use strict';
+
+  let w;
+  document.body.onclick = () => {
+    w = window.open("resources/opened-window.html");
+  };
+
+  promise_test(async test => {
+    let window_opened_msg_promise = receiveMessage("window-opened");
+
+    await test_driver.click(document.body);
+    assert_true(!!w, "A window is opened");
+
+    {
+      let window_opened_data = await window_opened_msg_promise;
+      assert_false(window_opened_data.isActive,
+          "Transient activation after window opened");
+      assert_false(window_opened_data.hasBeenActive,
+          "Sticky activation after window opened");
+    }
+
+    let link_clicked_msg_promise = receiveMessage("link-clicked");
+    let window_navigated_msg_promise = receiveMessage("window-navigated");
+
+    const link = w.document.getElementById("link");
+    await test_driver.click(link);
+
+    {
+      let link_clicked_data = await link_clicked_msg_promise;
+      assert_true(link_clicked_data.isActive,
+          "Transient activation after link clicked");
+      assert_true(link_clicked_data.hasBeenActive,
+          "Sticky activation after link clicked");
+    }
+
+    {
+      let window_navigated_data = await window_navigated_msg_promise;
+      assert_false(window_navigated_data.isActive,
+          "Transient activation after window navigated");
+      assert_true(window_navigated_data.hasBeenActive,
+          "Sticky activation after window navigated");
+    }
+  }, "User activation propagation across a same-origin navigation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/resources/opened-window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/resources/opened-window.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+
+<body onload="run()">
+  <a id="link" href="?post-nav">link</a>
+</body>
+
+<script>
+  'use strict';
+  const post_nav_page = location.search.substring(1) === "post-nav";
+
+  function sendActivationStateToOpener(msg_type) {
+    window.opener.postMessage(JSON.stringify({
+        "type": msg_type,
+        "isActive": navigator.userActivation.isActive,
+        "hasBeenActive": navigator.userActivation.hasBeenActive
+    }), "*");
+  }
+
+  document.getElementById("link").addEventListener("click", () => {
+    assert_false(post_nav_page, "No click in the post-navigation page");
+    sendActivationStateToOpener("link-clicked");
+  });
+
+  function run() {
+    if (!post_nav_page) {
+      sendActivationStateToOpener("window-opened");
+    } else {
+      sendActivationStateToOpener("window-navigated");
+    }
+  }
+</script>


### PR DESCRIPTION
#### 713dd53f52a7c6c6d881db3b458ffe09ccdbb33b
<pre>
Import WPT test for sticky user activation across same-origin navigations
<a href="https://bugs.webkit.org/show_bug.cgi?id=312241">https://bugs.webkit.org/show_bug.cgi?id=312241</a>

Reviewed by Anne van Kesteren.

Import navigate-to-sameorigin.html from upstream WPT.
The test is marked as [ Skip ] in TestExpectations because
WebKitTestRunner&apos;s eventSender cannot dispatch events to popup
windows (Bug 312719).

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/60af73525190d80aa07d8ca67e9e4ad2fd28982c">https://github.com/web-platform-tests/wpt/commit/60af73525190d80aa07d8ca67e9e4ad2fd28982c</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/resources/opened-window.html: Added.

Canonical link: <a href="https://commits.webkit.org/311953@main">https://commits.webkit.org/311953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbcccdff4c527fca0dcc4d7dfd81f2a4dee3d508

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167346 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122779 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103449 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15117 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169836 "Built successfully") | 
| | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21801 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130966 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31632 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131080 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141970 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89469 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24104 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25776 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18776 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31089 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30609 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30882 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->