### PR TITLE
[macOS] accessibility/mac/client/absolute-position-iframe.html is a flaky text failure.

### DIFF
--- a/LayoutTests/accessibility/mac/client/absolute-position-iframe.html
+++ b/LayoutTests/accessibility/mac/client/absolute-position-iframe.html
@@ -45,12 +45,13 @@ if (window.accessibilityController) {
             return text;
         });
 
-        var pageOrigin = { x: webArea.x, y: webArea.y };
+        // Wait for frame geometry to be resolved before reading coordinates
+        await waitForFrameGeometryReady();
 
         // The text in the iframe is offset by (20, 30).
         await waitFor(() => {
-            textX = text.x - pageOrigin.x;
-            textY = text.y - pageOrigin.y;
+            textX = text.x - webArea.x;
+            textY = text.y - webArea.y;
             return textX == 120 && textY == 80;
         });
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2342,8 +2342,6 @@ webkit.org/b/306278 [ arm64 ] media/media-source/media-managedmse-resume-after-r
 
 webkit.org/b/306294 http/wpt/offscreen-canvas/transferToImageBitmap-webgl.html [ ImageOnlyFailure Pass ]
 
-webkit.org/b/312818 accessibility/mac/client/absolute-position-iframe.html [ Pass Failure ]
-
 webkit.org/b/309917 imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html [ ImageOnlyFailure Pass ]
 
 webkit.org/b/306570 [ Tahoe arm64 ] http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html [ Pass Failure ]


### PR DESCRIPTION
#### 720f36e269f6fe4bb101564dd82eae86da174307
<pre>
[macOS] accessibility/mac/client/absolute-position-iframe.html is a flaky text failure.
<a href="https://rdar.apple.com/175195447">rdar://175195447</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312818">https://bugs.webkit.org/show_bug.cgi?id=312818</a>

Reviewed by Joshua Hoffman.

This test fails flakily due to the test capturing default x and y
coordiniates. The root cause is commit 311369@main which changes
the order in which geometry is set - storeTree() now becomes visible
and sets geometry as pending(previously geometry was applied during creation).
This inherently adds a timing issue where x and y can grab the stale coordinates
since they are only grabbed once in the test.

Changed files (1):
    absolute-position-iframe.html - Add await waitForFrameGeometryReady()
    in order for webArea coordinates to settle. Remove var pageOrigin and
    instead continuously poll webArea.x and webArea.y in await waitFor.

* LayoutTests/accessibility/mac/client/absolute-position-iframe.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/311863@main">https://commits.webkit.org/311863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/870c3d28e59879e943a5b65237cf967d22da1a80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122455 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85969 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103124 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23785 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22132 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14726 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169443 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130637 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130752 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35433 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141606 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89042 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18412 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30698 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30219 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->