### PR TITLE
API::PageConfiguration::Data::LazyInitializedRef wastefully initializes unneeded objects

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -102,6 +102,15 @@ void PageConfiguration::copyDataFrom(const PageConfiguration& other)
     m_data = other.m_data;
 }
 
+void PageConfiguration::ensureLazyInitializedRefsAreInitialized()
+{
+    m_data.processPool.get();
+    m_data.userContentController.get();
+    m_data.preferences.get();
+    m_data.visitedLinkStore.get();
+    m_data.defaultWebsitePolicies.get();
+}
+
 const std::optional<WebCore::WindowFeatures>& PageConfiguration::windowFeatures() const
 {
     return m_data.windowFeatures;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -117,6 +117,7 @@ public:
 
     Ref<PageConfiguration> copy() const;
     void copyDataFrom(const PageConfiguration&);
+    void ensureLazyInitializedRefsAreInitialized();
 
     struct OpenerInfo {
         Ref<WebKit::WebProcessProxy> process;
@@ -501,7 +502,8 @@ private:
         template<typename T, Ref<T>(*initializer)()> class LazyInitializedRef {
         public:
             LazyInitializedRef() = default;
-            void operator=(const LazyInitializedRef& other) { m_value = other.get(); }
+            LazyInitializedRef(const LazyInitializedRef&) = default;
+            void operator=(const LazyInitializedRef& other) { m_value = other.m_value; }
             void operator=(RefPtr<T>&& t) { m_value = WTF::move(t); }
             T& get() const
             {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -615,6 +615,8 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
     if (!configuration)
         [NSException raise:NSInvalidArgumentException format:@"Configuration cannot be nil"];
 
+    protect(*configuration->_pageConfiguration)->ensureLazyInitializedRefsAreInitialized();
+
     _configuration = adoptNS([configuration copy]);
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -660,9 +660,12 @@ SUPPRESS_NODELETE static NSString *NODELETE defaultApplicationNameForUserAgent()
 
 - (void)_setRelatedWebView:(WKWebView *)relatedWebView
 {
-    if (relatedWebView)
+    if (relatedWebView) {
         _pageConfiguration->setRelatedPage(relatedWebView->_page.get());
-    else
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        [self setProcessPool:[relatedWebView->_configuration processPool]];
+        ALLOW_DEPRECATED_DECLARATIONS_END
+    } else
         _pageConfiguration->setRelatedPage(nullptr);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewConfiguration.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -123,6 +123,67 @@ TEST(WebKit, InvalidConfiguration)
         [configuration _setRelatedWebView:ephemeralWebView.get()];
         ALLOW_DEPRECATED_DECLARATIONS_END
     }, true);
+}
+
+TEST(WebKit, ConfigurationCopyDoesNotLazilyInitializeProcessPool)
+{
+    // Create a configuration without explicitly setting processPool.
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    // Copy should not trigger lazy initialization of processPool on the source.
+    RetainPtr copy = adoptNS([configuration copy]);
+
+    // Accessing processPool on each should create independent pools,
+    // since neither was initialized by the copy operation.
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    RetainPtr pool1 = [configuration processPool];
+    RetainPtr pool2 = [copy processPool];
+    ALLOW_DEPRECATED_DECLARATIONS_END
+
+    // Each configuration should independently lazy-initialize its own pool,
+    // rather than sharing a pool that was created as a side effect of copying.
+    EXPECT_NE(pool1.get(), pool2.get());
+}
+
+TEST(WebKit, ConfigurationCopyPreservesExplicitlySetProcessPool)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] init]);
+    [configuration setProcessPool:pool.get()];
+    ALLOW_DEPRECATED_DECLARATIONS_END
+
+    RetainPtr copy = adoptNS([configuration copy]);
+
+    // An explicitly set processPool should be shared between source and copy.
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    EXPECT_EQ([configuration processPool], [copy processPool]);
+    ALLOW_DEPRECATED_DECLARATIONS_END
+}
+
+TEST(WebKit, RelatedWebViewSyncsProcessPool)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    // Capture the expected pool so we ensure one is initialized.
+    RetainPtr expectedPool = [configuration processPool];
+    ALLOW_DEPRECATED_DECLARATIONS_END
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    // A new configuration that hasn't explicitly set a process pool
+    // should adopt the related web view's pool when _relatedWebView is set.
+    RetainPtr newConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [newConfiguration _setRelatedWebView:webView.get()];
+    EXPECT_EQ([newConfiguration processPool], expectedPool.get());
+
+    // Creating a WKWebView with this configuration should not throw.
+    RetainPtr relatedWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:newConfiguration.get()]);
+    EXPECT_TRUE(!!relatedWebView);
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 TEST(WebKit, ConfigurationGroupIdentifierIsCopied)


### PR DESCRIPTION
#### f84460ba474e833aeeb26a335dc2bbd1e20d3549
<pre>
API::PageConfiguration::Data::LazyInitializedRef wastefully initializes unneeded objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=312803">https://bugs.webkit.org/show_bug.cgi?id=312803</a>
<a href="https://rdar.apple.com/175189199">rdar://175189199</a>

Reviewed by Ryosuke Niwa.

The copy assignment operator for Data::LazyInitializedRef always forces the lazy
initialization to happen (even on unset members) by calling `get()` on the source
.object. The current implementation of `get()` triggers lazy initialization on the
source `m_value` for ANY uninitialized member.

During `copyDataFrom`, the Data struct&apos;s generated copy assignment calls this for
all of its LazyInitializedRef members. For members not explicitly set on the source
(e.g., visitedLinkStore, defaultWebsitePolicies), this causes us to create throw-away
objects as a side-effect of copying.

This wasetful work should be avoided to reduce performance cost.

Ensure the invariant that the WKWebViewConfiguration&apos;s process pool member must
always match the process pool of it&apos;s related WKWebView by keeping them in sync
in _setRelatedWebView. This prevents a class of errors triggered by improper
use of the _setRelatedWebView SPI where calls would sometimes neglect to also set
the configuration&apos;s process pool when they updated the WKWebView. This error became
visible when the default initialization in LazyInitializedRef was removed.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewConfiguration.mm

* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::ensureLazyInitializedRefsAreInitialized):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::Data::initializer):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _setRelatedWebView:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewConfiguration.mm:
(TEST(WebKit, ConfigurationCopyDoesNotLazilyInitializeProcessPool)):
(TEST(WebKit, ConfigurationCopyPreservesExplicitlySetProcessPool)):
(TEST(WebKit, RelatedWebViewSyncsProcessPool)):

Canonical link: <a href="https://commits.webkit.org/312140@main">https://commits.webkit.org/312140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca042d4279adeddad8865c65d383cf5191f07dbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112652 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74577738-32a4-4563-93d2-b2475ac06743) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32061 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31980 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122822 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86189 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f098ac6-b132-417a-a724-ed6a81a11570) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103492 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49d9670b-109a-497d-a23a-113fca678edc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24139 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22533 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15168 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169887 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15632 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131008 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131122 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35563 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31629 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142009 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89535 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25820 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18817 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31140 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97154 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30660 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30933 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30814 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->