### PR TITLE
Web Inspector: Show layout root element

### DIFF
--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -550,10 +550,10 @@ void InspectorInstrumentation::willLayoutImpl(InstrumentingAgents& instrumenting
         pageTimelineAgent->willLayout();
 }
 
-void InspectorInstrumentation::didLayoutImpl(InstrumentingAgents& instrumentingAgents, const Vector<FloatQuad>& layoutAreas)
+void InspectorInstrumentation::didLayoutImpl(InstrumentingAgents& instrumentingAgents, const RenderElement& layoutRoot, const Vector<FloatQuad>& layoutAreas)
 {
     if (CheckedPtr pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
-        pageTimelineAgent->didLayout(layoutAreas);
+        pageTimelineAgent->didLayout(layoutRoot, layoutAreas);
     if (CheckedPtr pageAgent = instrumentingAgents.enabledPageAgent())
         pageAgent->didLayout();
 }

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -193,7 +193,7 @@ public:
     static void didFireTimer(ScriptExecutionContext&, int timerId, bool oneShot);
     static void didInvalidateLayout(LocalFrame&);
     static void willLayout(LocalFrame&);
-    static void didLayout(LocalFrame&, const Vector<FloatQuad>&);
+    static void didLayout(LocalFrame&, const RenderElement&, const Vector<FloatQuad>&);
     static void didScroll(Page&);
     static void willComposite(LocalFrame&);
     static void didComposite(LocalFrame&);
@@ -424,7 +424,7 @@ private:
     static void didFireTimerImpl(InstrumentingAgents&, int timerId, bool oneShot);
     static void didInvalidateLayoutImpl(InstrumentingAgents&);
     static void willLayoutImpl(InstrumentingAgents&);
-    static void didLayoutImpl(InstrumentingAgents&, const Vector<FloatQuad>&);
+    static void didLayoutImpl(InstrumentingAgents&, const RenderElement&, const Vector<FloatQuad>&);
     static void didScrollImpl(InstrumentingAgents&);
     static void willCompositeImpl(InstrumentingAgents&);
     static void didCompositeImpl(InstrumentingAgents&);
@@ -1015,10 +1015,10 @@ inline void InspectorInstrumentation::willLayout(LocalFrame& frame)
     willLayoutImpl(instrumentingAgents(frame));
 }
 
-inline void InspectorInstrumentation::didLayout(LocalFrame& frame, const Vector<FloatQuad>& layoutAreas)
+inline void InspectorInstrumentation::didLayout(LocalFrame& frame, const RenderElement& layoutRoot, const Vector<FloatQuad>& layoutAreas)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    didLayoutImpl(instrumentingAgents(frame), layoutAreas);
+    didLayoutImpl(instrumentingAgents(frame), layoutRoot, layoutAreas);
 }
 
 inline void InspectorInstrumentation::didScroll(Page& page)

--- a/Source/WebCore/inspector/TimelineRecordFactory.cpp
+++ b/Source/WebCore/inspector/TimelineRecordFactory.cpp
@@ -177,8 +177,9 @@ Ref<JSON::Object> TimelineRecordFactory::createScreenshotData(const String& imag
     return data;
 }
 
-void TimelineRecordFactory::appendLayoutRoot(JSON::Object& data, const FloatQuad& quad)
+void TimelineRecordFactory::appendLayoutRoot(JSON::Object& data, Inspector::Protocol::DOM::NodeId nodeId, const FloatQuad& quad)
 {
+    data.setInteger("nodeId"_s, nodeId);
     data.setArray("root"_s, createQuad(quad));
 }
 

--- a/Source/WebCore/inspector/TimelineRecordFactory.h
+++ b/Source/WebCore/inspector/TimelineRecordFactory.h
@@ -62,7 +62,7 @@ public:
     static Ref<JSON::Object> createPaintData(const FloatQuad&);
     static Ref<JSON::Object> createScreenshotData(const String& imageData);
 
-    static void appendLayoutRoot(JSON::Object& data, const FloatQuad&);
+    static void appendLayoutRoot(JSON::Object& data, Inspector::Protocol::DOM::NodeId, const FloatQuad&);
 
 private:
     TimelineRecordFactory() { }

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -33,9 +33,11 @@
 #include "ImageBuffer.h"
 #include "ImageUtilities.h"
 #include "InspectorBackendClient.h"
+#include "InspectorDOMAgent.h"
 #include "InstrumentingAgents.h"
 #include "Page.h"
 #include "PageInspectorController.h"
+#include "RenderElementInlines.h"
 #include "RenderObjectInlines.h"
 #include "RenderView.h"
 #include "TimelineRecordFactory.h"
@@ -197,7 +199,7 @@ void PageTimelineAgent::willLayout()
     pushCurrentRecord(JSON::Object::create(), TimelineRecordType::Layout, true);
 }
 
-void PageTimelineAgent::didLayout(const Vector<FloatQuad>& layoutAreas)
+void PageTimelineAgent::didLayout(const RenderElement& layoutRoot, const Vector<FloatQuad>& layoutAreas)
 {
     auto* entry = lastRecordEntry();
     if (!entry)
@@ -205,8 +207,22 @@ void PageTimelineAgent::didLayout(const Vector<FloatQuad>& layoutAreas)
 
     ASSERT(entry->type == TimelineRecordType::Layout);
     ASSERT(!layoutAreas.isEmpty());
-    if (!layoutAreas.isEmpty())
-        TimelineRecordFactory::appendLayoutRoot(entry->data.get(), layoutAreas[0]);
+
+    RefPtr<Node> node = layoutRoot.element();
+
+    if (layoutRoot.isRenderView())
+        node = &layoutRoot.document();
+    else if (layoutRoot.isBeforeOrAfterContent())
+        node = layoutRoot.generatingElement();
+    else if (layoutRoot.isAnonymous())
+        node = layoutRoot.parent()->element();
+
+    Inspector::Protocol::DOM::NodeId nodeID = 0;
+    if (CheckedPtr domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent())
+        nodeID = domAgent->pushNodeToFrontend(node);
+
+    if (nodeID && !layoutAreas.isEmpty())
+        TimelineRecordFactory::appendLayoutRoot(entry->data.get(), nodeID, layoutAreas[0]);
 
     didCompleteCurrentRecord(TimelineRecordType::Layout);
 }

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
@@ -50,7 +50,7 @@ public:
     // InspectorInstrumentation
     void didInvalidateLayout();
     void willLayout();
-    void didLayout(const Vector<FloatQuad>&);
+    void didLayout(const RenderElement&, const Vector<FloatQuad>&);
     void willComposite();
     void didComposite();
     void willPaint();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -314,7 +314,7 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         protect(view())->didLayout(layoutRoot, canDeferUpdateLayerPositions);
         runOrScheduleAsynchronousTasks(canDeferUpdateLayerPositions);
     }
-    InspectorInstrumentation::didLayout(frame, layoutAreas);
+    InspectorInstrumentation::didLayout(frame, *layoutRoot, layoutAreas);
     DebugPageOverlays::didLayout(frame);
 }
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
@@ -858,6 +858,7 @@ WI.TimelineManager = class TimelineManager extends WI.Object
             var layoutRecordType = sourceCodeLocation ? WI.LayoutTimelineRecord.EventType.ForcedLayout : WI.LayoutTimelineRecord.EventType.Layout;
             return new WI.LayoutTimelineRecord(layoutRecordType, startTime, endTime, stackTrace, sourceCodeLocation, {
                 quad: new WI.Quad(recordPayload.data.root),
+                domNode: WI.domManager.nodeForId(recordPayload.data.nodeId),
             });
 
         case InspectorBackend.Enum.Timeline.EventType.Paint:

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
@@ -437,7 +437,13 @@ WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
 
     _revealAndSelectNode(node, omitFocus)
     {
-        if (!node || this._suppressRevealAndSelect)
+        if (this._suppressRevealAndSelect)
+            return;
+
+        if (!this._includeRootDOMNode && this.rootDOMNode && node === this.rootDOMNode)
+            node = this.rootDOMNode.firstChild;
+
+        if (!node)
             return;
 
         var treeElement = this.createTreeElementFor(node);

--- a/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineDataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineDataGridNode.js
@@ -61,7 +61,7 @@ WI.LayoutTimelineDataGridNode = class LayoutTimelineDataGridNode extends WI.Time
         case "name":
             cell.classList.add(...this.iconClassNames());
 
-            if (this.record.eventType == WI.LayoutTimelineRecord.EventType.LargestContentfulPaint) {
+            if (this.record.eventType == WI.LayoutTimelineRecord.EventType.Layout || this.record.eventType == WI.LayoutTimelineRecord.EventType.LargestContentfulPaint) {
                 let fragment = document.createDocumentFragment();
                 fragment.append(value);
 


### PR DESCRIPTION
#### 5cf90e6136c2d55f33d374969946a196e193abb5
<pre>
Web Inspector: Show layout root element
<a href="https://bugs.webkit.org/show_bug.cgi?id=312761">https://bugs.webkit.org/show_bug.cgi?id=312761</a>

Reviewed by Devin Rousso.

Add support for displaying the layout root element for a &quot;Layout&quot; event
in Web Inspector timeline details view.

Reuse exising `WI.LayoutTimelineRecord.domNode` property to store the
layout root element, and show &quot;go to arrow&quot; which provides a button to
jump to the element.

If the layout root element is the document root element, jump to its
first child element.

* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didLayoutImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didLayout):
* Source/WebCore/inspector/TimelineRecordFactory.cpp:
(WebCore::TimelineRecordFactory::appendLayoutRoot):
* Source/WebCore/inspector/TimelineRecordFactory.h:
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::didLayout):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::performLayout):
* Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js:
(WI.TimelineManager.prototype._processRecord):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js:
(WI.DOMTreeOutline.prototype._revealAndSelectNode):
* Source/WebInspectorUI/UserInterface/Views/LayoutTimelineDataGridNode.js:
(WI.LayoutTimelineDataGridNode.prototype.createCellContent):
(WI.LayoutTimelineDataGridNode):

Canonical link: <a href="https://commits.webkit.org/311847@main">https://commits.webkit.org/311847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f4ada7481541aa51e3e388c86beb3ec7a9989a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122299 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85862 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102966 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23647 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21943 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14526 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169243 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14261 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21256 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130473 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130587 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35418 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30946 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141427 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88812 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25325 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18233 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30498 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95689 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30249 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->