### PR TITLE
Optimize CSS d property by skipping style resolution

### DIFF
--- a/Source/WebCore/css/ImmutableStyleProperties.cpp
+++ b/Source/WebCore/css/ImmutableStyleProperties.cpp
@@ -46,6 +46,8 @@ ImmutableStyleProperties::ImmutableStyleProperties(std::span<const CSSProperty> 
         RefPtr value = property.value();
         valueSpan[i] = value.get();
         value->ref();
+        if (property.id() == CSSPropertyD)
+            m_hasDProperty = true;
     }
 }
 

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -131,6 +131,7 @@ public:
 
     bool NODELETE hasCSSOMWrapper() const;
     bool isMutable() const { return m_isMutable; }
+    bool hasDProperty() const { return m_hasDProperty; }
 
     bool traverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>& handler) const;
     bool mayDependOnBaseURL() const;
@@ -152,7 +153,8 @@ protected:
 
     unsigned m_cssParserMode : 3;
     mutable unsigned m_isMutable : 1 { true };
-    unsigned m_arraySize : 28 { 0 };
+    unsigned m_hasDProperty : 1 { 0 };
+    unsigned m_arraySize : 27 { 0 };
 
 private:
     StringBuilder asTextInternal(const CSS::SerializationContext&) const;

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -542,6 +542,7 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
     usesFirstLetterRules = usesFirstLetterRules || other.usesFirstLetterRules;
     hasStartingStyleRules = hasStartingStyleRules || other.hasStartingStyleRules;
     usesHasPseudoClass = usesHasPseudoClass || other.usesHasPseudoClass;
+    usesDProperty = usesDProperty || other.usesDProperty;
 }
 
 void RuleFeatureSet::registerSubstitutionAttribute(const AtomString& attributeName)
@@ -571,6 +572,7 @@ void RuleFeatureSet::clear()
     usesFirstLineRules = false;
     usesFirstLetterRules = false;
     hasStartingStyleRules = false;
+    usesDProperty = false;
 }
 
 void RuleFeatureSet::shrinkToFit()

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -163,6 +163,7 @@ struct RuleFeatureSet {
     bool usesFirstLetterRules { false };
     bool hasStartingStyleRules { false };
     bool usesHasPseudoClass { false };
+    bool usesDProperty { false };
 
 private:
     struct SelectorFeatures {

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -172,8 +172,11 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     };
     ruleData.setLinkMatchType(computeLinkMatchType());
 
-    if (featureCollectionContext)
+    if (featureCollectionContext) {
         m_features.collectFeatures(*featureCollectionContext, ruleData, scopeRules);
+        if (!m_features.usesDProperty && ruleData.styleRule().properties().hasDProperty())
+            m_features.usesDProperty = true;
+    }
 
     unsigned classBucketSize = 0;
     const CSSSelector* idSelector = nullptr;

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -29,6 +29,7 @@
 #include "MutableStyleProperties.h"
 #include "RenderSVGPath.h"
 #include "RenderStyle+GettersInlines.h"
+#include "RenderStyle+SettersInlines.h"
 #include "SVGDocumentExtensions.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGMPathElement.h"
@@ -36,6 +37,9 @@
 #include "SVGPathUtilities.h"
 #include "SVGPoint.h"
 #include "Settings.h"
+#include "StyleResolver.h"
+#include "StyleSVGPathData.h"
+#include "StyleScope.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -149,8 +153,12 @@ void SVGPathElement::svgAttributeChanged(const QualifiedName& attrName)
             path->setNeedsShapeUpdate();
 
         updateSVGRendererForElementChange();
-        if (document().settings().cssDPropertyEnabled())
-            setPresentationalHintStyleIsDirty();
+        if (document().settings().cssDPropertyEnabled()) {
+            if (canDirectlyUpdateD())
+                m_needsDirectDStyleUpdate = true;
+            else
+                setPresentationalHintStyleIsDirty();
+        }
         invalidateResourceImageBuffersIfNeeded();
         return;
     }
@@ -238,6 +246,8 @@ RenderPtr<RenderElement> SVGPathElement::createElementRenderer(RenderStyle&& sty
 const SVGPathByteStream& SVGPathElement::pathByteStream() const
 {
     if (document().settings().cssDPropertyEnabled()) {
+        if (m_needsDirectDStyleUpdate)
+            const_cast<SVGPathElement&>(*this).flushDirectDStyleUpdate();
         if (CheckedPtr renderer = this->renderer()) {
             if (auto& pathFunction = renderer->style().d().tryPath())
                 return pathFunction->parameters.data.byteStream;
@@ -251,6 +261,8 @@ const SVGPathByteStream& SVGPathElement::pathByteStream() const
 Path SVGPathElement::path() const
 {
     if (document().settings().cssDPropertyEnabled()) {
+        if (m_needsDirectDStyleUpdate)
+            const_cast<SVGPathElement&>(*this).flushDirectDStyleUpdate();
         if (CheckedPtr renderer = this->renderer()) {
             CheckedRef style = renderer->style();
             if (auto& pathFunction = style->d().tryPath())
@@ -292,6 +304,47 @@ void SVGPathElement::collectDPresentationalHint(MutableStyleProperties& style)
 void SVGPathElement::pathDidChange()
 {
     invalidateMPathDependencies();
+}
+
+bool SVGPathElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
+{
+    if (name == SVGNames::dAttr && document().settings().cssDPropertyEnabled())
+        return false;
+    return SVGGeometryElement::hasPresentationalHintsForAttribute(name);
+}
+
+bool SVGPathElement::canDirectlyUpdateD() const
+{
+    if (!renderer())
+        return false;
+
+    // If any author CSS declares the d property, we must go through full style
+    // resolution.
+    auto& scope = const_cast<Style::Scope&>(Style::Scope::forNode(*this));
+    if (scope.resolver().ruleSets().authorStyle().features().usesDProperty)
+        return false;
+
+    return true;
+}
+
+void SVGPathElement::flushDirectDStyleUpdate()
+{
+    ASSERT(m_needsDirectDStyleUpdate);
+    m_needsDirectDStyleUpdate = false;
+
+    auto* renderer = this->renderer();
+    if (!renderer)
+        return;
+
+    auto& byteStream = Ref { m_pathSegList }->currentPathByteStream();
+
+    Style::SVGPathData newD { Style::PathFunction { Style::Path {
+        std::nullopt,
+        Style::Path::Data { byteStream },
+        1.0f
+    } } };
+
+    renderer->mutableStyle().setD(WTF::move(newD));
 }
 
 }

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -124,11 +124,16 @@ private:
 
     void invalidateMPathDependencies();
 
+    bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
     void collectExtraStyleForPresentationalHints(MutableStyleProperties&) override;
     void collectDPresentationalHint(MutableStyleProperties&);
 
+    bool canDirectlyUpdateD() const;
+    void flushDirectDStyleUpdate();
+
     const Ref<SVGAnimatedPathSegList> m_pathSegList { SVGAnimatedPathSegList::create(this) };
+    bool m_needsDirectDStyleUpdate { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### fcd999da2a3f
<pre>
Optimize CSS d property by skipping style resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=304761">https://bugs.webkit.org/show_bug.cgi?id=304761</a>
<a href="https://rdar.apple.com/167300890">rdar://167300890</a>

Reviewed by NOBODY (OOPS!).

When the CSS d property is enabled, every d attribute mutation on &lt;path&gt;
elements triggers full style resolution. In the common case where
no author CSS declares d, this is pure overhead.

This change adds a fast path: when a &lt;path&gt; element&apos;s d attribute changes
and no author CSS declares the d property, we directly update the
RenderStyle. This is safe because &lt;path&gt; is a leaf and non-inherited element (no children
inherit d).

                        Baseline    After
  React-Stockcharts-SVG   3.32%       0.07%
  PanTheChart             1.70%       0.08%
  ZoomTheChart            6.54%       0.01%

* Source/WebCore/css/ImmutableStyleProperties.cpp:
(WebCore::ImmutableStyleProperties::ImmutableStyleProperties):
* Source/WebCore/css/StyleProperties.h:
(WebCore::StyleProperties::hasDProperty const):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::add):
(WebCore::Style::RuleFeatureSet::clear):
* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::svgAttributeChanged):
(WebCore::SVGPathElement::pathByteStream const):
(WebCore::SVGPathElement::path const):
(WebCore::SVGPathElement::hasPresentationalHintsForAttribute const):
(WebCore::SVGPathElement::canDirectlyUpdateD const):
(WebCore::SVGPathElement::flushDirectDStyleUpdate):
* Source/WebCore/svg/SVGPathElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcd999da2a3f77c5a6c49eaeb69b8ab90ae9f107

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111547 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/905d3379-814a-4ce2-a38b-96683c9b8b92) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121940 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85648 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99000dc6-76b1-4edd-aae0-ac32d3fa3507) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102609 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7e6250a-6eb5-4c52-92d0-f3d53ea767a9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23267 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21519 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14060 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168774 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13036 "Found 3 new failures in svg/SVGPathElement.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130089 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30403 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130197 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30326 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88263 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25032 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17819 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189538 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30037 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94185 "Found 3 new failures in svg/SVGPathElement.cpp") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/189538 "Build is in progress. Recent messages:") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29559 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29789 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29686 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->