### PR TITLE
`git-webkit create-bug --radar` creates duplicate radar for Security bugs

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -743,9 +743,8 @@ class Tracker(GenericTracker):
         if radar and isinstance(radar.tracker, RadarTracker):
             if radar not in (issue.references or []):
                 comment_to_make = '<rdar://problem/{}>'.format(radar.id)
-            if user_to_cc:
-                keyword_to_add = 'InRadar'
-            elif comment_to_make:
+            keyword_to_add = 'InRadar'
+            if not user_to_cc and comment_to_make:
                 tracked_bug = issue.references[0] if issue.references else None
                 if tracked_bug:
                     sys.stderr.write("{} already CCed '{}' and tracking a different bug\n".format(
@@ -761,7 +760,8 @@ class Tracker(GenericTracker):
                         return None
                     if response == 'No':
                         raise ValueError('Radar is tracking a different bug')
-                else:
+                    user_to_cc = True
+                elif 'InRadar' not in (issue.keywords or []):
                     sys.stderr.write("{} already CCed but no Radar was imported\n".format(
                         self.radar_importer.name,
                     ))
@@ -774,7 +774,7 @@ class Tracker(GenericTracker):
                         return None
                     if response == 'No':
                         raise ValueError("Radar Importer is already CC'd")
-                user_to_cc = True  # Ensure that the user override is respected even if 'InRadar' is applied
+                    user_to_cc = True
 
         did_modify_cc = False
         if user_to_cc or keyword_to_add:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -633,6 +633,147 @@ What component in 'WebKit' should the bug be associated with?:
                 self.assertEqual(issue.references[0].link, 'rdar://1')
                 self.assertEqual(issue.references[0].title, 'Example issue 1')
 
+    def test_cc_radar_importer_already_cced_with_explicit_radar(self):
+        """When the importer is already CC'd (e.g. auto-CC on Security product) and
+        an explicit radar is provided, cc_radar should add InRadar + comment without
+        prompting.  This tests the fix for the unwanted Terminal.choose prompt."""
+        # Use issue data where the importer is already in watchers
+        issues_with_importer = [dict(
+            title='Security bug',
+            timestamp=1639536160,
+            opened=True,
+            creator=mocks.USERS['Tim Contributor'],
+            assignee=mocks.USERS['Tim Contributor'],
+            description='A security issue',
+            project='WebKit',
+            component='Text',
+            version='Other',
+            keywords=['InRadar'],
+            comments=[],
+            watchers=[
+                mocks.USERS['Tim Contributor'],
+                mocks.USERS['Radar WebKit Bug Importer'],  # Already CC'd
+            ],
+        )]
+        with OutputCapture(level=logging.INFO) as captured, mocks.Bugzilla(
+            self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ), users=mocks.USERS, issues=issues_with_importer, projects=mocks.PROJECTS,
+        ), mocks.Radar(
+            users=mocks.USERS, issues=mocks.ISSUES, projects=mocks.PROJECTS,
+        ), wkmocks.Time:
+            radar_tracker = radar.Tracker()
+            bugzilla_tracker = bugzilla.Tracker(self.URL, radar_importer=mocks.USERS['Radar WebKit Bug Importer'])
+
+            with patch('webkitbugspy.Tracker._trackers', [radar_tracker, bugzilla_tracker]):
+                issue = bugzilla_tracker.issue(1)
+                # Importer is already a watcher
+                self.assertIn(mocks.USERS['Radar WebKit Bug Importer'], issue.watchers)
+                # cc_radar should succeed without prompting
+                result = issue.cc_radar(block=True, radar=Tracker.from_string('<rdar://1>'))
+                self.assertIsNotNone(result)
+                # Should have added the rdar comment
+                self.assertEqual(issue.comments[-1].content, '<rdar://problem/1>')
+                # Should NOT have prompted (no Terminal.choose in output)
+                self.assertNotIn('Would you like to CC', captured.stderr.getvalue())
+                self.assertNotIn('Would you like to CC', captured.stdout.getvalue())
+
+    def test_cc_radar_importer_already_cced_no_inradar_prompts(self):
+        """When the importer is already CC'd, no radar is tracked, and InRadar
+        is NOT in keywords, cc_radar should prompt and proceed when user says Yes."""
+        issues_with_importer = [dict(
+            title='Bug without InRadar',
+            timestamp=1639536160,
+            opened=True,
+            creator=mocks.USERS['Tim Contributor'],
+            assignee=mocks.USERS['Tim Contributor'],
+            description='A test issue',
+            project='WebKit',
+            component='Text',
+            version='Other',
+            keywords=[],
+            comments=[],
+            watchers=[
+                mocks.USERS['Tim Contributor'],
+                mocks.USERS['Radar WebKit Bug Importer'],
+            ],
+        )]
+        with wkmocks.Terminal.input('Yes'), OutputCapture(level=logging.INFO) as captured, mocks.Bugzilla(
+            self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ), users=mocks.USERS, issues=issues_with_importer, projects=mocks.PROJECTS,
+        ), mocks.Radar(
+            users=mocks.USERS, issues=mocks.ISSUES, projects=mocks.PROJECTS,
+        ), wkmocks.Time:
+            radar_tracker = radar.Tracker()
+            bugzilla_tracker = bugzilla.Tracker(self.URL, radar_importer=mocks.USERS['Radar WebKit Bug Importer'])
+
+            with patch('webkitbugspy.Tracker._trackers', [radar_tracker, bugzilla_tracker]):
+                issue = bugzilla_tracker.issue(1)
+                result = issue.cc_radar(block=True, radar=Tracker.from_string('<rdar://1>'))
+                self.assertIsNotNone(result)
+                self.assertEqual(issue.comments[-1].content, '<rdar://problem/1>')
+                # Should have prompted
+                self.assertIn('already CCed but no Radar was imported', captured.stderr.getvalue())
+
+    def test_cc_radar_importer_already_cced_different_tracked_bug(self):
+        """When the importer is already CC'd and a different bug is already
+        tracked, cc_radar should prompt to overwrite and proceed when user says Yes."""
+        issues_with_tracked = [
+            dict(
+                title='Bug with tracked reference',
+                timestamp=1639536160,
+                opened=True,
+                creator=mocks.USERS['Tim Contributor'],
+                assignee=mocks.USERS['Tim Contributor'],
+                description='A test issue',
+                project='WebKit',
+                component='Text',
+                version='Other',
+                keywords=[],
+                comments=[],
+                watchers=[
+                    mocks.USERS['Tim Contributor'],
+                    mocks.USERS['Radar WebKit Bug Importer'],
+                ],
+                references=[2],
+            ),
+            dict(
+                title='Referenced bug',
+                timestamp=1639536160,
+                opened=True,
+                creator=mocks.USERS['Tim Contributor'],
+                assignee=mocks.USERS['Tim Contributor'],
+                description='Referenced',
+                project='WebKit',
+                component='Text',
+                version='Other',
+                keywords=[],
+                comments=[],
+                watchers=[mocks.USERS['Tim Contributor']],
+            ),
+        ]
+        with wkmocks.Terminal.input('Yes'), OutputCapture(level=logging.INFO) as captured, mocks.Bugzilla(
+            self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ), users=mocks.USERS, issues=issues_with_tracked, projects=mocks.PROJECTS,
+        ), mocks.Radar(
+            users=mocks.USERS, issues=mocks.ISSUES, projects=mocks.PROJECTS,
+        ), wkmocks.Time:
+            radar_tracker = radar.Tracker()
+            bugzilla_tracker = bugzilla.Tracker(self.URL, radar_importer=mocks.USERS['Radar WebKit Bug Importer'])
+
+            with patch('webkitbugspy.Tracker._trackers', [radar_tracker, bugzilla_tracker]):
+                issue = bugzilla_tracker.issue(1)
+                result = issue.cc_radar(block=True, radar=Tracker.from_string('<rdar://1>'))
+                self.assertIsNotNone(result)
+                self.assertEqual(issue.comments[-1].content, '<rdar://problem/1>')
+                # Should have prompted about overwriting
+                self.assertIn('tracking a different bug', captured.stderr.getvalue())
+
     def test_milestone(self):
         with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES):
             tracker = bugzilla.Tracker(self.URL)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/create_bug.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/create_bug.py
@@ -169,6 +169,14 @@ class CreateBug(Command):
         if args.keywords:
             keywords = [k.strip() for k in args.keywords.split(',')]
 
+        # Add InRadar keyword when --radar is provided, to prevent duplicate
+        # radar creation when the Security product auto-CCs the radar importer
+        # before cc_radar() runs.
+        if radar_issue:
+            keywords = keywords or []
+            if 'InRadar' not in keywords:
+                keywords.append('InRadar')
+
         # Create the bug (tracker.create prompts for project/component if not specified)
         try:
             issue = tracker.create(

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/create_bug_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/create_bug_unittest.py
@@ -185,6 +185,29 @@ class TestCreateBug(testing.PathTestCase):
             if line.startswith('Added CC:'):
                 self.assertNotIn(importer_email, line)
 
+    def test_radar_adds_inradar_keyword(self):
+        """When --radar is provided, InRadar must be in the keywords at creation time
+        to prevent duplicate radar creation when the Security product auto-CCs the importer."""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), bmocks.Radar(users=bmocks.USERS, issues=bmocks.ISSUES, projects=bmocks.PROJECTS), \
+                patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA), radar.Tracker()]):
+            self.assertEqual(0, program.main(
+                args=('create-bug', '--title', 'Test bug', '-F', self.desc_file,
+                      '--component', 'Text', '--project', 'WebKit',
+                      '--radar', 'rdar://1'),
+                path=self.path,
+            ))
+            self.assertIn('Created bug:', captured.stdout.getvalue())
+            # New bug (ID 4, after 3 existing issues) must have InRadar
+            new_issue = Tracker.instance().issue(4)
+            self.assertIn('InRadar', new_issue.keywords or [])
+
 
 class TestCreateBugRadarArgValidation(testing.PathTestCase):
     basepath = 'mock/repository'


### PR DESCRIPTION
#### a3545b2067bea22595baa52ed1e1b26bb9d60d50
<pre>
`git-webkit create-bug --radar` creates duplicate radar for Security bugs
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=312722">https://bugs.webkit.org/show_bug.cgi?id=312722</a>&gt;
&lt;<a href="https://rdar.apple.com/175112609">rdar://175112609</a>&gt;

Reviewed by Jonathan Bedard.

Bugzilla auto-CCs WebKit Bug Importer on Security-product bugs at
creation time.  Because `cc_radar()` only added the `InRadar` keyword
when the importer was not yet CC&apos;d, bugs created with
`git-webkit create-bug --radar` on the Security product never received
the keyword, and the importer created a duplicate radar.

A secondary issue occurred when `cc_radar()` detected the importer was
already CC&apos;d with no radar imported and prompted &quot;Would you like to CC
<a href="https://rdar.apple.com/NNNNNNNNN?&quot">rdar://NNNNNNNNN?&quot</a>; via `Terminal.choose()`, which failed with EOF when
stdin was not a TTY.

Fix the first issue by adding `InRadar` to the keywords list in
`CreateBug.main()` before calling `tracker.create()` when `--radar` is
provided.

Fix the second issue by checking whether `InRadar` is already present in
the bug&apos;s keywords inside `cc_radar()` before prompting -- when it is
(because `create-bug` set it at creation time), skip the prompt and
proceed to add the `&lt;<a href="https://rdar.apple.com/problem/NNNNNNNNN">rdar://problem/NNNNNNNNN</a>&gt;` comment.

Also set `keyword_to_add = &apos;InRadar&apos;` unconditionally in `cc_radar()`
when a radar is provided.  The old code only set it when `user_to_cc`
was truthy, so the &quot;overwrite different radar&quot; prompt path also forgot
to add `InRadar`.

Covered by newly added unit tests.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.cc_radar):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(TestBugzilla.test_cc_radar_importer_already_cced_with_explicit_radar): Add.
- Verify `cc_radar()` skips the prompt and adds the comment when the
  importer is already CC&apos;d and `InRadar` is already in keywords.
(TestBugzilla.test_cc_radar_importer_already_cced_no_inradar_prompts): Add.
- Verify `cc_radar()` prompts when the importer is already CC&apos;d, no
  radar is tracked, and `InRadar` is not in keywords.
(TestBugzilla.test_cc_radar_importer_already_cced_different_tracked_bug): Add.
- Verify `cc_radar()` prompts to overwrite when the importer is
  already CC&apos;d and a different bug is already tracked.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/create_bug.py:
(CreateBug.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/create_bug_unittest.py:
(TestCreateBug.test_radar_adds_inradar_keyword): Add.

Canonical link: <a href="https://commits.webkit.org/311605@main">https://commits.webkit.org/311605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90e8e604d56aa9d78e4ac4fdca423032176864e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166138 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111396 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c7ebd20-fb38-4357-a3a7-0be65c8ef509) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121837 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85553 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8806ffbe-3ae6-4bf3-a41d-545828dba799) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102505 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ac9b406-956f-400e-b256-f68f01d309c3) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/156636 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23137 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21384 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13909 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168623 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129971 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/156712 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25462 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130078 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140880 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88075 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23947 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24899 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17685 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29886 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29408 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29638 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29535 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->