### PR TITLE
[TextureMapper] Fix drop-shadow filter to align with the layer's transform

### DIFF
--- a/LayoutTests/compositing/filters/drop-shadow-transform-expected.html
+++ b/LayoutTests/compositing/filters/drop-shadow-transform-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      div div {
+        background: green;
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        top: 100px;
+        filter: drop-shadow(20px 20px black);
+      }
+      .a {
+        transform: translate(150px,0) rotate(90deg);
+      }
+      .b {
+        transform: translate(300px,0) rotate(180deg);
+      }
+      .c {
+        transform: translate(450px,0) rotate(270deg);
+      }
+      .d {
+        transform: translate(600px,0) rotate(360deg);
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <div class=a></div>
+      <div class=b></div>
+      <div class=c></div>
+      <div class=d></div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/compositing/filters/drop-shadow-transform.html
+++ b/LayoutTests/compositing/filters/drop-shadow-transform.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="fuzzy" content="maxDifference=0-16; totalPixels=0-300" />
+    <style>
+      .x div {
+	      will-change: transform;
+      }
+      div div {
+        background: green;
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        top: 100px;
+        filter: drop-shadow(20px 20px black);
+      }
+      .a {
+        transform: translate(150px,0) rotate(90deg);
+      }
+      .b {
+        transform: translate(300px,0) rotate(180deg);
+      }
+      .c {
+        transform: translate(450px,0) rotate(270deg);
+      }
+      .d {
+        transform: translate(600px,0) rotate(360deg);
+      }
+    </style>
+  </head>
+  <body>
+    <div class=x>
+      <div class=a></div>
+      <div class=b></div>
+      <div class=c></div>
+      <div class=d></div>
+    </div>
+  </body>
+</html>

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -943,7 +943,7 @@ void TextureMapperLayer::computeOverlapRegions(ComputeOverlapRegionData& data, c
     else if (m_contentsLayer || m_state.solidColor.isVisible())
         localBoundingRect = m_state.contentsRect;
 
-    if (m_currentFilters.hasOutsets() && !m_state.backdropLayer && !m_state.masksToBounds && !m_state.maskLayer) {
+    if (!data.skipFilterOutsets && m_currentFilters.hasOutsets() && !m_state.backdropLayer && !m_state.masksToBounds && !m_state.maskLayer) {
         auto outsets = m_currentFilters.outsets();
         localBoundingRect.move(-outsets.left(), -outsets.top());
         localBoundingRect.expand(outsets.left() + outsets.right(), outsets.top() + outsets.bottom());
@@ -1030,7 +1030,7 @@ void TextureMapperLayer::paintUsingOverlapRegions(TextureMapperPaintOptions& opt
     }
 }
 
-Vector<IntRect, 1> TextureMapperLayer::computeConsolidatedOverlapRegionRects(TextureMapperPaintOptions& options)
+Vector<IntRect, 1> TextureMapperLayer::computeConsolidatedOverlapRegionRects(TextureMapperPaintOptions& options, std::optional<IntRect> clipBoundsOverride, bool skipFilterOutsets)
 {
     Region overlapRegion;
     Region nonOverlapRegion;
@@ -1039,11 +1039,13 @@ Vector<IntRect, 1> TextureMapperLayer::computeConsolidatedOverlapRegionRects(Tex
         mode = ComputeOverlapRegionMode::Mask;
     ComputeOverlapRegionData data {
         mode,
-        options.textureMapper.clipBounds(),
+        clipBoundsOverride.value_or(options.textureMapper.clipBounds()),
         overlapRegion,
-        nonOverlapRegion
+        nonOverlapRegion,
+        skipFilterOutsets
     };
-    data.clipBounds.move(-options.offset);
+    if (!clipBoundsOverride)
+        data.clipBounds.move(-options.offset);
     computeOverlapRegions(data, options.transform, false);
     ASSERT(nonOverlapRegion.isEmpty());
 
@@ -1059,14 +1061,59 @@ Vector<IntRect, 1> TextureMapperLayer::computeConsolidatedOverlapRegionRects(Tex
 
 void TextureMapperLayer::paintSelfChildrenFilterAndMask(TextureMapperPaintOptions& options)
 {
+    bool useLocalSpaceTransform = !m_isBackdrop && !hasBackdrop();
+
+    SetForScope scopedTransform(options.transform, options.transform);
+    TransformationMatrix surfaceCommitTransform;
+    std::optional<IntRect> clipOverride;
+    IntOutsets surfaceOutsets;
+
+    if (useLocalSpaceTransform) {
+        auto layerCombinedInverse = m_layerTransforms.combined.inverse();
+        if (!layerCombinedInverse)
+            return;
+
+        auto combinedAffine = m_layerTransforms.combined.toAffineTransform();
+        double surfaceScaleX = combinedAffine.xScale();
+        double surfaceScaleY = combinedAffine.yScale();
+        if (!(surfaceScaleX > 0 && surfaceScaleY > 0))
+            surfaceScaleX = surfaceScaleY = 1.0;
+
+        surfaceCommitTransform = options.transform;
+        surfaceCommitTransform.multiply(m_layerTransforms.combined);
+        surfaceCommitTransform.scaleNonUniform(1.0 / surfaceScaleX, 1.0 / surfaceScaleY);
+
+        // Children paint into scaled-local-space: undo this layer's transform,
+        // then pre-scale so the surface dimensions match the rendered size.
+        options.transform = TransformationMatrix();
+        options.transform.scaleNonUniform(surfaceScaleX, surfaceScaleY);
+        options.transform.multiply(*layerCombinedInverse);
+
+        // Use a clip that comfortably covers any realistic scaled-local bounds
+        // without overflowing int32 when its corners are mapped.
+        constexpr int kLargeClipHalfExtent = 1 << 23;
+        clipOverride = IntRect(-kLargeClipHalfExtent, -kLargeClipHalfExtent, kLargeClipHalfExtent * 2, kLargeClipHalfExtent * 2);
+
+        if (m_currentFilters.hasOutsets() && !m_state.masksToBounds && !m_state.maskLayer)
+            surfaceOutsets = m_currentFilters.outsets();
+    }
+
+    auto rects = computeConsolidatedOverlapRegionRects(options, clipOverride, /*skipFilterOutsets=*/true);
+    if (!surfaceOutsets.isZero()) {
+        for (auto& rect : rects) {
+            rect.move(-surfaceOutsets.left(), -surfaceOutsets.top());
+            rect.expand(surfaceOutsets.left() + surfaceOutsets.right(), surfaceOutsets.top() + surfaceOutsets.bottom());
+        }
+    }
+
     IntSize maxTextureSize = options.textureMapper.maxTextureSize();
-    for (auto& rect : computeConsolidatedOverlapRegionRects(options)) {
+    for (auto& rect : rects) {
         for (int x = rect.x(); x < rect.maxX(); x += maxTextureSize.width()) {
             for (int y = rect.y(); y < rect.maxY(); y += maxTextureSize.height()) {
                 IntRect tileRect(IntPoint(x, y), maxTextureSize);
                 tileRect.intersect(rect);
 
-                paintSelfAndChildrenWithIntermediateSurface(options, tileRect);
+                paintSelfAndChildrenWithIntermediateSurface(options, tileRect, surfaceCommitTransform);
             }
         }
     }
@@ -1125,7 +1172,7 @@ void TextureMapperLayer::paintWithIntermediateSurface(TextureMapperPaintOptions&
     commitSurface(options, surface.get(), rect, options.opacity);
 }
 
-void TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions& options, const IntRect& rect)
+void TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions& options, const IntRect& rect, const TransformationMatrix& surfaceCommitTransform)
 {
     auto surface = BitmapTexturePool::singleton().acquireTexture(rect.size(), { BitmapTexture::Flags::SupportsAlpha });
     {
@@ -1137,7 +1184,12 @@ void TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface(TextureMapp
         surface = Ref { *options.surface };
     }
 
-    commitSurface(options, surface.get(), rect, options.opacity);
+    TransformationMatrix modelView;
+    modelView.translate(options.offset.width(), options.offset.height());
+    modelView.multiply(surfaceCommitTransform);
+
+    options.textureMapper.bindSurface(options.surface.get());
+    options.textureMapper.drawTexture(surface.get(), rect, modelView, options.opacity);
 }
 
 void TextureMapperLayer::paintSelfChildrenReplicaFilterAndMask(TextureMapperPaintOptions& options)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -167,9 +167,10 @@ private:
         IntRect clipBounds;
         Region& overlapRegion;
         Region& nonOverlapRegion;
+        bool skipFilterOutsets { false };
     };
     void computeOverlapRegions(ComputeOverlapRegionData&, const TransformationMatrix&, bool includesReplica = true);
-    Vector<IntRect, 1> computeConsolidatedOverlapRegionRects(TextureMapperPaintOptions&);
+    Vector<IntRect, 1> computeConsolidatedOverlapRegionRects(TextureMapperPaintOptions&, std::optional<IntRect> clipBoundsOverride = std::nullopt, bool skipFilterOutsets = false);
 
     void paintRecursive(TextureMapperPaintOptions&);
     void paintFlattened(TextureMapperPaintOptions&);
@@ -178,7 +179,7 @@ private:
     void paintUsingOverlapRegions(TextureMapperPaintOptions&);
     void paintIntoSurface(TextureMapperPaintOptions&);
     void paintWithIntermediateSurface(TextureMapperPaintOptions&, const IntRect&);
-    void paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions&, const IntRect&);
+    void paintSelfAndChildrenWithIntermediateSurface(TextureMapperPaintOptions&, const IntRect&, const TransformationMatrix& surfaceCommitTransform);
     void paintSelfChildrenFilterAndMask(TextureMapperPaintOptions&);
     void paintSelf(TextureMapperPaintOptions&);
     void paintSelfAndChildren(TextureMapperPaintOptions&);


### PR DESCRIPTION
#### 099eb0a77aff9b12a423ef10b80cfd9159b6ca9c
<pre>
[TextureMapper] Fix drop-shadow filter to align with the layer&apos;s transform
<a href="https://bugs.webkit.org/show_bug.cgi?id=218734">https://bugs.webkit.org/show_bug.cgi?id=218734</a>

Reviewed by NOBODY (OOPS!).

When a composited layer has a CSS filter, the layer&apos;s transform was
baked into the intermediate surface before the filter ran, so
drop-shadow(20px 20px) on a rotated layer produced an axis-aligned
shadow in surface space instead of one that rotates with the content.

Paint the intermediate surface in the layer&apos;s local (untransformed)
coordinate space, apply the filter there, and use the layer&apos;s
combined transform as the modelView when drawing the surface back.

Test: compositing/filters/drop-shadow-transform.html

* LayoutTests/compositing/filters/drop-shadow-transform-expected.html: Added.
* LayoutTests/compositing/filters/drop-shadow-transform.html: Added.
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::computeConsolidatedOverlapRegionRects):
(WebCore::TextureMapperLayer::paintSelfChildrenFilterAndMask):
(WebCore::TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fba0c022d41d1d8cd90a2b8a633b7e11782edfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167075 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112330 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122555 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86020 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103224 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23882 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22244 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14847 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169564 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15012 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21550 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130736 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130851 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141721 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89175 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25560 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18527 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30819 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96441 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30570 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->