### PR TITLE
Memory64 bulk memory operations in OMG tier

### DIFF
--- a/JSTests/wasm/stress/memory64-bulk-memory.js
+++ b/JSTests/wasm/stress/memory64-bulk-memory.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -391,9 +391,13 @@ Expected<PageCount, GrowFailReason> Memory::grow(VM& vm, PageCount delta)
     return oldPageCount;
 }
 
-bool Memory::fill(uint32_t offset, uint8_t targetValue, uint32_t count)
+bool Memory::fill(uint64_t offset, uint8_t targetValue, uint64_t count)
 {
-    if (sumOverflows<uint32_t>(offset, count))
+    bool doesOverflow = addressType().is64Bit()
+        ? sumOverflows<uint64_t>(offset, count)
+        : sumOverflows<uint32_t>(offset, count);
+
+    if (doesOverflow)
         return false;
 
     if (offset + count > m_handle->size())
@@ -403,13 +407,20 @@ bool Memory::fill(uint32_t offset, uint8_t targetValue, uint32_t count)
     return true;
 }
 
-bool Memory::copy(uint32_t dstAddress, uint32_t srcAddress, uint32_t count)
+bool Memory::copy(uint64_t dstAddress, uint64_t srcAddress, uint64_t count)
 {
-    if (sumOverflows<uint32_t>(dstAddress, count) || sumOverflows<uint32_t>(srcAddress, count))
+    bool srcAndCountOverflows = addressType().is64Bit()
+        ? sumOverflows<uint64_t>(srcAddress, count)
+        : sumOverflows<uint32_t>(srcAddress, count);
+    bool dstAndCountOverflows = addressType().is64Bit()
+        ? sumOverflows<uint64_t>(dstAddress, count)
+        : sumOverflows<uint32_t>(dstAddress, count);
+
+    if (srcAndCountOverflows || dstAndCountOverflows)
         return false;
 
-    const uint32_t lastDstAddress = dstAddress + count;
-    const uint32_t lastSrcAddress = srcAddress + count;
+    const uint64_t lastDstAddress = dstAddress + count;
+    const uint64_t lastSrcAddress = srcAddress + count;
 
     if (lastDstAddress > size() || lastSrcAddress > size())
         return false;

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -89,8 +89,8 @@ public:
     MemoryMode mode() const { return m_handle->mode(); }
 
     Expected<PageCount, GrowFailReason> grow(VM&, PageCount);
-    bool fill(uint32_t, uint8_t, uint32_t);
-    bool copy(uint32_t, uint32_t, uint32_t);
+    bool fill(uint64_t, uint8_t, uint64_t);
+    bool copy(uint64_t, uint64_t, uint64_t);
     bool init(uint64_t, const uint8_t*, uint32_t);
 
     void registerInstance(JSWebAssemblyInstance&);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2086,9 +2086,13 @@ auto OMGIRGenerator::addMemoryFill(ExpressionType dstAddress, ExpressionType tar
         auto* memorySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfCachedMemory0Size()));
         m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_cachedMemory0Size, memorySize);
 
-        auto* dstAddressValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
+        auto* dstAddressValue = m_info.memory(memoryIndex).isMemory64()
+            ? get(dstAddress)
+            : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
         auto* targetValue = get(target);
-        auto* countValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(count));
+        auto* countValue = m_info.memory(memoryIndex).isMemory64()
+            ? get(count)
+            : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(count));
 
         Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, Above, origin(), m_currentBlock->appendNew<Value>(m_proc, Add, origin(), dstAddressValue, countValue), memorySize);
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), outOfBounds);
@@ -2143,9 +2147,15 @@ auto OMGIRGenerator::addMemoryCopy(ExpressionType dstAddress, ExpressionType src
         auto* memorySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfCachedMemory0Size()));
         m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_cachedMemory0Size, memorySize);
 
-        auto* dstAddressValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
-        auto* srcAddressValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(srcAddress));
-        auto* countValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(count));
+        auto* dstAddressValue = m_info.memory(dstMemoryIndex).isMemory64()
+            ? get(dstAddress)
+            : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
+        auto* srcAddressValue = m_info.memory(srcMemoryIndex).isMemory64()
+            ? get(srcAddress)
+            : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(srcAddress));
+        auto* countValue = m_info.memory(srcMemoryIndex).isMemory64() || m_info.memory(dstMemoryIndex).isMemory64()
+            ? get(count)
+            : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(count));
 
         {
             CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), m_currentBlock->appendNew<Value>(m_proc, Above, origin(), m_currentBlock->appendNew<Value>(m_proc, Add, origin(), dstAddressValue, countValue), memorySize));

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1554,12 +1554,12 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemorySizeInPages, int64_t, (JSWe
     return instance->memory(memoryIndex)->memory().size() >> 16;
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryFill, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint32_t dstAddress, uint32_t targetValue, uint32_t count, uint8_t memoryIndex))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryFill, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t dstAddress, uint32_t targetValue, uint64_t count, uint8_t memoryIndex))
 {
     return toUCPUStrictInt32(memoryFill(instance, dstAddress, targetValue, count, memoryIndex));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryCopy, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint32_t dstAddress, uint32_t srcAddress, uint32_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryCopy, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t dstAddress, uint64_t srcAddress, uint64_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex))
 {
     return toUCPUStrictInt32(memoryCopy(instance, dstAddress, srcAddress, count, dstMemoryIndex, srcMemoryIndex));
 }
@@ -1641,7 +1641,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicNotify, UCPUStrictInt32, 
     return toUCPUStrictInt32(memoryAtomicNotify(instance, base, offset, countValue, memoryIndex));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned dataSegmentIndex, uint32_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned dataSegmentIndex, uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex))
 {
     return toUCPUStrictInt32(memoryInit(instance, dataSegmentIndex, dstAddress, srcAddress, length, memoryIndex));
 }

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -92,8 +92,8 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationPopcount32, UCPUStrictInt32, (int32_
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationPopcount64, uint64_t, (int64_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGrowMemory, int64_t, (JSWebAssemblyInstance*, int64_t, uint8_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemorySizeInPages, int64_t, (JSWebAssemblyInstance* instance, uint8_t memoryIndex));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryFill, UCPUStrictInt32, (JSWebAssemblyInstance*, uint32_t dstAddress, uint32_t targetValue, uint32_t count, uint8_t memoryIndex));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryCopy, UCPUStrictInt32, (JSWebAssemblyInstance*, uint32_t dstAddress, uint32_t srcAddress, uint32_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryFill, UCPUStrictInt32, (JSWebAssemblyInstance*, uint64_t dstAddress, uint32_t targetValue, uint64_t count, uint8_t memoryIndex));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryCopy, UCPUStrictInt32, (JSWebAssemblyInstance*, uint64_t dstAddress, uint64_t srcAddress, uint64_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableElement, EncodedJSValue, (JSWebAssemblyInstance*, unsigned, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationSetWasmTableElement, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned, uint32_t, EncodedJSValue encValue));
@@ -108,7 +108,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableSize, UCPUStrictInt32, (
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait32, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int32_t value, int64_t timeout, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait64, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int64_t value, int64_t timeout, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicNotify, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned, unsigned, int32_t, uint8_t memoryIndex));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned dataSegmentIndex, uint32_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned dataSegmentIndex, uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmDataDrop, void, (JSWebAssemblyInstance*, unsigned dataSegmentIndex));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmStructNewEmpty, EncodedJSValue, (JSWebAssemblyInstance*, uint32_t));

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -39,6 +39,7 @@
 #include "WasmIPIntGenerator.h"
 #include "WasmModuleInformation.h"
 #include "WasmTypeDefinition.h"
+#include <wtf/CheckedArithmetic.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -685,12 +686,15 @@ inline bool memoryInit(JSWebAssemblyInstance* instance, unsigned dataSegmentInde
     return instance->memoryInit(dstAddress, srcAddress, length, dataSegmentIndex, memoryIndex);
 }
 
-inline bool memoryFill(JSWebAssemblyInstance* instance, uint32_t dstAddress, uint32_t targetValue, uint32_t count, uint8_t memoryIndex)
+inline bool memoryFill(JSWebAssemblyInstance* instance, uint64_t dstAddress, uint32_t targetValue, uint64_t count, uint8_t memoryIndex)
 {
     auto* base = std::bit_cast<uint8_t*>(instance->memory(memoryIndex)->basePointer());
     uint64_t size = instance->memory(memoryIndex)->memory().size();
 
-    uint64_t lastDstAddress = static_cast<uint64_t>(dstAddress) + count;
+    if (sumOverflows<uint64_t>(dstAddress, count))
+        return false;
+
+    uint64_t lastDstAddress = dstAddress + count;
     if (lastDstAddress > size)
         return false;
 
@@ -698,15 +702,21 @@ inline bool memoryFill(JSWebAssemblyInstance* instance, uint32_t dstAddress, uin
     return true;
 }
 
-inline bool memoryCopy(JSWebAssemblyInstance* instance, uint32_t dstAddress, uint32_t srcAddress, uint32_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex)
+inline bool memoryCopy(JSWebAssemblyInstance* instance, uint64_t dstAddress, uint64_t srcAddress, uint64_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex)
 {
     auto* dstBase = std::bit_cast<uint8_t*>(instance->memory(dstMemoryIndex)->basePointer());
     uint64_t dstSize = instance->memory(dstMemoryIndex)->memory().size();
     auto* srcBase = std::bit_cast<uint8_t*>(instance->memory(srcMemoryIndex)->basePointer());
     uint64_t srcSize = instance->memory(srcMemoryIndex)->memory().size();
 
-    uint64_t lastDstAddress = static_cast<uint64_t>(dstAddress) + count;
-    uint64_t lastSrcAddress = static_cast<uint64_t>(srcAddress) + count;
+    if (sumOverflows<uint64_t>(dstAddress, count))
+        return false;
+
+    if (sumOverflows<uint64_t>(srcAddress, count))
+        return false;
+
+    uint64_t lastDstAddress = dstAddress + count;
+    uint64_t lastSrcAddress = srcAddress + count;
 
     if (lastDstAddress > dstSize || lastSrcAddress > srcSize)
         return false;


### PR DESCRIPTION
#### 88fb9a875ac59192e48e201cedf3473e63dae4db
<pre>
Memory64 bulk memory operations in OMG tier
<a href="https://bugs.webkit.org/show_bug.cgi?id=312794">https://bugs.webkit.org/show_bug.cgi?id=312794</a>
<a href="https://rdar.apple.com/175184009">rdar://175184009</a>

Reviewed by Keith Miller.

Implement the bulk memory operations in the OMG tier for memory64.

* JSTests/wasm/stress/memory64-bulk-memory.js:
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::fill):
(JSC::Wasm::Memory::copy):
* Source/JavaScriptCore/wasm/WasmMemory.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addMemoryFill):
(JSC::Wasm::OMGIRGenerator::addMemoryCopy):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::memoryFill):
(JSC::Wasm::memoryCopy):

Canonical link: <a href="https://commits.webkit.org/311796@main">https://commits.webkit.org/311796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fdac38c95652644add6a26f01a53aea8825d035

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157749 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111831 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122147 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85777 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102816 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23486 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21774 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14344 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149800 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169062 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18584 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13728 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130320 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130437 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35389 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88618 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25200 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18063 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189877 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30322 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95043 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48763 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29843 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30073 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29970 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->