### PR TITLE
[JSC] Fix megamorphic IC ownProperty check

### DIFF
--- a/JSTests/stress/megamorphic-cache-super-property.js
+++ b/JSTests/stress/megamorphic-cache-super-property.js
@@ -1,0 +1,32 @@
+function makeProtoObject(val) {
+    let obj = { x: val };
+    Object.create(obj);
+    return obj;
+}
+
+let obj1 = makeProtoObject(42);
+let obj2 = makeProtoObject(100);
+
+function readProp(obj) { return obj.x; }
+noInline(readProp);
+
+// Drive readProp IC to megamorphic.
+for (let i = 0; i < 200; i++) { let o = { x: i }; o['w' + i] = i; Object.create(o); readProp(o); }
+for (let i = 0; i < 5000; i++) readProp(makeProtoObject(i));
+
+// Drive super accessor IC to megamorphic.
+class Base { readSuper() { return super.x; } }
+for (let i = 0; i < 200; i++) {
+    let p = { x: i }; p['s' + i] = i; Object.create(p);
+    Object.setPrototypeOf(Base.prototype, p);
+    new Base().readSuper();
+}
+
+// Access super.x through obj1, then read obj2.x via regular GetById.
+gc();
+Object.setPrototypeOf(Base.prototype, obj1);
+new Base().readSuper();
+
+let result = readProp(obj2);
+if (result !== 100)
+    throw new Error("Expected 100 but got " + result);

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -439,7 +439,7 @@ static ALWAYS_INLINE JSValue getByIdMegamorphic(JSGlobalObject* globalObject, VM
         if (hasProperty) {
             if (cacheable && slot.isCacheableValue() && slot.cachedOffset() <= MegamorphicCache::maxOffset) [[likely]] {
                 if (slot.slotBase() == baseObject || !baseObject->structure()->isDictionary())
-                    vm.megamorphicCache()->initAsHit(baseObject->structureID(), uid, slot.slotBase(), slot.cachedOffset(), slot.slotBase() == thisValue);
+                    vm.megamorphicCache()->initAsHit(baseObject->structureID(), uid, slot.slotBase(), slot.cachedOffset(), slot.slotBase() == baseValue);
                 else {
                     if (baseObject->structure()->hasBeenFlattenedBefore()) [[unlikely]] {
                         if (propertyCache && propertyCache->considerRepatchingCacheMegamorphic(vm))


### PR DESCRIPTION
#### 9b1a02808762de105ee583bfe81c8535d498bfe7
<pre>
[JSC] Fix megamorphic IC ownProperty check
<a href="https://bugs.webkit.org/show_bug.cgi?id=312681">https://bugs.webkit.org/show_bug.cgi?id=312681</a>
<a href="https://rdar.apple.com/175079685">rdar://175079685</a>

Reviewed by Yusuke Suzuki.

309095@main introduced a bug where megamorphic ICs&apos; ownProperty check was
changed from `slot.slotBase() == baseObject` to `slot.slotBase() == thisValue`.
This broke the IC for super property access and this PR fixes that by checking
against baseValue.

Note that for the String optimization from 309095@main, checking == baseObject
(i.e. reverting the == thisValue change) is incorrect. The intention is to make
the megamorphic IC load properties directly from String.prototype. baseObject
in the String case *is* String.prototype, so == baseObject would mark it as an
ownProperty, meaning the megamorphic IC would not go down the fast path of
loading directly from the prototype. baseValue, in contrast, is the String
itself.

Test: JSTests/stress/megamorphic-cache-super-property.js

* JSTests/stress/megamorphic-cache-super-property.js: Added.
(makeProtoObject):
(readProp):
(Base.prototype.readSuper):
(Base):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::getByIdMegamorphic):

Canonical link: <a href="https://commits.webkit.org/311692@main">https://commits.webkit.org/311692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ce2db3060bb86a55f13cd1fc6eab5ec988daa9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111690 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122034 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85722 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102703 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23367 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21645 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14203 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149659 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168921 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18443 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13373 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130201 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130314 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35319 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141146 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88467 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25131 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17951 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189681 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30180 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94551 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48685 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29702 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29932 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29829 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->