### PR TITLE
Further reduce use of jsCast<>()

### DIFF
--- a/Source/JavaScriptCore/API/APICallbackFunction.h
+++ b/Source/JavaScriptCore/API/APICallbackFunction.h
@@ -48,7 +48,7 @@ EncodedJSValue APICallbackFunction::callImpl(JSGlobalObject* globalObject, CallF
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSContextRef execRef = toRef(globalObject);
     JSObjectRef functionRef = toRef(callFrame->jsCallee());
-    JSObjectRef thisObjRef = toRef(jsCast<JSObject*>(callFrame->thisValue().toThis(globalObject, ECMAMode::sloppy())));
+    JSObjectRef thisObjRef = toRef(uncheckedDowncast<JSObject>(callFrame->thisValue().toThis(globalObject, ECMAMode::sloppy())));
 
 #if CPU(ADDRESS64)
     auto argumentsSpan = Integrity::audit(callFrame->argumentsSpan());
@@ -67,7 +67,7 @@ EncodedJSValue APICallbackFunction::callImpl(JSGlobalObject* globalObject, CallF
     JSValueRef result;
     {
         JSLock::DropAllLocks dropAllLocks(globalObject);
-        result = jsCast<T*>(toJS(functionRef))->functionCallback()(execRef, functionRef, thisObjRef, argumentsSpan.size(), argumentsSpanData, &exception);
+        result = uncheckedDowncast<T>(toJS(functionRef))->functionCallback()(execRef, functionRef, thisObjRef, argumentsSpan.size(), argumentsSpanData, &exception);
     }
     if (exception) {
         throwException(globalObject, scope, toJS(globalObject, exception));
@@ -87,7 +87,7 @@ EncodedJSValue APICallbackFunction::constructImpl(JSGlobalObject* globalObject, 
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue callee = callFrame->jsCallee();
-    T* constructor = jsCast<T*>(callFrame->jsCallee());
+    T* constructor = uncheckedDowncast<T>(callFrame->jsCallee());
     JSContextRef ctx = toRef(globalObject);
     JSObjectRef constructorRef = toRef(constructor);
 
@@ -140,7 +140,7 @@ EncodedJSValue APICallbackFunction::constructImpl(JSGlobalObject* globalObject, 
         return JSValue::encode(newObject);
     }
     
-    return JSValue::encode(toJS(JSObjectMake(ctx, jsCast<JSCallbackConstructor*>(callee)->classRef(), nullptr)));
+    return JSValue::encode(toJS(JSObjectMake(ctx, uncheckedDowncast<JSCallbackConstructor>(callee)->classRef(), nullptr)));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/API/APICast.h
+++ b/Source/JavaScriptCore/API/APICast.h
@@ -80,7 +80,7 @@ inline JSC::JSValue toJS(JSC::JSGlobalObject* globalObject, JSValueRef v)
         return JSC::jsNull();
     JSC::JSValue result;
     if (jsCell->isAPIValueWrapper())
-        result = JSC::jsCast<JSC::JSAPIValueWrapper*>(jsCell)->value();
+        result = uncheckedDowncast<JSC::JSAPIValueWrapper>(jsCell)->value();
     else
         result = jsCell;
 #else

--- a/Source/JavaScriptCore/API/JSAPIWrapperObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIWrapperObject.mm
@@ -58,7 +58,7 @@ void JSAPIWrapperObjectHandleOwner::finalize(JSC::Handle<JSC::Unknown> handle, v
 
 bool JSAPIWrapperObjectHandleOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, ASCIILiteral*)
 {
-    JSC::JSAPIWrapperObject* wrapperObject = JSC::jsCast<JSC::JSAPIWrapperObject*>(handle.get().asCell());
+    JSC::JSAPIWrapperObject* wrapperObject = uncheckedDowncast<JSC::JSAPIWrapperObject>(handle.get().asCell());
     // We use the JSGlobalObject when processing weak handles to prevent the situation where using
     // the same Objective-C object in multiple global objects keeps all of the global objects alive.
     if (!wrapperObject->wrappedObject())
@@ -128,7 +128,7 @@ void JSAPIWrapperObject::setWrappedObject(void* wrappedObject)
 template<typename Visitor>
 void JSAPIWrapperObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSAPIWrapperObject* thisObject = JSC::jsCast<JSAPIWrapperObject*>(cell);
+    JSAPIWrapperObject* thisObject = uncheckedDowncast<JSAPIWrapperObject>(cell);
     Base::visitChildren(cell, visitor);
 
     void* wrappedObject = thisObject->wrappedObject();

--- a/Source/JavaScriptCore/API/JSCallbackObject.h
+++ b/Source/JavaScriptCore/API/JSCallbackObject.h
@@ -247,7 +247,7 @@ template <class Parent>
 template<typename Visitor>
 void JSCallbackObject<Parent>::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(cell);
+    JSCallbackObject* thisObject = uncheckedDowncast<JSCallbackObject>(cell);
     ASSERT_GC_OBJECT_INHERITS((static_cast<Parent*>(thisObject)), JSCallbackObject<Parent>::info());
     Parent::visitChildren(thisObject, visitor);
     thisObject->m_callbackObjectData->visitChildren(visitor);

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -46,7 +46,7 @@ template <class Parent>
 inline JSCallbackObject<Parent>* JSCallbackObject<Parent>::asCallbackObject(JSValue value)
 {
     ASSERT(asObject(value)->inheritsSlow(info()));
-    return jsCast<JSCallbackObject*>(asObject(value));
+    return uncheckedDowncast<JSCallbackObject>(asObject(value));
 }
 
 template <class Parent>
@@ -54,7 +54,7 @@ inline JSCallbackObject<Parent>* JSCallbackObject<Parent>::asCallbackObject(Enco
 {
     JSValue value = JSValue::decode(encodedValue);
     ASSERT(asObject(value)->inheritsSlow(info()));
-    return jsCast<JSCallbackObject*>(asObject(value));
+    return uncheckedDowncast<JSCallbackObject>(asObject(value));
 }
 
 template <class Parent>
@@ -105,7 +105,7 @@ void JSCallbackObject<Parent>::finishCreation(VM& vm)
     ASSERT(Parent::inherits(info()));
     ASSERT(Parent::isGlobalObject());
     Base::finishCreation(vm);
-    init(jsCast<JSGlobalObject*>(this));
+    init(static_cast<JSGlobalObject*>(this));
 }
 
 template <class Parent>
@@ -134,7 +134,7 @@ void JSCallbackObject<Parent>::init(JSGlobalObject* globalObject)
     for (int i = static_cast<int>(initRoutines.size()) - 1; i >= 0; i--) {
         JSLock::DropAllLocks dropAllLocks(globalObject);
         JSObjectInitializeCallback initialize = initRoutines[i];
-        initialize(toRef(globalObject), toRef(jsCast<JSObject*>(this)));
+        initialize(toRef(globalObject), toRef(static_cast<JSObject*>(this)));
     }
     
     m_classInfo = this->classInfo();
@@ -146,9 +146,9 @@ bool JSCallbackObject<Parent>::getOwnPropertySlot(JSObject* object, JSGlobalObje
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(object);
+    JSCallbackObject* thisObject = uncheckedDowncast<JSCallbackObject>(object);
     JSContextRef ctx = toRef(globalObject);
-    JSObjectRef thisRef = toRef(jsCast<JSObject*>(thisObject));
+    JSObjectRef thisRef = toRef(static_cast<JSObject*>(thisObject));
     RefPtr<OpaqueJSString> propertyNameRef;
     
     if (StringImpl* name = propertyName.uid()) {
@@ -239,7 +239,7 @@ EncodedJSValue JSCallbackObject<Parent>::customToPrimitive(JSGlobalObject* globa
     RETURN_IF_EXCEPTION(scope, { });
 
     JSContextRef ctx = toRef(globalObject);
-    JSObjectRef thisRef = toRef(jsCast<const JSObject*>(thisObject));
+    JSObjectRef thisRef = toRef(static_cast<JSObject*>(thisObject));
     ::JSType jsHint = hint == PreferString ? kJSTypeString : kJSTypeNumber;
 
     for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
@@ -266,9 +266,9 @@ bool JSCallbackObject<Parent>::put(JSCell* cell, JSGlobalObject* globalObject, P
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(cell);
+    JSCallbackObject* thisObject = uncheckedDowncast<JSCallbackObject>(cell);
     JSContextRef ctx = toRef(globalObject);
-    JSObjectRef thisRef = toRef(jsCast<JSObject*>(thisObject));
+    JSObjectRef thisRef = toRef(static_cast<JSObject*>(thisObject));
     RefPtr<OpaqueJSString> propertyNameRef;
     JSValueRef valueRef = toRef(globalObject, value);
 
@@ -336,9 +336,9 @@ bool JSCallbackObject<Parent>::putByIndex(JSCell* cell, JSGlobalObject* globalOb
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(cell);
+    JSCallbackObject* thisObject = uncheckedDowncast<JSCallbackObject>(cell);
     JSContextRef ctx = toRef(globalObject);
-    JSObjectRef thisRef = toRef(jsCast<JSObject*>(thisObject));
+    JSObjectRef thisRef = toRef(static_cast<JSObject*>(thisObject));
     RefPtr<OpaqueJSString> propertyNameRef;
     JSValueRef valueRef = toRef(globalObject, value);
     Identifier propertyName = Identifier::from(vm, propertyIndex);
@@ -396,9 +396,9 @@ bool JSCallbackObject<Parent>::deleteProperty(JSCell* cell, JSGlobalObject* glob
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(cell);
+    JSCallbackObject* thisObject = uncheckedDowncast<JSCallbackObject>(cell);
     JSContextRef ctx = toRef(globalObject);
-    JSObjectRef thisRef = toRef(jsCast<JSObject*>(thisObject));
+    JSObjectRef thisRef = toRef(static_cast<JSObject*>(thisObject));
     RefPtr<OpaqueJSString> propertyNameRef;
     
     if (StringImpl* name = propertyName.uid()) {
@@ -446,7 +446,7 @@ template <class Parent>
 bool JSCallbackObject<Parent>::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned propertyName)
 {
     VM& vm = getVM(globalObject);
-    JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(cell);
+    JSCallbackObject* thisObject = uncheckedDowncast<JSCallbackObject>(cell);
     return JSCell::deleteProperty(thisObject, globalObject, Identifier::from(vm, propertyName));
 }
 
@@ -454,7 +454,7 @@ template <class Parent>
 CallData JSCallbackObject<Parent>::getConstructData(JSCell* cell)
 {
     CallData constructData;
-    JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(cell);
+    JSCallbackObject* thisObject = uncheckedDowncast<JSCallbackObject>(cell);
     for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
         if (jsClass->callAsConstructor) {
             constructData.type = CallData::Type::Native;
@@ -477,7 +477,7 @@ EncodedJSValue JSCallbackObject<Parent>::constructImpl(JSGlobalObject* globalObj
     JSContextRef execRef = toRef(globalObject);
     JSObjectRef constructorRef = toRef(constructor);
     
-    for (JSClassRef jsClass = jsCast<JSCallbackObject<Parent>*>(constructor)->classRef(); jsClass; jsClass = jsClass->parentClass) {
+    for (JSClassRef jsClass = uncheckedDowncast<JSCallbackObject<Parent>>(constructor)->classRef(); jsClass; jsClass = jsClass->parentClass) {
         if (JSObjectCallAsConstructorCallback callAsConstructor = jsClass->callAsConstructor) {
 #if CPU(ADDRESS64)
             auto argumentsSpan = Integrity::audit(callFrame->argumentsSpan());
@@ -515,9 +515,9 @@ bool JSCallbackObject<Parent>::customHasInstance(JSObject* object, JSGlobalObjec
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(object);
+    JSCallbackObject* thisObject = uncheckedDowncast<JSCallbackObject>(object);
     JSContextRef execRef = toRef(globalObject);
-    JSObjectRef thisRef = toRef(jsCast<JSObject*>(thisObject));
+    JSObjectRef thisRef = toRef(static_cast<JSObject*>(thisObject));
     
     for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
         if (JSObjectHasInstanceCallback hasInstance = jsClass->hasInstance) {
@@ -540,7 +540,7 @@ template <class Parent>
 CallData JSCallbackObject<Parent>::getCallData(JSCell* cell)
 {
     CallData callData;
-    JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(cell);
+    JSCallbackObject* thisObject = uncheckedDowncast<JSCallbackObject>(cell);
     for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
         if (jsClass->callAsFunction) {
             callData.type = CallData::Type::Native;
@@ -561,9 +561,9 @@ EncodedJSValue JSCallbackObject<Parent>::callImpl(JSGlobalObject* globalObject, 
 
     JSContextRef execRef = toRef(globalObject);
     JSObjectRef functionRef = toRef(callFrame->jsCallee());
-    JSObjectRef thisObjRef = toRef(jsCast<JSObject*>(callFrame->thisValue().toThis(globalObject, ECMAMode::sloppy())));
+    JSObjectRef thisObjRef = toRef(uncheckedDowncast<JSObject>(callFrame->thisValue().toThis(globalObject, ECMAMode::sloppy())));
     
-    for (JSClassRef jsClass = jsCast<JSCallbackObject<Parent>*>(toJS(functionRef))->classRef(); jsClass; jsClass = jsClass->parentClass) {
+    for (JSClassRef jsClass = uncheckedDowncast<JSCallbackObject<Parent>>(toJS(functionRef))->classRef(); jsClass; jsClass = jsClass->parentClass) {
         if (JSObjectCallAsFunctionCallback callAsFunction = jsClass->callAsFunction) {
 #if CPU(ADDRESS64)
             auto argumentsSpan = Integrity::audit(callFrame->argumentsSpan());
@@ -600,9 +600,9 @@ template <class Parent>
 void JSCallbackObject<Parent>::getOwnSpecialPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder& propertyNames, DontEnumPropertiesMode mode)
 {
     VM& vm = getVM(globalObject);
-    JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(object);
+    JSCallbackObject* thisObject = uncheckedDowncast<JSCallbackObject>(object);
     JSContextRef execRef = toRef(globalObject);
-    JSObjectRef thisRef = toRef(jsCast<JSObject*>(thisObject));
+    JSObjectRef thisRef = toRef(static_cast<JSObject*>(thisObject));
     
     for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
         if (JSObjectGetPropertyNamesCallback getPropertyNames = jsClass->getPropertyNames) {
@@ -666,7 +666,7 @@ JSValue JSCallbackObject<Parent>::getStaticValue(JSGlobalObject* globalObject, P
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSObjectRef thisRef = toRef(jsCast<JSObject*>(this));
+    JSObjectRef thisRef = toRef(static_cast<JSObject*>(this));
     
     if (StringImpl* name = propertyName.uid()) {
         for (JSClassRef jsClass = classRef(); jsClass; jsClass = jsClass->parentClass) {
@@ -735,7 +735,7 @@ EncodedJSValue JSCallbackObject<Parent>::callbackGetterImpl(JSGlobalObject* glob
 
     JSCallbackObject* thisObj = asCallbackObject(thisValue);
     
-    JSObjectRef thisRef = toRef(jsCast<JSObject*>(thisObj));
+    JSObjectRef thisRef = toRef(static_cast<JSObject*>(thisObj));
     RefPtr<OpaqueJSString> propertyNameRef;
     
     if (StringImpl* name = propertyName.uid()) {

--- a/Source/JavaScriptCore/API/JSContextRef.cpp
+++ b/Source/JavaScriptCore/API/JSContextRef.cpp
@@ -194,7 +194,7 @@ JSObjectRef JSContextGetGlobalObject(JSContextRef ctx)
     VM& vm = globalObject->vm();
     JSLockHolder locker(vm);
 
-    return toRef(jsCast<JSObject*>(JSValue(globalObject).toThis(globalObject, ECMAMode::sloppy())));
+    return toRef(uncheckedDowncast<JSObject>(JSValue(globalObject).toThis(globalObject, ECMAMode::sloppy())));
 }
 
 JSContextGroupRef JSContextGetGroup(JSContextRef ctx)

--- a/Source/JavaScriptCore/API/JSManagedValue.mm
+++ b/Source/JavaScriptCore/API/JSManagedValue.mm
@@ -100,9 +100,9 @@ static JSManagedValueHandleOwner& managedValueHandleOwner()
 
     JSC::JSValue jsValue = toJS(globalObject, [value JSValueRef]);
     if (jsValue.isObject())
-        m_weakValue.setObject(JSC::jsCast<JSC::JSObject*>(jsValue.asCell()), owner, (__bridge void*)self);
+        m_weakValue.setObject(uncheckedDowncast<JSC::JSObject>(jsValue.asCell()), owner, (__bridge void*)self);
     else if (jsValue.isString())
-        m_weakValue.setString(JSC::jsCast<JSC::JSString*>(jsValue.asCell()), owner, (__bridge void*)self);
+        m_weakValue.setString(uncheckedDowncast<JSC::JSString>(jsValue.asCell()), owner, (__bridge void*)self);
     else
         m_weakValue.setPrimitive(jsValue);
     return self;

--- a/Source/JavaScriptCore/API/JSObjectRef.cpp
+++ b/Source/JavaScriptCore/API/JSObjectRef.cpp
@@ -623,15 +623,15 @@ JSValueRef JSObjectGetPrivateProperty(JSContextRef ctx, JSObjectRef object, JSSt
 
     // Get wrapped object if proxied
     if (jsObject->inherits<JSGlobalProxy>())
-        jsObject = jsCast<JSGlobalProxy*>(jsObject)->target();
+        jsObject = uncheckedDowncast<JSGlobalProxy>(jsObject)->target();
 
     if (jsObject->inherits<JSCallbackObject<JSGlobalObject>>())
-        result = jsCast<JSCallbackObject<JSGlobalObject>*>(jsObject)->getPrivateProperty(name);
+        result = uncheckedDowncast<JSCallbackObject<JSGlobalObject>>(jsObject)->getPrivateProperty(name);
     else if (jsObject->inherits<JSCallbackObject<JSNonFinalObject>>())
-        result = jsCast<JSCallbackObject<JSNonFinalObject>*>(jsObject)->getPrivateProperty(name);
+        result = uncheckedDowncast<JSCallbackObject<JSNonFinalObject>>(jsObject)->getPrivateProperty(name);
 #if JSC_OBJC_API_ENABLED
     else if (jsObject->inherits<JSCallbackObject<JSAPIWrapperObject>>())
-        result = jsCast<JSCallbackObject<JSAPIWrapperObject>*>(jsObject)->getPrivateProperty(name);
+        result = uncheckedDowncast<JSCallbackObject<JSAPIWrapperObject>>(jsObject)->getPrivateProperty(name);
 #endif
     return toRef(globalObject, result);
 }
@@ -647,19 +647,19 @@ bool JSObjectSetPrivateProperty(JSContextRef ctx, JSObjectRef object, JSStringRe
 
     // Get wrapped object if proxied
     if (jsObject->inherits<JSGlobalProxy>())
-        jsObject = jsCast<JSGlobalProxy*>(jsObject)->target();
+        jsObject = uncheckedDowncast<JSGlobalProxy>(jsObject)->target();
 
     if (jsObject->inherits<JSCallbackObject<JSGlobalObject>>()) {
-        jsCast<JSCallbackObject<JSGlobalObject>*>(jsObject)->setPrivateProperty(vm, name, jsValue);
+        uncheckedDowncast<JSCallbackObject<JSGlobalObject>>(jsObject)->setPrivateProperty(vm, name, jsValue);
         return true;
     }
     if (jsObject->inherits<JSCallbackObject<JSNonFinalObject>>()) {
-        jsCast<JSCallbackObject<JSNonFinalObject>*>(jsObject)->setPrivateProperty(vm, name, jsValue);
+        uncheckedDowncast<JSCallbackObject<JSNonFinalObject>>(jsObject)->setPrivateProperty(vm, name, jsValue);
         return true;
     }
 #if JSC_OBJC_API_ENABLED
     if (jsObject->inherits<JSCallbackObject<JSAPIWrapperObject>>()) {
-        jsCast<JSCallbackObject<JSAPIWrapperObject>*>(jsObject)->setPrivateProperty(vm, name, jsValue);
+        uncheckedDowncast<JSCallbackObject<JSAPIWrapperObject>>(jsObject)->setPrivateProperty(vm, name, jsValue);
         return true;
     }
 #endif
@@ -676,19 +676,19 @@ bool JSObjectDeletePrivateProperty(JSContextRef ctx, JSObjectRef object, JSStrin
 
     // Get wrapped object if proxied
     if (jsObject->inherits<JSGlobalProxy>())
-        jsObject = jsCast<JSGlobalProxy*>(jsObject)->target();
+        jsObject = uncheckedDowncast<JSGlobalProxy>(jsObject)->target();
 
     if (jsObject->inherits<JSCallbackObject<JSGlobalObject>>()) {
-        jsCast<JSCallbackObject<JSGlobalObject>*>(jsObject)->deletePrivateProperty(name);
+        uncheckedDowncast<JSCallbackObject<JSGlobalObject>>(jsObject)->deletePrivateProperty(name);
         return true;
     }
     if (jsObject->inherits<JSCallbackObject<JSNonFinalObject>>()) {
-        jsCast<JSCallbackObject<JSNonFinalObject>*>(jsObject)->deletePrivateProperty(name);
+        uncheckedDowncast<JSCallbackObject<JSNonFinalObject>>(jsObject)->deletePrivateProperty(name);
         return true;
     }
 #if JSC_OBJC_API_ENABLED
     if (jsObject->inherits<JSCallbackObject<JSAPIWrapperObject>>()) {
-        jsCast<JSCallbackObject<JSAPIWrapperObject>*>(jsObject)->deletePrivateProperty(name);
+        uncheckedDowncast<JSCallbackObject<JSAPIWrapperObject>>(jsObject)->deletePrivateProperty(name);
         return true;
     }
 #endif

--- a/Source/JavaScriptCore/API/JSValueRef.cpp
+++ b/Source/JavaScriptCore/API/JSValueRef.cpp
@@ -239,15 +239,15 @@ bool JSValueIsObjectOfClass(JSContextRef ctx, JSValueRef value, JSClassRef jsCla
     
     if (JSObject* o = jsValue.getObject()) {
         if (o->inherits<JSGlobalProxy>())
-            o = jsCast<JSGlobalProxy*>(o)->target();
+            o = uncheckedDowncast<JSGlobalProxy>(o)->target();
 
         if (o->inherits<JSCallbackObject<JSGlobalObject>>())
-            return jsCast<JSCallbackObject<JSGlobalObject>*>(o)->inherits(jsClass);
+            return uncheckedDowncast<JSCallbackObject<JSGlobalObject>>(o)->inherits(jsClass);
         if (o->inherits<JSCallbackObject<JSNonFinalObject>>())
-            return jsCast<JSCallbackObject<JSNonFinalObject>*>(o)->inherits(jsClass);
+            return uncheckedDowncast<JSCallbackObject<JSNonFinalObject>>(o)->inherits(jsClass);
 #if JSC_OBJC_API_ENABLED
         if (o->inherits<JSCallbackObject<JSAPIWrapperObject>>())
-            return jsCast<JSCallbackObject<JSAPIWrapperObject>*>(o)->inherits(jsClass);
+            return uncheckedDowncast<JSCallbackObject<JSAPIWrapperObject>>(o)->inherits(jsClass);
 #endif
     }
     return false;

--- a/Source/JavaScriptCore/API/JSWeakObjectMapRefPrivate.cpp
+++ b/Source/JavaScriptCore/API/JSWeakObjectMapRefPrivate.cpp
@@ -73,7 +73,7 @@ JSObjectRef JSWeakObjectMapGet(JSContextRef ctx, JSWeakObjectMapRef map, void* k
     }
     JSGlobalObject* globalObject = toJS(ctx);
     JSLockHolder locker(globalObject);
-    return toRef(jsCast<JSObject*>(map->map().get(key)));
+    return toRef(map->map().get(key));
 }
 
 void JSWeakObjectMapRemove(JSContextRef ctx, JSWeakObjectMapRef map, void* key)

--- a/Source/JavaScriptCore/API/JSWrapperMap.mm
+++ b/Source/JavaScriptCore/API/JSWrapperMap.mm
@@ -678,7 +678,7 @@ id tryUnwrapObjcObject(JSGlobalContextRef context, JSValueRef value)
     ASSERT(!exception);
     JSC::JSLockHolder locker(toJS(context));
     if (toJS(object)->inherits<JSC::JSCallbackObject<JSC::JSAPIWrapperObject>>())
-        return (__bridge id)JSC::jsCast<JSC::JSAPIWrapperObject*>(toJS(object))->wrappedObject();
+        return (__bridge id)uncheckedDowncast<JSC::JSAPIWrapperObject>(toJS(object))->wrappedObject();
     if (id target = tryUnwrapConstructor(object))
         return target;
     return nil;

--- a/Source/JavaScriptCore/API/glib/JSAPIWrapperObjectGLib.cpp
+++ b/Source/JavaScriptCore/API/glib/JSAPIWrapperObjectGLib.cpp
@@ -58,7 +58,7 @@ void JSAPIWrapperObjectHandleOwner::finalize(JSC::Handle<JSC::Unknown> handle, v
 
 bool JSAPIWrapperObjectHandleOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, ASCIILiteral*)
 {
-    JSC::JSAPIWrapperObject* wrapperObject = JSC::jsCast<JSC::JSAPIWrapperObject*>(handle.get().asCell());
+    JSC::JSAPIWrapperObject* wrapperObject = uncheckedDowncast<JSC::JSAPIWrapperObject>(handle.get().asCell());
     // We use the JSGlobalObject when processing weak handles to prevent the situation where using
     // the same wrapped object in multiple global objects keeps all of the global objects alive.
     if (!wrapperObject->wrappedObject())

--- a/Source/JavaScriptCore/API/glib/JSCClass.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCClass.cpp
@@ -116,8 +116,8 @@ static JSClassRef wrappedObjectClass(JSC::JSObject* jsObject)
 {
     ASSERT(isWrappedObject(jsObject));
     if (jsObject->isGlobalObject())
-        return JSC::jsCast<JSC::JSCallbackObject<JSC::JSAPIWrapperGlobalObject>*>(jsObject)->classRef();
-    return JSC::jsCast<JSC::JSCallbackObject<JSC::JSAPIWrapperObject>*>(jsObject)->classRef();
+        return uncheckedDowncast<JSC::JSCallbackObject<JSC::JSAPIWrapperGlobalObject>>(jsObject)->classRef();
+    return uncheckedDowncast<JSC::JSCallbackObject<JSC::JSAPIWrapperObject>>(jsObject)->classRef();
 }
 
 static GRefPtr<JSCContext> jscContextForObject(JSC::JSObject* jsObject)

--- a/Source/JavaScriptCore/API/glib/JSCWeakValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCWeakValue.cpp
@@ -99,9 +99,9 @@ static void jscWeakValueInitialize(JSCWeakValue* weakValue, JSCValue* value)
 
     JSC::JSValue jsValue = toJS(globalObject, jscValueGetJSValue(value));
     if (jsValue.isObject())
-        priv->weakValueRef.setObject(JSC::jsCast<JSC::JSObject*>(jsValue.asCell()), owner, weakValue);
+        priv->weakValueRef.setObject(uncheckedDowncast<JSC::JSObject>(jsValue.asCell()), owner, weakValue);
     else if (jsValue.isString())
-        priv->weakValueRef.setString(JSC::jsCast<JSC::JSString*>(jsValue.asCell()), owner, weakValue);
+        priv->weakValueRef.setString(uncheckedDowncast<JSC::JSString>(jsValue.asCell()), owner, weakValue);
     else
         priv->weakValueRef.setPrimitive(jsValue);
 }

--- a/Source/JavaScriptCore/API/glib/JSCWrapperMap.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCWrapperMap.cpp
@@ -127,11 +127,11 @@ gpointer WrapperMap::wrappedObject(JSGlobalContextRef jsContext, JSObjectRef jsO
     JSLockHolder locker(toJS(jsContext));
     auto* object = toJS(jsObject);
     if (object->inherits<JSC::JSCallbackObject<JSC::JSAPIWrapperObject>>()) {
-        if (auto* wrapper = JSC::jsCast<JSC::JSAPIWrapperObject*>(object)->wrappedObject())
+        if (auto* wrapper = uncheckedDowncast<JSC::JSAPIWrapperObject>(object)->wrappedObject())
             return static_cast<JSC::JSCGLibWrapperObject*>(wrapper)->object();
     }
     if (object->inherits<JSC::JSCallbackObject<JSC::JSAPIWrapperGlobalObject>>()) {
-        if (auto* wrapper = JSC::jsCast<JSC::JSAPIWrapperGlobalObject*>(object)->wrappedObject())
+        if (auto* wrapper = uncheckedDowncast<JSC::JSAPIWrapperGlobalObject>(object)->wrappedObject())
             return wrapper->object();
     }
     return nullptr;

--- a/Source/JavaScriptCore/API/tests/JSObjectGetProxyTargetTest.cpp
+++ b/Source/JavaScriptCore/API/tests/JSObjectGetProxyTargetTest.cpp
@@ -60,10 +60,10 @@ int testJSObjectGetProxyTarget()
 
     {
         JSLockHolder locker(vm);
-        JSGlobalProxy* globalObjectProxyObject = jsCast<JSGlobalProxy*>(toJS(globalObjectProxy));
-        globalObjectObject = jsCast<JSGlobalObject*>(globalObjectProxyObject->target());
+        JSGlobalProxy* globalObjectProxyObject = uncheckedDowncast<JSGlobalProxy>(toJS(globalObjectProxy));
+        globalObjectObject = globalObjectProxyObject->target();
         Structure* proxyStructure = JSGlobalProxy::createStructure(vm, globalObjectObject, globalObjectObject->objectPrototype());
-        globalObjectRef = toRef(jsCast<JSObject*>(globalObjectObject));
+        globalObjectRef = toRef(static_cast<JSObject*>(globalObjectObject));
         jsProxyObject = JSGlobalProxy::create(vm, proxyStructure);
     }
     

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -208,7 +208,7 @@ void CallLinkInfo::visitWeak(VM& vm)
 
     if (haveLastSeenCallee() && !vm.heap.isMarked(lastSeenCallee())) {
         if (lastSeenCallee()->type() == JSFunctionType)
-            handleSpecificCallee(jsCast<JSFunction*>(lastSeenCallee()));
+            handleSpecificCallee(uncheckedDowncast<JSFunction>(lastSeenCallee()));
         else
             m_clearedByGC = true;
         m_lastSeenCallee.clear();

--- a/Source/JavaScriptCore/bytecode/CallVariant.h
+++ b/Source/JavaScriptCore/bytecode/CallVariant.h
@@ -80,7 +80,7 @@ public:
     ALWAYS_INLINE CallVariant despecifiedClosure() const
     {
         if (m_callee->type() == JSFunctionType)
-            return CallVariant(jsCast<JSFunction*>(m_callee)->executable());
+            return CallVariant(uncheckedDowncast<JSFunction>(m_callee)->executable());
         return *this;
     }
     

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -113,7 +113,7 @@ CString CodeBlock::inferredName() const
     case EvalCode:
         return "<eval>"_span;
     case FunctionCode:
-        return jsCast<FunctionExecutable*>(ownerExecutable())->ecmaName().utf8();
+        return uncheckedDowncast<FunctionExecutable>(ownerExecutable())->ecmaName().utf8();
     case ModuleCode:
         return "<module>"_span;
     default:
@@ -165,7 +165,7 @@ CString CodeBlock::sourceCodeForTools() const
     if (codeType() != FunctionCode)
         return ownerExecutable()->source().toUTF8();
 
-    FunctionExecutable* executable = jsCast<FunctionExecutable*>(ownerExecutable());
+    FunctionExecutable* executable = uncheckedDowncast<FunctionExecutable>(ownerExecutable());
     return executable->source().provider()->getRange(
         executable->functionStart(),
         executable->parametersStartOffset() + executable->source().length()).utf8();
@@ -274,7 +274,7 @@ public:
     
     void dump(PrintStream& out) const final
     {
-        out.print("Linking put_to_scope in ", FunctionExecutableDump(jsCast<FunctionExecutable*>(m_codeBlock->ownerExecutable())), " for ", m_ident);
+        out.print("Linking put_to_scope in ", FunctionExecutableDump(uncheckedDowncast<FunctionExecutable>(m_codeBlock->ownerExecutable())), " for ", m_ident);
     }
     
 private:
@@ -411,7 +411,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
     // We already have the cloned symbol table for the module environment since we need to instantiate
     // the module environments before linking the code block. We replace the stored symbol table with the already cloned one.
     if (UnlinkedModuleProgramCodeBlock* unlinkedModuleProgramCodeBlock = dynamicDowncast<UnlinkedModuleProgramCodeBlock>(unlinkedCodeBlock)) {
-        SymbolTable* clonedSymbolTable = jsCast<ModuleProgramExecutable*>(ownerExecutable)->moduleEnvironmentSymbolTable();
+        SymbolTable* clonedSymbolTable = uncheckedDowncast<ModuleProgramExecutable>(ownerExecutable)->moduleEnvironmentSymbolTable();
         if (m_unlinkedCode->wasCompiledWithTypeProfilerOpcodes()) {
             ConcurrentJSLocker locker(clonedSymbolTable->m_lock);
             clonedSymbolTable->prepareForTypeProfiling(locker);
@@ -569,7 +569,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
             if (op.lexicalEnvironment) {
                 if (op.type == ModuleVar) {
                     // Keep the linked module environment strongly referenced.
-                    if (stronglyReferencedModuleEnvironments.add(jsCast<JSModuleEnvironment*>(op.lexicalEnvironment)).isNewEntry)
+                    if (stronglyReferencedModuleEnvironments.add(uncheckedDowncast<JSModuleEnvironment>(op.lexicalEnvironment)).isNewEntry)
                         addConstant(ConcurrentJSLocker(m_lock), op.lexicalEnvironment);
                     metadata.m_lexicalEnvironment.set(vm, this, op.lexicalEnvironment);
                 } else
@@ -614,7 +614,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
             if (bytecode.m_getPutInfo.resolveType() == ResolvedClosureVar) {
                 // Only do watching if the property we're putting to is not anonymous.
                 if (bytecode.m_var != UINT_MAX) {
-                    SymbolTable* symbolTable = jsCast<SymbolTable*>(getConstant(bytecode.m_symbolTableOrScopeDepth.symbolTable()));
+                    SymbolTable* symbolTable = uncheckedDowncast<SymbolTable>(getConstant(bytecode.m_symbolTableOrScopeDepth.symbolTable()));
                     const Identifier& ident = identifier(bytecode.m_var);
                     ConcurrentJSLocker locker(symbolTable->m_lock);
                     auto iter = symbolTable->find(locker, ident.impl());
@@ -685,7 +685,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
                 break;
             }
             case ProfileTypeBytecodeLocallyResolved: {
-                SymbolTable* symbolTable = jsCast<SymbolTable*>(getConstant(bytecode.m_symbolTableOrScopeDepth.symbolTable()));
+                SymbolTable* symbolTable = uncheckedDowncast<SymbolTable>(getConstant(bytecode.m_symbolTableOrScopeDepth.symbolTable()));
                 const Identifier& ident = identifier(bytecode.m_identifier);
                 ConcurrentJSLocker locker(symbolTable->m_lock);
                 // If our parent scope was created while profiling was disabled, it will not have prepared for profiling yet.
@@ -701,7 +701,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
             }
             case ProfileTypeBytecodeFunctionReturnStatement: {
                 RELEASE_ASSERT(ownerExecutable->isFunctionExecutable());
-                globalTypeSet = jsCast<FunctionExecutable*>(ownerExecutable)->returnStatementTypeSet();
+                globalTypeSet = uncheckedDowncast<FunctionExecutable>(ownerExecutable)->returnStatementTypeSet();
                 globalVariableID = TypeProfilerReturnStatement;
                 if (!shouldAnalyze) {
                     // Because a return statement can be added implicitly to return undefined at the end of a function,
@@ -1100,7 +1100,7 @@ void CodeBlock::initializeTemplateObjects(ScriptExecutable* topLevelExecutable, 
 {
     auto scope = DECLARE_THROW_SCOPE(vm());
     for (unsigned i : templateObjectIndices) {
-        auto* descriptor = jsCast<JSTemplateObjectDescriptor*>(m_constantRegisters[i].get());
+        auto* descriptor = uncheckedDowncast<JSTemplateObjectDescriptor>(m_constantRegisters[i].get());
         auto* templateObject = topLevelExecutable->createTemplateObject(globalObject(), descriptor);
         RETURN_IF_EXCEPTION(scope, void());
         m_constantRegisters[i].set(vm(), this, templateObject);
@@ -1135,7 +1135,7 @@ CodeBlock* CodeBlock::specialOSREntryBlockOrNull()
 
 size_t CodeBlock::estimatedSize(JSCell* cell, VM& vm)
 {
-    CodeBlock* thisObject = jsCast<CodeBlock*>(cell);
+    CodeBlock* thisObject = uncheckedDowncast<CodeBlock>(cell);
     size_t extraMemoryAllocated = 0;
     if (thisObject->m_metadata)
         extraMemoryAllocated += thisObject->m_metadata->sizeInBytesForGC();
@@ -1181,7 +1181,7 @@ inline void CodeBlock::forEachPropertyInlineCache(Func func)
 template<typename Visitor>
 void CodeBlock::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    CodeBlock* thisObject = jsCast<CodeBlock*>(cell);
+    CodeBlock* thisObject = uncheckedDowncast<CodeBlock>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(cell, visitor);
     thisObject->visitChildren(visitor);
@@ -2235,16 +2235,16 @@ CodeBlock* CodeBlock::replacement()
     const ClassInfo* classInfo = this->classInfo();
 
     if (classInfo == FunctionCodeBlock::info())
-        return jsCast<FunctionExecutable*>(ownerExecutable())->codeBlockFor(isConstructor() ? CodeSpecializationKind::CodeForConstruct : CodeSpecializationKind::CodeForCall);
+        return uncheckedDowncast<FunctionExecutable>(ownerExecutable())->codeBlockFor(isConstructor() ? CodeSpecializationKind::CodeForConstruct : CodeSpecializationKind::CodeForCall);
 
     if (classInfo == EvalCodeBlock::info())
-        return jsCast<EvalExecutable*>(ownerExecutable())->codeBlock();
+        return uncheckedDowncast<EvalExecutable>(ownerExecutable())->codeBlock();
 
     if (classInfo == ProgramCodeBlock::info())
-        return jsCast<ProgramExecutable*>(ownerExecutable())->codeBlock();
+        return uncheckedDowncast<ProgramExecutable>(ownerExecutable())->codeBlock();
 
     if (classInfo == ModuleProgramCodeBlock::info())
-        return jsCast<ModuleProgramExecutable*>(ownerExecutable())->codeBlock();
+        return uncheckedDowncast<ModuleProgramExecutable>(ownerExecutable())->codeBlock();
 
     RELEASE_ASSERT_NOT_REACHED();
     return nullptr;
@@ -3228,7 +3228,7 @@ void CodeBlock::tallyFrequentExitSites()
 void CodeBlock::notifyLexicalBindingUpdate()
 {
     JSGlobalObject* globalObject = m_globalObject.get();
-    JSGlobalLexicalEnvironment* globalLexicalEnvironment = jsCast<JSGlobalLexicalEnvironment*>(globalObject->globalScope());
+    JSGlobalLexicalEnvironment* globalLexicalEnvironment = uncheckedDowncast<JSGlobalLexicalEnvironment>(globalObject->globalScope());
     SymbolTable* symbolTable = globalLexicalEnvironment->symbolTable();
 
     ConcurrentJSLocker locker(m_lock);

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -1073,14 +1073,14 @@ void ScriptExecutable::prepareForExecution(VM& vm, JSFunction* function, JSScope
 {
     if (hasJITCodeFor(kind)) {
         if constexpr (std::same_as<ExecutableType, EvalExecutable>)
-            resultCodeBlock = jsCast<CodeBlock*>(jsCast<ExecutableType*>(this)->codeBlock());
+            resultCodeBlock = uncheckedDowncast<ExecutableType>(this)->codeBlock();
         else if constexpr (std::same_as<ExecutableType, ProgramExecutable>)
-            resultCodeBlock = jsCast<CodeBlock*>(jsCast<ExecutableType*>(this)->codeBlock());
+            resultCodeBlock = uncheckedDowncast<ExecutableType>(this)->codeBlock();
         else if constexpr (std::same_as<ExecutableType, ModuleProgramExecutable>)
-            resultCodeBlock = jsCast<CodeBlock*>(jsCast<ExecutableType*>(this)->codeBlock());
+            resultCodeBlock = uncheckedDowncast<ExecutableType>(this)->codeBlock();
         else {
             static_assert(std::same_as<ExecutableType, FunctionExecutable>);
-            resultCodeBlock = jsCast<CodeBlock*>(jsCast<ExecutableType*>(this)->codeBlockFor(kind));
+            resultCodeBlock = uncheckedDowncast<ExecutableType>(this)->codeBlockFor(kind);
         }
         return;
     }

--- a/Source/JavaScriptCore/bytecode/EvalCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/EvalCodeBlock.h
@@ -63,7 +63,7 @@ public:
 
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
-    UnlinkedEvalCodeBlock* unlinkedEvalCodeBlock() const { return jsCast<UnlinkedEvalCodeBlock*>(unlinkedCodeBlock()); }
+    UnlinkedEvalCodeBlock* unlinkedEvalCodeBlock() const { return uncheckedDowncast<UnlinkedEvalCodeBlock>(unlinkedCodeBlock()); }
 
 private:
     EvalCodeBlock(VM& vm, Structure* structure, CopyParsedBlockTag, EvalCodeBlock& other)

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
@@ -36,13 +36,13 @@ DEFINE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(InlineCallFrame);
 JSFunction* InlineCallFrame::calleeConstant() const
 {
     if (calleeRecovery.isConstant())
-        return jsCast<JSFunction*>(calleeRecovery.constant());
+        return uncheckedDowncast<JSFunction>(calleeRecovery.constant());
     return nullptr;
 }
 
 JSFunction* InlineCallFrame::calleeForCallFrame(CallFrame* callFrame) const
 {
-    return jsCast<JSFunction*>(calleeRecovery.recover(callFrame));
+    return uncheckedDowncast<JSFunction>(calleeRecovery.recover(callFrame));
 }
 
 CodeBlockHash InlineCallFrame::hash() const
@@ -52,7 +52,7 @@ CodeBlockHash InlineCallFrame::hash() const
 
 CString InlineCallFrame::inferredName() const
 {
-    return jsCast<FunctionExecutable*>(baselineCodeBlock->ownerExecutable())->ecmaName().utf8();
+    return uncheckedDowncast<FunctionExecutable>(baselineCodeBlock->ownerExecutable())->ecmaName().utf8();
 }
 
 String InlineCallFrame::inferredNameWithHash() const

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
@@ -328,7 +328,7 @@ ObjectPropertyConditionSet generateConditions(JSGlobalObject* globalObject, Stru
             return ObjectPropertyConditionSet::invalid();
         }
         
-        JSObject* object = jsCast<JSObject*>(value);
+        JSObject* object = uncheckedDowncast<JSObject>(value);
         structure = object->structure();
         
         if (structure->isDictionary()) {

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -190,7 +190,7 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
         CodeBlock* codeBlock = nullptr;
         if (variant.executable() && !variant.executable()->isHostFunction()) {
             ExecutableBase* executable = variant.executable();
-            codeBlock = jsCast<FunctionExecutable*>(executable)->codeBlockForCall();
+            codeBlock = uncheckedDowncast<FunctionExecutable>(executable)->codeBlockForCall();
             // If we cannot handle a callee, because we don't have a CodeBlock,
             // assume that it's better for this whole thing to be a virtual call.
             if (!codeBlock) {
@@ -496,8 +496,8 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
             if (isJSArray(baseCell)) {
                 if (propertyCache.cacheType() == CacheType::Unset
                     && slot.slotBase() == baseCell
-                    && InlineAccess::isCacheableArrayLength(propertyCache, jsCast<JSArray*>(baseCell))) {
-                    bool generatedCodeInline = InlineAccess::generateArrayLength(propertyCache, jsCast<JSArray*>(baseCell));
+                    && InlineAccess::isCacheableArrayLength(propertyCache, uncheckedDowncast<JSArray>(baseCell))) {
+                    bool generatedCodeInline = InlineAccess::generateArrayLength(propertyCache, uncheckedDowncast<JSArray>(baseCell));
                     if (generatedCodeInline) {
                         repatchSlowPathCall(codeBlock, propertyCache, appropriateGetByOptimizeFunction(kind));
                         propertyCache.initArrayLength(locker);
@@ -537,7 +537,7 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
 
         if (!propertyName.isSymbol() && baseCell->inherits<JSModuleNamespaceObject>() && !slot.isUnset()) {
             if (auto moduleNamespaceSlot = slot.moduleNamespaceSlot())
-                newCase = ModuleNamespaceAccessCase::create(vm, codeBlock, propertyName, jsCast<JSModuleNamespaceObject*>(baseCell), moduleNamespaceSlot->environment, ScopeOffset(moduleNamespaceSlot->scopeOffset));
+                newCase = ModuleNamespaceAccessCase::create(vm, codeBlock, propertyName, uncheckedDowncast<JSModuleNamespaceObject>(baseCell), moduleNamespaceSlot->environment, ScopeOffset(moduleNamespaceSlot->scopeOffset));
         }
 
         if (!propertyName.isPrivateName() && baseCell->inherits<ProxyObject>()) {
@@ -572,7 +572,7 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
             if (baseCell->type() == GlobalProxyType) {
                 if (isPrivate)
                     return GiveUpOnCache;
-                baseValue = jsCast<JSGlobalProxy*>(baseCell)->target();
+                baseValue = uncheckedDowncast<JSGlobalProxy>(baseCell)->target();
                 baseCell = baseValue.asCell();
                 structure = baseCell->structure();
                 loadTargetFromProxy = true;
@@ -619,7 +619,7 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
                 if (structure->isDictionary()) {
                     if (structure->hasBeenFlattenedBefore())
                         return GiveUpOnCache;
-                    structure->flattenDictionaryStructure(vm, jsCast<JSObject*>(baseCell));
+                    structure->flattenDictionaryStructure(vm, uncheckedDowncast<JSObject>(baseCell));
                     return RetryCacheLater; // We may have changed property offsets.
                 }
 
@@ -827,7 +827,7 @@ static InlineCacheAction tryCacheArrayGetByVal(JSGlobalObject* globalObject, Cod
         else if (base->type() == ProxyObjectType)
             accessType = AccessCase::IndexedProxyObjectLoad;
         else if (isTypedView(base->type())) {
-            auto* typedArray = jsCast<JSArrayBufferView*>(base);
+            auto* typedArray = uncheckedDowncast<JSArrayBufferView>(base);
 #if USE(JSVALUE32_64)
             if (typedArray->isResizableOrGrowableShared())
                 return GiveUpOnCache;
@@ -1080,7 +1080,7 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
         
         bool isGlobalProxy = false;
         if (baseCell->type() == GlobalProxyType) {
-            baseCell = jsCast<JSGlobalProxy*>(baseCell)->target();
+            baseCell = uncheckedDowncast<JSGlobalProxy>(baseCell)->target();
             baseValue = baseCell;
             isGlobalProxy = true;
 
@@ -1398,7 +1398,7 @@ static InlineCacheAction tryCacheArrayPutByVal(JSGlobalObject* globalObject, Cod
                 return RetryCacheLater;
             }
         } else if (isTypedView(base->type())) {
-            auto* typedArray = jsCast<JSArrayBufferView*>(base);
+            auto* typedArray = uncheckedDowncast<JSArrayBufferView>(base);
 #if USE(JSVALUE32_64)
             if (typedArray->isResizableOrGrowableShared())
                 return GiveUpOnCache;
@@ -1533,7 +1533,7 @@ static InlineCacheAction tryCacheDeleteBy(JSGlobalObject* globalObject, CodeBloc
         if (baseValue.asCell()->structure()->isDictionary()) {
             if (baseValue.asCell()->structure()->hasBeenFlattenedBefore())
                 return GiveUpOnCache;
-            jsCast<JSObject*>(baseValue)->flattenDictionaryObject(vm);
+            uncheckedDowncast<JSObject>(baseValue)->flattenDictionaryObject(vm);
             return RetryCacheLater;
         }
 
@@ -2002,7 +2002,7 @@ static InlineCacheAction tryCacheArrayInByVal(JSGlobalObject* globalObject, Code
         else if (base->type() == ProxyObjectType)
             accessType = AccessCase::IndexedProxyObjectIn;
         else if (isTypedView(base->type())) {
-            auto* typedArray = jsCast<JSArrayBufferView*>(base);
+            auto* typedArray = uncheckedDowncast<JSArrayBufferView>(base);
 #if USE(JSVALUE32_64)
             if (typedArray->isResizableOrGrowableShared())
                 return GiveUpOnCache;
@@ -2142,7 +2142,7 @@ void repatchInstanceOf(
 void linkDirectCall(DirectCallLinkInfo& callLinkInfo, CodeBlock* calleeCodeBlock, CodePtr<JSEntryPtrTag> codePtr)
 {
     // DirectCall is only used from DFG / FTL.
-    callLinkInfo.setCallTarget(jsCast<FunctionCodeBlock*>(calleeCodeBlock), CodeLocationLabel<JSEntryPtrTag>(codePtr));
+    callLinkInfo.setCallTarget(uncheckedDowncast<FunctionCodeBlock>(calleeCodeBlock), CodeLocationLabel<JSEntryPtrTag>(codePtr));
     if (calleeCodeBlock)
         calleeCodeBlock->linkIncomingCall(callLinkInfo.owner(), &callLinkInfo);
 }

--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -163,7 +163,7 @@ ALWAYS_INLINE void* linkFor(VM& vm, JSCell* owner, CallFrame* calleeFrame, CallL
         RELEASE_AND_RETURN(throwScope, handleHostCall(vm, owner, calleeFrame, calleeAsValue, callLinkInfo));
     }
 
-    JSFunction* callee = jsCast<JSFunction*>(calleeAsFunctionCell);
+    JSFunction* callee = uncheckedDowncast<JSFunction>(calleeAsFunctionCell);
     JSScope* scope = callee->scopeUnchecked();
     ExecutableBase* executable = callee->executable();
 
@@ -241,14 +241,14 @@ ALWAYS_INLINE void* virtualForWithFunction(VM& vm, JSCell* owner, CallFrame* cal
         RELEASE_AND_RETURN(throwScope, handleHostCall(vm, owner, calleeFrame, calleeAsValue, callLinkInfo));
     }
 
-    JSFunction* function = jsCast<JSFunction*>(calleeAsFunctionCell);
+    JSFunction* function = uncheckedDowncast<JSFunction>(calleeAsFunctionCell);
     JSScope* scope = function->scopeUnchecked();
     ExecutableBase* executable = function->executable();
 
     DeferTraps deferTraps(vm); // We can't jettison if we're going to call this CodeBlock.
 
     if (!executable->isHostFunction()) {
-        FunctionExecutable* functionExecutable = jsCast<FunctionExecutable*>(executable);
+        FunctionExecutable* functionExecutable = uncheckedDowncast<FunctionExecutable>(executable);
 
         if (!isCall(kind) && functionExecutable->constructAbility() == ConstructAbility::CannotConstruct) {
             auto* globalObject = callLinkInfo->globalObjectForSlowPath(owner);

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -600,7 +600,7 @@ SpeculatedType speculationFromCell(JSCell* cell)
     }
 
     if (cell->isString()) {
-        JSString* string = jsCast<JSString*>(cell);
+        JSString* string = uncheckedDowncast<JSString>(cell);
         if (const StringImpl* impl = string->tryGetValueImpl()) {
             if (!Integrity::isSanePointer(impl)) [[unlikely]] {
                 ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -95,7 +95,7 @@ void UnlinkedCodeBlock::initializeLoopHintExecutionCounter()
 template<typename Visitor>
 void UnlinkedCodeBlock::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    UnlinkedCodeBlock* thisObject = jsCast<UnlinkedCodeBlock*>(cell);
+    UnlinkedCodeBlock* thisObject = uncheckedDowncast<UnlinkedCodeBlock>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     Locker locker { thisObject->cellLock() };
@@ -127,7 +127,7 @@ DEFINE_VISIT_CHILDREN(UnlinkedCodeBlock);
 
 size_t UnlinkedCodeBlock::estimatedSize(JSCell* cell, VM& vm)
 {
-    UnlinkedCodeBlock* thisObject = jsCast<UnlinkedCodeBlock*>(cell);
+    UnlinkedCodeBlock* thisObject = uncheckedDowncast<UnlinkedCodeBlock>(cell);
     size_t extraSize = thisObject->metadataSizeInBytes();
     if (thisObject->m_instructions)
         extraSize += thisObject->m_instructions->sizeInBytes();

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -159,7 +159,7 @@ void UnlinkedFunctionExecutable::destroy(JSCell* cell)
 template<typename Visitor>
 void UnlinkedFunctionExecutable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    UnlinkedFunctionExecutable* thisObject = jsCast<UnlinkedFunctionExecutable*>(cell);
+    UnlinkedFunctionExecutable* thisObject = uncheckedDowncast<UnlinkedFunctionExecutable>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -181,7 +181,7 @@ void Debugger::attach(JSGlobalObject* globalObject)
                 auto* cell = static_cast<JSCell*>(heapCell);
                 if (auto* function = dynamicDowncast<JSFunction>(cell)) {
                     if (function->scope()->realm() == globalObject && function->executable()->isFunctionExecutable() && !function->isHostOrBuiltinFunction())
-                        sourceProviders.add(jsCast<FunctionExecutable*>(function->executable())->source().provider());
+                        sourceProviders.add(uncheckedDowncast<FunctionExecutable>(function->executable())->source().provider());
                 }
             }
             return IterationStatus::Continue;

--- a/Source/JavaScriptCore/debugger/DebuggerScope.cpp
+++ b/Source/JavaScriptCore/debugger/DebuggerScope.cpp
@@ -53,7 +53,7 @@ DebuggerScope::DebuggerScope(VM& vm, Structure* structure, JSScope* scope)
 template<typename Visitor>
 void DebuggerScope::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    DebuggerScope* thisObject = jsCast<DebuggerScope*>(cell);
+    DebuggerScope* thisObject = uncheckedDowncast<DebuggerScope>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(cell, visitor);
 
@@ -65,7 +65,7 @@ DEFINE_VISIT_CHILDREN(DebuggerScope);
 
 bool DebuggerScope::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
-    DebuggerScope* scope = jsCast<DebuggerScope*>(object);
+    DebuggerScope* scope = uncheckedDowncast<DebuggerScope>(object);
     if (!scope->isValid())
         return false;
     JSObject* thisObject = JSScope::objectAtScope(scope->jsScope());
@@ -95,7 +95,7 @@ bool DebuggerScope::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalO
 
 bool DebuggerScope::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
-    DebuggerScope* scope = jsCast<DebuggerScope*>(cell);
+    DebuggerScope* scope = uncheckedDowncast<DebuggerScope>(cell);
     ASSERT(scope->isValid());
     if (!scope->isValid())
         return false;
@@ -106,7 +106,7 @@ bool DebuggerScope::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName
 
 bool DebuggerScope::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
 {
-    DebuggerScope* scope = jsCast<DebuggerScope*>(cell);
+    DebuggerScope* scope = uncheckedDowncast<DebuggerScope>(cell);
     ASSERT(scope->isValid());
     if (!scope->isValid())
         return false;
@@ -116,7 +116,7 @@ bool DebuggerScope::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, P
 
 void DebuggerScope::getOwnPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArrayBuilder& propertyNames, DontEnumPropertiesMode mode)
 {
-    DebuggerScope* scope = jsCast<DebuggerScope*>(object);
+    DebuggerScope* scope = uncheckedDowncast<DebuggerScope>(object);
     ASSERT(scope->isValid());
     if (!scope->isValid())
         return;
@@ -126,7 +126,7 @@ void DebuggerScope::getOwnPropertyNames(JSObject* object, JSGlobalObject* global
 
 bool DebuggerScope::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, const PropertyDescriptor& descriptor, bool shouldThrow)
 {
-    DebuggerScope* scope = jsCast<DebuggerScope*>(object);
+    DebuggerScope* scope = uncheckedDowncast<DebuggerScope>(object);
     ASSERT(scope->isValid());
     if (!scope->isValid())
         return false;
@@ -218,7 +218,7 @@ DebuggerLocation DebuggerScope::location() const
 JSValue DebuggerScope::caughtValue(JSGlobalObject* globalObject) const
 {
     ASSERT(isCatchScope());
-    JSLexicalEnvironment* catchEnvironment = jsCast<JSLexicalEnvironment*>(m_scope.get());
+    JSLexicalEnvironment* catchEnvironment = uncheckedDowncast<JSLexicalEnvironment>(m_scope.get());
     SymbolTable* catchSymbolTable = catchEnvironment->symbolTable();
     RELEASE_ASSERT(catchSymbolTable->size() == 1);
     PropertyName errorName(catchSymbolTable->begin(catchSymbolTable->m_lock)->key.get());

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5215,7 +5215,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 if (asString(childConstant)->tryGetValueImpl() == uid)
                     break;
             } else if (childConstant.isSymbol()) {
-                if (&jsCast<Symbol*>(childConstant)->uid() == uid)
+                if (&uncheckedDowncast<Symbol>(childConstant)->uid() == uid)
                     break;
             }
         }

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2052,7 +2052,7 @@ ByteCodeParser::CallOptimizationResult ByteCodeParser::handleCallVariant(Node* c
     };
 
     if (callee.internalFunction() || callee.function()) {
-        JSObject* function = callee.internalFunction() ? jsCast<JSObject*>(callee.internalFunction()) : jsCast<JSObject*>(callee.function());
+        JSObject* function = callee.internalFunction() ? static_cast<JSObject*>(callee.internalFunction()) : static_cast<JSObject*>(callee.function());
         if (handleConstantFunction(callTargetNode, result, function, registerOffset, argumentCountIncludingThis, specializationKind, prediction, newTarget, insertChecksWithAccounting)) {
             endSpecialCase();
             return CallOptimizationResult::Inlined;
@@ -7269,7 +7269,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                         FrozenValue* frozen = m_graph.freeze(cachedFunction);
                         addToGraph(CheckIsConstant, OpInfo(frozen), callee);
 
-                        promiseConstructor = jsCast<JSPromiseConstructor*>(cachedFunction);
+                        promiseConstructor = uncheckedDowncast<JSPromiseConstructor>(cachedFunction);
                     }
                 }
                 if (promiseConstructor) {
@@ -9819,7 +9819,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                 addToGraph(Phantom, get(bytecode.m_scope));
                 WatchpointSet* watchpointSet;
                 ScopeOffset offset;
-                JSSegmentedVariableObject* scopeObject = jsCast<JSSegmentedVariableObject*>(JSScope::constantScopeForCodeBlock(resolveType, m_inlineStackTop->m_codeBlock));
+                JSSegmentedVariableObject* scopeObject = uncheckedDowncast<JSSegmentedVariableObject>(JSScope::constantScopeForCodeBlock(resolveType, m_inlineStackTop->m_codeBlock));
                 {
                     ConcurrentJSLocker locker(scopeObject->symbolTable()->m_lock);
                     SymbolTableEntry entry = scopeObject->symbolTable()->get(locker, uid);
@@ -10008,7 +10008,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                 if (resolveType == GlobalVar || resolveType == GlobalVarWithVarInjectionChecks)
                     m_graph.watchpoints().addLazily(globalObject->varReadOnlyWatchpointSet());
 
-                JSSegmentedVariableObject* scopeObject = jsCast<JSSegmentedVariableObject*>(JSScope::constantScopeForCodeBlock(resolveType, m_inlineStackTop->m_codeBlock));
+                JSSegmentedVariableObject* scopeObject = uncheckedDowncast<JSSegmentedVariableObject>(JSScope::constantScopeForCodeBlock(resolveType, m_inlineStackTop->m_codeBlock));
                 if (watchpoints) {
                     SymbolTableEntry entry = scopeObject->symbolTable()->get(uid);
                     ASSERT_UNUSED(entry, watchpoints == entry.watchpointSet());

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -467,7 +467,7 @@ private:
                                 constantUid = static_cast<const UniquedStringImpl*>(impl);
                         }
                     } else if (childConstant.isSymbol()) {
-                        Symbol* symbol = jsCast<Symbol*>(childConstant);
+                        Symbol* symbol = uncheckedDowncast<Symbol>(childConstant);
                         constantUid = &symbol->uid();
                     }
                 }

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -4138,7 +4138,7 @@ private:
         }
 
         if (node->child1()->shouldSpeculateString()) {
-            auto* globalObject = jsCast<JSGlobalObject*>(node->cellOperand()->cell());
+            auto* globalObject = uncheckedDowncast<JSGlobalObject>(node->cellOperand()->cell());
             insertCheck<StringUse>(node->child1().node());
             fixEdge<KnownStringUse>(node->child1());
             node->convertToNewStringObject(m_graph.registerStructure(globalObject->stringObjectStructure()));
@@ -4148,7 +4148,7 @@ private:
         // While ToObject(Null/Undefined) throws an error, CallObjectConstructor(Null/Undefined) generates a new empty object.
         if (node->child1()->shouldSpeculateOther()) {
             insertCheck<OtherUse>(node->child1().node());
-            node->convertToNewObject(m_graph.registerStructure(jsCast<JSGlobalObject*>(node->cellOperand()->cell())->objectStructureForObjectConstructor()));
+            node->convertToNewObject(m_graph.registerStructure(uncheckedDowncast<JSGlobalObject>(node->cellOperand()->cell())->objectStructureForObjectConstructor()));
             return;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGFrozenValue.h
+++ b/Source/JavaScriptCore/dfg/DFGFrozenValue.h
@@ -80,7 +80,7 @@ public:
     template<typename T>
     T cast()
     {
-        return jsCast<T>(value());
+        return uncheckedDowncast<std::remove_pointer_t<T>>(value());
     }
     
     Structure* structure() const { return m_structure; }

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -427,18 +427,18 @@ JSC_DEFINE_JIT_OPERATION(operationCreateThis, JSCell*, (JSGlobalObject* globalOb
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (constructor->type() == JSFunctionType && jsCast<JSFunction*>(constructor)->canUseAllocationProfiles()) {
+    if (constructor->type() == JSFunctionType && uncheckedDowncast<JSFunction>(constructor)->canUseAllocationProfiles()) {
         JSObject* result;
         {
             DeferTermination deferScope(vm);
-            auto rareData = jsCast<JSFunction*>(constructor)->ensureRareDataAndObjectAllocationProfile(globalObject, inlineCapacity);
+            auto rareData = uncheckedDowncast<JSFunction>(constructor)->ensureRareDataAndObjectAllocationProfile(globalObject, inlineCapacity);
             scope.releaseAssertNoException();
             ObjectAllocationProfileWithPrototype* allocationProfile = rareData->objectAllocationProfile();
             Structure* structure = allocationProfile->structure();
             result = constructEmptyObject(vm, structure);
             if (structure->hasPolyProto()) {
                 JSObject* prototype = allocationProfile->prototype();
-                ASSERT(prototype == jsCast<JSFunction*>(constructor)->prototypeForConstruction(vm, globalObject));
+                ASSERT(prototype == uncheckedDowncast<JSFunction>(constructor)->prototypeForConstruction(vm, globalObject));
                 result->putDirectOffset(vm, knownPolyProtoOffset, prototype);
                 prototype->didBecomePrototype(vm);
                 ASSERT_WITH_MESSAGE(!hasIndexedProperties(result->indexingType()), "We rely on JSFinalObject not starting out with an indexing type otherwise we would potentially need to convert to slow put storage");
@@ -1790,8 +1790,8 @@ JSC_DEFINE_JIT_OPERATION(operationSubHeapBigInt, EncodedJSValue, (JSGlobalObject
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     
-    JSBigInt* leftOperand = jsCast<JSBigInt*>(op1);
-    JSBigInt* rightOperand = jsCast<JSBigInt*>(op2);
+    JSBigInt* leftOperand = uncheckedDowncast<JSBigInt>(op1);
+    JSBigInt* rightOperand = uncheckedDowncast<JSBigInt>(op2);
     
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::sub(globalObject, leftOperand, rightOperand)));
 }
@@ -1803,7 +1803,7 @@ JSC_DEFINE_JIT_OPERATION(operationBitNotHeapBigInt, EncodedJSValue, (JSGlobalObj
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSBigInt* operand = jsCast<JSBigInt*>(op1);
+    JSBigInt* operand = uncheckedDowncast<JSBigInt>(op1);
 
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::bitwiseNot(globalObject, operand)));
 }
@@ -1815,8 +1815,8 @@ JSC_DEFINE_JIT_OPERATION(operationMulHeapBigInt, EncodedJSValue, (JSGlobalObject
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSBigInt* leftOperand = jsCast<JSBigInt*>(op1);
-    JSBigInt* rightOperand = jsCast<JSBigInt*>(op2);
+    JSBigInt* leftOperand = uncheckedDowncast<JSBigInt>(op1);
+    JSBigInt* rightOperand = uncheckedDowncast<JSBigInt>(op2);
 
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::multiply(globalObject, leftOperand, rightOperand)));
 }
@@ -1828,8 +1828,8 @@ JSC_DEFINE_JIT_OPERATION(operationModHeapBigInt, EncodedJSValue, (JSGlobalObject
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     
-    JSBigInt* leftOperand = jsCast<JSBigInt*>(op1);
-    JSBigInt* rightOperand = jsCast<JSBigInt*>(op2);
+    JSBigInt* leftOperand = uncheckedDowncast<JSBigInt>(op1);
+    JSBigInt* rightOperand = uncheckedDowncast<JSBigInt>(op2);
     
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::remainder(globalObject, leftOperand, rightOperand)));
 }
@@ -1841,8 +1841,8 @@ JSC_DEFINE_JIT_OPERATION(operationDivHeapBigInt, EncodedJSValue, (JSGlobalObject
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     
-    JSBigInt* leftOperand = jsCast<JSBigInt*>(op1);
-    JSBigInt* rightOperand = jsCast<JSBigInt*>(op2);
+    JSBigInt* leftOperand = uncheckedDowncast<JSBigInt>(op1);
+    JSBigInt* rightOperand = uncheckedDowncast<JSBigInt>(op2);
     
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::divide(globalObject, leftOperand, rightOperand)));
 }
@@ -1854,8 +1854,8 @@ JSC_DEFINE_JIT_OPERATION(operationPowHeapBigInt, EncodedJSValue, (JSGlobalObject
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     
-    JSBigInt* leftOperand = jsCast<JSBigInt*>(op1);
-    JSBigInt* rightOperand = jsCast<JSBigInt*>(op2);
+    JSBigInt* leftOperand = uncheckedDowncast<JSBigInt>(op1);
+    JSBigInt* rightOperand = uncheckedDowncast<JSBigInt>(op2);
     
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::exponentiate(globalObject, leftOperand, rightOperand)));
 }
@@ -1867,8 +1867,8 @@ JSC_DEFINE_JIT_OPERATION(operationBitAndHeapBigInt, EncodedJSValue, (JSGlobalObj
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSBigInt* leftOperand = jsCast<JSBigInt*>(op1);
-    JSBigInt* rightOperand = jsCast<JSBigInt*>(op2);
+    JSBigInt* leftOperand = uncheckedDowncast<JSBigInt>(op1);
+    JSBigInt* rightOperand = uncheckedDowncast<JSBigInt>(op2);
 
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::bitwiseAnd(globalObject, leftOperand, rightOperand)));
 }
@@ -1880,8 +1880,8 @@ JSC_DEFINE_JIT_OPERATION(operationBitLShiftHeapBigInt, EncodedJSValue, (JSGlobal
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSBigInt* leftOperand = jsCast<JSBigInt*>(op1);
-    JSBigInt* rightOperand = jsCast<JSBigInt*>(op2);
+    JSBigInt* leftOperand = uncheckedDowncast<JSBigInt>(op1);
+    JSBigInt* rightOperand = uncheckedDowncast<JSBigInt>(op2);
 
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::leftShift(globalObject, leftOperand, rightOperand)));
 }
@@ -1893,8 +1893,8 @@ JSC_DEFINE_JIT_OPERATION(operationAddHeapBigInt, EncodedJSValue, (JSGlobalObject
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     
-    JSBigInt* leftOperand = jsCast<JSBigInt*>(op1);
-    JSBigInt* rightOperand = jsCast<JSBigInt*>(op2);
+    JSBigInt* leftOperand = uncheckedDowncast<JSBigInt>(op1);
+    JSBigInt* rightOperand = uncheckedDowncast<JSBigInt>(op2);
     
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::add(globalObject, leftOperand, rightOperand)));
 }
@@ -1906,8 +1906,8 @@ JSC_DEFINE_JIT_OPERATION(operationBitRShiftHeapBigInt, EncodedJSValue, (JSGlobal
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     
-    JSBigInt* leftOperand = jsCast<JSBigInt*>(op1);
-    JSBigInt* rightOperand = jsCast<JSBigInt*>(op2);
+    JSBigInt* leftOperand = uncheckedDowncast<JSBigInt>(op1);
+    JSBigInt* rightOperand = uncheckedDowncast<JSBigInt>(op2);
     
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::signedRightShift(globalObject, leftOperand, rightOperand)));
 }
@@ -1919,8 +1919,8 @@ JSC_DEFINE_JIT_OPERATION(operationBitOrHeapBigInt, EncodedJSValue, (JSGlobalObje
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     
-    JSBigInt* leftOperand = jsCast<JSBigInt*>(op1);
-    JSBigInt* rightOperand = jsCast<JSBigInt*>(op2);
+    JSBigInt* leftOperand = uncheckedDowncast<JSBigInt>(op1);
+    JSBigInt* rightOperand = uncheckedDowncast<JSBigInt>(op2);
     
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::bitwiseOr(globalObject, leftOperand, rightOperand)));
 }
@@ -1932,8 +1932,8 @@ JSC_DEFINE_JIT_OPERATION(operationBitXorHeapBigInt, EncodedJSValue, (JSGlobalObj
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSBigInt* leftOperand = jsCast<JSBigInt*>(op1);
-    JSBigInt* rightOperand = jsCast<JSBigInt*>(op2);
+    JSBigInt* leftOperand = uncheckedDowncast<JSBigInt>(op1);
+    JSBigInt* rightOperand = uncheckedDowncast<JSBigInt>(op2);
 
     OPERATION_RETURN(scope, JSValue::encode(JSBigInt::bitwiseXor(globalObject, leftOperand, rightOperand)));
 }
@@ -2328,7 +2328,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewArrayBuffer, JSCell*, (VM* vmPointer, Struc
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(!arrayStructure->outOfLineCapacity());
-    auto* immutableButterfly = jsCast<JSCellButterfly*>(immutableButterflyCell);
+    auto* immutableButterfly = uncheckedDowncast<JSCellButterfly>(immutableButterflyCell);
     ASSERT(arrayStructure->indexingMode() == immutableButterfly->indexingMode() || hasAnyArrayStorage(arrayStructure->indexingMode()));
     auto* result = CommonSlowPaths::allocateNewArrayBuffer(vm, arrayStructure, immutableButterfly);
     ASSERT(result->indexingMode() == result->structure()->indexingMode());
@@ -2646,7 +2646,7 @@ JSC_DEFINE_JIT_OPERATION(operationArrayIsArray, size_t, (JSGlobalObject* globalO
 
     JSValue value = JSValue::decode(encodedValue);
     ASSERT(value.isCell() && value.asCell()->type() == ProxyObjectType);
-    OPERATION_RETURN(scope, isArraySlow(globalObject, jsCast<ProxyObject*>(value.asCell())));
+    OPERATION_RETURN(scope, isArraySlow(globalObject, uncheckedDowncast<ProxyObject>(value.asCell())));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationTypeOfObject, JSCell*, (JSGlobalObject* globalObject, JSCell* object))
@@ -2936,7 +2936,7 @@ JSC_DEFINE_JIT_OPERATION(operationEnumeratorInByVal, EncodedJSValue, (JSGlobalOb
 
     JSValue base = JSValue::decode(baseValue);
     if (modeNumber == JSPropertyNameEnumerator::IndexedMode && base.isObject())
-        OPERATION_RETURN(scope, JSValue::encode(jsBoolean(jsCast<JSObject*>(base)->hasProperty(globalObject, index))));
+        OPERATION_RETURN(scope, JSValue::encode(jsBoolean(uncheckedDowncast<JSObject>(base)->hasProperty(globalObject, index))));
 
     JSString* propertyName = downcast<JSString>(JSValue::decode(propertyNameValue));
     OPERATION_RETURN(scope, JSValue::encode(jsBoolean(CommonSlowPaths::opInByVal(globalObject, base, propertyName))));
@@ -2951,7 +2951,7 @@ JSC_DEFINE_JIT_OPERATION(operationEnumeratorHasOwnProperty, EncodedJSValue, (JSG
 
     JSValue base = JSValue::decode(baseValue);
     if (modeNumber == JSPropertyNameEnumerator::IndexedMode && base.isObject())
-        OPERATION_RETURN(scope, JSValue::encode(jsBoolean(jsCast<JSObject*>(base)->hasOwnProperty(globalObject, index))));
+        OPERATION_RETURN(scope, JSValue::encode(jsBoolean(uncheckedDowncast<JSObject>(base)->hasOwnProperty(globalObject, index))));
 
     JSString* propertyName = downcast<JSString>(JSValue::decode(propertyNameValue));
     auto identifier = propertyName->toIdentifier(globalObject);
@@ -3231,7 +3231,7 @@ JSC_DEFINE_JIT_OPERATION(operationStringSubstr, JSCell*, (JSGlobalObject* global
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    OPERATION_RETURN(scope, jsSubstring(globalObject, vm, jsCast<JSString*>(cell), from, span));
+    OPERATION_RETURN(scope, jsSubstring(globalObject, vm, uncheckedDowncast<JSString>(cell), from, span));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationStringSlice, JSString*, (JSGlobalObject* globalObject, JSString* string, int32_t start))
@@ -4094,29 +4094,29 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareStringImplGreaterEq, uintptr_t
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntLess, uintptr_t, (JSCell* a, JSCell* b))
 {
-    return JSBigInt::compare(jsCast<JSBigInt*>(a), jsCast<JSBigInt*>(b)) == JSBigInt::ComparisonResult::LessThan;
+    return JSBigInt::compare(uncheckedDowncast<JSBigInt>(a), uncheckedDowncast<JSBigInt>(b)) == JSBigInt::ComparisonResult::LessThan;
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntLessEq, uintptr_t, (JSCell* a, JSCell* b))
 {
-    auto result = JSBigInt::compare(jsCast<JSBigInt*>(a), jsCast<JSBigInt*>(b));
+    auto result = JSBigInt::compare(uncheckedDowncast<JSBigInt>(a), uncheckedDowncast<JSBigInt>(b));
     return result == JSBigInt::ComparisonResult::LessThan || result == JSBigInt::ComparisonResult::Equal;
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntGreater, uintptr_t, (JSCell* a, JSCell* b))
 {
-    return JSBigInt::compare(jsCast<JSBigInt*>(a), jsCast<JSBigInt*>(b)) == JSBigInt::ComparisonResult::GreaterThan;
+    return JSBigInt::compare(uncheckedDowncast<JSBigInt>(a), uncheckedDowncast<JSBigInt>(b)) == JSBigInt::ComparisonResult::GreaterThan;
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntGreaterEq, uintptr_t, (JSCell* a, JSCell* b))
 {
-    auto result = JSBigInt::compare(jsCast<JSBigInt*>(a), jsCast<JSBigInt*>(b));
+    auto result = JSBigInt::compare(uncheckedDowncast<JSBigInt>(a), uncheckedDowncast<JSBigInt>(b));
     return result == JSBigInt::ComparisonResult::GreaterThan || result == JSBigInt::ComparisonResult::Equal;
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompareHeapBigIntEq, uintptr_t, (JSCell* a, JSCell* b))
 {
-    return JSBigInt::equals(jsCast<JSBigInt*>(a), jsCast<JSBigInt*>(b));
+    return JSBigInt::equals(uncheckedDowncast<JSBigInt>(a), uncheckedDowncast<JSBigInt>(b));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationCompareStringLess, uintptr_t, (JSGlobalObject* globalObject, JSString* a, JSString* b))
@@ -4860,7 +4860,7 @@ JSC_DEFINE_JIT_OPERATION(operationSpreadGeneric, JSCell*, (JSGlobalObject* globa
         ASSERT(!arguments.hasOverflowed());
         JSValue arrayResult = call(globalObject, iterationFunction, callData, jsNull(), arguments);
         OPERATION_RETURN_IF_EXCEPTION(scope, nullptr);
-        array = jsCast<JSArray*>(arrayResult);
+        array = uncheckedDowncast<JSArray>(arrayResult);
     }
 
     OPERATION_RETURN(scope, JSCellButterfly::createFromArray(globalObject, vm, array));
@@ -4874,7 +4874,7 @@ JSC_DEFINE_JIT_OPERATION(operationSpreadSet, JSCell*, (JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     ASSERT(is<JSSet>(cell));
-    JSSet* set = jsCast<JSSet*>(cell);
+    JSSet* set = uncheckedDowncast<JSSet>(cell);
 
     OPERATION_RETURN(scope, JSCellButterfly::createFromSet(globalObject, set));
 }
@@ -4887,7 +4887,7 @@ JSC_DEFINE_JIT_OPERATION(operationSpreadFastArray, JSCell*, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     ASSERT(isJSArray(cell));
-    JSArray* array = jsCast<JSArray*>(cell);
+    JSArray* array = uncheckedDowncast<JSArray>(cell);
     ASSERT(array->isIteratorProtocolFastAndNonObservable());
 
     OPERATION_RETURN(scope, JSCellButterfly::createFromArray(globalObject, vm, array));
@@ -5099,7 +5099,7 @@ JSC_DEFINE_JIT_OPERATION(operationMapGet, JSValue*, (JSGlobalObject* globalObjec
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSMap* map = jsCast<JSMap*>(cell);
+    JSMap* map = uncheckedDowncast<JSMap>(cell);
     JSValue* keySlot = map->getKeySlot(globalObject, JSValue::decode(key), hash);
     OPERATION_RETURN(scope, keySlot);
 }
@@ -5109,7 +5109,7 @@ JSC_DEFINE_JIT_OPERATION(operationSetGet, JSValue*, (JSGlobalObject* globalObjec
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSSet* set = jsCast<JSSet*>(cell);
+    JSSet* set = uncheckedDowncast<JSSet>(cell);
     JSValue* keySlot = set->getKeySlot(globalObject, JSValue::decode(key), hash);
     OPERATION_RETURN(scope, keySlot);
 }
@@ -5123,7 +5123,7 @@ JSC_DEFINE_JIT_OPERATION(operationMapIterationNext, EncodedJSValue, (JSGlobalObj
     if (cell == vm.orderedHashTableSentinel())
         OPERATION_RETURN(scope, JSValue::encode(vm.orderedHashTableSentinel()));
 
-    JSMap::Storage& storage = *jsCast<JSMap::Storage*>(cell);
+    JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
     OPERATION_RETURN(scope, JSValue::encode(JSMap::Helper::nextAndUpdateIterationEntry(vm, storage, index)));
 }
 JSC_DEFINE_JIT_OPERATION(operationMapIterationEntry, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell))
@@ -5134,7 +5134,7 @@ JSC_DEFINE_JIT_OPERATION(operationMapIterationEntry, EncodedJSValue, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     ASSERT(cell != vm.orderedHashTableSentinel());
-    JSMap::Storage& storage = *jsCast<JSMap::Storage*>(cell);
+    JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
     OPERATION_RETURN(scope, JSValue::encode(JSMap::Helper::getIterationEntry(storage)));
 }
 JSC_DEFINE_JIT_OPERATION(operationMapIterationEntryKey, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell))
@@ -5145,7 +5145,7 @@ JSC_DEFINE_JIT_OPERATION(operationMapIterationEntryKey, EncodedJSValue, (JSGloba
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     ASSERT(cell != vm.orderedHashTableSentinel());
-    JSMap::Storage& storage = *jsCast<JSMap::Storage*>(cell);
+    JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
     OPERATION_RETURN(scope, JSValue::encode(JSMap::Helper::getIterationEntryKey(storage)));
 }
 JSC_DEFINE_JIT_OPERATION(operationMapIterationEntryValue, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell))
@@ -5156,7 +5156,7 @@ JSC_DEFINE_JIT_OPERATION(operationMapIterationEntryValue, EncodedJSValue, (JSGlo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     ASSERT(cell != vm.orderedHashTableSentinel());
-    JSMap::Storage& storage = *jsCast<JSMap::Storage*>(cell);
+    JSMap::Storage& storage = *uncheckedDowncast<JSMap::Storage>(cell);
     OPERATION_RETURN(scope, JSValue::encode(JSMap::Helper::getIterationEntryValue(storage)));
 }
 
@@ -5169,7 +5169,7 @@ JSC_DEFINE_JIT_OPERATION(operationSetIterationNext, EncodedJSValue, (JSGlobalObj
     if (cell == vm.orderedHashTableSentinel())
         OPERATION_RETURN(scope, JSValue::encode(vm.orderedHashTableSentinel()));
 
-    JSSet::Storage& storage = *jsCast<JSSet::Storage*>(cell);
+    JSSet::Storage& storage = *uncheckedDowncast<JSSet::Storage>(cell);
     OPERATION_RETURN(scope, JSValue::encode(JSSet::Helper::nextAndUpdateIterationEntry(vm, storage, index)));
 }
 JSC_DEFINE_JIT_OPERATION(operationSetIterationEntry, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell))
@@ -5180,7 +5180,7 @@ JSC_DEFINE_JIT_OPERATION(operationSetIterationEntry, EncodedJSValue, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     ASSERT(cell != vm.orderedHashTableSentinel());
-    JSSet::Storage& storage = *jsCast<JSSet::Storage*>(cell);
+    JSSet::Storage& storage = *uncheckedDowncast<JSSet::Storage>(cell);
     OPERATION_RETURN(scope, JSValue::encode(JSSet::Helper::getIterationEntry(storage)));
 }
 JSC_DEFINE_JIT_OPERATION(operationSetIterationEntryKey, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell))
@@ -5191,7 +5191,7 @@ JSC_DEFINE_JIT_OPERATION(operationSetIterationEntryKey, EncodedJSValue, (JSGloba
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     ASSERT(cell != vm.orderedHashTableSentinel());
-    JSSet::Storage& storage = *jsCast<JSSet::Storage*>(cell);
+    JSSet::Storage& storage = *uncheckedDowncast<JSSet::Storage>(cell);
     OPERATION_RETURN(scope, JSValue::encode(JSSet::Helper::getIterationEntryKey(storage)));
 }
 
@@ -5200,7 +5200,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMapIteratorNext, EncodedJSValue, (VM*
     VM& vm = *vmPointer;
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return JSValue::encode(jsCast<JSMapIterator*>(cell)->next(vm));
+    return JSValue::encode(uncheckedDowncast<JSMapIterator>(cell)->next(vm));
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationSetIteratorNext, EncodedJSValue, (VM* vmPointer, JSCell* cell))
@@ -5208,7 +5208,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationSetIteratorNext, EncodedJSValue, (VM*
     VM& vm = *vmPointer;
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return JSValue::encode(jsCast<JSSetIterator*>(cell)->next(vm));
+    return JSValue::encode(uncheckedDowncast<JSSetIterator>(cell)->next(vm));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationSetAdd, void, (JSGlobalObject* globalObject, JSCell* set, EncodedJSValue key, int32_t hash))
@@ -5217,7 +5217,7 @@ JSC_DEFINE_JIT_OPERATION(operationSetAdd, void, (JSGlobalObject* globalObject, J
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    jsCast<JSSet*>(set)->addNormalized(globalObject, JSValue::decode(key), JSValue(), hash);
+    uncheckedDowncast<JSSet>(set)->addNormalized(globalObject, JSValue::decode(key), JSValue(), hash);
     OPERATION_RETURN(scope);
 }
 JSC_DEFINE_JIT_OPERATION(operationMapSet, void, (JSGlobalObject* globalObject, JSCell* map, EncodedJSValue key, EncodedJSValue value, int32_t hash))
@@ -5226,7 +5226,7 @@ JSC_DEFINE_JIT_OPERATION(operationMapSet, void, (JSGlobalObject* globalObject, J
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    jsCast<JSMap*>(map)->addNormalized(globalObject, JSValue::decode(key), JSValue::decode(value), hash);
+    uncheckedDowncast<JSMap>(map)->addNormalized(globalObject, JSValue::decode(key), JSValue::decode(value), hash);
     OPERATION_RETURN(scope);
 }
 
@@ -5236,7 +5236,7 @@ JSC_DEFINE_JIT_OPERATION(operationSetDelete, size_t, (JSGlobalObject* globalObje
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    OPERATION_RETURN(scope, jsCast<JSSet*>(set)->removeNormalized(globalObject, JSValue::decode(key), hash));
+    OPERATION_RETURN(scope, uncheckedDowncast<JSSet>(set)->removeNormalized(globalObject, JSValue::decode(key), hash));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationMapDelete, size_t, (JSGlobalObject* globalObject, JSCell* map, EncodedJSValue key, int32_t hash))
@@ -5245,7 +5245,7 @@ JSC_DEFINE_JIT_OPERATION(operationMapDelete, size_t, (JSGlobalObject* globalObje
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    OPERATION_RETURN(scope, jsCast<JSMap*>(map)->removeNormalized(globalObject, JSValue::decode(key), hash));
+    OPERATION_RETURN(scope, uncheckedDowncast<JSMap>(map)->removeNormalized(globalObject, JSValue::decode(key), hash));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewMap, JSMap*, (VM* vmPointer, Structure* structure))
@@ -5278,7 +5278,7 @@ JSC_DEFINE_JIT_OPERATION(operationWeakSetAdd, void, (JSGlobalObject* globalObjec
         OPERATION_RETURN(scope);
     }
 
-    jsCast<JSWeakSet*>(set)->add(vm, key, JSValue(), hash);
+    uncheckedDowncast<JSWeakSet>(set)->add(vm, key, JSValue(), hash);
     OPERATION_RETURN(scope);
 }
 
@@ -5294,7 +5294,7 @@ JSC_DEFINE_JIT_OPERATION(operationWeakMapSet, void, (JSGlobalObject* globalObjec
         OPERATION_RETURN(scope);
     }
 
-    jsCast<JSWeakMap*>(map)->add(vm, key, JSValue::decode(value), hash);
+    uncheckedDowncast<JSWeakMap>(map)->add(vm, key, JSValue::decode(value), hash);
     OPERATION_RETURN(scope);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -4174,7 +4174,7 @@ void SpeculativeJIT::compileParseInt(Node* node)
 void SpeculativeJIT::compileOverridesHasInstance(Node* node)
 {
     Node* hasInstanceValueNode = node->child2().node();
-    JSFunction* defaultHasInstanceFunction = jsCast<JSFunction*>(node->cellOperand()->value());
+    JSFunction* defaultHasInstanceFunction = uncheckedDowncast<JSFunction>(node->cellOperand()->value());
 
     JumpList notDefault;
     SpeculateCellOperand base(this, node->child1());

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -1007,9 +1007,9 @@ void SpeculativeJIT::emitCall(Node* node)
         TaggedNativeFunction nativeFunction;
         if (executable->isHostFunction() && executable->intrinsic() == NoIntrinsic) {
             if (isConstruct)
-                nativeFunction = jsCast<NativeExecutable*>(executable)->constructor();
+                nativeFunction = uncheckedDowncast<NativeExecutable>(executable)->constructor();
             else
-                nativeFunction = jsCast<NativeExecutable*>(executable)->function();
+                nativeFunction = uncheckedDowncast<NativeExecutable>(executable)->function();
         }
 
         if (nativeFunction && !vm().isDebuggerHookInjected()) {
@@ -3000,7 +3000,7 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
 #if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
 void SpeculativeJIT::compileRegExpTestInline(Node* node)
 {
-    RegExp* regExp = jsCast<RegExp*>(node->cellOperand2()->value());
+    RegExp* regExp = uncheckedDowncast<RegExp>(node->cellOperand2()->value());
 
     auto jitCodeBlock = regExp->getRegExpJITCodeBlock();
     ASSERT(jitCodeBlock);

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1806,7 +1806,7 @@ private:
             // We gave up inlining a wrapped function, but still, we can inline bound function's wrapper by extracting it.
             // This also wipes bound-function thunk call which is suboptimal compared to directly calling a wrapped function here.
             if (executable->intrinsic() == BoundFunctionCallIntrinsic && function && (m_node->op() == Call || m_node->op() == TailCall || m_node->op() == TailCallInlinedCaller)) {
-                JSBoundFunction* boundFunction = jsCast<JSBoundFunction*>(function);
+                JSBoundFunction* boundFunction = uncheckedDowncast<JSBoundFunction>(function);
                 if (JSFunction* targetFunction = dynamicDowncast<JSFunction>(boundFunction->targetFunction())) {
                     auto* targetExecutable = targetFunction->executable();
                     if ((boundFunction->boundArgsLength() + m_node->numChildren()) <= Options::maximumDirectCallStackSize()) {

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -13009,9 +13009,9 @@ IGNORE_CLANG_WARNINGS_END
         TaggedNativeFunction nativeFunction;
         if (executable->isHostFunction() && executable->intrinsic() == NoIntrinsic) {
             if (isConstruct)
-                nativeFunction = jsCast<NativeExecutable*>(executable)->constructor();
+                nativeFunction = uncheckedDowncast<NativeExecutable>(executable)->constructor();
             else
-                nativeFunction = jsCast<NativeExecutable*>(executable)->function();
+                nativeFunction = uncheckedDowncast<NativeExecutable>(executable)->function();
         }
 
         CodeOrigin codeOrigin = codeOriginDescriptionOfCallSite();
@@ -18424,7 +18424,7 @@ IGNORE_CLANG_WARNINGS_END
 #if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
     void compileRegExpTestInline()
     {
-        RegExp* regExp = jsCast<RegExp*>(m_node->cellOperand2()->value());
+        RegExp* regExp = uncheckedDowncast<RegExp>(m_node->cellOperand2()->value());
 
         ASSERT(!regExp->globalOrSticky());
 
@@ -18432,7 +18432,7 @@ IGNORE_CLANG_WARNINGS_END
         ASSERT(jitCodeBlock);
         auto inlineCodeStats8Bit = jitCodeBlock->get8BitInlineStats();
 
-        JSGlobalObject* globalObjectConst = jsCast<JSGlobalObject*>(m_node->cellOperand()->value());
+        JSGlobalObject* globalObjectConst = uncheckedDowncast<JSGlobalObject>(m_node->cellOperand()->value());
 
         unsigned alignedFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(inlineCodeStats8Bit.stackSize());
 

--- a/Source/JavaScriptCore/ftl/FTLOSREntry.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSREntry.cpp
@@ -60,7 +60,7 @@ void* prepareOSREntry(
         bytecodeIndex);
     
     if (bytecodeIndex)
-        jsCast<ScriptExecutable*>(executable)->setDidTryToEnterInLoop(true);
+        uncheckedDowncast<ScriptExecutable>(executable)->setDidTryToEnterInLoop(true);
 
     if (bytecodeIndex != entryCode->bytecodeIndex()) {
         dataLogLnIf(Options::verboseOSR(), "    OSR failed because we don't have an entrypoint for ", bytecodeIndex, "; ours is for ", entryCode->bytecodeIndex());

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -83,7 +83,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
     case PhantomNewArrayWithButterfly: {
         auto scope = DECLARE_THROW_SCOPE(vm);
         // This might be unnecessary because operationMaterializeObjectInOSR does DeferGCForAWhile but its better to be safe.
-        JSArray* array = jsCast<JSArray*>(JSValue::decode(*encodedValue));
+        JSArray* array = uncheckedDowncast<JSArray>(JSValue::decode(*encodedValue));
 
         // This may be called during a GenericUnwind OSR exit (e.g. stack overflow caught by
         // try/catch), where vm.exception() is already set. Suspend it so the assertion below
@@ -110,7 +110,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
 
 
     case PhantomNewObject: {
-        JSFinalObject* object = jsCast<JSFinalObject*>(JSValue::decode(*encodedValue));
+        JSFinalObject* object = uncheckedDowncast<JSFinalObject>(JSValue::decode(*encodedValue));
         Structure* structure = object->structure();
 
         // Figure out what the heck to populate the object with. Use
@@ -149,7 +149,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
         break;
 
     case PhantomCreateActivation: {
-        JSLexicalEnvironment* activation = jsCast<JSLexicalEnvironment*>(JSValue::decode(*encodedValue));
+        JSLexicalEnvironment* activation = uncheckedDowncast<JSLexicalEnvironment>(JSValue::decode(*encodedValue));
 
         // Figure out what to populate the activation with
         for (unsigned i = materialization->properties().size(); i--;) {
@@ -176,41 +176,41 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
             }
         };
 
-        JSObject* target = jsCast<JSObject*>(JSValue::decode(*encodedValue));
+        JSObject* target = uncheckedDowncast<JSObject>(JSValue::decode(*encodedValue));
         switch (target->type()) {
         case JSArrayIteratorType:
-            materialize(jsCast<JSArrayIterator*>(target));
+            materialize(uncheckedDowncast<JSArrayIterator>(target));
             break;
         case JSMapIteratorType:
-            materialize(jsCast<JSMapIterator*>(target));
+            materialize(uncheckedDowncast<JSMapIterator>(target));
             break;
         case JSSetIteratorType:
-            materialize(jsCast<JSSetIterator*>(target));
+            materialize(uncheckedDowncast<JSSetIterator>(target));
             break;
         case JSStringIteratorType:
-            materialize(jsCast<JSStringIterator*>(target));
+            materialize(uncheckedDowncast<JSStringIterator>(target));
             break;
         case JSIteratorHelperType:
-            materialize(jsCast<JSIteratorHelper*>(target));
+            materialize(uncheckedDowncast<JSIteratorHelper>(target));
             break;
         case JSWrapForValidIteratorType:
-            materialize(jsCast<JSWrapForValidIterator*>(target));
+            materialize(uncheckedDowncast<JSWrapForValidIterator>(target));
             break;
         case JSAsyncFromSyncIteratorType:
-            materialize(jsCast<JSAsyncFromSyncIterator*>(target));
+            materialize(uncheckedDowncast<JSAsyncFromSyncIterator>(target));
             break;
         case JSRegExpStringIteratorType:
-            materialize(jsCast<JSRegExpStringIterator*>(target));
+            materialize(uncheckedDowncast<JSRegExpStringIterator>(target));
             break;
         case JSGeneratorType:
-            materialize(jsCast<JSGenerator*>(target));
+            materialize(uncheckedDowncast<JSGenerator>(target));
             break;
         case JSAsyncGeneratorType:
-            materialize(jsCast<JSAsyncGenerator*>(target));
+            materialize(uncheckedDowncast<JSAsyncGenerator>(target));
             break;
         case JSPromiseType:
             ASSERT(target->classInfo() == JSPromise::info());
-            materialize(jsCast<JSPromise*>(target));
+            materialize(uncheckedDowncast<JSPromise>(target));
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -220,7 +220,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
     }
 
     case PhantomNewRegExp: {
-        RegExpObject* regExpObject = jsCast<RegExpObject*>(JSValue::decode(*encodedValue));
+        RegExpObject* regExpObject = uncheckedDowncast<RegExpObject>(JSValue::decode(*encodedValue));
 
         for (unsigned i = materialization->properties().size(); i--;) {
             const ExitPropertyValue& property = materialization->properties()[i];
@@ -341,7 +341,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
                 continue;
 
             RELEASE_ASSERT(JSValue::decode(values[i]).asCell()->inherits<Structure>());
-            structure = jsCast<Structure*>(JSValue::decode(values[i]));
+            structure = uncheckedDowncast<Structure>(JSValue::decode(values[i]));
             break;
         }
         RELEASE_ASSERT(structure);
@@ -375,11 +375,11 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
             const ExitPropertyValue& property = materialization->properties()[i];
             if (property.location() == PromotedLocationDescriptor(FunctionExecutablePLoc)) {
                 RELEASE_ASSERT(JSValue::decode(values[i]).asCell()->inherits<FunctionExecutable>());
-                executable = jsCast<FunctionExecutable*>(JSValue::decode(values[i]));
+                executable = uncheckedDowncast<FunctionExecutable>(JSValue::decode(values[i]));
             }
             if (property.location() == PromotedLocationDescriptor(FunctionActivationPLoc)) {
                 RELEASE_ASSERT(JSValue::decode(values[i]).asCell()->inherits<JSScope>());
-                activation = jsCast<JSScope*>(JSValue::decode(values[i]));
+                activation = uncheckedDowncast<JSScope>(JSValue::decode(values[i]));
             }
         }
         RELEASE_ASSERT(executable && activation);
@@ -404,10 +404,10 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
             const ExitPropertyValue& property = materialization->properties()[i];
             if (property.location() == PromotedLocationDescriptor(ActivationScopePLoc)) {
                 RELEASE_ASSERT(JSValue::decode(values[i]).asCell()->inherits<JSScope>());
-                scope = jsCast<JSScope*>(JSValue::decode(values[i]));
+                scope = uncheckedDowncast<JSScope>(JSValue::decode(values[i]));
             } else if (property.location() == PromotedLocationDescriptor(ActivationSymbolTablePLoc)) {
                 RELEASE_ASSERT(JSValue::decode(values[i]).asCell()->inherits<SymbolTable>());
-                table = jsCast<SymbolTable*>(JSValue::decode(values[i]));
+                table = uncheckedDowncast<SymbolTable>(JSValue::decode(values[i]));
             }
         }
         RELEASE_ASSERT(scope);
@@ -471,7 +471,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
             const ExitPropertyValue& property = materialization->properties()[i];
             if (property.location() == PromotedLocationDescriptor(StructurePLoc)) {
                 RELEASE_ASSERT(JSValue::decode(values[i]).asCell()->inherits<Structure>());
-                structure = jsCast<Structure*>(JSValue::decode(values[i]));
+                structure = uncheckedDowncast<Structure>(JSValue::decode(values[i]));
             }
         }
         RELEASE_ASSERT(structure);
@@ -565,7 +565,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
                 if (property.location() != PromotedLocationDescriptor(ArgumentsCalleePLoc))
                     continue;
                 
-                callee = jsCast<JSFunction*>(JSValue::decode(values[i]));
+                callee = uncheckedDowncast<JSFunction>(JSValue::decode(values[i]));
                 break;
             }
         } else
@@ -689,7 +689,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
         for (unsigned i = materialization->properties().size(); i--;) {
             const ExitPropertyValue& property = materialization->properties()[i];
             if (property.location().kind() == SpreadPLoc) {
-                array = jsCast<JSArray*>(JSValue::decode(values[i]));
+                array = uncheckedDowncast<JSArray>(JSValue::decode(values[i]));
                 break;
             }
         }
@@ -709,7 +709,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
         for (unsigned i = materialization->properties().size(); i--;) {
             const ExitPropertyValue& property = materialization->properties()[i];
             if (property.location().kind() == NewArrayBufferPLoc) {
-                immutableButterfly = jsCast<JSCellButterfly*>(JSValue::decode(values[i]));
+                immutableButterfly = uncheckedDowncast<JSCellButterfly>(JSValue::decode(values[i]));
                 break;
             }
         }
@@ -830,7 +830,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
             const ExitPropertyValue& property = materialization->properties()[i];
             if (property.location() == PromotedLocationDescriptor(RegExpObjectRegExpPLoc)) {
                 RELEASE_ASSERT(JSValue::decode(values[i]).asCell()->inherits<RegExp>());
-                regExp = jsCast<RegExp*>(JSValue::decode(values[i]));
+                regExp = uncheckedDowncast<RegExp>(JSValue::decode(values[i]));
             }
         }
         RELEASE_ASSERT(regExp);

--- a/Source/JavaScriptCore/heap/ConservativeRoots.cpp
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.cpp
@@ -273,7 +273,7 @@ public:
     void markKnownJSCell(JSCell* cell)
     {
         if (cell->type() == CodeBlockType)
-            m_codeBlocks.mark(m_codeBlocksLocker, jsCast<CodeBlock*>(cell));
+            m_codeBlocks.mark(m_codeBlocksLocker, uncheckedDowncast<CodeBlock>(cell));
     }
 
 private:

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -320,7 +320,7 @@ String HeapSnapshotBuilder::descriptionForNode(const HeapSnapshotNode& node)
     Structure* structure = cell->structure();
 
     if (structure->classInfoForCells()->isSubClassOf(Structure::info())) {
-        Structure* cellAsStructure = jsCast<Structure*>(cell);
+        Structure* cellAsStructure = uncheckedDowncast<Structure>(cell);
         String className = cellAsStructure->classInfoForCells()->className;
         if (m_client)
             className = m_client->heapSnapshotBuilderOverrideClassName(*this, cell, className);

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
@@ -144,7 +144,7 @@ Expected<JSObject*, NakedPtr<Exception>> InjectedScriptManager::createInjectedSc
 
     JSValue globalThisValue = globalObject->globalThis();
 
-    auto* functionValue = jsCast<JSFunction*>(globalObject->linkTimeConstant(LinkTimeConstant::createInspectorInjectedScript));
+    auto* functionValue = uncheckedDowncast<JSFunction>(globalObject->linkTimeConstant(LinkTimeConstant::createInspectorInjectedScript));
     RETURN_IF_EXCEPTION(scope, makeUnexpected(scope.exception()));
     if (!functionValue)
         return nullptr;

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -137,7 +137,7 @@ JSValue JSInjectedScriptHost::internalConstructorName(JSGlobalObject* globalObje
         return jsUndefined();
 
     VM& vm = globalObject->vm();
-    JSObject* object = jsCast<JSObject*>(callFrame->uncheckedArgument(0).toThis(globalObject, ECMAMode::sloppy()));
+    JSObject* object = uncheckedDowncast<JSObject>(callFrame->uncheckedArgument(0).toThis(globalObject, ECMAMode::sloppy()));
     return jsString(vm, JSObject::calculatedClassName(object));
 }
 
@@ -681,14 +681,14 @@ static JSObject* cloneArrayIteratorObject(JSGlobalObject* globalObject, VM& vm, 
 
 static JSObject* cloneMapIteratorObject(JSGlobalObject* globalObject, VM& vm, JSMapIterator* iteratorObject)
 {
-    JSMapIterator* clone = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), jsCast<JSMap*>(iteratorObject->iteratedObject()), iteratorObject->kind());
+    JSMapIterator* clone = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), iteratorObject->iteratedObject(), iteratorObject->kind());
     clone->internalField(JSMapIterator::Field::Entry).set(vm, clone, iteratorObject->internalField(JSMapIterator::Field::Entry).get());
     return clone;
 }
 
 static JSObject* cloneSetIteratorObject(JSGlobalObject* globalObject, VM& vm, JSSetIterator* iteratorObject)
 {
-    JSSetIterator* clone = JSSetIterator::create(vm, globalObject->setIteratorStructure(), jsCast<JSSet*>(iteratorObject->iteratedObject()), iteratorObject->kind());
+    JSSetIterator* clone = JSSetIterator::create(vm, globalObject->setIteratorStructure(), iteratorObject->iteratedObject(), iteratorObject->kind());
     clone->internalField(JSSetIterator::Field::Entry).set(vm, clone, iteratorObject->internalField(JSSetIterator::Field::Entry).get());
     return clone;
 }
@@ -710,7 +710,7 @@ JSValue JSInjectedScriptHost::iteratorEntries(JSGlobalObject* globalObject, Call
         if (auto* arrayIterator = dynamicDowncast<JSArrayIterator>(iteratorObject)) {
             JSObject* iteratedObject = arrayIterator->iteratedObject();
             if (isJSArray(iteratedObject)) {
-                JSArray* array = jsCast<JSArray*>(iteratedObject);
+                JSArray* array = uncheckedDowncast<JSArray>(iteratedObject);
                 if (array->isIteratorProtocolFastAndNonObservable())
                     iterator = cloneArrayIteratorObject(globalObject, vm, arrayIterator);
             } else if (TypeInfo::isArgumentsType(iteratedObject->type())) {
@@ -718,12 +718,12 @@ JSValue JSInjectedScriptHost::iteratorEntries(JSGlobalObject* globalObject, Call
                     iterator = cloneArrayIteratorObject(globalObject, vm, arrayIterator);
             }
         } else if (auto* mapIterator = dynamicDowncast<JSMapIterator>(iteratorObject)) {
-            if (jsCast<JSMap*>(mapIterator->iteratedObject())->isIteratorProtocolFastAndNonObservable()) {
+            if (mapIterator->iteratedObject()->isIteratorProtocolFastAndNonObservable()) {
                 iterator = cloneMapIteratorObject(globalObject, vm, mapIterator);
                 RETURN_IF_EXCEPTION(scope, { });
             }
         } else if (auto* setIterator = dynamicDowncast<JSSetIterator>(iteratorObject)) {
-            if (jsCast<JSSet*>(setIterator->iteratedObject())->isIteratorProtocolFastAndNonObservable()) {
+            if (setIterator->iteratedObject()->isIteratorProtocolFastAndNonObservable()) {
                 iterator = cloneSetIteratorObject(globalObject, vm, setIterator);
                 RETURN_IF_EXCEPTION(scope, { });
             }

--- a/Source/JavaScriptCore/interpreter/CachedCall.h
+++ b/Source/JavaScriptCore/interpreter/CachedCall.h
@@ -61,7 +61,7 @@ public:
     JSFunction* function()
     {
         ASSERT(m_valid);
-        return jsCast<JSFunction*>(m_protoCallFrame.calleeValue.unboxedCell());
+        return uncheckedDowncast<JSFunction>(m_protoCallFrame.calleeValue.unboxedCell());
     }
     FunctionExecutable* functionExecutable() { return m_functionExecutable; }
     JSScope* scope() { return m_scope; }

--- a/Source/JavaScriptCore/interpreter/CallFrame.cpp
+++ b/Source/JavaScriptCore/interpreter/CallFrame.cpp
@@ -440,7 +440,7 @@ JSWebAssemblyInstance* CallFrame::wasmInstance() const
 #if USE(JSVALUE32_64)
     return std::bit_cast<JSWebAssemblyInstance*>(this[static_cast<int>(CallFrameSlot::codeBlock)].asanUnsafePointer());
 #else
-    return jsCast<JSWebAssemblyInstance*>(this[static_cast<int>(CallFrameSlot::codeBlock)].jsValue());
+    return uncheckedDowncast<JSWebAssemblyInstance>(this[static_cast<int>(CallFrameSlot::codeBlock)].jsValue());
 #endif
 }
 #endif

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -238,16 +238,16 @@ unsigned sizeOfVarargs(JSGlobalObject* globalObject, JSValue arguments, uint32_t
     unsigned length;
     switch (cell->type()) {
     case DirectArgumentsType:
-        length = jsCast<DirectArguments*>(cell)->length(globalObject);
+        length = uncheckedDowncast<DirectArguments>(cell)->length(globalObject);
         break;
     case ScopedArgumentsType:
-        length = jsCast<ScopedArguments*>(cell)->length(globalObject);
+        length = uncheckedDowncast<ScopedArguments>(cell)->length(globalObject);
         break;
     case ClonedArgumentsType:
-        length = jsCast<ClonedArguments*>(cell)->length(globalObject);
+        length = uncheckedDowncast<ClonedArguments>(cell)->length(globalObject);
         break;
     case JSCellButterflyType:
-        length = jsCast<JSCellButterfly*>(cell)->length();
+        length = uncheckedDowncast<JSCellButterfly>(cell)->length();
         break;
     case StringType:
     case SymbolType:
@@ -257,7 +257,7 @@ unsigned sizeOfVarargs(JSGlobalObject* globalObject, JSValue arguments, uint32_t
         
     default:
         RELEASE_ASSERT(arguments.isObject());
-        length = clampToUnsigned(toLength(globalObject, jsCast<JSObject*>(cell)));
+        length = clampToUnsigned(toLength(globalObject, uncheckedDowncast<JSObject>(cell)));
         break;
     }
     RETURN_IF_EXCEPTION(scope, 0);
@@ -317,26 +317,26 @@ void loadVarargs(JSGlobalObject* globalObject, JSValue* firstElementDest, JSValu
     switch (cell->type()) {
     case DirectArgumentsType:
         scope.release();
-        jsCast<DirectArguments*>(cell)->copyToArguments(globalObject, firstElementDest, offset, length);
+        uncheckedDowncast<DirectArguments>(cell)->copyToArguments(globalObject, firstElementDest, offset, length);
         return;
     case ScopedArgumentsType:
         scope.release();
-        jsCast<ScopedArguments*>(cell)->copyToArguments(globalObject, firstElementDest, offset, length);
+        uncheckedDowncast<ScopedArguments>(cell)->copyToArguments(globalObject, firstElementDest, offset, length);
         return;
     case ClonedArgumentsType:
         scope.release();
-        jsCast<ClonedArguments*>(cell)->copyToArguments(globalObject, firstElementDest, offset, length);
+        uncheckedDowncast<ClonedArguments>(cell)->copyToArguments(globalObject, firstElementDest, offset, length);
         return;
     case JSCellButterflyType:
         scope.release();
-        jsCast<JSCellButterfly*>(cell)->copyToArguments(globalObject, firstElementDest, offset, length);
+        uncheckedDowncast<JSCellButterfly>(cell)->copyToArguments(globalObject, firstElementDest, offset, length);
         return;
     default: {
         ASSERT(arguments.isObject());
-        JSObject* object = jsCast<JSObject*>(cell);
+        JSObject* object = uncheckedDowncast<JSObject>(cell);
         if (isJSArray(object)) {
             scope.release();
-            jsCast<JSArray*>(object)->copyToArguments(globalObject, firstElementDest, offset, length);
+            uncheckedDowncast<JSArray>(object)->copyToArguments(globalObject, firstElementDest, offset, length);
             return;
         }
         unsigned i;
@@ -845,7 +845,7 @@ public:
         if (!m_callFrame->isNativeCalleeFrame() && JSC::isRemoteFunction(m_callFrame->jsCallee()) && !m_isTermination) {
             // Continue searching for a handler, but mark that a marshalling function was on the stack so that we can
             // translate the exception before jumping to the handler.
-            m_seenRemoteFunction = jsCast<JSRemoteFunction*>(m_callFrame->jsCallee());
+            m_seenRemoteFunction = uncheckedDowncast<JSRemoteFunction>(m_callFrame->jsCallee());
         }
 
         JSGlobalObject* globalObject = m_callFrame->lexicalGlobalObject(m_vm);
@@ -1187,7 +1187,7 @@ failedJSONP:
             CodeBlock* tempCodeBlock;
             program->prepareForExecution<ProgramExecutable>(vm, nullptr, scope, CodeSpecializationKind::CodeForCall, tempCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, throwScope.exception());
-            codeBlock = jsCast<ProgramCodeBlock*>(tempCodeBlock);
+            codeBlock = uncheckedDowncast<ProgramCodeBlock>(tempCodeBlock);
             ASSERT(codeBlock && codeBlock->numParameters() == 1); // 1 parameter for 'this'.
         }
 
@@ -1275,7 +1275,7 @@ ALWAYS_INLINE JSValue Interpreter::executeCallImpl(VM& vm, JSObject* function, c
         CodeBlock* newCodeBlock = nullptr;
         if (isJSCall) {
             // Compile the callee:
-            functionExecutable->prepareForExecution<FunctionExecutable>(vm, jsCast<JSFunction*>(function), functionScope, CodeSpecializationKind::CodeForCall, newCodeBlock);
+            functionExecutable->prepareForExecution<FunctionExecutable>(vm, uncheckedDowncast<JSFunction>(function), functionScope, CodeSpecializationKind::CodeForCall, newCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
             ASSERT(newCodeBlock);
             newCodeBlock->m_shouldAlwaysBeInlined = false;
@@ -1298,7 +1298,7 @@ ALWAYS_INLINE JSValue Interpreter::executeCallImpl(VM& vm, JSObject* function, c
 
 #if ENABLE(WEBASSEMBLY)
     if (callData.native.isWasm)
-        return JSValue::decode(vmEntryToWasm(jsCast<WebAssemblyFunction*>(function)->jsToWasm(ArityCheckMode::MustCheckArity).taggedPtr(), &vm, &protoCallFrame));
+        return JSValue::decode(vmEntryToWasm(uncheckedDowncast<WebAssemblyFunction>(function)->jsToWasm(ArityCheckMode::MustCheckArity).taggedPtr(), &vm, &protoCallFrame));
 #endif
 
     return JSValue::decode(vmEntryToNative(nativeFunction.taggedPtr(), &vm, &protoCallFrame));
@@ -1311,7 +1311,7 @@ JSValue Interpreter::executeCall(JSObject* function, const CallData& callData, J
         return executeCallImpl(vm, function, callData, thisValue, context, args);
 
     // Only one-level unwrap is enough! We already made JSBoundFunction's nest smaller.
-    auto* boundFunction = jsCast<JSBoundFunction*>(function);
+    auto* boundFunction = uncheckedDowncast<JSBoundFunction>(function);
     if (boundFunction->isTainted())
         vm.setMightBeExecutingTaintedCode();
     if (!boundFunction->boundArgsLength()) {
@@ -1371,7 +1371,7 @@ JSObject* Interpreter::executeConstruct(JSObject* constructor, const CallData& c
         CodeBlock* newCodeBlock = nullptr;
         if (isJSConstruct) {
             // Compile the callee:
-            constructData.js.functionExecutable->prepareForExecution<FunctionExecutable>(vm, jsCast<JSFunction*>(constructor), scope, CodeSpecializationKind::CodeForConstruct, newCodeBlock);
+            constructData.js.functionExecutable->prepareForExecution<FunctionExecutable>(vm, uncheckedDowncast<JSFunction>(constructor), scope, CodeSpecializationKind::CodeForConstruct, newCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, nullptr);
             ASSERT(newCodeBlock);
             newCodeBlock->m_shouldAlwaysBeInlined = false;
@@ -1471,7 +1471,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
                     break;
                 }
                 if (node->isJSLexicalEnvironment()) {
-                    JSLexicalEnvironment* lexicalEnvironment = jsCast<JSLexicalEnvironment*>(node);
+                    JSLexicalEnvironment* lexicalEnvironment = uncheckedDowncast<JSLexicalEnvironment>(node);
                     if (lexicalEnvironment->symbolTable()->scopeType() == SymbolTable::ScopeType::VarScope) {
                         variableObject = node;
                         break;
@@ -1487,7 +1487,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
             CodeBlock* tempCodeBlock;
             eval->prepareForExecution<EvalExecutable>(vm, nullptr, scope, CodeSpecializationKind::CodeForCall, tempCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, throwScope.exception());
-            codeBlock = jsCast<EvalCodeBlock*>(tempCodeBlock);
+            codeBlock = uncheckedDowncast<EvalCodeBlock>(tempCodeBlock);
             ASSERT(codeBlock && codeBlock->numParameters() == 1); // 1 parameter for 'this'.
         }
 
@@ -1517,7 +1517,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
         if (isGlobalVariableEnvironment) {
             for (auto& slot : functionDecls) {
                 FunctionExecutable* function = slot.get();
-                bool canDeclare = jsCast<JSGlobalObject*>(variableObject)->canDeclareGlobalFunction(function->name());
+                bool canDeclare = uncheckedDowncast<JSGlobalObject>(variableObject)->canDeclareGlobalFunction(function->name());
                 RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
                 if (!canDeclare)
                     return throwException(globalObject, throwScope, createErrorForInvalidGlobalFunctionDeclaration(globalObject, function->name()));
@@ -1525,7 +1525,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
 
             if (!variableObject->isStructureExtensible()) {
                 for (auto& ident : variables) {
-                    bool canDeclare = jsCast<JSGlobalObject*>(variableObject)->canDeclareGlobalVar(ident);
+                    bool canDeclare = uncheckedDowncast<JSGlobalObject>(variableObject)->canDeclareGlobalVar(ident);
                     RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
                     if (!canDeclare)
                         return throwException(globalObject, throwScope, createErrorForInvalidGlobalVarDeclaration(globalObject, ident));
@@ -1550,10 +1550,10 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
                 RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
                 if (!resolvedScope.isUndefined()) {
                     if (isGlobalVariableEnvironment) {
-                        bool canDeclare = jsCast<JSGlobalObject*>(variableObject)->canDeclareGlobalVar(ident);
+                        bool canDeclare = uncheckedDowncast<JSGlobalObject>(variableObject)->canDeclareGlobalVar(ident);
                         RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
                         if (canDeclare) {
-                            jsCast<JSGlobalObject*>(variableObject)->createGlobalVarBinding<BindingCreationContext::Eval>(ident);
+                            uncheckedDowncast<JSGlobalObject>(variableObject)->createGlobalVarBinding<BindingCreationContext::Eval>(ident);
                             RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
                         }
                     } else {
@@ -1567,7 +1567,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
         for (auto& slot : functionDecls) {
             FunctionExecutable* function = slot.get();
             if (isGlobalVariableEnvironment) {
-                jsCast<JSGlobalObject*>(variableObject)->createGlobalFunctionBinding<BindingCreationContext::Eval>(function->name());
+                uncheckedDowncast<JSGlobalObject>(variableObject)->createGlobalFunctionBinding<BindingCreationContext::Eval>(function->name());
                 RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
             } else {
                 ensureBindingExists(function->name());
@@ -1577,7 +1577,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
 
         for (auto& ident : variables) {
             if (isGlobalVariableEnvironment) {
-                jsCast<JSGlobalObject*>(variableObject)->createGlobalVarBinding<BindingCreationContext::Eval>(ident);
+                uncheckedDowncast<JSGlobalObject>(variableObject)->createGlobalVarBinding<BindingCreationContext::Eval>(ident);
                 RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
             } else {
                 ensureBindingExists(ident);
@@ -1600,7 +1600,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
             CodeBlock* tempCodeBlock;
             eval->prepareForExecution<EvalExecutable>(vm, nullptr, scope, CodeSpecializationKind::CodeForCall, tempCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, throwScope.exception());
-            codeBlock = jsCast<EvalCodeBlock*>(tempCodeBlock);
+            codeBlock = uncheckedDowncast<EvalCodeBlock>(tempCodeBlock);
             entry = codeBlock->jitCode()->addressForCall();
             ASSERT(codeBlock && codeBlock->numParameters() == 1); // 1 parameter for 'this'.
         }
@@ -1619,7 +1619,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
             CodeBlock* tempCodeBlock;
             eval->prepareForExecution<EvalExecutable>(vm, nullptr, scope, CodeSpecializationKind::CodeForCall, tempCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, throwScope.exception());
-            codeBlock = jsCast<EvalCodeBlock*>(tempCodeBlock);
+            codeBlock = uncheckedDowncast<EvalCodeBlock>(tempCodeBlock);
             ASSERT(codeBlock && codeBlock->numParameters() == 1); // 1 parameter for 'this'.
         }
 
@@ -1690,7 +1690,7 @@ JSValue Interpreter::executeModuleProgram(JSModuleRecord* record, ModuleProgramE
             CodeBlock* tempCodeBlock;
             executable->prepareForExecution<ModuleProgramExecutable>(vm, nullptr, scope, CodeSpecializationKind::CodeForCall, tempCodeBlock);
             RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, throwScope.exception());
-            codeBlock = jsCast<ModuleProgramCodeBlock*>(tempCodeBlock);
+            codeBlock = uncheckedDowncast<ModuleProgramCodeBlock>(tempCodeBlock);
             ASSERT(codeBlock && codeBlock->numParameters() == numberOfArguments + 1);
         }
 

--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.h
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.h
@@ -65,7 +65,7 @@ public:
         auto* cell = functionObject.asCell();
         if (cell->type() != JSFunctionType) [[unlikely]]
             return false;
-        return m_functionExecutable == jsCast<JSFunction*>(cell)->executable();
+        return m_functionExecutable == uncheckedDowncast<JSFunction>(cell)->executable();
     }
 
     bool isInitializedFor(FunctionExecutable* executable) const

--- a/Source/JavaScriptCore/interpreter/RegisterInlines.h
+++ b/Source/JavaScriptCore/interpreter/RegisterInlines.h
@@ -83,7 +83,7 @@ ALWAYS_INLINE Register& Register::operator=(EncodedJSValue encodedJSValue)
 
 ALWAYS_INLINE JSScope* Register::scope() const
 {
-    return jsCast<JSScope*>(unboxedCell());
+    return uncheckedDowncast<JSScope>(unboxedCell());
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
+++ b/Source/JavaScriptCore/interpreter/ShadowChicken.cpp
@@ -190,7 +190,7 @@ void ShadowChicken::update(VM& vm, CallFrame* callFrame)
                 bool isTailDeleted = false;
                 // FIXME: Make shadow chicken work with Wasm.
                 // https://bugs.webkit.org/show_bug.cgi?id=165441
-                stackRightNow.append(Frame(jsCast<JSObject*>(visitor->callee().asCell()), visitor->callFrame(), isTailDeleted));
+                stackRightNow.append(Frame(uncheckedDowncast<JSObject>(visitor->callee().asCell()), visitor->callFrame(), isTailDeleted));
                 return IterationStatus::Continue;
             });
         stackRightNow.reverse();
@@ -338,14 +338,14 @@ void ShadowChicken::update(VM& vm, CallFrame* callFrame)
                 ? callFrame->registers()[codeBlock->scopeRegister().offset()].jsValue()
                 : jsUndefined();
             if (!scopeValue.isUndefined() && codeBlock->wasCompiledWithDebuggingOpcodes()) {
-                scope = jsCast<JSScope*>(scopeValue.asCell());
+                scope = uncheckedDowncast<JSScope>(scopeValue.asCell());
                 RELEASE_ASSERT(scope->inherits<JSScope>());
             } else if (foundFrame) {
                 scope = m_log[indexInLog].scope;
                 if (scope)
                     RELEASE_ASSERT(scope->inherits<JSScope>());
             }
-            toPush.append(Frame(jsCast<JSObject*>(visitor->callee().asCell()), callFrame, isTailDeleted, callFrame->thisValue(), scope, codeBlock, callFrame->callSiteIndex()));
+            toPush.append(Frame(uncheckedDowncast<JSObject>(visitor->callee().asCell()), callFrame, isTailDeleted, callFrame->thisValue(), scope, codeBlock, callFrame->callSiteIndex()));
 
             if (indexInLog < logCursorIndex
                 // This condition protects us from the case where advanceIndexInLogTo didn't find

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -398,11 +398,11 @@ String StackVisitor::Frame::functionName() const
     case CodeType::Native: {
         JSCell* callee = this->callee().asCell();
         if (callee)
-            traceLine = getCalculatedDisplayName(callFrame()->deprecatedVM(), jsCast<JSObject*>(callee)).impl();
+            traceLine = getCalculatedDisplayName(callFrame()->deprecatedVM(), uncheckedDowncast<JSObject>(callee)).impl();
         break;
     }
     case CodeType::Function: 
-        traceLine = getCalculatedDisplayName(callFrame()->deprecatedVM(), jsCast<JSObject*>(this->callee().asCell())).impl();
+        traceLine = getCalculatedDisplayName(callFrame()->deprecatedVM(), uncheckedDowncast<JSObject>(this->callee().asCell())).impl();
         break;
     case CodeType::Global:
         traceLine = "global code"_s;

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -1821,7 +1821,7 @@ void JIT::emit_op_new_reg_exp(const JSInstruction* currentInstruction)
     VirtualRegister regexp = bytecode.m_regexp;
     GPRReg globalGPR = argumentGPR0;
     loadGlobalObject(globalGPR);
-    callOperation(operationNewRegExp, globalGPR, TrustedImmPtr(jsCast<RegExp*>(m_unlinkedCodeBlock->getConstant(regexp))));
+    callOperation(operationNewRegExp, globalGPR, TrustedImmPtr(uncheckedDowncast<RegExp>(m_unlinkedCodeBlock->getConstant(regexp))));
     boxCell(returnValueGPR, returnValueJSR);
     emitPutVirtualRegister(dst, returnValueJSR);
 }

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -218,7 +218,7 @@ JSC_DEFINE_JIT_OPERATION(operationMaterializeBoundFunctionTargetCode, UGPRPair, 
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* targetFunction = jsCast<JSFunction*>(callee->targetFunction()); // We call this function only when JSBoundFunction's target is JSFunction.
+    auto* targetFunction = uncheckedDowncast<JSFunction>(callee->targetFunction()); // We call this function only when JSBoundFunction's target is JSFunction.
     OPERATION_RETURN(scope, materializeTargetCode(vm, targetFunction));
 }
 
@@ -230,7 +230,7 @@ JSC_DEFINE_JIT_OPERATION(operationMaterializeRemoteFunctionTargetCode, UGPRPair,
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(isRemoteFunction(callee));
-    auto* targetFunction = jsCast<JSFunction*>(callee->targetFunction()); // We call this function only when JSRemoteFunction's target is JSFunction.
+    auto* targetFunction = uncheckedDowncast<JSFunction>(callee->targetFunction()); // We call this function only when JSRemoteFunction's target is JSFunction.
     OPERATION_RETURN(scope, materializeTargetCode(vm, targetFunction));
 }
 
@@ -2761,7 +2761,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewFunction, EncodedJSValue, (JSGlobalObject* 
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     constexpr bool isInvalidated = false;
-    OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, JSFunction::selectStructureForNewFuncExp(globalObject, jsCast<FunctionExecutable*>(functionExecutable))));
+    OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, JSFunction::selectStructureForNewFuncExp(globalObject, uncheckedDowncast<FunctionExecutable>(functionExecutable))));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewFunctionWithInvalidatedReallocationWatchpoint, EncodedJSValue, (JSGlobalObject* globalObject, JSScope* environment, JSCell* functionExecutable))
@@ -2771,7 +2771,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewFunctionWithInvalidatedReallocationWatchpoi
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
     constexpr bool isInvalidated = true;
-    OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, JSFunction::selectStructureForNewFuncExp(globalObject, jsCast<FunctionExecutable*>(functionExecutable))));
+    OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, JSFunction::selectStructureForNewFuncExp(globalObject, uncheckedDowncast<FunctionExecutable>(functionExecutable))));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewSloppyFunction, EncodedJSValue, (JSGlobalObject* globalObject, JSScope* environment, JSCell* functionExecutable))
@@ -2782,7 +2782,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewSloppyFunction, EncodedJSValue, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
     constexpr bool isInvalidated = false;
     constexpr bool isBuiltin = false;
-    if (jsCast<FunctionExecutable*>(functionExecutable)->hasPrototypeProperty())
+    if (uncheckedDowncast<FunctionExecutable>(functionExecutable)->hasPrototypeProperty())
         OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->sloppyFunctionStructure(isBuiltin)));
     OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->sloppyMethodStructure(isBuiltin)));
 }
@@ -2795,7 +2795,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewSloppyFunctionWithInvalidatedReallocationWa
     auto scope = DECLARE_THROW_SCOPE(vm);
     constexpr bool isInvalidated = true;
     constexpr bool isBuiltin = false;
-    if (jsCast<FunctionExecutable*>(functionExecutable)->hasPrototypeProperty())
+    if (uncheckedDowncast<FunctionExecutable>(functionExecutable)->hasPrototypeProperty())
         OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->sloppyFunctionStructure(isBuiltin)));
     OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->sloppyMethodStructure(isBuiltin)));
 }
@@ -2808,7 +2808,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewStrictFunction, EncodedJSValue, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
     constexpr bool isInvalidated = false;
     constexpr bool isBuiltin = false;
-    if (jsCast<FunctionExecutable*>(functionExecutable)->hasPrototypeProperty())
+    if (uncheckedDowncast<FunctionExecutable>(functionExecutable)->hasPrototypeProperty())
         OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->strictFunctionStructure(isBuiltin)));
     OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->strictMethodStructure(isBuiltin)));
 }
@@ -2821,7 +2821,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewStrictFunctionWithInvalidatedReallocationWa
     auto scope = DECLARE_THROW_SCOPE(vm);
     constexpr bool isInvalidated = true;
     constexpr bool isBuiltin = false;
-    if (jsCast<FunctionExecutable*>(functionExecutable)->hasPrototypeProperty())
+    if (uncheckedDowncast<FunctionExecutable>(functionExecutable)->hasPrototypeProperty())
         OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->strictFunctionStructure(isBuiltin)));
     OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->strictMethodStructure(isBuiltin)));
 }
@@ -2915,7 +2915,7 @@ JSC_DEFINE_JIT_OPERATION(operationSetFunctionName, void, (JSGlobalObject* global
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSFunction* func = jsCast<JSFunction*>(funcCell);
+    JSFunction* func = uncheckedDowncast<JSFunction>(funcCell);
     JSValue name = JSValue::decode(encodedName);
     func->setFunctionName(globalObject, name);
     OPERATION_RETURN(scope);
@@ -3989,7 +3989,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameOptimize, EncodedJSValue, (Encod
         OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
         ASSERT(fieldName.isSymbol());
 
-        JSObject* base = jsCast<JSObject*>(baseValue.asCell());
+        JSObject* base = uncheckedDowncast<JSObject>(baseValue.asCell());
 
         PropertySlot slot(base, PropertySlot::InternalMethodType::GetOwnProperty);
         base->getPrivateField(globalObject, fieldName, slot);
@@ -4071,7 +4071,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameByIdOptimize, EncodedJSValue, (E
     JSValue baseValue = JSValue::decode(base);
 
     if (baseValue.isObject()) {
-        JSObject* base = jsCast<JSObject*>(baseValue.asCell());
+        JSObject* base = uncheckedDowncast<JSObject>(baseValue.asCell());
 
         PropertySlot slot(base, PropertySlot::InternalMethodType::GetOwnProperty);
         base->getPrivateField(globalObject, identifier, slot);
@@ -4358,7 +4358,7 @@ JSC_DEFINE_JIT_OPERATION(operationPushWithScope, JSCell*, (JSGlobalObject* globa
     JSObject* object = JSValue::decode(objectValue).toObject(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, nullptr);
 
-    JSScope* currentScope = jsCast<JSScope*>(currentScopeCell);
+    JSScope* currentScope = uncheckedDowncast<JSScope>(currentScopeCell);
 
     OPERATION_RETURN(scope, JSWithScope::create(vm, globalObject, currentScope, object));
 }
@@ -4369,7 +4369,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPushWithScopeObject, JSCell*, (JSGlob
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSScope* currentScope = jsCast<JSScope*>(currentScopeCell);
+    JSScope* currentScope = uncheckedDowncast<JSScope>(currentScopeCell);
     OPERATION_RETURN(scope, JSWithScope::create(vm, globalObject, currentScope, object));
 }
 
@@ -4546,7 +4546,7 @@ JSC_DEFINE_JIT_OPERATION(operationResolveScopeForBaseline, EncodedJSValue, (JSGl
     case UnresolvedProperty:
     case UnresolvedPropertyWithVarInjectionChecks: {
         if (resolvedScope->isGlobalObject()) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(resolvedScope);
+            JSGlobalObject* globalObject = uncheckedDowncast<JSGlobalObject>(resolvedScope);
             bool hasProperty = globalObject->hasProperty(globalObject, ident);
             OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
             if (hasProperty) {
@@ -4556,7 +4556,7 @@ JSC_DEFINE_JIT_OPERATION(operationResolveScopeForBaseline, EncodedJSValue, (JSGl
                 metadata.m_globalLexicalBindingEpoch = globalObject->globalLexicalBindingEpoch();
             }
         } else if (resolvedScope->isGlobalLexicalEnvironment()) {
-            JSGlobalLexicalEnvironment* globalLexicalEnvironment = jsCast<JSGlobalLexicalEnvironment*>(resolvedScope);
+            JSGlobalLexicalEnvironment* globalLexicalEnvironment = uncheckedDowncast<JSGlobalLexicalEnvironment>(resolvedScope);
             ConcurrentJSLocker locker(codeBlock->m_lock);
             metadata.m_resolveType = needsVarInjectionChecks(resolveType) ? GlobalLexicalVarWithVarInjectionChecks : GlobalLexicalVar;
             metadata.m_globalLexicalEnvironment.set(vm, codeBlock, globalLexicalEnvironment);
@@ -4581,7 +4581,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetFromScope, EncodedJSValue, (JSGlobalObject*
 
     auto bytecode = pc->as<OpGetFromScope>();
     const Identifier& ident = codeBlock->identifier(bytecode.m_var);
-    JSObject* environment = jsCast<JSObject*>(callFrame->uncheckedR(bytecode.m_scope).jsValue());
+    JSObject* environment = uncheckedDowncast<JSObject>(callFrame->uncheckedR(bytecode.m_scope).jsValue());
     GetPutInfo& getPutInfo = bytecode.metadata(codeBlock).m_getPutInfo;
 
     // ModuleVar is always converted to ClosureVar for get_from_scope.
@@ -4624,7 +4624,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutToScope, void, (JSGlobalObject* globalObjec
     auto& metadata = bytecode.metadata(codeBlock);
 
     const Identifier& ident = codeBlock->identifier(bytecode.m_var);
-    JSObject* jsScope = jsCast<JSObject*>(callFrame->uncheckedR(bytecode.m_scope).jsValue());
+    JSObject* jsScope = uncheckedDowncast<JSObject>(callFrame->uncheckedR(bytecode.m_scope).jsValue());
     JSValue value = callFrame->r(bytecode.m_value).jsValue();
     GetPutInfo& getPutInfo = metadata.m_getPutInfo;
 
@@ -4632,7 +4632,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutToScope, void, (JSGlobalObject* globalObjec
     ASSERT(getPutInfo.resolveType() != ModuleVar);
 
     if (getPutInfo.resolveType() == ResolvedClosureVar) {
-        JSLexicalEnvironment* environment = jsCast<JSLexicalEnvironment*>(jsScope);
+        JSLexicalEnvironment* environment = uncheckedDowncast<JSLexicalEnvironment>(jsScope);
         environment->variableAt(ScopeOffset(metadata.m_operand)).set(vm, environment, value);
         if (WatchpointSet* set = metadata.m_watchpointSet)
             set->touch(vm, "Executed op_put_scope<ResolvedClosureVar>");
@@ -4760,7 +4760,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationLookupExceptionHandlerFromCallerFrame
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     ASSERT(callFrame->isZombieFrame());
-    ASSERT(vm.hasPendingTerminationException() || jsCast<ErrorInstance*>(vm.exceptionForInspection()->value().asCell())->isStackOverflowError());
+    ASSERT(vm.hasPendingTerminationException() || uncheckedDowncast<ErrorInstance>(vm.exceptionForInspection()->value().asCell())->isStackOverflowError());
     genericUnwind(vm, callFrame);
     ASSERT(vm.targetMachinePCForThrow);
 }

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -577,7 +577,7 @@ public:
         VM& vm = globalObject->vm();
         PropertyNameArrayBuilder ownPropertyNames(vm, propertyNames.propertyNameMode(), propertyNames.privateSymbolMode());
         Base::getOwnPropertyNames(object, globalObject, ownPropertyNames, mode);
-        auto* thisObject = jsCast<GlobalObject*>(object);
+        auto* thisObject = uncheckedDowncast<GlobalObject>(object);
         auto& filter = thisObject->ensurePropertyFilter();
         for (auto& propertyName : ownPropertyNames) {
             if (!filter.contains(propertyName.impl()))
@@ -2084,13 +2084,13 @@ JSC_DEFINE_HOST_FUNCTION(functionWriteFile, (JSGlobalObject* globalObject, CallF
         data = asString(dataValue)->value(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
     } else if (dataValue.inherits<JSArrayBuffer>()) {
-        auto* arrayBuffer = jsCast<JSArrayBuffer*>(dataValue);
+        auto* arrayBuffer = uncheckedDowncast<JSArrayBuffer>(dataValue);
         if (arrayBuffer->impl()->isDetached())
             data = emptyString();
         else
             data = std::span(static_cast<const uint8_t*>(arrayBuffer->impl()->data()), arrayBuffer->impl()->byteLength());
     } else if (dataValue.inherits<JSArrayBufferView>()) {
-        auto* view = jsCast<JSArrayBufferView*>(dataValue);
+        auto* view = uncheckedDowncast<JSArrayBufferView>(dataValue);
         if (view->isDetached())
             data = emptyString();
         else
@@ -2482,7 +2482,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarEvalScript, (JSGlobalObject* globalObject
     JSValue global = callFrame->thisValue().get(globalObject, Identifier::fromString(vm, "global"_s));
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     while (global.inherits<JSGlobalProxy>())
-        global = jsCast<JSGlobalProxy*>(global)->target();
+        global = uncheckedDowncast<JSGlobalProxy>(global)->target();
     GlobalObject* realm = dynamicDowncast<GlobalObject>(global);
     if (!realm)
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Expected global to point to a global object"_s)));
@@ -3056,7 +3056,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateBigInt32, (JSGlobalObject* globalObject, 
     if (bigIntValue.isBigInt32())
         return JSValue::encode(bigIntValue);
     ASSERT(bigIntValue.isHeapBigInt());
-    JSBigInt* bigInt = jsCast<JSBigInt*>(bigIntValue);
+    JSBigInt* bigInt = uncheckedDowncast<JSBigInt>(bigIntValue);
     if (!bigInt->length())
         return JSValue::encode(jsBigInt32(0));
     if (bigInt->length() == 1) {
@@ -3773,7 +3773,7 @@ static bool checkUncaughtException(VM& vm, GlobalObject* globalObject, JSValue e
         return false;
     }
 
-    bool isInstanceOfExpectedException = jsCast<JSObject*>(exceptionClass)->hasInstance(globalObject, exception);
+    bool isInstanceOfExpectedException = uncheckedDowncast<JSObject>(exceptionClass)->hasInstance(globalObject, exception);
     if (scope.exception()) {
         printf("Expected uncaught exception with name '%s' but given exception class fails performing hasInstance\n", expectedExceptionName.utf8().data());
         return false;
@@ -3825,7 +3825,7 @@ static void checkException(GlobalObject* globalObject, bool isLastFile, bool has
 
 void GlobalObject::reportUncaughtExceptionAtEventLoop(JSGlobalObject* globalObject, Exception* exception)
 {
-    auto* global = jsCast<GlobalObject*>(globalObject);
+    auto* global = uncheckedDowncast<GlobalObject>(globalObject);
     dumpException(global, exception->value());
     bool hideNoReturn = true;
     if (hideNoReturn)
@@ -3894,12 +3894,12 @@ static void runWithOptions(GlobalObject* globalObject, CommandLine& options, boo
             }
 
             JSFunction* fulfillHandler = JSNativeStdFunction::create(vm, globalObject, 1, String(), [&success, &options, isLastFile](JSGlobalObject* globalObject, CallFrame* callFrame) {
-                checkException(jsCast<GlobalObject*>(globalObject), isLastFile, false, callFrame->argument(0), options, success);
+                checkException(uncheckedDowncast<GlobalObject>(globalObject), isLastFile, false, callFrame->argument(0), options, success);
                 return JSValue::encode(jsUndefined());
             });
 
             JSFunction* rejectHandler = JSNativeStdFunction::create(vm, globalObject, 1, String(), [&success, &options, isLastFile](JSGlobalObject* globalObject, CallFrame* callFrame) {
-                checkException(jsCast<GlobalObject*>(globalObject), isLastFile, true, callFrame->argument(0), options, success);
+                checkException(uncheckedDowncast<GlobalObject>(globalObject), isLastFile, true, callFrame->argument(0), options, success);
                 return JSValue::encode(jsUndefined());
             });
 

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -289,7 +289,7 @@ static void traceFunctionPrologue(CallFrame* callFrame, const char* comment, Cod
     if (!Options::traceLLIntExecution())
         return;
 
-    JSFunction* callee = jsCast<JSFunction*>(callFrame->jsCallee());
+    JSFunction* callee = uncheckedDowncast<JSFunction>(callFrame->jsCallee());
     FunctionExecutable* executable = callee->jsExecutable();
     CodeBlock* codeBlock = executable->codeBlockFor(kind);
     dataLogF("<%p> %p / %p: in %s of ", &Thread::currentSingleton(), codeBlock, callFrame, comment);
@@ -452,25 +452,25 @@ LLINT_SLOW_PATH_DECL(entry_osr)
 LLINT_SLOW_PATH_DECL(entry_osr_function_for_call)
 {
     UNUSED_PARAM(pc);
-    return entryOSR(jsCast<JSFunction*>(callFrame->jsCallee())->jsExecutable()->codeBlockForCall(), "entry_osr_function_for_call", Prologue);
+    return entryOSR(uncheckedDowncast<JSFunction>(callFrame->jsCallee())->jsExecutable()->codeBlockForCall(), "entry_osr_function_for_call", Prologue);
 }
 
 LLINT_SLOW_PATH_DECL(entry_osr_function_for_construct)
 {
     UNUSED_PARAM(pc);
-    return entryOSR(jsCast<JSFunction*>(callFrame->jsCallee())->jsExecutable()->codeBlockForConstruct(), "entry_osr_function_for_construct", Prologue);
+    return entryOSR(uncheckedDowncast<JSFunction>(callFrame->jsCallee())->jsExecutable()->codeBlockForConstruct(), "entry_osr_function_for_construct", Prologue);
 }
 
 LLINT_SLOW_PATH_DECL(entry_osr_function_for_call_arityCheck)
 {
     UNUSED_PARAM(pc);
-    return entryOSR(jsCast<JSFunction*>(callFrame->jsCallee())->jsExecutable()->codeBlockForCall(), "entry_osr_function_for_call_arityCheck", ArityCheck);
+    return entryOSR(uncheckedDowncast<JSFunction>(callFrame->jsCallee())->jsExecutable()->codeBlockForCall(), "entry_osr_function_for_call_arityCheck", ArityCheck);
 }
 
 LLINT_SLOW_PATH_DECL(entry_osr_function_for_construct_arityCheck)
 {
     UNUSED_PARAM(pc);
-    return entryOSR(jsCast<JSFunction*>(callFrame->jsCallee())->jsExecutable()->codeBlockForConstruct(), "entry_osr_function_for_construct_arityCheck", ArityCheck);
+    return entryOSR(uncheckedDowncast<JSFunction>(callFrame->jsCallee())->jsExecutable()->codeBlockForConstruct(), "entry_osr_function_for_construct_arityCheck", ArityCheck);
 }
 
 LLINT_SLOW_PATH_DECL(loop_osr)
@@ -689,7 +689,7 @@ LLINT_SLOW_PATH_DECL(slow_path_new_reg_exp)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpNewRegExp>();
-    RegExp* regExp = jsCast<RegExp*>(getOperand(callFrame, bytecode.m_regexp));
+    RegExp* regExp = uncheckedDowncast<RegExp>(getOperand(callFrame, bytecode.m_regexp));
     static constexpr bool areLegacyFeaturesEnabled = true;
     LLINT_RETURN(RegExpObject::create(vm, globalObject->regExpStructure(), regExp, areLegacyFeaturesEnabled));
 }
@@ -699,7 +699,7 @@ LLINT_SLOW_PATH_DECL(slow_path_create_lexical_environment)
     LLINT_BEGIN();
     auto bytecode = pc->as<OpCreateLexicalEnvironment>();
     JSScope* currentScope = callFrame->uncheckedR(bytecode.m_scope).Register::scope();
-    SymbolTable* symbolTable = jsCast<SymbolTable*>(getOperand(callFrame, bytecode.m_symbolTable));
+    SymbolTable* symbolTable = uncheckedDowncast<SymbolTable>(getOperand(callFrame, bytecode.m_symbolTable));
     JSValue initialValue = getOperand(callFrame, bytecode.m_initialValue);
     ASSERT(initialValue == jsUndefined() || initialValue == jsTDZValue());
     JSScope* newScope = JSLexicalEnvironment::create(vm, globalObject, currentScope, symbolTable, initialValue);
@@ -717,7 +717,7 @@ LLINT_SLOW_PATH_DECL(slow_path_create_scoped_arguments)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpCreateScopedArguments>();
-    JSLexicalEnvironment* scope = jsCast<JSLexicalEnvironment*>(getOperand(callFrame, bytecode.m_scope));
+    JSLexicalEnvironment* scope = uncheckedDowncast<JSLexicalEnvironment>(getOperand(callFrame, bytecode.m_scope));
     ScopedArgumentsTable* table = scope->symbolTable()->arguments();
     LLINT_RETURN(ScopedArguments::createByCopying(globalObject, callFrame, table, scope));
 }
@@ -855,7 +855,7 @@ static void setupGetByIdPrototypeCache(JSGlobalObject* globalObject, VM& vm, Cod
     if (structure->isDictionary()) {
         if (structure->hasBeenFlattenedBefore())
             return;
-        structure->flattenDictionaryStructure(vm, jsCast<JSObject*>(baseCell));
+        structure->flattenDictionaryStructure(vm, uncheckedDowncast<JSObject>(baseCell));
     }
 
     prepareChainForCaching(globalObject, baseCell, ident.impl(), slot);
@@ -2045,7 +2045,7 @@ LLINT_SLOW_PATH_DECL(slow_path_set_function_name)
 {
     LLINT_BEGIN();
     auto bytecode = pc->as<OpSetFunctionName>();
-    JSFunction* func = jsCast<JSFunction*>(getNonConstantOperand(callFrame, bytecode.m_function));
+    JSFunction* func = uncheckedDowncast<JSFunction>(getNonConstantOperand(callFrame, bytecode.m_function));
     JSValue name = getOperand(callFrame, bytecode.m_name);
     func->setFunctionName(globalObject, name);
     LLINT_END();
@@ -2124,7 +2124,7 @@ static inline UGPRPair setUpCall(CallFrame* calleeFrame, CodeSpecializationKind 
         }
         RELEASE_AND_RETURN(throwScope, handleHostCall(calleeFrame, calleeAsValue, kind));
     }
-    JSFunction* callee = jsCast<JSFunction*>(calleeAsFunctionCell);
+    JSFunction* callee = uncheckedDowncast<JSFunction>(calleeAsFunctionCell);
     JSScope* scope = callee->scopeUnchecked();
     ExecutableBase* executable = callee->executable();
 
@@ -2283,7 +2283,7 @@ static inline UGPRPair commonCallDirectEval(CallFrame* callFrame, const JSInstru
     calleeFrame->setCodeBlock(nullptr);
     callFrame->setCurrentVPC(pc);
     
-    JSScope* callerScopeChain = jsCast<JSScope*>(getOperand(callFrame, bytecode.m_scope));
+    JSScope* callerScopeChain = uncheckedDowncast<JSScope>(getOperand(callFrame, bytecode.m_scope));
     JSValue thisValue = getOperand(callFrame, bytecode.m_thisValue);
     JSValue result = eval(calleeFrame, thisValue, callerScopeChain, codeBlock, BytecodeIndex(codeBlock->bytecodeOffset(pc)), bytecode.m_lexicallyScopedFeatures);
     LLINT_CALL_CHECK_EXCEPTION(globalObject);
@@ -2365,7 +2365,7 @@ LLINT_SLOW_PATH_DECL(slow_path_get_from_scope)
     auto bytecode = pc->as<OpGetFromScope>();
     auto& metadata = bytecode.metadata(codeBlock);
     const Identifier& ident = codeBlock->identifier(bytecode.m_var);
-    JSObject* scope = jsCast<JSObject*>(getNonConstantOperand(callFrame, bytecode.m_scope));
+    JSObject* scope = uncheckedDowncast<JSObject>(getNonConstantOperand(callFrame, bytecode.m_scope));
 
     // ModuleVar is always converted to ClosureVar for get_from_scope.
     ASSERT(metadata.m_getPutInfo.resolveType() != ModuleVar);
@@ -2400,10 +2400,10 @@ LLINT_SLOW_PATH_DECL(slow_path_put_to_scope)
     auto bytecode = pc->as<OpPutToScope>();
     auto& metadata = bytecode.metadata(codeBlock);
     const Identifier& ident = codeBlock->identifier(bytecode.m_var);
-    JSObject* scope = jsCast<JSObject*>(getNonConstantOperand(callFrame, bytecode.m_scope));
+    JSObject* scope = uncheckedDowncast<JSObject>(getNonConstantOperand(callFrame, bytecode.m_scope));
     JSValue value = getOperand(callFrame, bytecode.m_value);
     if (metadata.m_getPutInfo.resolveType() == ResolvedClosureVar) {
-        JSLexicalEnvironment* environment = jsCast<JSLexicalEnvironment*>(scope);
+        JSLexicalEnvironment* environment = uncheckedDowncast<JSLexicalEnvironment>(scope);
         environment->variableAt(ScopeOffset(metadata.m_operand)).set(vm, environment, value);
         
         // Have to do this *after* the write, because if this puts the set into IsWatched, then we need

--- a/Source/JavaScriptCore/lol/LOLJIT.cpp
+++ b/Source/JavaScriptCore/lol/LOLJIT.cpp
@@ -1784,7 +1784,7 @@ void LOLJIT::emit_op_new_reg_exp(const JSInstruction* currentInstruction)
     constexpr GPRReg globalObjectGPR = preferredArgumentGPR<Operation, 0>();
 
     loadGlobalObject(globalObjectGPR);
-    callOperation(operationNewRegExp, globalObjectGPR, TrustedImmPtr(jsCast<RegExp*>(m_unlinkedCodeBlock->getConstant(regexp))));
+    callOperation(operationNewRegExp, globalObjectGPR, TrustedImmPtr(uncheckedDowncast<RegExp>(m_unlinkedCodeBlock->getConstant(regexp))));
     boxCell(returnValueGPR, returnValueJSR);
     emitPutVirtualRegister(dst, returnValueJSR);
 

--- a/Source/JavaScriptCore/lol/LOLJITOperations.cpp
+++ b/Source/JavaScriptCore/lol/LOLJITOperations.cpp
@@ -102,7 +102,7 @@ JSC_DEFINE_JIT_OPERATION(operationResolveScopeForLOL, EncodedJSValue, (CallFrame
     case UnresolvedProperty:
     case UnresolvedPropertyWithVarInjectionChecks: {
         if (resolvedScope->isGlobalObject()) {
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(resolvedScope);
+            JSGlobalObject* globalObject = uncheckedDowncast<JSGlobalObject>(resolvedScope);
             bool hasProperty = globalObject->hasProperty(globalObject, ident);
             OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
             if (hasProperty) {
@@ -112,7 +112,7 @@ JSC_DEFINE_JIT_OPERATION(operationResolveScopeForLOL, EncodedJSValue, (CallFrame
                 metadata.m_globalLexicalBindingEpoch = globalObject->globalLexicalBindingEpoch();
             }
         } else if (resolvedScope->isGlobalLexicalEnvironment()) {
-            JSGlobalLexicalEnvironment* globalLexicalEnvironment = jsCast<JSGlobalLexicalEnvironment*>(resolvedScope);
+            JSGlobalLexicalEnvironment* globalLexicalEnvironment = uncheckedDowncast<JSGlobalLexicalEnvironment>(resolvedScope);
             ConcurrentJSLocker locker(codeBlock->m_lock);
             metadata.m_resolveType = needsVarInjectionChecks(resolveType) ? GlobalLexicalVarWithVarInjectionChecks : GlobalLexicalVar;
             metadata.m_globalLexicalEnvironment.set(vm, codeBlock, globalLexicalEnvironment);
@@ -186,7 +186,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutToScopeForLOL, void, (CallFrame* callFrame,
     ASSERT(getPutInfo.resolveType() != ModuleVar);
 
     if (getPutInfo.resolveType() == ResolvedClosureVar) {
-        JSLexicalEnvironment* environment = jsCast<JSLexicalEnvironment*>(jsScope);
+        JSLexicalEnvironment* environment = uncheckedDowncast<JSLexicalEnvironment>(jsScope);
         environment->variableAt(ScopeOffset(metadata.m_operand)).set(vm, environment, value);
         if (RefPtr set = metadata.m_watchpointSet)
             set->touch(vm, "Executed op_put_scope<ResolvedClosureVar>");

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -281,7 +281,7 @@ template<typename Visitor>
 void Element::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     DollarVMAssertScope assertScope;
-    Element* thisObject = jsCast<Element*>(cell);
+    Element* thisObject = uncheckedDowncast<Element>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_root);
@@ -297,7 +297,7 @@ public:
         DollarVMAssertScope assertScope;
         if (reason) [[unlikely]]
             *reason = "JSC::Element is opaque root"_s;
-        Element* element = jsCast<Element*>(handle.slot()->asCell());
+        Element* element = uncheckedDowncast<Element>(handle.slot()->asCell());
         return visitor.containsOpaqueRoot(element->root());
     }
 };
@@ -428,7 +428,7 @@ template<typename Visitor>
 void SimpleObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     DollarVMAssertScope assertScope;
-    SimpleObject* thisObject = jsCast<SimpleObject*>(cell);
+    SimpleObject* thisObject = uncheckedDowncast<SimpleObject>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_hiddenValue);
@@ -481,7 +481,7 @@ public:
         DollarVMAssertScope assertScope;
         VM& vm = globalObject->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
-        ImpureGetter* thisObject = jsCast<ImpureGetter*>(object);
+        ImpureGetter* thisObject = uncheckedDowncast<ImpureGetter>(object);
         
         if (thisObject->m_delegate) {
             if (thisObject->m_delegate->getPropertySlot(globalObject, name, slot))
@@ -509,7 +509,7 @@ void ImpureGetter::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     DollarVMAssertScope assertScope;
     ASSERT_GC_OBJECT_INHERITS(cell, info());
     Base::visitChildren(cell, visitor);
-    ImpureGetter* thisObject = jsCast<ImpureGetter*>(cell);
+    ImpureGetter* thisObject = uncheckedDowncast<ImpureGetter>(cell);
     visitor.append(thisObject->m_delegate);
 }
 
@@ -554,7 +554,7 @@ public:
     {
         DollarVMAssertScope assertScope;
         VM& vm = globalObject->vm();
-        CustomGetter* thisObject = jsCast<CustomGetter*>(object);
+        CustomGetter* thisObject = uncheckedDowncast<CustomGetter>(object);
         if (propertyName == PropertyName(Identifier::fromString(vm, "customGetter"_s))) {
             slot.setCacheableCustom(thisObject, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum, customGetterValueGetter);
             return true;
@@ -641,7 +641,7 @@ IGNORE_WARNINGS_END
     {
         DollarVMAssertScope assertScope;
         VM& vm = globalObject->vm();
-        RuntimeArray* thisObject = jsCast<RuntimeArray*>(object);
+        RuntimeArray* thisObject = uncheckedDowncast<RuntimeArray>(object);
         if (propertyName == vm.propertyNames->length) {
             slot.setCacheableCustom(thisObject, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum, runtimeArrayLengthGetter);
             return true;
@@ -659,7 +659,7 @@ IGNORE_WARNINGS_END
     static bool getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* globalObject, unsigned index, PropertySlot& slot)
     {
         DollarVMAssertScope assertScope;
-        RuntimeArray* thisObject = jsCast<RuntimeArray*>(object);
+        RuntimeArray* thisObject = uncheckedDowncast<RuntimeArray>(object);
         if (index < thisObject->getLength()) {
             slot.setValue(thisObject, PropertyAttribute::DontDelete | PropertyAttribute::DontEnum, jsNumber(thisObject->m_vector[index]));
             return true;
@@ -1003,7 +1003,7 @@ public:
     static bool put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
     {
         DollarVMAssertScope assertScope;
-        auto* thisObject = jsCast<ObjectDoingSideEffectPutWithoutCorrectSlotStatus*>(cell);
+        auto* thisObject = uncheckedDowncast<ObjectDoingSideEffectPutWithoutCorrectSlotStatus>(cell);
         auto throwScope = DECLARE_THROW_SCOPE(globalObject->vm());
         auto* string = value.toString(globalObject);
         RETURN_IF_EXCEPTION(throwScope, false);
@@ -1728,7 +1728,7 @@ JSC_DEFINE_CUSTOM_GETTER(customGetValue2, (JSGlobalObject* globalObject, Encoded
 
     RELEASE_ASSERT(JSValue::decode(slotValue).inherits<JSTestCustomGetterSetter>());
 
-    auto* target = jsCast<JSTestCustomGetterSetter*>(JSValue::decode(slotValue));
+    auto* target = uncheckedDowncast<JSTestCustomGetterSetter>(JSValue::decode(slotValue));
     JSValue value = target->getDirect(vm, Identifier::fromString(vm, "value2"_s));
     return JSValue::encode(value ? value : jsUndefined());
 }
@@ -1817,7 +1817,7 @@ JSC_DEFINE_CUSTOM_SETTER(customSetValue2, (JSGlobalObject* globalObject, Encoded
     VM& vm = globalObject->vm();
 
     RELEASE_ASSERT(JSValue::decode(slotValue).inherits<JSTestCustomGetterSetter>());
-    auto* target = jsCast<JSTestCustomGetterSetter*>(JSValue::decode(slotValue));
+    auto* target = uncheckedDowncast<JSTestCustomGetterSetter>(JSValue::decode(slotValue));
     PutPropertySlot slot(target);
     target->putDirect(vm, Identifier::fromString(vm, "value2"_s), JSValue::decode(encodedValue));
     return true;
@@ -2073,7 +2073,7 @@ template<typename Visitor>
 void WasmStreamingCompiler::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     DollarVMAssertScope assertScope;
-    auto* thisObject = jsCast<WasmStreamingCompiler*>(cell);
+    auto* thisObject = uncheckedDowncast<WasmStreamingCompiler>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_promise);
@@ -3098,7 +3098,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(functionCallWithStackSize, SUPPRESS_ASA
     helper.updateVMStackLimits();
 
 #if OS(DARWIN) && CPU(X86_64)
-    JSFunction* function = jsCast<JSFunction*>(arg0);
+    JSFunction* function = uncheckedDowncast<JSFunction>(arg0);
 
     __asm__ volatile (
         "subq %[sizeDiff], %%rsp" "\n"
@@ -3600,7 +3600,7 @@ JSC_DEFINE_HOST_FUNCTION(functionShadowChickenFunctionsOnStack, (JSGlobalObject*
             return IterationStatus::Continue;
         if (visitor->isNativeCalleeFrame())
             return IterationStatus::Continue;
-        result->push(globalObject, jsCast<JSObject*>(visitor->callee().asCell()));
+        result->push(globalObject, uncheckedDowncast<JSObject>(visitor->callee().asCell()));
         scope.releaseAssertNoException(); // This function is only called from tests.
         return IterationStatus::Continue;
     });
@@ -3790,7 +3790,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGlobalObjectForObject, (JSGlobalObject*, CallFr
     DollarVMAssertScope assertScope;
     JSValue value = callFrame->argument(0);
     RELEASE_ASSERT(value.isObject());
-    JSGlobalObject* result = jsCast<JSObject*>(value)->realmMayBeNull();
+    JSGlobalObject* result = uncheckedDowncast<JSObject>(value)->realmMayBeNull();
     if (!result)
         return JSValue::encode(jsUndefined());
     return JSValue::encode(result->globalThis());
@@ -3972,7 +3972,7 @@ JSC_DEFINE_HOST_FUNCTION(functionHasOwnLengthProperty, (JSGlobalObject* globalOb
 JSC_DEFINE_HOST_FUNCTION(functionRejectPromiseAsHandled, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
-    JSPromise* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(0));
+    JSPromise* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
     JSValue reason = callFrame->uncheckedArgument(1);
     promise->rejectAsHandled(globalObject->vm(), globalObject, reason);
     return JSValue::encode(jsUndefined());
@@ -4301,7 +4301,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCallFromCPP, (JSGlobalObject* globalObject, Cal
     auto callData = JSC::getCallData(callback);
     if (callData.type == CallData::Type::None)
         return JSValue::encode(jsUndefined());
-    auto* callbackObject = jsCast<JSObject*>(callback);
+    auto* callbackObject = uncheckedDowncast<JSObject>(callback);
 
     int32_t count = callFrame->argument(1).toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -4335,7 +4335,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCachedCallFromCPP, (JSGlobalObject* globalObjec
     auto callData = JSC::getCallData(callback);
     if (callData.type != CallData::Type::JS)
         return JSValue::encode(jsUndefined());
-    auto* callbackObject = jsCast<JSFunction*>(callback);
+    auto* callbackObject = uncheckedDowncast<JSFunction>(callback);
 
     int32_t count = callFrame->argument(1).toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
@@ -4604,7 +4604,7 @@ void JSDollarVM::getOwnPropertyNames(JSObject* object, JSGlobalObject* globalObj
 template<typename Visitor>
 void JSDollarVM::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSDollarVM* thisObject = jsCast<JSDollarVM*>(cell);
+    JSDollarVM* thisObject = uncheckedDowncast<JSDollarVM>(cell);
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_objectDoingSideEffectPutWithoutCorrectSlotStatusStructureID);
 }

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -361,13 +361,13 @@ public:
             if (arraySignature.as<Wasm::ArrayType>()->elementType().type.unpacked().isV128()) {
                 result = createNewArray(structure, args.size(), { vectorAllZeros() });
                 WASM_ALLOCATOR_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
-                JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(JSValue::decode(result.getValue()));
+                JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(JSValue::decode(result.getValue()));
                 for (size_t i = 0; i < args.size(); i++)
                     arrayObject->set(arrayObject->vm(), i, args[i].value().getVector());
             } else {
                 result = createNewArray(structure, args.size(), { });
                 WASM_ALLOCATOR_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
-                JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(JSValue::decode(result.getValue()));
+                JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(JSValue::decode(result.getValue()));
                 for (size_t i = 0; i < args.size(); i++)
                     arrayObject->set(arrayObject->vm(), i, args[i].value().getValue());
             }
@@ -411,7 +411,7 @@ public:
         if (m_mode == Mode::Evaluate) {
             result = createNewStruct(typeIndex);
             WASM_ALLOCATOR_FAIL_IF(result.isInvalid(), "Failed to allocate new struct"_s);
-            JSWebAssemblyStruct* structObject = jsCast<JSWebAssemblyStruct*>(JSValue::decode(result.getValue()));
+            JSWebAssemblyStruct* structObject = uncheckedDowncast<JSWebAssemblyStruct>(JSValue::decode(result.getValue()));
             for (size_t i = 0; i < args.size(); i++) {
                 if (args[i].value().type() == ConstExprValue::Vector)
                     structObject->set(i, args[i].value().getVector());

--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -93,7 +93,7 @@ void validateWasmValue(uint64_t wasmValue, Type expectedType)
                 ASSERT(is<JSFunction>(value));
                 return;
             }
-            auto objectPtr = jsCast<WebAssemblyGCObjectBase*>(value);
+            auto objectPtr = uncheckedDowncast<WebAssemblyGCObjectBase>(value);
             auto& objectRTT = objectPtr->rtt();
             ASSERT(objectRTT.isSubRTT(expectedRTT.get()));
         }

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -713,7 +713,7 @@ WASM_IPINT_EXTERN_CPP_DECL(struct_get_s, EncodedJSValue object, uint32_t fieldIn
     Wasm::structGet(object, fieldIndex, result);
 
     // sign extension
-    JSWebAssemblyStruct* structObject = jsCast<JSWebAssemblyStruct*>(JSValue::decode(object).getObject());
+    JSWebAssemblyStruct* structObject = uncheckedDowncast<JSWebAssemblyStruct>(JSValue::decode(object).getObject());
     Wasm::StorageType type = structObject->fieldType(fieldIndex).type;
     ASSERT(type.is<Wasm::PackedType>());
     size_t elementSize = type.as<Wasm::PackedType>() == Wasm::PackedType::I8 ? sizeof(uint8_t) : sizeof(uint16_t);
@@ -820,7 +820,7 @@ WASM_IPINT_EXTERN_CPP_DECL(array_get, uint32_t type, IPIntStackEntry* sp)
         IPINT_THROW(Wasm::ExceptionType::NullAccess);
     JSValue arrayValue = JSValue::decode(array);
     ASSERT(arrayValue.isObject());
-    JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(arrayValue.getObject());
+    JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(arrayValue.getObject());
     if (index >= arrayObject->size()) [[unlikely]]
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsArrayGet);
     Wasm::arrayGet(instance, type, array, index, result);
@@ -840,7 +840,7 @@ WASM_IPINT_EXTERN_CPP_DECL(array_get_s, uint32_t type, IPIntStackEntry* sp)
         IPINT_THROW(Wasm::ExceptionType::NullAccess);
     JSValue arrayValue = JSValue::decode(array);
     ASSERT(arrayValue.isObject());
-    JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(arrayValue.getObject());
+    JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(arrayValue.getObject());
     if (index >= arrayObject->size()) [[unlikely]]
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsArrayGet);
 
@@ -868,7 +868,7 @@ WASM_IPINT_EXTERN_CPP_DECL(array_set, uint32_t type, IPIntStackEntry* sp)
 
     JSValue arrayValue = JSValue::decode(sp[2].ref);
     ASSERT(arrayValue.isObject());
-    JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(arrayValue.getObject());
+    JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(arrayValue.getObject());
     uint32_t index = static_cast<uint32_t>(sp[1].i32);
 
     if (index >= arrayObject->size()) [[unlikely]]
@@ -891,7 +891,7 @@ WASM_IPINT_EXTERN_CPP_DECL(array_fill, IPIntStackEntry* sp)
         IPINT_THROW(Wasm::ExceptionType::NullArrayFill);
 
     ASSERT(arrayValue.isObject());
-    JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(arrayValue.getObject());
+    JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(arrayValue.getObject());
 
     uint32_t offset = sp[2].i32;
     IPIntStackEntry* value = &sp[1];
@@ -1147,7 +1147,7 @@ WASM_IPINT_EXTERN_CPP_DECL(prepare_call_indirect, CallFrame* callFrame, Wasm::Fu
 
     Register& functionInfoSlot = calleeReturn[1];
     if (function->m_function.isJS())
-        functionInfoSlot = reinterpret_cast<uintptr_t>(jsCast<WebAssemblyFunctionBase*>(function->m_value.get())->callLinkInfo());
+        functionInfoSlot = reinterpret_cast<uintptr_t>(uncheckedDowncast<WebAssemblyFunctionBase>(function->m_value.get())->callLinkInfo());
     else {
         auto* targetInstance = function->m_function.targetInstance.get();
         functionInfoSlot = targetInstance;
@@ -1175,10 +1175,10 @@ WASM_IPINT_EXTERN_CPP_DECL(prepare_call_ref, CallFrame* callFrame, CallRefMetada
         IPINT_THROW(Wasm::ExceptionType::NullReference);
 
     ASSERT(targetReference.isObject());
-    JSObject* referenceAsObject = jsCast<JSObject*>(targetReference);
+    JSObject* referenceAsObject = uncheckedDowncast<JSObject>(targetReference);
 
     ASSERT(referenceAsObject->inherits<WebAssemblyFunctionBase>());
-    auto* wasmFunction = jsCast<WebAssemblyFunctionBase*>(referenceAsObject);
+    auto* wasmFunction = uncheckedDowncast<WebAssemblyFunctionBase>(referenceAsObject);
     auto& function = wasmFunction->importableFunction();
     JSWebAssemblyInstance* calleeInstance = wasmFunction->instance();
     auto boxedCallee = function.boxedCallee.encodedBits();

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -300,7 +300,7 @@ inline void arrayGet(JSWebAssemblyInstance* instance, uint32_t typeIndex, Encode
 
     JSValue arrayRef = JSValue::decode(arrayValue);
     ASSERT(arrayRef.isObject());
-    JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(arrayRef.getObject());
+    JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(arrayRef.getObject());
 
     if (arrayObject->elementType().type.unpacked().isV128())
         result->v128 = arrayObject->getVector(index);
@@ -316,7 +316,7 @@ inline void arraySet(JSWebAssemblyInstance* instance, uint32_t typeIndex, Encode
 
     JSValue arrayRef = JSValue::decode(arrayValue);
     ASSERT(arrayRef.isObject());
-    JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(arrayRef.getObject());
+    JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(arrayRef.getObject());
 
     Wasm::FieldType elementType = arraySignature.as<ArrayType>()->elementType();
     if (elementType.type.unpacked().isV128())
@@ -329,7 +329,7 @@ inline bool doArrayFill(VM& vm, EncodedJSValue arrayValue, uint32_t offset, Vari
 {
     JSValue arrayRef = JSValue::decode(arrayValue);
     ASSERT(arrayRef.isObject());
-    JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(arrayRef.getObject());
+    JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(arrayRef.getObject());
 
     CheckedUint32 lastElementIndexChecked = offset;
     lastElementIndexChecked += size;
@@ -368,8 +368,8 @@ inline bool arrayCopy(JSWebAssemblyInstance* instance, EncodedJSValue dst, uint3
     JSValue srcRef = JSValue::decode(src);
     ASSERT(dstRef.isObject());
     ASSERT(srcRef.isObject());
-    JSWebAssemblyArray* dstObject = jsCast<JSWebAssemblyArray*>(dstRef.getObject());
-    JSWebAssemblyArray* srcObject = jsCast<JSWebAssemblyArray*>(srcRef.getObject());
+    JSWebAssemblyArray* dstObject = uncheckedDowncast<JSWebAssemblyArray>(dstRef.getObject());
+    JSWebAssemblyArray* srcObject = uncheckedDowncast<JSWebAssemblyArray>(srcRef.getObject());
 
     CheckedUint32 lastDstElementIndexChecked = dstOffset;
     lastDstElementIndexChecked += size;
@@ -397,7 +397,7 @@ inline bool arrayInitElem(JSWebAssemblyInstance* instance, EncodedJSValue dst, u
 {
     JSValue dstRef = JSValue::decode(dst);
     ASSERT(dstRef.isObject());
-    JSWebAssemblyArray* dstObject = jsCast<JSWebAssemblyArray*>(dstRef.getObject());
+    JSWebAssemblyArray* dstObject = uncheckedDowncast<JSWebAssemblyArray>(dstRef.getObject());
 
     CheckedUint32 lastDstElementIndexChecked = dstOffset;
     lastDstElementIndexChecked += size;
@@ -433,7 +433,7 @@ inline bool arrayInitData(JSWebAssemblyInstance* instance, EncodedJSValue dst, u
 {
     JSValue dstRef = JSValue::decode(dst);
     ASSERT(dstRef.isObject());
-    JSWebAssemblyArray* dstObject = jsCast<JSWebAssemblyArray*>(dstRef.getObject());
+    JSWebAssemblyArray* dstObject = uncheckedDowncast<JSWebAssemblyArray>(dstRef.getObject());
 
     CheckedUint32 lastDstElementIndexChecked = dstOffset;
     lastDstElementIndexChecked += size;
@@ -498,9 +498,9 @@ inline void structGet(EncodedJSValue encodedStructReference, uint32_t fieldIndex
 {
     auto structReference = JSValue::decode(encodedStructReference);
     ASSERT(structReference.isObject());
-    JSObject* structureAsObject = jsCast<JSObject*>(structReference);
+    JSObject* structureAsObject = uncheckedDowncast<JSObject>(structReference);
     ASSERT(structureAsObject->inherits<JSWebAssemblyStruct>());
-    JSWebAssemblyStruct* structPointer = jsCast<JSWebAssemblyStruct*>(structureAsObject);
+    JSWebAssemblyStruct* structPointer = uncheckedDowncast<JSWebAssemblyStruct>(structureAsObject);
 
     Wasm::FieldType field = structPointer->fieldType(fieldIndex);
     if (field.type.unpacked().isV128())
@@ -513,9 +513,9 @@ inline void structSet(EncodedJSValue encodedStructReference, uint32_t fieldIndex
 {
     auto structReference = JSValue::decode(encodedStructReference);
     ASSERT(structReference.isObject());
-    JSObject* structureAsObject = jsCast<JSObject*>(structReference);
+    JSObject* structureAsObject = uncheckedDowncast<JSObject>(structReference);
     ASSERT(structureAsObject->inherits<JSWebAssemblyStruct>());
-    JSWebAssemblyStruct* structPointer = jsCast<JSWebAssemblyStruct*>(structureAsObject);
+    JSWebAssemblyStruct* structPointer = uncheckedDowncast<JSWebAssemblyStruct>(structureAsObject);
 
     Wasm::FieldType field = structPointer->fieldType(fieldIndex);
     if (field.type.unpacked().isV128())

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -154,8 +154,8 @@ void StreamingCompiler::didComplete()
     switch (m_compilerMode) {
     case CompilerMode::Validation: {
         m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [result = WTF::move(result), compileOptions = WTF::move(m_compileOptions)](DeferredWorkTimer::Ticket ticket) mutable {
-            JSPromise* promise = jsCast<JSPromise*>(ticket->target());
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies()[0]);
+            JSPromise* promise = uncheckedDowncast<JSPromise>(ticket->target());
+            JSGlobalObject* globalObject = uncheckedDowncast<JSGlobalObject>(ticket->dependencies()[0]);
             VM& vm = globalObject->vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -186,9 +186,9 @@ void StreamingCompiler::didComplete()
     case CompilerMode::FullCompile: {
         RefPtr<SourceProvider> provider = m_source.provider();
         m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [result = WTF::move(result), provider = WTF::move(provider), compileOptions = WTF::move(m_compileOptions)](DeferredWorkTimer::Ticket ticket) mutable {
-            JSPromise* promise = jsCast<JSPromise*>(ticket->target());
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies()[0]);
-            JSObject* importObject = jsCast<JSObject*>(ticket->dependencies()[1]);
+            JSPromise* promise = uncheckedDowncast<JSPromise>(ticket->target());
+            JSGlobalObject* globalObject = uncheckedDowncast<JSGlobalObject>(ticket->dependencies()[0]);
+            JSObject* importObject = uncheckedDowncast<JSObject>(ticket->dependencies()[1]);
             VM& vm = globalObject->vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -244,7 +244,7 @@ void StreamingCompiler::fail(JSGlobalObject* globalObject, JSValue error)
         m_eagerFailed = true;
     }
     auto ticket = std::exchange(m_ticket, nullptr);
-    JSPromise* promise = jsCast<JSPromise*>(ticket->target());
+    JSPromise* promise = uncheckedDowncast<JSPromise>(ticket->target());
     // The pending work TicketData was keeping the promise alive. We need to
     // make sure it is reachable from the stack before we remove it from the
     // pending work list. Note: m_ticket stores it as a PackedPtr, which is not

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -336,7 +336,7 @@ void FuncRefTable::set(uint32_t index, JSValue value)
     if (value.isNull())
         clear(index);
     else
-        setFunction(index, jsCast<WebAssemblyFunctionBase*>(value));
+        setFunction(index, uncheckedDowncast<WebAssemblyFunctionBase>(value));
 }
 
 void FuncRefTable::registerInstance(JSWebAssemblyInstance& instance)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -61,7 +61,7 @@ STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSWebAssembly);
 #define DEFINE_CALLBACK_FOR_CONSTRUCTOR(capitalName, lowerName, properName, instanceType, jsName, prototypeBase, featureFlag) \
 static UNUSED_FUNCTION JSValue create##capitalName(VM&, JSObject* object) \
 { \
-    JSWebAssembly* webAssembly = jsCast<JSWebAssembly*>(object); \
+    JSWebAssembly* webAssembly = uncheckedDowncast<JSWebAssembly>(object); \
     JSGlobalObject* globalObject = webAssembly->realm(); \
     return globalObject->properName##Constructor(); \
 }
@@ -372,7 +372,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyInstantiateFunc, (JSGlobalObject* globalObje
 
     JSValue firstArgument = callFrame->argument(0);
     if (firstArgument.inherits<JSWebAssemblyModule>())
-        instantiate(vm, globalObject, promise, jsCast<JSWebAssemblyModule*>(firstArgument), importObject, WTF::move(provider), JSWebAssemblyInstance::createPrivateModuleKey(), Resolve::WithInstance, Wasm::CreationMode::FromJS, /* alwaysAsync */ true);
+        instantiate(vm, globalObject, promise, uncheckedDowncast<JSWebAssemblyModule>(firstArgument), importObject, WTF::move(provider), JSWebAssemblyInstance::createPrivateModuleKey(), Resolve::WithInstance, Wasm::CreationMode::FromJS, /* alwaysAsync */ true);
     else {
         auto compileOptions = WebAssemblyCompileOptions::tryCreate(globalObject, compileOptionsObject);
         RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
@@ -105,7 +105,7 @@ void JSWebAssemblyArray::copy(VM& vm, JSWebAssemblyArray& dst, uint32_t dstOffse
 template<typename Visitor>
 void JSWebAssemblyArray::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSWebAssemblyArray* thisObject = jsCast<JSWebAssemblyArray*>(cell);
+    JSWebAssemblyArray* thisObject = uncheckedDowncast<JSWebAssemblyArray>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
@@ -67,7 +67,7 @@ void JSWebAssemblyException::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     Base::visitChildren(cell, visitor);
 
-    auto* exception = jsCast<JSWebAssemblyException*>(cell);
+    auto* exception = uncheckedDowncast<JSWebAssemblyException>(cell);
     SUPPRESS_UNCOUNTED_LOCAL const auto& tagType = exception->tag().type();
     unsigned offset = 0;
     for (unsigned i = 0; i < tagType.argumentCount(); ++i) {

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.cpp
@@ -62,7 +62,7 @@ void JSWebAssemblyGlobal::destroy(JSCell* cell)
 template<typename Visitor>
 void JSWebAssemblyGlobal::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSWebAssemblyGlobal* thisObject = jsCast<JSWebAssemblyGlobal*>(cell);
+    JSWebAssemblyGlobal* thisObject = uncheckedDowncast<JSWebAssemblyGlobal>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -125,7 +125,7 @@ ALWAYS_INLINE std::span<const uint8_t> getWasmBufferFromValue(JSGlobalObject* gl
             RETURN_IF_EXCEPTION(throwScope, { });
         } else {
             IdempotentArrayBufferByteLengthGetter<std::memory_order_relaxed> getter;
-            if (!jsCast<JSDataView*>(arrayBufferView)->viewByteLength(getter)) [[unlikely]] {
+            if (!uncheckedDowncast<JSDataView>(arrayBufferView)->viewByteLength(getter)) [[unlikely]] {
                 throwTypeError(globalObject, throwScope, typedArrayBufferHasBeenDetachedErrorMessage);
                 return { };
             }
@@ -164,12 +164,12 @@ ALWAYS_INLINE Vector<uint8_t> createSourceBufferFromValue(VM& vm, JSGlobalObject
 ALWAYS_INLINE bool isWebAssemblyHostFunction(JSObject* object, WebAssemblyFunction*& wasmFunction, WebAssemblyWrapperFunction*& wasmWrapperFunction)
 {
     if (object->inherits<WebAssemblyFunction>()) {
-        wasmFunction = jsCast<WebAssemblyFunction*>(object);
+        wasmFunction = uncheckedDowncast<WebAssemblyFunction>(object);
         wasmWrapperFunction = nullptr;
         return true;
     }
     if (object->inherits<WebAssemblyWrapperFunction>()) {
-        wasmWrapperFunction = jsCast<WebAssemblyWrapperFunction*>(object);
+        wasmWrapperFunction = uncheckedDowncast<WebAssemblyWrapperFunction>(object);
         wasmFunction = nullptr;
         return true;
     }
@@ -180,7 +180,7 @@ ALWAYS_INLINE bool isWebAssemblyHostFunction(JSValue value, WebAssemblyFunction*
 {
     if (!value.isObject())
         return false;
-    return isWebAssemblyHostFunction(jsCast<JSObject*>(value), wasmFunction, wasmWrapperFunction);
+    return isWebAssemblyHostFunction(uncheckedDowncast<JSObject>(value), wasmFunction, wasmWrapperFunction);
 }
 
 ALWAYS_INLINE bool isWebAssemblyHostFunction(JSValue object)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -189,7 +189,7 @@ void JSWebAssemblyInstance::destroy(JSCell* cell)
 template<typename Visitor>
 void JSWebAssemblyInstance::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSWebAssemblyInstance*>(cell);
+    auto* thisObject = uncheckedDowncast<JSWebAssemblyInstance>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -410,7 +410,7 @@ public:
 
     WriteBarrierStructureID& gcObjectStructureID(unsigned index) { return gcObjectStructureIDs()[index]; }
 
-    WebAssemblyGCStructure* gcObjectStructure(unsigned typeIndex) { return jsCast<WebAssemblyGCStructure*>(gcObjectStructureID(typeIndex).get()); }
+    WebAssemblyGCStructure* gcObjectStructure(unsigned typeIndex) { return uncheckedDowncast<WebAssemblyGCStructure>(gcObjectStructureID(typeIndex).get()); }
 
     Allocator& allocatorForGCObject(unsigned index) { ASSERT(moduleInformation().hasGCObjectTypes()); return allocators()[index]; }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
@@ -334,7 +334,7 @@ void JSWebAssemblyMemory::destroy(JSCell* cell)
 template<typename Visitor>
 void JSWebAssemblyMemory::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    auto* thisObject = jsCast<JSWebAssemblyMemory*>(cell);
+    auto* thisObject = uncheckedDowncast<JSWebAssemblyMemory>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
@@ -111,7 +111,7 @@ Wasm::Module& JSWebAssemblyModule::module()
 template<typename Visitor>
 void JSWebAssemblyModule::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSWebAssemblyModule* thisObject = jsCast<JSWebAssemblyModule*>(cell);
+    JSWebAssemblyModule* thisObject = uncheckedDowncast<JSWebAssemblyModule>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -186,7 +186,7 @@ void JSWebAssemblyStruct::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     Base::visitChildren(cell, visitor);
 
-    auto* wasmStruct = jsCast<JSWebAssemblyStruct*>(cell);
+    auto* wasmStruct = uncheckedDowncast<JSWebAssemblyStruct>(cell);
     if (!wasmStruct->structType().hasRefFieldTypes()) {
 #if ASSERT_ENABLED
         for (unsigned i = 0; i < wasmStruct->structType().fieldCount(); ++i)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
@@ -64,7 +64,7 @@ void JSWebAssemblyTable::destroy(JSCell* cell)
 template<typename Visitor>
 void JSWebAssemblyTable::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    JSWebAssemblyTable* thisObject = jsCast<JSWebAssemblyTable*>(cell);
+    JSWebAssemblyTable* thisObject = uncheckedDowncast<JSWebAssemblyTable>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
@@ -509,7 +509,7 @@ DEFINE_BUILTIN_IMPLEMENTATION(jsstring, fromCharCodeArray, JSGlobalObject* globa
 
     // At this point 'array' must be an (array mut i16), guaranteed by Wasm type rules
     // or by a runtime check in JS entrypoint wrapper.
-    auto* array = jsCast<JSWebAssemblyArray*>(arrayObject);
+    auto* array = uncheckedDowncast<JSWebAssemblyArray>(arrayObject);
     ASSERT(isMutI16Array(array));
 
     if (startArg < 0 || endArg < 0)
@@ -545,10 +545,10 @@ DEFINE_BUILTIN_IMPLEMENTATION_I32(jsstring, intoCharCodeArray, JSGlobalObject* g
     if (!arrayObject || !stringArg.isString()) [[unlikely]]
         THROW_ILLEGAL_ARGUMENT_EXCEPTION;
 
-    JSString* string = jsCast<JSString*>(stringArg);
+    JSString* string = uncheckedDowncast<JSString>(stringArg);
     // At this point 'array' must be an (array mut i16), guaranteed by Wasm type rules
     // or by a runtime check in JS entrypoint wrapper.
-    auto* array = jsCast<JSWebAssemblyArray*>(arrayObject);
+    auto* array = uncheckedDowncast<JSWebAssemblyArray>(arrayObject);
     ASSERT(isMutI16Array(array));
 
     size_t stringLength = string->length();

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -64,7 +64,7 @@ static JSC_DECLARE_HOST_FUNCTION(callWebAssemblyFunction);
 JSC_DEFINE_HOST_FUNCTION(callWebAssemblyFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
-    WebAssemblyFunction* wasmFunction = jsCast<WebAssemblyFunction*>(callFrame->jsCallee());
+    WebAssemblyFunction* wasmFunction = uncheckedDowncast<WebAssemblyFunction>(callFrame->jsCallee());
 
     if (wasmFunction->instance()->taintedness() >= SourceTaintedOrigin::IndirectlyTainted)
         vm.setMightBeExecutingTaintedCode();
@@ -108,7 +108,7 @@ WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, J
 template<typename Visitor>
 void WebAssemblyFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    WebAssemblyFunction* thisObject = jsCast<WebAssemblyFunction*>(cell);
+    WebAssemblyFunction* thisObject = uncheckedDowncast<WebAssemblyFunction>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
 
     Base::visitChildren(thisObject, visitor);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp
@@ -48,7 +48,7 @@ WebAssemblyFunctionBase::WebAssemblyFunctionBase(VM& vm, NativeExecutable* execu
 template<typename Visitor>
 void WebAssemblyFunctionBase::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    WebAssemblyFunctionBase* thisObject = jsCast<WebAssemblyFunctionBase*>(cell);
+    WebAssemblyFunctionBase* thisObject = uncheckedDowncast<WebAssemblyFunctionBase>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_importableFunction.targetInstance);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
@@ -44,7 +44,7 @@ WebAssemblyGCObjectBase::WebAssemblyGCObjectBase(VM& vm, WebAssemblyGCStructure*
 template<typename Visitor>
 void WebAssemblyGCObjectBase::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    WebAssemblyGCObjectBase* thisObject = jsCast<WebAssemblyGCObjectBase*>(cell);
+    WebAssemblyGCObjectBase* thisObject = uncheckedDowncast<WebAssemblyGCObjectBase>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
@@ -56,7 +56,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyGlobal, (JSGlobalObject* globalOb
         JSValue argument = callFrame->argument(0);
         if (!argument.isObject())
             return throwVMTypeError(globalObject, throwScope, "WebAssembly.Global expects its first argument to be an object"_s);
-        globalDescriptor = jsCast<JSObject*>(argument);
+        globalDescriptor = uncheckedDowncast<JSObject>(argument);
     }
 
     Wasm::Mutability mutability;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
@@ -166,7 +166,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyMemory, (JSGlobalObject* globalOb
         JSValue argument = callFrame->argument(0);
         if (!argument.isObject())
             return JSValue::encode(throwException(globalObject, throwScope, createTypeError(globalObject, "WebAssembly.Memory expects its first argument to be an object"_s)));
-        memoryDescriptor = jsCast<JSObject*>(argument);
+        memoryDescriptor = uncheckedDowncast<JSObject>(argument);
     }
 
     JSWebAssemblyMemory* memory = WebAssemblyMemoryConstructor::createMemoryFromDescriptor(globalObject, webAssemblyMemoryStructure, memoryDescriptor);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -88,7 +88,7 @@ void WebAssemblyModuleRecord::finishCreation(JSGlobalObject* globalObject, VM& v
 template<typename Visitor>
 void WebAssemblyModuleRecord::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    WebAssemblyModuleRecord* thisObject = jsCast<WebAssemblyModuleRecord*>(cell);
+    WebAssemblyModuleRecord* thisObject = uncheckedDowncast<WebAssemblyModuleRecord>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_instance);
@@ -202,7 +202,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                 return exception(createTypeError(globalObject, importFailMessage(import, "import"_s, "must be an object"_s), defaultSourceAppender, runtimeTypeForValue(importModuleValue)));
 
             // 3. Let v be the value of performing Get(o, i.item_name)
-            JSObject* object = jsCast<JSObject*>(importModuleValue);
+            JSObject* object = uncheckedDowncast<JSObject>(importModuleValue);
             value = object->get(globalObject, fieldName);
             RETURN_IF_EXCEPTION(scope, void());
         } else {
@@ -258,7 +258,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
             JSWebAssemblyInstance* calleeInstance = m_instance.get();
             WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = nullptr;
             CalleeBits boxedCallee { &Wasm::WasmToJSCallee::singleton() };
-            JSObject* function = jsCast<JSObject*>(value);
+            JSObject* function = uncheckedDowncast<JSObject>(value);
 
             // ii. If v is an Exported Function Exotic Object:
             WebAssemblyFunction* wasmFunction;
@@ -301,7 +301,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
             const Wasm::GlobalInformation& global = moduleInformation.globals[import.kindIndex];
             if (global.mutability == Wasm::Immutable) {
                 if (value.inherits<JSWebAssemblyGlobal>()) {
-                    JSWebAssemblyGlobal* globalValue = jsCast<JSWebAssemblyGlobal*>(value);
+                    JSWebAssemblyGlobal* globalValue = uncheckedDowncast<JSWebAssemblyGlobal>(value);
                     if (!Wasm::isSubtype(globalValue->global()->type(), global.type))
                         return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "must be a same type"_s)));
                     if (globalValue->global()->mutability() != Wasm::Immutable)
@@ -418,7 +418,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
             } else {
                 if (!value.inherits<JSWebAssemblyGlobal>())
                     return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "must be a WebAssembly.Global object since it is mutable"_s)));
-                JSWebAssemblyGlobal* globalValue = jsCast<JSWebAssemblyGlobal*>(value);
+                JSWebAssemblyGlobal* globalValue = uncheckedDowncast<JSWebAssemblyGlobal>(value);
                 if (!isSubtype(globalValue->global()->type(), global.type) || !isSubtype(global.type, globalValue->global()->type()))
                     return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "must be a same type"_s)));
                 if (globalValue->global()->mutability() != global.mutability)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
@@ -48,9 +48,9 @@ JSC_DEFINE_HOST_FUNCTION(runWebAssemblyPromisingFunction, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSObject* callee = callFrame->jsCallee();
-    JSFunctionWithFields* thisFunction = jsCast<JSFunctionWithFields*>(callee);
+    JSFunctionWithFields* thisFunction = uncheckedDowncast<JSFunctionWithFields>(callee);
     ASSERT(thisFunction);
-    JSFunction* wrappedFunction = jsCast<JSFunction*>(thisFunction->getField(JSFunctionWithFields::Field::WebAssemblyPromisingWrappedFunction));
+    JSFunction* wrappedFunction = uncheckedDowncast<JSFunction>(thisFunction->getField(JSFunctionWithFields::Field::WebAssemblyPromisingWrappedFunction));
 
     MarkedArgumentBuffer args;
     for (unsigned i = 0; i < callFrame->argumentCount(); ++i)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
@@ -116,7 +116,7 @@ void* runWebAssemblySuspendingFunction(JSGlobalObject* globalObject, CallFrame* 
     memcpySpan(std::span<CPURegister>(vmEntryFrameCalleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS), std::span(originalCalleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS));
 
     JSObject* callee = callFrame->jsCallee();
-    JSFunctionWithFields* self = jsCast<JSFunctionWithFields*>(callee);
+    JSFunctionWithFields* self = uncheckedDowncast<JSFunctionWithFields>(callee);
     JSValue callable = self->getField(JSFunctionWithFields::Field::WebAssemblySuspendingWrappedCallable);
 
     MarkedArgumentBuffer args;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
@@ -57,7 +57,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTable, (JSGlobalObject* globalObj
         JSValue argument = callFrame->argument(0);
         if (!argument.isObject())
             return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table expects its first argument to be an object"_s);
-        memoryDescriptor = jsCast<JSObject*>(argument);
+        memoryDescriptor = uncheckedDowncast<JSObject>(argument);
     }
 
     Wasm::TableElementType type;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
@@ -86,7 +86,7 @@ Structure* WebAssemblyWrapperFunction::createStructure(VM& vm, JSGlobalObject* g
 template<typename Visitor>
 void WebAssemblyWrapperFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    WebAssemblyWrapperFunction* thisObject = jsCast<WebAssemblyWrapperFunction*>(cell);
+    WebAssemblyWrapperFunction* thisObject = uncheckedDowncast<WebAssemblyWrapperFunction>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
@@ -99,7 +99,7 @@ JSC_DEFINE_HOST_FUNCTION(callWebAssemblyWrapperFunction, (JSGlobalObject* global
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    WebAssemblyWrapperFunction* wasmFunction = jsCast<WebAssemblyWrapperFunction*>(callFrame->jsCallee());
+    WebAssemblyWrapperFunction* wasmFunction = uncheckedDowncast<WebAssemblyWrapperFunction>(callFrame->jsCallee());
     JSObject* function = wasmFunction->function();
     auto callData = JSC::getCallDataInline(function);
     RELEASE_ASSERT(callData.type != CallData::Type::None);


### PR DESCRIPTION
#### e60220202a25de19758649614dd0611531782060
<pre>
Further reduce use of jsCast&lt;&gt;()
<a href="https://bugs.webkit.org/show_bug.cgi?id=312742">https://bugs.webkit.org/show_bug.cgi?id=312742</a>

Reviewed by Anne van Kesteren.

Further reduce use of jsCast&lt;&gt;(), in favor of uncheckedDowncast&lt;&gt;().

* Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp:
(JSC::WebAssemblyWrapperFunction::visitChildrenImpl):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/311565@main">https://commits.webkit.org/311565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe8ace51385047cd31876f941d4853a2a628ca3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166204 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111462 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c07bccaa-028c-4edb-95da-5aa014beacb0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121894 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85603 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c7c5b2b-bde9-48ef-a8fd-9fa154e84ce2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102562 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a317d6e8-9258-4364-b136-660c3442af62) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23197 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21445 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13975 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149431 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168689 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18215 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12847 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20765 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130032 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130139 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35245 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140939 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88172 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24967 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17744 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/189453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29952 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93966 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/189453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29474 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29704 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29601 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->