### PR TITLE
Add missing include directives

### DIFF
--- a/Source/JavaScriptCore/API/JSMarkingConstraintPrivate.cpp
+++ b/Source/JavaScriptCore/API/JSMarkingConstraintPrivate.cpp
@@ -27,6 +27,7 @@
 #include "JSMarkingConstraintPrivate.h"
 
 #include "APICast.h"
+#include "JSCellInlines.h"
 #include "SimpleMarkingConstraint.h"
 
 using namespace JSC;

--- a/Source/JavaScriptCore/API/JSWeakObjectMapRefPrivate.cpp
+++ b/Source/JavaScriptCore/API/JSWeakObjectMapRefPrivate.cpp
@@ -28,6 +28,7 @@
 
 #include "APICast.h"
 #include "JSCallbackObject.h"
+#include "JSGlobalObjectInlines.h"
 #include "JSWeakObjectMapRefInternal.h"
 #include "WeakGCMapInlines.h"
 

--- a/Source/JavaScriptCore/API/JSWeakPrivate.cpp
+++ b/Source/JavaScriptCore/API/JSWeakPrivate.cpp
@@ -28,6 +28,7 @@
 
 #include "APICast.h"
 #include "IntegrityInlines.h"
+#include "JSCellInlines.h"
 #include "Weak.h"
 #include <wtf/ThreadSafeRefCounted.h>
 

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
@@ -41,6 +41,7 @@
 #include "ScriptCallFrame.h"
 #include "ScriptCallStack.h"
 #include "ScriptCallStackFactory.h"
+#include "StrongInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace Inspector {

--- a/Source/JavaScriptCore/inspector/PerGlobalObjectWrapperWorld.cpp
+++ b/Source/JavaScriptCore/inspector/PerGlobalObjectWrapperWorld.cpp
@@ -27,6 +27,7 @@
 #include "PerGlobalObjectWrapperWorld.h"
 
 #include "JSGlobalObject.h"
+#include "StrongInlines.h"
 
 namespace Inspector {
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp
@@ -32,6 +32,8 @@
 #include "InjectedScriptManager.h"
 #include "InspectorEnvironment.h"
 #include "JSBigInt.h"
+#include "JSCJSValueInlines.h"
+#include "JSFunction.h"
 #include "VM.h"
 #include <wtf/Stopwatch.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/JavaScriptCore/runtime/IntlSegmentDataObject.h
+++ b/Source/JavaScriptCore/runtime/IntlSegmentDataObject.h
@@ -27,6 +27,7 @@
 
 #include "IntlSegmenter.h"
 #include "JSGlobalObject.h"
+#include "JSString.h"
 #include "ObjectConstructor.h"
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -255,6 +255,7 @@
 #include "StringIteratorPrototypeInlines.h"
 #include "StringObjectInlines.h"
 #include "StringPrototypeInlines.h"
+#include "StructureInlines.h"
 #include "SuppressedError.h"
 #include "SuppressedErrorConstructorInlines.h"
 #include "SuppressedErrorPrototypeInlines.h"

--- a/Source/JavaScriptCore/runtime/JSGlobalProxy.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalProxy.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "JSGlobalProxy.h"
 
+#include "JSCInlines.h"
 #include "JSGlobalObject.h"
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/Lookup.cpp
+++ b/Source/JavaScriptCore/runtime/Lookup.cpp
@@ -21,6 +21,7 @@
 #include "Lookup.h"
 
 #include "GetterSetter.h"
+#include "JSCInlines.h"
 #include <wtf/text/MakeString.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
+#include "Error.h"
 #include "ISO8601.h"
+#include "JSGlobalObject.h"
 #include "LazyProperty.h"
 #include "TemporalCalendar.h"
 

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.cpp
@@ -28,6 +28,7 @@
 #include "WeakMapImpl.h"
 
 #include "AuxiliaryBarrierInlines.h"
+#include "JSCJSValueInlines.h"
 #include "SlotVisitorInlines.h"
 #include "WeakMapImplInlines.h"
 

--- a/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "HashMapHelper.h"
+#include "Symbol.h"
 #include "WeakMapImpl.h"
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
@@ -33,6 +33,7 @@
 #include "JSWebAssemblyArrayInlines.h"
 #include "JSWebAssemblyInstance.h"
 #include "JSWebAssemblyRuntimeError.h"
+#include "OperationsInlines.h"
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2983,7 +2983,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/PaintPhase.h
     rendering/PathOperation.h
     rendering/RegionContext.h
-    rendering/RelayoutScopeForScrollbarChange
+    rendering/RelayoutScopeForScrollbarChange.h
     rendering/RenderAttachment.h
     rendering/RenderBlock.h
     rendering/RenderBlockFlow.h

--- a/Source/WebCore/bindings/js/JSDOMConvertInterface.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertInterface.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/Error.h>
+#include <JavaScriptCore/JSGlobalObjectInlines.h>
 #include <WebCore/IDLTypes.h>
 #include <WebCore/JSDOMConvertBase.h>
 #include <WebCore/JSDOMGlobalObject.h>

--- a/Source/WebCore/bindings/js/JSDOMConvertNumbers.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertNumbers.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSGlobalObjectInlines.h>
 #include <JavaScriptCore/PureNaN.h>
 #include <WebCore/IDLTypes.h>
 #include <WebCore/JSDOMConvertBase.h>

--- a/Source/WebCore/bindings/js/JSReadableStreamSourceCustom.cpp
+++ b/Source/WebCore/bindings/js/JSReadableStreamSourceCustom.cpp
@@ -30,6 +30,7 @@
 #include "JSReadableStreamSource.h"
 
 #include "JSDOMPromiseDeferred.h"
+#include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/WriteBarrierInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
@@ -30,6 +30,7 @@
 #include "JSCustomElementInterface.h"
 #include "JSElement.h"
 #include "JSNode.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/JSFunction.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/page/WebKitJSHandle.cpp
+++ b/Source/WebCore/page/WebKitJSHandle.cpp
@@ -31,6 +31,7 @@
 #include "JSWindowProxy.h"
 #include <JavaScriptCore/JSCellInlines.h>
 #include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/Weak.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/ScrollbarUpdateScope.cpp
+++ b/Source/WebCore/rendering/ScrollbarUpdateScope.cpp
@@ -28,6 +28,7 @@
 
 #include "InspectorInstrumentation.h"
 #include "Logging.h"
+#include "RenderBoxInlines.h"
 #include "RenderLayerScrollableArea.h"
 #include "ScrollAnchoringController.h"
 


### PR DESCRIPTION
#### 4e4c3bd8416af84027ab9d7ae90b6b95f6d12fae
<pre>
Add missing include directives
<a href="https://bugs.webkit.org/show_bug.cgi?id=312787">https://bugs.webkit.org/show_bug.cgi?id=312787</a>

Reviewed by Fujii Hironori.

Build fails in multiple sites with
build-webkit --wpe --cmakeargs=&quot;-DENABLE_UNIFIED_BUILDS=OFF&quot;

* Source/JavaScriptCore/API/JSMarkingConstraintPrivate.cpp:
* Source/JavaScriptCore/API/JSWeakObjectMapRefPrivate.cpp:
* Source/JavaScriptCore/API/JSWeakPrivate.cpp:
* Source/JavaScriptCore/inspector/ConsoleMessage.cpp:
* Source/JavaScriptCore/inspector/PerGlobalObjectWrapperWorld.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp:
* Source/JavaScriptCore/runtime/IntlSegmentDataObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
* Source/JavaScriptCore/runtime/JSGlobalProxy.cpp:
* Source/JavaScriptCore/runtime/Lookup.cpp:
* Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h:
* Source/JavaScriptCore/runtime/WeakMapImpl.cpp:
* Source/JavaScriptCore/runtime/WeakMapImplInlines.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp:
* Source/WebCore/Headers.cmake:
* Source/WebCore/bindings/js/JSDOMConvertInterface.h:
* Source/WebCore/bindings/js/JSDOMConvertNumbers.h:
* Source/WebCore/bindings/js/JSReadableStreamSourceCustom.cpp:
* Source/WebCore/inspector/agents/page/PageHeapAgent.cpp:
* Source/WebCore/page/WebKitJSHandle.cpp:
* Source/WebCore/rendering/ScrollbarUpdateScope.cpp:

Canonical link: <a href="https://commits.webkit.org/311932@main">https://commits.webkit.org/311932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccb3184688a705595536d48799906a3d97745727

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31906 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167310 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31893 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25001 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103415 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15081 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150530 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169800 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19314 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15534 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31596 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131048 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35465 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31542 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/141937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89417 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25740 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190762 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97055 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/49058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30573 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30846 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->