### PR TITLE
Remove unnecessary RefPtr { } wrapper in WebXR code

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -83,7 +83,7 @@ static GL::ExternalImageSource makeExternalImageSource(PlatformXR::FrameData::Ex
 {
 #if OS(ANDROID)
     return GraphicsContextGLExternalImageSource {
-        .hardwareBuffer = RefPtr { imageSource },
+        .hardwareBuffer = imageSource,
         .size = size,
     };
 #else

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
@@ -193,7 +193,7 @@ static GL::ExternalImageSource makeExternalImageSource(PlatformXR::FrameData::Ex
 #if PLATFORM(GTK) || PLATFORM(WPE)
 #if OS(ANDROID)
     return GraphicsContextGLExternalImageSource {
-        .hardwareBuffer = RefPtr { imageSource },
+        .hardwareBuffer = imageSource,
         .size = size,
     };
 #else


### PR DESCRIPTION
#### f4965a75f447b0122f1e7e5895c341e83b7d27a3
<pre>
Remove unnecessary RefPtr { } wrapper in WebXR code
<a href="https://bugs.webkit.org/show_bug.cgi?id=312857">https://bugs.webkit.org/show_bug.cgi?id=312857</a>
<a href="https://rdar.apple.com/175227740">rdar://175227740</a>

Reviewed by Ryosuke Niwa.

The .hardwareBuffer field is RefPtr&lt;AHardwareBuffer&gt; and the source is also
RefPtr&lt;AHardwareBuffer&gt;&amp;, so RefPtr&apos;s copy constructor handles the refcount
increment directly. The explicit RefPtr { } wrapper is redundant.

No new tests needed (no behavioral change).

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::makeExternalImageSource):
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp:
(WebCore::WebXRWebGLSwapchain::makeExternalImageSource):

Canonical link: <a href="https://commits.webkit.org/311719@main">https://commits.webkit.org/311719@main</a>
</pre>
