### PR TITLE
[GLib] WTF::span(char**) should return an empty span for null

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCContext.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCContext.cpp
@@ -448,10 +448,9 @@ JSValueRef jscContextGValueToJSValue(JSCContext* context, const GValue* value, J
                 return jscContextGArrayToJSArray(context, static_cast<GPtrArray*>(ptr), exception);
 
             if (g_type_is_a(G_VALUE_TYPE(value), G_TYPE_STRV)) {
-                auto** strv = static_cast<char**>(ptr);
-                auto strvLength = g_strv_length(strv);
-                GRefPtr<GPtrArray> gArray = adoptGRef(g_ptr_array_new_full(strvLength, g_object_unref));
-                for (auto* item : span(strv))
+                auto items = span(static_cast<char**>(ptr));
+                GRefPtr<GPtrArray> gArray = adoptGRef(g_ptr_array_new_full(items.size(), g_object_unref));
+                for (auto* item : items)
                     g_ptr_array_add(gArray.get(), jsc_value_new_string(context, item));
                 return jscContextGArrayToJSArray(context, gArray.get(), exception);
             }

--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -94,6 +94,8 @@ inline std::span<const uint8_t> span(const GRefPtr<GBytes>& bytes LIFETIME_BOUND
 
 inline std::span<const uint8_t> span(GByteArray* array LIFETIME_BOUND)
 {
+    if (!array)
+        return { };
     return unsafeMakeSpan<const uint8_t>(array->data, array->len);
 }
 
@@ -103,16 +105,16 @@ inline std::span<const uint8_t> span(const GRefPtr<GByteArray>& array LIFETIME_B
 }
 
 template <typename T = uint8_t*, typename = std::enable_if_t<std::is_pointer_v<T>>>
-inline std::span<T>span(GArray* array LIFETIME_BOUND)
+inline std::span<T> span(GArray* array LIFETIME_BOUND)
 {
     if (!array)
-        return unsafeMakeSpan<T>(nullptr, 0);
+        return { };
 
     return unsafeMakeSpan(static_cast<T*>(static_cast<void*>(array->data)), array->len);
 }
 
 template <typename T = uint8_t*, typename = std::enable_if_t<std::is_pointer_v<T>>>
-inline std::span<T>span(GRefPtr<GArray>& array LIFETIME_BOUND)
+inline std::span<T> span(GRefPtr<GArray>& array LIFETIME_BOUND)
 {
     return span<T>(array.get());
 }
@@ -131,6 +133,8 @@ inline std::span<const uint8_t> span(const GRefPtr<GVariant>& variant LIFETIME_B
 
 static inline std::span<char*> span(char** strv LIFETIME_BOUND)
 {
+    if (!strv)
+        return { };
     auto size = g_strv_length(strv);
     return unsafeMakeSpan(strv, size);
 }
@@ -142,6 +146,8 @@ static inline std::span<char*> span(const GUniquePtr<char*>& strv LIFETIME_BOUND
 
 static inline std::span<const char* const> span(const char* const* strv LIFETIME_BOUND)
 {
+    if (!strv)
+        return { };
     auto size = g_strv_length(const_cast<char**>(strv));
     return unsafeMakeSpan(strv, size);
 }
@@ -150,7 +156,7 @@ template <typename T = void*, typename = std::enable_if_t<std::is_pointer_v<T>>>
 inline std::span<T> span(GPtrArray* array LIFETIME_BOUND)
 {
     if (!array)
-        return unsafeMakeSpan<T>(nullptr, 0);
+        return { };
 
     return unsafeMakeSpan(static_cast<T*>(static_cast<void*>(array->pdata)), array->len);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
@@ -44,8 +44,6 @@ ProtectionSystemEvents::ProtectionSystemEvents(GstMessage* message)
         m_events.append(GRefPtr<GstEvent>(GST_EVENT_CAST(g_value_get_boxed(gst_value_list_get_value(streamEncryptionEventsList, i)))));
     const GValue* streamEncryptionAllowedSystemsValue = gst_structure_get_value(structure, "available-stream-encryption-systems");
     auto systemsArray = g_value_get_boxed(streamEncryptionAllowedSystemsValue);
-    if (!systemsArray)
-        return;
     for (const auto system : span(static_cast<char**>(systemsArray)))
         m_availableSystems.append(String::fromLatin1(system));
 }

--- a/Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h
+++ b/Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h
@@ -32,14 +32,11 @@ namespace IPC {
 template<> struct ArgumentCoder<GUniquePtr<char*>> {
     static void encode(Encoder& encoder, const GUniquePtr<char*>& strv)
     {
-        auto length = strv.get() ? g_strv_length(strv.get()) : 0;
+        auto strvSpan = span(strv.get());
+        unsigned length = strvSpan.size();
 
         encoder << length;
 
-        if (!length)
-            return;
-
-        auto strvSpan = span(strv.get());
         for (auto str : strvSpan)
             encoder << CString(str);
     }

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp
@@ -77,14 +77,10 @@ static inline UserScriptInjectionTime toUserScriptInjectionTime(WebKitUserScript
 
 static inline Vector<String> toStringVector(const char* const* strv)
 {
-    if (!strv)
-        return Vector<String>();
-
     const auto strvSpan = span(strv);
-    Vector<String> result(strvSpan.size(), [&strvSpan](size_t i) {
+    return Vector<String> { strvSpan.size(), [&strvSpan](size_t i) {
         return String::fromUTF8(strvSpan[i]);
-    });
-    return result;
+    }};
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -1640,10 +1640,10 @@ void webkit_web_context_set_preferred_languages(WebKitWebContext* context, const
 {
     g_return_if_fail(WEBKIT_IS_WEB_CONTEXT(context));
 
-    if (!languageList || !g_strv_length(const_cast<char**>(languageList)))
-        return;
-
     auto languagesSpan = span(const_cast<char**>(languageList));
+
+    if (!languagesSpan.size())
+        return;
 
     Vector<String> languages;
     for (auto language : languagesSpan) {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -5766,13 +5766,10 @@ void webkit_web_view_set_cors_allowlist(WebKitWebView* webView, const gchar* con
 {
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
 
-    Vector<String> allowListVector;
-    if (allowList) {
-        const auto allowListSpan = span(allowList);
-        allowListVector.reserveInitialCapacity(allowListSpan.size());
-        for (const char* str : allowListSpan)
-            allowListVector.append(String::fromUTF8(str));
-    }
+    const auto allowListSpan = span(allowList);
+    Vector<String> allowListVector { allowListSpan.size(), [&allowListSpan](size_t i) {
+        return String::fromUTF8(allowListSpan[i]);
+    }};
 
     getPage(webView).setCORSDisablingPatterns(WTF::move(allowListVector));
 }

--- a/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
@@ -47,10 +47,7 @@ using namespace WebCore;
 #if ENABLE(WPE_PLATFORM)
 static Vector<String> clipboardFormats(WPEClipboard* clipboard)
 {
-    auto* strv = wpe_clipboard_get_formats(clipboard);
-    if (!strv)
-        return { };
-    const auto formats = span(strv);
+    const auto formats = span(wpe_clipboard_get_formats(clipboard));
     return Vector<String>(formats.size(), [&formats](size_t index) {
         return String::fromUTF8(formats[index]);
     });
@@ -170,15 +167,13 @@ void WebPasteboardProxy::typesSafeForDOMToReadAndWrite(IPC::Connection&, const S
                     domTypes.add(type);
             }
 
-            if (auto* strv = wpe_clipboard_get_formats(clipboard)) {
-                for (const char* format : span(strv)) {
-                    String formatString = String::fromUTF8(format);
-                    if (formatString == PasteboardCustomData::wpeType())
-                        continue;
+            for (const char* format : span(wpe_clipboard_get_formats(clipboard))) {
+                String formatString = String::fromUTF8(format);
+                if (formatString == PasteboardCustomData::wpeType())
+                    continue;
 
-                    if (Pasteboard::isSafeTypeForDOMToReadAndWrite(formatString))
-                        domTypes.add(formatString);
-                }
+                if (Pasteboard::isSafeTypeForDOMToReadAndWrite(formatString))
+                    domTypes.add(formatString);
             }
             completionHandler(copyToVector(domTypes));
             return;


### PR DESCRIPTION
#### 19570fa4f1cb059d95e03568e7514671d01b0743
<pre>
[GLib] WTF::span(char**) should return an empty span for null
<a href="https://bugs.webkit.org/show_bug.cgi?id=312765">https://bugs.webkit.org/show_bug.cgi?id=312765</a>

Reviewed by Adrian Perez de Castro.

WTF::span(NSData*) returns an empty span for null.
Likewise, changed other WTF::span() overloades for GLib types.
- WTF::span(GByteArray*)
- WTF::span(char**)
- WTF::span(cosnt char* const*)

* Source/JavaScriptCore/API/glib/JSCContext.cpp:
(jscContextGValueToJSValue):
* Source/WTF/wtf/glib/GSpanExtras.h:
(WTF::span):
(WTF::std::span&lt;T&gt;span): Deleted.
* Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp:
(WebCore::ProtectionSystemEvents::ProtectionSystemEvents):
* Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h:
* Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp:
(toStringVector):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
* Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp:
(WebKit::clipboardFormats):
(WebKit::WebPasteboardProxy::typesSafeForDOMToReadAndWrite):

Canonical link: <a href="https://commits.webkit.org/311617@main">https://commits.webkit.org/311617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f32e9d771d2316baf8721fd49ca92b98f057765

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157433 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121923 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85628 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102592 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23237 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21492 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14028 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149484 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168742 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18268 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12900 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130072 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130179 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140987 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88229 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23952 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25001 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17792 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189506 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30005 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94019 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48661 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29527 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->