### PR TITLE
[JSC] Intl.DateTimeFormat needs to keep original legacy [[TimeZone]] instead of primary IANA ID

### DIFF
--- a/JSTests/stress/intl-canonical-gmt.js
+++ b/JSTests/stress/intl-canonical-gmt.js
@@ -3,4 +3,4 @@ function shouldBe(actual, expected) {
         throw new Error('bad value: ' + actual);
 }
 
-shouldBe(new Intl.DateTimeFormat('en', { timeZone: "GMT" }).resolvedOptions().timeZone, "UTC")
+shouldBe(new Intl.DateTimeFormat('en', { timeZone: "GMT" }).resolvedOptions().timeZone, "GMT")

--- a/JSTests/stress/intl-canonical-iana-time-zone.js
+++ b/JSTests/stress/intl-canonical-iana-time-zone.js
@@ -1,8 +1,11 @@
 //@ skip if $hostOS == "windows" || $hostOS == "linux"
 //@ requireOptions("--useTemporal=1")
 // https://bugs.webkit.org/show_bug.cgi?id=310866
-// Linked time zones (IANA "Backward" file) must canonicalize to the IANA
-// primary identifier per https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier.
+// Per spec, Intl.DateTimeFormat.resolvedOptions().timeZone returns the
+// [[Identifier]] (case-normalized accepted form) — not [[PrimaryIdentifier]].
+// The canonicalization to the IANA primary still happens internally for ICU
+// formatting (so legacy aliases produce the same formatted output as their
+// primary), and it is observable through Temporal.TimeZone.id.
 
 function shouldBe(actual, expected) {
     if (actual !== expected)
@@ -16,26 +19,26 @@ function resolved(tz) {
     return new Intl.DateTimeFormat("en", { timeZone: tz }).resolvedOptions().timeZone;
 }
 
-// Backward links collapse onto IANA primary identifiers, regardless of the
-// caller's casing.
-shouldBe(resolved("Asia/Calcutta"), "Asia/Kolkata");
-shouldBe(resolved("asia/calcutta"), "Asia/Kolkata");
+// resolvedOptions().timeZone preserves the accepted identifier (case-normalized)
+// rather than collapsing onto the IANA primary.
+shouldBe(resolved("Asia/Calcutta"), "Asia/Calcutta");
+shouldBe(resolved("asia/calcutta"), "Asia/Calcutta");
 shouldBe(resolved("Asia/Kolkata"), "Asia/Kolkata");
 
-shouldBe(resolved("America/Buenos_Aires"), "America/Argentina/Buenos_Aires");
+shouldBe(resolved("America/Buenos_Aires"), "America/Buenos_Aires");
 shouldBe(resolved("America/Argentina/Buenos_Aires"), "America/Argentina/Buenos_Aires");
 
-shouldBe(resolved("Europe/Kiev"), "Europe/Kyiv");
+shouldBe(resolved("Europe/Kiev"), "Europe/Kiev");
 shouldBe(resolved("Europe/Kyiv"), "Europe/Kyiv");
 
-// UTC-equivalent zones normalize to "UTC", overriding IANA's "Etc/UTC" primary.
+// UTC-equivalent names are likewise preserved as the accepted identifier.
 shouldBe(resolved("UTC"), "UTC");
-shouldBe(resolved("Etc/UTC"), "UTC");
-shouldBe(resolved("GMT"), "UTC");
-shouldBe(resolved("Etc/GMT"), "UTC");
-shouldBe(resolved("Universal"), "UTC");
-shouldBe(resolved("Zulu"), "UTC");
-shouldBe(resolved("Greenwich"), "UTC");
+shouldBe(resolved("Etc/UTC"), "Etc/UTC");
+shouldBe(resolved("GMT"), "GMT");
+shouldBe(resolved("Etc/GMT"), "Etc/GMT");
+shouldBe(resolved("Universal"), "Universal");
+shouldBe(resolved("Zulu"), "Zulu");
+shouldBe(resolved("Greenwich"), "Greenwich");
 
 // Intl.supportedValuesOf("timeZone") exposes IANA primary identifiers, not the
 // older CLDR canonical aliases.
@@ -73,8 +76,6 @@ for (const t of [summer, winter]) {
 }
 
 // Concern (2): Legacy non-primary IANA names must still be accepted as input.
-// Internally JSC canonicalizes to the primary, but rejection would be a
-// compatibility regression.
 const legacy = [
     "Asia/Calcutta", "America/Buenos_Aires", "Europe/Kiev", "Asia/Katmandu",
     "US/Pacific", "US/Eastern", "GB", "Brazil/East", "Canada/Eastern",
@@ -87,7 +88,8 @@ for (const tz of legacy) {
 }
 
 // Temporal.TimeZone uses the same hashmap-backed TimeZoneID lookup as Intl, so
-// legacy aliases must also be accepted there and resolve to the same primary.
+// legacy aliases must also be accepted there. Unlike Intl.DateTimeFormat,
+// Temporal.TimeZone.id surfaces the canonicalized primary identifier.
 if (typeof Temporal !== "undefined") {
     const pairs = [
         ["Asia/Calcutta",          "Asia/Kolkata"],

--- a/JSTests/stress/intl-datetimeformat.js
+++ b/JSTests/stress/intl-datetimeformat.js
@@ -253,33 +253,35 @@ shouldBe(Intl.DateTimeFormat('en', { timeZone: 'AMERICA/LOS_ANGELES' }).resolved
 // Default time zone is a valid canonical time zone.
 shouldBe(Intl.DateTimeFormat('en', { timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone }).resolvedOptions().timeZone, Intl.DateTimeFormat().resolvedOptions().timeZone);
 
-// Linked time zones canonicalize to their IANA primary zone identifier.
-// https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/ACT' }).resolvedOptions().timeZone, 'Australia/Sydney');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/North' }).resolvedOptions().timeZone, 'Australia/Darwin');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/South' }).resolvedOptions().timeZone, 'Australia/Adelaide');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/West' }).resolvedOptions().timeZone, 'Australia/Perth');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/East' }).resolvedOptions().timeZone, 'America/Sao_Paulo');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/West' }).resolvedOptions().timeZone, 'America/Manaus');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Atlantic' }).resolvedOptions().timeZone, 'America/Halifax');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Central' }).resolvedOptions().timeZone, 'America/Winnipeg');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Eastern' }).resolvedOptions().timeZone, 'America/Toronto');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Mountain' }).resolvedOptions().timeZone, 'America/Edmonton');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Pacific' }).resolvedOptions().timeZone, 'America/Vancouver');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GB' }).resolvedOptions().timeZone, 'Europe/London');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT+0' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT-0' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT0' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Greenwich' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'UCT' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Central' }).resolvedOptions().timeZone, 'America/Chicago');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Eastern' }).resolvedOptions().timeZone, 'America/New_York');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Michigan' }).resolvedOptions().timeZone, 'America/Detroit');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Mountain' }).resolvedOptions().timeZone, 'America/Denver');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Pacific' }).resolvedOptions().timeZone, 'America/Los_Angeles');
+// Time zone identifier is preserved (case-normalized) in resolvedOptions.
+// Per spec, resolvedOptions().timeZone returns [[Identifier]] (the accepted
+// form), not [[PrimaryIdentifier]]. The canonicalization to the IANA primary
+// happens internally for ICU formatting.
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/ACT' }).resolvedOptions().timeZone, 'Australia/ACT');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/North' }).resolvedOptions().timeZone, 'Australia/North');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/South' }).resolvedOptions().timeZone, 'Australia/South');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Australia/West' }).resolvedOptions().timeZone, 'Australia/West');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/East' }).resolvedOptions().timeZone, 'Brazil/East');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Brazil/West' }).resolvedOptions().timeZone, 'Brazil/West');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Atlantic' }).resolvedOptions().timeZone, 'Canada/Atlantic');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Central' }).resolvedOptions().timeZone, 'Canada/Central');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Eastern' }).resolvedOptions().timeZone, 'Canada/Eastern');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Mountain' }).resolvedOptions().timeZone, 'Canada/Mountain');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Canada/Pacific' }).resolvedOptions().timeZone, 'Canada/Pacific');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GB' }).resolvedOptions().timeZone, 'GB');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT+0' }).resolvedOptions().timeZone, 'GMT+0');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT-0' }).resolvedOptions().timeZone, 'GMT-0');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'GMT0' }).resolvedOptions().timeZone, 'GMT0');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Greenwich' }).resolvedOptions().timeZone, 'Greenwich');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'UCT' }).resolvedOptions().timeZone, 'UCT');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Central' }).resolvedOptions().timeZone, 'US/Central');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Eastern' }).resolvedOptions().timeZone, 'US/Eastern');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Michigan' }).resolvedOptions().timeZone, 'US/Michigan');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Mountain' }).resolvedOptions().timeZone, 'US/Mountain');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'US/Pacific' }).resolvedOptions().timeZone, 'US/Pacific');
 shouldBe(Intl.DateTimeFormat('en', { timeZone: 'UTC' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Universal' }).resolvedOptions().timeZone, 'UTC');
-shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Zulu' }).resolvedOptions().timeZone, 'UTC');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Universal' }).resolvedOptions().timeZone, 'Universal');
+shouldBe(Intl.DateTimeFormat('en', { timeZone: 'Zulu' }).resolvedOptions().timeZone, 'Zulu');
 
 // Timezone-sensitive format().
 shouldBe(Intl.DateTimeFormat('en', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/2015');

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -713,23 +713,30 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         RETURN_IF_EXCEPTION(scope, void());
     }
     TimeZone tz;
+    String tzForResolvedOptions;
     if (!tzValue.isUndefined()) {
         String originalTz = tzValue.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, void());
-        if (auto minutesValue = ISO8601::parseUTCOffsetInMinutes(originalTz))
-            tz = TimeZone::fromUTCOffset(minutesValue.value() * 60LL * 1000 * 1000 * 1000);
-        else if (auto id = intlResolveTimeZoneID(originalTz))
-            tz = TimeZone::fromID(id.value());
-        else {
+        if (auto minutesValue = ISO8601::parseUTCOffsetInMinutes(originalTz)) {
+            int64_t nanoseconds = minutesValue.value() * 60LL * 1000 * 1000 * 1000;
+            tz = TimeZone::fromUTCOffset(nanoseconds);
+            tzForResolvedOptions = ISO8601::formatTimeZoneOffsetString(nanoseconds);
+        } else if (auto resolved = intlAvailableNamedTimeZone(originalTz)) {
+            tz = TimeZone::fromID(resolved->id);
+            tzForResolvedOptions = resolved->identifier;
+        } else {
             String message = tryMakeString("invalid time zone: "_s, originalTz);
             if (!message)
                 message = "invalid time zone"_s;
             throwRangeError(globalObject, scope, message);
             return;
         }
-    } else
+    } else {
         tz = vm.dateCache.defaultTimeZone();
+        tzForResolvedOptions = tz.toString();
+    }
     m_timeZone = tz;
+    m_timeZoneForResolvedOptions = WTF::move(tzForResolvedOptions);
 
     Weekday weekday = intlOption<Weekday>(globalObject, options, vm.propertyNames->weekday, { { "narrow"_s, Weekday::Narrow }, { "short"_s, Weekday::Short }, { "long"_s, Weekday::Long } }, "weekday must be \"narrow\", \"short\", or \"long\""_s, Weekday::None);
     RETURN_IF_EXCEPTION(scope, void());
@@ -1149,7 +1156,7 @@ JSObject* IntlDateTimeFormat::resolvedOptions(JSGlobalObject* globalObject) cons
     options->putDirect(vm, vm.propertyNames->locale, jsNontrivialString(vm, m_locale));
     options->putDirect(vm, vm.propertyNames->calendar, jsNontrivialString(vm, m_calendar));
     options->putDirect(vm, vm.propertyNames->numberingSystem, jsNontrivialString(vm, m_numberingSystem));
-    options->putDirect(vm, vm.propertyNames->timeZone, jsNontrivialString(vm, m_timeZone.toString()));
+    options->putDirect(vm, vm.propertyNames->timeZone, jsNontrivialString(vm, m_timeZoneForResolvedOptions));
 
     if (m_hourCycle != HourCycle::None) {
         options->putDirect(vm, vm.propertyNames->hourCycle, jsNontrivialString(vm, hourCycleString(m_hourCycle)));

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -135,6 +135,12 @@ private:
     String m_calendar;
     String m_numberingSystem;
     TimeZone m_timeZone;
+    // Time zone string returned by resolvedOptions().timeZone. Per spec this is
+    // [[Identifier]] (the case-normalized accepted form, e.g. "Asia/Calcutta"),
+    // not [[PrimaryIdentifier]] (e.g. "Asia/Kolkata"). For UTC offset inputs
+    // this is the canonical "+HH:MM" form. m_timeZone holds the canonicalized
+    // primary used for ICU formatting.
+    String m_timeZoneForResolvedOptions;
     HourCycle m_hourCycle { HourCycle::None };
     Weekday m_weekday { Weekday::None };
     Era m_era { Era::None };

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -2073,13 +2073,13 @@ std::optional<TimeZoneID> intlResolveTimeZoneID(StringView name)
     return entry->value;
 }
 
-// https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier
-String availableNamedTimeZoneIdentifier(StringView timeZoneName)
+std::optional<AvailableNamedTimeZone> intlAvailableNamedTimeZone(StringView name)
 {
-    auto id = intlResolveTimeZoneID(timeZoneName);
-    if (!id)
-        return String();
-    return intlTimeZoneIDToString(*id);
+    const auto& index = intlAvailableTimeZoneIndex();
+    auto entry = index.find<ASCIICaseInsensitiveStringViewHashTranslator>(name);
+    if (entry == index.end())
+        return std::nullopt;
+    return AvailableNamedTimeZone { entry->value, entry->key };
 }
 
 String TimeZone::toString() const

--- a/Source/JavaScriptCore/runtime/IntlObject.h
+++ b/Source/JavaScriptCore/runtime/IntlObject.h
@@ -123,18 +123,22 @@ inline CalendarID iso8601CalendarID()
 // forms collapse to the same TimeZoneID.
 JS_EXPORT_PRIVATE std::optional<TimeZoneID> intlResolveTimeZoneID(StringView);
 
+// Same lookup as intlResolveTimeZoneID, but additionally returns the
+// case-normalized accepted identifier (the [[Identifier]] in spec terms — for
+// Backward links such as "Asia/Calcutta" this is "Asia/Calcutta", not the
+// primary "Asia/Kolkata"). The identifier is an immortal static string.
+struct AvailableNamedTimeZone {
+    TimeZoneID id;
+    String identifier;
+};
+JS_EXPORT_PRIVATE std::optional<AvailableNamedTimeZone> intlAvailableNamedTimeZone(StringView);
+
 // Map a known-valid IANA time zone ID to its primary IANA zone identifier,
 // using ICU 74's ucal_getIanaTimeZoneID when available and falling back to
 // ucal_getCanonicalTimeZoneID otherwise. UTC-equivalent zones are normalized
 // to "UTC" per ECMA-402.
 JS_EXPORT_PRIVATE String toPrimaryIanaTimeZoneIdentifier(std::span<const char16_t> timeZone);
 JS_EXPORT_PRIVATE String toPrimaryIanaTimeZoneIdentifier(StringView timeZone);
-
-// https://tc39.es/ecma402/#sec-getavailablenamedtimezoneidentifier
-// Look up timeZoneName case-insensitively against ICU's full time zone list
-// (canonical + Backward links) and return the matched zone's IANA primary
-// identifier, or a null String if the name is not a recognized IANA zone.
-JS_EXPORT_PRIVATE String availableNamedTimeZoneIdentifier(StringView timeZoneName);
 
 TriState intlBooleanOption(JSGlobalObject*, JSObject* options, PropertyName);
 String intlStringOption(JSGlobalObject*, JSObject* options, PropertyName, std::initializer_list<ASCIILiteral> values, ASCIILiteral notFound, ASCIILiteral fallback);


### PR DESCRIPTION
#### 239255f394a297fc03bedd089814c8ed11207085
<pre>
[JSC] Intl.DateTimeFormat needs to keep original legacy [[TimeZone]] instead of primary IANA ID
<a href="https://bugs.webkit.org/show_bug.cgi?id=312841">https://bugs.webkit.org/show_bug.cgi?id=312841</a>
<a href="https://rdar.apple.com/175206605">rdar://175206605</a>

Reviewed by Sosuke Suzuki.

From Time Zone Canonicalization proposal[1], we need to keep
[[TimeZone]] pointing at the non primary ID when it is an input.
This patch fixes the changes so that it behaves as specified.

[1]: <a href="https://github.com/tc39/proposal-canonical-tz">https://github.com/tc39/proposal-canonical-tz</a>

* JSTests/stress/intl-canonical-gmt.js:
* JSTests/stress/intl-canonical-iana-time-zone.js:
* JSTests/stress/intl-datetimeformat.js:
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):
(JSC::IntlDateTimeFormat::resolvedOptions const):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.h:
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::intlAvailableNamedTimeZone):
(JSC::availableNamedTimeZoneIdentifier): Deleted.
* Source/JavaScriptCore/runtime/IntlObject.h:

Canonical link: <a href="https://commits.webkit.org/311724@main">https://commits.webkit.org/311724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/066fd46196b08420281b9704619f6cc619f22058

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166609 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122177 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24473 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102846 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14380 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149836 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169098 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18620 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13813 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130346 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25878 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130463 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88654 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23998 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18110 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189913 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30358 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95135 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48769 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29879 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30109 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30006 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->