### PR TITLE
ThreadSanitizer reports false-positive data race on ThreadSafeWeakPtrControlBlock members after relaxed load of control block pointer

### DIFF
--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -225,7 +225,7 @@ public:
         if (didRefStrongOnly)
             return;
 
-        std::bit_cast<ThreadSafeWeakPtrControlBlock*>(m_bits.loadRelaxed())->strongRef();
+        std::bit_cast<ThreadSafeWeakPtrControlBlock*>(bits())->strongRef();
     }
 
     void deref() const
@@ -262,12 +262,12 @@ public:
             return;
         }
 
-        std::bit_cast<ThreadSafeWeakPtrControlBlock*>(m_bits.loadRelaxed())->template strongDeref<T, destructionThread>();
+        std::bit_cast<ThreadSafeWeakPtrControlBlock*>(bits())->template strongDeref<T, destructionThread>();
     }
 
     uint32_t refCount() const
     {
-        uintptr_t bits = m_bits.loadRelaxed();
+        uintptr_t bits = this->bits();
         if (isStrongOnly(bits)) {
             // FIXME: Add support for ref()/deref() during destruction like we support for other RefCounted types.
             ASSERT(!(bits & destructionStartedFlag));
@@ -282,7 +282,7 @@ public:
 
     // Ideally this would have been private but AbstractRefCounted subclasses need to be able to access this function
     // to provide its result to ThreadSafeWeakHashSet.
-    uint32_t weakRefCount() const { return !isStrongOnly(m_bits.loadRelaxed()) ? controlBlock().weakRefCount() : 0; }
+    uint32_t weakRefCount() const { return !isStrongOnly(bits()) ? controlBlock().weakRefCount() : 0; }
 
 protected:
     ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr() = default;
@@ -291,7 +291,7 @@ protected:
         // If we ever decided there was a lot of contention here we could have some lock bits in m_bits but
         // that seems unlikely since this is a one-way street. Once we add a controlBlock we don't go back
         // to strong only.
-        uintptr_t bits = m_bits.loadRelaxed();
+        uintptr_t bits = this->bits();
         if (!isStrongOnly(bits)) [[likely]]
             return *std::bit_cast<ThreadSafeWeakPtrControlBlock*>(bits);
 
@@ -315,11 +315,28 @@ protected:
             return *controlBlock;
 
         delete controlBlock;
-        return *std::bit_cast<ThreadSafeWeakPtrControlBlock*>(m_bits.loadRelaxed());
+        return *std::bit_cast<ThreadSafeWeakPtrControlBlock*>(this->bits());
     }
 
 private:
     static bool isStrongOnly(uintptr_t bits) { return bits & strongOnlyFlag; }
+
+    // Use memory_order_acquire under TSan to pair with the memory_order_release
+    // in controlBlock(). Without this, TSan reports a race between the
+    // non-atomic initialization of the control block's members and subsequent
+    // atomic operations on them (e.g., WordLock::lock()). ARM64 dependency
+    // ordering and x86 total store ordering make this benign in practice, but
+    // the C++ memory model requires acquire to formally synchronize with the
+    // release store.
+    ALWAYS_INLINE uintptr_t bits() const
+    {
+#if TSAN_ENABLED
+        return m_bits.load(std::memory_order_acquire);
+#else
+        return m_bits.loadRelaxed();
+#endif
+    }
+
     template<typename, typename> friend class ThreadSafeWeakPtr;
     template<typename, typename> friend class ThreadSafeWeakRef;
     template<typename> friend class ThreadSafeWeakHashSet;


### PR DESCRIPTION
#### 1ae1abc47aac1c3a39986bd5e4148a9eae40f009
<pre>
ThreadSanitizer reports false-positive data race on ThreadSafeWeakPtrControlBlock members after relaxed load of control block pointer
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=312726">https://bugs.webkit.org/show_bug.cgi?id=312726</a>&gt;
&lt;<a href="https://rdar.apple.com/175117037">rdar://175117037</a>&gt;

Reviewed by Geoffrey Garen.

Use `memory_order_acquire` when loading `m_bits` to obtain the
control block pointer, pairing with the `memory_order_release`
store in `controlBlock()`.  Without this, TSan reports a data race
between the non-atomic initialization of control block members and
subsequent atomic operations on them (e.g., `WordLock::lock()`).

ARM64 dependency ordering and x86 total store ordering make this
benign in practice, so gate the acquire behind `TSAN_ENABLED`.

No tests since this is only needed with TSan builds.

* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::refCount const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::weakRefCount const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::bits const): Add.

Canonical link: <a href="https://commits.webkit.org/311633@main">https://commits.webkit.org/311633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aec5d945955aea2d9270617d841288f5be3d6dc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166389 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8170750-6fec-488f-a0a5-ff3498ded4dc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30904 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2346cdd-8778-4934-8c06-b594b4715f9c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160523 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/24284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29c25b3a-cb2a-4ee5-acc3-56db20ab115e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/14160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149616 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168878 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18400 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/13287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20927 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130279 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141101 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23960 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25105 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/189638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30137 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/94456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/189638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/29659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->