### PR TITLE
Vertical writing-mode content incorrectly wraps when parent has auto height

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -222,7 +222,7 @@ h6 {
 table {
     display: table;
     border-collapse: separate;
-    border-spacing: 2px;
+    border-spacing: 10px;
     text-indent: initial;
     box-sizing: border-box;
 }


### PR DESCRIPTION
#### 293eb7cddc1e8aac125cfe1f5ccabac6c65e3803
<pre>
Vertical writing-mode content incorrectly wraps when parent has auto height
<a href="https://bugs.webkit.org/show_bug.cgi?id=312721">https://bugs.webkit.org/show_bug.cgi?id=312721</a>
<a href="https://rdar.apple.com/175123356">rdar://175123356</a>

Reviewed by NOBODY (OOPS!).

Just testing.

* Source/WebCore/css/html.css:
(table):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/293eb7cddc1e8aac125cfe1f5ccabac6c65e3803

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166163 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111421 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f47b1ffd-2cef-43af-bc82-6f8f9733d8fd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30678 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121860 "Failure limit exceed. At least found 492 new test failures: accessibility/table-one-cell.html accessibility/table-with-rules.html css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/20110323/table-caption-horizontal-alignment-001.htm css2.1/20110323/table-height-algorithm-023.htm css2.1/20110323/table-height-algorithm-024.htm ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85573 "8 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/acdcf11c-fbe6-41d9-b252-be8dd3f5bad3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160297 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24106 "Found 60 new test failures: css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/20110323/table-caption-horizontal-alignment-001.htm css2.1/20110323/table-height-algorithm-023.htm css2.1/20110323/table-height-algorithm-024.htm css2.1/t040302-c61-ex-len-00-b-a.html css2.1/t0803-c5501-mrgn-t-00-b-a.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102528 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f416d39-1f26-45ee-b06b-01ddf4965e5f) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23162 "Found 23 new test failures: imported/w3c/web-platform-tests/css/CSS2/linebox/vertical-align-baseline-008.xht imported/w3c/web-platform-tests/css/css-backgrounds/table-cell-background-local-002.html imported/w3c/web-platform-tests/css/css-backgrounds/table-cell-background-local-003.html imported/w3c/web-platform-tests/css/css-contain/contain-size-052.html imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-table-item.html imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-table-item.html imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-table-item.html imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-table-item.html imported/w3c/web-platform-tests/css/css-flexbox/table-as-item-cross-size.html imported/w3c/web-platform-tests/css/css-tables/absolute-tables-002.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21408 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13934 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168648 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12806 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20730 "Found 60 new test failures: accessibility/table-with-rules.html css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/20110323/table-caption-horizontal-alignment-001.htm css2.1/20110323/table-height-algorithm-023.htm css2.1/20110323/table-height-algorithm-024.htm css2.1/t040302-c61-ex-len-00-b-a.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129995 "Failure limit exceed. At least found 475 new test failures: accessibility/table-one-cell.html accessibility/table-with-rules.html css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/20110323/table-caption-horizontal-alignment-001.htm css2.1/20110323/table-height-algorithm-023.htm css2.1/20110323/table-height-algorithm-024.htm ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30277 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25486 "Found 60 new test failures: accessibility/mac/input-replacevalue-userinfo.html css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/t040302-c61-ex-len-00-b-a.html css2.1/t0803-c5501-mrgn-t-00-b-a.html css2.1/t0803-c5503-mrgn-b-00-b-a.html css2.1/t080301-c411-vt-mrgn-00-b.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130102 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140904 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88126 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24925 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17709 "Found 60 new test failures: compositing/animation/animation-backing.html css1/box_properties/border.html css1/box_properties/border_bottom.html css1/box_properties/border_left.html css1/box_properties/border_right_inline.html css1/box_properties/border_top.html css2.1/t040302-c61-ex-len-00-b-a.html css2.1/t0803-c5501-mrgn-t-00-b-a.html css2.1/t0803-c5503-mrgn-b-00-b-a.html css2.1/t080301-c411-vt-mrgn-00-b.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29911 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93925 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29433 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29663 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29560 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->