### PR TITLE
Memory64 atomic operations

### DIFF
--- a/JSTests/wasm/stress/memory64-atomics.js
+++ b/JSTests/wasm/stress/memory64-atomics.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 
@@ -165,5 +165,268 @@ import * as assert from "../assert.js";
         // === memory.atomic.notify ===
         clear();
         assert.eq(e.test_memory_atomic_notify(0, 1), 0); // no waiters
+    }
+}
+
+// Test atomics with shared memory64 (i64 addresses) — the combined case.
+// This exercises the parser accepting i64 pointers for atomic ops on memory64,
+// and the runtime performing atomic operations through 64-bit addressing.
+{
+    const offset = 256;
+
+    let wat = `
+    (module
+      (memory (export "memory") i64 1 1 shared)
+
+      ;; Non-atomic helpers (for setup/verification)
+      (func (export "i32_store") (param i64 i32) (local.get 0) (local.get 1) (i32.store offset=${offset}))
+      (func (export "i32_load") (param i64) (result i32) (local.get 0) (i32.load offset=${offset}))
+      (func (export "i64_store") (param i64 i64) (local.get 0) (local.get 1) (i64.store offset=${offset}))
+      (func (export "i64_load") (param i64) (result i64) (local.get 0) (i64.load offset=${offset}))
+
+      ;; Atomic loads with offset
+      (func (export "test_i32_atomic_load") (param i64) (result i32) (local.get 0) (i32.atomic.load offset=${offset}))
+      (func (export "test_i64_atomic_load") (param i64) (result i64) (local.get 0) (i64.atomic.load offset=${offset}))
+      (func (export "test_i32_atomic_load8_u") (param i64) (result i32) (local.get 0) (i32.atomic.load8_u offset=${offset}))
+      (func (export "test_i32_atomic_load16_u") (param i64) (result i32) (local.get 0) (i32.atomic.load16_u offset=${offset}))
+      (func (export "test_i64_atomic_load8_u") (param i64) (result i64) (local.get 0) (i64.atomic.load8_u offset=${offset}))
+      (func (export "test_i64_atomic_load16_u") (param i64) (result i64) (local.get 0) (i64.atomic.load16_u offset=${offset}))
+      (func (export "test_i64_atomic_load32_u") (param i64) (result i64) (local.get 0) (i64.atomic.load32_u offset=${offset}))
+
+      ;; Atomic stores with offset
+      (func (export "test_i32_atomic_store") (param i64 i32) (local.get 0) (local.get 1) (i32.atomic.store offset=${offset}))
+      (func (export "test_i64_atomic_store") (param i64 i64) (local.get 0) (local.get 1) (i64.atomic.store offset=${offset}))
+      (func (export "test_i32_atomic_store8") (param i64 i32) (local.get 0) (local.get 1) (i32.atomic.store8 offset=${offset}))
+      (func (export "test_i32_atomic_store16") (param i64 i32) (local.get 0) (local.get 1) (i32.atomic.store16 offset=${offset}))
+      (func (export "test_i64_atomic_store8") (param i64 i64) (local.get 0) (local.get 1) (i64.atomic.store8 offset=${offset}))
+      (func (export "test_i64_atomic_store16") (param i64 i64) (local.get 0) (local.get 1) (i64.atomic.store16 offset=${offset}))
+      (func (export "test_i64_atomic_store32") (param i64 i64) (local.get 0) (local.get 1) (i64.atomic.store32 offset=${offset}))
+
+      ;; Atomic RMW add with offset
+      (func (export "test_i32_atomic_rmw_add") (param i64 i32) (result i32) (local.get 0) (local.get 1) (i32.atomic.rmw.add offset=${offset}))
+      (func (export "test_i64_atomic_rmw_add") (param i64 i64) (result i64) (local.get 0) (local.get 1) (i64.atomic.rmw.add offset=${offset}))
+
+      ;; Atomic RMW sub with offset
+      (func (export "test_i32_atomic_rmw_sub") (param i64 i32) (result i32) (local.get 0) (local.get 1) (i32.atomic.rmw.sub offset=${offset}))
+      (func (export "test_i64_atomic_rmw_sub") (param i64 i64) (result i64) (local.get 0) (local.get 1) (i64.atomic.rmw.sub offset=${offset}))
+
+      ;; Atomic RMW and/or/xor with offset
+      (func (export "test_i32_atomic_rmw_and") (param i64 i32) (result i32) (local.get 0) (local.get 1) (i32.atomic.rmw.and offset=${offset}))
+      (func (export "test_i32_atomic_rmw_or") (param i64 i32) (result i32) (local.get 0) (local.get 1) (i32.atomic.rmw.or offset=${offset}))
+      (func (export "test_i32_atomic_rmw_xor") (param i64 i32) (result i32) (local.get 0) (local.get 1) (i32.atomic.rmw.xor offset=${offset}))
+
+      ;; Atomic RMW xchg with offset
+      (func (export "test_i32_atomic_rmw_xchg") (param i64 i32) (result i32) (local.get 0) (local.get 1) (i32.atomic.rmw.xchg offset=${offset}))
+      (func (export "test_i64_atomic_rmw_xchg") (param i64 i64) (result i64) (local.get 0) (local.get 1) (i64.atomic.rmw.xchg offset=${offset}))
+
+      ;; Atomic RMW cmpxchg with offset
+      (func (export "test_i32_atomic_rmw_cmpxchg") (param i64 i32 i32) (result i32) (local.get 0) (local.get 1) (local.get 2) (i32.atomic.rmw.cmpxchg offset=${offset}))
+      (func (export "test_i64_atomic_rmw_cmpxchg") (param i64 i64 i64) (result i64) (local.get 0) (local.get 1) (local.get 2) (i64.atomic.rmw.cmpxchg offset=${offset}))
+
+      ;; Atomic notify with offset
+      (func (export "test_memory_atomic_notify") (param i64 i32) (result i32) (local.get 0) (local.get 1) (memory.atomic.notify offset=${offset}))
+
+      ;; Atomic wait with offset
+      (func (export "test_memory_atomic_wait32") (param i64 i32 i64) (result i32) (local.get 0) (local.get 1) (local.get 2) (memory.atomic.wait32 offset=${offset}))
+      (func (export "test_memory_atomic_wait64") (param i64 i64 i64) (result i32) (local.get 0) (local.get 1) (local.get 2) (memory.atomic.wait64 offset=${offset}))
+
+      ;; Sub-width atomic RMW operations with offset
+      (func (export "test_i32_atomic_rmw8_add_u") (param i64 i32) (result i32) (local.get 0) (local.get 1) (i32.atomic.rmw8.add_u offset=${offset}))
+      (func (export "test_i32_atomic_rmw16_add_u") (param i64 i32) (result i32) (local.get 0) (local.get 1) (i32.atomic.rmw16.add_u offset=${offset}))
+      (func (export "test_i64_atomic_rmw8_add_u") (param i64 i64) (result i64) (local.get 0) (local.get 1) (i64.atomic.rmw8.add_u offset=${offset}))
+      (func (export "test_i64_atomic_rmw16_add_u") (param i64 i64) (result i64) (local.get 0) (local.get 1) (i64.atomic.rmw16.add_u offset=${offset}))
+      (func (export "test_i64_atomic_rmw32_add_u") (param i64 i64) (result i64) (local.get 0) (local.get 1) (i64.atomic.rmw32.add_u offset=${offset}))
+
+      ;; Atomic operations with offset=0 (exercises boundary==0 path for 8-bit ops)
+      (func (export "test_i32_atomic_load8_u_no_offset") (param i64) (result i32) (local.get 0) (i32.atomic.load8_u))
+      (func (export "test_i32_atomic_store8_no_offset") (param i64 i32) (local.get 0) (local.get 1) (i32.atomic.store8))
+      (func (export "test_i32_atomic_load_no_offset") (param i64) (result i32) (local.get 0) (i32.atomic.load))
+      (func (export "test_i32_atomic_store_no_offset") (param i64 i32) (local.get 0) (local.get 1) (i32.atomic.store))
+    )
+    `;
+
+    const instance = await instantiate(wat, {}, { threads: true, memory64: true });
+    const e = instance.exports;
+
+    function clear() {
+        e.i64_store(0n, 0n);
+        e.i64_store(8n, 0n);
+    }
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        // === Atomic Loads ===
+        clear();
+        e.i64_store(0n, 0x7766554433221142n);
+
+        assert.eq(e.test_i32_atomic_load(0n), 0x33221142);
+        assert.eq(e.test_i64_atomic_load(0n), 0x7766554433221142n);
+        assert.eq(e.test_i32_atomic_load8_u(0n), 0x42);
+        assert.eq(e.test_i32_atomic_load16_u(0n), 0x1142);
+        assert.eq(e.test_i64_atomic_load8_u(0n), 0x42n);
+        assert.eq(e.test_i64_atomic_load16_u(0n), 0x1142n);
+        assert.eq(e.test_i64_atomic_load32_u(0n), 0x33221142n);
+
+        // === Atomic Stores ===
+        clear();
+        e.test_i32_atomic_store(0n, 0x12345678);
+        assert.eq(e.i32_load(0n), 0x12345678);
+
+        clear();
+        e.test_i64_atomic_store(0n, 0x123456789ABCDEF0n);
+        assert.eq(e.i64_load(0n), 0x123456789ABCDEF0n);
+
+        clear();
+        e.test_i32_atomic_store8(0n, 0x42);
+        assert.eq(e.i32_load(0n), 0x42);
+
+        clear();
+        e.test_i32_atomic_store16(0n, 0x1234);
+        assert.eq(e.i32_load(0n), 0x1234);
+
+        clear();
+        e.test_i64_atomic_store8(0n, 0x42n);
+        assert.eq(e.i64_load(0n), 0x42n);
+
+        clear();
+        e.test_i64_atomic_store16(0n, 0x1234n);
+        assert.eq(e.i64_load(0n), 0x1234n);
+
+        clear();
+        e.test_i64_atomic_store32(0n, 0x12345678n);
+        assert.eq(e.i64_load(0n), 0x12345678n);
+
+        // === Atomic RMW add ===
+        clear();
+        e.i32_store(0n, 10);
+        assert.eq(e.test_i32_atomic_rmw_add(0n, 5), 10); // returns old value
+        assert.eq(e.i32_load(0n), 15);
+
+        clear();
+        e.i64_store(0n, 100n);
+        assert.eq(e.test_i64_atomic_rmw_add(0n, 50n), 100n);
+        assert.eq(e.i64_load(0n), 150n);
+
+        // === Atomic RMW sub ===
+        clear();
+        e.i32_store(0n, 100);
+        assert.eq(e.test_i32_atomic_rmw_sub(0n, 30), 100);
+        assert.eq(e.i32_load(0n), 70);
+
+        clear();
+        e.i64_store(0n, 200n);
+        assert.eq(e.test_i64_atomic_rmw_sub(0n, 50n), 200n);
+        assert.eq(e.i64_load(0n), 150n);
+
+        // === Atomic RMW and/or/xor ===
+        clear();
+        e.i32_store(0n, 0xFF);
+        assert.eq(e.test_i32_atomic_rmw_and(0n, 0x0F), 0xFF);
+        assert.eq(e.i32_load(0n), 0x0F);
+
+        clear();
+        e.i32_store(0n, 0xF0);
+        assert.eq(e.test_i32_atomic_rmw_or(0n, 0x0F), 0xF0);
+        assert.eq(e.i32_load(0n), 0xFF);
+
+        clear();
+        e.i32_store(0n, 0xFF);
+        assert.eq(e.test_i32_atomic_rmw_xor(0n, 0x0F), 0xFF);
+        assert.eq(e.i32_load(0n), 0xF0);
+
+        // === Atomic RMW xchg ===
+        clear();
+        e.i32_store(0n, 42);
+        assert.eq(e.test_i32_atomic_rmw_xchg(0n, 99), 42);
+        assert.eq(e.i32_load(0n), 99);
+
+        clear();
+        e.i64_store(0n, 42n);
+        assert.eq(e.test_i64_atomic_rmw_xchg(0n, 99n), 42n);
+        assert.eq(e.i64_load(0n), 99n);
+
+        // === Atomic RMW cmpxchg ===
+        clear();
+        e.i32_store(0n, 42);
+        assert.eq(e.test_i32_atomic_rmw_cmpxchg(0n, 42, 99), 42); // match: swap
+        assert.eq(e.i32_load(0n), 99);
+
+        clear();
+        e.i32_store(0n, 42);
+        assert.eq(e.test_i32_atomic_rmw_cmpxchg(0n, 0, 99), 42); // no match: no swap
+        assert.eq(e.i32_load(0n), 42);
+
+        clear();
+        e.i64_store(0n, 42n);
+        assert.eq(e.test_i64_atomic_rmw_cmpxchg(0n, 42n, 99n), 42n);
+        assert.eq(e.i64_load(0n), 99n);
+
+        // === memory.atomic.notify ===
+        clear();
+        assert.eq(e.test_memory_atomic_notify(0n, 1), 0); // no waiters
+
+        // === Test with non-zero base address ===
+        clear();
+        e.i32_store(16n, 0xCAFEBABE);
+        assert.eq(e.test_i32_atomic_load(16n), 0xCAFEBABE | 0);
+
+        clear();
+        e.test_i32_atomic_store(16n, 0xDEADBEEF);
+        assert.eq(e.i32_load(16n), 0xDEADBEEF | 0);
+
+        // === memory.atomic.wait32 ===
+        clear();
+        e.i32_store(0n, 42);
+        // Expected value doesn't match -> returns 1 ("not-equal")
+        assert.eq(e.test_memory_atomic_wait32(0n, 0, 0n), 1);
+        // Expected value matches, timeout=0 -> returns 2 ("timed-out")
+        assert.eq(e.test_memory_atomic_wait32(0n, 42, 0n), 2);
+
+        // === memory.atomic.wait64 ===
+        clear();
+        e.i64_store(0n, 42n);
+        // Expected value doesn't match -> returns 1
+        assert.eq(e.test_memory_atomic_wait64(0n, 0n, 0n), 1);
+        // Expected value matches, timeout=0 -> returns 2
+        assert.eq(e.test_memory_atomic_wait64(0n, 42n, 0n), 2);
+
+        // === Sub-width atomic RMW add ===
+        clear();
+        e.i32_store(0n, 0x10);
+        assert.eq(e.test_i32_atomic_rmw8_add_u(0n, 1), 0x10);
+        assert.eq(e.i32_load(0n), 0x11);
+
+        clear();
+        e.i32_store(0n, 0x0203);
+        assert.eq(e.test_i32_atomic_rmw8_add_u(0n, 1), 0x03);
+        assert.eq(e.i32_load(0n), 0x0204);
+
+        clear();
+        e.i32_store(0n, 0x1234);
+        assert.eq(e.test_i32_atomic_rmw16_add_u(0n, 1), 0x1234);
+        assert.eq(e.i32_load(0n), 0x1235);
+
+        clear();
+        e.i64_store(0n, 0x42n);
+        assert.eq(e.test_i64_atomic_rmw8_add_u(0n, 1n), 0x42n);
+        assert.eq(e.i64_load(0n), 0x43n);
+
+        clear();
+        e.i64_store(0n, 0x1234n);
+        assert.eq(e.test_i64_atomic_rmw16_add_u(0n, 1n), 0x1234n);
+        assert.eq(e.i64_load(0n), 0x1235n);
+
+        clear();
+        e.i64_store(0n, 0x12345678n);
+        assert.eq(e.test_i64_atomic_rmw32_add_u(0n, 1n), 0x12345678n);
+        assert.eq(e.i64_load(0n), 0x12345679n);
+
+        // === Offset=0 tests (exercises boundary==0 path for 8-bit ops) ===
+        clear();
+        e.test_i32_atomic_store8_no_offset(0n, 0x42);
+        assert.eq(e.test_i32_atomic_load8_u_no_offset(0n), 0x42);
+
+        clear();
+        e.test_i32_atomic_store_no_offset(0n, 0x12345678);
+        assert.eq(e.test_i32_atomic_load_no_offset(0n), 0x12345678);
     }
 }

--- a/JSTests/wasm/stress/memory64-overflow.js
+++ b/JSTests/wasm/stress/memory64-overflow.js
@@ -92,3 +92,246 @@ function testOverflow() {
 
 for (let i = 0; i < wasmTestLoopCount; i++)
     testOverflow();
+
+// Atomic instruction overflow tests.
+// Every atomic instruction with a memory offset must trap on address overflow.
+
+const kAtomicPrefix = 0xFE;
+
+const kExprAtomicNotify = 0x00;
+const kExprI32AtomicWait = 0x01;
+const kExprI64AtomicWait = 0x02;
+const kExprI32AtomicLoad = 0x10;
+const kExprI64AtomicLoad = 0x11;
+const kExprI32AtomicLoad8U = 0x12;
+const kExprI32AtomicLoad16U = 0x13;
+const kExprI64AtomicLoad8U = 0x14;
+const kExprI64AtomicLoad16U = 0x15;
+const kExprI64AtomicLoad32U = 0x16;
+const kExprI32AtomicStore = 0x17;
+const kExprI64AtomicStore = 0x18;
+const kExprI32AtomicStore8 = 0x19;
+const kExprI32AtomicStore16 = 0x1a;
+const kExprI64AtomicStore8 = 0x1b;
+const kExprI64AtomicStore16 = 0x1c;
+const kExprI64AtomicStore32 = 0x1d;
+const kExprI32AtomicRmwAdd = 0x1e;
+const kExprI64AtomicRmwAdd = 0x1f;
+const kExprI32AtomicRmw8AddU = 0x20;
+const kExprI32AtomicRmw16AddU = 0x21;
+const kExprI64AtomicRmw8AddU = 0x22;
+const kExprI64AtomicRmw16AddU = 0x23;
+const kExprI64AtomicRmw32AddU = 0x24;
+const kExprI32AtomicRmwSub = 0x25;
+const kExprI64AtomicRmwSub = 0x26;
+const kExprI32AtomicRmw8SubU = 0x27;
+const kExprI32AtomicRmw16SubU = 0x28;
+const kExprI64AtomicRmw8SubU = 0x29;
+const kExprI64AtomicRmw16SubU = 0x2a;
+const kExprI64AtomicRmw32SubU = 0x2b;
+const kExprI32AtomicRmwAnd = 0x2c;
+const kExprI64AtomicRmwAnd = 0x2d;
+const kExprI32AtomicRmw8AndU = 0x2e;
+const kExprI32AtomicRmw16AndU = 0x2f;
+const kExprI64AtomicRmw8AndU = 0x30;
+const kExprI64AtomicRmw16AndU = 0x31;
+const kExprI64AtomicRmw32AndU = 0x32;
+const kExprI32AtomicRmwOr = 0x33;
+const kExprI64AtomicRmwOr = 0x34;
+const kExprI32AtomicRmw8OrU = 0x35;
+const kExprI32AtomicRmw16OrU = 0x36;
+const kExprI64AtomicRmw8OrU = 0x37;
+const kExprI64AtomicRmw16OrU = 0x38;
+const kExprI64AtomicRmw32OrU = 0x39;
+const kExprI32AtomicRmwXor = 0x3a;
+const kExprI64AtomicRmwXor = 0x3b;
+const kExprI32AtomicRmw8XorU = 0x3c;
+const kExprI32AtomicRmw16XorU = 0x3d;
+const kExprI64AtomicRmw8XorU = 0x3e;
+const kExprI64AtomicRmw16XorU = 0x3f;
+const kExprI64AtomicRmw32XorU = 0x40;
+const kExprI32AtomicRmwXchg = 0x41;
+const kExprI64AtomicRmwXchg = 0x42;
+const kExprI32AtomicRmw8XchgU = 0x43;
+const kExprI32AtomicRmw16XchgU = 0x44;
+const kExprI64AtomicRmw8XchgU = 0x45;
+const kExprI64AtomicRmw16XchgU = 0x46;
+const kExprI64AtomicRmw32XchgU = 0x47;
+const kExprI32AtomicRmwCmpxchg = 0x48;
+const kExprI64AtomicRmwCmpxchg = 0x49;
+const kExprI32AtomicRmw8CmpxchgU = 0x4a;
+const kExprI32AtomicRmw16CmpxchgU = 0x4b;
+const kExprI64AtomicRmw8CmpxchgU = 0x4c;
+const kExprI64AtomicRmw16CmpxchgU = 0x4d;
+const kExprI64AtomicRmw32CmpxchgU = 0x4e;
+
+// Each entry: [name, sub-opcode, natural alignment (log2), category, value wasm type]
+// Categories: "load", "store", "rmw", "cmpxchg", "notify"
+const atomicOps = [
+    // Atomic loads
+    ["i32_atomic_load",     kExprI32AtomicLoad,     2, "load", kWasmI32],
+    ["i64_atomic_load",     kExprI64AtomicLoad,     3, "load", kWasmI64],
+    ["i32_atomic_load8_u",  kExprI32AtomicLoad8U,   0, "load", kWasmI32],
+    ["i32_atomic_load16_u", kExprI32AtomicLoad16U,  1, "load", kWasmI32],
+    ["i64_atomic_load8_u",  kExprI64AtomicLoad8U,   0, "load", kWasmI64],
+    ["i64_atomic_load16_u", kExprI64AtomicLoad16U,  1, "load", kWasmI64],
+    ["i64_atomic_load32_u", kExprI64AtomicLoad32U,  2, "load", kWasmI64],
+
+    // Atomic stores
+    ["i32_atomic_store",    kExprI32AtomicStore,    2, "store", kWasmI32],
+    ["i64_atomic_store",    kExprI64AtomicStore,    3, "store", kWasmI64],
+    ["i32_atomic_store8",   kExprI32AtomicStore8,   0, "store", kWasmI32],
+    ["i32_atomic_store16",  kExprI32AtomicStore16,  1, "store", kWasmI32],
+    ["i64_atomic_store8",   kExprI64AtomicStore8,   0, "store", kWasmI64],
+    ["i64_atomic_store16",  kExprI64AtomicStore16,  1, "store", kWasmI64],
+    ["i64_atomic_store32",  kExprI64AtomicStore32,  2, "store", kWasmI64],
+
+    // Atomic RMW add
+    ["i32_atomic_rmw_add",      kExprI32AtomicRmwAdd,     2, "rmw", kWasmI32],
+    ["i64_atomic_rmw_add",      kExprI64AtomicRmwAdd,     3, "rmw", kWasmI64],
+    ["i32_atomic_rmw8_add_u",   kExprI32AtomicRmw8AddU,   0, "rmw", kWasmI32],
+    ["i32_atomic_rmw16_add_u",  kExprI32AtomicRmw16AddU,  1, "rmw", kWasmI32],
+    ["i64_atomic_rmw8_add_u",   kExprI64AtomicRmw8AddU,   0, "rmw", kWasmI64],
+    ["i64_atomic_rmw16_add_u",  kExprI64AtomicRmw16AddU,  1, "rmw", kWasmI64],
+    ["i64_atomic_rmw32_add_u",  kExprI64AtomicRmw32AddU,  2, "rmw", kWasmI64],
+
+    // Atomic RMW sub
+    ["i32_atomic_rmw_sub",      kExprI32AtomicRmwSub,     2, "rmw", kWasmI32],
+    ["i64_atomic_rmw_sub",      kExprI64AtomicRmwSub,     3, "rmw", kWasmI64],
+    ["i32_atomic_rmw8_sub_u",   kExprI32AtomicRmw8SubU,   0, "rmw", kWasmI32],
+    ["i32_atomic_rmw16_sub_u",  kExprI32AtomicRmw16SubU,  1, "rmw", kWasmI32],
+    ["i64_atomic_rmw8_sub_u",   kExprI64AtomicRmw8SubU,   0, "rmw", kWasmI64],
+    ["i64_atomic_rmw16_sub_u",  kExprI64AtomicRmw16SubU,  1, "rmw", kWasmI64],
+    ["i64_atomic_rmw32_sub_u",  kExprI64AtomicRmw32SubU,  2, "rmw", kWasmI64],
+
+    // Atomic RMW and
+    ["i32_atomic_rmw_and",      kExprI32AtomicRmwAnd,     2, "rmw", kWasmI32],
+    ["i64_atomic_rmw_and",      kExprI64AtomicRmwAnd,     3, "rmw", kWasmI64],
+    ["i32_atomic_rmw8_and_u",   kExprI32AtomicRmw8AndU,   0, "rmw", kWasmI32],
+    ["i32_atomic_rmw16_and_u",  kExprI32AtomicRmw16AndU,  1, "rmw", kWasmI32],
+    ["i64_atomic_rmw8_and_u",   kExprI64AtomicRmw8AndU,   0, "rmw", kWasmI64],
+    ["i64_atomic_rmw16_and_u",  kExprI64AtomicRmw16AndU,  1, "rmw", kWasmI64],
+    ["i64_atomic_rmw32_and_u",  kExprI64AtomicRmw32AndU,  2, "rmw", kWasmI64],
+
+    // Atomic RMW or
+    ["i32_atomic_rmw_or",       kExprI32AtomicRmwOr,      2, "rmw", kWasmI32],
+    ["i64_atomic_rmw_or",       kExprI64AtomicRmwOr,      3, "rmw", kWasmI64],
+    ["i32_atomic_rmw8_or_u",    kExprI32AtomicRmw8OrU,    0, "rmw", kWasmI32],
+    ["i32_atomic_rmw16_or_u",   kExprI32AtomicRmw16OrU,   1, "rmw", kWasmI32],
+    ["i64_atomic_rmw8_or_u",    kExprI64AtomicRmw8OrU,    0, "rmw", kWasmI64],
+    ["i64_atomic_rmw16_or_u",   kExprI64AtomicRmw16OrU,   1, "rmw", kWasmI64],
+    ["i64_atomic_rmw32_or_u",   kExprI64AtomicRmw32OrU,   2, "rmw", kWasmI64],
+
+    // Atomic RMW xor
+    ["i32_atomic_rmw_xor",      kExprI32AtomicRmwXor,     2, "rmw", kWasmI32],
+    ["i64_atomic_rmw_xor",      kExprI64AtomicRmwXor,     3, "rmw", kWasmI64],
+    ["i32_atomic_rmw8_xor_u",   kExprI32AtomicRmw8XorU,   0, "rmw", kWasmI32],
+    ["i32_atomic_rmw16_xor_u",  kExprI32AtomicRmw16XorU,  1, "rmw", kWasmI32],
+    ["i64_atomic_rmw8_xor_u",   kExprI64AtomicRmw8XorU,   0, "rmw", kWasmI64],
+    ["i64_atomic_rmw16_xor_u",  kExprI64AtomicRmw16XorU,  1, "rmw", kWasmI64],
+    ["i64_atomic_rmw32_xor_u",  kExprI64AtomicRmw32XorU,  2, "rmw", kWasmI64],
+
+    // Atomic RMW xchg
+    ["i32_atomic_rmw_xchg",     kExprI32AtomicRmwXchg,    2, "rmw", kWasmI32],
+    ["i64_atomic_rmw_xchg",     kExprI64AtomicRmwXchg,    3, "rmw", kWasmI64],
+    ["i32_atomic_rmw8_xchg_u",  kExprI32AtomicRmw8XchgU,  0, "rmw", kWasmI32],
+    ["i32_atomic_rmw16_xchg_u", kExprI32AtomicRmw16XchgU, 1, "rmw", kWasmI32],
+    ["i64_atomic_rmw8_xchg_u",  kExprI64AtomicRmw8XchgU,  0, "rmw", kWasmI64],
+    ["i64_atomic_rmw16_xchg_u", kExprI64AtomicRmw16XchgU, 1, "rmw", kWasmI64],
+    ["i64_atomic_rmw32_xchg_u", kExprI64AtomicRmw32XchgU, 2, "rmw", kWasmI64],
+
+    // Atomic RMW cmpxchg
+    ["i32_atomic_rmw_cmpxchg",      kExprI32AtomicRmwCmpxchg,     2, "cmpxchg", kWasmI32],
+    ["i64_atomic_rmw_cmpxchg",      kExprI64AtomicRmwCmpxchg,     3, "cmpxchg", kWasmI64],
+    ["i32_atomic_rmw8_cmpxchg_u",   kExprI32AtomicRmw8CmpxchgU,   0, "cmpxchg", kWasmI32],
+    ["i32_atomic_rmw16_cmpxchg_u",  kExprI32AtomicRmw16CmpxchgU,  1, "cmpxchg", kWasmI32],
+    ["i64_atomic_rmw8_cmpxchg_u",   kExprI64AtomicRmw8CmpxchgU,   0, "cmpxchg", kWasmI64],
+    ["i64_atomic_rmw16_cmpxchg_u",  kExprI64AtomicRmw16CmpxchgU,  1, "cmpxchg", kWasmI64],
+    ["i64_atomic_rmw32_cmpxchg_u",  kExprI64AtomicRmw32CmpxchgU,  2, "cmpxchg", kWasmI64],
+
+    // memory.atomic.notify
+    ["memory_atomic_notify", kExprAtomicNotify, 2, "notify", kWasmI32],
+
+    // memory.atomic.wait32/wait64
+    ["memory_atomic_wait32", kExprI32AtomicWait, 2, "wait32", kWasmI32],
+    ["memory_atomic_wait64", kExprI64AtomicWait, 3, "wait64", kWasmI64],
+];
+
+function makeAtomicBody(cat, vtype, opcode, align, addrBytes, offsetBytes) {
+    const body = [...addrBytes];
+    const zeroConst = vtype === kWasmI64 ? [kExprI64Const, 0] : [kExprI32Const, 0];
+
+    switch (cat) {
+    case "store":
+    case "rmw":
+        body.push(...zeroConst);
+        break;
+    case "cmpxchg":
+        body.push(...zeroConst, ...zeroConst);
+        break;
+    case "notify":
+        body.push(kExprI32Const, 0);
+        break;
+    case "wait32":
+        body.push(kExprI32Const, 0, kExprI64Const, 0);
+        break;
+    case "wait64":
+        body.push(kExprI64Const, 0, kExprI64Const, 0);
+        break;
+    }
+
+    body.push(kAtomicPrefix, opcode, align, ...offsetBytes);
+    return body;
+}
+
+function resultTypeForCategory(cat, vtype) {
+    if (cat === "store") return null;
+    if (cat === "notify" || cat === "wait32" || cat === "wait64") return kWasmI32;
+    return vtype;
+}
+
+const atomicBuilder = new WasmModuleBuilder();
+atomicBuilder.addMemory64(1);
+
+for (const [name, opcode, align, cat, vtype] of atomicOps) {
+    const rtype = resultTypeForCategory(cat, vtype);
+    const runtimeSig = rtype !== null ? makeSig([kWasmI64], [rtype]) : makeSig([kWasmI64], []);
+    const staticSig = rtype !== null ? makeSig([], [rtype]) : makeSig([], []);
+
+    atomicBuilder.addFunction("test_" + name, runtimeSig)
+        .addBody(makeAtomicBody(cat, vtype, opcode, align, [kExprGetLocal, 0], [1]))
+        .exportAs("test_" + name);
+
+    atomicBuilder.addFunction("const_" + name, staticSig)
+        .addBody(makeAtomicBody(cat, vtype, opcode, align, [kExprI64Const, 0x7F], [1]))
+        .exportAs("const_" + name);
+
+    atomicBuilder.addFunction("offset_" + name, staticSig)
+        .addBody(makeAtomicBody(cat, vtype, opcode, align, [kExprI64Const, 0], kU64MaxLEB128))
+        .exportAs("offset_" + name);
+}
+
+const atomicExports = atomicBuilder.instantiate().exports;
+
+function testAtomicOverflow() {
+    for (const [name] of atomicOps) {
+        assert.throws(() => atomicExports["test_" + name](0xffffffffffffffffn),
+            WebAssembly.RuntimeError,
+            "Out of bounds memory access");
+
+        assert.throws(() => atomicExports["test_" + name](0xfffffffffffffffen),
+            WebAssembly.RuntimeError,
+            "Out of bounds memory access");
+
+        assert.throws(() => atomicExports["const_" + name](),
+            WebAssembly.RuntimeError,
+            "Out of bounds memory access");
+
+        assert.throws(() => atomicExports["offset_" + name](),
+            WebAssembly.RuntimeError,
+            "Out of bounds memory access");
+    }
+}
+
+for (let i = 0; i < wasmTestLoopCount; i++)
+    testAtomicOverflow();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -1217,9 +1217,12 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
 
 // Atomics
 
-[[nodiscard]] PartialResult BBQJIT::atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t uoffset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex)
 {
-    if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(loadOp))) [[unlikely]] {
+    const bool overflow = m_info.memory(memoryIndex).isMemory64()
+        ? sumOverflows<uint64_t>(uoffset, sizeOfAtomicOpMemoryAccess(loadOp))
+        : sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(loadOp));
+    if (overflow) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
         consume(pointer);
@@ -1232,10 +1235,13 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t uoffset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint64_t uoffset, uint8_t memoryIndex)
 {
+    const bool overflow = m_info.memory(memoryIndex).isMemory64()
+        ? sumOverflows<uint64_t>(uoffset, sizeOfAtomicOpMemoryAccess(storeOp))
+        : sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(storeOp));
     Location valueLocation = locationOf(value);
-    if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(storeOp))) [[unlikely]] {
+    if (overflow) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
         consume(pointer);
@@ -1248,10 +1254,13 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t uoffset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex)
 {
+    const bool overflow = m_info.memory(memoryIndex).isMemory64()
+        ? sumOverflows<uint64_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))
+        : sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op));
     Location valueLocation = locationOf(value);
-    if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
+    if (overflow) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
@@ -1266,10 +1275,13 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t uoffset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex)
 {
+    const bool overflow = m_info.memory(memoryIndex).isMemory64()
+        ? sumOverflows<uint64_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))
+        : sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op));
     Location valueLocation = locationOf(value);
-    if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
+    if (overflow) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
@@ -1285,12 +1297,12 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t uoffset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
         pointer,
-        Value::fromI32(uoffset),
+        Value::fromI64(uoffset),
         value,
         timeout,
         Value::fromI32(memoryIndex)
@@ -1309,12 +1321,12 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint32_t uoffset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult BBQJIT::atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
         pointer,
-        Value::fromI32(uoffset),
+        Value::fromI64(uoffset),
         count,
         Value::fromI32(memoryIndex)
     };

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -36,6 +36,7 @@
 #include "WasmLimits.h"
 #include "js/JSWebAssemblyInstance.h"
 #include <span>
+#include <wtf/CheckedArithmetic.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -1147,8 +1148,13 @@ public:
 
     // Memory
 
-    inline Location emitCheckAndPreparePointer(Value pointer, uint32_t uoffset, uint32_t sizeOfOperation, uint8_t memoryIndex)
+    inline Location emitCheckAndPreparePointer(Value pointer, uint64_t uoffset, uint32_t sizeOfOperation, uint8_t memoryIndex)
     {
+        if (WTF::sumOverflows<uint64_t>(static_cast<uint64_t>(sizeOfOperation), uoffset)) {
+            recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.jump());
+            return Location::fromGPR(wasmBaseMemoryPointer);
+        }
+
         ScratchScope<1, 0> scratches(*this);
         Location pointerLocation;
 
@@ -1167,7 +1173,18 @@ public:
                 boundsCheckingSizeRegister);
         }
 
+        uint64_t boundary = static_cast<uint64_t>(sizeOfOperation) + uoffset - 1;
+
         if (pointer.isConst()) {
+            uint64_t constantPointer = m_info.memory(memoryIndex).isMemory64()
+                ? pointer.asI64()
+                : static_cast<uint32_t>(pointer.asI32());
+
+            if (sumOverflows<uint64_t>(constantPointer, boundary)) {
+                recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.jump());
+                return Location::fromGPR(wasmBaseMemoryPointer);
+            }
+
             pointerLocation = Location::fromGPR(scratches.gpr(0));
             emitMoveConst(pointer, pointerLocation);
         } else
@@ -1181,20 +1198,31 @@ public:
         loadWebAssemblyGlobalState(wasmBaseMemoryPointer, wasmBoundsCheckingSizeRegister);
 #endif
 
-        uint64_t boundary = static_cast<uint64_t>(sizeOfOperation) + uoffset - 1;
         // conservatively force bounds checking if memoryIndex != 0
         switch (memoryIndex ? MemoryMode::BoundsChecking : m_mode) {
         case MemoryMode::BoundsChecking: {
             // We're not using signal handling only when the memory is not shared.
             // Regardless of signaling, we must check that no memory access exceeds the current memory size.
-            m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
-            if (boundary)
-                m_jit.addPtr(TrustedImmPtr(boundary), wasmScratchGPR);
+
+            if (m_info.memory(memoryIndex).isMemory64()) {
+                if (boundary) {
+                    m_jit.move(TrustedImmPtr(boundary), wasmScratchGPR);
+                    Jump overflow = m_jit.branchAddPtr(ResultCondition::Carry, pointerLocation.asGPR(), wasmScratchGPR);
+                    recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, overflow);
+                } else
+                    m_jit.move(pointerLocation.asGPR(), wasmScratchGPR);
+            } else {
+                m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
+                if (boundary)
+                    m_jit.addPtr(TrustedImmPtr(boundary), wasmScratchGPR);
+            }
+
             recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branchPtr(RelationalCondition::AboveOrEqual, wasmScratchGPR, boundsCheckingSizeRegister));
             break;
         }
 
         case MemoryMode::Signaling: {
+            RELEASE_ASSERT(!m_info.memory(memoryIndex).isMemory64());
             // We've virtually mapped 4GiB+redzone for this memory. Only the user-allocated pages are addressable, contiguously in range [0, current],
             // and everything above is mapped PROT_NONE. We don't need to perform any explicit bounds check in the 4GiB range because WebAssembly register
             // memory accesses are 32-bit. However WebAssembly register + offset accesses perform the addition in 64-bit which can push an access above
@@ -1217,10 +1245,17 @@ public:
         }
 
 #if CPU(ARM64)
-        m_jit.addZeroExtend64(baseRegister, pointerLocation.asGPR(), wasmScratchGPR);
+        if (m_info.memory(memoryIndex).isMemory64())
+            m_jit.addPtr(baseRegister, pointerLocation.asGPR(), wasmScratchGPR);
+        else
+            m_jit.addZeroExtend64(baseRegister, pointerLocation.asGPR(), wasmScratchGPR);
 #else
-        m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
-        m_jit.addPtr(baseRegister, wasmScratchGPR);
+        if (m_info.memory(memoryIndex).isMemory64())
+            m_jit.addPtr(baseRegister, pointerLocation.asGPR(), wasmScratchGPR);
+        else {
+            m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
+            m_jit.addPtr(baseRegister, wasmScratchGPR);
+        }
 #endif
 
         consume(pointer);
@@ -1355,25 +1390,25 @@ public:
     template<typename Functor>
     void emitAtomicOpGeneric(ExtAtomicOpType op, Address address, Location old, Location cur, const Functor& functor);
 
-    [[nodiscard]] Value emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset);
+    [[nodiscard]] Value emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint64_t uoffset);
 
-    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t uoffset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex);
 
-    void emitAtomicStoreOp(ExtAtomicOpType storeOp, Type, Location pointer, Value value, uint32_t uoffset);
+    void emitAtomicStoreOp(ExtAtomicOpType storeOp, Type, Location pointer, Value, uint64_t uoffset);
 
-    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t uoffset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint64_t uoffset, uint8_t memoryIndex);
 
     Value emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location pointer, Value value, uint32_t uoffset);
 
-    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t uoffset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex);
 
     [[nodiscard]] Value emitAtomicCompareExchange(ExtAtomicOpType op, Type, Location pointer, Value expected, Value value, uint32_t uoffset);
 
-    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t uoffset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex);
 
-    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t uoffset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex);
 
-    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint32_t uoffset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex);
 
     [[nodiscard]] PartialResult atomicFence(ExtAtomicOpType, uint8_t);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -640,13 +640,13 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, GPRReg old
 #endif
 }
 
-[[nodiscard]] Value BBQJIT::emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset)
+[[nodiscard]] Value BBQJIT::emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint64_t uoffset)
 {
     ASSERT(pointer.isGPR());
 
     // For Atomic access, we need SimpleAddress (uoffset = 0).
     if (uoffset)
-        m_jit.add64(TrustedImm64(static_cast<int64_t>(uoffset)), pointer.asGPR());
+        m_jit.add64(TrustedImm64(uoffset), pointer.asGPR());
     Address address = Address(pointer.asGPR());
 
     if (accessWidth(loadOp) != Width8)
@@ -732,7 +732,7 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, GPRReg old
     return result;
 }
 
-void BBQJIT::emitAtomicStoreOp(ExtAtomicOpType storeOp, Type, Location pointer, Value value, uint32_t uoffset)
+void BBQJIT::emitAtomicStoreOp(ExtAtomicOpType storeOp, Type, Location pointer, Value value, uint64_t uoffset)
 {
     ASSERT(pointer.isGPR());
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -113,10 +113,13 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint64
     case MemoryMode::BoundsChecking: {
         // We're not using signal handling only when the memory is not shared.
         // Regardless of signaling, we must check that no memory access exceeds the current memory size.
-        if (m_info.memory(memoryIndex).isMemory64() && boundary) {
-            m_jit.move(TrustedImmPtr(boundary), wasmScratchGPR);
-            Jump overflow = m_jit.branchAddPtr(ResultCondition::Carry, pointerLocation.asGPR(), wasmScratchGPR);
-            recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, overflow);
+        if (m_info.memory(memoryIndex).isMemory64()) {
+            if (boundary) {
+                m_jit.move(TrustedImmPtr(boundary), wasmScratchGPR);
+                Jump overflow = m_jit.branchAddPtr(ResultCondition::Carry, pointerLocation.asGPR(), wasmScratchGPR);
+                recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, overflow);
+            } else
+                m_jit.move(pointerLocation.asGPR(), wasmScratchGPR);
         } else {
             m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
             if (boundary)

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -285,12 +285,12 @@ public:
     [[nodiscard]] PartialResult addMemoryCopy(ExpressionType, ExpressionType, ExpressionType, uint8_t, uint8_t) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addMemoryInit(unsigned, ExpressionType, ExpressionType, ExpressionType, uint8_t) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addDataDrop(unsigned) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t, uint8_t) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t, uint8_t) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint64_t, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint64_t, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint64_t, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint64_t, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint64_t, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint64_t, uint8_t) CONST_EXPR_STUB
     [[nodiscard]] PartialResult atomicFence(ExtAtomicOpType, uint8_t) CONST_EXPR_STUB
     [[nodiscard]] PartialResult truncTrapping(OpType, ExpressionType, ExpressionType&, Type, Type) CONST_EXPR_STUB
     [[nodiscard]] PartialResult truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type) CONST_EXPR_STUB

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -732,11 +732,7 @@ auto FunctionParser<Context>::load(Type memoryType) -> PartialResult
 
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer"_s);
 
-    if (m_info.memory(memoryIndex).isMemory64())
-        WASM_VALIDATOR_FAIL_IF(!pointer.type().isI64(), m_currentOpcode, " pointer type mismatch"_s);
-    else
-        WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), m_currentOpcode, " pointer type mismatch"_s);
-
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), m_currentOpcode, " pointer type mismatch"_s);
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(load(static_cast<LoadOpType>(m_currentOpcode), pointer, result, offset, memoryIndex));
     m_expressionStack.constructAndAppend(memoryType, result);
@@ -769,10 +765,7 @@ auto FunctionParser<Context>::store(Type memoryType) -> PartialResult
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer"_s);
 
-    if (m_info.memory(memoryIndex).isMemory64())
-        WASM_VALIDATOR_FAIL_IF(!pointer.type().isI64(), m_currentOpcode, " pointer type mismatch"_s);
-    else
-        WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), m_currentOpcode, " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), m_currentOpcode, " pointer type mismatch"_s);
 
     WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, m_currentOpcode, " value type mismatch"_s);
 
@@ -800,16 +793,23 @@ auto FunctionParser<Context>::atomicLoad(ExtAtomicOpType op, Type memoryType) ->
     WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
-    uint32_t offset;
+    uint64_t offset;
     TypedExpression pointer;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
     uint8_t memoryIndex;
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
+
+    if (m_info.memory(memoryIndex).isMemory64())
+        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
+    else {
+        uint32_t offset32;
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get load offset"_s);
+        offset = offset32;
+    }
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
 
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(atomicLoad(op, memoryType, pointer, result, offset, memoryIndex));
@@ -823,18 +823,25 @@ auto FunctionParser<Context>::atomicStore(ExtAtomicOpType op, Type memoryType) -
     WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
-    uint32_t offset;
+    uint64_t offset;
     TypedExpression value;
     TypedExpression pointer;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get store alignment"_s);
     uint8_t memoryIndex;
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get store offset"_s);
+    if (m_info.memory(memoryIndex).isMemory64())
+        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get store offset"_s);
+    else {
+        uint32_t offset32;
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get store offset"_s);
+        offset = offset32;
+    }
+
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), m_currentOpcode, " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), m_currentOpcode, " pointer type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, m_currentOpcode, " value type mismatch"_s);
 
     WASM_TRY_ADD_TO_CONTEXT(atomicStore(op, memoryType, pointer, value, offset, memoryIndex));
@@ -847,18 +854,24 @@ auto FunctionParser<Context>::atomicBinaryRMW(ExtAtomicOpType op, Type memoryTyp
     WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
-    uint32_t offset;
+    uint64_t offset;
     TypedExpression pointer;
     TypedExpression value;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
     uint8_t memoryIndex;
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
+    if (m_info.memory(memoryIndex).isMemory64())
+        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
+    else {
+        uint32_t offset32;
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get load offset"_s);
+        offset = offset32;
+    }
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch"_s);
 
     ExpressionType result;
@@ -873,7 +886,7 @@ auto FunctionParser<Context>::atomicCompareExchange(ExtAtomicOpType op, Type mem
     WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
-    uint32_t offset;
+    uint64_t offset;
     TypedExpression pointer;
     TypedExpression expected;
     TypedExpression value;
@@ -881,12 +894,18 @@ auto FunctionParser<Context>::atomicCompareExchange(ExtAtomicOpType op, Type mem
     uint8_t memoryIndex;
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment !=  memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
+    if (m_info.memory(memoryIndex).isMemory64())
+        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
+    else {
+        uint32_t offset32;
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get load offset"_s);
+        offset = offset32;
+    }
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(expected, "expected"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(expected.type() != memoryType, static_cast<unsigned>(op), " expected type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch"_s);
 
@@ -902,7 +921,7 @@ auto FunctionParser<Context>::atomicWait(ExtAtomicOpType op, Type memoryType) ->
     WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
-    uint32_t offset;
+    uint64_t offset;
     TypedExpression pointer;
     TypedExpression value;
     TypedExpression timeout;
@@ -910,12 +929,18 @@ auto FunctionParser<Context>::atomicWait(ExtAtomicOpType op, Type memoryType) ->
     uint8_t memoryIndex;
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
+    if (m_info.memory(memoryIndex).isMemory64())
+        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
+    else {
+        uint32_t offset32;
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get load offset"_s);
+        offset = offset32;
+    }
     WASM_TRY_POP_EXPRESSION_STACK_INTO(timeout, "timeout"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(!timeout.type().isI64(), static_cast<unsigned>(op), " timeout type mismatch"_s);
 
@@ -931,18 +956,24 @@ auto FunctionParser<Context>::atomicNotify(ExtAtomicOpType op) -> PartialResult
     WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
-    uint32_t offset;
+    uint64_t offset;
     TypedExpression pointer;
     TypedExpression count;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
     uint8_t memoryIndex;
     WASM_PARSER_FAIL_IF(!parseMemoryIndexAndFixupAlignment(alignment, memoryIndex), "can't get memory index");
     WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
+    if (m_info.memory(memoryIndex).isMemory64())
+        WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
+    else {
+        uint32_t offset32;
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset32), "can't get load offset"_s);
+        offset = offset32;
+    }
     WASM_TRY_POP_EXPRESSION_STACK_INTO(count, "count"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(pointer.type().kind != m_info.memory(memoryIndex).addressType().asWasmTypeKind(), static_cast<unsigned>(op), " pointer type mismatch"_s);
     WASM_VALIDATOR_FAIL_IF(!count.type().isI32(), static_cast<unsigned>(op), " count type mismatch"_s); // The spec's definition is saying i64, but all implementations (including tests) are using i32. So looks like the spec is wrong.
 
     ExpressionType result;

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -315,13 +315,13 @@ public:
 
     // Atomics
 
-    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t, uint8_t);
-    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t, uint8_t);
-    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t);
-    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t);
+    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint64_t, uint8_t);
+    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint64_t, uint8_t);
+    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint64_t, uint8_t);
+    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint64_t, uint8_t);
 
-    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t);
-    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t);
+    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint64_t, uint8_t);
+    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint64_t, uint8_t);
     [[nodiscard]] PartialResult atomicFence(ExtAtomicOpType, uint8_t);
 
     // Saturated truncation
@@ -1128,37 +1128,37 @@ IPIntGenerator::ExpressionType IPIntGenerator::addSIMDConstant(v128_t)
 
 // Atomics
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t, uint8_t)
+[[nodiscard]] PartialResult IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint64_t, uint8_t)
 {
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t, uint8_t)
+[[nodiscard]] PartialResult IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint64_t, uint8_t)
 {
     changeStackSize(-2);
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t)
+[[nodiscard]] PartialResult IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint64_t, uint8_t)
 {
     changeStackSize(-1);
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t, uint8_t)
+[[nodiscard]] PartialResult IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint64_t, uint8_t)
 {
     changeStackSize(-2);
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint64_t offset, uint8_t memoryIndex)
 {
     changeStackSize(-2);
     m_metadata->addAtomicMemoryAccess(memoryIndex, offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint64_t offset, uint8_t memoryIndex)
 {
     changeStackSize(-1);
     m_metadata->addAtomicMemoryAccess(memoryIndex, offset, getCurrentInstructionLength());

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -749,13 +749,13 @@ public:
     [[nodiscard]] PartialResult addDataDrop(unsigned);
 
     // Atomics
-    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType& result, uint32_t offset, uint8_t memoryIndex);
-    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, uint32_t offset, uint8_t memoryIndex);
-    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset, uint8_t memoryIndex);
-    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t offset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType& result, uint64_t offset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, uint64_t offset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint64_t offset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint64_t offset, uint8_t memoryIndex);
 
-    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t offset, uint8_t memoryIndex);
-    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint64_t offset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint64_t offset, uint8_t memoryIndex);
     [[nodiscard]] PartialResult atomicFence(ExtAtomicOpType, uint8_t flags);
 
     // Saturated truncation.
@@ -932,14 +932,14 @@ private:
     void emitWriteBarrier(Value* cell);
     Value* emitCheckAndPreparePointer(Value* pointer, uint64_t offset, uint32_t sizeOfOp, uint8_t memoryIndex);
     B3::Kind memoryKind(B3::Opcode memoryOp);
-    Value* emitLoadOp(LoadOpType, Value* pointer, uint32_t offset);
-    void emitStoreOp(StoreOpType, Value* pointer, Value*, uint32_t offset);
+    Value* emitLoadOp(LoadOpType, Value* pointer, uint64_t offset);
+    void emitStoreOp(StoreOpType, Value* pointer, Value*, uint64_t offset);
 
     Value* sanitizeAtomicResult(ExtAtomicOpType, Type, Value* result);
-    Value* emitAtomicLoadOp(ExtAtomicOpType, Type, Value* pointer, uint32_t offset);
-    void emitAtomicStoreOp(ExtAtomicOpType, Type, Value* pointer, Value*, uint32_t offset);
-    Value* emitAtomicBinaryRMWOp(ExtAtomicOpType, Type, Value* pointer, Value*, uint32_t offset);
-    Value* emitAtomicCompareExchange(ExtAtomicOpType, Type, Value* pointer, Value* expected, Value*, uint32_t offset);
+    Value* emitAtomicLoadOp(ExtAtomicOpType, Type, Value* pointer, uint64_t offset);
+    void emitAtomicStoreOp(ExtAtomicOpType, Type, Value* pointer, Value*, uint64_t offset);
+    Value* emitAtomicBinaryRMWOp(ExtAtomicOpType, Type, Value* pointer, Value*, uint64_t offset);
+    Value* emitAtomicCompareExchange(ExtAtomicOpType, Type, Value* pointer, Value* expected, Value*, uint64_t offset);
 
     void mutatorFence();
 
@@ -2591,7 +2591,7 @@ inline B3::Kind OMGIRGenerator::memoryKind(B3::Opcode memoryOp)
     return memoryOp;
 }
 
-inline Value* OMGIRGenerator::emitLoadOp(LoadOpType op, Value* pointer, uint32_t uoffset)
+inline Value* OMGIRGenerator::emitLoadOp(LoadOpType op, Value* pointer, uint64_t uoffset)
 {
     int32_t offset = fixupPointerPlusOffset(pointer, uoffset);
 
@@ -2751,7 +2751,7 @@ inline uint32_t sizeOfStoreOp(StoreOpType op)
 }
 
 
-inline void OMGIRGenerator::emitStoreOp(StoreOpType op, Value* pointer, Value* value, uint32_t uoffset)
+inline void OMGIRGenerator::emitStoreOp(StoreOpType op, Value* pointer, Value* value, uint64_t uoffset)
 {
     int32_t offset = fixupPointerPlusOffset(pointer, uoffset);
 
@@ -2864,7 +2864,7 @@ Value* OMGIRGenerator::fixupPointerPlusOffsetForAtomicOps(ExtAtomicOpType op, Va
     return pointer;
 }
 
-inline Value* OMGIRGenerator::emitAtomicLoadOp(ExtAtomicOpType op, Type valueType, Value* pointer, uint32_t uoffset)
+inline Value* OMGIRGenerator::emitAtomicLoadOp(ExtAtomicOpType op, Type valueType, Value* pointer, uint64_t uoffset)
 {
     pointer = fixupPointerPlusOffsetForAtomicOps(op, pointer, uoffset);
 
@@ -2889,11 +2889,15 @@ inline Value* OMGIRGenerator::emitAtomicLoadOp(ExtAtomicOpType op, Type valueTyp
     return sanitizeAtomicResult(op, valueType, atomic);
 }
 
-auto OMGIRGenerator::atomicLoad(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t offset, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::atomicLoad(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType& result, uint64_t offset, uint8_t memoryIndex) -> PartialResult
 {
-    ASSERT(pointer.type() == Int32);
+    ASSERT(pointer.type().kind() == m_info.memory(memoryIndex).addressType().asB3TypeKind());
 
-    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
+    const bool overflows = m_info.memory(memoryIndex).isMemory64()
+        ? sumOverflows<uint64_t>(offset, sizeOfAtomicOpMemoryAccess(op))
+        : sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op));
+
+    if (overflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -2919,7 +2923,7 @@ auto OMGIRGenerator::atomicLoad(ExtAtomicOpType op, Type valueType, ExpressionTy
     return { };
 }
 
-inline void OMGIRGenerator::emitAtomicStoreOp(ExtAtomicOpType op, Type valueType, Value* pointer, Value* value, uint32_t uoffset)
+inline void OMGIRGenerator::emitAtomicStoreOp(ExtAtomicOpType op, Type valueType, Value* pointer, Value* value, uint64_t uoffset)
 {
     pointer = fixupPointerPlusOffsetForAtomicOps(op, pointer, uoffset);
 
@@ -2930,11 +2934,14 @@ inline void OMGIRGenerator::emitAtomicStoreOp(ExtAtomicOpType op, Type valueType
     m_heaps.decorateFencedAccess(&m_heaps.WebAssemblyMemory, atomic);
 }
 
-auto OMGIRGenerator::atomicStore(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t offset, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::atomicStore(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, uint64_t offset, uint8_t memoryIndex) -> PartialResult
 {
-    ASSERT(pointer.type() == Int32);
+    ASSERT(pointer.type().kind() == m_info.memory(memoryIndex).addressType().asB3TypeKind());
+    const bool overflows = m_info.memory(memoryIndex).isMemory64()
+        ? sumOverflows<uint64_t>(offset, sizeOfAtomicOpMemoryAccess(op))
+        : sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op));
 
-    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
+    if (overflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -2948,7 +2955,7 @@ auto OMGIRGenerator::atomicStore(ExtAtomicOpType op, Type valueType, ExpressionT
     return { };
 }
 
-inline Value* OMGIRGenerator::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Value* pointer, Value* value, uint32_t uoffset)
+inline Value* OMGIRGenerator::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Value* pointer, Value* value, uint64_t uoffset)
 {
     pointer = fixupPointerPlusOffsetForAtomicOps(op, pointer, uoffset);
 
@@ -3022,11 +3029,15 @@ inline Value* OMGIRGenerator::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type val
     return sanitizeAtomicResult(op, valueType, atomic);
 }
 
-auto OMGIRGenerator::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint64_t offset, uint8_t memoryIndex) -> PartialResult
 {
-    ASSERT(pointer.type() == Int32);
+    ASSERT(pointer.type().kind() == m_info.memory(memoryIndex).addressType().asB3TypeKind());
 
-    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
+    const bool overflows = m_info.memory(memoryIndex).isMemory64()
+        ? sumOverflows<uint64_t>(offset, sizeOfAtomicOpMemoryAccess(op))
+        : sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op));
+
+    if (overflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -3052,7 +3063,7 @@ auto OMGIRGenerator::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, Express
     return { };
 }
 
-Value* OMGIRGenerator::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueType, Value* pointer, Value* expected, Value* value, uint32_t uoffset)
+Value* OMGIRGenerator::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueType, Value* pointer, Value* expected, Value* value, uint64_t uoffset)
 {
     pointer = fixupPointerPlusOffsetForAtomicOps(op, pointer, uoffset);
 
@@ -3135,11 +3146,15 @@ Value* OMGIRGenerator::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueT
     return fieldType.is<Type>() && isRefType(fieldType.unpacked());
 }
 
-auto OMGIRGenerator::atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t offset, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint64_t offset, uint8_t memoryIndex) -> PartialResult
 {
-    ASSERT(pointer.type() == Int32);
+    ASSERT(pointer.type().kind() == m_info.memory(memoryIndex).addressType().asB3TypeKind());
 
-    if (sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
+    const bool overflows = m_info.memory(memoryIndex).isMemory64()
+        ? sumOverflows<uint64_t>(offset, sizeOfAtomicOpMemoryAccess(op))
+        : sumOverflows<uint32_t>(offset, sizeOfAtomicOpMemoryAccess(op));
+
+    if (overflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -3165,7 +3180,7 @@ auto OMGIRGenerator::atomicCompareExchange(ExtAtomicOpType op, Type valueType, E
     return { };
 }
 
-auto OMGIRGenerator::atomicWait(ExtAtomicOpType op, ExpressionType pointerVar, ExpressionType valueVar, ExpressionType timeoutVar, ExpressionType& result, uint32_t offset, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::atomicWait(ExtAtomicOpType op, ExpressionType pointerVar, ExpressionType valueVar, ExpressionType timeoutVar, ExpressionType& result, uint64_t offset, uint8_t memoryIndex) -> PartialResult
 {
     Value* pointer = get(pointerVar);
     Value* value = get(valueVar);
@@ -3173,10 +3188,10 @@ auto OMGIRGenerator::atomicWait(ExtAtomicOpType op, ExpressionType pointerVar, E
     Value* resultValue = nullptr;
     if (op == ExtAtomicOpType::MemoryAtomicWait32) {
         resultValue = callWasmOperation(m_currentBlock, Int32, operationMemoryAtomicWait32,
-            instanceValue(), pointer, constant(Int32, offset), value, timeout, constant(Int32, memoryIndex));
+            instanceValue(), pointer, constant(Int64, offset), value, timeout, constant(Int32, memoryIndex));
     } else {
         resultValue = callWasmOperation(m_currentBlock, Int32, operationMemoryAtomicWait64,
-            instanceValue(), pointer, constant(Int32, offset), value, timeout, constant(Int32, memoryIndex));
+            instanceValue(), pointer, constant(Int64, offset), value, timeout, constant(Int32, memoryIndex));
     }
 
     {
@@ -3192,10 +3207,10 @@ auto OMGIRGenerator::atomicWait(ExtAtomicOpType op, ExpressionType pointerVar, E
     return { };
 }
 
-auto OMGIRGenerator::atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint32_t offset, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint64_t offset, uint8_t memoryIndex) -> PartialResult
 {
     Value* resultValue = callWasmOperation(m_currentBlock, Int32, operationMemoryAtomicNotify,
-        instanceValue(), get(pointer), constant(Int32, offset), get(count), constant(Int32, memoryIndex));
+        instanceValue(), get(pointer), constant(Int64, offset), get(count), constant(Int32, memoryIndex));
     {
         result = push(resultValue);
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1626,17 +1626,17 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableSize, UCPUStrictInt32, (J
     return toUCPUStrictInt32(tableSize(instance, tableIndex));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait32, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int32_t value, int64_t timeoutInNanoseconds, uint8_t memoryIndex))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait32, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t base, uint64_t offset, int32_t value, int64_t timeoutInNanoseconds, uint8_t memoryIndex))
 {
     return toUCPUStrictInt32(memoryAtomicWait32(instance, base, offset, value, timeoutInNanoseconds, memoryIndex));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait64, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int64_t value, int64_t timeoutInNanoseconds, uint8_t memoryIndex))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait64, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t base, uint64_t offset, int64_t value, int64_t timeoutInNanoseconds, uint8_t memoryIndex))
 {
     return toUCPUStrictInt32(memoryAtomicWait64(instance, base, offset, value, timeoutInNanoseconds, memoryIndex));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicNotify, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int32_t countValue, uint8_t memoryIndex))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicNotify, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t base, uint64_t offset, int32_t countValue, uint8_t memoryIndex))
 {
     return toUCPUStrictInt32(memoryAtomicNotify(instance, base, offset, countValue, memoryIndex));
 }

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -105,9 +105,9 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTableFill, UCPUStrictInt32, (JSW
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmTableCopy, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned dstTableIndex, unsigned srcTableIndex, int32_t dstOffset, int32_t srcOffset, int32_t length));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableSize, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned));
 
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait32, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int32_t value, int64_t timeout, uint8_t memoryIndex));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait64, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int64_t value, int64_t timeout, uint8_t memoryIndex));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicNotify, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned, unsigned, int32_t, uint8_t memoryIndex));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait32, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t base, uint64_t offset, int32_t value, int64_t timeout, uint8_t memoryIndex));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait64, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t base, uint64_t offset, int64_t value, int64_t timeout, uint8_t memoryIndex));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicNotify, UCPUStrictInt32, (JSWebAssemblyInstance*, uint64_t, uint64_t, int32_t, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned dataSegmentIndex, uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmDataDrop, void, (JSWebAssemblyInstance*, unsigned dataSegmentIndex));
 

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -778,9 +778,11 @@ inline int32_t memoryAtomicWait32(JSWebAssemblyInstance* instance, uint64_t offs
     return waitImpl<int32_t>(vm, pointer, value, timeoutInNanoseconds);
 }
 
-inline int32_t memoryAtomicWait32(JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int32_t value, int64_t timeoutInNanoseconds, uint8_t memoryIndex)
+inline int32_t memoryAtomicWait32(JSWebAssemblyInstance* instance, uint64_t base, uint64_t offset, int32_t value, int64_t timeoutInNanoseconds, uint8_t memoryIndex)
 {
-    return memoryAtomicWait32(instance, static_cast<uint64_t>(base) + offset, value, timeoutInNanoseconds, memoryIndex);
+    if (sumOverflows<uint64_t>(base, offset))
+        return -1;
+    return memoryAtomicWait32(instance, base + offset, value, timeoutInNanoseconds, memoryIndex);
 }
 
 inline int32_t memoryAtomicWait64(JSWebAssemblyInstance* instance, uint64_t offsetInMemory, int64_t value, int64_t timeoutInNanoseconds, uint8_t memoryIndex)
@@ -800,14 +802,18 @@ inline int32_t memoryAtomicWait64(JSWebAssemblyInstance* instance, uint64_t offs
     return waitImpl<int64_t>(vm, pointer, value, timeoutInNanoseconds);
 }
 
-inline int32_t memoryAtomicWait64(JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int64_t value, int64_t timeoutInNanoseconds, uint8_t memoryIndex)
+inline int32_t memoryAtomicWait64(JSWebAssemblyInstance* instance, uint64_t base, uint64_t offset, int64_t value, int64_t timeoutInNanoseconds, uint8_t memoryIndex)
 {
-    return memoryAtomicWait64(instance, static_cast<uint64_t>(base) + offset, value, timeoutInNanoseconds, memoryIndex);
+    if (sumOverflows<uint64_t>(base, offset))
+        return -1;
+    return memoryAtomicWait64(instance, base + offset, value, timeoutInNanoseconds, memoryIndex);
 }
 
-inline int32_t memoryAtomicNotify(JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int32_t countValue, uint8_t memoryIndex)
+inline int32_t memoryAtomicNotify(JSWebAssemblyInstance* instance, uint64_t base, uint64_t offset, int32_t countValue, uint8_t memoryIndex)
 {
-    uint64_t offsetInMemory = static_cast<uint64_t>(base) + offset;
+    if (sumOverflows<uint64_t>(base, offset))
+        return -1;
+    uint64_t offsetInMemory = base + offset;
     if (offsetInMemory & (0x4 - 1))
         return -1;
     if (memoryIndex >= instance->moduleInformation().memoryCount())


### PR DESCRIPTION
#### 7a12263d0ac4cf2ba35586a2b0805782b91e31e1
<pre>
Memory64 atomic operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=312826">https://bugs.webkit.org/show_bug.cgi?id=312826</a>
<a href="https://rdar.apple.com/175201149">rdar://175201149</a>

Reviewed by Keith Miller.

Add WebAssembly Memory64 support for atomic operations.

* JSTests/wasm/stress/memory64-atomics.js:
(assert.eq.clear):
(assert.eq):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicLoad):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAtomicLoadOp):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAtomicStoreOp):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::load):
(JSC::Wasm::FunctionParser&lt;Context&gt;::store):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicLoad):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicStore):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicBinaryRMW):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicCompareExchange):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicNotify):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::atomicLoad):
(JSC::Wasm::IPIntGenerator::atomicStore):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::atomicLoad):

Canonical link: <a href="https://commits.webkit.org/311812@main">https://commits.webkit.org/311812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/100770b63bb54a70771499496a89fb1b0f4be2bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166930 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/31575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31440 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161059 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/31575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103103 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/31575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/14702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/150152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/31575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169419 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/18936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/14773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/31184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130727 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35396 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/31122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141590 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/31122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190230 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30674 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/96207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48833 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/30195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->