### PR TITLE
Copy webpushd launchd plist inside relocatable bundles

### DIFF
--- a/Source/WebKit/Configurations/webpushd.xcconfig
+++ b/Source/WebKit/Configurations/webpushd.xcconfig
@@ -78,7 +78,7 @@ LAUNCHD_PLIST_INPUT_FILE_MAC_YES = webpushd/com.apple.webkit.webpushd.relocatabl
 
 LAUNCHD_PLIST_INSTALL_PATH = $(LAUNCHD_PLIST_INSTALL_PATH_$(WK_RELOCATABLE_WEBPUSHD))
 LAUNCHD_PLIST_INSTALL_PATH_YES = /System/Library/LaunchDaemons
-LAUNCHD_PLIST_INSTALL_PATH_YES[sdk=macos*] = /Library/Apple/System/Library/LaunchAgents
+LAUNCHD_PLIST_INSTALL_PATH_YES[sdk=macos*] = $(WK_OVERRIDE_FRAMEWORKS_DIR)/../Library/LaunchAgents
 
 LAUNCHD_PLIST_INSTALL_PATH_NO = /System/Library/LaunchDaemons
 LAUNCHD_PLIST_INSTALL_PATH_NO[sdk=macos*] = $(SYSTEM_SECONDARY_CONTENT_PATH)/System/Library/LaunchAgents

--- a/Source/WebKit/Scripts/copy-launchd-plist-and-create-symlink.sh
+++ b/Source/WebKit/Scripts/copy-launchd-plist-and-create-symlink.sh
@@ -50,8 +50,8 @@ if [[ "${USE_SYSTEM_CONTENT_PATH}" == "YES" ]]; then
         exit 0;
     fi
 else
-    if [[ ${PLATFORM_NAME} != "macosx" || "${USE_STAGING_INSTALL_PATH}" == "YES" ]]; then
-        echo "Not creating symlink because current platform is not macOS or this isn't a standard install."
+    if [[ ${PLATFORM_NAME} != "macosx" || "${USE_STAGING_INSTALL_PATH}" == "YES" || "${WK_RELOCATABLE_WEBPUSHD}" == "YES" ]]; then
+        echo "Not creating symlink because current platform is not macOS, or this isn't a standard install."
         exit 0;
     fi
 fi


### PR DESCRIPTION
#### 539dc85659231a9a5b015351c322a06284d868f1
<pre>
Copy webpushd launchd plist inside relocatable bundles
<a href="https://rdar.apple.com/173912259">rdar://173912259</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312746">https://bugs.webkit.org/show_bug.cgi?id=312746</a>

Reviewed by NOBODY (OOPS!).

We need to place relocatable webpushd&apos;s launchd plist inside the relocatable bundle instead of install to a system path.

* Source/WebKit/Configurations/webpushd.xcconfig:
* Source/WebKit/Scripts/copy-launchd-plist-and-create-symlink.sh:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/539dc85659231a9a5b015351c322a06284d868f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166213 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111471 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c46f74a1-ea12-4c88-beae-a63b178b4d71) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121901 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85609 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c61aafec-d026-467a-becb-cfb50e4c2b47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102569 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2b7586a-e2c5-433c-89d0-e74e91e61071) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/156711 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23203 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21450 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13984 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132882 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168698 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130037 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130144 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140950 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88181 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17755 "Passed tests") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29961 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93975 "Built successfully") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29483 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29713 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29610 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->