### PR TITLE
Cherry-pick 311528@main (86601950f4eb). https://bugs.webkit.org/show_bug.cgi?id=299092

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -959,7 +959,7 @@ accessibility/visible-character-range-height-changes.html [ Skip ]
 accessibility/visible-character-range-scrolling.html [ Skip ]
 accessibility/visible-character-range-vertical-rl.html [ Skip ]
 
-[ Release ] accessibility/display-contents/tree-and-treeitems.html [ Failure ]
+accessibility/display-contents/tree-and-treeitems.html [ Failure ]
 
 webkit.org/b/212805 accessibility/svg-text.html [ Failure ]
 
@@ -4789,20 +4789,6 @@ webkit.org/b/298433 [ Release ] imported/w3c/web-platform-tests/selection/caret/
 
 # Needs rebaseline.
 fast/text/glyph-display-lists [ Skip ]
-
-# Tests crashing in Debug
-webkit.org/b/299092 [ Debug ] accessibility/aria-flowto.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/aria-selected.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/display-contents/element-roles.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/display-contents/list.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/display-contents/table-dynamic.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/display-contents/tree-and-treeitems.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/node-only-object-aria-owns-hang.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/node-only-object-element-rect.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/url-test.html [ Skip ]
-webkit.org/b/299092 [ Debug ] accessibility/non-data-table-cell-title-ui-element.html [ Crash ]
-webkit.org/b/299092 [ Debug ] imported/w3c/web-platform-tests/css/css-display/parsing/display-computed.html [ Crash Pass ]
-webkit.org/b/299092 [ Debug ] imported/w3c/web-platform-tests/css/css-display/focus/display-contents-focus.html [ Crash Pass ]
 
 # Depends on 'UIScriptController::singleTapAtPointWithModifiers', which is not implemented yet for GLIB.
 webkit.org/b/278719 fast/events/touch/touch-fractional-coordinates.html [ Skip ]

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -698,6 +698,9 @@ void AccessibilityObject::insertChild(AccessibilityObject& child, unsigned index
     auto insert = [this] (Ref<AXCoreObject>&& object, unsigned index) {
         std::ignore = setChildIndexInParent(object.get(), index);
         m_children.insert(index, WTF::move(object));
+        // Update child-index for children after the newly inserted object.
+        for (unsigned i = index + 1; i < m_children.size(); i++)
+            std::ignore = setChildIndexInParent(m_children[i].get(), i);
     };
 
     auto thisAncestorFlags = computeAncestorFlags();

--- a/Tools/Scripts/filter-test-logs
+++ b/Tools/Scripts/filter-test-logs
@@ -51,7 +51,7 @@ def parser():
     parser = argparse.ArgumentParser(description='filter test output')
     parser.add_argument(
         'filter_type',
-        choices=['jsc', 'layout', 'scan-build', 'webdriver', 'test262', 'minibrowser'],
+        choices=['jsc', 'layout', 'scan-build', 'webdriver', 'test262', 'minibrowser', 'api'],
         help='Choose which test logs to filter'
     )
     parser.add_argument(
@@ -162,6 +162,22 @@ def filter_minibrowser_tests(log_file_name):
                 keep_alive_stdout.maybe_update_progress()
 
 
+def filter_api_tests(log_file_name):
+    log_file = os.path.abspath(f'{log_file_name}')
+    keep_alive_stdout = KeepAliveStdoutProgress()
+    with open(log_file, 'w') as f:
+        print_all_lines = False
+        for line in sys.stdin:
+            f.write(line)
+            if print_all_lines:
+                print(line, end='')
+            elif re.match(r'.*Ran \d+ tests of \d+', line):
+                print_all_lines = True
+                print(line, end='')
+            else:
+                keep_alive_stdout.maybe_update_progress()
+
+
 def main():
     args = parser()
     if args.filter_type == 'jsc':
@@ -176,6 +192,8 @@ def main():
         filter_test262(args.output)
     elif args.filter_type == 'minibrowser':
         filter_minibrowser_tests(args.output)
+    elif args.filter_type == 'api':
+        filter_api_tests(args.output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### 431223a131a7ae823394855f4eda4c2be6cd5189
<pre>
Cherry-pick 311528@main (86601950f4eb). <a href="https://bugs.webkit.org/show_bug.cgi?id=299092">https://bugs.webkit.org/show_bug.cgi?id=299092</a>

    [GLIB] [Debug] ASSERT error in accessibility/aria-flowto.html
    <a href="https://bugs.webkit.org/show_bug.cgi?id=299092">https://bugs.webkit.org/show_bug.cgi?id=299092</a>

    Reviewed by Tyler Wilcock.

    The lambda used to insert children doesn&apos;t update the child-index
    for elements after the inserted one, which leaves their index
    corrupt. This doesn&apos;t seem to be an issue in non-atspi accessibility,
    because this method seems to be called to append children. In
    the atspi case, there can be items prepended, which can corrupt
    the indexes and cause this assertion to fire.

    Covered by existing tests, that can be unskipped now that they
    don&apos;t crash.

    * LayoutTests/platform/glib/TestExpectations:
    * Source/WebCore/accessibility/AccessibilityObject.cpp:
    (WebCore::AccessibilityObject::insertChild):

    Canonical link: <a href="https://commits.webkit.org/311528@main">https://commits.webkit.org/311528@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.450@webkitglib/2.52">https://commits.webkit.org/305877.450@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c4552eec950bd275c76cf9ea05a5feff3250799f
<pre>
Cherry-pick 310380@main (c1efc9fdbee6). <a href="https://bugs.webkit.org/show_bug.cgi?id=303568">https://bugs.webkit.org/show_bug.cgi?id=303568</a>

    Add API test support to filter-test-logs
    <a href="https://rdar.apple.com/165859561">rdar://165859561</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=303568">https://bugs.webkit.org/show_bug.cgi?id=303568</a>

    Reviewed by Aakash Jain.

    Add a new option that supports the output from run-api-tests. Adoption in buildbot steps
    will come in a separate change.

    * Tools/Scripts/filter-test-logs: Add new &apos;api&apos; option.

    Canonical link: <a href="https://commits.webkit.org/310380@main">https://commits.webkit.org/310380@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.449@webkitglib/2.52">https://commits.webkit.org/305877.449@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/617eb4b73e68f361dc7256dd40aa7cca9e9c0ca1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157455 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30792 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23985 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166279 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111537 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159326 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30927 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30794 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121934 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111537 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160413 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/30927 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/23985 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102603 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/30927 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/30794 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14050 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/30927 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/23985 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168816 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/14660 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/23985 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/168816 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30393 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/30794 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/168816 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30316 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/23985 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88251 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24047 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/30316 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/23985 "Unable to build WebKit without PR, please check manually (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30027 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/96094 "Build was cancelled. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29549 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29779 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29676 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->