### PR TITLE
[Swift Testing] Add Swift-callable wrapper around InstanceMethodSwizzler for TestWebKitAPI

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
@@ -144,6 +144,53 @@ public struct Future: Sendable, ~Copyable {
     }
 }
 
+/// Temporarily installs a block-based implementation for an Objective-C instance method.
+///
+/// Runs `body` while the swap is in effect, then restores the original implementation
+/// before returning. The original is restored even if `body` throws.
+///
+/// The block's first parameter must be the receiver, followed by the method's arguments.
+/// Declare it with `@convention(block)` so the Objective-C runtime can bridge it to an IMP.
+///
+/// ```swift
+/// let implementation: @convention(block) (NSPasteboard, Date) -> Bool = { _, _ in true }
+/// try await withSwizzledObjectiveCInstanceMethod(
+///     replacing: NSPasteboard.self,
+///     name: #selector(NSPasteboard.canReadItem(withDataConformingToTypes:)),
+///     with: implementation
+/// ) {
+///     // Code under test runs here with the mock in place.
+/// }
+/// ```
+///
+/// - Parameters:
+///   - class: The class whose instance method will be temporarily replaced.
+///   - name: The selector identifying the instance method to swap.
+///   - implementation: An `@convention(block)` closure whose signature matches the method.
+///   - body: The work to run while the swap is in effect.
+/// - Returns: The value returned by `body`.
+/// - Throws: Rethrows any error thrown by `body`.
+@discardableResult
+public nonisolated(nonsending) func withSwizzledObjectiveCInstanceMethod<Result, Failure>(
+    replacing class: AnyClass,
+    name: Selector,
+    with implementation: Any,
+    perform body: () async throws(Failure) -> sending Result
+) async throws(Failure) -> sending Result where Result: ~Copyable, Failure: Error {
+    guard let targetMethod = unsafe class_getInstanceMethod(`class`, name) else {
+        fatalError("\(`class`) does not respond to \(name)")
+    }
+
+    let replacementImplementation = unsafe imp_implementationWithBlock(implementation)
+    let originalImplementation = unsafe method_setImplementation(targetMethod, replacementImplementation)
+    defer {
+        unsafe method_setImplementation(targetMethod, originalImplementation)
+        unsafe imp_removeBlock(replacementImplementation)
+    }
+
+    return try await body()
+}
+
 /// Temporarily replaces the implementation of an Objective-C class method with a custom block implementation for the lifetime of `body`.
 ///
 /// For example, given a type


### PR DESCRIPTION
#### a41a909424f0b6a1e12afc674e8344d0dafaed38
<pre>
[Swift Testing] Add Swift-callable wrapper around InstanceMethodSwizzler for TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=312797">https://bugs.webkit.org/show_bug.cgi?id=312797</a>
<a href="https://rdar.apple.com/175186623">rdar://175186623</a>

Reviewed by Richard Robinson.

Swift tests in TestWebKitAPI have no ergonomic way to mock Objective-C
runtime behavior: the C++ InstanceMethodSwizzler RAII helper is awkward
to use from Swift, which prefers scoped `with*` functions over dropping
an RAII handle on the floor. This is the first piece of infrastructure
needed to port AppKit-heavy tests (NSPasteboard mocks, NSMenu pop-ups,
gesture recognizers, drag-and-drop) to the new Swift Testing framework.

Add ObjectiveCMethodSwizzling.swift, exposing two scoped helpers:

  - `withSwizzledObjectiveCInstanceMethod(replacing:name:with:perform:)`
    swaps in a block-derived IMP for an instance method.
  - `withSwizzledObjectiveCClassMethod(replacing:name:with:perform:)`
    is the class-method counterpart, backed by `class_getClassMethod`.

Both take an `@convention(block)` closure whose first parameter is the
receiver (or receiving class) followed by the method&apos;s arguments, and
both restore the original implementation via `defer` before returning,
including on error paths. They also call `imp_removeBlock` to balance
`imp_implementationWithBlock`.

* Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift:

Canonical link: <a href="https://commits.webkit.org/312863@main">https://commits.webkit.org/312863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba792041758af8f02b08af61ad233e7b736dddff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161260 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170163 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/117631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f34d91f3-d311-4082-a295-69b988c9d9cc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125086 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/117631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a096dbbc-1a18-4c06-b60d-2a3623218c20) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105683 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb88439f-8334-4bdb-9b5a-3760a07ab1c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26414 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17883 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172646 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133364 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133373 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36032 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96257 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27925 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21216 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33902 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33401 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33645 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33550 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->