### PR TITLE
Some filters tests call `setAcceleratedCompositingEnabled(false)` which is no longer a valid configuration

### DIFF
--- a/LayoutTests/css3/filters/blur-filter-page-scroll-parents.html
+++ b/LayoutTests/css3/filters/blur-filter-page-scroll-parents.html
@@ -6,12 +6,6 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script>
-            if (window.internals) {
-                // Force software rendering mode.
-                window.internals.settings.setAcceleratedCompositingEnabled(false);
-            }
-        </script>
         <style>
             body {
                 margin: 0px;

--- a/LayoutTests/css3/filters/blur-filter-page-scroll-self.html
+++ b/LayoutTests/css3/filters/blur-filter-page-scroll-self.html
@@ -6,12 +6,6 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script>
-            if (window.internals) {
-                // Force software rendering mode.
-                window.internals.settings.setAcceleratedCompositingEnabled(false);
-            }
-        </script>
         <style>
             body {
                 margin: 0px;

--- a/LayoutTests/css3/filters/blur-filter-page-scroll.html
+++ b/LayoutTests/css3/filters/blur-filter-page-scroll.html
@@ -6,12 +6,6 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script>
-            if (window.internals) {
-                // Force software rendering mode.
-                window.internals.settings.setAcceleratedCompositingEnabled(false);
-            }
-        </script>
         <style>
             body {
                 margin: 0px;

--- a/LayoutTests/css3/filters/effect-brightness-clamping.html
+++ b/LayoutTests/css3/filters/effect-brightness-clamping.html
@@ -1,9 +1,3 @@
-<script>
-if (window.internals) {
-    // Force software rendering mode.
-    window.internals.settings.setAcceleratedCompositingEnabled(false);
-}
-</script>
 <img style="filter: brightness(-1) brightness(1)" src="resources/reference.png">
 <img style="filter: brightness(-0.8) brightness(0.8)" src="resources/reference.png">
 <img style="filter: brightness(-0.5) brightness(0.5)" src="resources/reference.png">

--- a/LayoutTests/css3/filters/filter-repaint.html
+++ b/LayoutTests/css3/filters/filter-repaint.html
@@ -27,10 +27,6 @@
   <script>
       if (window.testRunner)
           testRunner.dumpAsText(true);
-      if (window.internals) {
-          // Force software rendering mode.
-          window.internals.settings.setAcceleratedCompositingEnabled(false);
-      }
 
       function repaintTest()
       {


### PR DESCRIPTION
#### 038e1b7b4d64d940cd18c3a7aea1682adb317ba5
<pre>
Some filters tests call `setAcceleratedCompositingEnabled(false)` which is no longer a valid configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=312825">https://bugs.webkit.org/show_bug.cgi?id=312825</a>
<a href="https://rdar.apple.com/175199267">rdar://175199267</a>

Reviewed by Abrar Rahman Protyasha.

Now that WebKit2 is built around compositing, it&apos;s no longer valid to call
`setAcceleratedCompositingEnabled(false)` in a layout test, and doing so causes
assertions in `WebPage::updateVisibleContentRects()` when the root scrolling
node is absent.

So just change the tests to not call `setAcceleratedCompositingEnabled(false)`.
Some are still valid; others that tested repaint on scrolling no longer
do that, but I kept them anyway.

* LayoutTests/css3/filters/blur-filter-page-scroll-parents.html:
* LayoutTests/css3/filters/blur-filter-page-scroll-self.html:
* LayoutTests/css3/filters/blur-filter-page-scroll.html:
* LayoutTests/css3/filters/effect-brightness-clamping.html:
* LayoutTests/css3/filters/filter-repaint.html:

Canonical link: <a href="https://commits.webkit.org/311689@main">https://commits.webkit.org/311689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f2c6af2e7b281ec3d8a99ded915f01fcd08987b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111657 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122007 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85702 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f968519-d9d2-4b8d-b24a-21e65b01c2b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102676 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16b9467c-7536-472c-a4bf-b707bbcb029e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23365 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21609 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14170 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168888 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130171 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130282 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35314 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88434 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25111 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17911 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30147 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29669 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29899 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29796 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->