### PR TITLE
Fullscreen animation targets a 1px-tall line instead of the video content area on ign.com

### DIFF
--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -88,9 +88,7 @@ static WebCore::IntRect screenRectOfContents(WebCore::Element& element)
         return { };
 
     IntRect contentsRect = renderer->absoluteBoundingBoxRect();
-    if (contentsRect.isEmpty()) {
-        // A zero-height element may contain visible overflow contents. If the element
-        // itself is empty, traverse its children to find its visual content area.
+    if (contentsRect.height() <= 1 || contentsRect.width() <= 1) {
         LayoutRect topLevelRect;
         contentsRect = snappedIntRect(renderer->paintingRootRect(topLevelRect));
     }


### PR DESCRIPTION
#### bb5f8114d0f6f9014d163bcceeee1d0a9a51dfde
<pre>
Fullscreen animation targets a 1px-tall line instead of the video content area on ign.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=312816">https://bugs.webkit.org/show_bug.cgi?id=312816</a>
<a href="https://rdar.apple.com/152181188">rdar://152181188</a>

Reviewed by Jer Noble.

Sites like ign.com request fullscreen on a zero-height div that contains an absolute-positioned
video child. After subpixel snapping, absoluteBoundingBoxRect() returns a 1px-tall rect rather than
a truly empty rect, so the existing isEmpty() check never triggers the paintingRootRect fallback.
This causes the fullscreen exit animation to target a 1px-tall line instead of the actual video
content area.

Change the guard from isEmpty() (which requires width or height &lt;= 0) to check height &lt;= 1 or
width &lt;= 1, so the fallback fires for elements whose bounding box rounds to a negligible size.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::screenRectOfContents):

Canonical link: <a href="https://commits.webkit.org/311640@main">https://commits.webkit.org/311640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2027b191e7c959400e1ca17924054f4aa4f970eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111631 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13a6ad1d-08a1-4d35-a3ea-fd7e09bcc074) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121992 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51ff5fd0-daf7-4397-9af3-2892b75ccb15) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102661 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8adfff25-589a-40ed-8bfe-15eb1ee3ea3c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23327 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21588 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14144 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133006 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168862 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13250 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130152 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130263 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35286 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88408 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25087 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17880 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30121 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94415 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29643 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29873 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29770 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->