### PR TITLE
REGRESSION(306624@main) [WPE] Null check the return value of wpe_clipboard_get_formats

### DIFF
--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1260,7 +1260,6 @@ webkit.org/b/310273 imported/w3c/web-platform-tests/uievents/textInput/basic.htm
 
 webkit.org/b/310279 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-closedby-simple.html [ Pass Failure ]
 
-webkit.org/b/310739 imported/w3c/web-platform-tests/editing/other/copy-elements-with-css-vars.tentative.html [ Pass Crash Failure ]
 webkit.org/b/310741 imported/w3c/web-platform-tests/navigation-api/navigate-event/defer/tentative/defer-restore-callback-abort.html [ Pass Timeout ]
 webkit.org/b/310743 imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-right.html [ Pass ImageOnlyFailure ]
 webkit.org/b/310744 imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-014.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/editing/other/copy-elements-with-css-vars.tentative-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/editing/other/copy-elements-with-css-vars.tentative-expected.txt
@@ -1,7 +1,6 @@
 Span text
 Row 1, Cell 1	Row 1, Cell 2
 
-
 PASS Test serialized html on copy has resolved css values
 FAIL Test for resolving css variables on copy null is not an object (evaluating 'span.style')
 

--- a/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
@@ -47,7 +47,10 @@ using namespace WebCore;
 #if ENABLE(WPE_PLATFORM)
 static Vector<String> clipboardFormats(WPEClipboard* clipboard)
 {
-    const auto formats = span(wpe_clipboard_get_formats(clipboard));
+    auto* strv = wpe_clipboard_get_formats(clipboard);
+    if (!strv)
+        return { };
+    const auto formats = span(strv);
     return Vector<String>(formats.size(), [&formats](size_t index) {
         return String::fromUTF8(formats[index]);
     });
@@ -167,13 +170,15 @@ void WebPasteboardProxy::typesSafeForDOMToReadAndWrite(IPC::Connection&, const S
                     domTypes.add(type);
             }
 
-            for (const char* format : span(wpe_clipboard_get_formats(clipboard))) {
-                String formatString = String::fromUTF8(format);
-                if (formatString == PasteboardCustomData::wpeType())
-                    continue;
+            if (auto* strv = wpe_clipboard_get_formats(clipboard)) {
+                for (const char* format : span(strv)) {
+                    String formatString = String::fromUTF8(format);
+                    if (formatString == PasteboardCustomData::wpeType())
+                        continue;
 
-                if (Pasteboard::isSafeTypeForDOMToReadAndWrite(formatString))
-                    domTypes.add(formatString);
+                    if (Pasteboard::isSafeTypeForDOMToReadAndWrite(formatString))
+                        domTypes.add(formatString);
+                }
             }
             completionHandler(copyToVector(domTypes));
             return;


### PR DESCRIPTION
#### 5a7b2c171b5decdba35219c6b4ededf5572a4d0e
<pre>
REGRESSION(306624@main) [WPE] Null check the return value of wpe_clipboard_get_formats
<a href="https://bugs.webkit.org/show_bug.cgi?id=310739">https://bugs.webkit.org/show_bug.cgi?id=310739</a>

Reviewed by Carlos Garcia Campos.

imported/w3c/web-platform-tests/editing/other/copy-elements-with-css-vars.tentative.html
was a flaky crash.

306624@main introduced WTF::span for the return value of wpe_clipboard_get_formats()
in WebPasteboardProxyWPE.cpp. However, it needs a null check.

* LayoutTests/platform/wpe/TestExpectations:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/editing/other/copy-elements-with-css-vars.tentative-expected.txt:
* Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp:
(WebKit::clipboardFormats):
(WebKit::WebPasteboardProxy::typesSafeForDOMToReadAndWrite):

Canonical link: <a href="https://commits.webkit.org/311564@main">https://commits.webkit.org/311564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9bf109d1de5234eba22e26cdc74b8b75cc536f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166186 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111444 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121878 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85589 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102546 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23180 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21426 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13957 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168671 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130014 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130121 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140922 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88154 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23933 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17727 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29934 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93948 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29456 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->