### PR TITLE
[CMake][Rice] Remove support for librice < 0.4.x

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -101,11 +101,7 @@ typedef struct _WebKitGstIceAgentPrivate {
     String turnServer;
 
     HashSet<URL> turnServers;
-#if RICE_CHECK_VERSION(0, 4, 0)
     Vector<GUniquePtr<RiceTurnConfig>> turnConfigs;
-#else
-    Vector<GRefPtr<RiceTurnConfig>> turnConfigs;
-#endif
 
     GRefPtr<GSource> recvSource;
     bool forceRelay { false };
@@ -258,7 +254,7 @@ static void webkitGstWebRTCIceAgentAddRiceTurnServer(WebKitGstIceAgent* agent, c
     GRefPtr<RiceTlsConfig> tlsConfig;
     if (isTurns)
         tlsConfig = adoptGRef(rice_tls_config_new_openssl(relayTransport));
-#if RICE_CHECK_VERSION(0, 4, 0)
+
     GUniquePtr<RiceTurnConfig> config(rice_turn_config_new(relayTransport, riceAddress.get(), credentials.get()));
     rice_turn_config_add_address_family(config.get(), RICE_ADDRESS_FAMILY_IPV4);
     rice_turn_config_add_address_family(config.get(), RICE_ADDRESS_FAMILY_IPV6);
@@ -268,14 +264,6 @@ static void webkitGstWebRTCIceAgentAddRiceTurnServer(WebKitGstIceAgent* agent, c
     rice_turn_config_add_supported_integrity(config.get(), RICE_INTEGRITY_ALGORITHM_SHA256);
     if (tlsConfig)
         rice_turn_config_set_tls_config(config.get(), tlsConfig.get());
-#else
-    const std::array<RiceAddressFamily, 2> families = { RICE_ADDRESS_FAMILY_IPV4, RICE_ADDRESS_FAMILY_IPV6 };
-    auto config = adoptGRef(rice_turn_config_new(relayTransport, riceAddress.get(), credentials.get(),
-#if RICE_CHECK_VERSION(0, 3, 0)
-        RICE_TRANSPORT_TYPE_UDP,
-#endif
-        families.size(), families.data(), tlsConfig.leakRef()));
-#endif // RICE_CHECK_VERSION(0, 4, 0)
     agent->priv->turnConfigs.append(WTF::move(config));
 }
 
@@ -795,7 +783,6 @@ const GRefPtr<RiceAgent>& webkitGstWebRTCIceAgentGetRiceAgent(WebKitGstIceAgent*
     return agent->priv->agent;
 }
 
-#if RICE_CHECK_VERSION(0, 4, 0)
 Vector<GUniquePtr<RiceTurnConfig>> webkitGstWebRTCIceAgentGetTurnConfigs(WebKitGstIceAgent* agent)
 {
     Vector<GUniquePtr<RiceTurnConfig>> result;
@@ -805,17 +792,6 @@ Vector<GUniquePtr<RiceTurnConfig>> webkitGstWebRTCIceAgentGetTurnConfigs(WebKitG
 
     return result;
 }
-#else
-Vector<GRefPtr<RiceTurnConfig>> webkitGstWebRTCIceAgentGetTurnConfigs(WebKitGstIceAgent* agent)
-{
-    Vector<GRefPtr<RiceTurnConfig>> result;
-    result.reserveInitialCapacity(agent->priv->turnConfigs.size());
-    for (const auto& config : agent->priv->turnConfigs)
-        result.append(GRefPtr(config));
-
-    return result;
-}
-#endif
 
 RiceGatherResult webkitGstWebRTCIceAgentGatherSocketAddresses(WebKitGstIceAgent* agent, unsigned streamId)
 {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h
@@ -117,11 +117,7 @@ WebKitGstIceAgent* webkitGstWebRTCCreateIceAgent(const String&, WebCore::ScriptE
 
 const GRefPtr<RiceAgent>& webkitGstWebRTCIceAgentGetRiceAgent(WebKitGstIceAgent*);
 
-#if RICE_CHECK_VERSION(0, 4, 0)
 Vector<GUniquePtr<RiceTurnConfig>> webkitGstWebRTCIceAgentGetTurnConfigs(WebKitGstIceAgent*);
-#else
-Vector<GRefPtr<RiceTurnConfig>> webkitGstWebRTCIceAgentGetTurnConfigs(WebKitGstIceAgent*);
-#endif
 
 WebCore::RiceGatherResult webkitGstWebRTCIceAgentGatherSocketAddresses(WebKitGstIceAgent*, unsigned);
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
@@ -198,13 +198,9 @@ static gboolean webkitGstWebRTCIceStreamGatherCandidates(GstWebRTCICEStream* ice
     auto turnAddressDataStorage = turnAddressValues.span();
 
     Vector<RiceTurnConfig*> turnConfigValues;
-    for (auto& config : turnConfigs) {
-#if RICE_CHECK_VERSION(0, 4, 0)
+    for (auto& config : turnConfigs)
         turnConfigValues.append(rice_turn_config_copy(config.get()));
-#else
-        turnConfigValues.append(config.ref());
-#endif
-    }
+
     auto turnConfigDataStorage = turnConfigValues.releaseBuffer();
 
     auto component = adoptGRef(rice_stream_get_component(stream->priv->riceStream.get(), 1));

--- a/Source/WebCore/platform/rice/GRefPtrRice.h
+++ b/Source/WebCore/platform/rice/GRefPtrRice.h
@@ -32,9 +32,6 @@ WTF_DEFINE_GREF_TRAITS_INLINE(RiceSockets, rice_sockets_ref, rice_sockets_unref)
 WTF_DEFINE_GREF_TRAITS_INLINE(RiceComponent, rice_component_ref, rice_component_unref)
 WTF_DEFINE_GREF_TRAITS_INLINE(RiceUdpSocket, rice_udp_socket_ref, rice_udp_socket_unref)
 WTF_DEFINE_GREF_TRAITS_INLINE(RiceTlsConfig, rice_tls_config_ref, rice_tls_config_unref)
-#if !RICE_CHECK_VERSION(0, 4, 0)
-WTF_DEFINE_GREF_TRAITS_INLINE(RiceTurnConfig, rice_turn_config_ref, rice_turn_config_unref)
-#endif
 WTF_DEFINE_GREF_TRAITS_INLINE(RiceTcpListener, rice_tcp_listener_ref, rice_tcp_listener_unref)
 
 } // namespace WTF

--- a/Source/WebCore/platform/rice/GUniquePtrRice.h
+++ b/Source/WebCore/platform/rice/GUniquePtrRice.h
@@ -30,9 +30,7 @@ namespace WTF {
 WTF_DEFINE_GPTR_DELETER(RiceAddress, rice_address_free)
 WTF_DEFINE_GPTR_DELETER(RiceCandidate, rice_candidate_free)
 WTF_DEFINE_GPTR_DELETER(RiceCredentials, rice_credentials_free)
-#if RICE_CHECK_VERSION(0, 4, 0)
 WTF_DEFINE_GPTR_DELETER(RiceTurnConfig, rice_turn_config_free)
-#endif
 
 }
 

--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp
@@ -434,15 +434,13 @@ const RiceAddress* RiceBackend::ensureRiceAddressFromCache(const String& address
     return result.get();
 }
 
-void RiceBackend::setSocketTypeOfService([[maybe_unused]] unsigned streamId, [[maybe_unused]] unsigned value)
+void RiceBackend::setSocketTypeOfService(unsigned streamId, unsigned value)
 {
-#if RICE_CHECK_VERSION(0, 2, 2)
     auto sockets = getSocketsForStream(streamId);
     if (!sockets) [[unlikely]]
         return;
 
     rice_sockets_set_tos(sockets.get(), value);
-#endif
 }
 
 struct SocketAllocationData {
@@ -504,13 +502,11 @@ void RiceBackend::removeSocket(unsigned streamId, unsigned componentId, WebCore:
 
 void RiceBackend::configureSocketBufferSizes()
 {
-#if RICE_CHECK_VERSION(0, 2, 2)
     // Setting same librice socket size options as LibWebRTC. 1MB for incoming streams and 256Kb for outgoing streams.
     static const uint32_t receiveBufferSize = 1048576;
     static const uint32_t sendBufferSize = 262144;
     for (auto& data : m_sockets.values())
         rice_sockets_set_buffer_sizes(data.sockets.get(), sendBufferSize, receiveBufferSize);
-#endif
 }
 
 } // namespace WebKit

--- a/Source/cmake/GStreamerChecks.cmake
+++ b/Source/cmake/GStreamerChecks.cmake
@@ -62,7 +62,7 @@ if (ENABLE_MEDIA_STREAM AND ENABLE_WEB_RTC)
         endif ()
 
         if (USE_LIBRICE)
-            find_package(Rice 0.1.1 COMPONENTS Io Proto)
+            find_package(Rice 0.4.2 COMPONENTS Io Proto)
             if (NOT Rice_Io_FOUND OR NOT Rice_Proto_FOUND)
                 message(FATAL_ERROR "librice-{io,proto} is needed for USE_LIBRICE.")
             endif ()


### PR DESCRIPTION
#### 7cb396c84a227b60f78e8ca2de352b8e627d93b8
<pre>
[CMake][Rice] Remove support for librice &lt; 0.4.x
<a href="https://bugs.webkit.org/show_bug.cgi?id=312768">https://bugs.webkit.org/show_bug.cgi?id=312768</a>

Reviewed by Adrian Perez de Castro.

Require version 0.4.2 and remove now un-needed ifdefs. LibRice not being widely packaged yet, we
don&apos;t want to maintain support for older versions with different APIs.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
(webkitGstWebRTCIceAgentAddRiceTurnServer):
(webkitGstWebRTCIceAgentGetTurnConfigs):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp:
(webkitGstWebRTCIceStreamGatherCandidates):
* Source/WebCore/platform/rice/GRefPtrRice.h:
* Source/WebCore/platform/rice/GUniquePtrRice.h:
* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp:
(WebKit::RiceBackend::setSocketTypeOfService):
(WebKit::RiceBackend::configureSocketBufferSizes):
* Source/cmake/GStreamerChecks.cmake:

Canonical link: <a href="https://commits.webkit.org/311622@main">https://commits.webkit.org/311622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d2941de3ea4be40859ac86fee834c35a1555b80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166283 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111541 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121936 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85643 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102605 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23261 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21512 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14054 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149510 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168768 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18294 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12993 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130084 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130191 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35275 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30320 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141006 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88257 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25021 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17811 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189532 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30031 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94133 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48663 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29553 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29783 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->