### PR TITLE
Speed up IDL bindings generation build step

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2864,7 +2864,7 @@ add_custom_command(
     OUTPUT ${WebCore_DERIVED_SOURCES_DIR}/UserAgentStyleSheetsData.cpp ${WebCore_DERIVED_SOURCES_DIR}/UserAgentStyleSheets.h
     MAIN_DEPENDENCY ${WEBCORE_DIR}/css/make-css-file-arrays.pl
     DEPENDS ${WebCore_USER_AGENT_STYLE_SHEETS} ${WEBCORE_DIR}/bindings/scripts/preprocessor.pm
-    COMMAND ${PERL_EXECUTABLE} ${WEBCORE_DIR}/css/make-css-file-arrays.pl --defines "${FEATURE_DEFINES_WITH_SPACE_SEPARATOR}" --preprocessor "${CODE_GENERATOR_PREPROCESSOR}" ${WebCore_DERIVED_SOURCES_DIR}/UserAgentStyleSheets.h ${WebCore_DERIVED_SOURCES_DIR}/UserAgentStyleSheetsData.cpp ${WebCore_USER_AGENT_STYLE_SHEETS}
+    COMMAND ${PERL_EXECUTABLE} ${WEBCORE_DIR}/css/make-css-file-arrays.pl --defines "${FEATURE_DEFINES_WITH_SPACE_SEPARATOR}" ${WebCore_DERIVED_SOURCES_DIR}/UserAgentStyleSheets.h ${WebCore_DERIVED_SOURCES_DIR}/UserAgentStyleSheetsData.cpp ${WebCore_USER_AGENT_STYLE_SHEETS}
     VERBATIM)
 list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/UserAgentStyleSheetsData.cpp)
 

--- a/Source/WebCore/WebCoreMacros.cmake
+++ b/Source/WebCore/WebCoreMacros.cmake
@@ -89,7 +89,6 @@ function(GENERATE_BINDINGS target)
         --idlFilesList ${idl_files_list}
         --idlFileNamesList ${included_idl_files_list}
         --ppIDLFilesList ${pp_idl_files_list}
-        --preprocessor "${CODE_GENERATOR_PREPROCESSOR}"
         --idlAttributesFile ${idl_attributes_file}
     )
     if (arg_SUPPLEMENTAL_DEPFILE)

--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -37,7 +37,6 @@ my $useDocument = "";
 my $useGenerator = "";
 my $useOutputDir = "";
 my $useOutputHeadersDir = "";
-my $preprocessor;
 my $idlAttributes;
 my $writeDependencies = 0;
 my $defines = "";
@@ -148,7 +147,6 @@ sub new
     $useGenerator = shift;
     $useOutputDir = shift;
     $useOutputHeadersDir = shift;
-    $preprocessor = shift;
     $writeDependencies = shift;
     $verbose = shift;
     $targetIdlFilePath = shift;
@@ -405,7 +403,7 @@ sub ProcessInterfaceSupplementalDependencies
         if (exists $cachedParsedDocuments{$idlFile}) {
             $document = dclone($cachedParsedDocuments{$idlFile});
         } else {
-            $document = IDLParser->new(!$verbose)->Parse($idlFile, $defines, $preprocessor, $idlAttributes);
+            $document = IDLParser->new(!$verbose)->Parse($idlFile, $defines, $idlAttributes);
             $cachedParsedDocuments{$idlFile} = dclone($document);
         }
 
@@ -488,7 +486,7 @@ sub ProcessDictionarySupplementalDependencies
         if (exists $cachedParsedDocuments{$idlFile}) {
             $document = dclone($cachedParsedDocuments{$idlFile});
         } else {
-            $document = IDLParser->new(!$verbose)->Parse($idlFile, $defines, $preprocessor, $idlAttributes);
+            $document = IDLParser->new(!$verbose)->Parse($idlFile, $defines, $idlAttributes);
             $cachedParsedDocuments{$idlFile} = dclone($document);
         }
 
@@ -669,7 +667,7 @@ sub ParseInterface
 
     # Step #2: Parse the found IDL file (in quiet mode).
     my $parser = IDLParser->new(1);
-    my $document = $parser->Parse($filename, $defines, $preprocessor, $idlAttributes);
+    my $document = $parser->Parse($filename, $defines, $idlAttributes);
 
     foreach my $interface (@{$document->interfaces}) {
         if ($interface->type->name eq $interfaceName) {
@@ -794,7 +792,7 @@ sub GetEnumByType
     if ($fileContents =~ /\benum\s+$name/gs) {
         # Parse the IDL.
         my $parser = IDLParser->new(1);
-        my $document = $parser->Parse($filename, $defines, $preprocessor, $idlAttributes);
+        my $document = $parser->Parse($filename, $defines, $idlAttributes);
 
         foreach my $enumeration (@{$document->enumerations}) {
             next unless $enumeration->type->name eq $name;
@@ -862,7 +860,7 @@ sub GetDictionaryByType
     if ($fileContents =~ /\bdictionary\s+$name/gs) {
         # Parse the IDL.
         my $parser = IDLParser->new(1);
-        my $document = $parser->Parse($filename, $defines, $preprocessor, $idlAttributes);
+        my $document = $parser->Parse($filename, $defines, $idlAttributes);
 
         foreach my $dictionary (@{$document->dictionaries}) {
             if ($dictionary->type->name eq $name) {

--- a/Source/WebCore/bindings/scripts/IDLParser.pm
+++ b/Source/WebCore/bindings/scripts/IDLParser.pm
@@ -349,12 +349,13 @@ sub Parse
     my $self = shift;
     my $fileName = shift;
     my $defines = shift;
-    my $preprocessor = shift;
     my $idlAttributes = shift;
 
     my @definitions = ();
 
-    my @lines = applyPreprocessor($fileName, $defines, $preprocessor);
+    my $keepComments = 0;
+    my $stripLineComments = 1;
+    my @lines = applyPreprocessor($fileName, $defines, $keepComments, $stripLineComments);
     $self->{Line} = $lines[0];
     $self->{DocumentContent} = join(' ', @lines);
     $self->{ExtendedAttributeMap} = $idlAttributes;

--- a/Source/WebCore/bindings/scripts/generate-bindings-all.pl
+++ b/Source/WebCore/bindings/scripts/generate-bindings-all.pl
@@ -41,7 +41,6 @@ my $idlFileNamesList;
 my $generator;
 my @generatorDependency;
 my $defines;
-my $preprocessor;
 my $supplementalDependencyFile;
 my @ppExtraOutput;
 my @ppExtraArgs;
@@ -57,7 +56,6 @@ GetOptions('outputDir=s' => \$outputDirectory,
            'generator=s' => \$generator,
            'generatorDependency=s@' => \@generatorDependency,
            'defines=s' => \$defines,
-           'preprocessor=s' => \$preprocessor,
            'supplementalDependencyFile=s' => \$supplementalDependencyFile,
            'ppExtraOutput=s@' => \@ppExtraOutput,
            'ppExtraArgs=s@' => \@ppExtraArgs,
@@ -119,7 +117,6 @@ my @args = (File::Spec->catfile($scriptDir, 'generate-bindings.pl'),
             '--idlAttributesFile', $idlAttributesFile,
             '--idlFileNamesList', $idlFileNamesList,
             '--write-dependencies');
-push @args, '--preprocessor', $preprocessor if $preprocessor;
 push @args, '--supplementalDependencyFile', $supplementalDependencyFile if $supplementalDependencyFile;
 
 my %directoryCache;

--- a/Source/WebCore/bindings/scripts/generate-bindings.pl
+++ b/Source/WebCore/bindings/scripts/generate-bindings.pl
@@ -50,7 +50,6 @@ my $generator;
 my $defines;
 my $filename;
 my $prefix;
-my $preprocessor;
 my $writeDependencies;
 my $verbose;
 my $supplementalDependencyFile;
@@ -63,7 +62,6 @@ GetOptions('outputDir=s' => \$outputDirectory,
            'defines=s' => \$defines,
            'filename=s' => \$filename,
            'prefix=s' => \$prefix,
-           'preprocessor=s' => \$preprocessor,
            'verbose' => \$verbose,
            'write-dependencies' => \$writeDependencies,
            'supplementalDependencyFile=s' => \$supplementalDependencyFile,
@@ -125,9 +123,9 @@ sub generateBindings
 
     # Parse the target IDL file.
     my $targetParser = IDLParser->new(!$verbose);
-    my $targetDocument = $targetParser->Parse($targetIdlFile, $defines, $preprocessor, $idlAttributes);
+    my $targetDocument = $targetParser->Parse($targetIdlFile, $defines, $idlAttributes);
 
     # Generate desired output for the target IDL file.
-    my $codeGen = CodeGenerator->new($generator, $outputDirectory, $outputHeadersDirectory, $preprocessor, $writeDependencies, $verbose, $targetIdlFile, $idlAttributes, \%supplementalDependencies, $idlFileNamesList);
+    my $codeGen = CodeGenerator->new($generator, $outputDirectory, $outputHeadersDirectory, $writeDependencies, $verbose, $targetIdlFile, $idlAttributes, \%supplementalDependencies, $idlFileNamesList);
     $codeGen->ProcessDocument($targetDocument, $defines);
 }

--- a/Source/WebCore/bindings/scripts/preprocess-idls.pl
+++ b/Source/WebCore/bindings/scripts/preprocess-idls.pl
@@ -36,7 +36,6 @@ use Data::Dumper;
 use IDLParser;
 
 my $defines;
-my $preprocessor;
 my $idlFileNamesList;
 my $testGlobalContextName;
 my $supplementalDependencyFile;
@@ -78,7 +77,6 @@ my @supportedGlobalContexts = (
 my $validateAgainstParser = 0;
 
 GetOptions('defines=s' => \$defines,
-           'preprocessor=s' => \$preprocessor,
            'idlFileNamesList=s' => \$idlFileNamesList,
            'testGlobalContextName=s' => \$testGlobalContextName,
            'supplementalDependencyFile=s' => \$supplementalDependencyFile,
@@ -605,7 +603,7 @@ sub processIDL
 
     if ($validateAgainstParser) {
         my $parser = IDLParser->new(1);
-        $idlFile->parsedDocument($parser->Parse($filePath, $defines, $preprocessor, $idlAttributes));
+        $idlFile->parsedDocument($parser->Parse($filePath, $defines, $idlAttributes));
     }
 
     return $idlFile;

--- a/Source/WebCore/bindings/scripts/preprocessor.pm
+++ b/Source/WebCore/bindings/scripts/preprocessor.pm
@@ -21,11 +21,6 @@
 use strict;
 use warnings;
 
-use Config;
-use IPC::Open2;
-use IPC::Open3;
-use Text::ParseWords;
-
 BEGIN {
    use Exporter   ();
    our ($VERSION, @ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
@@ -36,84 +31,106 @@ BEGIN {
    @EXPORT_OK   = ();
 }
 
+# Reads a file, strips comments, and evaluates simple #if / #else / #endif
+# preprocessor directives without forking an external process.
 # Returns an array of lines.
 sub applyPreprocessor
 {
     my $fileName = shift;
     my $defines = shift;
-    my $preprocessor = shift;
     my $keepComments = shift;
+    my $stripLineComments = shift;
 
-    my @args = ();
-    if (!$preprocessor) {
-        if ($Config::Config{"osname"} eq "MSWin32") {
-            $preprocessor = $ENV{CC} || "cl";
-            push(@args, qw(/nologo /EP /TP));
-        } else {
-            $preprocessor = $ENV{CC} || (-x "/usr/bin/clang" ? "/usr/bin/clang" : "/usr/bin/gcc");
-            push(@args, qw(-E -P -x c++));
-            if ($keepComments) {
-                push(@args, qw(-C));
-            }
-        }
+    open(my $fh, '<', $fileName) or die "Failed to open $fileName";
+    local $/;
+    my $content = <$fh>;
+    close($fh);
+
+    unless ($keepComments) {
+        # Strip block comments.
+        $content =~ s|/\*.*?\*/||gs;
+        # Strip // line comments only when requested. CSS files use // in URLs
+        # so callers processing CSS must not pass $stripLineComments.
+        $content =~ s|//[^\n]*||g if $stripLineComments;
     }
 
-    if ($Config::Config{"osname"} eq "darwin") {
-        if ($ENV{ARCHS}) {
-            (my $arch, @_) = split(" ", $ENV{ARCHS});
-            my $vendor = $ENV{LLVM_TARGET_TRIPLE_VENDOR};
-            my $os = $ENV{LLVM_TARGET_TRIPLE_OS_VERSION} . ($ENV{LLVM_TARGET_TRIPLE_SUFFIX} // "");
-            push(@args, "-target", "$arch-$vendor-$os");
-        }
-        # When ARCHS is unset (CMake builds), clang defaults to the host
-        # triple, which is correct for preprocessing.
-        push(@args, "-I" . $ENV{BUILT_PRODUCTS_DIR} . "/usr/local/include") if $ENV{BUILT_PRODUCTS_DIR};
-        push(@args, "-isysroot", $ENV{SDKROOT}) if $ENV{SDKROOT};
+    if ($content !~ /^\s*#/m) {
+        return split(/^/m, $content);
     }
 
-    my @macros;
+    # The file has preprocessor directives. Evaluate simple
+    # #if defined(X) && X / #if !(defined(X) && X) / #else / #endif
+    # patterns in Perl instead of forking clang.
+    my %macros;
     if ($defines) {
-        # Remove double quotations from $defines and extract macros.
-        # For example, if $defines is ' "A=1" "B=1" C=1 ""    D  ',
-        # then it is converted into four macros -DA=1, -DB=1, -DC=1 and -DD.
-        $defines =~ s/\"//g;
-        @macros = grep { $_ } split(/\s+/, $defines); # grep skips empty macros.
-        @macros = map { "-D$_" } @macros;
+        $macros{$_} = 1 for grep { $_ } split(/\s+/, $defines =~ s/"//gr);
+    }
+    return split(/^/m, _evaluatePreprocessorDirectives($content, \%macros));
+}
+
+# Simple #if / #else / #endif evaluator. Supports:
+#   #if defined(X) && X
+#   #if defined(X)
+#   #if defined(X) && X && defined(Y) && Y  (conjunctions)
+#   #if !(defined(X) && X)                  (negation)
+#   #else
+#   #endif
+#   #endif // comment
+#   Nesting
+sub _evaluatePreprocessorDirectives
+{
+    my ($content, $macros) = @_;
+    my $output = "";
+    # Stack of [emittingBeforeThisIf, conditionWasTrue].
+    my @ifStack = ();
+    my $emitting = 1;
+
+    for my $line (split(/^/m, $content)) {
+        if ($line =~ /^\s*#\s*if\s+(.*)/) {
+            my $cond = _evaluateCondition($1, $macros);
+            push @ifStack, [$emitting, $cond];
+            $emitting = $emitting && $cond;
+        } elsif ($line =~ /^\s*#\s*else\b/) {
+            my $frame = $ifStack[-1];
+            $emitting = $frame->[0] && !$frame->[1];
+        } elsif ($line =~ /^\s*#\s*endif\b/) {
+            my $frame = pop @ifStack;
+            $emitting = $frame->[0];
+        } else {
+            $output .= $line if $emitting;
+        }
+    }
+    return $output;
+}
+
+sub _evaluateCondition
+{
+    my ($expr, $macros) = @_;
+
+    # Handle negation: "!(defined(X) && X)"
+    if ($expr =~ /^\s*!\s*\((.+)\)\s*$/) {
+        return _evaluateCondition($1, $macros) ? 0 : 1;
     }
 
-    my $pid = 0;
-    if ($Config{osname} eq "cygwin") {
-        $ENV{PATH} = "$ENV{PATH}:/cygdrive/c/cygwin/bin";
-        my @preprocessorAndFlags = shellwords($preprocessor);
-        if ($preprocessorAndFlags[0] =~ "cl.exe") {
-            $fileName = Cygwin::posix_to_win_path($fileName);
-        }
-        $preprocessorAndFlags[0] = Cygwin::win_to_posix_path($preprocessorAndFlags[0]);
-        # This call can fail if Windows rebases cygwin, so retry a few times until it succeeds.
-        for (my $tries = 0; !$pid && ($tries < 20); $tries++) {
-            eval {
-                # Suppress STDERR so that if we're using cl.exe, the output
-                # name isn't needlessly echoed.
-                use Symbol 'gensym'; my $err = gensym;
-                $pid = open3(\*PP_IN, \*PP_OUT, $err, @preprocessorAndFlags, @args, @macros, $fileName);
-                1;
-            } or do {
-                sleep 1;
-            }
-        };
-    } elsif ($Config::Config{"osname"} eq "MSWin32") {
-        # Suppress STDERR so that if we're using cl.exe, the output
-        # name isn't needlessly echoed.
-        use Symbol 'gensym'; my $err = gensym;
-        $pid = open3(\*PP_IN, \*PP_OUT, $err, $preprocessor, @args, @macros, $fileName);
-    } else {
-        $pid = open2(\*PP_OUT, \*PP_IN, shellwords($preprocessor), @args, @macros, $fileName);
+    # Handle parenthesized expression: "(defined(X) && X)"
+    if ($expr =~ /^\s*\((.+)\)\s*$/) {
+        return _evaluateCondition($1, $macros);
     }
-    close PP_IN;
-    my @documentContent = <PP_OUT>;
-    close PP_OUT;
-    waitpid($pid, 0);
-    return @documentContent;
+
+    # Handle conjunctions: "defined(X) && X && defined(Y) && Y"
+    my @parts = split(/\s*&&\s*/, $expr);
+    for my $part (@parts) {
+        $part =~ s/^\s+|\s+$//g;
+        if ($part =~ /^\(?defined\((\w+)\)\)?$/) {
+            return 0 unless $macros->{$1};
+        } elsif ($part =~ /^(\w+)$/) {
+            return 0 unless $macros->{$1};
+        } else {
+            # Unrecognized expression — conservatively treat as true.
+            next;
+        }
+    }
+    return 1;
 }
 
 1;

--- a/Source/WebCore/css/make-css-file-arrays.pl
+++ b/Source/WebCore/css/make-css-file-arrays.pl
@@ -28,9 +28,7 @@ use lib "$FindBin::Bin/../bindings/scripts";
 use Getopt::Long;
 
 my $defines;
-my $preprocessor;
-GetOptions('defines=s' => \$defines,
-           'preprocessor=s' => \$preprocessor);
+GetOptions('defines=s' => \$defines);
 
 my $header = $ARGV[0];
 shift;
@@ -54,7 +52,7 @@ for my $in (@ARGV) {
     # Slurp in the CSS file.
     my $text;
     require preprocessor;
-    $text = join('', applyPreprocessor($in, $defines, $preprocessor));
+    $text = join('', applyPreprocessor($in, $defines));
 
     # Remove comments in a simple-minded way that will work fine for our files.
     # Could do this a fancier way if we were worried about arbitrary CSS source.

--- a/Source/WebCore/preprocess-localizable-strings.pl
+++ b/Source/WebCore/preprocess-localizable-strings.pl
@@ -28,9 +28,7 @@ use lib "$FindBin::Bin/bindings/scripts";
 use Getopt::Long;
 
 my $defines;
-my $preprocessor;
-GetOptions('defines=s' => \$defines,
-           'preprocessor=s' => \$preprocessor);
+GetOptions('defines=s' => \$defines);
 
 my $out = $ARGV[0];
 shift;
@@ -42,7 +40,7 @@ for my $in (@ARGV) {
 
     my $text;
     require preprocessor;
-    $text = join('', applyPreprocessor($in, $defines, $preprocessor, "YES"));
+    $text = join('', applyPreprocessor($in, $defines, "YES"));
 
     print OUT $text;
 }

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -121,7 +121,7 @@ add_custom_command(
     OUTPUT ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.cpp ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.h
     MAIN_DEPENDENCY ${WEBCORE_DIR}/css/make-css-file-arrays.pl
     DEPENDS ${WebKit_DirectoryInputStream_DATA}
-    COMMAND ${PERL_EXECUTABLE} ${WEBCORE_DIR}/css/make-css-file-arrays.pl --defines "${FEATURE_DEFINES_WITH_SPACE_SEPARATOR}" --preprocessor "${CODE_GENERATOR_PREPROCESSOR}" ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.h ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.cpp ${WebKit_DirectoryInputStream_DATA}
+    COMMAND ${PERL_EXECUTABLE} ${WEBCORE_DIR}/css/make-css-file-arrays.pl --defines "${FEATURE_DEFINES_WITH_SPACE_SEPARATOR}" ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.h ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.cpp ${WebKit_DirectoryInputStream_DATA}
     VERBATIM
 )
 

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -156,7 +156,7 @@ add_custom_command(
     OUTPUT ${WebKit_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.cpp ${WebKit_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.h
     MAIN_DEPENDENCY ${WEBCORE_DIR}/css/make-css-file-arrays.pl
     DEPENDS ${WebKit_DirectoryInputStream_DATA}
-    COMMAND ${PERL_EXECUTABLE} ${WEBCORE_DIR}/css/make-css-file-arrays.pl --defines "${FEATURE_DEFINES_WITH_SPACE_SEPARATOR}" --preprocessor "${CODE_GENERATOR_PREPROCESSOR}" ${WebKit_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.h ${WebKit_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.cpp ${WebKit_DirectoryInputStream_DATA}
+    COMMAND ${PERL_EXECUTABLE} ${WEBCORE_DIR}/css/make-css-file-arrays.pl --defines "${FEATURE_DEFINES_WITH_SPACE_SEPARATOR}" ${WebKit_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.h ${WebKit_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.cpp ${WebKit_DirectoryInputStream_DATA}
     VERBATIM
 )
 

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -412,13 +412,6 @@ if (UNIX AND NOT APPLE AND NOT ENABLED_COMPILER_SANITIZERS)
     set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined ${CMAKE_SHARED_LINKER_FLAGS}")
 endif ()
 
-if (MSVC)
-    set(CODE_GENERATOR_PREPROCESSOR "\"${CMAKE_CXX_COMPILER}\" /nologo /EP /TP")
-elseif (COMPILER_IS_QCC)
-    set(CODE_GENERATOR_PREPROCESSOR "\"${CMAKE_CXX_COMPILER}\" -E -Wp,-P -x c++")
-else ()
-    set(CODE_GENERATOR_PREPROCESSOR "\"${CMAKE_CXX_COMPILER}\" -E -P -x c++")
-endif ()
 
 # Ensure that the default include system directories are added to the list of CMake implicit includes.
 # This workarounds an issue that happens when using GCC 6 and using system includes (-isystem).


### PR DESCRIPTION
#### 4ed26b82fdb27bf273ff90a7026a46f958ce193a
<pre>
Speed up IDL bindings generation build step
<a href="https://bugs.webkit.org/show_bug.cgi?id=312747">https://bugs.webkit.org/show_bug.cgi?id=312747</a>

Reviewed by Sam Weinig.

This PR applies the following optimization to the IDL bindings generation
build step:

applyPreprocessor() unconditionally forks clang to preprocess every
file, even though most files don&apos;t contain C preprocessor directives.
For those files, reading and stripping comments in Perl avoids the
expensive fork+exec of clang/gcc (~25ms per invocation).

For the files that do use directives, they all follow simple
(including nesting), so evaluate these in Perl as well, eliminating all
clang invocations during the build step. This covers both IDL files
(25 out of ~1,823 use directives) and user agent CSS stylesheets.

Note: // line comments are only stripped for .idl files, not for CSS
files where // appears in URLs and is not a comment delimiter.

This reduces the generate-bindings-all.pl build step from 1 minute 36 seconds
to 21 seconds, on a M4 Max machine.

Additionally, remove the --preprocessor command-line option from all scripts
and the CODE_GENERATOR_PREPROCESSOR CMake variable. The CMake build was passing
an explicit preprocessor path (e.g. clang -E -P -x c++) that did exactly the
same thing the Xcode build was doing implicitly via a fallback default in
applyPreprocessor(). Since the Perl-based preprocessor now handles all cases,
there is no longer any need for an external preprocessor codepath.

* Source/WebCore/bindings/scripts/preprocessor.pm:
(applyPreprocessor): Handle preprocessing entirely in Perl: read the file,
strip comments (/* */ for all files, // only for .idl files), and if the
file contains preprocessor directives, evaluate them using
_evaluatePreprocessorDirectives instead of forking clang. Remove the
$preprocessor parameter and the _applyExternalPreprocessor function.
(_evaluatePreprocessorDirectives): Added. #if / #else / #endif evaluator
using a stack to track nesting.
(_evaluateCondition): Added. Evaluates preprocessor condition expressions
supporting conjunctions (&amp;&amp;), defined() checks, negation (!(...)), and
parenthesized sub-expressions.
* Source/WebCore/bindings/scripts/CodeGenerator.pm:
(new): Remove $preprocessor parameter.
* Source/WebCore/bindings/scripts/IDLParser.pm:
(Parse): Remove $preprocessor parameter.
* Source/WebCore/bindings/scripts/generate-bindings.pl: Remove --preprocessor option.
* Source/WebCore/bindings/scripts/generate-bindings-all.pl: Remove --preprocessor option.
* Source/WebCore/bindings/scripts/preprocess-idls.pl: Remove --preprocessor option.
* Source/WebCore/css/make-css-file-arrays.pl: Remove --preprocessor option.
* Source/WebCore/preprocess-localizable-strings.pl: Remove --preprocessor option.
* Source/WebCore/CMakeLists.txt: Remove --preprocessor from make-css-file-arrays.pl invocation.
* Source/WebCore/WebCoreMacros.cmake: Remove --preprocessor from bindings generation args.
* Source/WebKit/PlatformGTK.cmake: Remove --preprocessor from make-css-file-arrays.pl invocation.
* Source/WebKit/PlatformWPE.cmake: Remove --preprocessor from make-css-file-arrays.pl invocation.
* Source/cmake/WebKitCompilerFlags.cmake: Remove CODE_GENERATOR_PREPROCESSOR variable.

Canonical link: <a href="https://commits.webkit.org/311901@main">https://commits.webkit.org/311901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1389aaae27a4928ccd2f6506746f7bea8a428621

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166988 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112242 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122485 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85983 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103154 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23812 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22163 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14760 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150210 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169477 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18994 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14831 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130666 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130781 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35450 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141637 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89076 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25491 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18443 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190288 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30732 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96265 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48840 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30253 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30483 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30380 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->