### PR TITLE
Element.innerText should collect option text when called directly on a <select> element

### DIFF
--- a/LayoutTests/fast/forms/menulist-no-renderer-for-unexpected-children-expected.txt
+++ b/LayoutTests/fast/forms/menulist-no-renderer-for-unexpected-children-expected.txt
@@ -3,7 +3,7 @@ Check that a select control does not render children that are not <option> or <o
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS select.innerText is ""
+PASS select.innerText is "PASS"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/menulist-no-renderer-for-unexpected-children.html
+++ b/LayoutTests/fast/forms/menulist-no-renderer-for-unexpected-children.html
@@ -12,9 +12,6 @@ var div = select.appendChild(document.createElement('div'));
 div.innerText = 'FAIL';
 div.style.background = 'red';
 
-// innerText uses the render tree, and the "FAIL" text (from either the initial 
-// HTML or the dynamially inserted <div>) should not be in the render tree, thus 
-// not appear.
-shouldBeEqualToString('select.innerText', '');
+shouldBeEqualToString('select.innerText', 'PASS');
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -129,8 +129,8 @@ PASS <svg> text contents preserved ("<div><svg><text>abc</text></svg></div>")
 FAIL <svg><defs> text contents ignored ("<div><svg><defs><text>abc</text></defs></svg></div>") assert_equals: innerText expected "" but got "abc"
 PASS <svg> non-rendered text ignored ("<div><svg><stop>abc</stop></svg></div>")
 PASS <foreignObject> contents preserved ("<svg><foreignObject><span id='target'>abc</span></foreignObject></svg>")
-FAIL <select size='1'> contents of options preserved ("<select size='1'><option>abc</option><option>def") assert_equals: innerText expected "abc\ndef" but got ""
-FAIL <select size='2'> contents of options preserved ("<select size='2'><option>abc</option><option>def") assert_equals: innerText expected "abc\ndef" but got ""
+PASS <select size='1'> contents of options preserved ("<select size='1'><option>abc</option><option>def")
+PASS <select size='2'> contents of options preserved ("<select size='2'><option>abc</option><option>def")
 PASS <select size='1'> contents of target option preserved ("<select size='1'><option id='target'>abc</option><option>def")
 PASS <select size='2'> contents of target option preserved ("<select size='2'><option id='target'>abc</option><option>def")
 PASS empty <select> ("<div>a<select></select>bc")
@@ -138,13 +138,13 @@ FAIL empty <optgroup> in <select> ("<div>a<select><optgroup></select>bc") assert
 FAIL empty <option> in <select> ("<div>a<select><option></select>bc") assert_equals: innerText expected "a\nbc" but got "abc"
 PASS <select> containing text node child ("<select class='poke'></select>")
 PASS <optgroup> containing <optgroup> ("<select><optgroup class='poke-optgroup'></select>")
-FAIL <optgroup> containing <option> ("<select><optgroup><option>abc</select>") assert_equals: innerText expected "abc" but got ""
-FAIL <div> in <option> ("<select><option class='poke-div'>123</select>") assert_equals: innerText expected "123\nabc" but got ""
+PASS <optgroup> containing <option> ("<select><optgroup><option>abc</select>")
+FAIL <div> in <option> ("<select><option class='poke-div'>123</select>") assert_equals: innerText expected "123\nabc" but got "123abc"
 FAIL empty <optgroup> in <div> ("<div>a<optgroup></optgroup>bc") assert_equals: innerText expected "a\nbc" but got "abc"
 FAIL <optgroup> in <div> ("<div>a<optgroup>123</optgroup>bc") assert_equals: innerText expected "a\nbc" but got "a123bc"
 FAIL empty <option> in <div> ("<div>a<option></option>bc") assert_equals: innerText expected "a\nbc" but got "abc"
 FAIL <option> in <div> ("<div>a<option>123</option>bc") assert_equals: innerText expected "a\n123\nbc" but got "a123bc"
-FAIL undefined ("<select><option>one</option><div><optgroup label=optgroup><div><option><span>two") assert_equals: innerText expected "one\ntwo" but got ""
+PASS undefined ("<select><option>one</option><div><optgroup label=optgroup><div><option><span>two")
 PASS <button> contents preserved ("<div><button>abc")
 PASS <fieldset> contents preserved ("<div><fieldset>abc")
 PASS <fieldset> <legend> contents preserved ("<div><fieldset><legend>abc")

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4523,6 +4523,13 @@ String Element::innerText()
     if (renderer()->isSkippedContent())
         return String();
 
+    // When innerText is called directly on a <select>, we must collect option
+    // text explicitly because the options have no renderers and would be skipped
+    // by the TextIterator. When a <select> is encountered as a child of another
+    // element, TextIterator::handleReplacedElement() handles this instead.
+    if (auto* selectElement = dynamicDowncast<HTMLSelectElement>(this))
+        return selectElement->collectOptionInnerText();
+
     return plainText(makeRangeSelectingNodeContents(*this), { TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec });
 }
 

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -46,8 +46,6 @@
 #include "HTMLLegendElement.h"
 #include "HTMLMeterElement.h"
 #include "HTMLNames.h"
-#include "HTMLOptGroupElement.h"
-#include "HTMLOptionElement.h"
 #include "HTMLParagraphElement.h"
 #include "HTMLProgressElement.h"
 #include "HTMLSelectElement.h"
@@ -800,25 +798,6 @@ void TextIterator::handleTextNodeFirstLetter(RenderTextFragment& renderer)
     m_handledFirstLetter = true;
 }
 
-static String collectSelectInnerText(const HTMLSelectElement& selectElement)
-{
-    StringBuilder builder;
-    for (Ref child : childrenOfType<HTMLElement>(selectElement)) {
-        if (auto* option = dynamicDowncast<HTMLOptionElement>(child.get())) {
-            if (!builder.isEmpty())
-                builder.append('\n');
-            builder.append(option->text());
-        } else if (auto* optgroup = dynamicDowncast<HTMLOptGroupElement>(child.get())) {
-            for (Ref option : childrenOfType<HTMLOptionElement>(*optgroup)) {
-                if (!builder.isEmpty())
-                    builder.append('\n');
-                builder.append(option->text());
-            }
-        }
-    }
-    return builder.toString();
-}
-
 bool TextIterator::handleReplacedElement()
 {
     if (m_fullyClippedStack.top())
@@ -917,7 +896,7 @@ bool TextIterator::handleReplacedElement()
     if (m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec)) {
         if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(m_currentNode)) {
             m_handledChildren = true;
-            if (String selectText = collectSelectInnerText(*selectElement); !selectText.isEmpty()) {
+            if (String selectText = selectElement->collectOptionInnerText(); !selectText.isEmpty()) {
                 m_hasEmitted = true;
                 m_lastCharacter = selectText[selectText.length() - 1];
                 m_copyableText.set(WTF::move(selectText));

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -80,6 +80,7 @@
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
 
 #if !PLATFORM(IOS_FAMILY)
 #include <WebCore/PopupMenu.h>
@@ -502,6 +503,19 @@ String HTMLSelectElement::value() const
         }
     }
     return emptyString();
+}
+
+String HTMLSelectElement::collectOptionInnerText() const
+{
+    StringBuilder builder;
+    for (auto& item : listItems()) {
+        if (RefPtr option = dynamicDowncast<HTMLOptionElement>(item.get())) {
+            if (!builder.isEmpty())
+                builder.append('\n');
+            builder.append(option->text());
+        }
+    }
+    return builder.toString();
 }
 
 void HTMLSelectElement::setValue(const String& value)

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -95,6 +95,8 @@ public:
     WEBCORE_EXPORT String value() const;
     WEBCORE_EXPORT void setValue(const String&);
 
+    String collectOptionInnerText() const;
+
     WEBCORE_EXPORT Ref<HTMLOptionsCollection> options();
     Ref<HTMLCollection> selectedOptions();
 


### PR DESCRIPTION
#### b37b0cb33a7cc5461943fc7d0dc83e72deaa29ba
<pre>
Element.innerText should collect option text when called directly on a &lt;select&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=312738">https://bugs.webkit.org/show_bug.cgi?id=312738</a>

Reviewed by Anne van Kesteren.

When innerText is called directly on a &lt;select&gt;, Element::innerText() calls
plainText() with a range over the select&apos;s children. Since &lt;option&gt; elements
inside a &lt;select&gt; have no renderers, TextIterator skips them and returns an
empty string. The special &lt;select&gt; handling in TextIterator::handleReplacedElement()
only fires when the &lt;select&gt; is encountered as a child of another element.

Fix this by adding HTMLSelectElement::collectOptionInnerText() which uses
m_listItems to collect all option text regardless of nesting depth, and
calling it from Element::innerText() when the element is a &lt;select&gt;. The
same method is now also used by TextIterator::handleReplacedElement(),
replacing the previous static collectSelectInnerText() which only checked
direct children and missed options nested inside &lt;div&gt; or &lt;optgroup&gt; wrappers.

No new tests, rebaselined existing WPT test. Chrome was already passing
the subtests we are now passing. The test that went from FAIL to FAIL
is also failing in Chrome.

* LayoutTests/fast/forms/menulist-no-renderer-for-unexpected-children-expected.txt:
* LayoutTests/fast/forms/menulist-no-renderer-for-unexpected-children.html:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::innerText):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::handleReplacedElement):
(WebCore::collectSelectInnerText): Deleted.
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::collectOptionInnerText const):
* Source/WebCore/html/HTMLSelectElement.h:

Canonical link: <a href="https://commits.webkit.org/311576@main">https://commits.webkit.org/311576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3199b2a5816d736df1634124fa6194a764835f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166243 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9c0a8c3-0d19-4a28-88e8-9249bc052bc0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30758 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6b88cbf-a1f6-4f9b-a51b-d239cece10eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141353 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a27f27e6-65e8-4632-89a3-2767d6c564f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23228 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21481 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14014 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132907 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168728 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12886 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130061 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130168 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35254 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140975 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88215 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24991 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17780 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29991 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94005 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29513 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29640 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->