### PR TITLE
[TextureMapper] Fix drop-shadow filter to align with the layer's transform

### DIFF
--- a/LayoutTests/compositing/filters/drop-shadow-transform-expected.html
+++ b/LayoutTests/compositing/filters/drop-shadow-transform-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-200" />
+    <style>
+      div div {
+        background: green;
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        top: 100px;
+        filter: drop-shadow(20px 20px black);
+      }
+      .a {
+        transform: translate(150px,0) rotate(90deg);
+      }
+      .b {
+        transform: translate(300px,0) rotate(180deg);
+      }
+      .c {
+        transform: translate(450px,0) rotate(270deg);
+      }
+      .d {
+        transform: translate(600px,0) rotate(360deg);
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <div class=a></div>
+      <div class=b></div>
+      <div class=c></div>
+      <div class=d></div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/compositing/filters/drop-shadow-transform.html
+++ b/LayoutTests/compositing/filters/drop-shadow-transform.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="fuzzy" content="maxDifference=0-16; totalPixels=0-300" />
+    <style>
+      .x div {
+	      will-change: transform;
+      }
+      div div {
+        background: green;
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        top: 100px;
+        filter: drop-shadow(20px 20px black);
+      }
+      .a {
+        transform: translate(150px,0) rotate(90deg);
+      }
+      .b {
+        transform: translate(300px,0) rotate(180deg);
+      }
+      .c {
+        transform: translate(450px,0) rotate(270deg);
+      }
+      .d {
+        transform: translate(600px,0) rotate(360deg);
+      }
+    </style>
+  </head>
+  <body>
+    <div class=x>
+      <div class=a></div>
+      <div class=b></div>
+      <div class=c></div>
+      <div class=d></div>
+    </div>
+  </body>
+</html>

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -1030,7 +1030,7 @@ void TextureMapperLayer::paintUsingOverlapRegions(TextureMapperPaintOptions& opt
     }
 }
 
-Vector<IntRect, 1> TextureMapperLayer::computeConsolidatedOverlapRegionRects(TextureMapperPaintOptions& options)
+Vector<IntRect, 1> TextureMapperLayer::computeConsolidatedOverlapRegionRects(TextureMapperPaintOptions& options, std::optional<IntRect> clipBoundsOverride)
 {
     Region overlapRegion;
     Region nonOverlapRegion;
@@ -1039,11 +1039,12 @@ Vector<IntRect, 1> TextureMapperLayer::computeConsolidatedOverlapRegionRects(Tex
         mode = ComputeOverlapRegionMode::Mask;
     ComputeOverlapRegionData data {
         mode,
-        options.textureMapper.clipBounds(),
+        clipBoundsOverride.value_or(options.textureMapper.clipBounds()),
         overlapRegion,
         nonOverlapRegion
     };
-    data.clipBounds.move(-options.offset);
+    if (!clipBoundsOverride)
+        data.clipBounds.move(-options.offset);
     computeOverlapRegions(data, options.transform, false);
     ASSERT(nonOverlapRegion.isEmpty());
 
@@ -1059,14 +1060,37 @@ Vector<IntRect, 1> TextureMapperLayer::computeConsolidatedOverlapRegionRects(Tex
 
 void TextureMapperLayer::paintSelfChildrenFilterAndMask(TextureMapperPaintOptions& options)
 {
+    auto layerCombinedInverse = m_isBackdrop
+        ? TransformationMatrix()
+        : m_layerTransforms.combined.inverse().value_or(TransformationMatrix());
+
+    SetForScope scopedTransform(options.transform, options.transform);
+    auto outerTransform = options.transform;
+    if (!m_isBackdrop)
+        options.transform.multiply(layerCombinedInverse);
+
+    TransformationMatrix surfaceCommitTransform = outerTransform;
+    if (!m_isBackdrop)
+        surfaceCommitTransform.multiply(m_layerTransforms.combined);
+
+    // Use a clip that comfortably covers any realistic layer bounds (no
+    // layer tree should ever approach ±8M pixels in local coordinates),
+    // while staying small enough that corner arithmetic (x + width,
+    // matrix-mapped corners) won't overflow int32_t or lose precision
+    // when promoted to float.
+    constexpr int kLargeClipHalfExtent = 1 << 23;
+    std::optional<IntRect> clipOverride;
+    if (!m_isBackdrop)
+        clipOverride = IntRect(-kLargeClipHalfExtent, -kLargeClipHalfExtent, kLargeClipHalfExtent * 2, kLargeClipHalfExtent * 2);
+
     IntSize maxTextureSize = options.textureMapper.maxTextureSize();
-    for (auto& rect : computeConsolidatedOverlapRegionRects(options)) {
+    for (auto& rect : computeConsolidatedOverlapRegionRects(options, clipOverride)) {
         for (int x = rect.x(); x < rect.maxX(); x += maxTextureSize.width()) {
             for (int y = rect.y(); y < rect.maxY(); y += maxTextureSize.height()) {
                 IntRect tileRect(IntPoint(x, y), maxTextureSize);
                 tileRect.intersect(rect);
 
-                paintSelfAndChildrenWithIntermediateSurface(options, tileRect);
+                paintSelfAndChildrenWithIntermediateSurface(options, tileRect, surfaceCommitTransform);
             }
         }
     }
@@ -1125,7 +1149,7 @@ void TextureMapperLayer::paintWithIntermediateSurface(TextureMapperPaintOptions&
     commitSurface(options, surface.get(), rect, options.opacity);
 }
 
-void TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions& options, const IntRect& rect)
+void TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions& options, const IntRect& rect, const TransformationMatrix& surfaceCommitTransform)
 {
     auto surface = BitmapTexturePool::singleton().acquireTexture(rect.size(), { BitmapTexture::Flags::SupportsAlpha });
     {
@@ -1137,7 +1161,12 @@ void TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface(TextureMapp
         surface = Ref { *options.surface };
     }
 
-    commitSurface(options, surface.get(), rect, options.opacity);
+    TransformationMatrix modelView;
+    modelView.translate(options.offset.width(), options.offset.height());
+    modelView.multiply(surfaceCommitTransform);
+
+    options.textureMapper.bindSurface(options.surface.get());
+    options.textureMapper.drawTexture(surface.get(), rect, modelView, options.opacity);
 }
 
 void TextureMapperLayer::paintSelfChildrenReplicaFilterAndMask(TextureMapperPaintOptions& options)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -169,7 +169,7 @@ private:
         Region& nonOverlapRegion;
     };
     void computeOverlapRegions(ComputeOverlapRegionData&, const TransformationMatrix&, bool includesReplica = true);
-    Vector<IntRect, 1> computeConsolidatedOverlapRegionRects(TextureMapperPaintOptions&);
+    Vector<IntRect, 1> computeConsolidatedOverlapRegionRects(TextureMapperPaintOptions&, std::optional<IntRect> clipBoundsOverride = std::nullopt);
 
     void paintRecursive(TextureMapperPaintOptions&);
     void paintFlattened(TextureMapperPaintOptions&);
@@ -178,7 +178,7 @@ private:
     void paintUsingOverlapRegions(TextureMapperPaintOptions&);
     void paintIntoSurface(TextureMapperPaintOptions&);
     void paintWithIntermediateSurface(TextureMapperPaintOptions&, const IntRect&);
-    void paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions&, const IntRect&);
+    void paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions&, const IntRect&, const TransformationMatrix& surfaceCommitTransform);
     void paintSelfChildrenFilterAndMask(TextureMapperPaintOptions&);
     void paintSelf(TextureMapperPaintOptions&);
     void paintSelfAndChildren(TextureMapperPaintOptions&);


### PR DESCRIPTION
#### 10474bc30bbd702fe549ee3299868ac2b0885847
<pre>
[TextureMapper] Fix drop-shadow filter to align with the layer&apos;s transform
<a href="https://bugs.webkit.org/show_bug.cgi?id=218734">https://bugs.webkit.org/show_bug.cgi?id=218734</a>

Reviewed by NOBODY (OOPS!).

When a composited layer has a CSS filter, the layer&apos;s transform was
baked into the intermediate surface before the filter ran, so
drop-shadow(20px 20px) on a rotated layer produced an axis-aligned
shadow in surface space instead of one that rotates with the content.

Paint the intermediate surface in the layer&apos;s local (untransformed)
coordinate space, apply the filter there, and use the layer&apos;s
combined transform as the modelView when drawing the surface back.

Test: compositing/filters/drop-shadow-transform.html

* LayoutTests/compositing/filters/drop-shadow-transform-expected.html: Added.
* LayoutTests/compositing/filters/drop-shadow-transform.html: Added.
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::computeConsolidatedOverlapRegionRects):
(WebCore::TextureMapperLayer::paintSelfChildrenFilterAndMask):
(WebCore::TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
</pre>
----------------------------------------------------------------------
#### e3174ffa2a2eebcecdf44cb940f70cf3a1103e05
<pre>
Add missing include directives
<a href="https://bugs.webkit.org/show_bug.cgi?id=312787">https://bugs.webkit.org/show_bug.cgi?id=312787</a>

Reviewed by NOBODY (OOPS!).

Build fails in multiple sites with
build-webkit --wpe --cmakeargs=&quot;-DENABLE_UNIFIED_BUILDS=OFF&quot;

* Source/JavaScriptCore/API/JSCallbackObjectFunctions.h:
* Source/JavaScriptCore/API/JSMarkingConstraintPrivate.cpp:
* Source/JavaScriptCore/API/JSWeakObjectMapRefPrivate.cpp:
* Source/JavaScriptCore/API/JSWeakPrivate.cpp:
* Source/JavaScriptCore/inspector/ConsoleMessage.cpp:
* Source/JavaScriptCore/inspector/PerGlobalObjectWrapperWorld.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.cpp:
* Source/JavaScriptCore/runtime/IntlSegmentDataObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
* Source/JavaScriptCore/runtime/JSGlobalProxy.cpp:
* Source/JavaScriptCore/runtime/Lookup.cpp:
* Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h:
* Source/JavaScriptCore/runtime/WeakMapImpl.cpp:
* Source/JavaScriptCore/runtime/WeakMapImplInlines.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp:
* Source/WebCore/Headers.cmake:
* Source/WebCore/bindings/js/JSDOMConvertInterface.h:
* Source/WebCore/bindings/js/JSDOMConvertNumbers.h:
* Source/WebCore/bindings/js/JSReadableStreamSourceCustom.cpp:
* Source/WebCore/inspector/agents/page/PageHeapAgent.cpp:
* Source/WebCore/page/WebKitJSHandle.cpp:
* Source/WebCore/rendering/ScrollbarUpdateScope.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/099eb0a77aff9b12a423ef10b80cfd9159b6ca9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24059 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/166353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30868 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/166353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160487 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/24260 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/166353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21571 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/14124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168842 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/13203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20890 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30468 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/130247 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141064 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25074 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30101 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/94366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/29623 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->