### PR TITLE
[macOS Debug] TestWebKitAPI.SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync is a flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
@@ -1633,12 +1633,7 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnore)
     EXPECT_WK_STREQ(testURL.get().absoluteString, finalURL);
 }
 
-// FIXME when webkit.org/b/312290 is resolved.
-#if PLATFORM(MAC) && !defined(NDEBUG)
-TEST(SOAuthorizationRedirect, DISABLED_SOAuthorizationLoadPolicyAllowAsync)
-#else
 TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)
-#endif
 {
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
@@ -2625,11 +2620,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
 
-    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
-    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setIsAsyncExecution:true];
@@ -2647,12 +2638,11 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
-    auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, "window.close();"_s).utf8(); // The pop up closes itself.
-    // The secret WKWebView needs to be destroyed right the way.
+    auto responseHtmlCString = generateHTML(newWindowResponseTemplate, "window.close();"_s).utf8();
     @autoreleasepool {
-        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.data() length:resonseHtmlCString.length()]).get()];
+        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:responseHtmlCString.data() length:responseHtmlCString.length()]).get()];
     }
-    Util::run(&allMessagesReceived);
+    [webView waitForMessagesUnordered:@[@"Hello.", @"WindowClosed."]];
 }
 
 


### PR DESCRIPTION
#### 1ac3c21646404d6a64af680c0b24a174677c3d5f
<pre>
[macOS Debug] TestWebKitAPI.SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync is a flaky failure
<a href="https://rdar.apple.com/174759296">rdar://174759296</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312290">https://bugs.webkit.org/show_bug.cgi?id=312290</a>

Reviewed by NOBODY (OOPS!).

Same race as SOAuthorizationPopUp.InterceptionSucceedCloseByItself (fixed in <a href="https://commits.webkit.org/310750@main">310750@main</a>):
the popup posts &quot;Hello.&quot; and calls window.close() synchronously, but the opener&apos;s 200ms
closed-window poll can fire before postMessage is delivered, so &quot;WindowClosed.&quot; arrives
before &quot;Hello.&quot; Use waitForMessagesUnordered: instead of ordered message expectations.

Also re-enable SOAuthorizationRedirect.SOAuthorizationLoadPolicyAllowAsync, which was
incorrectly disabled by the gardening in <a href="https://commits.webkit.org/311218@main">311218@main</a>.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ac3c21646404d6a64af680c0b24a174677c3d5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166421 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111679 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30936 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122023 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85713 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160555 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102692 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23381 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21641 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14192 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168910 "Built successfully") | | 
| | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20950 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 8 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130192 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130305 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141124 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88456 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17929 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30169 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29691 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29921 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29818 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->