### PR TITLE
[Scroll anchoring] Scroll anchoring interferes with rubberbanding on bbc.com pages

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-during-rubberband-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-during-rubberband-expected.txt
@@ -1,0 +1,6 @@
+PASS window.pageYOffset is -100
+PASS window.pageYOffset is -100
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-during-rubberband.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-during-rubberband.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+        
+        .changer {
+            background-color: cyan;
+            width: 300px;
+            height: 200px;
+            overflow-anchor: none;
+        }
+        
+        body.changed .changer {
+            height: 220px;
+        }
+
+        .anchor {
+            background-color: green;
+            width: 300px;
+            height: 300px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                internals.unconstrainedScrollTo(document.scrollingElement, 0, -100);
+
+            shouldBe('window.pageYOffset', '-100');
+            document.body.classList.add('changed');
+            shouldBe('window.pageYOffset', '-100');
+            
+            finishJSTest();
+        }, false);
+    </script>    
+</head>
+<body>
+    <div class="changer"></div>
+    <div class="anchor">
+    </div>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -580,7 +580,13 @@ void ScrollAnchoringController::updateBeforeLayout()
     }
 
     CheckedPtr scrollerBox = scrollableAreaBox();
-    if (!hasScrolledFromOriginInBlockDirection(m_owningScrollableArea->scrollPosition(), scrollerBox->writingMode())) {
+
+    auto scrollPosition = m_owningScrollableArea->scrollPosition();
+    auto isRubberBanding = [&]() {
+        return m_owningScrollableArea->constrainedScrollPosition(scrollPosition) != scrollPosition;
+    };
+
+    if (!hasScrolledFromOriginInBlockDirection(scrollPosition, scrollerBox->writingMode()) || isRubberBanding()) {
         clearAnchor();
         return;
     }


### PR DESCRIPTION
#### ea13c69a37999ef6f705d61dea5d6b10afa91182
<pre>
[Scroll anchoring] Scroll anchoring interferes with rubberbanding on bbc.com pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=312839">https://bugs.webkit.org/show_bug.cgi?id=312839</a>
<a href="https://rdar.apple.com/175195943">rdar://175195943</a>

Reviewed by Abrar Rahman Protyasha.

Prevent any scroll anchoring adjustments during rubberbanding, since they kill the
rubberband animation, and the user is in control at this point.

`ScrollAnchoringController::updateBeforeLayout()` detects rubberbanding by
simply comparing the constrained and unconstrained scroll positions.

Test: fast/scrolling/scroll-anchoring/scroll-anchoring-during-rubberband.html

* LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-during-rubberband-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-anchoring/scroll-anchoring-during-rubberband.html: Added.
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::updateBeforeLayout):

Canonical link: <a href="https://commits.webkit.org/311686@main">https://commits.webkit.org/311686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ff7a00cc138b43af4c4199da51a48621ca5e081

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166426 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111684 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122028 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85716 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141513 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102697 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23359 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21637 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14197 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168915 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13359 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130196 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130309 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35313 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141131 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88461 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25125 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17936 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30174 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94537 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29696 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29926 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29823 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->