### PR TITLE
[:has() perf] Key invalidation RuleSet on invalidation selector

### DIFF
--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -313,54 +313,52 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
         if (!features)
             return nullptr;
 
-        struct Builder {
-            RefPtr<RuleSet> ruleSet;
-            Vector<const CSSSelectorList*> invalidationSelectors;
+        struct RuleSetKey {
             MatchElement matchElement;
             IsNegation isNegation;
-        };
-        using BuilderKey = std::tuple<GenericHashKey<MatchElement>, bool>;
+            const CSSSelectorList* invalidationSelector { nullptr };
 
-        HashMap<BuilderKey, Builder> builderMap;
+            unsigned hash() const
+            {
+                Hasher hasher;
+                add(hasher, matchElement.relation, matchElement.hasRelation, isNegation);
+                if (invalidationSelector)
+                    add(hasher, *invalidationSelector);
+                return hasher.hash();
+            }
+            bool operator==(const RuleSetKey& other) const
+            {
+                return matchElement == other.matchElement
+                    && isNegation == other.isNegation
+                    && arePointingToEqualData(invalidationSelector, other.invalidationSelector);
+            }
+        };
+
+        HashMap<GenericHashKey<RuleSetKey>, RefPtr<RuleSet>> ruleSetMap;
 
         for (auto& feature : *features) {
-            auto key = BuilderKey { feature.matchElement, static_cast<bool>(feature.isNegation) };
+            auto key = [&] {
+                if constexpr (std::is_same_v<typename RuleFeatureVectorType::ValueType, RuleFeatureWithInvalidationSelector>)
+                    return GenericHashKey<RuleSetKey> { { feature.matchElement, feature.isNegation, &feature.invalidationSelector } };
+                else
+                    return GenericHashKey<RuleSetKey> { { feature.matchElement, feature.isNegation } };
+            }();
 
-            auto& builder = builderMap.ensure(key, [&] {
-                return Builder {
-                    RuleSet::create(),
-                    { },
-                    feature.matchElement,
-                    feature.isNegation,
-                };
+            auto& ruleSet = ruleSetMap.ensure(key, [] {
+                return RuleSet::create();
             }).iterator->value;
 
-            builder.ruleSet->addRule(*feature.styleRule, feature.selectorIndex, feature.selectorListIndex);
-
-            if constexpr (std::is_same<typename RuleFeatureVectorType::ValueType, RuleFeatureWithInvalidationSelector>::value) {
-                auto alreadyContains = [&](const CSSSelectorList& invalidationSelector) {
-                    constexpr auto maximumSearchCount = 8;
-                    auto count = 0;
-                    for (auto& existing : builder.invalidationSelectors | std::views::reverse) {
-                        if (++count > maximumSearchCount)
-                            break;
-                        if (invalidationSelector == *existing)
-                            return true;
-                    }
-                    return false;
-                };
-                if (!alreadyContains(feature.invalidationSelector))
-                    builder.invalidationSelectors.append(&feature.invalidationSelector);
-            }
+            ruleSet->addRule(*feature.styleRule, feature.selectorIndex, feature.selectorListIndex);
         }
 
-        return makeUnique<Vector<InvalidationRuleSet>>(WTF::map(builderMap.values(), [](auto&& builder) {
-            builder.ruleSet->shrinkToFit();
+        return makeUnique<Vector<InvalidationRuleSet>>(WTF::map(ruleSetMap, [](auto& entry) {
+            auto& key = entry.key.key();
+            entry.value->shrinkToFit();
             return InvalidationRuleSet {
-                WTF::move(builder.ruleSet),
-                CSSSelectorList::makeJoining(builder.invalidationSelectors),
-                builder.matchElement,
-                builder.isNegation
+                WTF::move(entry.value),
+                key.invalidationSelector ? *key.invalidationSelector : CSSSelectorList { },
+                key.matchElement,
+                key.isNegation
             };
         }));
     }).iterator->value.get();


### PR DESCRIPTION
#### a214322c045e6fe421af461d12516959511d4d30
<pre>
[:has() perf] Key invalidation RuleSet on invalidation selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=312777">https://bugs.webkit.org/show_bug.cgi?id=312777</a>
<a href="https://rdar.apple.com/175161107">rdar://175161107</a>

Reviewed by Alan Baradlay.

We may do unnecessary invalidation because a single invalidation selector matching can cause
many rules to be evaluated that don&apos;t contain that selector.

* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ensureInvalidationRuleSets):

Include invalidation selector itself to the hash key when building invalidation RuleSets.
This also removes the need to do explicit deduping for selectors.

Canonical link: <a href="https://commits.webkit.org/311593@main">https://commits.webkit.org/311593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e6bf0024691d27c7b1a333e0ac70495c0e079c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23987 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/166281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111539 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a357d1f-cbc4-429d-8f53-f32ee593b28e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30796 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/166281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85641 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e658574-d341-4d17-9f4d-9d467c0d307b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141383 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/166281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb4209ea-770b-45ce-9878-d1bf0db58e03) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23258 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21510 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14052 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168766 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12984 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20831 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130083 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30395 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130190 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35260 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141005 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88255 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25022 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17810 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94121 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29551 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29781 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29678 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->