### PR TITLE
Remove unused IPC support from WebCore::Style numeric types

### DIFF
--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -84,10 +84,6 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
 
     explicit LengthWrapperBase(WTF::HashTableEmptyValueType token) : m_value(token) { }
 
-    // IPC Support
-    explicit LengthWrapperBase(LengthWrapperData::IPCData&& data) : m_value { toData(WTF::move(data)) } { }
-    LengthWrapperData::IPCData ipcData() const { return m_value.ipcData(); }
-
     ALWAYS_INLINE bool isFixed() const { return holdsAlternative<Fixed>(); }
     ALWAYS_INLINE bool isPercent() const { return holdsAlternative<Percentage>(); }
     ALWAYS_INLINE bool isCalculated() const { return holdsAlternative<Calc>();}
@@ -175,21 +171,6 @@ private:
                 return LengthWrapperData { indexForCalc, protect(calc.calculation()) };
             }
         );
-    }
-
-    static LengthWrapperData toData(LengthWrapperData::IPCData&& ipcData)
-    {
-        RELEASE_ASSERT(ipcData.opaqueType <= maxIndex);
-        RELEASE_ASSERT(ipcData.opaqueType != indexForCalc);
-
-        if (ipcData.opaqueType == indexForFixed) {
-            RELEASE_ASSERT(CSS::isWithinRange<Fixed::range>(ipcData.value));
-        }
-        if (ipcData.opaqueType == indexForPercentage) {
-            RELEASE_ASSERT(CSS::isWithinRange<Percentage::range>(ipcData.value));
-        }
-
-        return LengthWrapperData { WTF::move(ipcData) };
     }
 
     LengthWrapperDataEvaluationKind evaluationKind() const

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
@@ -57,25 +57,6 @@ void LengthWrapperData::deref() const
     Calculation::ValueMap::calculationValues().deref(m_calculationValueHandle);
 }
 
-LengthWrapperData::LengthWrapperData(IPCData&& data)
-    : m_floatValue { data.value }
-    , m_opaqueType { data.opaqueType }
-    , m_kind { LengthWrapperDataKind::Default }
-    , m_hasQuirk { data.hasQuirk }
-{
-}
-
-auto LengthWrapperData::ipcData() const -> IPCData
-{
-    ASSERT(m_kind == LengthWrapperDataKind::Default);
-
-    return IPCData {
-        .value = value(),
-        .opaqueType = m_opaqueType,
-        .hasQuirk = m_hasQuirk
-    };
-}
-
 float LengthWrapperData::nonNanCalculatedValue(float maxValue, const ZoomFactor& usedZoom) const
 {
     ASSERT(m_kind == LengthWrapperDataKind::Calculation);

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
@@ -68,14 +68,6 @@ struct LengthWrapperData {
     float value() const { ASSERT(m_kind != LengthWrapperDataKind::Calculation); return m_floatValue; }
     Calculation::Value& calculationValue() const;
 
-    struct IPCData {
-        float value;
-        uint8_t opaqueType;
-        bool hasQuirk;
-    };
-    WEBCORE_EXPORT LengthWrapperData(IPCData&&);
-    WEBCORE_EXPORT IPCData NODELETE ipcData() const;
-
     bool isKnownZero(LengthWrapperDataEvaluationKind) const;
     bool isKnownPositive(LengthWrapperDataEvaluationKind) const;
     bool isKnownNegative(LengthWrapperDataEvaluationKind) const;

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -239,22 +239,6 @@ template<CSS::DimensionPercentageNumeric CSSType> struct PrimitiveNumeric<CSSTyp
     {
     }
 
-    // NOTE: CalculatedValue is intentionally not part of IPCData.
-    using IPCData = Variant<Dimension, Percentage>;
-    PrimitiveNumeric(IPCData&& data)
-        : m_value { WTF::switchOn(WTF::move(data), [&](auto&& data) -> Representation { return { WTF::move(data) }; }) }
-    {
-    }
-
-    IPCData ipcData() const
-    {
-        return WTF::switchOn(m_value,
-            [](const Dimension& dimension) -> IPCData { return dimension; },
-            [](const Percentage& percentage) -> IPCData { return percentage; },
-            [](const Calc&) -> IPCData { ASSERT_NOT_REACHED(); return Dimension { 0 }; }
-        );
-    }
-
     constexpr size_t index() const { return m_value.index(); }
 
     template<typename T> constexpr bool holdsAlternative() const { return WTF::holdsAlternative<T>(m_value); }


### PR DESCRIPTION
#### 49f05f903acb4f9a316ed7ee3ed4fada8bbdd2d1
<pre>
Remove unused IPC support from WebCore::Style numeric types
<a href="https://bugs.webkit.org/show_bug.cgi?id=312729">https://bugs.webkit.org/show_bug.cgi?id=312729</a>

Reviewed by Chris Dumez.

With the completion of the AcceleratedEffect type set, the IPC support in
the WebCore::Style numeric types is now unused and can be removed.

* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp:
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h:

Canonical link: <a href="https://commits.webkit.org/311554@main">https://commits.webkit.org/311554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dbe4f92acddaade3b73f16e620b283d173082f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166165 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111423 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121862 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85574 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23161 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21410 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13936 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168650 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12808 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129996 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130103 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35238 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140906 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88129 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24924 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17711 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29913 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93927 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29435 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->