### PR TITLE
[Swift Testing] Add Swift mouse-event helpers for TestWKWebView

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
@@ -96,46 +96,102 @@ extension WebPage {
     }
 
     #if os(macOS)
+    /// Sends a left mouse-down NSEvent to the web view at the given location.
+    ///
+    /// - Parameter location: The location in window coordinates.
+    public func mouseDown(at location: NSPoint) {
+        backingWebView.mouseDown(with: mouseEvent(.leftMouseDown, at: location, clickCount: 1, pressure: 1))
+    }
+
+    /// Sends a left mouse-up NSEvent to the web view at the given location.
+    ///
+    /// - Parameter location: The location in window coordinates.
+    public func mouseUp(at location: NSPoint) {
+        backingWebView.mouseUp(with: mouseEvent(.leftMouseUp, at: location, clickCount: 1, pressure: 0))
+    }
+
+    /// Sends a mouse-moved NSEvent to the web view at the given location.
+    ///
+    /// - Parameters:
+    ///   - location: The location in window coordinates.
+    ///   - flags: Modifier flags to include in the event.
+    public func mouseMove(to location: NSPoint, flags: NSEvent.ModifierFlags = []) {
+        backingWebView.mouseMoved(with: mouseEvent(.mouseMoved, at: location, flags: flags, clickCount: 0, pressure: 0))
+    }
+
+    /// Sends a left mouse-dragged NSEvent to the web view at the given location.
+    ///
+    /// - Parameter location: The location in window coordinates.
+    public func mouseDrag(to location: NSPoint) {
+        backingWebView.mouseDragged(with: mouseEvent(.leftMouseDragged, at: location, clickCount: 1, pressure: 1))
+    }
+
     /// Performs a mouse click at the given location by sending a mouse down and mouse up NSEvent.
     ///
     /// - Parameter location: The location to click at, in window coordinates.
     public func click(at location: NSPoint) {
+        mouseDown(at: location)
+        mouseUp(at: location)
+    }
+
+    /// Performs `count` sequential mouse clicks at the given location, incrementing the clickCount on each
+    /// event so that AppKit interprets them as a compound gesture (double-click, triple-click, etc.).
+    ///
+    /// - Parameters:
+    ///   - location: The location to click at, in window coordinates.
+    ///   - count: The number of clicks to send.
+    public func clicks(at location: NSPoint, count: Int) {
+        for clickCount in 1...count {
+            backingWebView.mouseDown(with: mouseEvent(.leftMouseDown, at: location, clickCount: clickCount, pressure: 1))
+            backingWebView.mouseUp(with: mouseEvent(.leftMouseUp, at: location, clickCount: clickCount, pressure: 0))
+        }
+    }
+
+    /// Performs a right mouse click at the given location by sending a right mouse down and right mouse up NSEvent.
+    ///
+    /// - Parameter location: The location to click at, in window coordinates.
+    public func rightClick(at location: NSPoint) {
+        backingWebView.rightMouseDown(with: mouseEvent(.rightMouseDown, at: location, clickCount: 1, pressure: 1))
+        backingWebView.rightMouseUp(with: mouseEvent(.rightMouseUp, at: location, clickCount: 1, pressure: 0))
+    }
+
+    /// Suspends until WebKit has processed all pending mouse events delivered to this page.
+    public func waitForPendingMouseEvents() async {
+        await withCheckedContinuation { continuation in
+            backingWebView._do(afterProcessingAllPendingMouseEvents: {
+                continuation.resume()
+            })
+        }
+    }
+
+    private func mouseEvent(
+        _ type: NSEvent.EventType,
+        at location: NSPoint,
+        flags: NSEvent.ModifierFlags = [],
+        clickCount: Int,
+        pressure: Float
+    ) -> NSEvent {
         guard let window = unsafe backingWebView.window else {
             preconditionFailure("Could not create NSEvent because there is no NSWindow.")
         }
 
-        let timestamp = GetCurrentEventTime()
-
-        let mouseDown = NSEvent.mouseEvent(
-            with: .leftMouseDown,
-            location: location,
-            modifierFlags: [],
-            timestamp: timestamp,
-            windowNumber: window.windowNumber,
-            context: nil,
-            eventNumber: 0,
-            clickCount: 1,
-            pressure: 1
-        )
-
-        let mouseUp = NSEvent.mouseEvent(
-            with: .leftMouseUp,
-            location: location,
-            modifierFlags: [],
-            timestamp: timestamp,
-            windowNumber: window.windowNumber,
-            context: nil,
-            eventNumber: 0,
-            clickCount: 1,
-            pressure: 0
-        )
-
-        guard let mouseDown, let mouseUp else {
+        guard
+            let event = NSEvent.mouseEvent(
+                with: type,
+                location: location,
+                modifierFlags: flags,
+                timestamp: GetCurrentEventTime(),
+                windowNumber: window.windowNumber,
+                context: nil,
+                eventNumber: 0,
+                clickCount: clickCount,
+                pressure: pressure
+            )
+        else {
             preconditionFailure("Could not create NSEvent.")
         }
 
-        backingWebView.mouseDown(with: mouseDown)
-        backingWebView.mouseUp(with: mouseUp)
+        return event
     }
     #endif // os(macOS)
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -574,6 +574,7 @@
 				WebKit/WebPage/URLSchemeHandlerTests.swift,
 				WebKit/WebPage/WebPageNavigationTests.swift,
 				WebKit/WebPage/WebPageTests.swift,
+				WebKit/WebPage/WebPageMouseEventsTests.swift,
 				WebKit/WebPage/WebPageTransferableTests.swift,
 				WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift,
 			);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageMouseEventsTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageMouseEventsTests.swift
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if os(macOS) && ENABLE_SWIFTUI
+
+import AppKit
+import SwiftUI
+import Testing
+@_spi(Testing) import WebKit
+private import TestWebKitAPILibrary
+
+@MainActor
+struct WebPageMouseEventsTests {
+    private let page = WebPage()
+    private let window: NSWindow
+
+    init() async throws {
+        self.window = NSWindow(size: NSSize(width: 400, height: 400)) { [page] in
+            WebView(page)
+        }
+        self.window.setFrameOrigin(.zero)
+        self.window.makeKeyAndOrderFront(nil)
+    }
+
+    @Test
+    func mouseDownUpFiresClickHandler() async throws {
+        let html = """
+            <body style="margin:0;width:100%;height:100vh"
+                  onclick="window.clicked=true">x</body>
+            """
+        try await page.load(html: html).wait()
+
+        let center = CGPoint(x: 200, y: 200)
+        page.mouseDown(at: center)
+        page.mouseUp(at: center)
+        await page.waitForPendingMouseEvents()
+
+        let fired = try await page.callJavaScript("return window.clicked === true;") as? Bool
+        #expect(fired == true)
+    }
+}
+
+#endif // os(macOS) && ENABLE_SWIFTUI


### PR DESCRIPTION
#### 695318725b7de8269ea1cb9714e1b33fe8290f62
<pre>
[Swift Testing] Add Swift mouse-event helpers for TestWKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=312809">https://bugs.webkit.org/show_bug.cgi?id=312809</a>
<a href="https://rdar.apple.com/175191513">rdar://175191513</a>

Reviewed by Richard Robinson.

Add a @MainActor extension on WebPage exposing simulate* mouse
helpers (mouseDown, mouseUp, mouseMove, mouseDrag, click, clicks,
rightClick) plus an async waitForPendingMouseEvents() that wraps
_doAfterProcessingAllPendingMouseEvents: with
withCheckedContinuation. Unblocks porting AppKit-heavy
SiteIsolation tests to Swift Testing without blocking the main
thread on Util::run.

* Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift:
(mouseDown(at:)):
(mouseUp(at:)):
(mouseMove(to:flags:)):
(mouseDrag(to:)):
(click(at:)):
(clicks(at:count:)):
(rightClick(at:)):
(waitForPendingMouseEvents):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageMouseEventsTests.swift: Added.
(WebPageMouseEventsTests.mouseDownUpFiresClickHandler):

Canonical link: <a href="https://commits.webkit.org/312960@main">https://commits.webkit.org/312960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f33c68073c4742ac1e2d24002395c70f26900502

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117907 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b7c9235e-a42d-46a3-a6b8-9091a4cab740) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125322 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c85b3ac3-0cc4-4921-9857-bf23fdcdb941) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27617 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145101 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIAction.ClearTabSpecificActionPropertiesOnNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105918 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/769255df-871b-41ef-8f52-d73789188639) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26666 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25179 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18160 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172927 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133608 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133615 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36117 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144653 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96573 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28141 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21472 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34178 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33678 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33921 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33827 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->