### PR TITLE
REGRESSION(311577@main): [GStreamer] imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTcpIceCandidate.html crashes

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp
@@ -32,9 +32,24 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/StringBuilder.h>
+
+struct SocketAllocationData {
+    ThreadSafeWeakPtr<WebKit::RiceBackend> backend;
+    unsigned streamId;
+    unsigned componentId;
+    WebCore::RTCIceProtocol protocol;
+    String from;
+    String to;
+};
+WEBKIT_DEFINE_ASYNC_DATA_STRUCT(SocketAllocationData);
+
+namespace WTF {
+WTF_DEFINE_GPTR_DELETER(SocketAllocationData, destroySocketAllocationData);
+}
 
 namespace WebKit {
 using namespace WebCore;
@@ -443,16 +458,6 @@ void RiceBackend::setSocketTypeOfService(unsigned streamId, unsigned value)
     rice_sockets_set_tos(sockets.get(), value);
 }
 
-struct SocketAllocationData {
-    ThreadSafeWeakPtr<RiceBackend> backend;
-    unsigned streamId;
-    unsigned componentId;
-    WebCore::RTCIceProtocol protocol;
-    String from;
-    String to;
-};
-WEBKIT_DEFINE_ASYNC_DATA_STRUCT(SocketAllocationData);
-
 void RiceBackend::allocateSocket(unsigned streamId, unsigned componentId, WebCore::RTCIceProtocol protocol, const String& from, const String& to)
 {
     if (protocol == WebCore::RTCIceProtocol::Udp)
@@ -469,23 +474,28 @@ void RiceBackend::allocateSocket(unsigned streamId, unsigned componentId, WebCor
     data->to = to;
 
     rice_tcp_connect(remoteAddress.get(), [](auto socket, void* userData) {
-        auto data = reinterpret_cast<SocketAllocationData*>(userData);
-        RefPtr backend = data->backend.get();
-        if (!backend) {
-            destroySocketAllocationData(data);
+        GUniquePtr<SocketAllocationData> data(reinterpret_cast<SocketAllocationData*>(userData));
+        if (!socket)
             return;
-        }
+
+        RefPtr backend = data->backend.get();
+        if (!backend)
+            return;
+
         auto sockets = backend->getSocketsForStream(data->streamId);
-        rice_sockets_add_tcp(sockets.get(), socket);
-        backend->configureSocketBufferSizes();
+        if (!sockets)
+            return;
 
         GUniquePtr<RiceAddress> localAddress(rice_tcp_socket_local_addr(socket));
         auto localAddressString = riceAddressToString(localAddress.get());
+
+        rice_sockets_add_tcp(sockets.get(), socket);
+        backend->configureSocketBufferSizes();
+
         callOnMainRunLoopAndWait([&, address = WTF::move(localAddressString)] mutable {
             if (RefPtr connection = backend->messageSenderConnection())
                 connection->send(Messages::RiceBackendProxy::AllocatedSocket { data->streamId, data->componentId, data->protocol, data->from, data->to, address }, backend->messageSenderDestinationID());
         });
-        destroySocketAllocationData(data);
     }, data, nullptr);
 }
 


### PR DESCRIPTION
#### a7759f50432c6abbc4d2215eac3e513665a7a751
<pre>
REGRESSION(311577@main): [GStreamer] imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTcpIceCandidate.html crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=312808">https://bugs.webkit.org/show_bug.cgi?id=312808</a>

Reviewed by Xabier Rodriguez-Calvar.

When TCP connection fails the RiceTcpSocket passed from the rice_tcp_connect callback is nullptr, so
we should check for that case. Passing by, allow conversion of SocketAllocationData to GUniquePtr
for improved RAII.

* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp:
(WebKit::RiceBackend::allocateSocket):

Canonical link: <a href="https://commits.webkit.org/311666@main">https://commits.webkit.org/311666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/793c0b0e52ff6d8afff5b05a0ffd135c720a001b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166505 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31020 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24374 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102759 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14276 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168994 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/13529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130257 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130374 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35302 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/141198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30254 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/94717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30005 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->