### PR TITLE
[JSC] Add B3::StoreBarrier / B3::FencedStoreBarrier

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -249,6 +249,9 @@
 		0F30FB611DC2DE99003124F2 /* ArrayBufferSharingMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F30FB601DC2DE96003124F2 /* ArrayBufferSharingMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0F32BD111BB34F190093A57F /* HeapHelperPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F32BD0F1BB34F190093A57F /* HeapHelperPool.h */; };
 		0F338DF21BE93AD10013C88F /* B3StackmapValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F338DF01BE93AD10013C88F /* B3StackmapValue.h */; };
+		7C31DE8B745B482EA02C18D7 /* B3StoreBarrierUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C9D4EEB89374F7E8841E456 /* B3StoreBarrierUtils.h */; };
+		688D59BB4C9547C6A093A908 /* B3StoreBarrierElisionPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = FEE2E3F1DFBC40E9A652E013 /* B3StoreBarrierElisionPhase.h */; };
+		B2310A7329144B04A216B3A9 /* B3StoreBarrierClusteringPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C8B645668EB4E8B8613C9D9 /* B3StoreBarrierClusteringPhase.h */; };
 		0F338DF61BE93D550013C88F /* B3ConstrainedValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F338DF41BE93D550013C88F /* B3ConstrainedValue.h */; };
 		0F338DFA1BE96AA80013C88F /* B3CCallValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F338DF81BE96AA80013C88F /* B3CCallValue.h */; };
 		0F338DFE1BED51270013C88F /* AirSimplifyCFG.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F338DFC1BED51270013C88F /* AirSimplifyCFG.h */; };
@@ -3042,6 +3045,11 @@
 		0F32BD0F1BB34F190093A57F /* HeapHelperPool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HeapHelperPool.h; sourceTree = "<group>"; };
 		0F338DEF1BE93AD10013C88F /* B3StackmapValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3StackmapValue.cpp; path = b3/B3StackmapValue.cpp; sourceTree = "<group>"; };
 		0F338DF01BE93AD10013C88F /* B3StackmapValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3StackmapValue.h; path = b3/B3StackmapValue.h; sourceTree = "<group>"; };
+		EBC316497F9045C3BAC83BD9 /* B3StoreBarrierElisionPhase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3StoreBarrierElisionPhase.cpp; path = b3/B3StoreBarrierElisionPhase.cpp; sourceTree = "<group>"; };
+		FEE2E3F1DFBC40E9A652E013 /* B3StoreBarrierElisionPhase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3StoreBarrierElisionPhase.h; path = b3/B3StoreBarrierElisionPhase.h; sourceTree = "<group>"; };
+		3963789034D8470A9D6D5D77 /* B3StoreBarrierClusteringPhase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3StoreBarrierClusteringPhase.cpp; path = b3/B3StoreBarrierClusteringPhase.cpp; sourceTree = "<group>"; };
+		7C8B645668EB4E8B8613C9D9 /* B3StoreBarrierClusteringPhase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3StoreBarrierClusteringPhase.h; path = b3/B3StoreBarrierClusteringPhase.h; sourceTree = "<group>"; };
+		2C9D4EEB89374F7E8841E456 /* B3StoreBarrierUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3StoreBarrierUtils.h; path = b3/B3StoreBarrierUtils.h; sourceTree = "<group>"; };
 		0F338DF31BE93D550013C88F /* B3ConstrainedValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3ConstrainedValue.cpp; path = b3/B3ConstrainedValue.cpp; sourceTree = "<group>"; };
 		0F338DF41BE93D550013C88F /* B3ConstrainedValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3ConstrainedValue.h; path = b3/B3ConstrainedValue.h; sourceTree = "<group>"; };
 		0F338DF71BE96AA80013C88F /* B3CCallValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3CCallValue.cpp; path = b3/B3CCallValue.cpp; sourceTree = "<group>"; };
@@ -7024,6 +7032,11 @@
 				0FEC84E71BDACDAC0080FF74 /* B3StackmapSpecial.h */,
 				0F338DEF1BE93AD10013C88F /* B3StackmapValue.cpp */,
 				0F338DF01BE93AD10013C88F /* B3StackmapValue.h */,
+				3963789034D8470A9D6D5D77 /* B3StoreBarrierClusteringPhase.cpp */,
+				7C8B645668EB4E8B8613C9D9 /* B3StoreBarrierClusteringPhase.h */,
+				EBC316497F9045C3BAC83BD9 /* B3StoreBarrierElisionPhase.cpp */,
+				FEE2E3F1DFBC40E9A652E013 /* B3StoreBarrierElisionPhase.h */,
+				2C9D4EEB89374F7E8841E456 /* B3StoreBarrierUtils.h */,
 				0FEC84EC1BDACDAC0080FF74 /* B3SuccessorCollection.h */,
 				0FEC84ED1BDACDAC0080FF74 /* B3SwitchCase.cpp */,
 				0FEC84EE1BDACDAC0080FF74 /* B3SwitchCase.h */,
@@ -11087,6 +11100,9 @@
 				0F33FCF81C136E2500323F67 /* B3StackmapGenerationParams.h in Headers */,
 				0FEC85311BDACDAC0080FF74 /* B3StackmapSpecial.h in Headers */,
 				0F338DF21BE93AD10013C88F /* B3StackmapValue.h in Headers */,
+				B2310A7329144B04A216B3A9 /* B3StoreBarrierClusteringPhase.h in Headers */,
+				688D59BB4C9547C6A093A908 /* B3StoreBarrierElisionPhase.h in Headers */,
+				7C31DE8B745B482EA02C18D7 /* B3StoreBarrierUtils.h in Headers */,
 				0FEC85361BDACDAC0080FF74 /* B3SuccessorCollection.h in Headers */,
 				0FEC85381BDACDAC0080FF74 /* B3SwitchCase.h in Headers */,
 				0FEC853A1BDACDAC0080FF74 /* B3SwitchValue.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -176,6 +176,8 @@ b3/B3SlotBaseValue.cpp
 b3/B3StackmapGenerationParams.cpp
 b3/B3StackmapSpecial.cpp
 b3/B3StackmapValue.cpp
+b3/B3StoreBarrierClusteringPhase.cpp
+b3/B3StoreBarrierElisionPhase.cpp
 b3/B3SwitchCase.cpp
 b3/B3SwitchValue.cpp
 b3/B3TZoneImpls.cpp

--- a/Source/JavaScriptCore/b3/B3Generate.cpp
+++ b/Source/JavaScriptCore/b3/B3Generate.cpp
@@ -47,6 +47,8 @@
 #include "B3Procedure.h"
 #include "B3ReduceDoubleToFloat.h"
 #include "B3ReduceStrength.h"
+#include "B3StoreBarrierClusteringPhase.h"
+#include "B3StoreBarrierElisionPhase.h"
 #include "B3Validate.h"
 #include "CompilerTimingScope.h"
 
@@ -99,6 +101,14 @@ void generateToAir(Procedure& procedure)
     } else if (procedure.optLevel() >= 1) {
         // FIXME: Explore better "quick mode" optimizations.
         reduceStrength(procedure, ReduceStrengthPass::Initial);
+    }
+
+    // Drop redundant StoreBarriers and coalesce neighbours into clusters before they get
+    // expanded into the full check + slow-path sequence by lowerMacros. The procedure-level
+    // gate makes both phases an O(1) early-out for non-wasm B3 compiles.
+    if (procedure.usesStoreBarriers()) {
+        storeBarrierElision(procedure);
+        storeBarrierClustering(procedure);
     }
 
     // This puts the IR in quirks mode.

--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -58,6 +58,7 @@
 #include "B3WasmStructSetValue.h"
 #include "CCallHelpers.h"
 #include "GPRInfo.h"
+#include "JITOperations.h"
 #include "JSCJSValueInlines.h"
 #include "JSCell.h"
 #include "JSObject.h"
@@ -66,6 +67,7 @@
 #include "JSWebAssemblyStruct.h"
 #include "LinkBuffer.h"
 #include "MarkedSpace.h"
+#include "VM.h"
 #include "WasmExceptionType.h"
 #include "WasmFaultSignalHandler.h"
 #include "WasmOperations.h"
@@ -1048,6 +1050,57 @@ private:
                 break;
             }
 #endif
+
+            case StoreBarrier:
+            case FencedStoreBarrier: {
+                // Lower the (Fenced)StoreBarrier(cell, vm) macro into the GC store-barrier
+                // sequence. The narrow StoreBarrier skips the fence and the post-fence cellState
+                // re-check; the FencedStoreBarrier emits the full sequence (matching what the
+                // wasm OMG IR generator used to emit by hand). The slow path calls the JS-side
+                // operationWriteBarrierSlowPath (no wasm-operation prepare dance).
+                bool isFenced = m_value->opcode() == FencedStoreBarrier;
+                Value* cell = m_value->child(0);
+                Value* vm = m_value->child(1);
+
+                BasicBlock* before = m_blockInsertionSet.splitForward(m_block, m_index, &m_insertionSet);
+                BasicBlock* slowPath = m_blockInsertionSet.insertBefore(m_block);
+                BasicBlock* recheckPath = isFenced ? m_blockInsertionSet.insertBefore(m_block) : nullptr;
+
+                // splitForward leaves a Jump at the end of `before`. Replace it with Nop so we
+                // can append the threshold check + Branch.
+                before->replaceLastWithNew<Value>(m_proc, Nop, m_origin);
+
+                Value* threshold = before->appendNew<MemoryValue>(m_proc, Load, Int32, m_origin, vm,
+                    safeCast<int32_t>(VM::offsetOfHeapBarrierThreshold()));
+                Value* cellStateFast = before->appendNew<MemoryValue>(m_proc, Load8Z, Int32, m_origin, cell,
+                    safeCast<int32_t>(JSCell::cellStateOffset()));
+                Value* fastCheck = before->appendNew<Value>(m_proc, Above, m_origin, cellStateFast, threshold);
+                before->appendNewControlValue(m_proc, Branch, m_origin, fastCheck,
+                    FrequentedBlock(m_block, FrequencyClass::Normal),
+                    FrequentedBlock(isFenced ? recheckPath : slowPath, FrequencyClass::Rare));
+
+                if (isFenced) {
+                    recheckPath->appendNew<FenceValue>(m_proc, m_origin);
+                    Value* cellStateAfterFence = recheckPath->appendNew<MemoryValue>(m_proc, Load8Z, Int32, m_origin, cell,
+                        safeCast<int32_t>(JSCell::cellStateOffset()));
+                    Value* recheckThreshold = recheckPath->appendIntConstant(m_proc, m_origin, Int32, blackThreshold);
+                    Value* recheck = recheckPath->appendNew<Value>(m_proc, Above, m_origin, cellStateAfterFence, recheckThreshold);
+                    recheckPath->appendNewControlValue(m_proc, Branch, m_origin, recheck,
+                        FrequentedBlock(m_block, FrequencyClass::Normal),
+                        FrequentedBlock(slowPath, FrequencyClass::Rare));
+                }
+
+                Value* opPtr = slowPath->appendNew<ConstPtrValue>(m_proc, m_origin,
+                    tagCFunction<OperationPtrTag>(operationWriteBarrierSlowPath));
+                slowPath->appendNew<CCallValue>(m_proc, B3::Void, m_origin, Effects::forCall(),
+                    opPtr, vm, cell);
+                slowPath->appendNewControlValue(m_proc, Jump, m_origin, FrequentedBlock(m_block));
+
+                m_value->replaceWithNop();
+                before->updatePredecessorsAfter();
+                m_changed = true;
+                break;
+            }
 
             default:
                 break;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -362,6 +362,14 @@ enum Opcode : uint8_t {
     // workings of wasm to be able to perform such optimizations.
     WasmBoundsCheck,
 
+    // GC store barriers used by the wasm OMG B3 IR generator. These are high-level macros
+    // that B3LowerMacros expands into the threshold-check + (optional fence + recheck) +
+    // slow-path call sequence. StoreBarrierElisionPhase / StoreBarrierClusteringPhase run
+    // before LowerMacros to drop redundant ones and downgrade non-leading members of a
+    // cluster from FencedStoreBarrier to the narrow StoreBarrier. Two children: (cell, vm).
+    StoreBarrier,
+    FencedStoreBarrier,
+
     WasmArrayGet,
     WasmArraySet,
     WasmArrayNew,

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -293,7 +293,7 @@ public:
     JS_EXPORT_PRIVATE void NODELETE setShouldDumpIR();
 
     void setUsessSIMD()
-    { 
+    {
         RELEASE_ASSERT(Options::useWasmSIMD());
         m_usesSIMD = true;
     }
@@ -308,6 +308,12 @@ public:
         ASSERT(Options::useWasmIPInt());
         return m_usesSIMD;
     }
+
+    // Set by emitters of the StoreBarrier / FencedStoreBarrier opcodes (currently the
+    // wasm OMG IR generator). Gates the StoreBarrierElision / StoreBarrierClustering
+    // phases so non-wasm B3 compiles skip them entirely.
+    void setUsesStoreBarriers() { m_usesStoreBarriers = true; }
+    bool usesStoreBarriers() const { return m_usesStoreBarriers; }
 
     void setIonGraphPasses(Ref<JSON::Array>&&);
     void appendIonGraphPass(ASCIILiteral);
@@ -347,6 +353,7 @@ private:
     bool m_needsPCToOriginMap { false };
     bool m_shouldDumpIR { false };
     bool m_usesSIMD { false };
+    bool m_usesStoreBarriers { false };
 };
     
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3StoreBarrierClusteringPhase.cpp
+++ b/Source/JavaScriptCore/b3/B3StoreBarrierClusteringPhase.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "B3StoreBarrierClusteringPhase.h"
+
+#if ENABLE(B3_JIT)
+
+#include "B3BasicBlockInlines.h"
+#include "B3InsertionSetInlines.h"
+#include "B3Origin.h"
+#include "B3PhaseScope.h"
+#include "B3Procedure.h"
+#include "B3StoreBarrierUtils.h"
+#include "B3Value.h"
+#include <wtf/BitVector.h>
+#include <wtf/Vector.h>
+
+namespace JSC { namespace B3 {
+
+namespace {
+
+class StoreBarrierClustering {
+public:
+    StoreBarrierClustering(Procedure& proc)
+        : m_proc(proc)
+        , m_insertionSet(proc)
+    {
+    }
+
+    bool run()
+    {
+        bool changed = false;
+        for (BasicBlock* block : m_proc) {
+            if (cluster(block))
+                changed = true;
+        }
+        return changed;
+    }
+
+private:
+    bool cluster(BasicBlock* block)
+    {
+        // Backward pass: identify "barrier points". A barrier point is the position of the
+        // latest barrier before a GC point (or terminal, or back-edge). Earlier barriers in
+        // the same no-GC zone fold into the cluster anchored at the barrier point.
+        BitVector barrierPoints;
+        barrierPoints.ensureSize(block->size());
+        bool futureGC = true; // Back-edge could see GC.
+        for (size_t i = block->size(); i--; ) {
+            Value* value = block->at(i);
+            if (value->effects().terminal || mayGC(value)) {
+                futureGC = true;
+                continue;
+            }
+            if (isStoreBarrier(value) && futureGC) {
+                barrierPoints.set(i);
+                futureGC = false;
+            }
+        }
+
+        // Forward pass: collect barriers and, at each barrier point, emit a deduplicated
+        // cluster (FencedStoreBarrier leader, narrow StoreBarrier followers).
+        bool changed = false;
+        Vector<Pending, 8> needed;
+        for (size_t i = 0; i < block->size(); ++i) {
+            Value* value = block->at(i);
+            if (!isStoreBarrier(value))
+                continue;
+
+            needed.append(Pending { value->child(0), value->child(1), value->origin() });
+            if (!barrierPoints.quickGet(i)) {
+                value->replaceWithNop();
+                changed = true;
+                continue;
+            }
+
+            // We're at the cluster anchor. Replace the anchor barrier itself with Nop too
+            // — we'll re-emit the whole cluster via the insertion set below.
+            value->replaceWithNop();
+
+            // Stable sort by cell pointer so duplicate-by-cell entries are adjacent. Using
+            // pointer identity is sound: B3 SSA guarantees a single Value* per definition.
+            std::sort(needed.begin(), needed.end(), [](const Pending& a, const Pending& b) {
+                return a.cell < b.cell;
+            });
+            // Deduplicate adjacent same-cell entries.
+            unsigned out = 0;
+            for (unsigned in = 0; in < needed.size(); ++in) {
+                if (out && needed[out - 1].cell == needed[in].cell)
+                    continue;
+                if (out != in)
+                    needed[out] = needed[in];
+                ++out;
+            }
+            needed.shrink(out);
+
+            for (unsigned k = 0; k < needed.size(); ++k) {
+                Opcode opcode = !k ? FencedStoreBarrier : StoreBarrier;
+                m_insertionSet.insert<Value>(i, opcode, needed[k].origin, needed[k].cell, needed[k].vm);
+            }
+            needed.shrinkToFit();
+            needed.clear();
+            changed = true;
+        }
+        m_insertionSet.execute(block);
+        return changed;
+    }
+
+    struct Pending {
+        Value* cell;
+        Value* vm;
+        Origin origin;
+    };
+
+    Procedure& m_proc;
+    InsertionSet m_insertionSet;
+};
+
+} // anonymous namespace
+
+bool storeBarrierClustering(Procedure& proc)
+{
+    if (!proc.usesStoreBarriers())
+        return false;
+    PhaseScope phaseScope(proc, "storeBarrierClustering"_s);
+    StoreBarrierClustering phase(proc);
+    return phase.run();
+}
+
+} } // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3StoreBarrierClusteringPhase.h
+++ b/Source/JavaScriptCore/b3/B3StoreBarrierClusteringPhase.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+namespace JSC { namespace B3 {
+
+class Procedure;
+
+// Coalesces multiple StoreBarrier / FencedStoreBarrier nodes that occur within the same
+// "no-GC zone" of a basic block. Within such a zone all barriers are moved to the last
+// barrier's position and deduplicated by base. The first barrier in the resulting cluster
+// keeps the FencedStoreBarrier opcode (one fence drains all the prior stores); the rest
+// are downgraded to the narrow StoreBarrier (no fence, no recheck). Direct port of
+// DFGStoreBarrierClusteringPhase.
+bool storeBarrierClustering(Procedure&);
+
+} } // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3StoreBarrierElisionPhase.cpp
+++ b/Source/JavaScriptCore/b3/B3StoreBarrierElisionPhase.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "B3StoreBarrierElisionPhase.h"
+
+#if ENABLE(B3_JIT)
+
+#include "B3BasicBlock.h"
+#include "B3PhaseScope.h"
+#include "B3Procedure.h"
+#include "B3StoreBarrierUtils.h"
+#include "B3Value.h"
+#include <wtf/HashMap.h>
+
+namespace JSC { namespace B3 {
+
+namespace {
+
+// Local epoch type. Kept private to this phase to avoid a dependency on DFGEpoch
+// (which is gated on ENABLE(DFG_JIT)). Two values share an epoch iff no may-GC point
+// was observed between the points where they were tagged.
+class Epoch {
+public:
+    Epoch() = default;
+
+    static Epoch first() { return Epoch(1); }
+
+    Epoch next() const { return Epoch(m_value + 1); }
+    void bump() { *this = next(); }
+
+    bool isPrimordial() const { return !m_value; }
+
+    friend bool operator==(const Epoch&, const Epoch&) = default;
+
+private:
+    explicit Epoch(unsigned value)
+        : m_value(value)
+    {
+    }
+
+    unsigned m_value { 0 };
+};
+
+class StoreBarrierElision {
+public:
+    StoreBarrierElision(Procedure& proc)
+        : m_proc(proc)
+    {
+    }
+
+    bool run()
+    {
+        bool changed = false;
+        for (BasicBlock* block : m_proc) {
+            m_valueEpoch.clear();
+            m_currentEpoch = Epoch::first();
+            for (Value* value : *block) {
+                if (isStoreBarrier(value)) {
+                    Value* cell = value->child(0);
+                    auto it = m_valueEpoch.find(cell);
+                    if (it != m_valueEpoch.end() && it->value == m_currentEpoch) {
+                        value->replaceWithNop();
+                        changed = true;
+                    }
+                    // A barrier itself does not GC: do not bump the epoch.
+                    continue;
+                }
+
+                // Anything stored or passed by value into the heap may now be visible to
+                // the concurrent collector. Conservatively reset its epoch to primordial
+                // so future stores through that value still emit a real barrier.
+                handleEscapes(value);
+
+                bool isAllocator = isFreshAllocation(value);
+                if (mayGC(value))
+                    m_currentEpoch.bump();
+                if (isAllocator)
+                    m_valueEpoch.set(value, m_currentEpoch);
+            }
+        }
+        return changed;
+    }
+
+private:
+    void handleEscapes(Value* value)
+    {
+        switch (value->opcode()) {
+        case Store:
+        case Store8:
+        case Store16:
+        case AtomicXchgAdd:
+        case AtomicXchgAnd:
+        case AtomicXchgOr:
+        case AtomicXchgSub:
+        case AtomicXchgXor:
+        case AtomicXchg:
+        case AtomicWeakCAS:
+        case AtomicStrongCAS:
+            // child(0) is the value being stored; remaining children are address parts.
+            escape(value->child(0));
+            return;
+        case CCall:
+        case Patchpoint:
+            // child(0) is the callee for CCall; everything after is an argument that may
+            // be retained by callee. For Patchpoints all children are stackmap entries.
+            for (unsigned i = (value->opcode() == CCall ? 1 : 0); i < value->numChildren(); ++i)
+                escape(value->child(i));
+            return;
+        default:
+            return;
+        }
+    }
+
+    void escape(Value* value)
+    {
+        auto it = m_valueEpoch.find(value);
+        if (it != m_valueEpoch.end())
+            it->value = Epoch();
+    }
+
+    Procedure& m_proc;
+    UncheckedKeyHashMap<Value*, Epoch> m_valueEpoch;
+    Epoch m_currentEpoch;
+};
+
+} // anonymous namespace
+
+bool storeBarrierElision(Procedure& proc)
+{
+    if (!proc.usesStoreBarriers())
+        return false;
+    PhaseScope phaseScope(proc, "storeBarrierElision"_s);
+    StoreBarrierElision phase(proc);
+    return phase.run();
+}
+
+} } // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3StoreBarrierElisionPhase.h
+++ b/Source/JavaScriptCore/b3/B3StoreBarrierElisionPhase.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+namespace JSC { namespace B3 {
+
+class Procedure;
+
+// Drops StoreBarrier and FencedStoreBarrier nodes whose base is provably a young object
+// allocated since the last GC point in the same basic block. Mirrors the analysis half of
+// DFGStoreBarrierInsertionPhase, run inverted: the wasm OMG IR generator emits a
+// FencedStoreBarrier at every site that could need one, and this phase removes the ones
+// that don't.
+//
+// Each value carries an epoch. The current epoch is bumped at every may-GC point. A fresh
+// allocation (WasmStructNew / WasmArrayNew) records its result in the post-bump epoch.
+// A barrier whose cell is in the current epoch is redundant and replaced with Nop.
+//
+// V1 limitation: epoch state is not propagated across basic block boundaries, so cross-
+// block elision is not performed. Same-block elision still wins for the common pattern
+// of allocate-then-fill on a fresh object.
+bool storeBarrierElision(Procedure&);
+
+} } // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3StoreBarrierUtils.h
+++ b/Source/JavaScriptCore/b3/B3StoreBarrierUtils.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+#include "B3CCallValue.h"
+#include "B3Opcode.h"
+#include "B3StackmapValue.h"
+#include "B3Value.h"
+
+namespace JSC { namespace B3 {
+
+inline bool isStoreBarrier(const Value* value)
+{
+    Opcode op = value->opcode();
+    return op == StoreBarrier || op == FencedStoreBarrier;
+}
+
+// Returns true if the wasm allocator opcodes WasmStructNew / WasmArrayNew produced this
+// value. Their result is a freshly-allocated young object whose cellState is known to be
+// in the "no-barrier-needed" range, so the StoreBarrierElisionPhase can elide barriers
+// targeting this value.
+inline bool isFreshAllocation(const Value* value)
+{
+    switch (value->opcode()) {
+    case WasmStructNew:
+    case WasmArrayNew:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// Returns true if executing this value may trigger garbage collection (any allocator,
+// any C call that could allocate or run JS, any patchpoint that exits sideways). The
+// StoreBarrierElisionPhase bumps the epoch on each true answer so that allocations
+// performed before a GC point lose their "fresh" status. The clustering phase uses the
+// same predicate to terminate clusters.
+inline bool mayGC(const Value* value)
+{
+    switch (value->opcode()) {
+    case WasmStructNew:
+    case WasmArrayNew:
+        // Allocators may take the slow path and trigger GC themselves.
+        return true;
+    case CCall:
+        // Conservative: any C call could allocate or invoke runtime code that GCs.
+        return true;
+    case Patchpoint:
+        // Patchpoints with side-exits might call into runtime code.
+        return value->effects().exitsSideways;
+    default:
+        return false;
+    }
+}
+
+} } // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -893,6 +893,14 @@ public:
                 }
                 VALIDATE(m_procedure.code().wasmBoundsCheckGenerator(), ("At ", *value));
                 break;
+            case StoreBarrier:
+            case FencedStoreBarrier:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 2, ("At ", *value));
+                VALIDATE(value->child(0)->type() == pointerType(), ("At ", *value));
+                VALIDATE(value->child(1)->type() == pointerType(), ("At ", *value));
+                VALIDATE(value->type() == Void, ("At ", *value));
+                break;
             case WasmStructGet:
                 VALIDATE(value->numChildren() == 1, ("At ", *value));
                 VALIDATE(value->child(0)->type() == Int64, ("At ", *value)); // struct pointer

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -896,6 +896,17 @@ Effects Value::effects() const
         result.exitsSideways = true;
         result.reads = HeapRange::top();
         break;
+    case StoreBarrier:
+        result.reads = HeapRange::top();
+        result.writes = HeapRange::top();
+        result.exitsSideways = true;
+        break;
+    case FencedStoreBarrier:
+        result.reads = HeapRange::top();
+        result.writes = HeapRange::top();
+        result.fence = true;
+        result.exitsSideways = true;
+        break;
     case WasmStructGet: {
         const auto* derived = as<WasmStructGetValue>();
         result.reads = derived->range();
@@ -1197,6 +1208,8 @@ ValueKey Value::key() const
     case WasmArrayGet:
     case WasmArraySet:
     case WasmArrayNew:
+    case StoreBarrier:
+    case FencedStoreBarrier:
     case MemoryCopy:
     case MemoryFill:
     case Fence:
@@ -1347,6 +1360,8 @@ Type Value::typeFor(Kind kind, Value* firstChild, Value* secondChild)
     case Oops:
     case EntrySwitch:
     case WasmBoundsCheck:
+    case StoreBarrier:
+    case FencedStoreBarrier:
         return Void;
     case Select:
         ASSERT(secondChild);

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -525,6 +525,8 @@ protected:
         case WasmStructNew:
         case WasmRefCast:
         case WasmRefTest:
+        case StoreBarrier:
+        case FencedStoreBarrier:
         case VectorReplaceLane:
         case VectorEqual:
         case VectorNotEqual:
@@ -831,6 +833,8 @@ private:
         case VectorRelaxedMax:
         case VectorRelaxedDotI8x16I7x16:
         case Stitch:
+        case StoreBarrier:
+        case FencedStoreBarrier:
             if (numArgs != 2) [[unlikely]]
                 badKind(kind, numArgs);
             return Two;

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -131,6 +131,8 @@ namespace JSC { namespace B3 {
     case BelowEqual: \
     case EqualOrUnordered: \
     case Select: \
+    case StoreBarrier: \
+    case FencedStoreBarrier: \
         return MACRO(Value); \
     case WasmArrayLength: \
         return MACRO(WasmArrayLengthValue); \

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -283,6 +283,8 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
     case WasmArrayGet:
     case WasmArraySet:
     case WasmArrayNew:
+    case StoreBarrier:
+    case FencedStoreBarrier:
     case MemoryCopy:
     case MemoryFill:
     case Fence:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1738,8 +1738,8 @@ private:
         case SuperSamplerEnd:
             compileSuperSamplerEnd();
             break;
-        case StoreBarrier:
-        case FencedStoreBarrier:
+        case DFG::StoreBarrier:
+        case DFG::FencedStoreBarrier:
             compileStoreBarrier();
             break;
         case HasIndexedProperty:
@@ -17021,7 +17021,7 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileStoreBarrier()
     {
-        emitStoreBarrier(lowCell(m_node->child1()), m_node->op() == FencedStoreBarrier);
+        emitStoreBarrier(lowCell(m_node->child1()), m_node->op() == DFG::FencedStoreBarrier);
     }
 
     LValue compileHasIndexedPropertyImpl(LValue index, S_JITOperation_GCZ slowPathOperation)

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2408,45 +2408,8 @@ inline void OMGIRGenerator::emitWriteBarrierForJSWrapper()
 
 inline void OMGIRGenerator::emitWriteBarrier(Value* cell)
 {
-    Value* cellState = m_currentBlock->appendNew<MemoryValue>(m_proc, Load8Z, Int32, origin(), cell, safeCast<int32_t>(JSCell::cellStateOffset()));
-    m_heaps.decorateMemory(&m_heaps.JSCell_cellState, cellState);
-
-    auto* vm = vmValue();
-    Value* threshold = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, origin(), vm, safeCast<int32_t>(VM::offsetOfHeapBarrierThreshold()));
-    m_heaps.decorateMemory(&m_heaps.VM_heap_barrierThreshold, threshold);
-
-    BasicBlock* recheckPath = m_proc.addBlock();
-    BasicBlock* doSlowPath = m_proc.addBlock();
-    BasicBlock* continuation = m_proc.addBlock();
-
-    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(),
-        m_currentBlock->appendNew<Value>(m_proc, Above, origin(), cellState, threshold),
-        FrequentedBlock(continuation), FrequentedBlock(recheckPath, FrequencyClass::Rare));
-    recheckPath->addPredecessor(m_currentBlock);
-    continuation->addPredecessor(m_currentBlock);
-    m_currentBlock = recheckPath;
-
-    auto* fence = m_currentBlock->appendNew<FenceValue>(m_proc, origin());
-    m_heaps.decorateFenceRead(&m_heaps.root, fence);
-    m_heaps.decorateFenceWrite(&m_heaps.JSCell_cellState, fence);
-
-    Value* cellStateLoadAfterFence = m_currentBlock->appendNew<MemoryValue>(m_proc, Load8Z, Int32, origin(), cell, safeCast<int32_t>(JSCell::cellStateOffset()));
-    m_heaps.decorateMemory(&m_heaps.JSCell_cellState, cellStateLoadAfterFence);
-
-    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(),
-        m_currentBlock->appendNew<Value>(m_proc, Above, origin(), cellStateLoadAfterFence, constant(Int32, blackThreshold)),
-        FrequentedBlock(continuation), FrequentedBlock(doSlowPath, FrequencyClass::Rare));
-    doSlowPath->addPredecessor(m_currentBlock);
-    continuation->addPredecessor(m_currentBlock);
-    m_currentBlock = doSlowPath;
-
-    Value* call = callWasmOperation(m_currentBlock, B3::Void, operationWasmWriteBarrierSlowPath, cell, vm);
-    m_heaps.decorateCCallRead(&m_heaps.root, call);
-    m_heaps.decorateCCallWrite(&m_heaps.JSCell_cellState, call);
-    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
-
-    continuation->addPredecessor(m_currentBlock);
-    m_currentBlock = continuation;
+    m_proc.setUsesStoreBarriers();
+    m_currentBlock->appendNew<Value>(m_proc, FencedStoreBarrier, origin(), cell, vmValue());
 }
 
 inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint64_t offset, uint32_t sizeOfOperation, uint8_t memoryIndex)


### PR DESCRIPTION
#### f1f079c8a5e906888c0e56006885198c6e170094
<pre>
[JSC] Add B3::StoreBarrier / B3::FencedStoreBarrier
<a href="https://bugs.webkit.org/show_bug.cgi?id=312856">https://bugs.webkit.org/show_bug.cgi?id=312856</a>
<a href="https://rdar.apple.com/175223929">rdar://175223929</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/b3/B3Generate.cpp:
(JSC::B3::generateToAir):
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::setUsessSIMD):
(JSC::B3::Procedure::setUsesStoreBarriers):
(JSC::B3::Procedure::usesStoreBarriers const):
* Source/JavaScriptCore/b3/B3StoreBarrierClusteringPhase.cpp: Added.
(JSC::B3::storeBarrierClustering):
* Source/JavaScriptCore/b3/B3StoreBarrierClusteringPhase.h: Added.
* Source/JavaScriptCore/b3/B3StoreBarrierElisionPhase.cpp: Added.
(JSC::B3::storeBarrierElision):
* Source/JavaScriptCore/b3/B3StoreBarrierElisionPhase.h: Added.
* Source/JavaScriptCore/b3/B3StoreBarrierUtils.h: Added.
(JSC::B3::isStoreBarrier):
(JSC::B3::isFreshAllocation):
(JSC::B3::mayGC):
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
(JSC::B3::Value::typeFor):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitWriteBarrier):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1f079c8a5e906888c0e56006885198c6e170094

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111737 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122067 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85739 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24350 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102736 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23406 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21689 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14250 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149706 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133085 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168968 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18490 "Found 21 new JSC stress test failures: stress/taintedness-tracking-wasm.js.bytecode-cache, stress/taintedness-tracking-wasm.js.default, stress/taintedness-tracking-wasm.js.dfg-eager, stress/taintedness-tracking-wasm.js.dfg-eager-no-cjit-validate, stress/taintedness-tracking-wasm.js.eager-jettison-no-cjit, stress/taintedness-tracking-wasm.js.ftl-eager, stress/taintedness-tracking-wasm.js.ftl-eager-no-cjit-b3o1, stress/taintedness-tracking-wasm.js.ftl-no-cjit-b3o0, stress/taintedness-tracking-wasm.js.ftl-no-cjit-no-inline-validate, stress/taintedness-tracking-wasm.js.ftl-no-cjit-no-put-stack-validate ... (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13473 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21003 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130234 "Found 1 new test failure: media/media-sources-selection.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130351 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141176 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88514 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25161 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17981 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189782 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30227 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94655 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48748 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29749 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29876 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->