### PR TITLE
CI/CD smoke test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<title>User activation propagation across a same-origin navigation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="resources/utils.js"></script>
+
+<body>
+  <p>Placeholder</p>
+</body>
+
+<script>
+  'use strict';
+
+  let w;
+  document.body.onclick = () => {
+    w = window.open("resources/opened-window.html");
+  };
+
+  promise_test(async test => {
+    let window_opened_msg_promise = receiveMessage("window-opened");
+
+    await test_driver.click(document.body);
+    assert_true(!!w, "A window is opened");
+
+    {
+      let window_opened_data = await window_opened_msg_promise;
+      assert_false(window_opened_data.isActive,
+          "Transient activation after window opened");
+      assert_false(window_opened_data.hasBeenActive,
+          "Sticky activation after window opened");
+    }
+
+    let link_clicked_msg_promise = receiveMessage("link-clicked");
+    let window_navigated_msg_promise = receiveMessage("window-navigated");
+
+    const link = w.document.getElementById("link");
+    await test_driver.click(link);
+
+    {
+      let link_clicked_data = await link_clicked_msg_promise;
+      assert_true(link_clicked_data.isActive,
+          "Transient activation after link clicked");
+      assert_true(link_clicked_data.hasBeenActive,
+          "Sticky activation after link clicked");
+    }
+
+    {
+      let window_navigated_data = await window_navigated_msg_promise;
+      assert_false(window_navigated_data.isActive,
+          "Transient activation after window navigated");
+      assert_true(window_navigated_data.hasBeenActive,
+          "Sticky activation after window navigated");
+    }
+  }, "User activation propagation across a same-origin navigation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/resources/opened-window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/resources/opened-window.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+
+<body onload="run()">
+  <a id="link" href="?post-nav">link</a>
+</body>
+
+<script>
+  'use strict';
+  const post_nav_page = location.search.substring(1) === "post-nav";
+
+  function sendActivationStateToOpener(msg_type) {
+    window.opener.postMessage(JSON.stringify({
+        "type": msg_type,
+        "isActive": navigator.userActivation.isActive,
+        "hasBeenActive": navigator.userActivation.hasBeenActive
+    }), "*");
+  }
+
+  document.getElementById("link").addEventListener("click", () => {
+    assert_false(post_nav_page, "No click in the post-navigation page");
+    sendActivationStateToOpener("link-clicked");
+  });
+
+  function run() {
+    if (!post_nav_page) {
+      sendActivationStateToOpener("window-opened");
+    } else {
+      sendActivationStateToOpener("window-navigated");
+    }
+  }
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7881,6 +7881,20 @@ StandardFontFamily:
     WebCore:
       default: '""_str'
 
+StickyUserActivationAcrossSameOriginNavigationEnabled:
+  type: bool
+  status: stable
+  category: dom
+  humanReadableName: "Sticky User Activation Carry-Over on Same-Origin Navigation"
+  humanReadableDescription: "Carry over sticky user activation state across same-origin navigations"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 StorageAPIEnabled:
   type: bool
   status: stable
@@ -7896,20 +7910,6 @@ StorageAPIEnabled:
     WebCore:
       "PLATFORM(COCOA)" : true
       default: false
-
-StickyUserActivationAcrossSameOriginNavigationEnabled:
-  type: bool
-  status: stable
-  category: dom
-  humanReadableName: "Sticky User Activation Carry-Over on Same-Origin Navigation"
-  humanReadableDescription: "Carry over sticky user activation state across same-origin navigations"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
 
 StorageAPIEstimateEnabled:
   type: bool

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7897,6 +7897,20 @@ StorageAPIEnabled:
       "PLATFORM(COCOA)" : true
       default: false
 
+StickyUserActivationAcrossSameOriginNavigationEnabled:
+  type: bool
+  status: stable
+  category: dom
+  humanReadableName: "Sticky User Activation Carry-Over on Same-Origin Navigation"
+  humanReadableDescription: "Carry over sticky user activation state across same-origin navigations"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 StorageAPIEstimateEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -207,6 +207,17 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
     frameLoader->setOutgoingReferrer(url);
     frame->setDocument(document.copyRef());
 
+    // Preserves the sticky user activation state after a page navigates to
+    // another same-origin page.
+    // https://bugs.webkit.org/show_bug.cgi?id=312241
+    if (frame->settings().stickyUserActivationAcrossSameOriginNavigationEnabled()
+        && previousWindow && previousWindow->hasStickyActivation() && existingDocument) {
+        if (existingDocument->securityOrigin().isSameOriginAs(SecurityOrigin::create(url))) {
+            if (auto* newWindow = document->window())
+                newWindow->setLastActivationTimestamp(-MonotonicTime::infinity());
+        }
+    }
+
     if (RefPtr decoder = m_decoder)
         document->setDecoder(decoder.get());
     if (ownerDocument) {


### PR DESCRIPTION
Empty commit to exercise the push and CI flow. Not a real change.

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7afd2b82a2aaee850bc239772260243189e148d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30977 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122059 "Found 2 new test failures: imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85735 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160596 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24341 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102728 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23397 "Found 1 new test failure: imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21676 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14233 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149689 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168951 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18473 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13441 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20990 "Found 2 new test failures: imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130228 "Found 2 new test failures: imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30577 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25748 "Found 2 new test failures: imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130343 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30499 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141164 "Exiting early after 10 failures. 10 tests run. 1 missing results") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88497 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25156 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17969 "Found 2 new test failures: imported/w3c/web-platform-tests/html/user-activation/navigate-to-sameorigin.html imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189711 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94620 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48688 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29732 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->