### PR TITLE
Mirroring large/stretchy operators using the OpenType `rtlm` feature

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/presentation-markup/radicals/glyph-level-mirroring-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/presentation-markup/radicals/glyph-level-mirroring-expected.txt
@@ -1,0 +1,9 @@
+
+PASS LTR Direction
+PASS RTL Direction
+
+
+
+
+
+

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
@@ -399,6 +399,35 @@ void OpenTypeMathData::getMathVariants(Glyph, bool, Vector<Glyph>&, Vector<Assem
 #endif
 }
 
+#if !ENABLE(OPENTYPE_MATH) && USE(HARFBUZZ)
+Glyph OpenTypeMathData::getMirroredGlyph(char32_t codePoint) const
+{
+    if (!codePoint)
+        return 0;
+
+    HbUniquePtr<hb_buffer_t> buffer(hb_buffer_create());
+    hb_buffer_set_direction(buffer.get(), HB_DIRECTION_RTL);
+    hb_buffer_set_content_type(buffer.get(), HB_BUFFER_CONTENT_TYPE_UNICODE);
+    hb_buffer_add(buffer.get(), codePoint, 0 /* cluster */);
+
+    hb_feature_t rtlmFeature = { HB_TAG('r', 't', 'l', 'm'), 1 /* enabled value */, HB_FEATURE_GLOBAL_START /* start cluster */, HB_FEATURE_GLOBAL_END /* end cluster */ };
+    hb_shape(m_mathFont.get(), buffer.get(), &rtlmFeature, 1 /* number of features */);
+
+    unsigned glyphCount = 0;
+    hb_glyph_info_t* glyphInfos = hb_buffer_get_glyph_infos(buffer.get(), &glyphCount);
+    // We don't support mirroring text with more than one glyph
+    if (glyphCount == 1)
+        return glyphInfos[0].codepoint;
+
+    return 0;
+}
+#else
+Glyph OpenTypeMathData::getMirroredGlyph(char32_t) const
+{
+    return 0;
+}
+#endif
+
 } // namespace WebCore
 
 #endif // ENABLE(MATHML)

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.h
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.h
@@ -130,6 +130,7 @@ public:
     float getMathConstant(const Font&, MathConstant) const;
     float getItalicCorrection(const Font&, Glyph) const;
     void getMathVariants(Glyph, bool isVertical, Vector<Glyph>& sizeVariants, Vector<AssemblyPart>& assemblyParts) const;
+    Glyph getMirroredGlyph(char32_t codePoint) const;
 
 private:
     explicit OpenTypeMathData(const FontPlatformData&);

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -108,6 +108,7 @@ void MathOperator::reset(const RenderStyle& style)
     m_descent = 0;
     m_italicCorrection = 0;
     m_radicalVerticalScale = 1;
+    m_baseGlyphMirroredByRTLM = false;
     m_unstretchedSize = 0;
 
     // We use the base size for the calculation of the preferred width.
@@ -138,6 +139,19 @@ bool MathOperator::getGlyph(const RenderStyle& style, char32_t character, GlyphD
 {
     glyph = style.fontCascade().glyphDataForCharacter(character, style.writingMode().isBidiRTL());
     return glyph.font && glyph.font == &style.fontCascade().primaryFont();
+}
+
+bool MathOperator::getBaseGlyph(const RenderStyle& style, GlyphData& glyph)
+{
+    bool isPrimary = getGlyph(style, m_baseCharacter, glyph);
+    if (isPrimary && style.writingMode().isBidiRTL() && glyph.font->mathData()) {
+        Glyph mirroredGlyph = glyph.font->mathData()->getMirroredGlyph(m_baseCharacter);
+        if (mirroredGlyph && mirroredGlyph != glyph.glyph) {
+            glyph.glyph = mirroredGlyph;
+            this->m_baseGlyphMirroredByRTLM = true;
+        }
+    }
+    return isPrimary;
 }
 
 void MathOperator::setSizeVariant(const GlyphData& sizeVariant)
@@ -704,7 +718,9 @@ void MathOperator::paint(const RenderStyle& style, PaintInfo& info, const Layout
 
     // For a radical character, we may need some scale transform to stretch it vertically or mirror it.
     if (m_baseCharacter == kRadicalOperator) {
-        float radicalHorizontalScale = style.writingMode().isBidiLTR() ? 1 : -1;
+        float radicalHorizontalScale = 1;
+        if (style.writingMode().isBidiRTL())
+            radicalHorizontalScale = m_baseGlyphMirroredByRTLM ? 1 : -1;
         if (radicalHorizontalScale == -1 || m_radicalVerticalScale > 1) {
             LayoutPoint scaleOrigin = paintOffset;
             scaleOrigin.move(m_width / 2, 0_lu);

--- a/Source/WebCore/rendering/mathml/MathOperator.h
+++ b/Source/WebCore/rendering/mathml/MathOperator.h
@@ -83,7 +83,7 @@ private:
 
     LayoutUnit NODELETE stretchSize() const;
     bool getGlyph(const RenderStyle&, char32_t character, GlyphData&) const;
-    bool getBaseGlyph(const RenderStyle& style, GlyphData& baseGlyph) const { return getGlyph(style, m_baseCharacter, baseGlyph); }
+    bool getBaseGlyph(const RenderStyle&, GlyphData&);
     void setSizeVariant(const GlyphData&);
     void setGlyphAssembly(const RenderStyle&, const GlyphAssemblyData&);
     void getMathVariantsWithFallback(const RenderStyle&, bool isVertical, Vector<Glyph>&, Vector<OpenTypeMathData::AssemblyPart>&);
@@ -111,6 +111,7 @@ private:
     LayoutUnit m_italicCorrection { 0 };
     LayoutUnit m_unstretchedSize { 0 };
     float m_radicalVerticalScale { 1 };
+    bool m_baseGlyphMirroredByRTLM { false };
 };
 
 }


### PR DESCRIPTION
#### 82fdbe64ec544d51e40bfb0ad769854bb49c70cb
<pre>
Mirroring large/stretchy operators using the OpenType `rtlm` feature
<a href="https://bugs.webkit.org/show_bug.cgi?id=312756">https://bugs.webkit.org/show_bug.cgi?id=312756</a>

Reviewed by Frédéric Wang Nélar.

Use glyph level mirroring in MathML when the text direction is RTL and
the font supports the OpenType rtlm feature.

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/presentation-markup/radicals/glyph-level-mirroring-expected.txt: Added.
* Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp:
* Source/WebCore/platform/graphics/opentype/OpenTypeMathData.h:
* Source/WebCore/rendering/mathml/MathOperator.cpp:
(WebCore::MathOperator::reset):
(WebCore::MathOperator::getBaseGlyph):
(WebCore::MathOperator::paint):
* Source/WebCore/rendering/mathml/MathOperator.h:
(WebCore::MathOperator::getBaseGlyph const): Deleted.

Canonical link: <a href="https://commits.webkit.org/314019@main">https://commits.webkit.org/314019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80186ac0d6f1c9489ccfa56ee330317fe504ea5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119915 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126955 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89498 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107513 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28279 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26909 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20110 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174912 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135258 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36621 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135244 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36754 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146470 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99410 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30549 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23315 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36117 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109180 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35614 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1359 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35862 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->