### PR TITLE
Passkey largeBlob output nil

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.h
@@ -32,12 +32,22 @@
 NS_ASSUME_NONNULL_BEGIN
 
 WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
+@interface _WKAuthenticationExtensionsClientLargeBlobOutputs : NSObject
+
+@property (nonatomic, readonly) BOOL supported;
+@property (nullable, nonatomic, readonly, copy) NSData *blob;
+@property (nonatomic, readonly) BOOL written;
+
+@end
+
+WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 @interface _WKAuthenticationExtensionsClientOutputs : NSObject
 
 @property (nonatomic, readonly) BOOL appid;
 @property (nonatomic, readonly) BOOL prfEnabled;
 @property (nullable, nonatomic, readonly, copy) NSData *prfFirst;
 @property (nullable, nonatomic, readonly, copy) NSData *prfSecond;
+@property (nullable, nonatomic, readonly, strong) _WKAuthenticationExtensionsClientLargeBlobOutputs *largeBlob;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm
@@ -28,9 +28,37 @@
 
 #import <wtf/RetainPtr.h>
 
+@implementation _WKAuthenticationExtensionsClientLargeBlobOutputs {
+    RetainPtr<NSData> _blob;
+}
+
+- (instancetype)initWithSupported:(BOOL)supported blob:(NSData *)blob written:(BOOL)written
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _supported = supported;
+    _blob = blob;
+    _written = written;
+    return self;
+}
+
+- (NSData *)blob
+{
+    return _blob.get();
+}
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+@end
+
 @implementation _WKAuthenticationExtensionsClientOutputs {
     RetainPtr<NSData> _prfFirst;
     RetainPtr<NSData> _prfSecond;
+    RetainPtr<_WKAuthenticationExtensionsClientLargeBlobOutputs> _largeBlob;
 }
 
 - (instancetype)initWithAppid:(BOOL)appid
@@ -55,6 +83,19 @@
     return self;
 }
 
+- (instancetype)initWithAppid:(BOOL)appid prfEnabled:(BOOL)prfEnabled prfFirst:(NSData *)prfFirst prfSecond:(NSData *)prfSecond largeBlobOutputs:(_WKAuthenticationExtensionsClientLargeBlobOutputs *)largeBlobOutputs
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _appid = appid;
+    _prfEnabled = prfEnabled;
+    _prfFirst = prfFirst;
+    _prfSecond = prfSecond;
+    _largeBlob = largeBlobOutputs;
+    return self;
+}
+
 - (NSData *)prfFirst
 {
     return _prfFirst.get();
@@ -63,6 +104,11 @@
 - (NSData *)prfSecond
 {
     return _prfSecond.get();
+}
+
+- (_WKAuthenticationExtensionsClientLargeBlobOutputs *)largeBlob
+{
+    return _largeBlob.get();
 }
 
 - (void)dealloc

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputsInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputsInternal.h
@@ -29,10 +29,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface _WKAuthenticationExtensionsClientLargeBlobOutputs ()
+
+- (instancetype)initWithSupported:(BOOL)supported blob:(nullable NSData *)blob written:(BOOL)written;
+
+@end
+
 @interface _WKAuthenticationExtensionsClientOutputs ()
 
 - (instancetype)initWithAppid:(BOOL)appid;
 - (instancetype)initWithAppid:(BOOL)appid prfEnabled:(BOOL)prfEnabled prfFirst:(NSData *)prfFirst prfSecond:(NSData *)prfSecond;
+- (instancetype)initWithAppid:(BOOL)appid prfEnabled:(BOOL)prfEnabled prfFirst:(nullable NSData *)prfFirst prfSecond:(nullable NSData *)prfSecond largeBlobOutputs:(nullable _WKAuthenticationExtensionsClientLargeBlobOutputs *)largeBlobOutputs;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -1108,7 +1108,16 @@ static RetainPtr<_WKAuthenticationExtensionsClientOutputs> wkAuthenticationExten
         if (secondBuffer)
             second = WTF::toNSData(secondBuffer->span());
     }
-    return adoptNS([[_WKAuthenticationExtensionsClientOutputs alloc] initWithAppid:(outputs.appid && *outputs.appid) prfEnabled:(outputs.prf && outputs.prf->enabled && *outputs.prf->enabled) prfFirst:first.get() prfSecond:second.get()]);
+
+    RetainPtr<_WKAuthenticationExtensionsClientLargeBlobOutputs> largeBlobOutputs;
+    if (outputs.largeBlob) {
+        RetainPtr<NSData> blobData;
+        if (RefPtr blobBuffer = outputs.largeBlob->blob)
+            blobData = WTF::toNSData(blobBuffer->span());
+        largeBlobOutputs = adoptNS([[_WKAuthenticationExtensionsClientLargeBlobOutputs alloc] initWithSupported:(outputs.largeBlob->supported && *outputs.largeBlob->supported) blob:blobData.get() written:(outputs.largeBlob->written && *outputs.largeBlob->written)]);
+    }
+
+    return adoptNS([[_WKAuthenticationExtensionsClientOutputs alloc] initWithAppid:(outputs.appid && *outputs.appid) prfEnabled:(outputs.prf && outputs.prf->enabled && *outputs.prf->enabled) prfFirst:first.get() prfSecond:second.get() largeBlobOutputs:largeBlobOutputs.get()]);
 }
 
 static RetainPtr<_WKAuthenticatorAttestationResponse> wkAuthenticatorAttestationResponse(const WebCore::AuthenticatorResponseData& data, NSData *clientDataJSON, WebCore::AuthenticatorAttachment attachment)


### PR DESCRIPTION
#### 201cac0fbb4eac85c52bbaa0a470e75ebbc2f6c8
<pre>
Passkey largeBlob output nil
<a href="https://bugs.webkit.org/show_bug.cgi?id=312791">https://bugs.webkit.org/show_bug.cgi?id=312791</a>
<a href="https://rdar.apple.com/173450970">rdar://173450970</a>

Reviewed by NOBODY (OOPS!).

A while back we changed the structure of WebAuthn extensions from passing raw data
between WebKit and AuthenticationServices to use strongly typed data structures.
In the process, we neglected to add largeBlob to this type and ended up losing it.
This patch adds a type for largeBlob and includes it in the extension struct.

* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm:
(-[_WKAuthenticationExtensionsClientLargeBlobOutputs initWithSupported:blob:written:]):
(-[_WKAuthenticationExtensionsClientLargeBlobOutputs blob]):
(-[_WKAuthenticationExtensionsClientLargeBlobOutputs dealloc]):
(-[_WKAuthenticationExtensionsClientOutputs initWithAppid:prfEnabled:prfFirst:prfSecond:largeBlobOutputs:]):
(-[_WKAuthenticationExtensionsClientOutputs largeBlob]):
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputsInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(wkAuthenticationExtensionsClientOutputs):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/201cac0fbb4eac85c52bbaa0a470e75ebbc2f6c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111677 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122021 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85710 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102690 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23357 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21633 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14190 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133036 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168908 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13348 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Found 33422 issues") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130189 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130302 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141123 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88454 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17928 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94522 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29689 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29919 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->