### PR TITLE
[YARR] Forward references are no longer JIT-compiled

### DIFF
--- a/JSTests/microbenchmarks/regexp-forward-reference.js
+++ b/JSTests/microbenchmarks/regexp-forward-reference.js
@@ -1,0 +1,12 @@
+(function() {
+    const iterations = 2000000;
+
+    let re1 = /\2(a)(b)/;
+    let re2 = /\k<y>(?<x>a)(?<y>b)/;
+    for (let i = 0; i < iterations; ++i) {
+        re1.test("ab");
+        re1.test("xx");
+        re2.test("ab");
+        re2.test("xx");
+    }
+})();

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3332,7 +3332,6 @@ class YarrGenerator final : public YarrJITInfo {
 
         case PatternTerm::Type::NumberedForwardReference:
         case PatternTerm::Type::NamedForwardReference:
-            m_failureReason = JITFailureReason::ForwardReference;
             break;
 
         case PatternTerm::Type::ParenthesesSubpattern:
@@ -3415,7 +3414,6 @@ class YarrGenerator final : public YarrJITInfo {
 
         case PatternTerm::Type::NumberedForwardReference:
         case PatternTerm::Type::NamedForwardReference:
-            m_failureReason = JITFailureReason::ForwardReference;
             break;
 
         case PatternTerm::Type::ParenthesesSubpattern:
@@ -5694,9 +5692,11 @@ class YarrGenerator final : public YarrJITInfo {
 
         case PatternTerm::Type::NumberedBackReference:
         case PatternTerm::Type::NamedBackReference:
+            return std::nullopt;
+
         case PatternTerm::Type::NumberedForwardReference:
         case PatternTerm::Type::NamedForwardReference:
-            return std::nullopt;
+            return cursor;
 
         case PatternTerm::Type::ParenthesesSubpattern: {
             // Right now, we only support /(...)/ or /(...)?/ case.
@@ -7130,7 +7130,7 @@ public:
 
             case PatternTerm::Type::NumberedForwardReference:
             case PatternTerm::Type::NamedForwardReference:
-                out.printf("%sForwardReference <not handled> checked-offset:(%u)", term->type == PatternTerm::Type::NumberedForwardReference ? "Numbered" : "Named", op.m_checkedOffset.value());
+                out.printf("%sForwardReference checked-offset:(%u)", term->type == PatternTerm::Type::NumberedForwardReference ? "Numbered" : "Named", op.m_checkedOffset.value());
                 break;
 
             case PatternTerm::Type::ParenthesesSubpattern:
@@ -7496,9 +7496,6 @@ static void dumpCompileFailure(JITFailureReason failure)
         break;
     case JITFailureReason::BackReference:
         dataLog("Can't JIT some patterns containing back references\n");
-        break;
-    case JITFailureReason::ForwardReference:
-        dataLog("Can't JIT some patterns containing forward references\n");
         break;
     case JITFailureReason::Lookbehind:
         dataLog("Can't JIT a pattern containing lookbehinds\n");

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -59,7 +59,6 @@ class YarrCodeBlock;
 enum class JITFailureReason : uint8_t {
     DecodeSurrogatePair,
     BackReference,
-    ForwardReference,
     Lookbehind,
     VariableCountedParenthesisWithNonZeroMinimum,
     ParenthesizedSubpattern,


### PR DESCRIPTION
#### 582f25b3e6970f2e75fda3bdbdf29a6644dccd84
<pre>
[YARR] Forward references are no longer JIT-compiled
<a href="https://bugs.webkit.org/show_bug.cgi?id=312741">https://bugs.webkit.org/show_bug.cgi?id=312741</a>

Reviewed by Yusuke Suzuki.

307322@main made forward references no-ops in the YARR JIT (per spec, a
backreference to a group that hasn&apos;t captured yet always matches the empty
string). 309655@main split PatternTerm::Type::ForwardReference into
NumberedForwardReference / NamedForwardReference and accidentally
reintroduced `m_failureReason = JITFailureReason::ForwardReference` in
generateTerm() / backtrackTerm(), causing patterns like /\2(a)(b)/ to fall
back to the bytecode interpreter again.

This patch restores the no-op handling for both new term types and removes
the now-unused JITFailureReason::ForwardReference enum value.

                                Baseline                  Patched

regexp-forward-reference   177.6213+-2.2410     ^     53.3873+-1.0550        ^ definitely 3.3270x faster

Test: JSTests/microbenchmarks/regexp-forward-reference.js

* JSTests/microbenchmarks/regexp-forward-reference.js: Added.
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::dumpCompileFailure):
* Source/JavaScriptCore/yarr/YarrJIT.h:

Canonical link: <a href="https://commits.webkit.org/311657@main">https://commits.webkit.org/311657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11e87c087f8ce37433345af270ae8b247901fb68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166202 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111460 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121895 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85602 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102563 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23199 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21443 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13973 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149429 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168687 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18213 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12845 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130033 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130140 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35297 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140940 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88170 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24959 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17745 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189449 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93964 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48649 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29472 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->