### PR TITLE
AX: Convert recursive descendant traversal functions to iterative to prevent stack overflow

### DIFF
--- a/LayoutTests/accessibility/aria-hidden-deep-dom-no-crash-expected.txt
+++ b/LayoutTests/accessibility/aria-hidden-deep-dom-no-crash-expected.txt
@@ -1,0 +1,9 @@
+This test ensures toggling aria-hidden on a deep DOM does not crash due to unbounded recursion in enumerateDescendantsIncludingIgnored.
+
+PASS: webArea.childrenCount === 0
+PASS: webArea.childrenCount > 0 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Deep content

--- a/LayoutTests/accessibility/aria-hidden-deep-dom-no-crash.html
+++ b/LayoutTests/accessibility/aria-hidden-deep-dom-no-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container"></div>
+
+<script>
+var output = "This test ensures toggling aria-hidden on a deep DOM does not crash due to unbounded recursion in enumerateDescendantsIncludingIgnored.\n\n";
+
+let container = document.getElementById("container");
+let deepest = container;
+for (let i = 0; i < 509; i++) {
+    const div = document.createElement("div");
+    deepest.appendChild(div);
+    deepest = div;
+}
+deepest.innerText = "Deep content";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    setTimeout(async function() {
+        // Toggle aria-hidden to trigger recomputeIsIgnoredForDescendants, which
+        // calls enumerateDescendantsIncludingIgnored on the entire subtree.
+        container.setAttribute("aria-hidden", "true");
+        output += await expectAsync("webArea.childrenCount", "0");
+
+        container.setAttribute("aria-hidden", "false");
+        output += await expectAsync("webArea.childrenCount > 0", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1553,6 +1553,8 @@ inline bool AXCoreObject::emitsNewline() const
 
 namespace Accessibility {
 
+constexpr unsigned maxDescendantTraversalIterations = 100000;
+
 template<typename T, typename MatchFunctionT, typename StopFunctionT>
 T* crossFrameFindAncestor(const T& object, bool includeSelf, const MatchFunctionT& matches, const StopFunctionT& shouldStop)
 {
@@ -1640,11 +1642,36 @@ AXCoreObject* findUnignoredDescendant(T& object, bool includeSelf, const F& matc
     if (includeSelf && matches(object) && !object.isIgnored())
         return &object;
 
-    for (Ref child : object.childrenIncludingIgnored()) {
-        if (RefPtr descendant = findUnignoredDescendant(child.get(), /* includeSelf */ true, matches))
-            return descendant.unsafeGet();
+    Vector<Ref<AXCoreObject>> stack;
+    for (const auto& child : object.childrenIncludingIgnored())
+        stack.append(child);
+
+    unsigned iterationCount = 0;
+#if AX_ASSERTS_ENABLED
+    HashSet<Ref<AXCoreObject>> visited;
+#endif
+
+    RefPtr<AXCoreObject> result = nullptr;
+    while (!stack.isEmpty()) {
+        if (++iterationCount > maxDescendantTraversalIterations)
+            break;
+
+        Ref current = stack.takeLast();
+#if AX_ASSERTS_ENABLED
+        bool foundCycle = !visited.add(current.copyRef()).isNewEntry;
+        AX_ASSERT(!foundCycle);
+        if (foundCycle)
+            break;
+#endif
+        if (matches(current.get()) && !current->isIgnored()) {
+            result = current.ptr();
+            break;
+        }
+
+        for (const auto& child : current->childrenIncludingIgnored())
+            stack.append(child);
     }
-    return nullptr;
+    return result.unsafeGet();
 }
 
 template<typename T, typename F>
@@ -1673,8 +1700,30 @@ void enumerateDescendantsIncludingIgnored(T& object, bool includeSelf, const F& 
     if (includeSelf)
         lambda(object);
 
-    for (const auto& child : object.childrenIncludingIgnored())
-        enumerateDescendantsIncludingIgnored(child.get(), true, lambda);
+    unsigned iterationCount = 0;
+#if AX_ASSERTS_ENABLED
+    HashSet<Ref<AXCoreObject>> visited;
+#endif
+
+    Vector<Ref<AXCoreObject>> stack;
+    for (auto& child : object.childrenIncludingIgnored())
+        stack.append(child);
+
+    while (!stack.isEmpty()) {
+        if (++iterationCount > maxDescendantTraversalIterations)
+            break;
+
+        Ref current = stack.takeLast();
+#if AX_ASSERTS_ENABLED
+        bool foundCycle = !visited.add(current.copyRef()).isNewEntry;
+        AX_ASSERT(!foundCycle);
+        if (foundCycle)
+            break;
+#endif
+        lambda(current.get());
+        for (auto& child : current->childrenIncludingIgnored())
+            stack.append(child);
+    }
 }
 
 template<typename T, typename F>
@@ -1683,11 +1732,30 @@ void enumerateUnignoredDescendants(T& object, bool includeSelf, const F& lambda)
     if (includeSelf)
         lambda(object);
 
-    // We have a reference to unignored children here, so it's possible that it will change when enumerating the unignored
-    // descendants, so copying here ensures they don't change.
-    auto children = object.unignoredChildren();
-    for (const auto& child : children)
-        enumerateUnignoredDescendants(child.get(), true, lambda);
+    Vector<Ref<AXCoreObject>> stack;
+    for (const auto& child : object.unignoredChildren())
+        stack.append(child);
+
+    unsigned iterationCount = 0;
+#if AX_ASSERTS_ENABLED
+    HashSet<Ref<AXCoreObject>> visited;
+#endif
+
+    while (!stack.isEmpty()) {
+        if (++iterationCount > maxDescendantTraversalIterations)
+            break;
+
+        Ref current = stack.takeLast();
+#if AX_ASSERTS_ENABLED
+        bool foundCycle = !visited.add(current.copyRef()).isNewEntry;
+        AX_ASSERT(!foundCycle);
+        if (foundCycle)
+            break;
+#endif
+        lambda(current.get());
+        for (const auto& child : current->unignoredChildren())
+            stack.append(child);
+    }
 }
 
 template<typename U> inline void performFunctionOnMainThreadAndWait(U&& lambda)


### PR DESCRIPTION
#### e22f4427f1ee76be7e8959406d6ae92e4578c1f3
<pre>
AX: Convert recursive descendant traversal functions to iterative to prevent stack overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=312780">https://bugs.webkit.org/show_bug.cgi?id=312780</a>
<a href="https://rdar.apple.com/172861598">rdar://172861598</a>

Reviewed by Joshua Hoffman.

enumerateDescendantsIncludingIgnored, findUnignoredDescendant, and
enumerateUnignoredDescendants used unbounded recursion to traverse the
accessibility tree. This could cause stack overflow in two scenarios:

  1. JavaScript constructs a deeply nested DOM (e.g. via appendChild) and
     toggles aria-hidden, recomputeIsIgnoredForDescendants calls enumerateDescendantsIncludingIgnored,
     which recurses through every descendant with no depth limit.

  2. The tree has a cycle, and we recurse infinitely following the cycle
     until we crash.

This commit converts all three functions from recursion to iterative DFS
using an explicit Vector stack, preventing the possibility of stack overflow.
An iteration limit is added to avoid looping forever, and asserts are
added to detect cyles so we can try to debug and fix them (if that is
indeed what was causing this).

* LayoutTests/accessibility/aria-hidden-deep-dom-no-crash-expected.txt: Added.
* LayoutTests/accessibility/aria-hidden-deep-dom-no-crash.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::Accessibility::findUnignoredDescendant):
(WebCore::Accessibility::enumerateDescendantsIncludingIgnored):
(WebCore::Accessibility::enumerateUnignoredDescendants):

Canonical link: <a href="https://commits.webkit.org/311611@main">https://commits.webkit.org/311611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d8028d970e9f3a8c85ec01f5f9f46c33eb45994

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157464 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111546 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7daa5f9f-b653-4591-89ad-7e3b2d1b1bad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121938 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85647 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/835e0d2d-debd-48a1-bc4a-3e06762a1867) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102607 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cc28f84-02f1-40f4-8a30-3fae73779ab2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23265 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21518 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14059 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168773 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13026 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130087 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130194 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35272 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141012 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88262 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17817 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94175 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29558 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29788 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->