### PR TITLE
[GTK][WPE] Probe dma-buf+mmap capability before enabling MemoryMappedGPUBuffer path

### DIFF
--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -51,6 +51,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/egl/PlatformDisplayDefault.h
     platform/graphics/egl/PlatformDisplaySurfaceless.h
 
+    platform/graphics/gbm/GBMUtilities.h
     platform/graphics/gbm/GBMVersioning.h
     platform/graphics/gbm/PlatformDisplayGBM.h
 

--- a/Source/WebCore/PlatformWPE.cmake
+++ b/Source/WebCore/PlatformWPE.cmake
@@ -56,6 +56,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/egl/PlatformDisplayDefault.h
     platform/graphics/egl/PlatformDisplaySurfaceless.h
 
+    platform/graphics/gbm/GBMUtilities.h
     platform/graphics/gbm/GBMVersioning.h
     platform/graphics/gbm/PlatformDisplayGBM.h
 

--- a/Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp
@@ -30,6 +30,7 @@
 #include "CoordinatedPlatformLayerBuffer.h"
 #include "GBMVersioning.h"
 #include "GLDisplay.h"
+#include "MemoryMappedGPUBuffer.h"
 #include <atomic>
 #include <drm_fourcc.h>
 #include <fcntl.h>
@@ -91,18 +92,8 @@ std::optional<DMABufBufferAttributes> DMABufBufferAttributes::fromGBMBufferObjec
     attributes.fourcc = gbm_bo_get_format(bo);
     attributes.modifier = enableModifiers == EnableModifiers::Yes ? gbm_bo_get_modifier(bo) : DRM_FORMAT_MOD_INVALID;
 
-    auto getMappableFDForPlane = [](struct gbm_bo* bo, int plane) {
-        auto handle = gbm_bo_get_handle_for_plane(bo, plane);
-        if (handle.s32 == -1)
-            return -1;
-
-        int fd;
-        int ret = drmPrimeHandleToFD(gbm_device_get_fd(gbm_bo_get_device(bo)), handle.u32, DRM_CLOEXEC | DRM_RDWR, &fd);
-        return ret < 0 ? -1 : fd;
-    };
-
     for (int i = 0; i < planeCount; ++i) {
-        int fd = getMappableFDForPlane(bo, i);
+        int fd = MemoryMappedGPUBuffer::exportFDForPlane(bo, i);
         if (fd < 0) {
             LOG_ERROR("DMABufBufferAttributes::fromGBMBufferObject(), failed to export dma-buf for plane %d", i);
             return std::nullopt;

--- a/Source/WebCore/platform/graphics/gbm/GBMUtilities.h
+++ b/Source/WebCore/platform/graphics/gbm/GBMUtilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,28 +25,23 @@
 
 #pragma once
 
-#include "RendererBufferFormat.h"
-#include <wtf/text/WTFString.h>
+#if USE(GBM)
 
-namespace WebKit {
+#include <fcntl.h>
+#include <gbm.h>
+#include <xf86drm.h>
 
-struct RenderProcessInfo {
-    String platform;
-    String drmVersion;
-    String glRenderer;
-    String glVendor;
-    String glVersion;
-    String glShadingVersion;
-    String glExtensions;
-    String eglVersion;
-    String eglVendor;
-    String eglExtensions;
-    unsigned cpuPaintingThreadsCount { 0 };
-    unsigned gpuPaintingThreadsCount { 0 };
-    unsigned msaaSampleCount { 0 };
-    Vector<RendererBufferFormat::Format> supportedBufferFormats;
-    String dmabufExportStrategy;
-    bool memoryMappedGPUBufferSupported { false };
-};
+// Forces DRM_RDWR so callers that mmap(PROT_WRITE) on the returned FD don't SIGBUS
+// on backends where gbm_bo_get_fd_for_plane() silently returns O_RDONLY.
+static inline int gbmExportPlaneFDWithExplicitReadWriteMapping(struct gbm_bo* bo, int plane)
+{
+    auto handle = gbm_bo_get_handle_for_plane(bo, plane);
+    if (handle.s32 == -1)
+        return -1;
 
-} // namespace WebKit
+    int fd;
+    int ret = drmPrimeHandleToFD(gbm_device_get_fd(gbm_bo_get_device(bo)), handle.u32, DRM_CLOEXEC | DRM_RDWR, &fd);
+    return ret < 0 ? -1 : fd;
+}
+
+#endif // USE(GBM)

--- a/Source/WebCore/platform/graphics/gbm/GBMVersioning.h
+++ b/Source/WebCore/platform/graphics/gbm/GBMVersioning.h
@@ -27,12 +27,20 @@
 
 #if USE(GBM)
 
+#include "GBMUtilities.h"
 #include <gbm.h>
 
 #if !HAVE(GBM_BO_CREATE_WITH_MODIFIERS2)
 static inline struct gbm_bo* gbm_bo_create_with_modifiers2(struct gbm_device* gbm, uint32_t width, uint32_t height, uint32_t format, const uint64_t* modifiers, const unsigned count, uint32_t)
 {
     return gbm_bo_create_with_modifiers(gbm, width, height, format, modifiers, count);
+}
+#endif
+
+#if !HAVE(GBM_BO_GET_FD_FOR_PLANE)
+static inline int gbm_bo_get_fd_for_plane(struct gbm_bo* bo, int plane)
+{
+    return gbmExportPlaneFDWithExplicitReadWriteMapping(bo, plane);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
@@ -29,6 +29,7 @@
 #if USE(GBM)
 #include "DRMDeviceManager.h"
 #include "GBMDevice.h"
+#include "GBMUtilities.h"
 #include "GBMVersioning.h"
 #include "IntRect.h"
 #include "Logging.h"
@@ -39,15 +40,42 @@
 #include <linux/dma-buf.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <unistd.h>
 #include <wtf/SafeStrerror.h>
+#include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
 
 #if USE(LIBDRM)
 #include <drm_fourcc.h>
-#include <xf86drm.h>
 #endif
 
 namespace WebCore {
+
+enum class DMABufExportStrategy : uint8_t {
+    Unsupported,
+    GBMCall,
+    DRMSystemCall
+};
+
+enum class SupportsReadWriteMemoryMapping : bool { No, Yes };
+
+struct DMABufExportCapabilities {
+    DMABufExportStrategy strategy { DMABufExportStrategy::Unsupported };
+    SupportsReadWriteMemoryMapping memoryMappable { SupportsReadWriteMemoryMapping::No };
+};
+
+static ASCIILiteral strategyName(DMABufExportStrategy strategy)
+{
+    switch (strategy) {
+    case DMABufExportStrategy::GBMCall:
+        return "gbm_bo_get_fd_for_plane()"_s;
+    case DMABufExportStrategy::DRMSystemCall:
+        return "drmPrimeHandleToFD(DRM_RDWR)"_s;
+    case DMABufExportStrategy::Unsupported:
+        return "Unavailable"_s;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
 
 MemoryMappedGPUBuffer::MemoryMappedGPUBuffer(const IntSize& size, OptionSet<BufferFlag> flags)
     : m_size(size)
@@ -61,14 +89,133 @@ MemoryMappedGPUBuffer::~MemoryMappedGPUBuffer()
     unmapIfNeeded();
 }
 
+static bool probeReadWriteMappability(int fd, size_t length)
+{
+    int flags = fcntl(fd, F_GETFL);
+    if (flags < 0 || (flags & O_ACCMODE) != O_RDWR)
+        return false;
+
+    void* mapped = mmap(nullptr, length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (mapped == MAP_FAILED)
+        return false;
+
+    munmap(mapped, length);
+    return true;
+}
+
+static DMABufExportCapabilities runCapabilityProbe()
+{
+    // The probe result is cached for the rest of the session; if we
+    // ran before DRM init, we'd remember Unsupported and silently
+    // disable the MemoryMappedGPUBuffer path on hardware where it works.
+    // Crash instead of hiding the ordering bug, if that happens.
+    auto& manager = WebCore::DRMDeviceManager::singleton();
+    RELEASE_ASSERT_WITH_MESSAGE(manager.isInitialized(), "MemoryMappedGPUBuffer capability probe ran before DRMDeviceManager initialization");
+
+    auto gbmDevice = manager.mainGBMDevice(WebCore::DRMDeviceManager::NodeType::Render);
+    if (!gbmDevice) {
+        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer capability probe: no GBM render device node");
+        return { };
+    }
+
+    struct ProbeResult {
+        bool exported { false };
+        bool mappable { false };
+    };
+
+    // mmap capability depends on the kernel dma-buf subsystem and the GBM backend, not on
+    // buffer size, format, or modifier -- so the single-plane linear probe generalizes.
+    static constexpr int probeSize = 16;
+    auto runProbe = [&](auto&& exportFD) -> ProbeResult {
+        struct gbm_bo* bo = gbm_bo_create(gbmDevice->device(), probeSize, probeSize, DRM_FORMAT_ARGB8888, GBM_BO_USE_LINEAR | GBM_BO_USE_RENDERING);
+        if (!bo) {
+            RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer capability probe: gbm_bo_create failed: %s", safeStrerror(errno).data());
+            return { };
+        }
+
+        auto cleanup = makeScopeExit([&] {
+            gbm_bo_destroy(bo);
+        });
+
+        UnixFileDescriptor fd { exportFD(bo), UnixFileDescriptor::Adopt };
+        if (!fd)
+            return { };
+
+        return { true, probeReadWriteMappability(fd.value(), gbm_bo_get_stride_for_plane(bo, 0) * probeSize) };
+    };
+
+    ProbeResult gbmCall;
+#if HAVE(GBM_BO_GET_FD_FOR_PLANE)
+    // Without HAVE(GBM_BO_GET_FD_FOR_PLANE) the GBMVersioning.h shim forwards to the
+    // DRMSystemCall path, so there's no point in probing GBMCall separately.
+    gbmCall = runProbe([](struct gbm_bo* bo) {
+        return gbm_bo_get_fd_for_plane(bo, 0);
+    });
+#endif
+
+    ProbeResult drmSystemCall = runProbe([](struct gbm_bo* bo) {
+        return gbmExportPlaneFDWithExplicitReadWriteMapping(bo, 0);
+    });
+
+    // Pick the first mmap-capable path. Otherwise keep any path that at
+    // least exports, so non-mmap callers (e.g. EGLImage wrapping) still work.
+    DMABufExportCapabilities caps;
+    if (gbmCall.mappable)
+        caps = { DMABufExportStrategy::GBMCall, SupportsReadWriteMemoryMapping::Yes };
+    else if (drmSystemCall.mappable)
+        caps = { DMABufExportStrategy::DRMSystemCall, SupportsReadWriteMemoryMapping::Yes };
+    else if (gbmCall.exported)
+        caps = { DMABufExportStrategy::GBMCall, SupportsReadWriteMemoryMapping::No };
+    else if (drmSystemCall.exported)
+        caps = { DMABufExportStrategy::DRMSystemCall, SupportsReadWriteMemoryMapping::No };
+
+    RELEASE_LOG(GraphicsBuffer, "MemoryMappedGPUBuffer capability probe: strategy=%s mmap-capable=%s",
+        strategyName(caps.strategy).characters(),
+        caps.memoryMappable == SupportsReadWriteMemoryMapping::Yes ? "yes" : "no");
+
+    return caps;
+}
+
+static const DMABufExportCapabilities& cachedExportCapabilities()
+{
+    static const DMABufExportCapabilities caps = runCapabilityProbe();
+    return caps;
+}
+
+bool MemoryMappedGPUBuffer::isSupported()
+{
+    return cachedExportCapabilities().memoryMappable == SupportsReadWriteMemoryMapping::Yes;
+}
+
+int MemoryMappedGPUBuffer::exportFDForPlane(struct gbm_bo* bo, int plane)
+{
+    switch (cachedExportCapabilities().strategy) {
+    case DMABufExportStrategy::GBMCall:
+        return gbm_bo_get_fd_for_plane(bo, plane);
+    case DMABufExportStrategy::DRMSystemCall:
+        return gbmExportPlaneFDWithExplicitReadWriteMapping(bo, plane);
+    case DMABufExportStrategy::Unsupported:
+        return -1;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+ASCIILiteral MemoryMappedGPUBuffer::exportStrategyDescription()
+{
+    return strategyName(cachedExportCapabilities().strategy);
+}
+
 std::unique_ptr<MemoryMappedGPUBuffer> MemoryMappedGPUBuffer::create(const IntSize& size, OptionSet<BufferFlag> flags)
 {
+    if (!isSupported())
+        return nullptr;
+
     auto& manager = WebCore::DRMDeviceManager::singleton();
     ASSERT(manager.isInitialized());
 
     auto gbmDevice = manager.mainGBMDevice(WebCore::DRMDeviceManager::NodeType::Render);
     if (!gbmDevice) {
-        LOG_ERROR("MemoryMappedGPUBuffer::create(), failed to get GBM render device node");
+        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer::create(), failed to get GBM render device node");
         return nullptr;
     }
 
@@ -116,19 +263,19 @@ std::unique_ptr<MemoryMappedGPUBuffer> MemoryMappedGPUBuffer::create(const IntSi
     }
 
     if (!bufferFormat.has_value()) {
-        LOG_ERROR("MemoryMappedGPUBuffer::create(), failed to negotiate buffer format");
+        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer::create(), failed to negotiate buffer format");
         return nullptr;
     }
 
     auto buffer = std::unique_ptr<MemoryMappedGPUBuffer>(new MemoryMappedGPUBuffer(size, flags));
     auto* bo = buffer->allocate(gbmDevice->device(), bufferFormat.value());
     if (!bo) {
-        LOG_ERROR("MemoryMappedGPUBuffer::create(), failed to create GBM buffer of size %dx%d: %s", size.width(), size.height(), safeStrerror(errno).data());
+        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer::create(), failed to create GBM buffer of size %dx%d: %s", size.width(), size.height(), safeStrerror(errno).data());
         return nullptr;
     }
 
     if (!buffer->createDMABufFromGBMBufferObject(bo)) {
-        LOG_ERROR("MemoryMappedGPUBuffer::create(), failed to create dma-buf from GBM buffer object");
+        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer::create(), failed to create dma-buf from GBM buffer object");
         gbm_bo_destroy(bo);
         return nullptr;
     }
@@ -249,7 +396,7 @@ EGLImage MemoryMappedGPUBuffer::createEGLImageFromDMABuf()
     auto& display = WebCore::PlatformDisplay::sharedDisplay();
     auto eglImage = m_dmaBuf->createEGLImage(display.glDisplay());
     if (!eglImage)
-        LOG_ERROR("MemoryMappedGPUBuffer::createEGLImageFromDMABuf(), failed to export GBM buffer as EGLImage");
+        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer::createEGLImageFromDMABuf(), failed to export GBM buffer as EGLImage");
 
     return eglImage;
 }
@@ -362,7 +509,7 @@ bool MemoryMappedGPUBuffer::performDMABufSyncSystemCall(OptionSet<DMABufSyncFlag
     } while (result == -1 && (errno == EAGAIN || errno == EINTR) && (counter++) < maxRetries);
 
     if (result < 0) {
-        LOG_ERROR("MemoryMappedGPUBuffer::performDMABufSyncSystemCall(), DMA_BUF_SYNC_IOCTL failed - may result in visual artifacts.");
+        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer::performDMABufSyncSystemCall(), DMA_BUF_SYNC_IOCTL failed - may result in visual artifacts.");
         return false;
     }
 

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2025 Igalia S.L.
+ * Copyright (C) 2024, 2025, 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "GLDisplay.h"
 #include "IntSize.h"
 #include <wtf/OptionSet.h>
+#include <wtf/text/ASCIILiteral.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
 struct gbm_bo;
@@ -52,6 +53,17 @@ public:
         ForceVivanteSuperTiled = 1 << 1,
         UseBGRALayout = 1 << 2
     };
+
+    // On some non-Mesa stacks gbm_bo allocation and dma-buf export succeed but mmap still
+    // fails; the probe verifies all three once per session before committing to this path.
+    // Gates only MemoryMappedGPUBuffer::create() -- exportFDForPlane() remains usable for
+    // non-mmap callers (e.g. EGLImage wrapping) when export works but the FD isn't RDWR.
+    static bool isSupported();
+
+    // The returned FD may not be RDWR-mappable; callers that mmap must gate on isSupported().
+    static int exportFDForPlane(struct gbm_bo*, int plane);
+
+    static ASCIILiteral exportStrategyDescription();
 
     // Will only return a MemoryMappedGPUBuffer, if gbm_bo allocation + mapping to userland + EGLImage creation succeeded.
     static std::unique_ptr<MemoryMappedGPUBuffer> create(const IntSize&, OptionSet<BufferFlag>);

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -42,6 +42,10 @@
 #include "SkiaRecordingResult.h"
 #include "SkiaReplayCanvas.h"
 #include "SkiaUtilities.h"
+
+#if USE(GBM)
+#include "MemoryMappedGPUBuffer.h"
+#endif
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/core/SkPictureRecorder.h>
@@ -373,6 +377,12 @@ bool SkiaPaintingEngine::shouldUseDMABufAtlasTextures()
             if (envStringView == "1"_s)
                 shouldUseDMABufAtlas = false;
         }
+
+        // On systems where allocating/exporting a gbm_bo succeeds but mmap'ing its dma-buf FD
+        // does not, stay on the pure-OpenGL path from the start rather than tripping the
+        // RELEASE_ASSERT in SkiaGPUAtlas::uploadImages() later.
+        if (shouldUseDMABufAtlas && !MemoryMappedGPUBuffer::isSupported())
+            shouldUseDMABufAtlas = false;
     });
 
     return shouldUseDMABufAtlas;

--- a/Source/WebKit/Shared/glib/RenderProcessInfo.serialization.in
+++ b/Source/WebKit/Shared/glib/RenderProcessInfo.serialization.in
@@ -35,4 +35,6 @@ struct WebKit::RenderProcessInfo {
     unsigned gpuPaintingThreadsCount;
     unsigned msaaSampleCount;
     Vector<WebKit::RendererBufferFormat::Format> supportedBufferFormats;
+    String dmabufExportStrategy;
+    bool memoryMappedGPUBufferSupported;
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -765,6 +765,12 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request, RenderPro
         if (!info.drmVersion.isEmpty())
             addTableRow(hardwareAccelerationObject, "DRM version"_s, info.drmVersion);
 
+#if USE(GBM)
+        if (!info.dmabufExportStrategy.isEmpty())
+            addTableRow(hardwareAccelerationObject, "DMA-BUF export strategy"_s, info.dmabufExportStrategy);
+        addTableRow(hardwareAccelerationObject, "DMA-BUF memory-mapped GPU buffers"_s, info.memoryMappedGPUBufferSupported ? "Yes"_s : "No"_s);
+#endif
+
         addTableRow(hardwareAccelerationObject, "Threaded rendering"_s, threadedRenderingInfo(info));
         addTableRow(hardwareAccelerationObject, "MSAA"_s, info.msaaSampleCount ? makeString(info.msaaSampleCount, " samples"_s) : String("Disabled"_s));
 

--- a/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
@@ -63,6 +63,7 @@
 #if USE(GBM)
 #include <WebCore/DRMDeviceManager.h>
 #include <WebCore/GBMDevice.h>
+#include <WebCore/MemoryMappedGPUBuffer.h>
 #include <gbm.h>
 #include <xf86drm.h>
 #endif
@@ -304,6 +305,8 @@ void WebPage::getRenderProcessInfo(CompletionHandler<void(RenderProcessInfo&&)>&
             };
         });
     }
+    info.dmabufExportStrategy = MemoryMappedGPUBuffer::exportStrategyDescription();
+    info.memoryMappedGPUBufferSupported = MemoryMappedGPUBuffer::isSupported();
 #endif // USE(GBM)
 
     static_cast<DrawingAreaCoordinatedGraphics*>(m_drawingArea.get())->fillGLInformation(WTF::move(info), WTF::move(completionHandler));

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -314,6 +314,7 @@ if (USE_GBM)
 
     set(CMAKE_REQUIRED_LIBRARIES GBM::GBM)
     WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_CREATE_WITH_MODIFIERS2 gbm_bo_create_with_modifiers2 gbm.h)
+    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_GET_FD_FOR_PLANE gbm_bo_get_fd_for_plane gbm.h)
     unset(CMAKE_REQUIRED_LIBRARIES)
 endif ()
 

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -440,6 +440,7 @@ if (USE_GBM)
 
     set(CMAKE_REQUIRED_LIBRARIES GBM::GBM)
     WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_CREATE_WITH_MODIFIERS2 gbm_bo_create_with_modifiers2 gbm.h)
+    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_GET_FD_FOR_PLANE gbm_bo_get_fd_for_plane gbm.h)
     unset(CMAKE_REQUIRED_LIBRARIES)
 endif ()
 


### PR DESCRIPTION
#### 6887c89d076270e7818d5494cae06f37b48dea71
<pre>
[GTK][WPE] Probe dma-buf+mmap capability before enabling MemoryMappedGPUBuffer path
<a href="https://bugs.webkit.org/show_bug.cgi?id=312782">https://bugs.webkit.org/show_bug.cgi?id=312782</a>

Reviewed by Carlos Garcia Campos.

On some non-Mesa GBM stacks or older Mesa &lt; 25.02, gbm_bo allocation and
dma-buf export succeed but mmap(PROT_WRITE) on the exported FD silently
returns an O_RDONLY mapping that SIGBUSes at first store. Run a one-shot
probe at session start -- in the Web process, where DRMDeviceManager is
initialized -- to pick between gbm_bo_get_fd_for_plane() and the manual
drmPrimeHandleToFD(DRM_RDWR) path, or disable the MemoryMappedGPUBuffer
code path entirely if neither yields a writable mapping.

Plumb the probe outcome through RenderProcessInfo so the webkit://gpu
diagnostic page can expose both the chosen export strategy and whether
memory-mapped GPU buffers are supported, in the &quot;Render Process&quot; section.
Emit the probe result via RELEASE_LOG on the GraphicsBuffer channel so
the decision is visible in release builds journal as well, when
WEBKIT_DEBUG=GraphicsBuffer is enabled.

Not testable in the CI.

* Source/WebCore/PlatformGTK.cmake:
* Source/WebCore/PlatformWPE.cmake:
* Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp:
(WebCore::DMABufBufferAttributes::fromGBMBufferObject):
* Source/WebCore/platform/graphics/gbm/GBMUtilities.h: Copied from Source/WebCore/platform/graphics/gbm/GBMVersioning.h.
(gbmExportPlaneFDWithExplicitReadWriteMapping):
* Source/WebCore/platform/graphics/gbm/GBMVersioning.h:
(gbm_bo_get_fd_for_plane):
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp:
(WebCore::strategyName):
(WebCore::probeReadWriteMappability):
(WebCore::runCapabilityProbe):
(WebCore::cachedExportCapabilities):
(WebCore::MemoryMappedGPUBuffer::isSupported):
(WebCore::MemoryMappedGPUBuffer::exportFDForPlane):
(WebCore::MemoryMappedGPUBuffer::exportStrategyDescription):
(WebCore::MemoryMappedGPUBuffer::create):
(WebCore::MemoryMappedGPUBuffer::createEGLImageFromDMABuf):
(WebCore::MemoryMappedGPUBuffer::performDMABufSyncSystemCall):
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h:
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::shouldUseDMABufAtlasTextures):
* Source/WebKit/Shared/glib/RenderProcessInfo.h:
* Source/WebKit/Shared/glib/RenderProcessInfo.serialization.in:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp:
(WebKit::WebPage::getRenderProcessInfo):
* Source/cmake/OptionsGTK.cmake:
* Source/cmake/OptionsWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/311802@main">https://commits.webkit.org/311802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58ff1fb4cb30604a8b98099fb600fab07735749b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166671 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111925 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122225 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85816 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141739 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103066 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23565 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21858 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14444 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149894 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133246 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169161 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18678 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13938 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130399 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130512 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141342 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88714 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24026 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25248 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18148 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189972 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30416 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95271 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48780 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29937 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->