### PR TITLE
Port recent WebBackForwardList.cpp changes to WebBackForwardList.swift

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -940,9 +940,7 @@ RefPtr<WebBackForwardListItem> WebBackForwardListWrapper::forwardItem() const
 
 RefPtr<WebBackForwardListItem> WebBackForwardListWrapper::itemAtDeltaFromCurrentIndex(int index, AllowSkippingBackForwardItems allowSkipping) const
 {
-    // FIXME: Update the Swift interface and pass this value through.
-    UNUSED_PARAM(allowSkipping);
-    return m_impl->itemAtDeltaFromCurrentIndex(index);
+    return m_impl->itemAtDeltaFromCurrentIndex(index, allowSkipping == AllowSkippingBackForwardItems::Yes ? true : false);
 }
 
 unsigned WebBackForwardListWrapper::backListCount() const

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -127,6 +127,14 @@ final class WebBackForwardList {
         case forward
     }
 
+    private static let shouldSkipItemsWithoutUserGestureForWebKitAPI: Bool = {
+        #if os(Darwin)
+        return WTF.linkedOnOrAfterSDKWithBehavior(WTF.SDKAlignedBehavior.AllBackForwardItemsWithoutUserGestureInvisibleToUI)
+        #else
+        return false
+        #endif
+    }()
+
     init(page: WebKit.WeakPtrWebPageProxy) {
         self.page = page
         self.messageForwarder = WebKit.WebBackForwardListMessageForwarder.create(target: self)
@@ -351,6 +359,10 @@ final class WebBackForwardList {
             return nil
         }
 
+        guard !WebBackForwardList.shouldSkipItemsWithoutUserGestureForWebKitAPI else {
+            return itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(direction: .backward, startingIndex: currentIndex).item
+        }
+
         guard currentIndex > 0 else {
             return nil
         }
@@ -368,13 +380,17 @@ final class WebBackForwardList {
             return nil
         }
 
+        guard !WebBackForwardList.shouldSkipItemsWithoutUserGestureForWebKitAPI else {
+            return itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(direction: .forward, startingIndex: currentIndex).item
+        }
+
         guard currentIndex < entries.count - 1 else {
             return nil
         }
         return entries[currentIndex + 1]
     }
 
-    func itemAtDeltaFromCurrentIndex(delta: Int) -> WebKit.WebBackForwardListItem? {
+    func itemAtDeltaFromCurrentIndex(delta: Int, allowSkipping: Bool = true) -> WebKit.WebBackForwardListItem? {
         assertValidIndex()
 
         guard page.__convertToBool() else {
@@ -389,7 +405,28 @@ final class WebBackForwardList {
             return nil
         }
 
-        return itemAtIndexWithoutSkipping(index: currentIndex + delta).item
+        // API requests to get the current item will always get the current item without any skipping logic.
+        guard delta != 0 else {
+            return itemAtIndexWithoutSkipping(index: currentIndex).item
+        }
+
+        guard allowSkipping && WebBackForwardList.shouldSkipItemsWithoutUserGestureForWebKitAPI else {
+            return itemAtIndexWithoutSkipping(index: currentIndex + delta).item
+        }
+
+        let direction: Direction = delta < 0 ? .backward : .forward
+        var stepsLeft = abs(delta)
+        var nextIndex = currentIndex
+        while stepsLeft > 0 {
+            let result = itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(direction: direction, startingIndex: nextIndex)
+            stepsLeft -= 1
+            if result.item == nil || stepsLeft == 0 {
+                return result.item
+            }
+            nextIndex = result.index
+        }
+
+        return nil
     }
 
     func itemAtIndexWithoutSkipping(index: Int) -> (item: WebKit.WebBackForwardListItem?, index: Int) {
@@ -443,18 +480,39 @@ final class WebBackForwardList {
             return API.Array.create()
         }
 
-        if currentIndex == nil {
+        guard let unwrappedCurrentIndex = currentIndex else {
             return API.Array.create()
         }
 
-        let backListSize = backListCount()
+        var backListSize = backListCount()
         let size = min(backListSize, Int(limit))
         guard size > 0 else {
             return API.Array.create()
         }
         assert(backListSize >= size)
-        let startIndex = backListSize - size
 
+        guard !WebBackForwardList.shouldSkipItemsWithoutUserGestureForWebKitAPI else {
+            var items: [WebKit.WebBackForwardListItem] = []
+            var nextStartingIndex = unwrappedCurrentIndex
+            while backListSize > 0 {
+                let result = itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(
+                    direction: .backward,
+                    startingIndex: nextStartingIndex
+                )
+                if let item = result.item {
+                    items.append(item)
+                }
+                backListSize -= 1
+                if result.item == nil || backListSize == 0 || result.index == 0 {
+                    break
+                }
+                nextStartingIndex = result.index
+            }
+            items.reverse()
+            return API.Array.create(list: items.map { WebKit.toAPIObject($0) })
+        }
+
+        let startIndex = backListSize - size
         return API.Array.create(list: entries[startIndex..<startIndex + size].map { WebKit.toAPIObject($0) })
     }
 
@@ -469,10 +527,31 @@ final class WebBackForwardList {
             return API.Array.create()
         }
 
-        let size = min(forwardListCount(), Int(limit))
+        var size = min(forwardListCount(), Int(limit))
         guard size > 0 else {
             return API.Array.create()
         }
+
+        guard !WebBackForwardList.shouldSkipItemsWithoutUserGestureForWebKitAPI else {
+            var items: [WebKit.WebBackForwardListItem] = []
+            var nextStartingIndex = unwrappedCurrentIndex
+            while size > 0 {
+                let result = itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(
+                    direction: .forward,
+                    startingIndex: nextStartingIndex
+                )
+                if let item = result.item {
+                    items.append(item)
+                }
+                size -= 1
+                if result.item == nil || size == 0 || result.index == 0 {
+                    break
+                }
+                nextStartingIndex = result.index
+            }
+            return API.Array.create(list: items.map { WebKit.toAPIObject($0) })
+        }
+
         let startIndex = unwrappedCurrentIndex + 1
         return API.Array.create(list: entries[startIndex..<startIndex + size].map { WebKit.toAPIObject($0) })
     }
@@ -619,10 +698,8 @@ final class WebBackForwardList {
         if itemIndex >= entries.count {
             return (nil, 0)
         }
+
         let maybeItem = itemAtIndexWithoutSkipping(index: itemIndex)
-        if maybeItem.item == nil {
-            assertionFailure("Should have an item by now")
-        }
 
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
         if !WTF.linkedOnOrAfterSDKWithBehavior(WTF.SDKAlignedBehavior.UIBackForwardSkipsHistoryItemsWithoutUserGesture) {
@@ -630,13 +707,37 @@ final class WebBackForwardList {
         }
         #endif
 
+        guard maybeItem.item != nil else {
+            return (nil, 0)
+        }
+
         // For example:
-        // Yahoo -> Yahoo#a (no userInteraction) -> Google -> Google#a (no user interaction) -> Google#b (no user interaction)
-        // If we're on Google and navigate back, we don't want to skip anything and load Yahoo#a.
-        // However, if we're on Yahoo and navigate forward, we do want to skip items and end up on Google#b.
+        // A -> A#a (no userInteraction) -> B -> B#a (no user interaction) -> B#b (no user interaction)
+        // If we're on B and navigate back, we don't want to skip anything and load A#a.
+        // However, if we're on A and navigate forward, we do want to skip items and end up on B#b.
         // swift-format-ignore: NeverForceUnwrap
         if direction == Direction.backward && !currentItem()!.wasCreatedByJSWithoutUserInteraction() {
-            return maybeItem
+            // The exception to the above is that if the entire list of back items is missing user interaction,
+            // they should all be ignored. For example:
+            // A (no userInteraction) -> B (no userInteraction) -> C*
+            // From the API perspective, C should be item 0, and going back is not an option.
+            // This happens e.g. with new windows that undergo a series of JS driven client redirects.
+            // See https://bugs.webkit.org/show_bug.cgi?id=310243
+            let itemToReturn = maybeItem
+            var checkItem = maybeItem
+            while true {
+                guard let checkItemUnwrapped = checkItem.item, checkItemUnwrapped.wasCreatedByJSWithoutUserInteraction() else {
+                    break
+                }
+                guard checkItem.index > 0 else {
+                    // We reached the beginning of the list and still didn't find an item with user interaction,
+                    // therefore we are returning nothing.
+                    return (nil, 0)
+                }
+
+                checkItem = itemAtIndexWithoutSkipping(index: checkItem.index - 1)
+            }
+            return itemToReturn
         }
 
         let (definiteItem, index) = maybeItem
@@ -655,7 +756,13 @@ final class WebBackForwardList {
             itemIndex += delta
             let (thisItem, thisItemIndex) = itemAtIndexWithoutSkipping(index: itemIndex)
             guard let thisItem else {
-                return originalItem
+                // If there are no more back items that ever had a user gesture, then we should not enable going back.
+                // This happens when e.g. a new window is created by JavaScript then client redirects occur that create
+                // a sequence of history items, each without user interaction.
+                loadingReleaseLog(
+                    "UI Navigation is disabling going back because no more WebBackForwardListItem items in the back list had user interaction"
+                )
+                return (nil, 0)
             }
             item = (thisItem, thisItemIndex)
 
@@ -734,7 +841,7 @@ final class WebBackForwardList {
         guard let childFrameItem = parentFrameItem.childItemAtIndex(childFrameIndex) else {
             return nil
         }
-        return childFrameItem.frameState()
+        return getFrameState(childFrameItem)
     }
 
     func loggingString() -> Swift.String {
@@ -930,6 +1037,8 @@ final class WebBackForwardList {
                 }
             }
         }
+
+        webPageProxy.updateCanGoBackAndForward()
     }
 
     func updateFrameIdentifier(oldFrameID: WebCore.FrameIdentifier, newFrameID: WebCore.FrameIdentifier) {
@@ -1001,7 +1110,7 @@ final class WebBackForwardList {
     ) {
         // FIXME: This should verify that the web process requesting the item hosts the specified frame.
         let delta = Int(delta)
-        guard let item = itemAtDeltaFromCurrentIndex(delta: delta) else {
+        guard let item = itemAtDeltaFromCurrentIndex(delta: delta, allowSkipping: false) else {
             callCompletionHandler(completionHandler, consuming: WebKit.RefPtrFrameState())
             return
         }

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -27,6 +27,7 @@
 
 #include "Logging.h"
 #include "SessionState.h"
+#include "WebBackForwardListFrameItem.h"
 #include "WebBackForwardListItem.h"
 #include "WebBackForwardListMessages.h"
 #include "WebProcessProxy.h"
@@ -92,6 +93,12 @@ inline void callCompletionHandler(CompletionHandlers::WebBackForwardList::BackFo
 inline bool filterSpecified(WebBackForwardListItemFilter& fn)
 {
     return bool(*fn);
+}
+
+// Workaround for rdar://168057355
+inline WebKit::FrameState* getFrameState(WebKit::WebBackForwardListFrameItem& item)
+{
+    return &item.frameState();
 }
 
 // Workarounds for rdar://171011011


### PR DESCRIPTION
#### 2156f81a710cb78d36fa98a67c4fce24adb6b8f9
<pre>
Port recent WebBackForwardList.cpp changes to WebBackForwardList.swift
<a href="https://rdar.apple.com/157664628">rdar://157664628</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312810">https://bugs.webkit.org/show_bug.cgi?id=312810</a>

Reviewed by Richard Robinson and Adrian Taylor.

Update the Swift implementation of the bflist with all the new item skipping logic.

* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardListWrapper::itemAtDeltaFromCurrentIndex const):
* Source/WebKit/UIProcess/WebBackForwardList.swift:
(Direction.backItem):
(Direction.forwardItem):
(Direction.itemAtDeltaFromCurrentIndex(_:allowSkipping:)):
(Direction.backListAsAPIArrayWithLimit(_:)):
(Direction.forwardListAsAPIArrayWithLimit(_:)):
(Direction.backForwardUpdateItem(_:frameState:)):
(Direction.itemAtDeltaFromCurrentIndex(_:)): Deleted.
* Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h:
(getFrameState):

Canonical link: <a href="https://commits.webkit.org/311688@main">https://commits.webkit.org/311688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0cfc42ba000560e4bd58971be101682967b31bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166553 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122132 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24418 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102801 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14324 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169042 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13633 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130300 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130417 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35316 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141242 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88596 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18047 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30302 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94899 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29823 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30053 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29950 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->