### PR TITLE
[CMake] Adopt CMP0157 to separate Swift compile and link phases

### DIFF
--- a/Tools/Scripts/swift/swiftc-wrapper.sh
+++ b/Tools/Scripts/swift/swiftc-wrapper.sh
@@ -7,17 +7,6 @@ set -e
 REAL_SWIFTC=swiftc
 args=()
 
-# Detect link mode: CMake passes -emit-library or -emit-executable for link steps.
-# In link mode, standalone -I flags (from CMake INCLUDES) must be wrapped with -Xcc
-# so the Clang importer sees them but they don't leak to ld as input files.
-# Joined -I<path> flags (from CMake FLAGS, e.g. Swift module search) are left as-is.
-is_link=
-for arg in "$@"; do
-    case "$arg" in
-        "-emit-library"|"-emit-executable") is_link=1; break ;;
-    esac
-done
-
 for arg in "$@"; do
     case "$arg" in
         "-mfpmath=sse") ;;
@@ -25,32 +14,11 @@ for arg in "$@"; do
         "-msse2") ;;
         "-pthread") ;;
         "-include") skip_next=1 ;;
-        # CMake passes -output-file-map to compile steps but also to the combined
-        # compile+link step. During linking, ld receives the .json as an input file.
-        # Only strip in link mode; compile-only steps need it.
-        "-output-file-map")
-            if [[ -n "$is_link" ]]; then
-                skip_next=1
-                output_file_map_next=1
-            else
-                args+=("$arg")
-            fi
-            ;;
-        "-emit-module-path")
-            args+=("$arg")
-            emit_module_path_next=1
-            ;;
-        # Standalone -I: CMake INCLUDES use "-I" "/path" as separate args.
-        # In link mode, wrap with -Xcc so the path goes to the Clang importer
-        # instead of leaking to ld (which tries to mmap directories as inputs).
-        "-I")
-            if [[ -n "$is_link" ]]; then
-                redirect_next_as_xcc_include=1
-            else
-                args+=("$arg")
-            fi
-            ;;
         # CMake leaks clang linker flags into swiftc; translate them.
+        "-compatibility_version"|"-current_version")
+            args+=("-Xlinker" "$arg")
+            skip_next_as_xlinker=1
+            ;;
         "-weak_framework")
             args+=("-Xlinker" "-weak_framework")
             skip_next_as_xlinker=1
@@ -67,21 +35,10 @@ for arg in "$@"; do
             ;;
         *)
             if [[ -n "$skip_next" ]]; then
-                if [[ -n "$output_file_map_next" ]]; then
-                    stripped_output_file_map="$arg"
-                    output_file_map_next=
-                fi
                 skip_next=
-            elif [[ -n "$emit_module_path_next" ]]; then
-                emit_module_path="$arg"
-                args+=("$arg")
-                emit_module_path_next=
             elif [[ -n "$skip_next_as_xlinker" ]]; then
                 args+=("-Xlinker" "$arg")
                 skip_next_as_xlinker=
-            elif [[ -n "$redirect_next_as_xcc_include" ]]; then
-                args+=("-Xcc" "-I$arg")
-                redirect_next_as_xcc_include=
             else
                 args+=("$arg")
             fi
@@ -89,27 +46,4 @@ for arg in "$@"; do
     esac
 done
 
-"$REAL_SWIFTC" "${args[@]}" || swiftc_status=$?
-swiftc_status=${swiftc_status:-0}
-
-# In the combined compile+link step, we strip -output-file-map to prevent ld
-# from receiving the .json as an input file.  However, without it swiftc in WMO
-# mode does not produce individual .o files that CMake's Ninja generator declares
-# as build outputs.  Touch the expected .o paths so Ninja does not consider the
-# rule perpetually out-of-date.  Also touch the .swiftmodule since swiftc may
-# skip writing it when content is unchanged.
-if [[ $swiftc_status -eq 0 && -n "$stripped_output_file_map" && -f "$stripped_output_file_map" ]]; then
-    python3 -c "
-import json, pathlib, sys
-with open(sys.argv[1]) as f:
-    for v in json.load(f).values():
-        o = v.get('object')
-        if o:
-            pathlib.Path(o).touch()
-" "$stripped_output_file_map" 2>/dev/null || true
-fi
-if [[ $swiftc_status -eq 0 && -n "$emit_module_path" && -f "$emit_module_path" ]]; then
-    touch "$emit_module_path" 2>/dev/null || true
-fi
-
-exit $swiftc_status
+exec "$REAL_SWIFTC" "${args[@]}"


### PR DESCRIPTION
#### 1f6f32f3174c2ff817718a4744bd6f1f444d8b60
<pre>
[CMake] Adopt CMP0157 to separate Swift compile and link phases
<a href="https://bugs.webkit.org/show_bug.cgi?id=312829">https://bugs.webkit.org/show_bug.cgi?id=312829</a>
<a href="https://rdar.apple.com/175201990">rdar://175201990</a>

Reviewed by Adrian Taylor.

Originally, CMake+Swift did compilation and linking as one giant combined thing.
That&apos;s not really a sustainable design because compilation and linking are
separate in myriad ways.

This patch adopts CMP0157, which separates Swift compilation and linking, when
building with Swift targets enabled,.

This patch does not upgrade the minimum CMake version (which would enable
CMP0157 by default) because some Linux users still build WebKit with an older
CMake version, and we don&apos;t want to disturb that workflow since we don&apos;t have
to.

* CMakeLists.txt: Adopt CMP0157 when building with Swift. Going forward, it&apos;s
  not going to be sustainable to do anything else.

* Source/cmake/OptionsMac.cmake: Disable WebXR by default because the build
  fails and WebXR is disabled in the Xcode build by default.

* Tools/Scripts/swift/swiftc-wrapper.sh: Pre-CMP0157, this was a workaround
  script that separated compiling and linking. Now we can nearly get rid of
  it -- except that we still need a small number of workarounds for cases
  where CMake passes flags in the wrong format.

Canonical link: <a href="https://commits.webkit.org/311677@main">https://commits.webkit.org/311677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9efc976dfa0e2df408d670f5e2cdfe64560e183

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111665 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eefdf89c-2927-46a7-a3f4-468a07a2b0b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122012 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85706 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ff0ff52-edee-49e9-9803-41bade54bfe9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102681 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e33b8b6-8963-4784-870f-ed3b26dcc325) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23347 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21620 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14178 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149634 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168896 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18418 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130180 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130292 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141111 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88442 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23979 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17916 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189656 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30155 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48678 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29677 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29907 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29804 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->