### PR TITLE
Add site-specific quirk to make anchor elements mouse-focusable on thesaurus.com and dictionary.com

### DIFF
--- a/LayoutTests/fast/events/anchor-mouse-focusable-quirk-expected.txt
+++ b/LayoutTests/fast/events/anchor-mouse-focusable-quirk-expected.txt
@@ -1,0 +1,12 @@
+Tests that the anchor mouse-focusability quirk works on thesaurus.com and dictionary.com, but not on unrelated sites.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.activeElement is link
+PASS document.activeElement is link
+PASS document.activeElement is not link
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Click me

--- a/LayoutTests/fast/events/anchor-mouse-focusable-quirk.html
+++ b/LayoutTests/fast/events/anchor-mouse-focusable-quirk.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<!-- Test for the anchor mouse-focusability quirk on thesaurus.com and dictionary.com.
+     Anchor elements with href but no explicit tabindex are normally not mouse-focusable.
+     The quirk makes them focusable on click for these specific sites. -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<a id="link" href="#">Click me</a>
+<script>
+description("Tests that the anchor mouse-focusability quirk works on thesaurus.com and dictionary.com, but not on unrelated sites.");
+
+var link = document.getElementById("link");
+
+function clickLink() {
+    let rect = link.getBoundingClientRect();
+    eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+}
+
+// Test 1: thesaurus.com — anchor should become focused on click.
+document.activeElement?.blur();
+window.internals.setTopDocumentURLForQuirks("https://www.thesaurus.com");
+clickLink();
+shouldBe("document.activeElement", "link");
+
+// Test 2: dictionary.com — anchor should become focused on click.
+document.activeElement?.blur();
+window.internals.setTopDocumentURLForQuirks("https://www.dictionary.com");
+clickLink();
+shouldBe("document.activeElement", "link");
+
+// Test 3: unrelated site — anchor should NOT become focused on click.
+document.activeElement?.blur();
+window.internals.setTopDocumentURLForQuirks("https://www.example.com");
+clickLink();
+shouldNotBe("document.activeElement", "link");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5484,6 +5484,9 @@ webkit.org/b/313058 media/media-vp8-webm.html [ Pass Timeout ImageOnlyFailure ]
 
 webkit.org/b/312985 svg/transforms/svg-transform-scale-with-and-without-layer.html [ ImageOnlyFailure ]
 
+# Anchor mouse-focusability quirk is Cocoa-only.
+webkit.org/b/312692 fast/events/anchor-mouse-focusable-quirk.html [ Skip ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -5672,6 +5672,7 @@ fast/dom/Geolocation/startUpdatingOnlyWhenPageVisible.html [ Skip ]
 fast/dom/Geolocation/stopUpdatingForHiddenPage.html [ Skip ]
 
 # eventSender.mouseDown is not implemented
+fast/events/anchor-mouse-focusable-quirk.html [ Skip ]
 fast/loader/location-hash-user-gesture.html [ Skip ]
 imported/blink/editing/selection/selectstart-event-crash.html [ Skip ]
 imported/blink/fast/forms/label/label-contains-other-interactive-content.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -2432,6 +2432,7 @@ fast/canvas/font-family-system-ui-canvas.html [ Skip ] # ImageOnlyFailure
 fast/css-grid-layout/grid-align-baseline-vertical.html [ Failure ]
 fast/dom/call-a-constructor-as-a-function.html [ Failure ]
 fast/dynamic/float-in-trailing-whitespace-after-last-line-break-2.html [ Failure ]
+fast/events/anchor-mouse-focusable-quirk.html [ Skip ] # Cocoa-only quirk
 fast/events/attempt-scroll-with-no-scrollbars.html [ Failure ]
 fast/events/autoscroll-when-input-is-offscreen.html [ Skip ] # UIScript
 fast/events/autoscroll-with-software-keyboard.html [ Skip ] # UIScript

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -30,6 +30,7 @@
 #include "ContainerNodeInlines.h"
 #include "DOMTokenList.h"
 #include "DocumentPage.h"
+#include "DocumentQuirks.h"
 #include "DocumentSecurityOrigin.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "EventHandler.h"
@@ -110,7 +111,7 @@ bool HTMLAnchorElement::isMouseFocusable() const
 {
 #if !(PLATFORM(GTK) || PLATFORM(WPE))
     // Only allow links with tabIndex or contentEditable to be mouse focusable.
-    if (isLink())
+    if (isLink() && !protect(document())->quirks().needsAnchorToBeMouseFocusable())
         return HTMLElement::supportsFocus();
 #endif
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -247,6 +247,18 @@ bool Quirks::isEmbedDomain(const String& domainString) const
     return RegistrableDomain(document->url()).string() == domainString;
 }
 
+// thesaurus.com, dictionary.com https://bugs.webkit.org/show_bug.cgi?id=312692 rdar://174959285
+bool Quirks::needsAnchorToBeMouseFocusable() const
+{
+#if PLATFORM(COCOA)
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsAnchorToBeMouseFocusableQuirk);
+#else
+    return false;
+#endif // PLATFORM(COCOA)
+}
+
 // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=193478
 // weather.com rdar://139689157
 // madisoncity.k12.al.us https://bugs.webkit.org/show_bug.cgi?id=296989
@@ -2766,26 +2778,16 @@ static void handleSlackQuirks(QuirksData& quirksData, const URL&, const String& 
 #endif
 }
 
+#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
 static void handleScriptToEvaluateBeforeRunningScriptFromURLQuirk(QuirksData& quirksData, const URL& /* quirksURL */, const String& topDomain, const URL& /* documentURL */)
 {
-    if (topDomain == "dictionary.com"_s) {
-        quirksData.isDictionary = true;
-        quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk);
-    }
-
-    if (topDomain == "thesaurus.com"_s) {
-        quirksData.isThesaurus = true;
-        quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk);
-    }
-
-#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
     if (topDomain == "webex.com"_s) {
         quirksData.isWebEx = true;
         quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk);
     }
-#endif
 }
 #endif
+#endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(TWO_PHASE_CLICKS)
 static void handleWalmartQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
@@ -2892,6 +2894,32 @@ static void handleWPDevelopmentQuirks(QuirksData& quirksData, const URL& /* quir
     quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsFormControlToBeMouseFocusableQuirk);
 }
 #endif
+
+static void handleThesaurusQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
+{
+    QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("thesaurus.com"_s);
+
+    quirksData.isThesaurus = true;
+#if PLATFORM(IOS_FAMILY)
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk);
+#endif
+#if PLATFORM(COCOA)
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsAnchorToBeMouseFocusableQuirk);
+#endif
+}
+
+static void handleDictionaryQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
+{
+    QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("dictionary.com"_s);
+
+    quirksData.isDictionary = true;
+#if PLATFORM(IOS_FAMILY)
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk);
+#endif
+#if PLATFORM(COCOA)
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsAnchorToBeMouseFocusableQuirk);
+#endif
+}
 
 static void handleTikTokQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
 {
@@ -3802,8 +3830,8 @@ void Quirks::determineRelevantQuirks()
         { "crunchyroll"_s, &handleCrunchyRollQuirks },
         { "t-mobile"_s, &handleTMobileQuirks },
         { "descript"_s, &handleDescriptQuirks },
+        { "dictionary"_s, &handleDictionaryQuirks },
 #if PLATFORM(IOS_FAMILY)
-        { "dictionary"_s, &handleScriptToEvaluateBeforeRunningScriptFromURLQuirk },
         { "disneyplus"_s, &handleDisneyPlusQuirks },
 #endif
         { "ea"_s, &handleEAQuirks },
@@ -3881,8 +3909,8 @@ void Quirks::determineRelevantQuirks()
         { "state"_s, &handleCEACStateGovQuirks },
 #if PLATFORM(IOS_FAMILY)
         { "theguardian"_s, &handleGuardianQuirks },
-        { "thesaurus"_s, &handleScriptToEvaluateBeforeRunningScriptFromURLQuirk },
 #endif
+        { "thesaurus"_s, &handleThesaurusQuirks },
         { "tiktok"_s, &handleTikTokQuirks },
 #if PLATFORM(MAC)
         { "trix-editor"_s, &handleTrixEditorQuirks },

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -71,6 +71,7 @@ public:
     bool shouldDeferIntersectionObserversDuringResize() const;
     bool NODELETE shouldSilenceMediaQueryListChangeEvents() const;
     bool shouldIgnoreInvalidSignal() const;
+    bool needsAnchorToBeMouseFocusable() const;
     bool needsFormControlToBeMouseFocusable() const;
     bool needsAutoplayPlayPauseEvents() const;
     bool needsSeekingSupportDisabled() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -89,7 +89,8 @@ struct QuirksData {
         NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk,
 #endif
         NeedsFacebookRemoveNotSupportedQuirk,
-#if PLATFORM(MAC)
+#if PLATFORM(COCOA)
+        NeedsAnchorToBeMouseFocusableQuirk,
         NeedsFormControlToBeMouseFocusableQuirk,
 #endif
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 4509531a0302a134f49aae23194372ed4ba9d0d8
<pre>
Add site-specific quirk to make anchor elements mouse-focusable on thesaurus.com and dictionary.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=312692">https://bugs.webkit.org/show_bug.cgi?id=312692</a>
<a href="https://rdar.apple.com/174959285">rdar://174959285</a>

Reviewed by Abrar Protyasha.

Clicking links on thesaurus.com and dictionary.com causes blur events with a
null relatedTarget, breaking dropdown menus that rely on relatedTarget to stay
open.

Rather than changing the default behavior for all sites, add a site-specific
quirk following the existing needsFormControlToBeMouseFocusable pattern. The
broader behavior discussion is tracked in bug 22261.

Widen platform guards from PLATFORM(MAC) to PLATFORM(COCOA) so the quirk is
also effective on iPad desktop-class browsing and visionOS.

* LayoutTests/fast/events/anchor-mouse-focusable-quirk-expected.txt: Added.
* LayoutTests/fast/events/anchor-mouse-focusable-quirk.html: Added.
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::isMouseFocusable):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsAnchorToBeMouseFocusable):
(WebCore::handleThesaurusQuirks):
(WebCore::handleDictionaryQuirks):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/311907@main">https://commits.webkit.org/311907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/653e5173fb45d33e228f6b87bba3886e6370be24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112270 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122503 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85992 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103172 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23831 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22189 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14788 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169505 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14859 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130687 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130802 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35453 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141661 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89104 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18467 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30760 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96293 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30281 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30408 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->