### PR TITLE
[JSC] Refine clobberize rule for ObjectCreate

### DIFF
--- a/JSTests/microbenchmarks/object-create-null-cse.js
+++ b/JSTests/microbenchmarks/object-create-null-cse.js
@@ -1,0 +1,21 @@
+function test(o, proto)
+{
+    var s = o.a + o.b + o.c + o.d + o.e + o.f;
+    Object.create(proto);
+    s += o.a + o.b + o.c + o.d + o.e + o.f;
+    s += o.a + o.b + o.c + o.d + o.e + o.f;
+    s += o.a + o.b + o.c + o.d + o.e + o.f;
+    s += o.a + o.b + o.c + o.d + o.e + o.f;
+    s += o.a + o.b + o.c + o.d + o.e + o.f;
+    s += o.a + o.b + o.c + o.d + o.e + o.f;
+    s += o.a + o.b + o.c + o.d + o.e + o.f;
+    return s;
+}
+noInline(test);
+
+var o = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 };
+var result = 0;
+for (var i = 0; i < 2e6; ++i)
+    result += test(o, null);
+if (result !== 168 * 2e6)
+    throw new Error("bad result: " + result);

--- a/JSTests/stress/object-create-untyped-clobberize.js
+++ b/JSTests/stress/object-create-untyped-clobberize.js
@@ -1,0 +1,76 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    var error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error("bad error: " + error);
+}
+
+(function testCSEAcrossUntypedCreate() {
+    function go(o, proto) {
+        var a = o.value;
+        Object.create(proto);
+        var b = o.value;
+        return a + b;
+    }
+    noInline(go);
+
+    var o = { value: 21 };
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(go(o, i & 1 ? {} : null), 42);
+})();
+
+(function testThrowOnBadPrototype() {
+    function go(o, proto) {
+        var a = o.value;
+        Object.create(proto);
+        return a + o.value;
+    }
+    noInline(go);
+
+    var o = { value: 1 };
+    for (var i = 0; i < testLoopCount; ++i)
+        go(o, null);
+    shouldThrow(() => go(o, 42), TypeError);
+    shouldThrow(() => go(o, "string"), TypeError);
+    shouldThrow(() => go(o, undefined), TypeError);
+})();
+
+(function testNoHoistPastGuard() {
+    function go(taken, proto) {
+        var result = 0;
+        for (var i = 0; i < 100; ++i) {
+            if (taken)
+                result += Object.create(proto) !== null;
+        }
+        return result;
+    }
+    noInline(go);
+
+    for (var i = 0; i < testLoopCount; ++i)
+        go(true, null);
+    shouldBe(go(false, 42), 0);
+})();
+
+(function testResultPrototype() {
+    function go(proto) {
+        return Object.create(proto);
+    }
+    noInline(go);
+
+    var p = { tag: 1 };
+    for (var i = 0; i < testLoopCount; ++i) {
+        if (i & 1)
+            shouldBe(Object.getPrototypeOf(go(null)), null);
+        else
+            shouldBe(Object.getPrototypeOf(go(p)), p);
+    }
+})();

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4049,12 +4049,12 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             }
 
             if (structure) {
-                didFoldClobberWorld();
+                didFoldClobberStructures();
                 setForNode(node, structure);
                 break;
             }
         }
-        clobberWorld();
+        clobberStructures();
         setTypeForNode(node, SpecFinalObject);
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2125,21 +2125,14 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
     }
 
-    case ObjectCreate: {
-        switch (node->child1().useKind()) {
-        case ObjectUse:
-            read(HeapObjectCount);
-            write(HeapObjectCount);
-            write(JSCell_structureID); // prototype object can be transitioned.
-            return;
-        case UntypedUse:
-            clobberTop();
-            return;
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-            return;
-        }
-    }
+    case ObjectCreate:
+        read(HeapObjectCount);
+        write(HeapObjectCount);
+        write(JSCell_structureID); // prototype object can be transitioned.
+        write(Watchpoint_fire);
+        if (node->child1().useKind() == UntypedUse)
+            write(SideState);
+        return;
 
     case NewSymbol:
         if (!node->child1() || node->child1().useKind() == StringUse) {


### PR DESCRIPTION
#### 10c13e90401d5a664b4db19dcd6eb773617f15fb
<pre>
[JSC] Refine clobberize rule for ObjectCreate
<a href="https://bugs.webkit.org/show_bug.cgi?id=312731">https://bugs.webkit.org/show_bug.cgi?id=312731</a>

Reviewed by Yusuke Suzuki.

ObjectCreate(UntypedUse) was calling clobberTop().

operationObjectCreate never runs user JS: for non-object/non-null it
throws TypeError, for null it allocates with nullPrototypeObjectStructure(),
and for an object it calls constructEmptyObject. The only mutation of pre-existing
heap state is StructureCache::createEmptyStructure -&gt; JSObject::didBecomePrototype
on the prototype, which performs becomePrototypeTransition. That
transition rewrites only the prototype&apos;s structureID (indexingType and
typeInfo are carried over verbatim), touches no butterfly, does not
trigger haveABadTime, and fires the prototype&apos;s transition watchpoint set
via DeferredStructureTransitionWatchpointFire.

Unify both useKinds under read/write(HeapObjectCount) +
write(JSCell_structureID, Watchpoint_fire), plus write(SideState) for
UntypedUse to model the conditional throw. Watchpoint_fire was also
missing from the existing ObjectUse rule, so InvalidationPoints were
never inserted after ObjectCreate.

                            TipOfTree                  Patched

object-create-null-cse   21.1291+-0.1360     ^     19.6590+-0.1359        ^ definitely 1.0748x faster

Tests: JSTests/microbenchmarks/object-create-null-cse.js
       JSTests/stress/object-create-untyped-clobberize.js

* JSTests/microbenchmarks/object-create-null-cse.js: Added.
(test):
* JSTests/stress/object-create-untyped-clobberize.js: Added.
(shouldBe):
(shouldThrow):
(testCSEAcrossUntypedCreate.go):
(testCSEAcrossUntypedCreate):
(testThrowOnBadPrototype.go):
(testNoHoistPastGuard.go):
(testResultPrototype.go):
(testResultPrototype):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):

Canonical link: <a href="https://commits.webkit.org/312000@main">https://commits.webkit.org/312000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae4fd6945a469abf53784c88036701a909c93d8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166178 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111436 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121873 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85584 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102541 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23171 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21421 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13949 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149405 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168663 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18189 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12821 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130010 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30292 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130117 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35502 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30215 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140912 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88146 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17717 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189373 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29926 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93940 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48589 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->