### PR TITLE
Tiktok.com: Unable to drag volume slider in video's media control.

### DIFF
--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -115,7 +115,8 @@ public:
     static Ref<MouseEvent> create(const AtomString& eventType, const MouseEventInit&);
 
 #if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
-    static Ref<MouseEvent> create(const PlatformTouchEvent&, unsigned touchIndex, Ref<WindowProxy>&&, IsCancelable = IsCancelable::Yes);
+    enum class ShouldComputeMovementDelta : bool { No, Yes };
+    static Ref<MouseEvent> create(const PlatformTouchEvent&, unsigned touchIndex, Ref<WindowProxy>&&, IsCancelable = IsCancelable::Yes, ShouldComputeMovementDelta = ShouldComputeMovementDelta::No);
 #endif
 
     virtual ~MouseEvent();

--- a/Source/WebCore/dom/ios/MouseEventIOS.cpp
+++ b/Source/WebCore/dom/ios/MouseEventIOS.cpp
@@ -48,8 +48,31 @@ static AtomString mouseEventType(PlatformTouchPoint::TouchPhaseType phase)
     return nullAtom();
 }
 
-Ref<MouseEvent> MouseEvent::create(const PlatformTouchEvent& event, unsigned index, Ref<WindowProxy>&& view, IsCancelable cancelable)
+static DoublePoint computeMovementDelta(const PlatformTouchEvent& event, unsigned index)
 {
+    const auto phase = event.touchPhaseAtIndex(index);
+
+    switch (phase) {
+    case PlatformTouchPoint::TouchPhaseBegan:
+        return { };
+    case PlatformTouchPoint::TouchPhaseMoved:
+    case PlatformTouchPoint::TouchPhaseStationary: {
+        auto currentPosition = event.touchLocationInRootViewAtIndex(index);
+        auto previousPosition = event.touchPreviousLocationInRootViewAtIndex(index);
+        return DoublePoint { currentPosition - previousPosition };
+    }
+    case PlatformTouchPoint::TouchPhaseEnded:
+    case PlatformTouchPoint::TouchPhaseCancelled:
+        return { };
+    }
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+Ref<MouseEvent> MouseEvent::create(const PlatformTouchEvent& event, unsigned index, Ref<WindowProxy>&& view, IsCancelable cancelable, ShouldComputeMovementDelta shouldComputeMovementDelta)
+{
+    const auto movementDelta = shouldComputeMovementDelta == ShouldComputeMovementDelta::Yes ? computeMovementDelta(event, index) : DoublePoint { };
+
     return adoptRef(
         *new MouseEvent(
             EventInterfaceType::MouseEvent,
@@ -62,8 +85,8 @@ Ref<MouseEvent> MouseEvent::create(const PlatformTouchEvent& event, unsigned ind
             0,
             event.touchLocationInRootViewAtIndex(index),
             event.touchLocationInRootViewAtIndex(index),
-            0,
-            0,
+            movementDelta.x(),
+            movementDelta.y(),
             event.modifiers(),
             MouseButton::Left,
             0,

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -499,7 +499,10 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
         // facebook.com rdar://174179871
         if (m_quirksData.isFacebook)
-            return QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetForFacebook;
+            return QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetWithSliderRole;
+        // tiktok.com rdar://174179805
+        if (m_quirksData.isTikTok)
+            return QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetWithSliderRole;
 
         const URL& topDocumentURL = this->topDocumentURL();
         const auto registrableDomainString = RegistrableDomain(topDocumentURL).string();
@@ -547,7 +550,7 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
     case QuirksData::ShouldDispatchSimulatedMouseEvents::No:
         return false;
 
-    case QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetForFacebook:
+    case QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetWithSliderRole:
         for (RefPtr node = dynamicDowncast<Node>(target); node; node = node->parentNode()) {
             if (RefPtr element = dynamicDowncast<Element>(*node); element && element->attributeWithoutSynchronization(HTMLNames::roleAttr) == "slider"_s)
                 return true;
@@ -598,7 +601,19 @@ bool Quirks::shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented(EventTar
     if (m_quirksData.isSoundCloud)
         return element->hasClassName("sceneLayer"_s);
 
+    // facebook.com rdar://174179871 tiktok.com rdar://174179805
+    if (m_quirksData.isFacebook || m_quirksData.isTikTok)
+        return element->attributeWithoutSynchronization(HTMLNames::roleAttr) == "slider"_s;
+
     return false;
+}
+
+// facebook.com rdar://174179871 tiktok.com rdar://174179805
+bool Quirks::shouldComputeSimulatedMouseEventMovementDelta() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.isTikTok || m_quirksData.isFacebook;
 }
 
 // sites.google.com rdar://58653069
@@ -2882,7 +2897,12 @@ static void handleTikTokQuirks(QuirksData& quirksData, const URL& /* quirksURL *
 {
     QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("tiktok.com"_s);
 
-    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsTikTokOverflowingContentQuirk);
+    quirksData.isTikTok = true;
+    quirksData.enableQuirks({
+        QuirksData::SiteSpecificQuirk::NeedsTikTokOverflowingContentQuirk,
+        // tiktok.com rdar://174179805
+        QuirksData::SiteSpecificQuirk::ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
+    });
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -2970,6 +2990,8 @@ static void handleFacebookQuirks(QuirksData& quirksData, const URL& /* quirksURL
     quirksData.enableQuirks({
         // facebook.com rdar://100871402
         QuirksData::SiteSpecificQuirk::NeedsFacebookRemoveNotSupportedQuirk,
+        // facebook.com rdar://174179871
+        QuirksData::SiteSpecificQuirk::ShouldDispatchSimulatedMouseEventsAssumeDefaultPreventedQuirk,
 #if ENABLE(VIDEO_PRESENTATION_MODE)
         // facebook.com rdar://67273166
         QuirksData::SiteSpecificQuirk::RequiresUserGestureToPauseInPictureInPictureQuirk,

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -81,6 +81,7 @@ public:
 #if ENABLE(TOUCH_EVENTS)
     bool shouldDispatchSimulatedMouseEvents(const EventTarget*) const;
     bool shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented(EventTarget*) const;
+    bool shouldComputeSimulatedMouseEventMovementDelta() const;
     bool shouldPreventDispatchOfTouchEvent(const AtomString&, EventTarget*) const;
 #endif
     bool NODELETE shouldDisablePointerEventsQuirk() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -51,6 +51,7 @@ struct QuirksData {
     bool isOutlook : 1 { false };
     bool isSoundCloud : 1 { false };
     bool isThesaurus : 1 { false };
+    bool isTikTok : 1 { false };
     bool isVimeo : 1 { false };
     bool isWalmart : 1 { false };
     bool isWebEx : 1 { false };
@@ -295,7 +296,7 @@ struct QuirksData {
     enum class ShouldDispatchSimulatedMouseEvents : uint8_t {
         Unknown,
         No,
-        DependingOnTargetForFacebook,
+        DependingOnTargetWithSliderRole,
         DependingOnTargetFor_mybinder_org,
         Yes,
     };

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -127,6 +127,7 @@ class WebKit::WebTouchEvent : WebKit::WebEvent {
 #if PLATFORM(IOS_FAMILY)
     unsigned identifier()
     WebCore::DoublePoint locationInRootView()
+    WebCore::DoublePoint previousLocationInRootView()
     WebCore::DoublePoint locationInViewport()
     WebKit::WebPlatformTouchPoint::State phase()
 #endif

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -459,7 +459,7 @@ public:
 WebKit2PlatformTouchPoint(const WebPlatformTouchPoint& webTouchPoint)
     : PlatformTouchPoint(webTouchPoint.identifier(), DoublePoint(webTouchPoint.locationInRootView()), DoublePoint(webTouchPoint.locationInViewport()), touchEventType(webTouchPoint)
 #if ENABLE(IOS_TOUCH_EVENTS)
-        , webTouchPoint.radiusX(), webTouchPoint.radiusY(), webTouchPoint.rotationAngle(), webTouchPoint.twist(), webTouchPoint.force(), webTouchPoint.altitudeAngle(), webTouchPoint.azimuthAngle(), webPlatformTouchTypeToPlatform(webTouchPoint.touchType())
+        , webTouchPoint.radiusX(), webTouchPoint.radiusY(), webTouchPoint.rotationAngle(), webTouchPoint.twist(), webTouchPoint.force(), webTouchPoint.altitudeAngle(), webTouchPoint.azimuthAngle(), webPlatformTouchTypeToPlatform(webTouchPoint.touchType()), DoublePoint(webTouchPoint.previousLocationInRootView())
 #endif
     )
 {

--- a/Source/WebKit/Shared/WebTouchEvent.cpp
+++ b/Source/WebKit/Shared/WebTouchEvent.cpp
@@ -68,6 +68,7 @@ void WebTouchEvent::transformToRemoteFrameCoordinates(const WebCore::RemoteFrame
 void WebPlatformTouchPoint::transformToRemoteFrameCoordinates(const WebCore::RemoteFrameGeometryTransformer& transformer)
 {
     m_locationInRootView = transformer.transformToRemoteFrameCoordinates(m_locationInRootView);
+    m_previousLocationInRootView = transformer.transformToRemoteFrameCoordinates(m_previousLocationInRootView);
 
     // When translating to the coordinate space of a site isolated iframe,
     // viewport coordinates become the same as root view coordinates because

--- a/Source/WebKit/Shared/WebTouchEvent.h
+++ b/Source/WebKit/Shared/WebTouchEvent.h
@@ -56,17 +56,19 @@ public:
     };
 
     WebPlatformTouchPoint() = default;
-    WebPlatformTouchPoint(unsigned identifier, WebCore::DoublePoint locationInRootView, WebCore::DoublePoint locationInViewport, State phase)
+    WebPlatformTouchPoint(unsigned identifier, WebCore::DoublePoint locationInRootView, WebCore::DoublePoint previousLocationInRootView, WebCore::DoublePoint locationInViewport, State phase)
         : m_identifier(identifier)
         , m_locationInRootView(locationInRootView)
+        , m_previousLocationInRootView(previousLocationInRootView)
         , m_locationInViewport(locationInViewport)
         , m_phase(phase)
     {
     }
 #if ENABLE(IOS_TOUCH_EVENTS)
-    WebPlatformTouchPoint(unsigned identifier, WebCore::DoublePoint locationInRootView, WebCore::DoublePoint locationInViewport, State phase, double radiusX, double radiusY, double rotationAngle, double twist, double force, double altitudeAngle, double azimuthAngle, TouchType touchType)
+    WebPlatformTouchPoint(unsigned identifier, WebCore::DoublePoint locationInRootView, WebCore::DoublePoint previousLocationInRootView, WebCore::DoublePoint locationInViewport, State phase, double radiusX, double radiusY, double rotationAngle, double twist, double force, double altitudeAngle, double azimuthAngle, TouchType touchType)
         : m_identifier(identifier)
         , m_locationInRootView(locationInRootView)
+        , m_previousLocationInRootView(previousLocationInRootView)
         , m_locationInViewport(locationInViewport)
         , m_phase(phase)
         , m_radiusX(radiusX)
@@ -83,6 +85,7 @@ public:
 
     unsigned identifier() const { return m_identifier; }
     WebCore::DoublePoint locationInRootView() const { return m_locationInRootView; }
+    WebCore::DoublePoint previousLocationInRootView() const { return m_previousLocationInRootView; }
     WebCore::DoublePoint locationInViewport() const { return m_locationInViewport; }
     State phase() const { return m_phase; }
     State state() const { return phase(); }
@@ -112,6 +115,7 @@ public:
 private:
     unsigned m_identifier { 0 };
     WebCore::DoublePoint m_locationInRootView;
+    WebCore::DoublePoint m_previousLocationInRootView;
     WebCore::DoublePoint m_locationInViewport;
     State m_phase { State::Released };
 #if ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
+++ b/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
@@ -101,9 +101,10 @@ Vector<WebPlatformTouchPoint> NativeWebTouchEvent::extractWebTouchPoints(const W
     return event.touchPoints.map([](auto& touchPoint) {
         unsigned identifier = touchPoint.identifier;
         auto locationInRootView = positionForCGPoint(touchPoint.locationInRootViewCoordinates);
+        auto previousLocationInRootView = positionForCGPoint(touchPoint.previousLocationInRootViewCoordinates);
         auto locationInViewport = positionForCGPoint(touchPoint.locationInViewport);
         WebPlatformTouchPoint::State phase = convertTouchPhase(touchPoint.phase);
-        WebPlatformTouchPoint platformTouchPoint = WebPlatformTouchPoint(identifier, locationInRootView, locationInViewport, phase);
+        WebPlatformTouchPoint platformTouchPoint = WebPlatformTouchPoint(identifier, locationInRootView, previousLocationInRootView, locationInViewport, phase);
 #if ENABLE(IOS_TOUCH_EVENTS)
         auto radius = radiusForTouchPoint(touchPoint);
         platformTouchPoint.setRadiusX(radius);

--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
@@ -36,6 +36,7 @@
 namespace WebKit {
 
 struct WKTouchPoint {
+    CGPoint previousLocationInRootViewCoordinates;
     CGPoint locationInRootViewCoordinates;
     CGPoint locationInViewport;
     unsigned identifier { 0 };

--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
@@ -244,10 +244,13 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
 {
     auto locationInWindow = [touch locationInView:nil];
     auto locationInRootView = [[self view] convertPoint:locationInWindow fromView:nil];
+    auto previousLocationInWindow = [touch previousLocationInView:nil];
+    auto previousLocationInRootView = [[self view] convertPoint:previousLocationInWindow fromView:nil];
     RetainPtr contentView = [self contentView];
 
     WebKit::WKTouchPoint touchPoint;
     touchPoint.locationInRootViewCoordinates = locationInRootView;
+    touchPoint.previousLocationInRootViewCoordinates = previousLocationInRootView;
     touchPoint.locationInViewport = mapRootViewToViewport(locationInRootView, contentView.get());
     touchPoint.identifier = parentTouchPoint.identifier;
     touchPoint.phase = touch.phase;
@@ -328,7 +331,10 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
         auto& touchPoint = _lastTouchEvent.touchPoints[touchIndex];
         auto locationInWindow = [touch locationInView:nil];
         auto locationInRootView = [[self view] convertPoint:locationInWindow fromView:nil];
+        auto previousLocationInWindow = [touch previousLocationInView:nil];
+        auto previousLocationInRootView = [[self view] convertPoint:previousLocationInWindow fromView:nil];
         touchPoint.locationInRootViewCoordinates = locationInRootView;
+        touchPoint.previousLocationInRootViewCoordinates = previousLocationInRootView;
         touchPoint.locationInViewport = mapRootViewToViewport(locationInRootView, contentView.get());
         touchPoint.identifier = [associatedIdentifier unsignedIntValue];
         touchPoint.phase = touch.phase;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TouchEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TouchEventTests.mm
@@ -73,8 +73,31 @@ static Class touchEventsGestureRecognizerClassSingleton()
 
 namespace TestWebKitAPI {
 
-static WebKit::WKTouchPoint globalTouchPoint { CGPointZero, CGPointZero, 100, UITouchPhaseBegan, 1, 0, 0, 0, 0, WebKit::WKTouchPointType::Direct };
-static WebKit::WKTouchEvent globalTouchEvent { WebKit::WKTouchEventType::Begin, CACurrentMediaTime(), CGPointZero, 1, 0, false, { globalTouchPoint }, { }, { }, true };
+static WebKit::WKTouchPoint globalTouchPoint {
+    .previousLocationInRootViewCoordinates = CGPointZero,
+    .locationInRootViewCoordinates = CGPointZero,
+    .locationInViewport = CGPointZero,
+    .identifier = 100,
+    .phase = UITouchPhaseBegan,
+    .majorRadiusInWindowCoordinates = 1,
+    .twist = 0,
+    .force = 0,
+    .altitudeAngle = 0,
+    .azimuthAngle = 0,
+    .touchType = WebKit::WKTouchPointType::Direct,
+};
+static WebKit::WKTouchEvent globalTouchEvent {
+    .type = WebKit::WKTouchEventType::Begin,
+    .timestamp = CACurrentMediaTime(),
+    .locationInRootViewCoordinates = CGPointZero,
+    .scale = 1,
+    .rotation = 0,
+    .inJavaScriptGesture = false,
+    .touchPoints = { globalTouchPoint },
+    .coalescedEvents = { },
+    .predictedEvents = { },
+    .isPotentialTap = true,
+};
 static void updateSimulatedTouchEvent(CGPoint location, UITouchPhase phase)
 {
     globalTouchEvent.locationInRootViewCoordinates = location;


### PR DESCRIPTION
#### 0d62f64ce6047f513f9f4c8cb2875fcbd145b97a
<pre>
Tiktok.com: Unable to drag volume slider in video&apos;s media control.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311585">https://bugs.webkit.org/show_bug.cgi?id=311585</a>
<a href="https://rdar.apple.com/174179805">rdar://174179805</a>

Reviewed by Lily Spiniolas.

The problem: iPad converts touches to simulated mouse
events but always sets movementX = 0. TikTok&apos;s volume
slider checks Math.abs(e.movementX) &gt; 0 before processing drags,
so all touch drags are silently ignored.

Compute real movementX/movementY in simulated mouse events
by plumbing [previousLocationInView:] through the touch
event pipeline. Enable simulated mouse event dispatch for
TikTok and Facebook, scoped to elements with role=&quot;slider&quot;,
and prevent background scrolling during slider drags.

* Source/WebCore/dom/MouseEvent.h:
* Source/WebCore/dom/ios/MouseEventIOS.cpp:
(WebCore::computeMovementDelta):
(WebCore::MouseEvent::create):
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformTouchPoint::WebKit2PlatformTouchPoint):
* Source/WebKit/Shared/WebTouchEvent.cpp:
(WebKit::WebPlatformTouchPoint::transformToRemoteFrameCoordinates):
* Source/WebKit/Shared/WebTouchEvent.h:
(WebKit::WebPlatformTouchPoint::WebPlatformTouchPoint):
(WebKit::WebPlatformTouchPoint::previousLocationInRootView const):
* Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm:
(WebKit::NativeWebTouchEvent::extractWebTouchPoints):
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h:
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(-[WKTouchEventsGestureRecognizer _touchEventForChildTouch:withParent:]):
(-[WKTouchEventsGestureRecognizer _recordTouches:ofType:forEvent:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TouchEventTests.mm:

Canonical link: <a href="https://commits.webkit.org/311889@main">https://commits.webkit.org/311889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32627f51b4d5e0723a18cbf25371a96e44d6051e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167141 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160183 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/31798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31667 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161271 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/31798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103279 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/31798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14914 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/31798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169633 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/15253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21616 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/31416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130907 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/31354 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141785 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24070 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/31354 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30886 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/96683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30406 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->