### PR TITLE
[GLib] Set real time limits for the sched_setscheduler path

### DIFF
--- a/Source/WTF/wtf/linux/RealTimeThreads.cpp
+++ b/Source/WTF/wtf/linux/RealTimeThreads.cpp
@@ -54,6 +54,34 @@ namespace WTF {
 
 static const int s_realTimeThreadPriority = 5;
 
+#if USE(GLIB) && defined(RLIMIT_RTTIME)
+// Matches rtkit's default RTTimeUSecMax; used on the direct sched_setscheduler
+// path where we don't query rtkit/portal for a value.
+static constexpr rlim_t s_realTimeLimitDefaultUSec = 200000;
+
+// Lower RLIMIT_RTTIME to maxUSec (and its soft limit to 80% of that, so
+// SIGXCPU fires before the hard cap) if the current hard limit is higher.
+static void tightenRealTimeLimit(rlim_t maxUSec)
+{
+    struct rlimit rl;
+    if (getrlimit(RLIMIT_RTTIME, &rl) < 0)
+        return;
+    if (rl.rlim_max <= maxUSec)
+        return;
+    rl.rlim_cur = static_cast<rlim_t>(0.8 * maxUSec);
+    rl.rlim_max = maxUSec;
+    setrlimit(RLIMIT_RTTIME, &rl);
+}
+
+static void ensureRealTimeLimitSet()
+{
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        tightenRealTimeLimit(s_realTimeLimitDefaultUSec);
+    });
+}
+#endif
+
 RealTimeThreads& RealTimeThreads::singleton()
 {
     static LazyNeverDestroyed<RealTimeThreads> realTimeThreads;
@@ -116,6 +144,14 @@ void RealTimeThreads::setEnabled(bool enabled)
 void RealTimeThreads::promoteThreadToRealTime(const Thread& thread)
 {
     ASSERT(isMainThread());
+
+#if USE(GLIB) && defined(RLIMIT_RTTIME)
+    // Seed RLIMIT_RTTIME with a sensible default so the direct
+    // sched_setscheduler path below is protected by SIGXCPU. If we
+    // fall back to rtkit/portal, realTimeKitMakeThreadRealTime may
+    // tighten this further using RTTimeUSecMax.
+    ensureRealTimeLimitSet();
+#endif
 
     struct sched_param param;
     param.sched_priority = std::clamp(s_realTimeThreadPriority, sched_get_priority_min(SCHED_RR), sched_get_priority_max(SCHED_RR));
@@ -265,24 +301,16 @@ void RealTimeThreads::realTimeKitMakeThreadRealTime(uint64_t processID, uint64_t
 
 #ifdef RLIMIT_RTTIME
     // RealTimeKit requires the client to have RLIMIT_RTTIME set.
-    struct rlimit rl;
-    if (getrlimit(RLIMIT_RTTIME, &rl) >= 0) {
-        auto rttimeMax = realTimeKitGetProperty(m_realTimeKitProxy->get(), "RTTimeUSecMax", &error.outPtr());
-        if (error) {
-            LOG_ERROR("Failed to get RTTimeUSecMax from RealtimeKit: %s", error->message);
-            if (!g_error_matches(error.get(), G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_INTERFACE))
-                m_realTimeKitProxy = nullptr;
+    auto rttimeMax = realTimeKitGetProperty(m_realTimeKitProxy->get(), "RTTimeUSecMax", &error.outPtr());
+    if (error) {
+        LOG_ERROR("Failed to get RTTimeUSecMax from RealtimeKit: %s", error->message);
+        if (!g_error_matches(error.get(), G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_INTERFACE))
+            m_realTimeKitProxy = nullptr;
 
-            scheduleDiscardRealTimeKitProxy();
-            return;
-        }
-
-        if (rl.rlim_max > static_cast<uint64_t>(rttimeMax)) {
-            rl.rlim_cur = static_cast<uint64_t>(0.8 * rttimeMax);
-            rl.rlim_max = rttimeMax;
-            setrlimit(RLIMIT_RTTIME, &rl);
-        }
+        scheduleDiscardRealTimeKitProxy();
+        return;
     }
+    tightenRealTimeLimit(static_cast<rlim_t>(rttimeMax));
 #endif
 
     GRefPtr<GVariant> result = adoptGRef(g_dbus_proxy_call_sync(m_realTimeKitProxy->get(), "MakeThreadRealtimeWithPID",


### PR DESCRIPTION
#### 2fa13e45b258fcf2d1c54d224562dc878fdd3373
<pre>
[GLib] Set real time limits for the sched_setscheduler path
<a href="https://bugs.webkit.org/show_bug.cgi?id=312730">https://bugs.webkit.org/show_bug.cgi?id=312730</a>

Reviewed by Michael Catanzaro.

When promoting threads to real-time, the code can take two paths:
one based on sched_setscheduler, another using D-Bus (rtkit or portal).

When taking the 2nd path, the code sets real time limits (mainly because
rtkit expects them). If the soft limit is exceeded, SIGXCPU is sent, if
the hard limit is exceeded, SIGKILL is sent.

When taking the first path, real-time threads would run unchecked,
possibly affecting the entire system.

This commit updates that path, setting the same limits --using the
same default 200000us value. If sched_setscheduler fails, this max is
still refined with rttmax.

Tested on X86 with NetworkProcess&apos; Cache Storage thread running in RT.
Both the sched_setscheduler and the D-Bus paths successfully demote
threads exceeding their budgets. In order to test sched_setscheduler,
sudo prlimit --rtprio=99 --pid &lt;MiniBrowser&apos;s parent&gt; was used.

* Source/WTF/wtf/linux/RealTimeThreads.cpp:
(WTF::tightenRealTimeLimit):
(WTF::ensureRealTimeLimitSet):
(WTF::RealTimeThreads::promoteThreadToRealTime):
(WTF::RealTimeThreads::realTimeKitMakeThreadRealTime):

Canonical link: <a href="https://commits.webkit.org/311660@main">https://commits.webkit.org/311660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64faa75a7de3ec88b4d120b2291c657af5d48278

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166270 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111528 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121930 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85636 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102599 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23255 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21501 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIStorage.Set (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14041 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149497 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168755 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18281 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12935 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130077 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25579 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/130346 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35300 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140996 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88242 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25009 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17801 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189519 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94056 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48662 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29540 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29770 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29667 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->