### PR TITLE
Setting font to a size that matches a legacy <font> size are not portable and are rendered incorrectly with different default font sizes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/editing/run/inserttext_2001-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/run/inserttext_2001-last-expected.txt
@@ -355,7 +355,7 @@ PASS [["inserttext","a"]] "foo<s>[bar</s>baz]" queryCommandState("inserttext") a
 PASS [["inserttext","a"]] "foo<s>[bar</s>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<sub>[bar</sub>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sub>a</sub>" but got "foo<font size=\"2\">a</font>"
+FAIL [["inserttext","a"]] "foo<sub>[bar</sub>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sub>a</sub>" but got "foo<font size=\"2\"><span style=\"font-size:13.333333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandValue("inserttext") before
@@ -364,7 +364,7 @@ PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandState("inserttext
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<sup>[bar</sup>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sup>a</sup>" but got "foo<font size=\"2\">a</font>"
+FAIL [["inserttext","a"]] "foo<sup>[bar</sup>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sup>a</sup>" but got "foo<font size=\"2\"><span style=\"font-size:13.333333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" queryCommandValue("inserttext") before
@@ -499,7 +499,7 @@ PASS [["inserttext","a"]] "foo<sub><font size=2>[bar</font></sub>baz]" queryComm
 PASS [["inserttext","a"]] "foo<sub><font size=2>[bar</font></sub>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"2\"><sub>a</sub></font>" but got "foo<font size=\"1\">a</font>"
+FAIL [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"2\"><sub>a</sub></font>" but got "foo<font size=\"1\"><span style=\"font-size:10.833333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" queryCommandValue("inserttext") before
@@ -517,7 +517,7 @@ PASS [["inserttext","a"]] "foo<sub><font size=3>[bar</font></sub>baz]" queryComm
 PASS [["inserttext","a"]] "foo<sub><font size=3>[bar</font></sub>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"3\"><sub>a</sub></font>" but got "foo<font size=\"2\">a</font>"
+FAIL [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"3\"><sub>a</sub></font>" but got "foo<font size=\"2\"><span style=\"font-size:13.333333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" queryCommandValue("inserttext") before

--- a/LayoutTests/platform/ios-simulator-18/imported/w3c/web-platform-tests/editing/run/inserttext_2001-last-expected.txt
+++ b/LayoutTests/platform/ios-simulator-18/imported/w3c/web-platform-tests/editing/run/inserttext_2001-last-expected.txt
@@ -355,7 +355,7 @@ PASS [["inserttext","a"]] "foo<s>[bar</s>baz]" queryCommandState("inserttext") a
 PASS [["inserttext","a"]] "foo<s>[bar</s>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<sub>[bar</sub>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sub>a</sub>" but got "foo<font size=\"2\">a</font>"
+FAIL [["inserttext","a"]] "foo<sub>[bar</sub>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sub>a</sub>" but got "foo<font size=\"2\"><span style=\"font-size:13.333333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandValue("inserttext") before
@@ -364,7 +364,7 @@ PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandState("inserttext
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<sup>[bar</sup>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sup>a</sup>" but got "foo<font size=\"2\">a</font>"
+FAIL [["inserttext","a"]] "foo<sup>[bar</sup>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sup>a</sup>" but got "foo<font size=\"2\"><span style=\"font-size:13.333333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" queryCommandValue("inserttext") before
@@ -499,7 +499,7 @@ PASS [["inserttext","a"]] "foo<sub><font size=2>[bar</font></sub>baz]" queryComm
 PASS [["inserttext","a"]] "foo<sub><font size=2>[bar</font></sub>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"2\"><sub>a</sub></font>" but got "foo<font size=\"1\">a</font>"
+FAIL [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"2\"><sub>a</sub></font>" but got "foo<font size=\"1\"><span style=\"font-size:10.833333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" queryCommandValue("inserttext") before
@@ -517,7 +517,7 @@ PASS [["inserttext","a"]] "foo<sub><font size=3>[bar</font></sub>baz]" queryComm
 PASS [["inserttext","a"]] "foo<sub><font size=3>[bar</font></sub>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"3\"><sub>a</sub></font>" but got "foo<font size=\"2\">a</font>"
+FAIL [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"3\"><sub>a</sub></font>" but got "foo<font size=\"2\"><span style=\"font-size:13.333333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" queryCommandValue("inserttext") before

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/run/inserttext_2001-last-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/run/inserttext_2001-last-expected.txt
@@ -355,7 +355,7 @@ PASS [["inserttext","a"]] "foo<s>[bar</s>baz]" queryCommandState("inserttext") a
 PASS [["inserttext","a"]] "foo<s>[bar</s>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<sub>[bar</sub>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sub>a</sub>" but got "foo<font size=\"2\">a</font>"
+FAIL [["inserttext","a"]] "foo<sub>[bar</sub>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sub>a</sub>" but got "foo<font size=\"2\"><span style=\"font-size:13.333333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandValue("inserttext") before
@@ -364,7 +364,7 @@ PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandState("inserttext
 PASS [["inserttext","a"]] "foo<sub>[bar</sub>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<sup>[bar</sup>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sup>a</sup>" but got "foo<font size=\"2\">a</font>"
+FAIL [["inserttext","a"]] "foo<sup>[bar</sup>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<sup>a</sup>" but got "foo<font size=\"2\"><span style=\"font-size:13.333333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<sup>[bar</sup>baz]" queryCommandValue("inserttext") before
@@ -499,7 +499,7 @@ PASS [["inserttext","a"]] "foo<sub><font size=2>[bar</font></sub>baz]" queryComm
 PASS [["inserttext","a"]] "foo<sub><font size=2>[bar</font></sub>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"2\"><sub>a</sub></font>" but got "foo<font size=\"1\">a</font>"
+FAIL [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"2\"><sub>a</sub></font>" but got "foo<font size=\"1\"><span style=\"font-size:10.833333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=2><sub>[bar</sub></font>baz]" queryCommandValue("inserttext") before
@@ -517,7 +517,7 @@ PASS [["inserttext","a"]] "foo<sub><font size=3>[bar</font></sub>baz]" queryComm
 PASS [["inserttext","a"]] "foo<sub><font size=3>[bar</font></sub>baz]" queryCommandValue("inserttext") after
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]": execCommand("inserttext", false, "a") return value
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" checks for modifications to non-editable content
-FAIL [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"3\"><sub>a</sub></font>" but got "foo<font size=\"2\">a</font>"
+FAIL [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "foo<font size=\"3\"><sub>a</sub></font>" but got "foo<font size=\"2\"><span style=\"font-size:13.333333px\">a</span></font>"
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" queryCommandIndeterm("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" queryCommandState("inserttext") before
 PASS [["inserttext","a"]] "foo<font size=3><sub>[bar</sub></font>baz]" queryCommandValue("inserttext") before

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -1454,7 +1454,7 @@ void ApplyStyleCommand::applyInlineStyleChange(Node& passedStart, Node& passedEn
         startNode = startNodeFirstChild;
     }
 
-    // Font tags need to go outside of CSS so that CSS font sizes override leagcy font sizes.
+    // Font tags need to go outside of CSS so that CSS font sizes override legacy font sizes.
     if (styleChange.applyFontColor() || styleChange.applyFontFace() || styleChange.applyFontSize()) {
         if (fontContainer) {
             if (styleChange.applyFontColor())

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -2050,7 +2050,13 @@ void StyleChange::extractTextStyles(Document& document, MutableStyleProperties& 
     if (RefPtr fontSize = style.getPropertyCSSValue(CSSPropertyFontSize)) {
         if (int legacyFontSize = legacyFontSizeFromCSSValue(document, *fontSize, shouldUseFixedFontDefaultSize, LegacyFontSizeMode::UseLegacyFontSizeOnlyIfPixelValuesMatch)) {
             m_applyFontSize = AtomString::number(legacyFontSize);
-            style.removeProperty(CSSPropertyFontSize);
+            // For CSS keyword values (e.g. "large"), the legacy <font size> is
+            // a lossless representation, so remove the CSS property.
+            // For explicit lengths (e.g. "13px"), keep the CSS property nested inside
+            // the legacy <font size> so that renderers that understand CSS use the exact value.
+            RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(*fontSize);
+            if (!primitiveValue || !primitiveValue->isFontIndependentLength())
+                style.removeProperty(CSSPropertyFontSize);
         }
     }
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -578,6 +578,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				WebKit/WebPage/AppKitGesturesTests.swift,
+				WebKit/WebPage/EditingFontSizeTests.swift,
 				WebKit/WebPage/URLSchemeHandlerTests.swift,
 				WebKit/WebPage/WebPageNavigationTests.swift,
 				WebKit/WebPage/WebPageTests.swift,
@@ -1309,6 +1310,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				WebKit/WebPage/AppKitGesturesTests.swift,
+				WebKit/WebPage/EditingFontSizeTests.swift,
 				WebKit/WebPage/URLSchemeHandlerTests.swift,
 				WebKit/WebPage/WebPageNavigationTests.swift,
 				WebKit/WebPage/WebPageTests.swift,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FontManagerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FontManagerTests.mm
@@ -241,7 +241,7 @@ TEST(FontManagerTests, ChangeFontWithPanel)
     setOverrideSelectedFaceName(fontPanel, @"Bold");
     [fontManager modifyFontViaPanel:fontPanel];
     EXPECT_WK_STREQ("bar", [webView selectedText]);
-    EXPECT_WK_STREQ("<span id=\"bar\"><font face=\"Times New Roman\" size=\"1\"><b>bar</b></font></span>", [webView stringByEvaluatingJavaScript:@"bar.outerHTML"]);
+    EXPECT_WK_STREQ("<span id=\"bar\" style=\"font-size: 10px;\"><font face=\"Times New Roman\" size=\"1\"><b>bar</b></font></span>", [webView stringByEvaluatingJavaScript:@"bar.outerHTML"]);
     EXPECT_WK_STREQ("\"Times New Roman\"", [webView stringByEvaluatingJavaScript:@"getComputedStyle(bar.firstChild.firstChild)['font-family']"]);
     EXPECT_WK_STREQ("10px", [webView stringByEvaluatingJavaScript:@"getComputedStyle(bar.firstChild.firstChild)['font-size']"]);
     EXPECT_WK_STREQ("700", [webView stringByEvaluatingJavaScript:@"getComputedStyle(bar.firstChild.firstChild)['font-weight']"]);
@@ -266,7 +266,7 @@ TEST(FontManagerTests, ChangeFontWithPanel)
     setOverrideSelectedFaceName(fontPanel, @"Light Oblique");
     [fontManager modifyFontViaPanel:fontPanel];
     EXPECT_WK_STREQ("foo bar baz", [webView selectedText]);
-    EXPECT_WK_STREQ("<font face=\"Avenir-LightOblique\" size=\"5\"><i><span id=\"foo\"><font>foo</font></span> <span id=\"bar\">bar</span> <span id=\"baz\"><font>baz</font></span></i></font>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
+    EXPECT_WK_STREQ("<font face=\"Avenir-LightOblique\" size=\"5\"><span style=\"font-size: 24px;\"><i><span id=\"foo\"><font>foo</font></span> <span id=\"bar\">bar</span> <span id=\"baz\"><font>baz</font></span></i></span></font>", [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
     EXPECT_WK_STREQ("Avenir-LightOblique", [webView stringByEvaluatingJavaScript:@"getComputedStyle(foo)['font-family']"]);
     EXPECT_WK_STREQ("24px", [webView stringByEvaluatingJavaScript:@"getComputedStyle(foo)['font-size']"]);
     EXPECT_WK_STREQ("400", [webView stringByEvaluatingJavaScript:@"getComputedStyle(foo)['font-weight']"]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/EditingFontSizeTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/EditingFontSizeTests.swift
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if os(macOS) && ENABLE_SWIFTUI
+
+import AppKit
+import struct Swift.String
+import Testing
+@_spi(CrossImportOverlay) import WebKit
+import WebKit_Private.WKPreferencesPrivate
+import WebKit_Private.WKWebViewPrivate
+private import TestWebKitAPILibrary
+
+@MainActor
+struct EditingFontSizeTests {
+    @Test(.bug("rdar://15292320", "https://bugs.webkit.org/show_bug.cgi?id=312755"))
+    func fontSizeMatchingLegacySizePreservesCSSValue() async throws {
+        let page = WebPage()
+
+        try await page.load(html: "<div id='target' contenteditable>Hello world</div>").wait()
+
+        let webView = page.backingWebView
+
+        try await page.callJavaScript(
+            """
+            getSelection().selectAllChildren(document.getElementById("target"));
+            """
+        )
+
+        // 13px matches legacy font size 2 ("small") when the default font size is 16 (the default).
+        try webView._setFont(#require(NSFont(name: "Helvetica", size: 13)), sender: nil)
+
+        let innerHTML = try #require(await page.callJavaScript("return document.getElementById('target').innerHTML") as? String)
+        // The markup should contain a <font> element with size="2" for legacy compatibility.
+        #expect(innerHTML.contains(#"size="2""#))
+        // The markup should also contain the explicit CSS font-size for renderers that respect CSS.
+        #expect(innerHTML.contains("font-size: 13px"))
+
+        // Change the default font size so <font size="2"> alone would resolve to 10px.
+        webView.configuration.preferences._defaultFontSize = 12
+
+        let computedSize = try #require(
+            await page.callJavaScript(
+                "return getComputedStyle(document.getElementById('target').querySelector('[style]')).fontSize"
+            ) as? String
+        )
+        #expect(computedSize == "13px")
+    }
+}
+
+#endif


### PR DESCRIPTION
#### c1e16fd16e14611ae6f3afba50a0fde1ea4a8dde
<pre>
Setting font to a size that matches a legacy &lt;font&gt; size are not portable and are rendered incorrectly with different default font sizes
<a href="https://bugs.webkit.org/show_bug.cgi?id=312755">https://bugs.webkit.org/show_bug.cgi?id=312755</a>
<a href="https://rdar.apple.com/15292320">rdar://15292320</a>

Reviewed by Wenson Hsieh and Ryosuke Niwa.

When applying a font change, if the new font size matches a legacy &lt;font&gt; integer size,
we&apos;ll apply that instead of an explicit point size. This is all well and good,
except that it&apos;s not portable, because the legacy sizes are relative to the web view&apos;s
default font size, which can (and does!) vary.

Fix this by leaving the explicit point size intact when possible. We still wrap
it in a &lt;font&gt; tag with a legacy size for compatibility&apos;s sake, but override
it with a proper point size for renderers that speak proper CSS.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditingFontSizeTests.swift

* LayoutTests/imported/w3c/web-platform-tests/editing/run/inserttext_2001-last-expected.txt:
* LayoutTests/platform/ios-simulator-18/imported/w3c/web-platform-tests/editing/run/inserttext_2001-last-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/run/inserttext_2001-last-expected.txt:
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::applyInlineStyleChange):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::StyleChange::extractTextStyles):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FontManagerTests.mm:
(TestWebKitAPI::TEST(FontManagerTests, ChangeFontWithPanel)):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/EditingFontSizeTests.swift: Added.
(EditingFontSizeTests.fontSizeMatchingLegacySizePreservesCSSValue):

Canonical link: <a href="https://commits.webkit.org/311700@main">https://commits.webkit.org/311700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fa5420840febf24e6f6658c695ff6af7ad851f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31082 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/24275 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166569 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31084 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24425 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102812 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14340 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/19463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169058 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13710 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130311 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130428 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35325 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/141257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88614 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95025 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29839 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30069 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29966 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->