### PR TITLE
[JSC] Produce flat string from `padStart` / `padEnd` for short results

### DIFF
--- a/JSTests/microbenchmarks/string-pad-end-consume.js
+++ b/JSTests/microbenchmarks/string-pad-end-consume.js
@@ -1,0 +1,13 @@
+// padEnd a short string and consume the result via charCodeAt.
+function bench() {
+    let total = 0;
+    const base = "hello";
+    for (let i = 0; i < 1e6; ++i) {
+        const s = base.padEnd(80);
+        total += s.charCodeAt(79);
+    }
+    return total;
+}
+noInline(bench);
+
+bench();

--- a/JSTests/microbenchmarks/string-pad-end-indexof.js
+++ b/JSTests/microbenchmarks/string-pad-end-indexof.js
@@ -1,0 +1,13 @@
+// padEnd then indexOf forces full rope resolution + linear scan.
+function bench() {
+    let total = 0;
+    const base = "hello";
+    for (let i = 0; i < 1e6; ++i) {
+        const s = base.padEnd(80);
+        total += s.indexOf("x");
+    }
+    return total;
+}
+noInline(bench);
+
+bench();

--- a/JSTests/stress/string-pad-flat-result.js
+++ b/JSTests/stress/string-pad-flat-result.js
@@ -1,0 +1,61 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+// Default filler (space), small result -> flat path.
+shouldBe("abc".padEnd(8), "abc     ");
+shouldBe("abc".padStart(8), "     abc");
+
+// Single-char filler.
+shouldBe("abc".padEnd(8, "x"), "abcxxxxx");
+shouldBe("abc".padStart(8, "x"), "xxxxxabc");
+
+// Multi-char filler with truncation.
+shouldBe("abc".padEnd(10, "123"), "abc1231231");
+shouldBe("abc".padStart(10, "123"), "1231231abc");
+
+// 16-bit this.
+shouldBe("\u3042".padEnd(4, "x"), "\u3042xxx");
+shouldBe("\u3042".padStart(4, "x"), "xxx\u3042");
+
+// 16-bit filler.
+shouldBe("a".padEnd(4, "\u3042"), "a\u3042\u3042\u3042");
+shouldBe("a".padStart(4, "\u3042"), "\u3042\u3042\u3042a");
+
+// Result length exactly at flat threshold (1024).
+{
+    let s = "abc".padEnd(1024);
+    shouldBe(s.length, 1024);
+    shouldBe(s.slice(0, 3), "abc");
+    shouldBe(s[1023], " ");
+}
+{
+    let s = "abc".padStart(1024);
+    shouldBe(s.length, 1024);
+    shouldBe(s.slice(1021), "abc");
+    shouldBe(s[0], " ");
+}
+
+// Result length just above flat threshold (1025) -> rope path, must still be correct.
+{
+    let s = "abc".padEnd(1025, "xy");
+    shouldBe(s.length, 1025);
+    shouldBe(s.slice(0, 3), "abc");
+    shouldBe(s.slice(3, 7), "xyxy");
+    shouldBe(s[1024], "y");
+}
+{
+    let s = "abc".padStart(1025, "xy");
+    shouldBe(s.length, 1025);
+    shouldBe(s.slice(1022), "abc");
+    shouldBe(s.slice(0, 4), "xyxy");
+}
+
+// No padding needed.
+shouldBe("hello".padEnd(3), "hello");
+shouldBe("hello".padStart(3), "hello");
+
+// Empty filler.
+shouldBe("abc".padEnd(10, ""), "abc");
+shouldBe("abc".padStart(10, ""), "abc");

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1768,10 +1768,27 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncConcat, (JSGlobalObject* globalObject, C
     return JSValue::encode(ropeBuilder.release());
 }
 
+static constexpr unsigned maxPatternLengthForFlatRepeat = 8;
+static constexpr unsigned maxResultLengthForFlatRepeat = 1024;
+
 enum class PadKind : uint8_t {
     PadStart,
     PadEnd
 };
+
+template<typename CharacterType>
+static void fillBufferWithPattern(std::span<CharacterType> buffer, StringView pattern)
+{
+    unsigned fillLength = buffer.size();
+    unsigned initialCopyLength = std::min(pattern.length(), fillLength);
+    pattern.left(initialCopyLength).getCharacters(buffer.first(initialCopyLength));
+    unsigned copied = initialCopyLength;
+    while (copied < fillLength) {
+        unsigned copyLen = std::min(copied, fillLength - copied);
+        memcpySpan(buffer.subspan(copied, copyLen), buffer.first(copyLen));
+        copied += copyLen;
+    }
+}
 
 template<typename CharacterType>
 static JSString* createFillerString(JSGlobalObject* globalObject, StringView fillStringView, unsigned fillLength)
@@ -1786,15 +1803,32 @@ static JSString* createFillerString(JSGlobalObject* globalObject, StringView fil
         return nullptr;
     }
 
-    unsigned fillStringLength = fillStringView.length();
-    unsigned initialCopyLength = std::min(fillStringLength, fillLength);
-    fillStringView.left(initialCopyLength).getCharacters(buffer.first(initialCopyLength));
-    unsigned copied = initialCopyLength;
-    while (copied < fillLength) {
-        unsigned copyLen = std::min(copied, fillLength - copied);
-        memcpySpan(buffer.subspan(copied, copyLen), buffer.first(copyLen));
-        copied += copyLen;
+    fillBufferWithPattern(buffer, fillStringView);
+    RELEASE_AND_RETURN(scope, jsString(vm, impl.releaseNonNull()));
+}
+
+template<typename CharacterType, PadKind padKind>
+static JSString* createPaddedString(JSGlobalObject* globalObject, StringView thisView, StringView fillStringView, unsigned maxLength, unsigned fillLength)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    std::span<CharacterType> buffer;
+    auto impl = StringImpl::tryCreateUninitialized(maxLength, buffer);
+    if (!impl) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
     }
+
+    unsigned stringLength = thisView.length();
+    if constexpr (padKind == PadKind::PadStart) {
+        fillBufferWithPattern(buffer.first(fillLength), fillStringView);
+        thisView.getCharacters(buffer.last(stringLength));
+    } else {
+        thisView.getCharacters(buffer.first(stringLength));
+        fillBufferWithPattern(buffer.last(fillLength), fillStringView);
+    }
+
     RELEASE_AND_RETURN(scope, jsString(vm, impl.releaseNonNull()));
 }
 
@@ -1841,6 +1875,16 @@ static JSValue padString(JSGlobalObject* globalObject, CallFrame* callFrame)
 
     unsigned fillLength = maxLength - stringLength;
 
+    if (maxLength <= maxResultLengthForFlatRepeat) {
+        auto thisView = thisString->view(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        StringView fillStringView(fillString);
+        scope.release();
+        if (thisView->is8Bit() && fillString.is8Bit())
+            return createPaddedString<Latin1Character, padKind>(globalObject, thisView, fillStringView, maxLength, fillLength);
+        return createPaddedString<char16_t, padKind>(globalObject, thisView, fillStringView, maxLength, fillLength);
+    }
+
     unsigned fillStringLength = fillString.length();
     JSString* fillerString;
 
@@ -1861,9 +1905,7 @@ static JSValue padString(JSGlobalObject* globalObject, CallFrame* callFrame)
         if (checkedTotalLength.hasOverflowed() || checkedTotalLength > JSString::MaxLength) [[unlikely]]
             return throwOutOfMemoryError(globalObject, scope);
 
-        constexpr unsigned maxFillStringLength = 8;
-        constexpr unsigned maxFillerResultLength = 1024;
-        if (fillStringLength <= maxFillStringLength && fillLength <= maxFillerResultLength) {
+        if (fillStringLength <= maxPatternLengthForFlatRepeat && fillLength <= maxResultLengthForFlatRepeat) {
             // Short string optimization: build sequential buffer
             StringView fillStringView(fillString);
             if (fillString.is8Bit())
@@ -2017,9 +2059,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncRepeat, (JSGlobalObject* globalObject, C
         return JSValue::encode(throwOutOfMemoryError(globalObject, scope));
     unsigned resultLength = checkedResultLength;
 
-    constexpr unsigned maxStringLength = 8;
-    constexpr unsigned maxResultLength = 1024;
-    if (stringLength <= maxStringLength) {
+    if (stringLength <= maxPatternLengthForFlatRepeat) {
         auto view = thisString->view(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
 
@@ -2035,7 +2075,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncRepeat, (JSGlobalObject* globalObject, C
 
         // Even if the string length is not single, if the resulting string length is small,
         // allocating a sequential buffer and fill with the repeated string for efficiency.
-        if (resultLength <= maxResultLength) {
+        if (resultLength <= maxResultLengthForFlatRepeat) {
             scope.release();
             if (view->is8Bit())
                 return JSValue::encode(repeatString<Latin1Character>(globalObject, view, repeatCount));


### PR DESCRIPTION
#### f6d1b6eb589dcf909f1770238f5a682260990f73
<pre>
[JSC] Produce flat string from `padStart` / `padEnd` for short results
<a href="https://bugs.webkit.org/show_bug.cgi?id=312740">https://bugs.webkit.org/show_bug.cgi?id=312740</a>

Reviewed by Yusuke Suzuki.

Currently padStart / padEnd always return a 2-fiber rope by concatenating
the filler and `this` via jsString(). When the result is consumed (e.g.
charCodeAt, indexOf, or as an element passed to Array#join), the rope must
be resolved, allocating yet another buffer.

This patch produces a flat string directly when the result length is
&lt;= 1024, matching the existing threshold used by String.prototype.repeat.
The filler is written via doubling memcpy and `this` is copied into the
same buffer in one allocation. The 8 / 1024 thresholds are now shared
between repeat and padStart/padEnd as maxPatternLengthForFlatRepeat /
maxResultLengthForFlatRepeat.

                                TipOfTree                  Patched

string-pad-end-indexof       94.1830+-15.9586    ^     58.3430+-2.8945        ^ definitely 1.6143x faster
string-pad-end-consume       69.5300+-4.4738     ^     49.9553+-4.2149        ^ definitely 1.3918x faster

Tests: JSTests/microbenchmarks/string-pad-end-consume.js
       JSTests/microbenchmarks/string-pad-end-indexof.js
       JSTests/stress/string-pad-flat-result.js

* JSTests/microbenchmarks/string-pad-end-consume.js: Added.
(bench):
* JSTests/microbenchmarks/string-pad-end-indexof.js: Added.
(bench):
* JSTests/stress/string-pad-flat-result.js: Added.
(shouldBe):
(shouldBe.string_appeared_here.padStart):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::fillBufferWithPattern):
(JSC::createFillerString):
(JSC::createPaddedString):
(JSC::padString):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/312007@main">https://commits.webkit.org/312007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e8c23410aa3f148fcce1f07797bf3717b9a2821

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167478 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122895 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25151 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103564 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15250 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/150698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169969 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19482 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/15713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131082 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31765 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131196 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35507 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31710 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89625 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25890 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18896 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190930 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31221 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97235 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49091 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->