### PR TITLE
[JSC] GreedyRegAlloc: Split SplitMetadata into per-kind types

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -732,15 +732,33 @@ private:
     List m_instPoints;
 };
 
-// SplitMetadata tracks a Tmp that has been split into multiple Tmps in an effort
-// to either allocate the original Tmp or the split Tmps, depending on the split type.
-struct SplitMetadata {
-    enum class Type : uint8_t {
-        Invalid,
-        AroundClobbers,
-        IntraBlock,
+// AroundClobbersSplitMetadata tracks a Tmp that has been split to carry its value
+// across register-clobbering instructions.
+struct AroundClobbersSplitMetadata {
+    struct Split {
+        Tmp tmp;
+
+        void dump(PrintStream& out) const { out.print(tmp); }
     };
 
+    AroundClobbersSplitMetadata() = default;
+
+    AroundClobbersSplitMetadata(Tmp tmp)
+        : originalTmp(tmp) { }
+
+    void dump(PrintStream& out) const
+    {
+        out.print(originalTmp, " : AroundClobbers { ", listDump(splits), " } ");
+    }
+
+    Tmp originalTmp;
+    Vector<Split> splits;
+};
+
+// IntraBlockSplitMetadata tracks a Tmp that has been split into per-cluster Tmps
+// within basic blocks. The original Tmp is spilled and each cluster Tmp may get its
+// own register allocation for the duration of a cluster of uses/defs.
+struct IntraBlockSplitMetadata {
     struct Split {
         Tmp tmp;
         Point lastDefPoint;
@@ -753,19 +771,14 @@ struct SplitMetadata {
         }
     };
 
-    SplitMetadata()
-        : type(Type::Invalid) { }
-
-    SplitMetadata(Type t, Tmp tmp)
-        : type(t)
-        , originalTmp(tmp) { }
+    IntraBlockSplitMetadata(Tmp tmp)
+        : originalTmp(tmp) { }
 
     void dump(PrintStream& out) const
     {
-        out.print(originalTmp, " : ", type, " { ", listDump(splits), " } ");
+        out.print(originalTmp, " : IntraBlock { ", listDump(splits), " } ");
     }
 
-    Type type;
     Tmp originalTmp;
     Vector<Split> splits;
 };
@@ -778,7 +791,7 @@ public:
         , m_tailPoints(code.size())
         , m_map(code)
         , m_useDefLists()
-        , m_splitMetadata(1) // Sacrifice index 0.
+        , m_aroundClobbersMetadata(1) // Sacrifice index 0.
         , m_spillSlotTable(FillWith { }, 1, nullptr) // Sacrifice index 0.
         , m_regRanges(Reg::maxIndex() + 1)
         , m_insertionSets(code.size())
@@ -866,7 +879,8 @@ public:
         m_code.forEachTmp([&](Tmp tmp) {
             out.println("    ", tmp, ": ", m_map[tmp], " useWidth=", m_tmpWidth.useWidth(tmp));
         });
-        out.println("Splits:\n", listDump(m_splitMetadata, "\n"));
+        out.println("AroundClobbers splits:\n", listDump(m_aroundClobbersMetadata, "\n"));
+        out.println("IntraBlock splits:\n", listDump(m_intraBlockMetadata, "\n"));
         out.println("SpillSlotTable: ", pointerListDump(m_spillSlotTable));
         out.println("Stats (GP):", m_stats[GP]);
         out.println("Stats (FP):", m_stats[FP]);
@@ -2473,10 +2487,10 @@ private:
             });
 
         tmpData.liveRange = LiveRange::subtract(tmpData.liveRange, holeRange);
-        tmpData.splitAroundClobbersMetadataIndex = m_splitMetadata.size();
+        tmpData.splitAroundClobbersMetadataIndex = m_aroundClobbersMetadata.size();
         setStageAndEnqueue(tmp, tmpData, Stage::TryAllocate);
 
-        SplitMetadata metadata(SplitMetadata::Type::AroundClobbers, tmp);
+        AroundClobbersSplitMetadata metadata(tmp);
         // Create tmps to carry the value across register clobbering instructions. These tmps
         // might spill or be assigned another register.
         for (Interval hole : holeRange.intervals()) {
@@ -2494,11 +2508,11 @@ private:
             // analysis (see lowerAfterRegAlloc()), and that's unlikely to be worth it.
             Interval gapInterval = hole | Interval(hole.begin() - 1);
             Tmp gapTmp = addSplitTmp(tmp, UseDefCost(freq), gapInterval);
-            metadata.splits.append({ gapTmp, 0 });
+            metadata.splits.append({ gapTmp });
             setStageAndEnqueue(gapTmp, m_map.get<bank>(gapTmp), Stage::TryAllocate);
         }
         dataLogLnIf(verbose(), "Split (clobbers): reg = ", bestSplitReg, " spillCost = ", m_map.get<bank>(tmp).spillCost().value(), " splitCost = ", minSplitCost.value(), " split tmp = ", metadata);
-        m_splitMetadata.append(WTF::move(metadata));
+        m_aroundClobbersMetadata.append(WTF::move(metadata));
         m_stats[bank].numSplitAroundClobbers++;
         return true;
     }
@@ -2579,7 +2593,7 @@ private:
 
         ensureUseDefLists();
 
-        SplitMetadata* metadata = nullptr;
+        IntraBlockSplitMetadata* metadata = nullptr;
         Vector<Tmp*, 8> tmpPtrs;
         Vector<std::pair<Tmp*, Point>, 4> coldUsePtrs;
         size_t cursor = 0;
@@ -2616,8 +2630,8 @@ private:
                 if (tmpPtrs.size() > 1) {
                     ASSERT(cluster);
                     if (!metadata) {
-                        m_splitMetadata.constructAndAppend(SplitMetadata::Type::IntraBlock, tmp);
-                        metadata = &m_splitMetadata.last();
+                        m_intraBlockMetadata.constructAndAppend(tmp);
+                        metadata = &m_intraBlockMetadata.last();
                     }
                     Point pre = pointAtOffset(cluster.begin(), PointOffsets::Pre);
                     // If the Tmp is live into the cluster then cluster range is extended to model the fixup load from
@@ -2681,8 +2695,7 @@ private:
         dataLogLnIf(verbose(), "Spilled ", tmp);
 
         if (tmpData.splitAroundClobbersMetadataIndex) {
-            auto& metadata = m_splitMetadata[tmpData.splitAroundClobbersMetadataIndex];
-            ASSERT(metadata.type == SplitMetadata::Type::AroundClobbers);
+            auto& metadata = m_aroundClobbersMetadata[tmpData.splitAroundClobbersMetadataIndex];
             // Splitting didn't prevent originalTmp from spilling after all, so no point assigning
             // registers or stack slots to the gap tmps for this split.
             dataLogLnIf(verbose(), "   evicting tmps created during split");
@@ -2994,25 +3007,18 @@ private:
 
     void insertFixupCode()
     {
-        for (auto& metadata : m_splitMetadata) {
-            switch (metadata.type) {
-            case SplitMetadata::Type::Invalid:
-                break;
-            case SplitMetadata::Type::AroundClobbers:
-                insertSplitAroundClobbersFixupCode(metadata);
-                break;
-            case SplitMetadata::Type::IntraBlock:
-                insertSplitIntraBlockFixupCode(metadata);
-                break;
-            }
-        }
+        // Skip index 0 which is sacrificed so that splitAroundClobbersMetadataIndex == 0 means "none".
+        for (size_t i = 1; i < m_aroundClobbersMetadata.size(); i++)
+            insertSplitAroundClobbersFixupCode(m_aroundClobbersMetadata[i]);
+        for (auto& metadata : m_intraBlockMetadata)
+            insertSplitIntraBlockFixupCode(metadata);
         for (BasicBlock* block : m_code)
             m_insertionSets[block].execute(block);
     }
 
-    void insertSplitAroundClobbersFixupCode(SplitMetadata& metadata)
+    void insertSplitAroundClobbersFixupCode(AroundClobbersSplitMetadata& metadata)
     {
-        ASSERT(metadata.type == SplitMetadata::Type::AroundClobbers);
+        ASSERT(metadata.originalTmp);
 
         if (m_map[metadata.originalTmp].stage == Stage::Spilled) {
             m_stats[metadata.originalTmp.bank()].numSplitAroundClobberSpilled++;
@@ -3042,9 +3048,8 @@ private:
         }
     }
 
-    void insertSplitIntraBlockFixupCode(SplitMetadata& metadata)
+    void insertSplitIntraBlockFixupCode(IntraBlockSplitMetadata& metadata)
     {
-        ASSERT(metadata.type == SplitMetadata::Type::IntraBlock);
 
         Tmp originalTmp = metadata.originalTmp;
         Bank bank = originalTmp.bank();
@@ -3174,7 +3179,8 @@ private:
     Vector<Point> m_tailPoints;
     TmpMap<TmpData> m_map;
     TmpMap<UseDefList> m_useDefLists;
-    Vector<SplitMetadata> m_splitMetadata;
+    Vector<AroundClobbersSplitMetadata> m_aroundClobbersMetadata;
+    Vector<IntraBlockSplitMetadata> m_intraBlockMetadata;
     Vector<StackSlot*> m_spillSlotTable;
     IndexMap<Reg, RegisterRange> m_regRanges;
     GenerationalSet<uint8_t, SaVector> m_visited;


### PR DESCRIPTION
#### 0b634d738806db5de0d151920a066b5170fd20d5
<pre>
[JSC] GreedyRegAlloc: Split SplitMetadata into per-kind types
<a href="https://bugs.webkit.org/show_bug.cgi?id=312801">https://bugs.webkit.org/show_bug.cgi?id=312801</a>
<a href="https://rdar.apple.com/175188148">rdar://175188148</a>

Reviewed by Yusuke Suzuki.

Replace the single SplitMetadata struct with separate
AroundClobbersSplitMetadata and IntraBlockSplitMetadata types, each
stored in its own vector. This makes the per-kind invariants explicit
in the type system and prepares for adding a third split kind.

AroundClobbersSplitMetadata::Split no longer carries the unused
lastDefPoint field. The type-switch dispatch in insertFixupCode() is
replaced by separate loops over each vector.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::AroundClobbersSplitMetadata::Split::dump const):
(JSC::B3::Air::Greedy::AroundClobbersSplitMetadata::AroundClobbersSplitMetadata):
(JSC::B3::Air::Greedy::AroundClobbersSplitMetadata::dump const):
(JSC::B3::Air::Greedy::IntraBlockSplitMetadata::IntraBlockSplitMetadata):
(JSC::B3::Air::Greedy::IntraBlockSplitMetadata::dump const):
(JSC::B3::Air::Greedy::GreedyAllocator::GreedyAllocator):
(JSC::B3::Air::Greedy::GreedyAllocator::dump const):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitAroundClobbers):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitIntraBlock):
(JSC::B3::Air::Greedy::GreedyAllocator::spill):
(JSC::B3::Air::Greedy::GreedyAllocator::insertFixupCode):
(JSC::B3::Air::Greedy::GreedyAllocator::insertSplitAroundClobbersFixupCode):
(JSC::B3::Air::Greedy::GreedyAllocator::insertSplitIntraBlockFixupCode):
(JSC::B3::Air::Greedy::SplitMetadata::Split::dump const): Deleted.
(JSC::B3::Air::Greedy::SplitMetadata::SplitMetadata): Deleted.
(JSC::B3::Air::Greedy::SplitMetadata::dump const): Deleted.

Canonical link: <a href="https://commits.webkit.org/311682@main">https://commits.webkit.org/311682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b63bb165f98883965e5bfbc813b79cc030893b7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111656 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/efcd2ad2-c8a2-4d55-a2ed-69e04962b57c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122006 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85700 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102675 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/555938a5-bc5f-4d13-a430-23f7e09ddd5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23344 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21610 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14169 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149625 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168887 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18409 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13303 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130170 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30513 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130281 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141103 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88433 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23981 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17908 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189647 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94476 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48675 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29668 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29795 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->