### PR TITLE
[:has() perf] Include full selector context to :has() invalidation selectors

### DIFF
--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
@@ -1,0 +1,13 @@
+:has(> .trigger) with compound peer .c1
+  Traversal count: 7
+:has(.trigger) with compound peer .c2
+  Traversal count: 14
+:has(> .trigger) without compound peer
+  Traversal count: 7
+:has(> .trigger) in non-subject position with compound peer .c4
+  Traversal count: 14
+:has(+ .trigger) with compound peer .c5
+  Traversal count: 3
+:has(:is(.trigger + .other)) with compound peer .c6
+  Traversal count: 7
+

--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+/* Subject :has() with child combinator and compound peer */
+.c1:has(> .trigger) > .target { color: green; }
+/* Subject :has() with descendant combinator and compound peer */
+.c2:has(.trigger) > .target { color: green; }
+/* Subject :has() without compound peer */
+:has(> .trigger) > .target { color: green; }
+/* :has() in non-subject position with compound peer */
+.c4:has(> .trigger) .target { color: green; }
+/* :has() with sibling combinator */
+.c5:has(+ .trigger) { color: green; }
+/* :has() with :is() wrapping */
+.c6:has(:is(.trigger + .other)) > .target { color: green; }
+</style>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+</head>
+<body>
+<pre id="log"></pre>
+<div id="tests"></div>
+<script>
+function log(message) {
+    document.getElementById("log").textContent += message + "\n";
+}
+
+function makeTree(containerClass, childCount) {
+    var container = document.createElement("div");
+    if (containerClass)
+        container.className = containerClass;
+    container.id = "container";
+    for (var i = 0; i < childCount; i++) {
+        var child = document.createElement("div");
+        child.className = "other";
+        container.appendChild(child);
+    }
+    var target = document.createElement("div");
+    target.className = "target";
+    container.appendChild(target);
+    document.getElementById("tests").appendChild(container);
+    return container;
+}
+
+function runTest(description, containerClass, mutate, expectGreen) {
+    var container = makeTree(containerClass, 5);
+    // Force initial style.
+    document.body.offsetHeight;
+
+    internals.resetStyleInvalidationTraversalCount();
+
+    mutate(container);
+
+    // Force style resolution.
+    document.body.offsetHeight;
+
+    var count = internals.styleInvalidationTraversalCount;
+    var target = container.querySelector(".target");
+    var color = target ? getComputedStyle(target).color : "";
+    var passed = expectGreen ? color === "rgb(0, 128, 0)" : color !== "rgb(0, 128, 0)";
+
+    log(description);
+    log("  Traversal count: " + count);
+    if (!passed)
+        log("  FAIL: unexpected color " + color);
+
+    container.remove();
+}
+
+runTest(":has(> .trigger) with compound peer .c1", "c1", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.appendChild(trigger);
+}, true);
+
+runTest(":has(.trigger) with compound peer .c2", "c2", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.firstElementChild.appendChild(trigger);
+}, true);
+
+runTest(":has(> .trigger) without compound peer", null, function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.appendChild(trigger);
+}, true);
+
+runTest(":has(> .trigger) in non-subject position with compound peer .c4", "c4", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.appendChild(trigger);
+}, true);
+
+runTest(":has(+ .trigger) with compound peer .c5", "c5", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.parentNode.insertBefore(trigger, container.nextSibling);
+}, true);
+
+runTest(":has(:is(.trigger + .other)) with compound peer .c6", "c6", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.insertBefore(trigger, container.querySelector(".other"));
+}, true);
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1538,4 +1538,62 @@ std::optional<Style::PseudoElementIdentifier> CSSSelectorParser::parsePseudoElem
     }
 }
 
+CSSSelectorList CSSSelectorParser::makeHasArgumentReplacingScope(const CSSSelector& hasArgument, const CSSSelector& hasPseudoClass)
+{
+    // Collect compound peers of :has() (other simple selectors in the same compound, excluding :has() itself).
+    Vector<const CSSSelector*> compoundPeers;
+    for (auto* selector = hasPseudoClass.lastInCompound(); selector; selector = selector->precedingInCompound()) {
+        if (selector != &hasPseudoClass)
+            compoundPeers.append(selector);
+    }
+
+    if (compoundPeers.isEmpty())
+        return CSSSelectorList::makeCopyingComplexSelector(hasArgument);
+
+    auto* firstInCompound = hasPseudoClass.firstInCompound();
+    auto compoundRelation = firstInCompound->relation();
+    auto* leftStart = firstInCompound->precedingInComplexSelector();
+
+    auto appendSelector = [](MutableCSSSelectorList& result, MutableCSSSelector*& leftmost, std::unique_ptr<MutableCSSSelector> selector) {
+        if (!leftmost) {
+            result.append(WTF::move(selector));
+            leftmost = result.last().get();
+        } else {
+            leftmost->setPrecedingInComplexSelector(WTF::move(selector));
+            leftmost = leftmost->precedingInComplexSelector();
+        }
+    };
+
+    MutableCSSSelector* leftmost = nullptr;
+    MutableCSSSelectorList result;
+
+    // Copy :has() argument selectors, stopping at HasScope.
+    for (auto* selector = &hasArgument; selector; selector = selector->precedingInComplexSelector()) {
+        if (selector->match() == CSSSelector::Match::HasScope)
+            break;
+        auto mutableSelector = makeUnique<MutableCSSSelector>(*selector, MutableCSSSelector::SimpleSelector);
+        mutableSelector->setRelation(selector->relation());
+        appendSelector(result, leftmost, WTF::move(mutableSelector));
+    }
+
+    // Copy compound peers.
+    for (auto* peer : compoundPeers) {
+        auto mutableSelector = makeUnique<MutableCSSSelector>(*peer, MutableCSSSelector::SimpleSelector);
+        mutableSelector->setRelation(peer->relation());
+        appendSelector(result, leftmost, WTF::move(mutableSelector));
+    }
+
+    // The leftmost peer adopts the compound's combinator to the left side.
+    leftmost->setRelation(compoundRelation);
+
+    // Copy remaining left-side selectors.
+    for (auto* selector = leftStart; selector; selector = selector->precedingInComplexSelector()) {
+        auto mutableSelector = makeUnique<MutableCSSSelector>(*selector, MutableCSSSelector::SimpleSelector);
+        mutableSelector->setRelation(selector->relation());
+        appendSelector(result, leftmost, WTF::move(mutableSelector));
+    }
+
+    return CSSSelectorList { WTF::move(result) };
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -59,6 +59,7 @@ public:
 
     static bool supportsComplexSelector(CSSParserTokenRange, const CSSSelectorParserContext&);
     static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList, bool parentRuleIsScope = false);
+    static CSSSelectorList makeHasArgumentReplacingScope(const CSSSelector& hasArgument, const CSSSelector& hasPseudoClass);
     static std::optional<Style::PseudoElementIdentifier> parsePseudoElement(const String&, const CSSSelectorParserContext&);
 
 private:

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -788,6 +788,9 @@ public:
     bool updateStyleIfNeededIgnoringPendingStylesheets();
     bool NODELETE needsStyleRecalc() const;
     unsigned lastStyleUpdateSizeForTesting() const { return m_lastStyleUpdateSizeForTesting; }
+    size_t styleInvalidationTraversalCountForTesting() const { return m_styleInvalidationTraversalCountForTesting; }
+    void incrementStyleInvalidationTraversalCountForTesting(size_t count) { m_styleInvalidationTraversalCountForTesting += count; }
+    void resetStyleInvalidationTraversalCountForTesting() { m_styleInvalidationTraversalCountForTesting = 0; }
 
     enum class UpdateLayoutResult {
         NoChange,
@@ -2665,6 +2668,7 @@ private:
     unsigned m_referencingNodeCount { 0 };
     int m_loadEventDelayCount { 0 };
     unsigned m_lastStyleUpdateSizeForTesting { 0 };
+    size_t m_styleInvalidationTraversalCountForTesting { 0 };
 
     // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#throw-on-dynamic-markup-insertion-counter
     unsigned m_throwOnDynamicMarkupInsertionCount { 0 };

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -31,6 +31,7 @@
 
 #include "CSSSelector.h"
 #include "CSSSelectorList.h"
+#include "CSSSelectorParser.h"
 #include "HTMLNames.h"
 #include "RuleSet.h"
 #include "StyleProperties.h"
@@ -272,7 +273,7 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
                 auto pseudoClassDoesBreakScope = recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, subResult, subSelectorIsNegation, canBreakScope);
 
                 if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Has)
-                    selectorFeatures.hasPseudoClasses.append({ &subSelector, subResult, isNegation, pseudoClassDoesBreakScope });
+                    selectorFeatures.hasPseudoClasses.append({ &subSelector, subResult, isNegation, pseudoClassDoesBreakScope, selector });
 
                 if (pseudoClassDoesBreakScope == DoesBreakScope::Yes)
                     doesBreakScope = DoesBreakScope::Yes;
@@ -462,7 +463,7 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
     }
 
     for (auto& entry : selectorFeatures.hasPseudoClasses) {
-        auto& [selector, matchElement, isNegation, doesBreakScope] = entry;
+        auto& [selector, matchElement, isNegation, doesBreakScope, hasPseudoClass] = entry;
         // The selector argument points to a selector inside :has() selector list instead of :has() itself.
         auto& featureVector = *hasPseudoClassRules.ensure(makePseudoClassInvalidationKey(CSSSelector::PseudoClass::Has, *selector), [] {
             return makeUnique<Vector<RuleFeatureWithInvalidationSelector>>();
@@ -472,7 +473,7 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
             ruleData,
             matchElement,
             isNegation,
-            CSSSelectorList::makeCopyingComplexSelector(*selector)
+            CSSSelectorParser::makeHasArgumentReplacingScope(*selector, *hasPseudoClass)
         });
 
         if (doesBreakScope == DoesBreakScope::Yes)

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -167,7 +167,7 @@ struct RuleFeatureSet {
 private:
     struct SelectorFeatures {
         using InvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation>;
-        using HasInvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation, DoesBreakScope>;
+        using HasInvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation, DoesBreakScope, const CSSSelector*>;
 
         Vector<InvalidationFeature> ids;
         Vector<InvalidationFeature> classes;

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -161,6 +161,7 @@ static void invalidateAssignedElements(HTMLSlotElement& slot)
 
 Invalidator::CheckDescendants Invalidator::invalidateIfNeeded(Element& element, SelectorMatchingState* selectorMatchingState)
 {
+    ++m_elementTraversalCount;
     invalidateInShadowTreeIfNeeded(element);
 
     if (m_ruleInformation.hasSlottedPseudoElementRules) {
@@ -550,6 +551,7 @@ void Invalidator::invalidateWithMatchElementRuleSets(Element& element, const Mat
     for (auto& matchElementAndRuleSet : matchElementRuleSets) {
         Invalidator invalidator(matchElementAndRuleSet.value);
         invalidator.invalidateStyleWithMatchElement(element, matchElementAndRuleSet.key.key());
+        element.document().incrementStyleInvalidationTraversalCountForTesting(invalidator.m_elementTraversalCount);
     }
 }
 

--- a/Source/WebCore/style/StyleInvalidator.h
+++ b/Source/WebCore/style/StyleInvalidator.h
@@ -97,6 +97,7 @@ private:
     RuleInformation m_ruleInformation;
 
     bool m_dirtiesAllStyle { false };
+    size_t m_elementTraversalCount { 0 };
 };
 
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4364,6 +4364,20 @@ unsigned Internals::lastStyleUpdateSize() const
     return document->lastStyleUpdateSizeForTesting();
 }
 
+unsigned Internals::styleInvalidationTraversalCount() const
+{
+    Document* document = contextDocument();
+    if (!document)
+        return 0;
+    return document->styleInvalidationTraversalCountForTesting();
+}
+
+void Internals::resetStyleInvalidationTraversalCount()
+{
+    if (Document* document = contextDocument())
+        document->resetStyleInvalidationTraversalCountForTesting();
+}
+
 ExceptionOr<void> Internals::startTrackingLayoutUpdates()
 {
     Document* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -736,6 +736,8 @@ public:
     ExceptionOr<void> startTrackingStyleRecalcs();
     ExceptionOr<unsigned> styleRecalcCount();
     unsigned NODELETE lastStyleUpdateSize() const;
+    unsigned styleInvalidationTraversalCount() const;
+    void resetStyleInvalidationTraversalCount();
 
     ExceptionOr<void> startTrackingLayoutUpdates();
     ExceptionOr<unsigned> layoutUpdateCount();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -957,6 +957,8 @@ enum ContentsFormat {
     undefined startTrackingStyleRecalcs();
     unsigned long styleRecalcCount();
     readonly attribute unsigned long lastStyleUpdateSize;
+    readonly attribute unsigned long styleInvalidationTraversalCount;
+    undefined resetStyleInvalidationTraversalCount();
 
     undefined startTrackingLayoutUpdates();
     unsigned long layoutUpdateCount();


### PR DESCRIPTION
#### e5380247bac696f9220484a8947d4302bda6204f
<pre>
[:has() perf] Include full selector context to :has() invalidation selectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=312786">https://bugs.webkit.org/show_bug.cgi?id=312786</a>
<a href="https://rdar.apple.com/175177078">rdar://175177078</a>

Reviewed by Alan Baradlay.

When there is a mutation that may affect :has() we run the selector in has argument to see if any of the
added or removed elements match. Previously this was done with the argument as is. For

    .foo:has(.bar) .baz

the invalidation selector was

    &lt;has-scope&gt; .bar

where &lt;has-scope&gt; would always match. Any appearance of .bar would trigger invalidation traversal.

With this patch we include the full context to invalidation selector so in above case it will be

    .foo .bar

potentially ruling out many cases where .bar alone matches.

Test: fast/selectors/has-invalidation-traversal-size.html

Document some traversal sizes.

* LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt: Added.
* LayoutTests/fast/selectors/has-invalidation-traversal-size.html: Added.
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::makeHasArgumentReplacingScope):

Add helper for resolving &lt;has-scope&gt;.

* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/dom/Document.h:
(WebCore::Document::styleInvalidationTraversalCountForTesting const):
(WebCore::Document::incrementStyleInvalidationTraversalCountForTesting):
(WebCore::Document::resetStyleInvalidationTraversalCountForTesting):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::collectFeatures):

Resolve the scope.

* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateIfNeeded):
(WebCore::Style::Invalidator::invalidateWithMatchElementRuleSets):
* Source/WebCore/style/StyleInvalidator.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::styleInvalidationTraversalCount const):
(WebCore::Internals::resetStyleInvalidationTraversalCount):

Add testing support

* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/311642@main">https://commits.webkit.org/311642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61b1526657204da51c2cfc938f9165c849f3746e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111589 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2d0e1bb-d1d4-4a81-abd9-0ff76df4069d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121964 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85671 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ab3b1c1-99c8-442c-9f2d-1bb05d0c855f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141429 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102633 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df2a1812-5a44-4f77-a3e6-61bc90bcc92f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23305 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21556 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14102 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168826 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13153 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130126 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130237 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35288 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141051 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88370 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25065 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17856 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 3 flakes") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94319 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29601 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29831 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29728 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->