### PR TITLE
[Smart Lists] Use endash instead of emdash for smart dashed lists

### DIFF
--- a/Source/WebCore/editing/TextListParser.cpp
+++ b/Source/WebCore/editing/TextListParser.cpp
@@ -98,7 +98,7 @@ std::optional<TextList> tryConsumeUnorderedDiscTextList(StringParsingBuffer<Char
 template<typename Character>
 std::optional<TextList> tryConsumeUnorderedDashTextList(StringParsingBuffer<Character>& input)
 {
-    static constexpr std::array marker { WTF::Unicode::emDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace };
+    static constexpr std::array marker { WTF::Unicode::enDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace };
 
     if (WTF::skipExactly(input, WTF::Unicode::hyphenMinus)) {
         if (input.atEnd())
@@ -214,7 +214,7 @@ std::optional<TextList> parseTextList(StringView input)
     // The input is parsed to a TextList using these rules:
     //
     //  <U+002A | U+2022>EOF                        |= <U+2022>          (unordered, disc)
-    //  <U+2010>EOF                                 |= <U+2014  >        (unordered, dash)
+    //  <U+2010>EOF                                 |= <U+2013  >        (unordered, dash)
     //  <ordinal><U+002E | U+0029>EOF , ordinal > 0 |= <ordinal><U+002E> (ordered, start=ordinal)
     //  otherwise                                   |= invalid
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm
@@ -244,7 +244,7 @@ TEST(SmartLists, InsertingSpaceAndTextAfterBulletPointGeneratesListWithText)
 
 TEST(SmartLists, InsertingSpaceAndTextAfterHyphenGeneratesDashedList)
 {
-    auto marker = WTF::makeString(WTF::Unicode::emDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
+    auto marker = WTF::makeString(WTF::Unicode::enDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
 
     static constexpr auto expectedHTMLTemplate = R"""(
     <body contenteditable="">
@@ -360,7 +360,7 @@ TEST(SmartLists, InsertingSpaceAfterLargeNumberDoesNotGenerateOrderedList)
 
 TEST(SmartLists, InsertingDifferentListStylesDoesNotMergeLists)
 {
-    auto dashMarker = WTF::makeString(WTF::Unicode::emDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
+    auto dashMarker = WTF::makeString(WTF::Unicode::enDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
 
     static constexpr auto expectedHTMLTemplate = R"""(
     <body contenteditable="">


### PR DESCRIPTION
#### a4cc66ce1d238031bb69a5b648fe65c39c1b362a
<pre>
[Smart Lists] Use endash instead of emdash for smart dashed lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=312827">https://bugs.webkit.org/show_bug.cgi?id=312827</a>
<a href="https://rdar.apple.com/175194298">rdar://175194298</a>

Reviewed by Richard Robinson and Lily Spiniolas.

As the title says, we should use endash instead of emdash for
smart lists.

Update API tests that use emdash to endash.

* Source/WebCore/editing/TextListParser.cpp:
(WebCore::tryConsumeUnorderedDashTextList):
(WebCore::parseTextList):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm:
(InsertingSpaceAndTextAfterHyphenGeneratesDashedList)):
((SmartLists, InsertingDifferentListStylesDoesNotMergeLists)):

Canonical link: <a href="https://commits.webkit.org/311697@main">https://commits.webkit.org/311697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de036afa30da145e54fa0fa5e941ee08829a5777

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166409 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111667 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a73e4af0-5df0-4233-ba66-570fd559859b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122014 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85708 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99f30895-8b8c-4877-b9d8-36963f2ec0b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102683 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f87bd65-0853-4419-9578-18d439f20c13) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23348 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21622 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14180 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168898 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13330 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130181 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130293 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141113 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88444 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23986 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17918 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30157 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94498 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29679 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29909 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29806 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->