### PR TITLE
Clean up and apply minor optimizations to StyledElement

### DIFF
--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -115,8 +115,8 @@ void StyledElement::attributeChanged(const QualifiedName& name, const AtomString
 
 CSSStyleProperties* StyledElement::inlineStyleCSSOMWrapper()
 {
-    if (!inlineStyle() || !inlineStyle()->hasCSSOMWrapper())
-        return 0;
+    if (auto* style = inlineStyle(); !style || !style->hasCSSOMWrapper())
+        return nullptr;
     SUPPRESS_UNCOUNTED_LOCAL auto* cssomWrapper = ensureMutableInlineStyle()->cssStyleProperties();
     ASSERT(cssomWrapper && cssomWrapper->parentElement() == this);
     return cssomWrapper;
@@ -164,18 +164,22 @@ void StyledElement::styleAttributeChanged(const AtomString& newStyleString, Attr
     InspectorInstrumentation::didInvalidateStyleAttr(*this);
 }
 
+void StyledElement::synchronizeStyleAttributeForSelectorInvalidation()
+{
+    if (RefPtr inlineStyle = this->inlineStyle()) {
+        elementData()->setStyleAttributeIsDirty(false);
+        auto newValue = inlineStyle->asTextAtom(CSS::defaultSerializationContext());
+        Style::AttributeChangeInvalidation styleInvalidation(*this, styleAttr, attributeWithoutSynchronization(styleAttr), newValue);
+        setSynchronizedLazyAttribute(styleAttr, newValue);
+    }
+}
+
 void StyledElement::dirtyStyleAttribute()
 {
     elementData()->setStyleAttributeIsDirty(true);
 
-    if (styleResolver().ruleSets().selectorsForStyleAttribute() != Style::SelectorsForStyleAttribute::None) {
-        if (RefPtr inlineStyle = this->inlineStyle()) {
-            elementData()->setStyleAttributeIsDirty(false);
-            auto newValue = inlineStyle->asTextAtom(CSS::defaultSerializationContext());
-            Style::AttributeChangeInvalidation styleInvalidation(*this, styleAttr, attributeWithoutSynchronization(styleAttr), newValue);
-            setSynchronizedLazyAttribute(styleAttr, newValue);
-        }
-    }
+    if (styleResolver().ruleSets().selectorsForStyleAttribute() != Style::SelectorsForStyleAttribute::None)
+        synchronizeStyleAttributeForSelectorInvalidation();
 }
 
 void StyledElement::invalidateStyleAttribute()
@@ -194,20 +198,12 @@ void StyledElement::invalidateStyleAttribute()
 
     Node::invalidateStyle(validity);
 
-    if (isSVGElement()) {
-        if (auto* svgElement = dynamicDowncast<SVGElement>(this))
-            svgElement->invalidateInstances();
-    }
+    if (auto* svgElement = dynamicDowncast<SVGElement>(*this))
+        svgElement->invalidateInstances();
 
     // In the rare case of selectors like "[style] ~ div" we need to synchronize immediately to invalidate.
-    if (selectorsForStyleAttribute == Style::SelectorsForStyleAttribute::NonSubjectPosition) {
-        if (RefPtr inlineStyle = this->inlineStyle()) {
-            elementData()->setStyleAttributeIsDirty(false);
-            auto newValue = inlineStyle->asTextAtom(CSS::defaultSerializationContext());
-            Style::AttributeChangeInvalidation styleInvalidation(*this, styleAttr, attributeWithoutSynchronization(styleAttr), newValue);
-            setSynchronizedLazyAttribute(styleAttr, newValue);
-        }
-    }
+    if (selectorsForStyleAttribute == Style::SelectorsForStyleAttribute::NonSubjectPosition)
+        synchronizeStyleAttributeForSelectorInvalidation();
 }
 
 void StyledElement::inlineStyleChanged()
@@ -256,9 +252,10 @@ bool StyledElement::setInlineStyleCustomProperty(const AtomString& property, con
 
 bool StyledElement::setInlineStyleCustomProperty(Ref<CSSValue>&& customPropertyValue, IsImportant important)
 {
-    ensureMutableInlineStyle()->addParsedProperty(CSSProperty(CSSPropertyCustom, WTF::move(customPropertyValue), important));
-    inlineStyleChanged();
-    return true;
+    bool changes = ensureMutableInlineStyle()->addParsedProperty(CSSProperty(CSSPropertyCustom, WTF::move(customPropertyValue), important));
+    if (changes)
+        inlineStyleChanged();
+    return changes;
 }
 
 bool StyledElement::removeInlineStyleProperty(CSSPropertyID propertyID)

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -97,6 +97,7 @@ protected:
 private:
     void styleAttributeChanged(const AtomString& newStyleString, AttributeModificationReason);
     void synchronizeStyleAttributeInternalImpl();
+    void synchronizeStyleAttributeForSelectorInvalidation();
 
     void inlineStyleChanged();
     CSSStyleProperties* inlineStyleCSSOMWrapper();


### PR DESCRIPTION
#### 353f068cb24637277e325ab7610ef33b3d794486
<pre>
Clean up and apply minor optimizations to StyledElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=312855">https://bugs.webkit.org/show_bug.cgi?id=312855</a>

Reviewed by Anne van Kesteren and Rupin Mittal.

- Extract synchronizeStyleAttributeForSelectorInvalidation() to eliminate
  duplicated style attribute synchronization logic between dirtyStyleAttribute()
  and invalidateStyleAttribute().
- Remove redundant isSVGElement() guard around dynamicDowncast&lt;SVGElement&gt;,
  which already performs the same type check.
- Avoid unnecessary inlineStyleChanged() in setInlineStyleCustomProperty()
  when addParsedProperty() reports no changes were made.
- Cache inlineStyle() in inlineStyleCSSOMWrapper() to avoid double lookup,
  and use nullptr instead of 0.

* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::inlineStyleCSSOMWrapper):
(WebCore::StyledElement::synchronizeStyleAttributeForSelectorInvalidation):
(WebCore::StyledElement::dirtyStyleAttribute):
(WebCore::StyledElement::invalidateStyleAttribute):
(WebCore::StyledElement::setInlineStyleCustomProperty):
* Source/WebCore/dom/StyledElement.h:

Canonical link: <a href="https://commits.webkit.org/311740@main">https://commits.webkit.org/311740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d05794b7a059ff7866144c7975737341ec5265ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111793 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122118 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85762 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102787 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23460 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21746 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14306 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169024 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13590 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130286 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130403 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35346 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141232 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88573 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25191 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18037 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94781 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29805 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30035 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29932 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->