### PR TITLE
[WTF] Use more SIMDUTF

### DIFF
--- a/Source/WTF/wtf/SIMDUTF.h
+++ b/Source/WTF/wtf/SIMDUTF.h
@@ -35,6 +35,10 @@ IGNORE_WARNINGS_BEGIN("cast-align")
 IGNORE_WARNINGS_BEGIN("documentation")
 
 #define SIMDUTF_CPLUSPLUS20 1
+// simdutf 8.2.0's `if consteval` branches in some span overloads (e.g.
+// convert_utf16le_to_utf8_with_replacement) pass char8_t* to scalar helpers
+// that expect char*, which fails to compile in C++23. Force the runtime branch
+// by disabling the C++23 path. Spans remain available via C++20.
 #define SIMDUTF_CPLUSPLUS23 0
 
 #include <wtf/simdutf/simdutf_impl.h>

--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -34,19 +34,7 @@ namespace WTF {
 
 constexpr const char nonAlphabet = -1;
 
-constexpr unsigned encodeMapSize = 64;
 constexpr unsigned decodeMapSize = 128;
-
-static constexpr std::array<char, encodeMapSize> base64EncMap {
-    0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
-    0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50,
-    0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
-    0x59, 0x5A, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
-    0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E,
-    0x6F, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76,
-    0x77, 0x78, 0x79, 0x7A, 0x30, 0x31, 0x32, 0x33,
-    0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x2B, 0x2F
-};
 
 static constexpr std::array<char, decodeMapSize> base64DecMap {
     nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet,
@@ -65,17 +53,6 @@ static constexpr std::array<char, decodeMapSize> base64DecMap {
     0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
     0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30,
     0x31, 0x32, 0x33, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet
-};
-
-static constexpr std::array<char, encodeMapSize> base64URLEncMap {
-    0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
-    0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50,
-    0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
-    0x59, 0x5A, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
-    0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E,
-    0x6F, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76,
-    0x77, 0x78, 0x79, 0x7A, 0x30, 0x31, 0x32, 0x33,
-    0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x2D, 0x5F
 };
 
 static constexpr std::array<char, decodeMapSize> base64URLDecMap {
@@ -117,39 +94,12 @@ template<typename CharacterType> static void base64EncodeInternal(std::span<cons
     if constexpr (sizeof(CharacterType) == 1) {
         size_t bytesWritten = simdutf::binary_to_base64(inputDataBuffer, destinationDataBuffer, toSIMDUTFEncodeOptions(options));
         ASSERT_UNUSED(bytesWritten, bytesWritten == destinationDataBuffer.size());
-        return;
+    } else {
+        Vector<char, 64> scratch(destinationDataBuffer.size());
+        size_t bytesWritten = simdutf::binary_to_base64(inputDataBuffer, scratch.mutableSpan(), toSIMDUTFEncodeOptions(options));
+        ASSERT_UNUSED(bytesWritten, bytesWritten == destinationDataBuffer.size());
+        copyElements(destinationDataBuffer, byteCast<Latin1Character>(scratch.span()));
     }
-
-    auto encodeMap = options.contains(Base64EncodeOption::URL) ? base64URLEncMap : base64EncMap;
-
-    unsigned sidx = 0;
-    unsigned didx = 0;
-
-    if (inputDataBuffer.size() > 1) {
-        while (sidx < inputDataBuffer.size() - 2) {
-            destinationDataBuffer[didx++] = encodeMap[ (inputDataBuffer[sidx    ] >> 2) & 077];
-            destinationDataBuffer[didx++] = encodeMap[((inputDataBuffer[sidx + 1] >> 4) & 017) | ((inputDataBuffer[sidx    ] << 4) & 077)];
-            destinationDataBuffer[didx++] = encodeMap[((inputDataBuffer[sidx + 2] >> 6) & 003) | ((inputDataBuffer[sidx + 1] << 2) & 077)];
-            destinationDataBuffer[didx++] = encodeMap[  inputDataBuffer[sidx + 2]       & 077];
-            sidx += 3;
-        }
-    }
-
-    if (sidx < inputDataBuffer.size()) {
-        destinationDataBuffer[didx++] = encodeMap[(inputDataBuffer[sidx] >> 2) & 077];
-        if (sidx < inputDataBuffer.size() - 1) {
-            destinationDataBuffer[didx++] = encodeMap[((inputDataBuffer[sidx + 1] >> 4) & 017) | ((inputDataBuffer[sidx] << 4) & 077)];
-            destinationDataBuffer[didx++] = encodeMap[ (inputDataBuffer[sidx + 1] << 2) & 077];
-        } else
-            destinationDataBuffer[didx++] = encodeMap[ (inputDataBuffer[sidx    ] << 4) & 077];
-    }
-
-    if (!options.contains(Base64EncodeOption::OmitPadding)) {
-        while (didx < destinationDataBuffer.size())
-            destinationDataBuffer[didx++] = '=';
-    }
-
-    ASSERT(didx == destinationDataBuffer.size());
 }
 
 template<typename CharacterType> static void base64EncodeInternal(std::span<const std::byte> input, std::span<CharacterType> destinationDataBuffer, OptionSet<Base64EncodeOption> options)
@@ -211,9 +161,27 @@ static std::optional<Vector<uint8_t, 0, CrashOnOverflow, 16, Malloc>> base64Deco
     if (!inputDataBuffer.size())
         return Vector<uint8_t, 0, CrashOnOverflow, 16, Malloc> { };
 
+    auto ignoreWhitespace = options.contains(Base64DecodeOption::IgnoreWhitespace);
+
+    // Fast path via simdutf. simdutf has no "ignore-whitespace-only" mode
+    // (its accept_garbage modes ignore arbitrary garbage too), and it rejects
+    // some non-standard inputs WebKit accepts (notably trailing extra '=' when
+    // ValidatePadding is off). For those cases we fall through to the scalar
+    // path below.
+    if (!ignoreWhitespace) {
+        size_t maxBinaryLength = simdutf::maximal_binary_length_from_base64(inputDataBuffer);
+        Vector<uint8_t, 0, CrashOnOverflow, 16, Malloc> destination(maxBinaryLength);
+        auto simdutfOptions = options.contains(Base64DecodeOption::URL) ? simdutf::base64_url : simdutf::base64_default;
+        auto lastChunkOptions = options.contains(Base64DecodeOption::ValidatePadding) ? simdutf::last_chunk_handling_options::strict : simdutf::last_chunk_handling_options::loose;
+        auto result = simdutf::base64_to_binary(inputDataBuffer, destination.mutableSpan(), simdutfOptions, lastChunkOptions);
+        if (result.error == simdutf::error_code::SUCCESS) {
+            destination.shrink(result.count);
+            return destination;
+        }
+    }
+
     auto decodeMap = options.contains(Base64DecodeOption::URL) ? base64URLDecMap : base64DecMap;
     auto validatePadding = options.contains(Base64DecodeOption::ValidatePadding);
-    auto ignoreWhitespace = options.contains(Base64DecodeOption::IgnoreWhitespace);
 
     Vector<uint8_t, 0, CrashOnOverflow, 16, Malloc> destination(inputDataBuffer.size());
 

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -141,21 +141,72 @@ ConversionResult<char8_t> convert(std::span<const char16_t> source, std::span<ch
 
 ConversionResult<char16_t> convert(std::span<const char8_t> source, std::span<char16_t> buffer)
 {
+    if (buffer.size() < source.size())
+        return convertInternal(source, buffer);
+
+#if CPU(BIG_ENDIAN)
+    auto result = simdutf::convert_utf8_to_utf16be_with_errors(source, buffer);
+#else
+    auto result = simdutf::convert_utf8_to_utf16le_with_errors(source, buffer);
+#endif
+
+    if (result.error == simdutf::error_code::SUCCESS) {
+        bool isAllASCII = result.count == source.size();
+        return { ConversionResultCode::Success, buffer.first(result.count), isAllASCII };
+    }
+
     return convertInternal(source, buffer);
 }
 
 ConversionResult<char8_t> convert(std::span<const Latin1Character> source, std::span<char8_t> buffer)
 {
-    return convertInternal(source, buffer);
+    size_t requiredLength = simdutf::utf8_length_from_latin1(source);
+
+    if (buffer.size() < requiredLength)
+        return convertInternal(source, buffer);
+
+    size_t written = simdutf::convert_latin1_to_utf8(source, buffer);
+    bool isAllASCII = written == source.size();
+    return { ConversionResultCode::Success, buffer.first(written), isAllASCII };
 }
 
 ConversionResult<char8_t> convertReplacingInvalidSequences(std::span<const char16_t> source, std::span<char8_t> buffer)
 {
-    return convertInternal<Replacement::ReplaceInvalidSequences>(source, buffer);
+#if CPU(BIG_ENDIAN)
+    auto lengthResult = simdutf::utf8_length_from_utf16be_with_replacement(source);
+#else
+    auto lengthResult = simdutf::utf8_length_from_utf16le_with_replacement(source);
+#endif
+
+    if (buffer.size() < lengthResult.count)
+        return convertInternal<Replacement::ReplaceInvalidSequences>(source, buffer);
+
+#if CPU(BIG_ENDIAN)
+    size_t written = simdutf::convert_utf16be_to_utf8_with_replacement(source, buffer);
+#else
+    size_t written = simdutf::convert_utf16le_to_utf8_with_replacement(source, buffer);
+#endif
+
+    bool isAllASCII = written == source.size();
+    return { ConversionResultCode::Success, buffer.first(written), isAllASCII };
 }
 
 ConversionResult<char16_t> convertReplacingInvalidSequences(std::span<const char8_t> source, std::span<char16_t> buffer)
 {
+    if (buffer.size() < source.size())
+        return convertInternal<Replacement::ReplaceInvalidSequences>(source, buffer);
+
+#if CPU(BIG_ENDIAN)
+    auto result = simdutf::convert_utf8_to_utf16be_with_errors(source, buffer);
+#else
+    auto result = simdutf::convert_utf8_to_utf16le_with_errors(source, buffer);
+#endif
+
+    if (result.error == simdutf::error_code::SUCCESS) {
+        bool isAllASCII = result.count == source.size();
+        return { ConversionResultCode::Success, buffer.first(result.count), isAllASCII };
+    }
+
     return convertInternal<Replacement::ReplaceInvalidSequences>(source, buffer);
 }
 


### PR DESCRIPTION
#### 9cf3d9c0587dede21257c071294c7a473e0c5a4b
<pre>
[WTF] Use more SIMDUTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=312749">https://bugs.webkit.org/show_bug.cgi?id=312749</a>
<a href="https://rdar.apple.com/175141891">rdar://175141891</a>

Reviewed by NOBODY (OOPS!).

Apply SIMDUTF more, in UTF-8 / UTF-16 / Latin-1 conversion, and base64.

* Source/WTF/wtf/SIMDUTF.h:
* Source/WTF/wtf/text/Base64.cpp:
(WTF::base64EncodeInternal):
(WTF::base64DecodeInternal):
* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::convert):
(WTF::Unicode::convertReplacingInvalidSequences):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cf3d9c0587dede21257c071294c7a473e0c5a4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111480 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6330207-dddd-4d1e-a5ca-59cc9688fe9b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30870 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30737 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121903 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85610 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e85df0de-ca6c-47fa-b62a-3b9af8421eb1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24157 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141331 "Found 1 new API test failure: TestWebKitAPI.RFC8941.ParseItemStructuredFieldValue (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102571 "Found 1 new API test failure: TestWebCore:RFC8941.ParseItemStructuredFieldValue (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29a54ee1-f570-43cb-af0f-739f77cb21b0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23213 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21462 "Found 1 new API test failure: TestWebKitAPI.RFC8941.ParseItemStructuredFieldValue (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13993 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149449 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132892 "Found 1 new API test failure: TestWebKitAPI.RFC8941.ParseItemStructuredFieldValue (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168707 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18233 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12865 "Found 3 new failures in wtf/text/Base64.cpp, wtf/unicode/UTF8Conversion.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130045 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30336 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25540 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130152 "Found 1 new API test failure: TestWebCore:RFC8941.ParseItemStructuredFieldValue (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140953 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88190 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24975 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17758 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189471 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29970 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93984 "Found 3 new failures in wtf/text/Base64.cpp, wtf/unicode/UTF8Conversion.cpp") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48653 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29492 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29722 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29619 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->