### PR TITLE
[libpas] Fix libpas standalone build

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_iso.c
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_iso.c
@@ -69,6 +69,16 @@ void* bmalloc_iso_allocate(pas_heap_ref* heap_ref, pas_allocation_mode allocatio
     return bmalloc_iso_allocate_inline(heap_ref, allocation_mode);
 }
 
+void* bmalloc_try_iso_allocate_array_by_size(pas_heap_ref* heap_ref, size_t size, pas_allocation_mode allocation_mode)
+{
+    return bmalloc_try_iso_allocate_array_by_size_inline(heap_ref, size, allocation_mode);
+}
+
+void* bmalloc_iso_allocate_array_by_size(pas_heap_ref* heap_ref, size_t size, pas_allocation_mode allocation_mode)
+{
+    return bmalloc_iso_allocate_array_by_size_inline(heap_ref, size, allocation_mode);
+}
+
 void* bmalloc_try_iso_allocate_zeroed_array_by_size(pas_heap_ref* heap_ref, size_t size, pas_allocation_mode allocation_mode)
 {
     return bmalloc_try_iso_allocate_zeroed_array_by_size_inline(heap_ref, size, allocation_mode);

--- a/Source/bmalloc/libpas/src/libpas/hotbit_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/hotbit_heap.h
@@ -29,6 +29,9 @@
 
 #if PAS_ENABLE_HOTBIT
 
+#include "pas_allocation_mode.h"
+#include "pas_reallocate_free_mode.h"
+
 PAS_BEGIN_EXTERN_C;
 
 PAS_API void* hotbit_try_allocate(size_t size, pas_allocation_mode allocation_mode);
@@ -50,4 +53,3 @@ PAS_END_EXTERN_C;
 #endif /* PAS_ENABLE_HOTBIT */
 
 #endif /* HOTBIT_HEAP_H */
-

--- a/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h
@@ -29,6 +29,13 @@
 
 #if PAS_ENABLE_HOTBIT
 
+#include "hotbit_heap.h"
+#include "hotbit_heap_config.h"
+#include "hotbit_heap_innards.h"
+#include "pas_deallocate.h"
+#include "pas_try_allocate_intrinsic.h"
+#include "pas_try_reallocate.h"
+
 PAS_BEGIN_EXTERN_C;
 
 PAS_CREATE_TRY_ALLOCATE_INTRINSIC(

--- a/Source/bmalloc/libpas/src/libpas/iso_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/iso_heap_inlines.h
@@ -29,6 +29,19 @@
 
 #if PAS_ENABLE_ISO
 
+#include "iso_heap.h"
+#include "iso_heap_config.h"
+#include "iso_heap_innards.h"
+#include "pas_deallocate.h"
+#include "pas_get_allocation_size.h"
+#include "pas_get_heap.h"
+#include "pas_has_object.h"
+#include "pas_try_allocate.h"
+#include "pas_try_allocate_array.h"
+#include "pas_try_allocate_intrinsic.h"
+#include "pas_try_allocate_primitive.h"
+#include "pas_try_reallocate.h"
+
 PAS_BEGIN_EXTERN_C;
 
 PAS_CREATE_TRY_ALLOCATE_INTRINSIC(

--- a/Source/bmalloc/libpas/src/libpas/pas_mte.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte.h
@@ -189,12 +189,12 @@ enum pas_mte_tag_constraint {
 
 typedef enum pas_mte_tag_constraint pas_mte_tag_constraint;
 
-PAS_ALWAYS_INLINE pas_mte_tag_constraint pas_mte_exclude_tag(pas_mte_tag_constraint base, uint8_t tag_value_to_exclude)
+static PAS_ALWAYS_INLINE pas_mte_tag_constraint pas_mte_exclude_tag(pas_mte_tag_constraint base, uint8_t tag_value_to_exclude)
 {
     return (pas_mte_tag_constraint)((unsigned)base | (1u << tag_value_to_exclude));
 }
 
-PAS_ALWAYS_INLINE pas_mte_tag_constraint
+static PAS_ALWAYS_INLINE pas_mte_tag_constraint
 pas_mte_compute_valid_tags_under_adjacent_tag_exclusion(
     uintptr_t ptr,
     size_t size,
@@ -480,7 +480,7 @@ inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_switching(uint8_t*
 
 PAS_IGNORE_WARNINGS_END
 
-PAS_ALWAYS_INLINE void
+static PAS_ALWAYS_INLINE void
 pas_mte_assert_prior_tag_is_disjoint(uintptr_t begin)
 {
     uint8_t* prev_ptr = (uint8_t*)((uintptr_t)begin - 16);
@@ -496,7 +496,7 @@ pas_mte_assert_prior_tag_is_disjoint(uintptr_t begin)
     }
 }
 
-PAS_ALWAYS_INLINE void
+static PAS_ALWAYS_INLINE void
 pas_mte_tag_region_from_pointer(
     uintptr_t begin,
     size_t size,
@@ -579,7 +579,7 @@ pas_mte_tag_region_from_pointer(
 #define PAS_MTE_IS_KNOWN_MEDIUM_PAGE(page_config) 0
 #endif
 
-PAS_ALWAYS_INLINE uintptr_t
+static PAS_ALWAYS_INLINE uintptr_t
 pas_mte_generate_random_tag(
     uintptr_t begin,
     pas_mte_tag_constraint constraint)
@@ -605,7 +605,7 @@ pas_mte_generate_random_tag(
  * that the size passed be the allocation size of the object, not the
  * actual size.
  */
-PAS_ALWAYS_INLINE uintptr_t
+static PAS_ALWAYS_INLINE uintptr_t
 pas_mte_generate_tag_and_tag_region(
     uintptr_t begin,
     size_t size,
@@ -647,7 +647,7 @@ pas_mte_generate_tag_and_tag_region(
     return begin;
 }
 
-PAS_ALWAYS_INLINE void
+static PAS_ALWAYS_INLINE void
 pas_mte_check_tag_for_deallocation(uintptr_t ptr)
 {
     if (!PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_CHECK_TAG_ON_DEALLOC))
@@ -662,7 +662,7 @@ pas_mte_check_tag_for_deallocation(uintptr_t ptr)
 extern "C" {
 #endif
 
-PAS_ALWAYS_INLINE uintptr_t
+static PAS_ALWAYS_INLINE uintptr_t
 pas_mte_maybe_tag_allocated_region(
     uintptr_t begin,
     size_t size,
@@ -671,7 +671,7 @@ pas_mte_maybe_tag_allocated_region(
     pas_allocation_initiality initiality,
     bool is_known_medium);
 
-PAS_ALWAYS_INLINE uintptr_t
+static PAS_ALWAYS_INLINE uintptr_t
 pas_mte_retag_freed_region_if_tagged(
     uintptr_t begin,
     size_t size,
@@ -741,7 +741,7 @@ pas_mte_retag_freed_region_if_tagged(
  * the point of view of the orderings mentioned above, as scavenging always
  * happens at some point before a subsequent allocation.
  */
-PAS_ALWAYS_INLINE uintptr_t
+static PAS_ALWAYS_INLINE uintptr_t
 pas_mte_maybe_tag_allocated_region(
     uintptr_t begin,
     size_t size,
@@ -768,7 +768,7 @@ pas_mte_maybe_tag_allocated_region(
     return begin;
 }
 
-PAS_ALWAYS_INLINE uintptr_t
+static PAS_ALWAYS_INLINE uintptr_t
 pas_mte_retag_freed_region_if_tagged(
     uintptr_t begin,
     size_t size,

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -32,6 +32,7 @@
 #include "pas_thread.h"
 #if defined(__has_include)
 #if __has_include(<pthread/tsd_private.h>)
+#include <pthread/tsd_private.h>
 #define PAS_HAVE_PTHREAD_MACHDEP_H 1
 #else
 #define PAS_HAVE_PTHREAD_MACHDEP_H 0


### PR DESCRIPTION
#### d7b3180cbfe81056d109ad298b3c901645e89908
<pre>
[libpas] Fix libpas standalone build
<a href="https://bugs.webkit.org/show_bug.cgi?id=312733">https://bugs.webkit.org/show_bug.cgi?id=312733</a>
<a href="https://rdar.apple.com/175129910">rdar://175129910</a>

Reviewed by Yusuke Suzuki.

311133@main removed includes from headers whose macro bodies are guarded
by PAS_ENABLE_ISO / PAS_ENABLE_HOTBIT. These macros are 0 in WebKit
(PAS_BMALLOC=1) but 1 in the libpas standalone build, so the includes
were silently required by the standalone build. Restore them inside the

Also fix several pre-existing issues that surface once the standalone
build gets past the include errors:

- Guard &lt;stdatomic.h&gt; in pas_utils.h for C-only. It conflicts with C++
  &lt;atomic&gt; before C++23 and breaks Verifier.cpp. The macros that use
  atomics (PAS_ATOMIC_TYPE / PAS_ATOMIC_LOAD_RELAXED) only use the
  _Atomic keyword and __c11_atomic_* clang builtins, neither of which
  needs the header.

- Restore &lt;pthread/tsd_private.h&gt; in pas_utils.h. TSDTests.cpp and
  pas_fast_tls.h depend on pthread_key_init_np,
  _pthread_setspecific_direct, and __PTK_FRAMEWORK_* keys from it.

- Add missing bmalloc_iso_allocate_array_by_size and
  bmalloc_try_iso_allocate_array_by_size definitions to
  bmalloc_heap_iso.c. They&apos;re declared in bmalloc_heap.h but were lost
  in db6887c9076e when bmalloc_heap.c was split.

- Add &apos;static&apos; to the 9 PAS_ALWAYS_INLINE functions in pas_mte.h. C99
  inline semantics require an external definition when the compiler
  chooses not to inline (which happens in Debug, where PAS_ALWAYS_INLINE
  drops __attribute__((always_inline))). The codebase convention is
  &apos;static PAS_ALWAYS_INLINE&apos; for header-only inline functions (489
  occurrences across 87 files); the pas_mte.h functions are anomalies.

* Source/bmalloc/libpas/src/libpas/bmalloc_heap_iso.c:
(bmalloc_try_iso_allocate_array_by_size):
(bmalloc_iso_allocate_array_by_size):
* Source/bmalloc/libpas/src/libpas/hotbit_heap.h:
* Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h:
* Source/bmalloc/libpas/src/libpas/iso_heap_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_mte.h:
(pas_mte_exclude_tag):
* Source/bmalloc/libpas/src/libpas/pas_utils.h:

Canonical link: <a href="https://commits.webkit.org/311770@main">https://commits.webkit.org/311770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78270d44ed1a037b3e1534e74d0026641b9b036b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166765 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122310 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24606 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102977 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14538 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149988 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169255 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18772 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130484 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130598 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35372 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141442 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88832 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18248 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190066 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30510 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48800 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30031 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30261 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30158 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->