### PR TITLE
Enable explicitly passing in a parser document for HTML Script Tags

### DIFF
--- a/LayoutTests/fast/dom/scripts-in-detached-document-write.html
+++ b/LayoutTests/fast/dom/scripts-in-detached-document-write.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="container"></div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+test(() => {
+    const container = document.getElementById("container");
+    const detached = document.implementation.createHTMLDocument();
+    let executed = false;
+    
+    detached.write("<div>");
+    const root = detached.body.firstElementChild;
+    container.appendChild(root); 
+    
+    detached.write("<script>window.executedByDetachedWrite = true;<\/script>");
+    detached.write("</div>");
+    
+    assert_false(!!window.executedByDetachedWrite, "Script should not have executed");
+}, "Scripts in detached documents should not execute if the detached DOM gets connected to the main frame via document.write");
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -253,9 +253,8 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
         m_forceAsync = false;
     }
 
-    if (m_parserDocument && &(element->document()) != m_parserDocument.get()) {
+    if (m_parserDocument && &element->document() != m_parserDocument.get())
         return false;
-    }
 
     m_alreadyStarted = true;
 

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -23,6 +23,7 @@
 
 #include "config.h"
 #include "ScriptElement.h"
+#include <iostream>
 
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
@@ -81,9 +82,10 @@ namespace WebCore {
 
 static const auto maxUserGesturePropagationTime = 1_s;
 
-ScriptElement::ScriptElement(Element& element, bool parserInserted, bool alreadyStarted)
+ScriptElement::ScriptElement(Element& element, Document* parserDocument, bool parserInserted, bool alreadyStarted)
     : ActiveDOMObject(element.document())
     , m_element(element)
+    , m_parserDocument(parserDocument)
     , m_parserInserted(parserInserted ? ParserInserted::Yes : ParserInserted::No)
     , m_alreadyStarted(alreadyStarted)
     , m_forceAsync(!parserInserted)
@@ -252,9 +254,12 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
         m_forceAsync = false;
     }
 
+    if (m_parserDocument && &(element->document()) != m_parserDocument.get()) {
+        return false;
+    }
+
     m_alreadyStarted = true;
 
-    // FIXME: If script is parser inserted, verify it's still in the original document.
     Ref document = element->document();
 
     // FIXME: Eventually we'd like to evaluate scripts which are inserted into a

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -23,7 +23,6 @@
 
 #include "config.h"
 #include "ScriptElement.h"
-#include <iostream>
 
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -32,12 +32,14 @@
 #include <WebCore/ScriptType.h>
 #include <WebCore/UserGestureIndicator.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/TextPosition.h>
 
 namespace WebCore {
 
 class CachedScript;
 class ContainerNode;
+class Document;
 class Element;
 class LoadableModuleScript;
 class Node;
@@ -90,7 +92,7 @@ public:
     bool virtualHasPendingActivity() const final;
 
 protected:
-    ScriptElement(Element&, bool createdByParser, bool isEvaluated);
+    ScriptElement(Element&, Document* parserDocument, bool createdByParser, bool isEvaluated);
 
     void setHaveFiredLoadEvent(bool haveFiredLoad) { m_haveFiredLoad = haveFiredLoad; }
     void setErrorOccurred(bool errorOccurred) { m_errorOccurred = errorOccurred; }
@@ -141,6 +143,7 @@ private:
     virtual bool isScriptPreventedByAttributes() const { return false; }
 
     WeakRef<Element, WeakPtrImplWithEventTargetData> m_element;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_parserDocument;
     OrdinalNumber m_startLineNumber { OrdinalNumber::beforeFirst() };
     JSC::SourceTaintedOrigin m_taintedOrigin;
     ParserInserted m_parserInserted : bitWidthOfParserInserted;

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -175,7 +175,7 @@ ExceptionOr<void> HTMLScriptElement::setTextContent(ExceptionOr<String> value)
 
     setTrustedScriptText(newValue);
     setTextContent(WTF::move(newValue));
-    return {};
+    return { };
 }
 
 ExceptionOr<void> HTMLScriptElement::setInnerText(Variant<Ref<TrustedScript>, String>&& value)
@@ -188,7 +188,7 @@ ExceptionOr<void> HTMLScriptElement::setInnerText(Variant<Ref<TrustedScript>, St
 
     setTrustedScriptText(newValue);
     setInnerText(WTF::move(newValue));
-    return {};
+    return { };
 }
 
 void HTMLScriptElement::setAsync(bool async)
@@ -219,7 +219,7 @@ ExceptionOr<void> HTMLScriptElement::setSrc(Variant<Ref<TrustedScriptURL>, Strin
         return stringValueHolder.releaseException();
 
     setAttributeWithoutSynchronization(HTMLNames::srcAttr, AtomString { stringValueHolder.releaseReturnValue() });
-    return {};
+    return { };
 }
 
 void HTMLScriptElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -54,14 +54,12 @@ inline HTMLScriptElement::HTMLScriptElement(const QualifiedName& tagName, Docume
 
 Ref<HTMLScriptElement> HTMLScriptElement::create(const QualifiedName& tagName, Document& document, bool wasInsertedByParser, bool alreadyStarted)
 {
-    Ref scriptElement = adoptRef(*new HTMLScriptElement(tagName, document, wasInsertedByParser ? &document : nullptr, wasInsertedByParser, alreadyStarted));
-    scriptElement->suspendIfNeeded();
-    return scriptElement;
+    return create(tagName, document, document, wasInsertedByParser, alreadyStarted);
 }
 
 Ref<HTMLScriptElement> HTMLScriptElement::create(const QualifiedName& tagName, Document& document, Document& parserDocument, bool wasInsertedByParser, bool alreadyStarted)
 {
-    Ref scriptElement = adoptRef(*new HTMLScriptElement(tagName, document, &parserDocument, wasInsertedByParser, alreadyStarted));
+    Ref scriptElement = adoptRef(*new HTMLScriptElement(tagName, document, wasInsertedByParser ? &parserDocument : nullptr, wasInsertedByParser, alreadyStarted));
     scriptElement->suspendIfNeeded();
     return scriptElement;
 }
@@ -177,7 +175,7 @@ ExceptionOr<void> HTMLScriptElement::setTextContent(ExceptionOr<String> value)
 
     setTrustedScriptText(newValue);
     setTextContent(WTF::move(newValue));
-    return { };
+    return {};
 }
 
 ExceptionOr<void> HTMLScriptElement::setInnerText(Variant<Ref<TrustedScript>, String>&& value)
@@ -190,7 +188,7 @@ ExceptionOr<void> HTMLScriptElement::setInnerText(Variant<Ref<TrustedScript>, St
 
     setTrustedScriptText(newValue);
     setInnerText(WTF::move(newValue));
-    return { };
+    return {};
 }
 
 void HTMLScriptElement::setAsync(bool async)
@@ -221,7 +219,7 @@ ExceptionOr<void> HTMLScriptElement::setSrc(Variant<Ref<TrustedScriptURL>, Strin
         return stringValueHolder.releaseException();
 
     setAttributeWithoutSynchronization(HTMLNames::srcAttr, AtomString { stringValueHolder.releaseReturnValue() });
-    return { };
+    return {};
 }
 
 void HTMLScriptElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -45,16 +45,23 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLScriptElement);
 
 using namespace HTMLNames;
 
-inline HTMLScriptElement::HTMLScriptElement(const QualifiedName& tagName, Document& document, bool wasInsertedByParser, bool alreadyStarted)
+inline HTMLScriptElement::HTMLScriptElement(const QualifiedName& tagName, Document& document, Document* parserDocument, bool wasInsertedByParser, bool alreadyStarted)
     : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
-    , ScriptElement(*this, wasInsertedByParser, alreadyStarted)
+    , ScriptElement(*this, parserDocument, wasInsertedByParser, alreadyStarted)
 {
     ASSERT(hasTagName(scriptTag));
 }
 
 Ref<HTMLScriptElement> HTMLScriptElement::create(const QualifiedName& tagName, Document& document, bool wasInsertedByParser, bool alreadyStarted)
 {
-    Ref scriptElement = adoptRef(*new HTMLScriptElement(tagName, document, wasInsertedByParser, alreadyStarted));
+    Ref scriptElement = adoptRef(*new HTMLScriptElement(tagName, document, wasInsertedByParser ? &document : nullptr, wasInsertedByParser, alreadyStarted));
+    scriptElement->suspendIfNeeded();
+    return scriptElement;
+}
+
+Ref<HTMLScriptElement> HTMLScriptElement::create(const QualifiedName& tagName, Document& document, Document& parserDocument, bool wasInsertedByParser, bool alreadyStarted)
+{
+    Ref scriptElement = adoptRef(*new HTMLScriptElement(tagName, document, &parserDocument, wasInsertedByParser, alreadyStarted));
     scriptElement->suspendIfNeeded();
     return scriptElement;
 }

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -38,7 +38,8 @@ class HTMLScriptElement final : public HTMLElement, public ScriptElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLScriptElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLScriptElement);
 public:
-    static Ref<HTMLScriptElement> create(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted = false);
+    static Ref<HTMLScriptElement> create(const QualifiedName&, Document& ownerDocument, bool wasInsertedByParser, bool alreadyStarted = false);
+    static Ref<HTMLScriptElement> create(const QualifiedName&, Document& ownerDocument, Document& parserDocument, bool wasInsertedByParser, bool alreadyStarted = false);
 
     String text() const { return scriptContent(); }
     WEBCORE_EXPORT void setText(String&&);
@@ -73,7 +74,7 @@ public:
     WEBCORE_EXPORT DOMTokenList& blocking();
 
 private:
-    HTMLScriptElement(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted);
+    HTMLScriptElement(const QualifiedName&, Document& ownerDocument, Document* parserDocument, bool wasInsertedByParser, bool alreadyStarted);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) final;

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -636,7 +636,7 @@ void HTMLConstructionSite::insertScriptElement(AtomHTMLToken&& token)
     // those flags or effects thereof.
     const bool parserInserted = !m_parserContentPolicy.contains(ParserContentPolicy::DoNotMarkAlreadyStarted);
     const bool alreadyStarted = m_isParsingFragment && parserInserted;
-    auto element = HTMLScriptElement::create(scriptTag, ownerDocumentForCurrentNode(), parserInserted, alreadyStarted);
+    auto element = HTMLScriptElement::create(scriptTag, ownerDocumentForCurrentNode(), m_document.get(), parserInserted, alreadyStarted);
     setAttributes(element, token, m_parserContentPolicy);
     if (scriptingContentIsAllowed(m_parserContentPolicy))
         attachLater(protect(currentNode()), element.copyRef());

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGScriptElement);
 inline SVGScriptElement::SVGScriptElement(const QualifiedName& tagName, Document& document, bool wasInsertedByParser, bool alreadyStarted)
     : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGURIReference(this)
-    , ScriptElement(*this, wasInsertedByParser, alreadyStarted)
+    , ScriptElement(*this, &document, wasInsertedByParser, alreadyStarted)
 {
     ASSERT(hasTagName(SVGNames::scriptTag));
 }


### PR DESCRIPTION
# Pull Request Template

## File a Bug

https://bugs.webkit.org/show_bug.cgi?id=312603

## Provided Tooling

These tools are not working for me

## Template

DO NOT SUBMIT. Will recreate with tooling later
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4b506d02582265a2592c778b37752ee8933c911

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113107 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32438 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123212 "Found 3 new test failures: fast/dom/scripts-in-detached-document-write.html fast/parser/move-during-parsing.html fast/parser/script-modify-page-outer.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86517 "1 missing results") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161980 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25494 "Found 3 new test failures: fast/dom/scripts-in-detached-document-write.html fast/parser/move-during-parsing.html fast/parser/script-modify-page-outer.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103879 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24549 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22954 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15625 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170345 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16087 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22270 "Found 3 new test failures: fast/dom/scripts-in-detached-document-write.html fast/parser/move-during-parsing.html fast/parser/script-modify-page-outer.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131402 "Found 3 new test failures: fast/dom/scripts-in-detached-document-write.html fast/parser/move-during-parsing.html fast/parser/script-modify-page-outer.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32140 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27023 "Found 3 new test failures: fast/dom/scripts-in-detached-document-write.html fast/parser/move-during-parsing.html fast/parser/script-modify-page-outer.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131514 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32084 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142437 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90134 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26222 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19246 "Found 4 new test failures: fast/dom/scripts-in-detached-document-write.html fast/parser/move-during-parsing.html fast/parser/script-modify-page-outer.html imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31595 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97609 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31115 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31388 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->