### PR TITLE
Speed up check-webkit-style (and git webkit pr)

### DIFF
--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -1260,7 +1260,7 @@ class StyleProcessor(ProcessorBase):
 
         _log.debug("Using class: " + checker.__class__.__name__)
 
-        checker.check(lines)
+        checker.check(lines, line_numbers=line_numbers)
         if isinstance(checker, SwiftChecker) and checker.has_swift_format_errors:
             _log.info("These errors can be fixed using swift format --in-place \"%s\"" % file_path)
 

--- a/Tools/Scripts/webkitpy/style/checker_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checker_unittest.py
@@ -748,7 +748,7 @@ class StyleProcessor_CodeCoverageTest(LoggingTestCase):
             self.min_confidence = min_confidence
             self.style_error_handler = style_error_handler
 
-        def check(self, lines):
+        def check(self, lines, line_numbers=None):
             self.lines = lines
 
     class MockDispatcher(object):

--- a/Tools/Scripts/webkitpy/style/checkers/basexcconfig.py
+++ b/Tools/Scripts/webkitpy/style/checkers/basexcconfig.py
@@ -68,7 +68,7 @@ class BaseXcconfigChecker(object):
 
         return inherited_vars, override_vars
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         (inherited_vars, override_vars) = self.read_common_base_xcconfig_variables()
 
         for line_number, line in enumerate(lines, start=1):

--- a/Tools/Scripts/webkitpy/style/checkers/changelog.py
+++ b/Tools/Scripts/webkitpy/style/checkers/changelog.py
@@ -79,7 +79,7 @@ class ChangeLogChecker(object):
 
         self.check_for_unwanted_security_phrases(first_line_checked, entry_lines)
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         self._tab_checker.check(lines)
         self._inclusive_language_checker.check(lines)
         first_line_checked = 0

--- a/Tools/Scripts/webkitpy/style/checkers/cmake.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cmake.py
@@ -95,7 +95,7 @@ class CMakeChecker(object):
         self._handle_style_error = handle_style_error
         self._tab_checker = TabChecker(file_path, handle_style_error)
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         self._tab_checker.check(lines)
         for line_number, line in enumerate(lines, start=1):
             self._process_line(line_number, line)

--- a/Tools/Scripts/webkitpy/style/checkers/common.py
+++ b/Tools/Scripts/webkitpy/style/checkers/common.py
@@ -79,7 +79,7 @@ class CarriageReturnChecker(object):
     def __init__(self, handle_style_error):
         self._handle_style_error = handle_style_error
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         """Check for and strip trailing carriage returns from lines."""
         for line_number in range(len(lines)):
             if not lines[line_number].endswith("\r"):
@@ -104,7 +104,7 @@ class TabChecker(object):
         self.file_path = file_path
         self.handle_style_error = handle_style_error
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         # FIXME: share with cpp_style.
         for line_number, line in enumerate(lines):
             if "\t" in line:

--- a/Tools/Scripts/webkitpy/style/checkers/contributors.py
+++ b/Tools/Scripts/webkitpy/style/checkers/contributors.py
@@ -37,7 +37,7 @@ class ContributorsChecker(JSONChecker):
         super(ContributorsChecker, self).__init__(file_path, handle_style_error)
         self._file_path = file_path
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         super(ContributorsChecker, self).check(lines)
         canonicalized = CommitterList().as_json()
         actual = FileSystem().read_text_file(self._file_path)

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -1227,6 +1227,9 @@ def check_os_version_checks(filename, clean_lines, line_number, error):
 
     line = clean_lines.elided[line_number]
 
+    if 'VERSION_M' not in line:
+        return
+
     for version_match in _RE_PATTERN_XCODE_MIN_REQUIRED_MACRO.finditer(line):
         version_number = int(version_match.group(2))
         if version_number % 100 != 0:
@@ -3874,7 +3877,8 @@ def check_safer_cpp(clean_lines, line_number, error):
         error(line_number, 'safercpp/protected_getter_for_init', 4,
               "Do not use protect() for variable initialization. Use the declared type (not auto) and remove the call to protect().")
 
-def check_style(clean_lines, line_number, file_extension, class_state, file_state, enum_state, error):
+
+def check_style(clean_lines, line_number, file_extension, class_state, file_state, enum_state, error, line_numbers=None):
     """Checks rules from the 'C++ style rules' section of cppguide.html.
 
     Most of these rules are hard to test (naming, comment style), but we
@@ -3895,6 +3899,12 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
 
     raw_lines = clean_lines.raw_lines
     line = raw_lines[line_number]
+
+    check_namespace_indentation(clean_lines, line_number, file_extension, file_state, error)
+    check_enum_members(clean_lines, line_number, enum_state, error)
+
+    if line_numbers is not None and line_number not in line_numbers:
+        return
 
     if line.find('\t') != -1:
         error(line_number, 'whitespace/tab', 1,
@@ -3931,7 +3941,6 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
               'operators on the left side of the line instead of the right side.')
 
     # Some more style checks
-    check_namespace_indentation(clean_lines, line_number, file_extension, file_state, error)
     check_directive_indentation(clean_lines, line_number, file_state, error)
     check_using_std(clean_lines, line_number, file_state, error)
     check_variant_usage(clean_lines, line_number, file_state, error)
@@ -3959,7 +3968,6 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
     check_for_null(clean_lines, line_number, file_state, error)
     check_soft_link_class_alloc(clean_lines, line_number, error)
     check_indentation_amount(clean_lines, line_number, error)
-    check_enum_members(clean_lines, line_number, enum_state, error)
     check_once_flag(clean_lines, line_number, error)
     check_arguments_for_wk_api_available(clean_lines, line_number, error)
     check_objc_protocol(clean_lines, line_number, file_extension, error)
@@ -4237,7 +4245,7 @@ def check_include_line(filename, file_extension, clean_lines, line_number, inclu
 
 
 def check_language(filename, clean_lines, line_number, file_extension, include_state,
-                   file_state, error):
+                   file_state, error, line_numbers=None):
     """Checks rules from the 'C++ language rules' section of cppguide.html.
 
     Some of these rules are hard to test (function overloading, using
@@ -4262,6 +4270,9 @@ def check_language(filename, clean_lines, line_number, file_extension, include_s
     matched = _RE_PATTERN_INCLUDE.search(line)
     if matched:
         check_include_line(filename, file_extension, clean_lines, line_number, include_state, error)
+        return
+
+    if line_numbers is not None and line_number not in line_numbers:
         return
 
     # FIXME: figure out if they're using default arguments in fn proto.
@@ -4927,7 +4938,7 @@ def update_include_state(filename, include_state, io=codecs):
     return True
 
 
-def check_for_include_what_you_use(filename, clean_lines, include_state, error):
+def check_for_include_what_you_use(filename, clean_lines, include_state, error, line_numbers=None):
     """Reports for missing stl includes.
 
     This function will output warnings to make sure you are including the headers
@@ -4946,6 +4957,8 @@ def check_for_include_what_you_use(filename, clean_lines, include_state, error):
         # Example of required: { '<functional>': (1219, 'less<>') }
 
     for line_number in range(clean_lines.num_lines()):
+        if line_numbers is not None and line_number not in line_numbers:
+            continue
         line = clean_lines.elided[line_number]
         if not line or line[0] == '#':
             continue
@@ -5025,7 +5038,7 @@ def check_platformh_comments(lines, error):
 
 def process_line(filename, file_extension,
                  clean_lines, line, include_state, function_state,
-                 class_state, file_state, enum_state, asm_state, error):
+                 class_state, file_state, enum_state, asm_state, error, line_numbers=None):
     """Processes a single line in the file.
 
     Args:
@@ -5059,12 +5072,16 @@ def process_line(filename, file_extension,
         return
     check_function_definition(filename, file_extension, clean_lines, line, class_state, function_state, error)
     check_function_body(filename, file_extension, clean_lines, line, class_state, function_state, error)
+    check_style(clean_lines, line, file_extension, class_state, file_state, enum_state, error, line_numbers)
+    check_language(filename, clean_lines, line, file_extension, include_state,
+                   file_state, error, line_numbers)
+    check_for_non_standard_constructs(clean_lines, line, class_state, error)
+
+    if line_numbers is not None and line not in line_numbers:
+        return
+
     check_for_leaky_patterns(clean_lines, line, function_state, error)
     check_for_multiline_comments(clean_lines, line, error)
-    check_style(clean_lines, line, file_extension, class_state, file_state, enum_state, error)
-    check_language(filename, clean_lines, line, file_extension, include_state,
-                   file_state, error)
-    check_for_non_standard_constructs(clean_lines, line, class_state, error)
     check_posix_threading(clean_lines, line, error)
     check_invalid_increment(clean_lines, line, error)
     check_os_version_checks(filename, clean_lines, line, error)
@@ -5089,7 +5106,7 @@ class _InlineASMState(object):
         return self._is_in_asm
 
 
-def _process_lines(filename, file_extension, lines, error, min_confidence):
+def _process_lines(filename, file_extension, lines, error, min_confidence, line_numbers=None):
     """Performs lint checks and reports any errors to the given error function.
 
     Args:
@@ -5121,10 +5138,10 @@ def _process_lines(filename, file_extension, lines, error, min_confidence):
     for line in range(clean_lines.num_lines()):
         process_line(filename, file_extension, clean_lines, line,
                      include_state, function_state, class_state, file_state,
-                     enum_state, asm_state, error)
+                     enum_state, asm_state, error, line_numbers)
     class_state.check_finished(error)
 
-    check_for_include_what_you_use(filename, clean_lines, include_state, error)
+    check_for_include_what_you_use(filename, clean_lines, include_state, error, line_numbers)
 
     # We check here rather than inside process_line so that we see raw
     # lines rather than "cleaned" lines.
@@ -5321,9 +5338,17 @@ class CppChecker(object):
         # Python does not automatically deduce __ne__() from __eq__().
         return not self.__eq__(other)
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
+        """Check the given lines for style errors.
+
+        Args:
+          lines: File contents.
+          line_numbers: 1-based set of changed lines from the diff.
+                       None means check all lines (whole-file mode).
+        """
         if is_generated_file(self.file_path):
             return
         _process_lines(self.file_path, self.file_extension, lines,
-                       self.handle_style_error, self.min_confidence)
+                       self.handle_style_error, self.min_confidence,
+                       set(line_numbers) if line_numbers is not None else None)
         self._inclusive_language_checker.check(lines)

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -7614,6 +7614,27 @@ class WebKitStyleTest(CppStyleTestBase):
         # FIXME: Implement this.
         pass
 
+    def test_line_numbers_filters_errors(self):
+        code = ['void f() {', '\tint x;', '}', '']
+        error_collector = ErrorCollector(self.assertTrue, FilterConfiguration(('-', '+whitespace/tab')))
+        checker = CppChecker('foo.cpp', 'cpp', error_collector, self.min_confidence, {})
+        checker.check(code, line_numbers=[1])
+        self.assertEqual('', error_collector.results())
+
+    def test_line_numbers_reports_errors_on_listed_lines(self):
+        code = ['void f() {', '\tint x;', '}', '']
+        error_collector = ErrorCollector(self.assertTrue, FilterConfiguration(('-', '+whitespace/tab')))
+        checker = CppChecker('foo.cpp', 'cpp', error_collector, self.min_confidence, {})
+        checker.check(code, line_numbers=[2])
+        self.assertNotEqual('', error_collector.results())
+
+    def test_empty_line_numbers_suppresses_all_errors(self):
+        code = ['void f() {', '\tint x;', '}', '']
+        error_collector = ErrorCollector(self.assertTrue, FilterConfiguration(('-', '+whitespace/tab')))
+        checker = CppChecker('foo.cpp', 'cpp', error_collector, self.min_confidence, {})
+        checker.check(code, line_numbers=[])
+        self.assertEqual('', error_collector.results())
+
 
 class CppCheckerTest(unittest.TestCase):
 

--- a/Tools/Scripts/webkitpy/style/checkers/inclusive_language.py
+++ b/Tools/Scripts/webkitpy/style/checkers/inclusive_language.py
@@ -29,7 +29,7 @@ class InclusiveLanguageChecker(object):
     def __init__(self, handle_style_error):
         self.handle_style_error = handle_style_error
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         for line_number, line in enumerate(lines):
             for non_inclusive_term in self.NON_INCLUSIVE_TERMS:
                 if non_inclusive_term in line.lower():

--- a/Tools/Scripts/webkitpy/style/checkers/js.py
+++ b/Tools/Scripts/webkitpy/style/checkers/js.py
@@ -47,7 +47,7 @@ class JSChecker(object):
         self._single_quote_checker = SingleQuoteChecker(file_path, handle_style_error)
         self._inclusive_language_checker = InclusiveLanguageChecker(handle_style_error)
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         self._tab_checker.check(lines)
         self._single_quote_checker.check(lines)
         self._inclusive_language_checker.check(lines)
@@ -60,7 +60,7 @@ class SingleQuoteChecker(object):
         self._file_path = file_path
         self._handle_style_error = handle_style_error
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         line_number = 0
         for line in lines:
             line = line.strip()

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -39,7 +39,7 @@ class JSONChecker(object):
         self._handle_style_error = handle_style_error
         self._handle_style_error.turn_off_line_filtering()
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         try:
             json.loads('\n'.join(lines) + '\n')
         except ValueError as e:
@@ -56,7 +56,7 @@ class JSONChecker(object):
 class JSONContributorsChecker(JSONChecker):
     """Processes contributors.json lines"""
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         super(JSONContributorsChecker, self).check(lines)
         self._handle_style_error(0, 'json/syntax', 5, 'contributors.json should not be modified through the commit queue')
 
@@ -64,7 +64,7 @@ class JSONContributorsChecker(JSONChecker):
 class JSONFeaturesChecker(JSONChecker):
     """Processes the features.json lines"""
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         super(JSONFeaturesChecker, self).check(lines)
 
         try:
@@ -118,7 +118,7 @@ class JSONFeaturesChecker(JSONChecker):
 class JSONCSSPropertiesChecker(JSONChecker):
     """Processes CSSProperties.json"""
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         super(JSONCSSPropertiesChecker, self).check(lines)
 
         try:
@@ -503,7 +503,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
 class JSONImportExpectationsChecker(JSONChecker):
     """Processes the import-expectations.json lines"""
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         super(JSONImportExpectationsChecker, self).check(lines)
 
         try:

--- a/Tools/Scripts/webkitpy/style/checkers/jstest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jstest.py
@@ -95,7 +95,7 @@ class JSTestChecker(object):
         self._host = SystemHost.get_default()
         self._fs = self._host.filesystem
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         """Run all the checks."""
         for file_group in KEEP_JS_TEST_FILES_IN_SYNC:
             if self._file_path in file_group:

--- a/Tools/Scripts/webkitpy/style/checkers/messagesin.py
+++ b/Tools/Scripts/webkitpy/style/checkers/messagesin.py
@@ -37,7 +37,7 @@ class MessagesInChecker(object):
         self.handle_style_error = handle_style_error
         self._tab_checker = TabChecker(file_path, handle_style_error)
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         self._tab_checker.check(lines)
         self.check_WTF_prefix(lines)
 

--- a/Tools/Scripts/webkitpy/style/checkers/python.py
+++ b/Tools/Scripts/webkitpy/style/checkers/python.py
@@ -42,7 +42,7 @@ class PythonChecker(object):
         self._handle_style_error = handle_style_error
         self._inclusive_language_checker = InclusiveLanguageChecker(handle_style_error)
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         self._check_pycodestyle(lines)
         # FIXME: https://bugs.webkit.org/show_bug.cgi?id=204133
         # Pylint disabled for now
@@ -145,7 +145,7 @@ class Python3Checker(object):
         self._file_path = file_path
         self._handle_style_error = handle_style_error
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         from webkitpy.thirdparty.autoinstalled import pycodestyle
 
         def handler(line_number, offset, text, check):

--- a/Tools/Scripts/webkitpy/style/checkers/spi_allowlist.py
+++ b/Tools/Scripts/webkitpy/style/checkers/spi_allowlist.py
@@ -15,7 +15,7 @@ class SPIAllowlistChecker(object):
         self.file_path = file_path
         self.handle_style_error = handle_style_error
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         self._check_oops_in_bug_url(lines)
 
     def _check_oops_in_bug_url(self, lines):

--- a/Tools/Scripts/webkitpy/style/checkers/swift.py
+++ b/Tools/Scripts/webkitpy/style/checkers/swift.py
@@ -84,6 +84,6 @@ class SwiftChecker(object):
             if re.search(r'@safe\b', line) and not re.search(r'@unsafe\b', line):
                 self.handle_style_error(index + 1, 'webkit/unsafe', 5, "Please avoid new use of '@safe' in WebKit. See https://github.com/WebKit/WebKit/wiki/Safer-Swift-Guidelines.")
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         self._swift_format(self.file_path, lines, self.handle_style_error)
         self._check_unsafe(lines)

--- a/Tools/Scripts/webkitpy/style/checkers/test_expectations.py
+++ b/Tools/Scripts/webkitpy/style/checkers/test_expectations.py
@@ -91,7 +91,7 @@ class TestExpectationsChecker(object):
     def check_tabs(self, lines):
         self._tab_checker.check(lines)
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         expectations = '\n'.join(lines)
         if self._port_obj:
             self.check_test_expectations(expectations_str=expectations, tests=None)

--- a/Tools/Scripts/webkitpy/style/checkers/text.py
+++ b/Tools/Scripts/webkitpy/style/checkers/text.py
@@ -43,6 +43,6 @@ class TextChecker(object):
         self._tab_checker = TabChecker(file_path, handle_style_error)
         self._inclusive_language_checker = InclusiveLanguageChecker(handle_style_error)
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         self._tab_checker.check(lines)
         self._inclusive_language_checker.check(lines)

--- a/Tools/Scripts/webkitpy/style/checkers/watchlist.py
+++ b/Tools/Scripts/webkitpy/style/checkers/watchlist.py
@@ -41,7 +41,7 @@ class WatchListChecker(object):
         self._handle_style_error = handle_style_error
         self._handle_style_error.turn_off_line_filtering()
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         def log_to_style_error(message):
             # Always report line 0 since we don't have anything better.
             self._handle_style_error(0,

--- a/Tools/Scripts/webkitpy/style/checkers/xcodeproj.py
+++ b/Tools/Scripts/webkitpy/style/checkers/xcodeproj.py
@@ -47,7 +47,7 @@ class XcodeProjectFileChecker(object):
                                     'developmentRegion is not en.')
         return True
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         development_region_is_detected = False
         for line_index, line in enumerate(lines):
             if self._check_development_region(line_index, line):

--- a/Tools/Scripts/webkitpy/style/checkers/xcscheme.py
+++ b/Tools/Scripts/webkitpy/style/checkers/xcscheme.py
@@ -132,6 +132,6 @@ class XcodeSchemeChecker:
                                          'xcscheme/sync', 5,
                                          'internal attribute \'internalIOSLaunchStyle\' used')
 
-    def check(self, lines, rules=None):
+    def check(self, lines, rules=None, line_numbers=None):
         self._check_inclusion_rules(rules)
         self._check_invalide_launch_style(lines)

--- a/Tools/Scripts/webkitpy/style/checkers/xml.py
+++ b/Tools/Scripts/webkitpy/style/checkers/xml.py
@@ -32,7 +32,7 @@ class XMLChecker(object):
         self._handle_style_error = handle_style_error
         self._handle_style_error.turn_off_line_filtering()
 
-    def check(self, lines):
+    def check(self, lines, line_numbers=None):
         parser = expat.ParserCreate()
         try:
             for line in lines:


### PR DESCRIPTION
#### 3b961212f23f526f686ed95b8bfbc943e8cf77f5
<pre>
Speed up check-webkit-style (and git webkit pr)
<a href="https://bugs.webkit.org/show_bug.cgi?id=312739">https://bugs.webkit.org/show_bug.cgi?id=312739</a>
<a href="https://rdar.apple.com/175135229">rdar://175135229</a>

Reviewed by David Kilzer.

4.1X speedup (75.8s =&gt; 18.4s for a large patch).

check-webkit-style runs on every git webkit pr, so it&apos;s important for it to be
fast.

Pass through line_numbers and short-circuit single-line checkers when the line
in question wasn&apos;t modified by the current patch.

Pre-flight check_os_version_checks with a simple substring check because the
regular expression is written in O(N^2) backtracking style.

Canonical link: <a href="https://commits.webkit.org/311595@main">https://commits.webkit.org/311595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4d58a88e29108f2db95073dc6c2b156fdfc3d31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24000 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/166294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9df041c0-3a0c-4df3-90fb-74f54911dc1b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30809 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/166294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98544510-f4b0-4b17-bfdc-096f457b5491) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141391 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/166294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d80596b1-47c3-4f96-9bde-1c222c20bab9) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/156792 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21522 "Passed tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/14065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149521 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168779 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20839 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30408 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25600 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/130199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141013 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88268 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23943 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17818 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30042 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29564 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29794 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29691 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->