### PR TITLE
[JSC][JSPI] Change the signing scheme of return PCs in EvacuatedStackSlices

### DIFF
--- a/Source/JavaScriptCore/runtime/EvacuatedStack.cpp
+++ b/Source/JavaScriptCore/runtime/EvacuatedStack.cpp
@@ -38,7 +38,6 @@
 #include <wtf/StringPrintStream.h>
 #include <wtf/text/MakeString.h>
 
-extern "C" void* SYSV_ABI relocateJITReturnPC(const void* codePtr, const void* oldSignatureSP, const void* newSignatureSP);
 extern "C" void* SYSV_ABI getSentinelFrameReturnPC(const void* signatureSP);
 
 namespace JSC {
@@ -53,31 +52,27 @@ std::unique_ptr<EvacuatedStackSlice> EvacuatedStackSlice::create(std::span<Regis
     return slice;
 }
 
-EvacuatedStackSlice::EvacuatedStackSlice(std::span<Register> stackSpan, Vector<unsigned>&& frameOffsets, const CallFrame* frameToReturnFromForEntry)
-    : Base(stackSpan.size())
-    , m_originalBase(stackSpan.data())
-    , m_frameOffsets(WTF::move(frameOffsets))
-    , m_entryPC(frameToReturnFromForEntry->rawReturnPC())
-    , m_entryPCFrame(frameToReturnFromForEntry)
-{
-    memcpySpan(slots(), stackSpan);
-}
-
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-void* relocateReturnPC(void* returnPC, const CallerFrameAndPC* originalFP, const CallerFrameAndPC* newFP)
+EvacuatedStackSlice::EvacuatedStackSlice(std::span<Register> stackSpan, Vector<unsigned>&& frameOffsets, const CallFrame* frameToReturnFromForEntry)
+    : Base(stackSpan.size())
+    , m_frameOffsets(WTF::move(frameOffsets))
+    , m_entryPC(frameToReturnFromForEntry->rawReturnPC())
 {
-#if CPU(ARM64E)
-    auto* originalSignatureSP = reinterpret_cast<const void*>(originalFP + 1);
-    auto* newSignatureSP = reinterpret_cast<const void*>(newFP + 1);
-    if (Options::useJITCage() && isJITPC(removeCodePtrTag(returnPC)))
-        return relocateJITReturnPC(returnPC, originalSignatureSP, newSignatureSP);
-    return ptrauth_auth_and_resign(returnPC, ptrauth_key_asib, originalSignatureSP, ptrauth_key_asib, newSignatureSP);
-#else
-    UNUSED_PARAM(originalFP);
-    UNUSED_PARAM(newFP);
-    return returnPC;
-#endif
+    memcpySpan(slots(), stackSpan);
+
+    // Re-sign all return PCs
+    for (unsigned offset : m_frameOffsets) {
+        SUPPRESS_MEMORY_UNSAFE_CAST // this and other casts are guaranteed by stack construction
+        auto* frameRecord = reinterpret_cast<CallerFrameAndPC*>(slots().data() + offset);
+        SUPPRESS_MEMORY_UNSAFE_CAST
+        auto* originalDiscriminator = reinterpret_cast<const void*>(reinterpret_cast<const CallerFrameAndPC*>(stackSpan.data() + offset) + 1);
+        frameRecord->returnPC = relocateReturnPC(frameRecord->returnPC, originalDiscriminator, saltedDiscriminator(frameRecord));
+    }
+
+    SUPPRESS_MEMORY_UNSAFE_CAST
+    auto* entryOriginalDiscriminator = reinterpret_cast<const void*>(reinterpret_cast<const CallerFrameAndPC*>(frameToReturnFromForEntry) + 1);
+    m_entryPC = relocateReturnPC(const_cast<void*>(m_entryPC), entryOriginalDiscriminator, saltedDiscriminator(this));
 }
 
 CallFrame* EvacuatedStackSlice::implant(Register* base, CallFrame* lastFrame)
@@ -95,14 +90,16 @@ CallFrame* EvacuatedStackSlice::implant(Register* base, CallFrame* lastFrame)
 
         SUPPRESS_MEMORY_UNSAFE_CAST // cast validity is guaranteed by stack construction
         auto* frameRecord = reinterpret_cast<CallerFrameAndPC*>(base + offset);
-        SUPPRESS_MEMORY_UNSAFE_CAST // ditto
-        auto* originalFrameRecordAddr = reinterpret_cast<const CallerFrameAndPC*>(m_originalBase + offset);
 
         // Link this frame to the one above and re-sign the returnPC for the new location
         frameRecord->callerFrame = lastFrame;
-        frameRecord->returnPC = isReturnToSentinelFrame
-            ? getSentinelFrameReturnPC(frameRecord + 1)
-            : relocateReturnPC(frameRecord->returnPC, originalFrameRecordAddr, frameRecord);
+        if (isReturnToSentinelFrame)
+            frameRecord->returnPC = getSentinelFrameReturnPC(frameRecord + 1);
+        else {
+            auto* originalDiscriminator = saltedDiscriminator(reinterpret_cast<const void*>(slots().data() + offset));
+            auto* newDiscriminator = reinterpret_cast<const void*>(frameRecord + 1);
+            frameRecord->returnPC = relocateReturnPC(frameRecord->returnPC, originalDiscriminator, newDiscriminator);
+        }
 
         lastFrame = static_cast<CallFrame*>(static_cast<void*>(frameRecord));
         ASSERT(isStackAligned(lastFrame));

--- a/Source/JavaScriptCore/runtime/EvacuatedStack.h
+++ b/Source/JavaScriptCore/runtime/EvacuatedStack.h
@@ -28,7 +28,9 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/CallFrame.h>
+#include <JavaScriptCore/ExecutableAllocator.h>
 #include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/Options.h>
 #include <JavaScriptCore/Register.h>
 #include <JavaScriptCore/VMEntryRecord.h>
 
@@ -66,12 +68,9 @@ public:
     CallFrame* implant(Register* base, CallFrame* previousFrame);
 
     // The PC to return to to enter the top (logically) frame of the slice.
-    // The value as it was on the original stack--if PAC is in use, signed by 'pacibsp'.
+    // On ARM64E, signed with this slice's address as the discriminator.
+    // (Other PCs in the slice use their frame record address as the discriminator.)
     const void* entryPC() const { return m_entryPC; };
-
-    // The address of the original frame that contained entryPC. Saved for authenticating entryPC.
-    // 'void*' because the frame does not exist anymore--do not dereference!
-    const void* entryPCFrame() const { return m_entryPCFrame; }
 
     void dump(PrintStream& out) const;
 
@@ -80,10 +79,8 @@ private:
 
     EvacuatedStackSlice(std::span<Register> stackSpan, Vector<unsigned>&& frameOffsets, const CallFrame* frameToReturnFromForEntry);
 
-    const Register* m_originalBase;
     Vector<unsigned> m_frameOffsets;
     const void* m_entryPC;
-    const void* m_entryPCFrame;
 };
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -95,9 +92,29 @@ inline std::span<Register> EvacuatedStackSlice::slots()
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-// Authenticate 'returnPC' assuming is was stored in a frame pointed at by 'originalFP', and
-// re-sign it so it can be used in a frame pointed at by 'newFP'.
-void* NODELETE relocateReturnPC(void* returnPC, const CallerFrameAndPC* originalFP, const CallerFrameAndPC* newFP);
+extern "C" void* SYSV_ABI relocateJITReturnPC(const void* codePtr, const void* oldSignatureSP, const void* newSignatureSP);
+
+ALWAYS_INLINE void* relocateReturnPC(void* returnPC, const void* originalDiscriminator, const void* newDiscriminator)
+{
+#if CPU(ARM64E)
+    if (Options::useJITCage() && isJITPC(removeCodePtrTag(returnPC)))
+        return relocateJITReturnPC(returnPC, originalDiscriminator, newDiscriminator);
+    return ptrauth_auth_and_resign(returnPC, ptrauth_key_asib, originalDiscriminator, ptrauth_key_asib, newDiscriminator);
+#else
+    UNUSED_PARAM(originalDiscriminator);
+    UNUSED_PARAM(newDiscriminator);
+    return returnPC;
+#endif
+}
+
+ALWAYS_INLINE const void* saltedDiscriminator(const void* address)
+{
+#if CPU(ARM64E)
+    return reinterpret_cast<const void*>(ptrauth_blend_discriminator(address, ptrauth_string_discriminator("EvacuatedStackSlice")));
+#else
+    return address;
+#endif
+}
 
 // An abstract class with a set of utilities for implementing a concrete stack slicer.
 // A stack slicer is a class driven by a StackVisitor via a StackSlicerFunctor. It

--- a/Source/JavaScriptCore/runtime/PinballCompletion.cpp
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.cpp
@@ -205,7 +205,9 @@ void pinballHandlerImplantSlice(PinballHandlerContext* context, Register *base, 
     auto* slice = context->slice.get();
     CallFrame* bottommostImplantedFrame = slice->implant(base, sentinelFrame);
     returnFrame->callerFrame = bottommostImplantedFrame;
-    returnFrame->returnPC = relocateReturnPC(const_cast<void*>(slice->entryPC()), reinterpret_cast<const CallerFrameAndPC*>(slice->entryPCFrame()), returnFrame);
+    auto* originalDiscriminator = saltedDiscriminator(reinterpret_cast<const void*>(slice));
+    auto* newDiscriminator = reinterpret_cast<const void*>(returnFrame + 1);
+    returnFrame->returnPC = relocateReturnPC(const_cast<void*>(slice->entryPC()), originalDiscriminator, newDiscriminator);
 
     vm.removeEvacuatedStackSlice(slice); // the slice data is now scanned as part of the stack
     context->slice.reset();


### PR DESCRIPTION
#### 475a14fe40916905ac2f2a20bea842ecfa118843
<pre>
[JSC][JSPI] Change the signing scheme of return PCs in EvacuatedStackSlices
<a href="https://bugs.webkit.org/show_bug.cgi?id=312616">https://bugs.webkit.org/show_bug.cgi?id=312616</a>
<a href="https://rdar.apple.com/175047995">rdar://175047995</a>

Reviewed by Mark Lam.

The existing implementation of EvacuatedStackSlice keeps the original return PCs copied
from the suspended stack unchanged, and recomputes their discriminator SP values to
authenticate them at the implantation time.

This patch changes the authentication approach so that return PCs stored in the
EvacuatedStackSlice data on the heap are re-signed at the slice creation time using their
salted storage address.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/312101@main">https://commits.webkit.org/312101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67640cf889b47679c96d573adb5986f0f8877c1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112650 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ef7bcd2-1bcb-458b-9903-9a3d32d14bbf) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160435 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122820 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86186 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aaf87717-7036-47c4-a9c1-575fabd17b38) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103490 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0dc1f8a0-6e53-45cf-8080-8c2e2bd924fe) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24135 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22530 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15166 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150615 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169885 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19399 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15630 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131006 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/157962 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31681 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131120 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35550 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89533 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25814 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18815 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190847 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31138 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97152 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49071 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30658 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30931 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30812 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->