### PR TITLE
[iOS] nfl.com rubberbanding behaves incorrectly

### DIFF
--- a/LayoutTests/fast/scrolling/ios/scroll-to-smooth-during-rubberband-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/scroll-to-smooth-during-rubberband-expected.txt
@@ -1,0 +1,11 @@
+Tests that a smooth scroll to 0,0 during a rubberband does not leave the view with a negative scroll position.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.pageYOffset > 0 is true
+PASS window.pageYOffset is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/scroll-to-smooth-during-rubberband.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-to-smooth-during-rubberband.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body {
+    width: 100%;
+    height: 5000px;
+    background: repeating-linear-gradient(transparent, silver 250px);
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+async function runTest()
+{
+    description("Tests that a smooth scroll to 0,0 during a rubberband does not leave the view with a negative scroll position.");
+
+    if (!window.testRunner) {
+        finishJSTest();
+        return;
+    }
+
+    window.scrollTo(0, 1000);
+    shouldBeTrue("window.pageYOffset > 0");
+    
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+
+    let triggeredScrollToZero = false;
+    window.addEventListener("scroll", () => {
+        if (triggeredScrollToZero)
+            return;
+
+        if (window.pageYOffset < 0) {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+            triggeredScrollToZero = true;
+        }
+    });
+
+    const xOffset = 100;
+    await UIHelper.dragFromPointToPoint(xOffset, 1120, xOffset, 1600, 0.05);
+    await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
+
+    shouldBe("window.pageYOffset", "0");
+
+    finishJSTest();
+}
+
+window.addEventListener("load", runTest);
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1493,12 +1493,6 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     CGPoint scrollViewContentOffset = [_scrollView contentOffset];
 
     if (!CGPointEqualToPoint(contentOffsetInScrollViewCoordinates, scrollViewContentOffset)) {
-        if (WTF::areEssentiallyEqual<float>(scrollPosition.x(), 0) && scrollViewContentOffset.x < 0)
-            contentOffsetInScrollViewCoordinates.x = scrollViewContentOffset.x;
-
-        if (WTF::areEssentiallyEqual<float>(scrollPosition.y(), 0) && scrollViewContentOffset.y < 0)
-            contentOffsetInScrollViewCoordinates.y = scrollViewContentOffset.y;
-
         if (interruptAnimation || animated)
             [_scrollView setContentOffset:contentOffsetInScrollViewCoordinates animated:animated];
         else


### PR DESCRIPTION
#### 2874cfdad914dc82b9e27db23b297ef08a839e60
<pre>
[iOS] nfl.com rubberbanding behaves incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=312813">https://bugs.webkit.org/show_bug.cgi?id=312813</a>
<a href="https://rdar.apple.com/170705188">rdar://170705188</a>

Reviewed by Abrar Rahman Protyasha.

The changes in 254640@main added code that, if scrolling to 0,0, replaces the target zero position
with the current scroll offset, in an attempt to fix an issue in Mail on iPad. This code behaved
poorly when the user scrolls to the top with a rubberband, and the site does a
`window.scrollTo({ top: 0, behavior: &apos;smooth&apos; })`, (which nfl.com does), which interrupts
any running scroll animation; it captured the currently negative Y offset as the static scroll position.

Fix by removing the changes in `_scrollToContentScrollPosition:...`. I could not reproduce the original
bug with these changes removed; it&apos;s possible that other OS changes fixed the `CGRectNull` issues that
254640@main was working around.

Test: fast/scrolling/ios/scroll-to-smooth-during-rubberband.html

* LayoutTests/fast/scrolling/ios/scroll-to-smooth-during-rubberband-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/scroll-to-smooth-during-rubberband.html: Added.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _scrollToContentScrollPosition:scrollOrigin:animated:interruptAnimation:]):

Canonical link: <a href="https://commits.webkit.org/311641@main">https://commits.webkit.org/311641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66c359b486bc221448c5af56417039dfa66bf5b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111626 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/663d0280-82d2-4d72-86ac-ab0bd3d16f30) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121986 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85687 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95fe4575-64b2-4a3f-a944-7f8590192732) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102655 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8135b22f-c56c-4309-a5fd-bc50f4d3938c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23324 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21582 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14139 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168857 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13239 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130148 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30483 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130259 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35287 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141070 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88403 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25089 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17875 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30116 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94397 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29638 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29868 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29765 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->