### PR TITLE
ANGLE: Metal: Avoid showing most windows for tests

### DIFF
--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp
@@ -621,8 +621,8 @@ void ANGLETestBase::initOSWindow()
         return;
     }
 
-    // On Linux we must keep the test windows visible. On Windows it doesn't seem to need it.
-    setWindowVisible(getOSWindow(), !IsWindows());
+    // On Linux we must keep the test windows visible. On Windows or Metal it doesn't seem to need it.
+    setWindowVisible(getOSWindow(), !(IsWindows() || IsMac() || IsIOS()));
 
     switch (mCurrentParams->driver)
     {


### PR DESCRIPTION
#### 1f41867848acbe98dd9a7680365eecc2945de48d
<pre>
ANGLE: Metal: Avoid showing most windows for tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=312771">https://bugs.webkit.org/show_bug.cgi?id=312771</a>
<a href="https://rdar.apple.com/175158230">rdar://175158230</a>

Reviewed by Dan Glastonbury.

Avoid showing window for most tests. This helps developing during
test runs, as the popping test windows would otherwise steal focus.

* Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp:
(ANGLETestBase::initOSWindow):

Canonical link: <a href="https://commits.webkit.org/311653@main">https://commits.webkit.org/311653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ce31180f4cd51fba6102f4f52059135ead73255

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166269 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111527 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80bba371-55c5-41c7-b0d3-874aeb7cc236) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30784 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121928 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85635 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d997697-0fda-415f-8702-9258881ffd51) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102597 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e853c81d-59d3-4a53-bd89-fae693a45a29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23249 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21500 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14040 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168754 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130075 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130182 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35295 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140993 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88241 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17798 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30017 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29539 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29769 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29666 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->