### PR TITLE
REGRESSION (256320@main?): [iOS] 2 TestWebKitAPI.FullscreenVideoTextRecognition tests are flaky failures

### DIFF
--- a/Tools/TestWebKitAPI/Resources/cocoa/element-fullscreen.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/element-fullscreen.html
@@ -24,7 +24,7 @@ video {
 </head>
 <body>
     <div class="container">
-        <video muted loop></video>
+        <video muted loop playsinline></video>
     </div>
 </body>
 <script>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm
@@ -86,6 +86,9 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     configuration.preferences.elementFullscreenEnabled = YES;
+#if PLATFORM(IOS_FAMILY)
+    configuration.allowsInlineMediaPlayback = YES;
+#endif
     RetainPtr webView = adoptNS([[FullscreenVideoTextRecognitionWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"element-fullscreen"];
     return webView;
@@ -287,12 +290,7 @@ TEST(FullscreenVideoTextRecognition, TogglePlaybackInElementFullscreen)
     [webView waitForImageAnalysisToEnd];
 }
 
-// FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved.
-#if PLATFORM(IOS) || PLATFORM(VISION)
-TEST(FullscreenVideoTextRecognition, DISABLED_AddVideoAfterEnteringFullscreen)
-#else
 TEST(FullscreenVideoTextRecognition, AddVideoAfterEnteringFullscreen)
-#endif
 {
     auto webView = [FullscreenVideoTextRecognitionWebView create];
     [webView loadVideoSource:@"test.mp4"];
@@ -306,12 +304,7 @@ TEST(FullscreenVideoTextRecognition, AddVideoAfterEnteringFullscreen)
     [webView waitForImageAnalysisToBegin];
 }
 
-// FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved.
-#if PLATFORM(IOS) || PLATFORM(VISION)
-TEST(FullscreenVideoTextRecognition, DISABLED_DoNotAnalyzeVideoAfterExitingFullscreen)
-#else
 TEST(FullscreenVideoTextRecognition, DoNotAnalyzeVideoAfterExitingFullscreen)
-#endif
 {
     auto webView = [FullscreenVideoTextRecognitionWebView create];
     [webView loadVideoSource:@"test.mp4"];


### PR DESCRIPTION
#### b4caee3eb24f6cfebb97b426d153ab77d2c7a806
<pre>
REGRESSION (256320@main?): [iOS] 2 TestWebKitAPI.FullscreenVideoTextRecognition tests are flaky failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=248094">https://bugs.webkit.org/show_bug.cgi?id=248094</a>
<a href="https://rdar.apple.com/102522560">rdar://102522560</a>

Reviewed by Eric Carlson.

The tests AddVideoAfterEnteringFullscreen and DoNotAnalyzeVideoAfterExitingFullscreen were failing on iOS as
video.play() triggered automatic entry into native video fullscreen via the HAVE(AVEXPERIENCECONTROLLER) path in
MediaElementSession::requiresFullscreenForVideoPlayback().
This caused DoNotAnalyzeVideoAfterExitingFullscreen to fail because after exiting element fullscreen,
playing the video would re-enter native video fullscreen, and the subsequent pause would correctly
trigger text recognition in that new fullscreen context — violating the test&apos;s
expectation.

Fixed by adding playsinline to the video element in element-fullscreen.html and setting allowsInlineMediaPlayback =
YES on the test&apos;s WKWebViewConfiguration, ensuring the video plays inline rather than automatically entering native
video fullscreen on iOS.

* Tools/TestWebKitAPI/Resources/cocoa/element-fullscreen.html:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm:
(+[FullscreenVideoTextRecognitionWebView create]):
(TestWebKitAPI::TEST(FullscreenVideoTextRecognition, AddVideoAfterEnteringFullscreen)):
(TestWebKitAPI::TEST(FullscreenVideoTextRecognition, DoNotAnalyzeVideoAfterExitingFullscreen)):

Canonical link: <a href="https://commits.webkit.org/311627@main">https://commits.webkit.org/311627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e08faf2de65a3931e62eb6ea76065ed7d41d3d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111500 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38ad35fd-82fd-4d39-b156-0a9ef42e5bd3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121913 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85622 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51e6085c-77a5-41a2-9e10-302cdb12737f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102581 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be4c82ec-638d-4ef4-bb07-f306b333b0ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23226 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21479 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14013 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168727 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130058 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130165 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35279 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140971 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88214 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24992 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17776 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29990 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29512 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29742 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29639 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->