### PR TITLE
[JSC] Fix hole-handling when rematerializing sunk double arrays

### DIFF
--- a/JSTests/stress/array-allocation-sink-double-hole-inline-materialization.js
+++ b/JSTests/stress/array-allocation-sink-double-hole-inline-materialization.js
@@ -1,0 +1,30 @@
+
+function test(i) {
+    let arr = new Array(4);
+    arr[0] = 1.1;
+    arr[2] = 3.3;
+    if (i & 1) arr[1] = 2.2;
+    arr[0] = i + 0.5;
+    // Escape on ~50% of iterations so the FTL compiles this as an inline
+    // materialization (not an OSR exit).
+    if (i & 2) return arr;
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let arr = test(i);
+    if (arr) {
+        // i & 2 is true. Check hole vs written depending on i & 1.
+        if (i & 1) {
+            // arr[1] was written
+            if (arr[1] !== 2.2)
+                throw new Error("expected 2.2 at i=" + i + ", got " + arr[1]);
+        } else {
+            // arr[1] is a hole
+            if (arr[1] !== undefined)
+                throw new Error("expected undefined at i=" + i + ", got " + arr[1]);
+            if (1 in arr)
+                throw new Error("expected hole at i=" + i);
+        }
+    }
+}

--- a/JSTests/stress/array-allocation-sink-double-hole-osr-exit.js
+++ b/JSTests/stress/array-allocation-sink-double-hole-osr-exit.js
@@ -1,0 +1,19 @@
+
+// Even iterations leave arr[1] as a hole. The loop needs enough iterations for
+// FTL allocation sinking to kick in; the break fires on an even iteration so
+// arr[1] is unwritten (a hole).
+let ftlV, ftlHas;
+let breakAt = testLoopCount - 2;
+if (breakAt % 2 !== 0) breakAt--;
+for (let i = 0; i < testLoopCount; i++) {
+    let arr = new Array(4);
+    arr[0] = 1.1;
+    arr[2] = 3.3;
+    if (i & 1) arr[1] = 2.2;
+    arr[0] = i + 0.5;
+    if (i === breakAt) { ftlV = arr[1]; ftlHas = 1 in arr; break; }
+}
+if (ftlV !== undefined)
+    throw new Error("expected undefined, got " + ftlV);
+if (ftlHas !== false)
+    throw new Error("expected false, got " + ftlHas);

--- a/JSTests/stress/array-allocation-sink-double-nan-not-hole.js
+++ b/JSTests/stress/array-allocation-sink-double-nan-not-hole.js
@@ -1,0 +1,27 @@
+
+function makeNaN() { return 0/0; }
+noInline(makeNaN);
+
+// The array escapes because writing NaN to a double array triggers a
+// double-to-contiguous conversion at runtime, which the DFG cannot sink.
+let result;
+let breakAt = testLoopCount - 1;
+if (breakAt % 2 !== 1) breakAt--;
+for (let i = 0; i < testLoopCount; i++) {
+    let arr = new Array(4);
+    arr[0] = 1.1;
+    arr[1] = 2.2;
+    arr[2] = 3.3;
+    if (i & 1) arr[1] = makeNaN();
+    arr[0] = i + 0.5;
+    if (i === breakAt) {
+        result = arr[1];
+        break;
+    }
+}
+// breakAt is odd, so arr[1] = makeNaN() was executed. The value should be NaN.
+if (!isNaN(result))
+    throw new Error("expected NaN, got " + result);
+// NaN is a value, not a hole, so 1 should be "in" arr.
+// (This array escaped the sinking phase due to the NaN write, so it is a
+// real runtime array and the in-operator checks its actual storage.)

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -98,7 +98,17 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
             JSValue value = JSValue::decode(values[i]);
             unsigned index = property.location().info();
 
-            array->putDirectIndex(globalObject, index, value);
+            // When a double array element's Phi resolves to PNaN (the hole default), the OSR exit
+            // compiler boxes it as jsNumber(NaN). To preserve hole semantics for double Arrays,
+            // store PNaN directly instead of going through putDirectIndex which would trigger a
+            // double-to-contiguous conversion. This is safe because values written to sunk double
+            // arrays use DoubleRepRealUse (proven non-NaN), so any NaN here must be the hole
+            // sentinel and is not user-visible.
+            if (hasDouble(array->indexingType()) && value.isNumber() && std::isnan(value.asNumber())) [[unlikely]]
+                array->butterfly()->contiguousDouble().atUnsafe(index) = PNaN;
+            else
+                array->putDirectIndex(globalObject, index, value);
+
             scope.assertNoExceptionExceptTermination();
         }
 


### PR DESCRIPTION
#### 289a55e3913bd4347d997fb7ed143d9a51baab30
<pre>
[JSC] Fix hole-handling when rematerializing sunk double arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=312664">https://bugs.webkit.org/show_bug.cgi?id=312664</a>
<a href="https://rdar.apple.com/175064220">rdar://175064220</a>

Reviewed by Keith Miller and Yijia Huang.

A double JS Array uses PNaN to represent holes. If such an array were sunk and
has holes, the PNaN can be boxed into a NaN JSValue if it flows into a Phi.
This manifests as an incorrect rematerialization where a hole appears as NaN.

This PR fixes it by special casing NaNs and directly writing the PNaN hole
value during rematerialization. This is safe to do as NaN element values that
appear during rematerialization are never user-visible. Further, the
non-rematerialization inline FTL paths are not affected as the Phis from sunk
array elements do not flow into user-visible results.

Tests: JSTests/stress/array-allocation-sink-double-hole-inline-materialization.js
       JSTests/stress/array-allocation-sink-double-hole-osr-exit.js
       JSTests/stress/array-allocation-sink-double-nan-not-hole.js

* JSTests/stress/array-allocation-sink-double-hole-inline-materialization.js: Added.
(test):
* JSTests/stress/array-allocation-sink-double-hole-osr-exit.js: Added.
* JSTests/stress/array-allocation-sink-double-nan-not-hole.js: Added.
(makeNaN):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/311962@main">https://commits.webkit.org/311962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4fc1e72c5eb2eb067c3d2d4beb42d314f7b8401

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166891 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112146 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122407 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85934 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103076 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23757 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22060 "Found 4 new API test failures: TestWebKitAPI.WKWebExtensionContext.TopLevelThrowInModuleBackground, TestWebKitAPI.WKWebExtensionContext.LoadNonExistentImage, TestWebKitAPI.WKWebExtensionContext.SyntaxErrorInBackground, TestWebKitAPI.WKWebExtensionContext.ReferenceErrorInBackground (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14664 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150114 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169381 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18898 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14735 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130579 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130694 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35483 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141538 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88980 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25429 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18344 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190192 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96169 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48826 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30157 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30387 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30284 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->