### PR TITLE
REGRESSION(311425@main) [GLIB] Flaky view-transition test crashes

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4683,11 +4683,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/navigation/custom-scrol
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/auto-name-from-id.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/start-skip-start.html [ Pass Failure ]
 
-webkit.org/b/312629 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-with-redirect.html [ Crash Pass ]
-webkit.org/b/312629 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition.html [ Crash Pass ]
-webkit.org/b/312629 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-replace-navigation.html [ Crash Pass ]
-webkit.org/b/312629 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-with-view-transition.html [ Crash Pass ]
-
 imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html [ ImageOnlyFailure ]
 
 # Kerning for SVG not working as expected.

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -136,12 +136,12 @@ void ThreadedCompositor::invalidate()
         Locker locker { m_state.lock };
         stopRenderTimer();
         m_state.didCompositeRenderingUpdateFunction = nullptr;
-        m_state.state = State::Idle;
+        m_state.state = State::Invalidated;
     }
 
     m_didCompositeRunLoopObserver->invalidate();
     m_workQueue->dispatchSync([this] {
-        if (m_textureMapper && (!m_context || !m_context->makeContextCurrent()))
+        if (!m_useSkia && (!m_context || !m_context->makeContextCurrent()))
             return;
 
         // Update the scene at this point ensures the layers state are correctly propagated.
@@ -208,7 +208,7 @@ void ThreadedCompositor::resume()
 bool ThreadedCompositor::isActive() const
 {
     Locker locker { m_state.lock };
-    return m_state.state != State::Idle;
+    return m_state.state != State::Idle && m_state.state != State::Invalidated;
 }
 
 void ThreadedCompositor::backgroundColorDidChange()
@@ -281,10 +281,10 @@ void ThreadedCompositor::flushCompositingState(const OptionSet<CompositionReason
 
 void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
 {
-    if (m_textureMapper)
-        paintToTextureMapper(matrix, size, reasons);
-    else
+    if (m_useSkia)
         paintToSkiaCanvas(matrix, size, reasons);
+    else
+        paintToTextureMapper(matrix, size, reasons);
 }
 
 void ThreadedCompositor::paintToTextureMapper(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)
@@ -431,6 +431,9 @@ void ThreadedCompositor::renderLayerTree()
     {
         Locker locker { m_state.lock };
 
+        if (m_state.state == State::Invalidated)
+            return;
+
         // The timer has been stopped.
         if (!m_state.isRenderTimerActive)
             return;
@@ -449,7 +452,7 @@ void ThreadedCompositor::renderLayerTree()
         m_state.state = State::InProgress;
     }
 
-    if (m_textureMapper && (!m_context || !m_context->makeContextCurrent()))
+    if (!m_useSkia && (!m_context || !m_context->makeContextCurrent()))
         return;
 
     // Retrieve the scene attributes in a thread-safe manner.
@@ -531,6 +534,8 @@ ASCIILiteral ThreadedCompositor::stateToString(ThreadedCompositor::State state)
         return "InProgress"_s;
     case State::ScheduledWhileInProgress:
         return "ScheduledWhileInProgress"_s;
+    case State::Invalidated:
+        return "Invalidated"_s;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
@@ -554,6 +559,7 @@ void ThreadedCompositor::scheduleUpdateLocked()
         m_state.state = State::ScheduledWhileInProgress;
         break;
     case State::ScheduledWhileInProgress:
+    case State::Invalidated:
         break;
     }
 }
@@ -568,6 +574,7 @@ void ThreadedCompositor::frameComplete()
     switch (m_state.state) {
     case State::Idle:
     case State::Scheduled:
+    case State::Invalidated:
         break;
     case State::InProgress:
         if (m_state.reasons.contains(CompositionReason::RenderingUpdate) && m_state.isWaitingForTiles)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -133,7 +133,8 @@ private:
         Idle,
         Scheduled,
         InProgress,
-        ScheduledWhileInProgress
+        ScheduledWhileInProgress,
+        Invalidated
     };
     static ASCIILiteral stateToString(State);
 


### PR DESCRIPTION
#### 4c334d3b96b00674f9cacce1df7a59ca852d1649
<pre>
REGRESSION(311425@main) [GLIB] Flaky view-transition test crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=312629">https://bugs.webkit.org/show_bug.cgi?id=312629</a>

Reviewed by Nikolas Zimmermann.

The problem is that in ThreadedCompositor renderLayerTree can be called
after invalidate. Before 311425@main we returned early because m_context
is also set to nullptr in invalidate, but now the context is always
nullptr when using skia compositor and we are assuming that a null
texture mapper means we are using skia. This patch adds an Invalidated state
to ThreadedCompositor to make sure we always return early from
renderLayerTree after invalidate, and it always uses m_useSkia to check
if we are using the skia compositor.

Fixes: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-with-redirect.html
       imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition.html
       imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-replace-navigation.html
       imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-with-view-transition.html

* LayoutTests/platform/glib/TestExpectations:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::invalidate):
(WebKit::ThreadedCompositor::isActive const):
(WebKit::ThreadedCompositor::paintToCurrentGLContext):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::stateToString):
(WebKit::ThreadedCompositor::scheduleUpdateLocked):
(WebKit::ThreadedCompositor::frameComplete):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:

Canonical link: <a href="https://commits.webkit.org/311654@main">https://commits.webkit.org/311654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f37fc8bf5d81fd56ef23e0c067f4d5f6d2bd57f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166467 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122062 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24346 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102731 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14238 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168956 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/13450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20995 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30582 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130348 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141169 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23967 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25160 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/189716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30215 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/94632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/189716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29737 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29967 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->