### PR TITLE
Deliver delayed safebrowsing results before timeout

### DIFF
--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -180,6 +180,17 @@ void Navigation::setSafeBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&& safeBr
     m_safeBrowsingWarning = WTF::move(safeBrowsingWarning);
 }
 
+void Navigation::setSafeBrowsingCheckCompletionHandler(CompletionHandler<void()>&& handler)
+{
+    m_safeBrowsingCheckCompletionHandler = WTF::move(handler);
+}
+
+void Navigation::didCompleteSafeBrowsingCheck()
+{
+    if (auto handler = std::exchange(m_safeBrowsingCheckCompletionHandler, { }))
+        handler();
+}
+
 size_t Navigation::redirectChainIndex(const WTF::URL& url)
 {
     size_t index = m_redirectChain.find(url);

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -40,6 +40,7 @@
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/SubstituteData.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Ref.h>
@@ -189,6 +190,8 @@ public:
     RefPtr<WebKit::BrowsingWarning> NODELETE safeBrowsingWarning();
     void setSafeBrowsingCheckTimedOut() { m_safeBrowsingCheckTimedOut = true; }
     bool safeBrowsingCheckTimedOut() { return m_safeBrowsingCheckTimedOut; }
+    void setSafeBrowsingCheckCompletionHandler(CompletionHandler<void()>&&);
+    void didCompleteSafeBrowsingCheck();
     bool hadSafeBrowsingWarning() const { return m_hadSafeBrowsingWarning; }
     MonotonicTime requestStart() const { return m_requestStart; }
     void resetRequestStart();
@@ -249,6 +252,7 @@ private:
     MonotonicTime m_requestStart { MonotonicTime::now() };
     RefPtr<WebKit::BrowsingWarning> m_safeBrowsingWarning;
     ListHashSet<size_t> m_ongoingSafeBrowsingChecks;
+    CompletionHandler<void()> m_safeBrowsingCheckCompletionHandler;
     RefPtr<WebKit::FrameProcess> m_pendingSharedProcess;
     RefPtr<WebKit::FrameState> m_backForwardFrameState;
 };

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -308,8 +308,11 @@ void WebPageProxy::beginSafeBrowsingCheck(const URL& url, API::Navigation& navig
                 return;
 
             navigation->setSafeBrowsingCheckOngoing(redirectChainIndex, false);
-            if (error)
+            if (error) {
+                if (!navigation->safeBrowsingCheckOngoing())
+                    navigation->didCompleteSafeBrowsingCheck();
                 return protectedThis->completeSafeBrowsingCheckForModals(true);
+            }
 
             RefPtr navigationState = NavigationState::fromWebPage(*protectedThis);
             auto historyDelegate = navigationState ? navigationState->historyDelegate() : nullptr;
@@ -331,6 +334,9 @@ void WebPageProxy::beginSafeBrowsingCheck(const URL& url, API::Navigation& navig
                 protectedThis->showBrowsingWarning(navigation->safeBrowsingWarning());
             } else if (!navigation->safeBrowsingWarning())
                 protectedThis->completeSafeBrowsingCheckForModals(true);
+
+            if (!navigation->safeBrowsingCheckOngoing())
+                navigation->didCompleteSafeBrowsingCheck();
         });
     };
 

--- a/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp
@@ -28,7 +28,6 @@
 
 #include "APINavigation.h"
 #include "APIWebsitePolicies.h"
-#include "BrowsingWarning.h"
 #include "WebFrameProxy.h"
 #include "WebsiteDataStore.h"
 #include "WebsitePoliciesData.h"
@@ -39,7 +38,7 @@ WebFramePolicyListenerProxy::WebFramePolicyListenerProxy(Reply&& reply, ShouldEx
     : m_reply(WTF::move(reply))
 {
     if (expectSafeBrowsingResult == ShouldExpectSafeBrowsingResult::No)
-        didReceiveSafeBrowsingResults({ });
+        didReceiveSafeBrowsingResults();
     if (expectAppBoundDomainResult == ShouldExpectAppBoundDomainResult::No)
         didReceiveAppBoundDomainResult({ });
     if (shouldWaitForInitialLinkDecorationFilteringData == ShouldWaitForInitialLinkDecorationFilteringData::No)
@@ -56,21 +55,21 @@ void WebFramePolicyListenerProxy::didReceiveAppBoundDomainResult(std::optional<N
 {
     ASSERT(RunLoop::isMain());
 
-    if (m_policyResult && m_safeBrowsingWarning && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
+    if (m_policyResult && m_safeBrowsingDone && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
     } else
         m_isNavigatingToAppBoundDomain = isNavigatingToAppBoundDomain;
 }
 
-void WebFramePolicyListenerProxy::didReceiveSafeBrowsingResults(RefPtr<BrowsingWarning>&& safeBrowsingWarning)
+void WebFramePolicyListenerProxy::didReceiveSafeBrowsingResults()
 {
     ASSERT(isMainRunLoop());
     if (m_policyResult && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
-    } else if (!m_safeBrowsingWarning)
-        m_safeBrowsingWarning = WTF::move(safeBrowsingWarning);
+    } else if (!m_safeBrowsingDone)
+        m_safeBrowsingDone = true;
 }
 
 void WebFramePolicyListenerProxy::didReceiveInitialLinkDecorationFilteringData()
@@ -78,7 +77,7 @@ void WebFramePolicyListenerProxy::didReceiveInitialLinkDecorationFilteringData()
     ASSERT(RunLoop::isMain());
     ASSERT(!m_doneWaitingForLinkDecorationFilteringData);
 
-    if (m_policyResult && m_isNavigatingToAppBoundDomain && m_safeBrowsingWarning && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
+    if (m_policyResult && m_isNavigatingToAppBoundDomain && m_safeBrowsingDone && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
         return;
@@ -92,7 +91,7 @@ void WebFramePolicyListenerProxy::didReceiveSiteHasStorageResults()
     ASSERT(RunLoop::isMain());
     ASSERT(!m_doneWaitingForSiteHasStorage);
 
-    if (m_policyResult && m_safeBrowsingWarning && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForEnhancedSecurityLink) {
+    if (m_policyResult && m_safeBrowsingDone && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForEnhancedSecurityLink) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
         return;
@@ -106,7 +105,7 @@ void WebFramePolicyListenerProxy::didReceiveEnhancedSecurityLinkResults()
     ASSERT(RunLoop::isMain());
     ASSERT(!m_doneWaitingForEnhancedSecurityLink);
 
-    if (m_policyResult && m_safeBrowsingWarning && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage) {
+    if (m_policyResult && m_safeBrowsingDone && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
         return;
@@ -117,7 +116,7 @@ void WebFramePolicyListenerProxy::didReceiveEnhancedSecurityLinkResults()
 
 void WebFramePolicyListenerProxy::use(API::WebsitePolicies* policies, ProcessSwapRequestedByClient processSwapRequestedByClient)
 {
-    if (m_safeBrowsingWarning && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
+    if (m_safeBrowsingDone && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
         if (m_reply)
             m_reply(WebCore::PolicyAction::Use, policies, processSwapRequestedByClient, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
     } else if (!m_policyResult)

--- a/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
+++ b/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
@@ -61,7 +61,7 @@ public:
     void download();
     void ignore(WasNavigationIntercepted = WasNavigationIntercepted::No);
     
-    void didReceiveSafeBrowsingResults(RefPtr<BrowsingWarning>&&);
+    void didReceiveSafeBrowsingResults();
     void didReceiveAppBoundDomainResult(std::optional<NavigatingToAppBoundDomain>);
     void didReceiveManagedDomainResult(std::optional<NavigatingToAppBoundDomain>);
     void didReceiveInitialLinkDecorationFilteringData();
@@ -72,7 +72,7 @@ private:
     WebFramePolicyListenerProxy(Reply&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck);
 
     std::optional<std::pair<RefPtr<API::WebsitePolicies>, ProcessSwapRequestedByClient>> m_policyResult;
-    std::optional<RefPtr<BrowsingWarning>> m_safeBrowsingWarning;
+    bool m_safeBrowsingDone { false };
     std::optional<std::optional<NavigatingToAppBoundDomain>> m_isNavigatingToAppBoundDomain;
     bool m_doneWaitingForSiteHasStorage { false };
     bool m_doneWaitingForEnhancedSecurityLink { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9412,10 +9412,13 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
         completionHandlerWrapper(policyAction);
     }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No);
     if (expectSafeBrowsing == ShouldExpectSafeBrowsingResult::Yes && navigation) {
+        navigation->setSafeBrowsingCheckCompletionHandler([listener] {
+            listener->didReceiveSafeBrowsingResults();
+        });
         Seconds timeout = (MonotonicTime::now() - requestStart) * 1.5 + 0.25_s;
-        RunLoop::mainSingleton().dispatchAfter(timeout, [listener, navigation] mutable {
-            listener->didReceiveSafeBrowsingResults({ });
+        RunLoop::mainSingleton().dispatchAfter(timeout, [navigation] mutable {
             navigation->setSafeBrowsingCheckTimedOut();
+            navigation->didCompleteSafeBrowsingCheck();
         });
     }
 


### PR DESCRIPTION
#### 04598daa1d431213ed4d26f9e12a693c297dae11
<pre>
Deliver delayed safebrowsing results before timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=312807">https://bugs.webkit.org/show_bug.cgi?id=312807</a>
<a href="https://rdar.apple.com/165058397">rdar://165058397</a>

Reviewed by NOBODY (OOPS!).

Schedule for didReceiveSafeBrowsingResults() to run when
SafeBrowsing results arrive, with whenSafeBrowsingCheckCompletes().
This fixes a race that can cause the UIProcess to wait for a
timeout instead of delivering SafeBrowsing lookup results as soon
as the answer becomes available. The previous behavior could
significantly harm load time.

The race triggers if the page responded faster than the SafeBrowsing
service. Here&apos;s a breakdown of the (now removed) race:
1) Navigation to an URL is triggered
2) PolicyChecker::checkNavigationPolicy() validates the navigation
   action. It also starts a SafeBrowsing lookup
   (WebPageProxy::beginSafeBrowsingCheck()), but doesn&apos;t wait on
   it - results are simply parked for later use
3) If the policy check (which is *not* the SafeBrowsing check) is ok,
   the page is requested
4) Resource arrives, now the WebContent process requests the
   SafeBrowsing results before committing the load
5) UIProcess (who owns the SafeBrowsing logic) receives IPC requesting
   the SafeBrowsing answer. Answer is provided immediately, if
   available. If not available, a timeout handler to send an answer
   is queued. Receiving SafeBrowsing results before the timeout causes
   the appropriate state to be set (which may cause an alert to be
   shown), but does not expedite the response. The response is only
   sent after the dealine, which is
   `timeout = (MonotonicTime::now() - requestStart) * 1.5 + 0.25_s`
6) The navigation is only committed when the SafeBrowsing results
   are received by the WebContent process. Only after this can the
   page begin to be parsed
</pre>