### PR TITLE
Remove a few compilation guards from test files that are no longer needed

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift
@@ -21,9 +21,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-// FIXME: Remove !SWIFT_WEBKIT_TOOLCHAIN once Swift toolchain is fixed (see webkit.org/b/307344).
-#if canImport(Testing) && !SWIFT_WEBKIT_TOOLCHAIN
-
 import Testing
 import WebKit
 
@@ -45,5 +42,3 @@ struct WKWebViewSwiftOverlayTests {
         #expect(response == nil)
     }
 }
-
-#endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift
@@ -21,8 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-// FIXME: Remove !SWIFT_WEBKIT_TOOLCHAIN once Swift toolchain is fixed (see webkit.org/b/307344).
-#if ENABLE_SWIFTUI && canImport(Testing) && !SWIFT_WEBKIT_TOOLCHAIN
+#if ENABLE_SWIFTUI
 
 import Testing
 import WebKit
@@ -210,4 +209,4 @@ struct URLSchemeHandlerTests {
     }
 }
 
-#endif
+#endif // ENABLE_SWIFTUI

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift
@@ -21,8 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-// FIXME: Remove !SWIFT_WEBKIT_TOOLCHAIN once Swift toolchain is fixed (see webkit.org/b/307344).
-#if ENABLE_SWIFTUI && canImport(Testing) && !SWIFT_WEBKIT_TOOLCHAIN
+#if ENABLE_SWIFTUI
 
 import Testing
 @_spi(Testing) import WebKit
@@ -165,4 +164,4 @@ struct WebPageNavigationTests {
     }
 }
 
-#endif // ENABLE_SWIFTUI && canImport(Testing) && !SWIFT_WEBKIT_TOOLCHAIN
+#endif // ENABLE_SWIFTUI

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -21,8 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-// FIXME: Remove !SWIFT_WEBKIT_TOOLCHAIN once Swift toolchain is fixed (see webkit.org/b/307344).
-#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2) && !SWIFT_WEBKIT_TOOLCHAIN
+#if ENABLE_SWIFTUI
 
 import SwiftUI
 import Observation
@@ -137,4 +136,4 @@ struct WebPageTests {
     }
 }
 
-#endif
+#endif // ENABLE_SWIFTUI

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTransferableTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTransferableTests.swift
@@ -21,8 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-// FIXME: Remove !SWIFT_WEBKIT_TOOLCHAIN once Swift toolchain is fixed (see webkit.org/b/307344).
-#if ENABLE_SWIFTUI && canImport(Testing) && !SWIFT_WEBKIT_TOOLCHAIN
+#if ENABLE_SWIFTUI
 
 import Testing
 @_spi(Testing) import WebKit
@@ -185,4 +184,4 @@ struct WebPageTransferableTests {
     }
 }
 
-#endif // ENABLE_SWIFTUI && canImport(Testing) && !SWIFT_WEBKIT_TOOLCHAIN
+#endif // ENABLE_SWIFTUI


### PR DESCRIPTION
#### 5f516fcc0c7004f7db4825a88b87d4e728871de2
<pre>
Remove a few compilation guards from test files that are no longer needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=312844">https://bugs.webkit.org/show_bug.cgi?id=312844</a>
<a href="https://rdar.apple.com/175215199">rdar://175215199</a>

Reviewed by Abrar Rahman Protyasha.

These aren&apos;t needed anymore since Safer CPP no longer builds TestWebKitAPI

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTransferableTests.swift:

Canonical link: <a href="https://commits.webkit.org/311693@main">https://commits.webkit.org/311693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b06ada412989f30090a6bf56ffcb8efcc3082bf9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111706 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122047 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85728 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141531 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102716 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23382 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21662 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14219 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149675 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133061 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168937 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130214 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130329 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35320 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88483 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17953 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30196 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29718 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29948 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29845 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->