### PR TITLE
innerText should emit a newline for empty <option> or <optgroup> inside <select>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -134,8 +134,8 @@ PASS <select size='2'> contents of options preserved ("<select size='2'><option>
 PASS <select size='1'> contents of target option preserved ("<select size='1'><option id='target'>abc</option><option>def")
 PASS <select size='2'> contents of target option preserved ("<select size='2'><option id='target'>abc</option><option>def")
 PASS empty <select> ("<div>a<select></select>bc")
-FAIL empty <optgroup> in <select> ("<div>a<select><optgroup></select>bc") assert_equals: innerText expected "a\nbc" but got "abc"
-FAIL empty <option> in <select> ("<div>a<select><option></select>bc") assert_equals: innerText expected "a\nbc" but got "abc"
+PASS empty <optgroup> in <select> ("<div>a<select><optgroup></select>bc")
+PASS empty <option> in <select> ("<div>a<select><option></select>bc")
 PASS <select> containing text node child ("<select class='poke'></select>")
 PASS <optgroup> containing <optgroup> ("<select><optgroup class='poke-optgroup'></select>")
 PASS <optgroup> containing <option> ("<select><optgroup><option>abc</select>")

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -896,7 +896,7 @@ bool TextIterator::handleReplacedElement()
     if (m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec)) {
         if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(m_currentNode)) {
             m_handledChildren = true;
-            if (String selectText = selectElement->collectOptionInnerText(); !selectText.isEmpty()) {
+            if (String selectText = selectElement->collectOptionInnerText(HTMLSelectElement::EmitNewlineForEmptyItems::Yes); !selectText.isEmpty()) {
                 m_hasEmitted = true;
                 m_lastCharacter = selectText[selectText.length() - 1];
                 m_copyableText.set(WTF::move(selectText));

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -505,7 +505,7 @@ String HTMLSelectElement::value() const
     return emptyString();
 }
 
-String HTMLSelectElement::collectOptionInnerText() const
+String HTMLSelectElement::collectOptionInnerText(EmitNewlineForEmptyItems emitNewlineForEmptyItems) const
 {
     StringBuilder builder;
     for (auto& item : listItems()) {
@@ -515,6 +515,10 @@ String HTMLSelectElement::collectOptionInnerText() const
             builder.append(option->text());
         }
     }
+    // Even when options/optgroups have no text, their presence as block-level
+    // elements should generate a required line break per the innerText spec.
+    if (builder.isEmpty() && emitNewlineForEmptyItems == EmitNewlineForEmptyItems::Yes && !listItems().isEmpty())
+        return "\n"_s;
     return builder.toString();
 }
 

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -95,7 +95,8 @@ public:
     WEBCORE_EXPORT String value() const;
     WEBCORE_EXPORT void setValue(const String&);
 
-    String collectOptionInnerText() const;
+    enum class EmitNewlineForEmptyItems : bool { No, Yes };
+    String collectOptionInnerText(EmitNewlineForEmptyItems = EmitNewlineForEmptyItems::No) const;
 
     WEBCORE_EXPORT Ref<HTMLOptionsCollection> options();
     Ref<HTMLCollection> selectedOptions();


### PR DESCRIPTION
#### e59d6bd9c64bc488a7a252c5825c56818ccbfee1
<pre>
innerText should emit a newline for empty &lt;option&gt; or &lt;optgroup&gt; inside &lt;select&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=312770">https://bugs.webkit.org/show_bug.cgi?id=312770</a>

Reviewed by Anne van Kesteren.

When a &lt;select&gt; contains an empty &lt;option&gt; or &lt;optgroup&gt;, collectOptionInnerText()
returns an empty string and the TextIterator emits nothing for the select element.
However, per the innerText spec, each &lt;option&gt; and &lt;optgroup&gt; acts as a block-level
element that should generate a required line break.

Fix this by adding an EmitNewlineForEmptyItems enum parameter to
collectOptionInnerText(). When passed Yes (as done from the TextIterator), the
method returns &quot;\n&quot; if listItems() is non-empty but all options have empty text.
This keeps the empty-item logic in the select&apos;s own method rather than in the
TextIterator. The default is No, preserving the existing behavior when innerText
is called directly on a &lt;select&gt; element.

No new tests, rebaselined existing WPT test. Chrome was already passing
the subtests that we are newly passing.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::handleReplacedElement):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::collectOptionInnerText):
* Source/WebCore/html/HTMLSelectElement.h:

Canonical link: <a href="https://commits.webkit.org/311673@main">https://commits.webkit.org/311673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b004ea0e7fbcbbe99f442ef3d1c339dd59a68bea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111704 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122046 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85729 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102715 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23383 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21660 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14217 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133062 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168935 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13405 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130215 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130330 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35305 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141151 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88481 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25142 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17956 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94586 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29716 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29946 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29843 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->