### PR TITLE
AX: iOS Voice Control doesn't generate actionable-numbers for base-select option elements

### DIFF
--- a/LayoutTests/accessibility/base-select-basic-expected.txt
+++ b/LayoutTests/accessibility/base-select-basic-expected.txt
@@ -5,7 +5,7 @@ PASS: select.role.toLowerCase().includes('popup') === true
 PASS: select.stringValue.includes('Banana') === true
 PASS: select.isExpanded === false
 PASS: select.isExpanded === true
-PASS: select.childrenCount === 1
+PASS: menu != null === true
 PASS: menu.role.toLowerCase().includes('menu') === true
 PASS: menu.childrenCount === 3
 PASS: (menu.childAtIndex(0)).role.toLowerCase().includes('menuitem') === true

--- a/LayoutTests/accessibility/base-select-basic.html
+++ b/LayoutTests/accessibility/base-select-basic.html
@@ -44,8 +44,10 @@ if (window.accessibilityController) {
         output += await expectAsync("select.isExpanded", "true");
 
         // The select should contain a Menu which wraps the MenuItems.
-        output += expect("select.childrenCount", "1");
-        window.menu = select.childAtIndex(0);
+        // Except on iOS, where the Menu is reparented to be a sibling
+        // of the select (see findBaseSelectMenu for details).
+        window.menu = findBaseSelectMenu(select);
+        output += expect("menu != null", "true");
         output += expect("menu.role.toLowerCase().includes('menu')", "true");
         output += expect("menu.childrenCount", "3");
 

--- a/LayoutTests/accessibility/base-select-complex-options.html
+++ b/LayoutTests/accessibility/base-select-complex-options.html
@@ -51,7 +51,7 @@ if (window.accessibilityController) {
         select.press();
         output += await expectAsync("select.isExpanded", "true");
 
-        window.menu = select.childAtIndex(0);
+        window.menu = findBaseSelectMenu(select);
         output += expect("menu.role.toLowerCase().includes('menu')", "true");
 
         output += "\n--- Simple option: text is NOT exposed as a StaticText child ---\n";

--- a/LayoutTests/accessibility/base-select-option-press-closes-popover.html
+++ b/LayoutTests/accessibility/base-select-option-press-closes-popover.html
@@ -35,7 +35,7 @@ if (window.accessibilityController) {
         select.press();
         output += await expectAsync("select.isExpanded", "true");
 
-        window.menu = select.childAtIndex(0);
+        window.menu = findBaseSelectMenu(select);
         output += expect("menu.role.toLowerCase().includes('menu')", "true");
 
         // Press an unselected option (Apple). This simulates VoiceOver activating a menu item.

--- a/LayoutTests/accessibility/ios-simulator/base-select-popover-is-sibling-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/base-select-popover-is-sibling-expected.txt
@@ -1,0 +1,18 @@
+This test verifies that the base-select popover (Menu) is a sibling of the select in the iOS accessibility tree, not a child. On iOS, isAccessibilityElement=YES elements are treated as leaves -- assistive technologies won't recurse into their children. The select is an accessibility element, so the popover must be a sibling for its menu items to be reachable.
+
+PASS: select.isExpanded === true
+--- Menu is a sibling of the select, not a child ---
+PASS: hasMenuChild === false
+PASS: menu != null === true
+PASS: menu.role.toLowerCase().includes('menu') === true
+
+--- Menu items have MenuItem role ---
+PASS: menu.childAtIndex(0).role.toLowerCase().includes('menuitem') === true
+PASS: menu.childAtIndex(1).role.toLowerCase().includes('menuitem') === true
+PASS: menu.childAtIndex(2).role.toLowerCase().includes('menuitem') === true
+PASS: select.isExpanded === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/ios-simulator/base-select-popover-is-sibling.html
+++ b/LayoutTests/accessibility/ios-simulator/base-select-popover-is-sibling.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+select, select::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+
+<div id="content">
+<select id="select">
+    <option id="option1">Apple</option>
+    <option id="option2" selected>Banana</option>
+    <option id="option3">Cherry</option>
+</select>
+</div>
+
+<script>
+var output = "This test verifies that the base-select popover (Menu) is a sibling of the select in the iOS accessibility tree, not a child. On iOS, isAccessibilityElement=YES elements are treated as leaves -- assistive technologies won't recurse into their children. The select is an accessibility element, so the popover must be a sibling for its menu items to be reachable.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var select = accessibilityController.accessibleElementById("select");
+
+    setTimeout(async function() {
+        select.press();
+        output += await expectAsync("select.isExpanded", "true");
+
+        output += "--- Menu is a sibling of the select, not a child ---\n";
+        // On iOS, the popover is reparented: the select should have no Menu child.
+        window.hasMenuChild = false;
+        for (var i = 0; i < select.childrenCount; i++) {
+            var child = select.childAtIndex(i);
+            var childRole = child ? child.role : null;
+            if (childRole && childRole.toLowerCase().includes("menu"))
+                hasMenuChild = true;
+        }
+        output += expect("hasMenuChild", "false");
+
+        // The menu should be a sibling of the select (child of the select's parent).
+        window.menu = findBaseSelectMenu(select);
+        output += expect("menu != null", "true");
+        output += expect("menu.role.toLowerCase().includes('menu')", "true");
+
+        output += "\n--- Menu items have MenuItem role ---\n";
+        output += expect("menu.childAtIndex(0).role.toLowerCase().includes('menuitem')", "true");
+        output += expect("menu.childAtIndex(1).role.toLowerCase().includes('menuitem')", "true");
+        output += expect("menu.childAtIndex(2).role.toLowerCase().includes('menuitem')", "true");
+
+        select.press();
+        output += await expectAsync("select.isExpanded", "false");
+
+        document.getElementById("content").style.visibility = "hidden";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -336,6 +336,30 @@ function pathAsBoundsOfID(id) {
     return { x: parseFloat(match[1]), y: parseFloat(match[2]), width: parseFloat(match[3]), height: parseFloat(match[4]) };
 }
 
+// Finds the popover Menu for a base-appearance select. On macOS, the menu is a
+// child of the select. On iOS, it is reparented to be a sibling, as both the menu
+// and menu items need to be isAccessibilityElement=YES at the same time (the menu
+// so it can be expanded and collapsed, and menu items so they can be selected).
+function findBaseSelectMenu(select) {
+    for (var i = 0; i < select.childrenCount; i++) {
+        var child = select.childAtIndex(i);
+        var childRole = child ? child.role : null;
+        if (childRole && childRole.toLowerCase().includes("menu"))
+            return child;
+    }
+
+    var parent = select.parentElement();
+    if (parent) {
+        for (var i = 0; i < parent.childrenCount; i++) {
+            var sibling = parent.childAtIndex(i);
+            var siblingRole = sibling ? sibling.role : null;
+            if (siblingRole && siblingRole.toLowerCase().includes("menu"))
+                return sibling;
+        }
+    }
+    return null;
+}
+
 // Executes the operation and waits until an accessibility notification of the provided
 // `notificationName` is received. A notification listener is added to the passed
 // AccessibilityUIElement if not null, or a global listener is installed, before

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
@@ -59,6 +59,18 @@ AccessibilityListBoxOption::AccessibilityListBoxOption(AXID axID, HTMLElement& e
 
 AccessibilityListBoxOption::~AccessibilityListBoxOption() = default;
 
+AccessibilityRole AccessibilityListBoxOption::determineAccessibilityRole()
+{
+    // Base-appearance select options live inside a popover and behave as menu
+    // items (activate to select and close), not listbox options (toggle selection
+    // in an always-visible list).
+    if (RefPtr option = dynamicDowncast<HTMLOptionElement>(m_node.get())) {
+        if (RefPtr select = option->ownerSelectElement(); select && select->usesBaseAppearancePicker())
+            return AccessibilityRole::MenuItem;
+    }
+    return AccessibilityRole::ListBoxOption;
+}
+
 Ref<AccessibilityListBoxOption> AccessibilityListBoxOption::create(AXID axID, HTMLElement& element, AXObjectCache& cache)
 {
     if (CheckedPtr renderer = element.renderer())

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.h
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.h
@@ -47,7 +47,7 @@ private:
     explicit AccessibilityListBoxOption(AXID, RenderObject&, AXObjectCache&);
     explicit AccessibilityListBoxOption(AXID, HTMLElement&, AXObjectCache&);
 
-    AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::ListBoxOption; }
+    AccessibilityRole determineAccessibilityRole() final;
     bool isEnabled() const final;
     bool isSelectedOptionActive() const final;
     String stringValue() const final;

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -47,6 +47,7 @@
 #import "HTMLFrameOwnerElement.h"
 #import "HTMLInputElement.h"
 #import "HTMLNames.h"
+#import "HTMLSelectElement.h"
 #import "HTMLTextAreaElement.h"
 #import "HitTestResult.h"
 #import "IntRect.h"
@@ -59,6 +60,7 @@
 #import "RenderView.h"
 #import "SVGElementInlines.h"
 #import "SVGNames.h"
+#import "SelectPopoverElement.h"
 #import "SelectionGeometry.h"
 #import "Settings.h"
 #import "SimpleRange.h"
@@ -426,6 +428,86 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
         cache->stopCachingComputedObjectAttributes();
 }
 
+enum class AccessibilityElementsCollectionMode : bool {
+    CountOnly,
+    Elements,
+};
+
+struct AccessibilityElementsResult {
+    NSInteger count { 0 };
+    RetainPtr<NSMutableArray> elements;
+};
+
+- (AccessibilityElementsResult)_collectAccessibilityElements:(AccessibilityElementsCollectionMode)mode
+{
+    AccessibilityElementsResult result;
+    bool shouldCollectElements = mode == AccessibilityElementsCollectionMode::Elements;
+    if (shouldCollectElements)
+        result.elements = adoptNS([[NSMutableArray alloc] init]);
+
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    if ([self hasImageControls]) {
+        if (shouldCollectElements)
+            [result.elements addObject:[self mockImageElement]];
+        result.count++;
+    }
+#endif
+
+    for (const auto& child : self.axBackingObject->stitchedUnignoredChildren()) {
+        // Base-select popovers are reparented from children of the select to siblings
+        // of the select in the iOS accessibility tree. On iOS, isAccessibilityElement=YES
+        // elements are treated as leaves — assistive technologies won't recurse into
+        // their children. The select is an accessibility element, so without reparenting
+        // the popover to be a sibling, its menu items are unreachable.
+        if (is<SelectPopoverElement>(child->node()))
+            continue;
+
+        if (shouldCollectElements) {
+            auto* wrapper = child->wrapper();
+            if (child->isRemoteFrame()) {
+                if (id platformRemoteFrame = child->remoteFramePlatformElement().unsafeGet())
+                    [result.elements addObject:platformRemoteFrame];
+                else
+                    [result.elements addObject:wrapper];
+            } else if (child->isAttachment()) {
+                if (id attachmentView = [wrapper attachmentView])
+                    [result.elements addObject:attachmentView];
+                else
+                    [result.elements addObject:wrapper];
+            } else
+                [result.elements addObject:wrapper];
+        }
+        result.count++;
+
+        // After adding a base-select to its parent's children, inject the popover as
+        // a sibling based on the reasoning above.
+        if (auto* select = dynamicDowncast<HTMLSelectElement>(child->node()); select && select->usesBaseAppearancePicker()) {
+            if (auto* popover = select->pickerPopoverElement()) {
+                if (shouldCollectElements) {
+                    CheckedPtr cache = downcast<AccessibilityObject>(child.get()).axObjectCache();
+                    if (auto* axPopover = cache ? cache->getOrCreate(*popover) : nullptr) {
+                        if (auto* popoverWrapper = axPopover->wrapper())
+                            [result.elements addObject:popoverWrapper];
+                    }
+                }
+                result.count++;
+            }
+        }
+    }
+
+#if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
+    if (self.axBackingObject->isModel()) {
+        for (auto child : self.axBackingObject->modelElementChildren().children) {
+            if (shouldCollectElements)
+                [result.elements addObject:child.get()];
+            result.count++;
+        }
+    }
+#endif
+
+    return result;
+}
+
 - (NSArray *)accessibilityElements
 {
     if (![self _prepareAccessibilityCall])
@@ -436,33 +518,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
             return [attachmentView accessibilityElements];
     }
 
-    auto array = adoptNS([[NSMutableArray alloc] init]);
-
-#if ENABLE(SPATIAL_IMAGE_CONTROLS)
-    if ([self hasImageControls])
-        [array addObject:[self mockImageElement]];
-#endif
-
-    for (const auto& child : self.axBackingObject->stitchedUnignoredChildren()) {
-        auto* wrapper = child->wrapper();
-        if (child->isRemoteFrame()) {
-            if (id platformRemoteFrame = child->remoteFramePlatformElement().unsafeGet())
-                [array addObject:platformRemoteFrame];
-        } else if (child->isAttachment()) {
-            if (id attachmentView = [wrapper attachmentView])
-                [array addObject:attachmentView];
-        } else
-            [array addObject:wrapper];
-    }
-
-#if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
-    if (self.axBackingObject->isModel()) {
-        for (auto child : self.axBackingObject->modelElementChildren().children)
-            [array addObject:child.get()];
-    }
-#endif
-
-    return array.autorelease();
+    return [self _collectAccessibilityElements:AccessibilityElementsCollectionMode::Elements].elements.autorelease();
 }
 
 - (NSInteger)accessibilityElementCount
@@ -475,14 +531,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
             return [attachmentView accessibilityElementCount];
     }
 
-    NSInteger count = self.axBackingObject->stitchedUnignoredChildren().size();
-
-#if ENABLE(SPATIAL_IMAGE_CONTROLS)
-    if ([self hasImageControls])
-        count += 1;
-#endif
-
-    return count;
+    return [self _collectAccessibilityElements:AccessibilityElementsCollectionMode::CountOnly].count;
 }
 
 - (id)accessibilityElementAtIndex:(NSInteger)index
@@ -495,31 +544,10 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
             return [attachmentView accessibilityElementAtIndex:index];
     }
 
-    const auto& children = self.axBackingObject->stitchedUnignoredChildren();
-    size_t elementIndex = static_cast<size_t>(index);
-
-#if ENABLE(SPATIAL_IMAGE_CONTROLS)
-    if ([self hasImageControls]) {
-        if (!index)
-            return [self mockImageElement];
-
-        elementIndex -= 1;
-    }
-#endif
-
-    if (elementIndex >= children.size())
+    auto elements = [self _collectAccessibilityElements:AccessibilityElementsCollectionMode::Elements].elements;
+    if (index < 0 || static_cast<NSUInteger>(index) >= [elements count])
         return nil;
-
-    AccessibilityObjectWrapper* wrapper = children[elementIndex]->wrapper();
-    if (children[elementIndex]->isAttachment()) {
-        if (id attachmentView = [wrapper attachmentView])
-            return attachmentView;
-    } else if (children[elementIndex]->isRemoteFrame()) {
-        if (id remoteFramePlatformElement = children[elementIndex]->remoteFramePlatformElement().unsafeGet())
-            return remoteFramePlatformElement;
-    }
-
-    return wrapper;
+    return elements[index];
 }
 
 - (NSInteger)indexOfAccessibilityElement:(id)element
@@ -532,27 +560,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
             return [attachmentView indexOfAccessibilityElement:element];
     }
 
-#if ENABLE(SPATIAL_IMAGE_CONTROLS)
-    if ([self hasImageControls]) {
-        if (element == [self mockImageElement])
-            return 0;
-    }
-#endif
-
-    const auto& children = self.axBackingObject->stitchedUnignoredChildren();
-    unsigned count = children.size();
-    for (unsigned k = 0; k < count; ++k) {
-        AccessibilityObjectWrapper* wrapper = children[k]->wrapper();
-        if (wrapper == element || (children[k]->isAttachment() && [wrapper attachmentView] == element)) {
-#if ENABLE(SPATIAL_IMAGE_CONTROLS)
-            if ([self hasImageControls])
-                return k + 1;
-#endif
-            return k;
-        }
-    }
-
-    return NSNotFound;
+    return [[self _collectAccessibilityElements:AccessibilityElementsCollectionMode::Elements].elements indexOfObject:element];
 }
 
 - (CGPathRef)_accessibilityPath
@@ -921,7 +929,9 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
         traits |= [self _axAdjustableTrait];
         break;
     case AccessibilityRole::MenuItem:
-        traits |= [self _axMenuItemTrait];
+        // Menu items need _axButtonTrait so iOS Voice Control recognizes them
+        // as actionable elements and generates numbered overlays for them.
+        traits |= [self _axMenuItemTrait] | [self _axButtonTrait];
         break;
     case AccessibilityRole::MenuItemCheckbox:
     case AccessibilityRole::MenuItemRadio:

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -399,7 +399,9 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElementIOS::titleUIElement()
 
 RefPtr<AccessibilityUIElement> AccessibilityUIElementIOS::parentElement()
 {
-    return nil;
+    if (id container = [m_element accessibilityContainer])
+        return AccessibilityUIElement::create(container);
+    return nullptr;
 }
 
 RefPtr<AccessibilityUIElement> AccessibilityUIElementIOS::disclosedByRow()


### PR DESCRIPTION
#### 1e4383d0fdd819260d6a9042bfdb3743d011f65b
<pre>
AX: iOS Voice Control doesn&apos;t generate actionable-numbers for base-select option elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=312805">https://bugs.webkit.org/show_bug.cgi?id=312805</a>
<a href="https://rdar.apple.com/175189776">rdar://175189776</a>

Reviewed by Joshua Hoffman.

On iOS, isAccessibilityElement=YES elements are treated as leaves by assistive
technologies, meaning they won&apos;t recurse into their children. The base-select popover
(Menu) was a child of the select element, which is an accessibility element, so
ATs like Voice Control could never reach the menu items inside.

This patch makes three changes:

1. Reparent the base-select popover from a child of the select to a sibling in
the iOS accessibility tree. This is done entirely in the iOS wrapper layer
(WebAccessibilityObjectWrapperIOS.mm), allowing the core accessibility tree to
match the DOM and thus keeping it simple. A new _collectAccessibilityElements:
internal method centralizes the child collection logic with a CountOnly/Elements mode
to avoid unnecessary NSArray allocation when only the count is needed. This avoids
re-implementing the same logic in multiple places (accessibilityElements, accessibilityElementCount, ...).

2. Report base-select options as MenuItem role instead of ListBoxOption. The
options live inside a role=&quot;menu&quot; popover and behave as menu items (activate
to select and dismiss), not listbox options (toggle in an always-visible list).
AccessibilityRenderObject::determineAccessibilityRole() already had this logic
but it was unreachable because AccessibilityListBoxOption::determineAccessibilityRole()
was final and unconditionally returned ListBoxOption.

Ideally in the future, we could collapse AccessibilityListBoxOption into
AccessibilityRenderObject.

3. Add _axButtonTrait to MenuItem in the iOS accessibilityTraits so Voice Control
recognizes menu items as actionable and generates numbered overlays for them.

Also implements AccessibilityUIElementIOS::parentElement() (was a nil stub) using
accessibilityContainer, which is needed by the new findBaseSelectMenu() test helper.

* LayoutTests/accessibility/base-select-basic-expected.txt:
* LayoutTests/accessibility/base-select-basic.html:
* LayoutTests/accessibility/base-select-complex-options.html:
* LayoutTests/accessibility/base-select-option-press-closes-popover.html:
* LayoutTests/accessibility/ios-simulator/base-select-popover-is-sibling-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/base-select-popover-is-sibling.html: Added.
* LayoutTests/resources/accessibility-helper.js:
* Source/WebCore/accessibility/AccessibilityListBoxOption.cpp:
(WebCore::AccessibilityListBoxOption::determineAccessibilityRole):
* Source/WebCore/accessibility/AccessibilityListBoxOption.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper _collectAccessibilityElements:]):
(-[WebAccessibilityObjectWrapper accessibilityElements]):
(-[WebAccessibilityObjectWrapper accessibilityElementCount]):
(-[WebAccessibilityObjectWrapper accessibilityElementAtIndex:]):
(-[WebAccessibilityObjectWrapper indexOfAccessibilityElement:]):
(-[WebAccessibilityObjectWrapper accessibilityTraits]):
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElementIOS::parentElement):

Canonical link: <a href="https://commits.webkit.org/312667@main">https://commits.webkit.org/312667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f250f55c8f5093009e709a6d74162ab6bd4c20a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158374 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112457 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122661 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86090 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103331 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23968 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22353 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14975 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169694 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15323 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130846 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130960 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35903 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141833 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89311 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25649 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18639 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30947 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96741 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30467 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30740 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->