### PR TITLE
Use protect() instead of Ref { } in WebXR code

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRFrame.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.cpp
@@ -229,7 +229,7 @@ ExceptionOr<RefPtr<WebXRViewerPose>> WebXRFrame::getViewerPose(const Document& d
             return TransformationMatrix::fromProjection(fov, aspect, near, far).toColumnMajorFloatArray();
         });
 
-        Ref xrView = WebXRView::create(Ref { *this }, view.eye, WTF::move(transform), Float32Array::create(projection.data(), projection.size()));
+        Ref xrView = WebXRView::create(protect(*this), view.eye, WTF::move(transform), Float32Array::create(projection.data(), projection.size()));
         xrView->setViewportModifiable(m_session->supportsViewportScaling());
 
         //  8.8. Append xrview to xrviews

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
@@ -133,7 +133,7 @@ void WebXRInputSource::pollEvents(Vector<Ref<XRInputSourceEvent>>& events)
         auto init = XRInputSourceEvent::Init {
             { false, false, false },
             WebXRFrame::create(*session, WebXRFrame::IsAnimationFrame::No),
-            Ref { *this }
+            protect(*this)
         };
         return XRInputSourceEvent::create(name, WTF::move(init));
     };

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -114,7 +114,7 @@ void WebXRInputSourceArray::update(double timestamp, const InputSourceList& inpu
         // 5. Set frame’s active boolean to false.
 
         for (Ref event : inputEvents) {
-            ActiveDOMObject::queueTaskKeepingObjectAlive(m_session, TaskSource::WebXR, [session = Ref { m_session }, event = WTF::move(event)](auto&) {
+            ActiveDOMObject::queueTaskKeepingObjectAlive(m_session, TaskSource::WebXR, [session = protect(m_session), event = WTF::move(event)](auto&) {
                 event->setFrameActive(true);
                 session->dispatchEvent(event.copyRef());
                 event->setFrameActive(false);

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -456,7 +456,7 @@ void WebXRSession::didCompleteShutdown()
 
     // From https://immersive-web.github.io/webxr/#shut-down-the-session
     // 7. Queue a task that fires an XRSessionEvent named end on session.
-    Ref event = XRSessionEvent::create(eventNames().endEvent, { { false, false, false }, Ref { *this } });
+    Ref event = XRSessionEvent::create(eventNames().endEvent, { { false, false, false }, protect(*this) });
     queueTaskToDispatchEvent(*this, TaskSource::WebXR, WTF::move(event));
 }
 
@@ -532,7 +532,7 @@ void WebXRSession::updateSessionVisibilityState(PlatformXR::VisibilityState visi
     // From https://immersive-web.github.io/webxr/#event-types
     // A user agent MUST dispatch a visibilitychange event on an XRSession each time the
     // visibility state of the XRSession has changed. The event MUST be of type XRSessionEvent.
-    Ref event = XRSessionEvent::create(eventNames().visibilitychangeEvent, { { false, false, false }, Ref { *this } });
+    Ref event = XRSessionEvent::create(eventNames().visibilitychangeEvent, { { false, false, false }, protect(*this) });
     queueTaskToDispatchEvent(*this, TaskSource::WebXR, WTF::move(event));
 }
 
@@ -638,7 +638,7 @@ void WebXRSession::requestFrameIfNeeded()
     if (!device)
         return;
     m_isDeviceFrameRequestPending = true;
-    device->requestFrame(WTF::move(m_requestData), [this, protectedThis = Ref { *this }](auto&& frameData) {
+    device->requestFrame(WTF::move(m_requestData), [this, protectedThis = protect(*this)](auto&& frameData) {
         m_isDeviceFrameRequestPending = false;
         onFrame(WTF::move(frameData));
     });
@@ -844,7 +844,7 @@ void WebXRSession::requestHitTestSource(const XRHitTestOptionsInit& init, Reques
     if (init.offsetRay)
         ray = PlatformXR::Ray { toFloatPoint3D(init.offsetRay->origin()), toFloatPoint3D(init.offsetRay->direction()) };
     PlatformXR::HitTestOptions options = { *WTF::move(maybeNativeOrigin), entityTypesFromOptions(init), WTF::move(ray) };
-    device->requestHitTestSource(options, [protectedThis = Ref { *this }, space = init.space, promise = WTF::move(promise)](ExceptionOr<PlatformXR::HitTestSource> exceptionOrSource) mutable {
+    device->requestHitTestSource(options, [protectedThis = protect(*this), space = init.space, promise = WTF::move(promise)](ExceptionOr<PlatformXR::HitTestSource> exceptionOrSource) mutable {
         if (exceptionOrSource.hasException()) {
             promise.reject(exceptionOrSource.releaseException());
             return;
@@ -879,7 +879,7 @@ void WebXRSession::requestHitTestSourceForTransientInput(const XRTransientInputH
     if (init.offsetRay)
         ray = PlatformXR::Ray { toFloatPoint3D(init.offsetRay->origin()), toFloatPoint3D(init.offsetRay->direction()) };
     PlatformXR::TransientInputHitTestOptions options = { init.profile, entityTypesFromOptions(init), WTF::move(ray) };
-    device->requestTransientInputHitTestSource(options, [protectedThis = Ref { *this }, promise = WTF::move(promise)](ExceptionOr<PlatformXR::TransientInputHitTestSource> exceptionOrSource) mutable {
+    device->requestTransientInputHitTestSource(options, [protectedThis = protect(*this), promise = WTF::move(promise)](ExceptionOr<PlatformXR::TransientInputHitTestSource> exceptionOrSource) mutable {
         if (exceptionOrSource.hasException()) {
             promise.reject(exceptionOrSource.releaseException());
             return;

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -105,7 +105,7 @@ void WebXRSystem::ensureImmersiveXRDeviceIsSelected(CompletionHandler<void()>&& 
     }
 
     bool isFirstXRDevicesEnumeration = !m_immersiveXRDevicesHaveBeenEnumerated;
-    document->page()->chrome().client().enumerateImmersiveXRDevices([this, protectedThis = Ref { *this }, isFirstXRDevicesEnumeration, callback = WTF::move(callback)](auto& immersiveXRDevices) mutable {
+    document->page()->chrome().client().enumerateImmersiveXRDevices([this, protectedThis = protect(*this), isFirstXRDevicesEnumeration, callback = WTF::move(callback)](auto& immersiveXRDevices) mutable {
         m_immersiveXRDevicesHaveBeenEnumerated = true;
 
         auto callbackOnExit = makeScopeExit([&]() {

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -586,7 +586,7 @@ ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLBinding::getSubImage(XRCompositionLayer
             subImage->setImageIndex(init.textureType == XRTextureType::TextureArray ? index : 0);
 
             if (layer.backing().allColorTexturesAreBound()) {
-                ActiveDOMObject::queueTaskKeepingObjectAlive(m_session.get(), TaskSource::WebXR, [layerRef = Ref { layer }](auto&) {
+                ActiveDOMObject::queueTaskKeepingObjectAlive(m_session.get(), TaskSource::WebXR, [layerRef = protect(layer)](auto&) {
                     layerRef->setNeedsRedraw(false);
                 });
             }

--- a/Source/WebCore/testing/WebXRTest.cpp
+++ b/Source/WebCore/testing/WebXRTest.cpp
@@ -64,7 +64,7 @@ static PlatformXR::Device::FeatureList parseFeatures(const Vector<JSC::JSValue>&
 void WebXRTest::simulateDeviceConnection(ScriptExecutionContext& context, const FakeXRDeviceInit& init, WebFakeXRDevicePromise&& promise)
 {
     // https://immersive-web.github.io/webxr-test-api/#dom-xrtest-simulatedeviceconnection
-    context.postTask([this, protectedThis = Ref { *this }, init, promise = WTF::move(promise)] (ScriptExecutionContext& context) mutable {
+    context.postTask([this, protectedThis = protect(*this), init, promise = WTF::move(promise)] (ScriptExecutionContext& context) mutable {
         auto device = WebFakeXRDevice::create();
         auto& simulatedDevice = device->simulatedXRDevice();
 

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
@@ -189,7 +189,7 @@ void PlatformXRSystemProxy::deref() const
 #if ENABLE(WEBXR_HIT_TEST)
 void PlatformXRSystemProxy::requestHitTestSource(const PlatformXR::HitTestOptions& options, CompletionHandler<void(WebCore::ExceptionOr<PlatformXR::HitTestSource>)>&& completionHandler)
 {
-    protect(m_page)->sendWithAsyncReply(Messages::PlatformXRSystem::RequestHitTestSource(options), [protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)](Expected<PlatformXR::HitTestSource, WebCore::ExceptionData> exceptionOrSource) mutable {
+    protect(m_page)->sendWithAsyncReply(Messages::PlatformXRSystem::RequestHitTestSource(options), [protectedThis = protect(*this), completionHandler = WTF::move(completionHandler)](Expected<PlatformXR::HitTestSource, WebCore::ExceptionData> exceptionOrSource) mutable {
         if (exceptionOrSource)
             completionHandler(WTF::move(exceptionOrSource).value());
         else
@@ -204,7 +204,7 @@ void PlatformXRSystemProxy::deleteHitTestSource(PlatformXR::HitTestSource source
 
 void PlatformXRSystemProxy::requestTransientInputHitTestSource(const PlatformXR::TransientInputHitTestOptions& options, CompletionHandler<void(WebCore::ExceptionOr<PlatformXR::TransientInputHitTestSource>)>&& completionHandler)
 {
-    protect(m_page)->sendWithAsyncReply(Messages::PlatformXRSystem::RequestTransientInputHitTestSource(options), [protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)](Expected<PlatformXR::TransientInputHitTestSource, WebCore::ExceptionData> exceptionOrSource) mutable {
+    protect(m_page)->sendWithAsyncReply(Messages::PlatformXRSystem::RequestTransientInputHitTestSource(options), [protectedThis = protect(*this), completionHandler = WTF::move(completionHandler)](Expected<PlatformXR::TransientInputHitTestSource, WebCore::ExceptionData> exceptionOrSource) mutable {
         if (exceptionOrSource)
             completionHandler(WTF::move(exceptionOrSource).value());
         else


### PR DESCRIPTION
#### 1c840423dadd667e15edaa641e936149dc163d64
<pre>
Use protect() instead of Ref { } in WebXR code
<a href="https://bugs.webkit.org/show_bug.cgi?id=312840">https://bugs.webkit.org/show_bug.cgi?id=312840</a>
<a href="https://rdar.apple.com/175206688">rdar://175206688</a>

Reviewed by Ryosuke Niwa.

Mechanical migration from Ref { expr } to protect(expr) across all WebXR
code, aligning with the codebase-wide transition away from brace-initialized
smart pointer temporaries.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/Modules/webxr/WebXRFrame.cpp:
(WebCore::WebXRFrame::views):
* Source/WebCore/Modules/webxr/WebXRInputSource.cpp:
(WebCore::WebXRInputSource::update):
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp:
(WebCore::WebXRInputSourceArray::update):
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::shutdown):
(WebCore::WebXRSession::visibilityStateChanged):
(WebCore::WebXRSession::requestAnimationFrame):
(WebCore::WebXRSession::requestHitTestSource):
(WebCore::WebXRSession::requestTransientInputHitTestSource):
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::ensureImmersiveXRDevicesAreEnumerated):
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
(WebCore::XRWebGLBinding::getSubImage):
* Source/WebCore/testing/WebXRTest.cpp:
(WebCore::WebXRTest::simulateDeviceConnection):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:
(WebKit::PlatformXRSystemProxy::requestHitTestSource):
(WebKit::PlatformXRSystemProxy::requestTransientInputHitTestSource):

Canonical link: <a href="https://commits.webkit.org/311690@main">https://commits.webkit.org/311690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bafe6ce7d98cc821935444ceeae98e7d7aefec44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111685 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122029 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85717 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102698 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23361 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21638 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14198 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168916 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13361 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130195 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130308 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35317 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141134 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88462 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17939 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30175 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94539 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29697 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29927 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29824 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->