### PR TITLE
[WebXR][OpenXR] Support Equirect layer

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -139,6 +139,7 @@ private:
         std::optional<PlatformXR::LayerInfo> createLayerProjection(uint32_t, uint32_t, bool) final { return std::nullopt; }
 #if ENABLE(WEBXR_LAYERS)
         std::optional<PlatformXR::LayerInfo> createQuadLayer(IntSize, PlatformXR::LayerLayout) final { return std::nullopt; }
+        std::optional<PlatformXR::LayerInfo> createEquirectLayer(IntSize, PlatformXR::LayerLayout) final { return std::nullopt; }
 #endif
         void deleteLayer(PlatformXR::LayerHandle) final { }
 #if ENABLE(WEBXR_HIT_TEST)

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -339,6 +339,7 @@ PlatformXR::DeviceLayer WebXRWebGLLayer::endFrame()
         .blendTextureSourceAlpha = false,
         .forceMonoPresentation = false,
         .quadLayerData = std::nullopt,
+        .equirectLayerData = std::nullopt,
 #endif
 #endif
     };

--- a/Source/WebCore/Modules/webxr/XREquirectLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XREquirectLayer.cpp
@@ -24,14 +24,133 @@
  */
 
 #include "config.h"
+#include "XREquirectLayer.h"
 
 #if ENABLE(WEBXR_LAYERS)
-#include "XREquirectLayer.h"
+
+#include "Logging.h"
+#include "WebXRRigidTransform.h"
+#include "WebXRSession.h"
+#include "XRLayerBacking.h"
+#include "XRWebGLBinding.h"
+#include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-XREquirectLayer::~XREquirectLayer() = default;
+WTF_MAKE_TZONE_ALLOCATED_IMPL(XREquirectLayer);
 
+XREquirectLayer::XREquirectLayer(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XREquirectLayerInit& init)
+    : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing), init)
+    , m_space(init.space)
+    , m_transform((init.transform) ? init.transform : WebXRRigidTransform::create())
+    , m_radius(init.radius)
+    , m_centralHorizontalAngle(init.centralHorizontalAngle)
+    , m_upperVerticalAngle(init.upperVerticalAngle)
+    , m_lowerVerticalAngle(init.lowerVerticalAngle)
+{
+    setIsStatic(init.isStatic);
 }
 
+XREquirectLayer::~XREquirectLayer() = default;
+
+const WebXRSpace& XREquirectLayer::space() const
+{
+    ASSERT(m_space);
+    return *m_space;
+}
+
+void XREquirectLayer::setSpace(WebXRSpace& space)
+{
+    if (m_space == &space)
+        return;
+
+    m_space = space;
+    setNeedsRedraw(true);
+}
+
+const WebXRRigidTransform& XREquirectLayer::transform() const
+{
+    ASSERT(m_transform);
+    return *m_transform;
+}
+
+void XREquirectLayer::setTransform(WebXRRigidTransform& transform)
+{
+    if (m_transform == &transform)
+        return;
+
+    m_transform = transform;
+    setNeedsRedraw(true);
+}
+
+void XREquirectLayer::startFrame(PlatformXR::FrameData& frameData)
+{
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    auto it = frameData.layers.find(m_backing->handle());
+    if (it == frameData.layers.end())
+        return;
+
+    if (needsRedraw())
+        m_backing->startFrame(frameData);
+#else
+    UNUSED_PARAM(frameData);
 #endif
+}
+
+void XREquirectLayer::recomputePose()
+{
+    auto scopeExit = makeScopeExit([&]() {
+        RELEASE_LOG_ERROR(XR, "Failed to invert space transform, using identity transform for layer pose");
+        m_poseInLocalSpace = PlatformXR::FrameData::Pose { .position = { 0, 0, 0 }, .orientation = { 0, 0, 0, 1 } };
+    });
+
+    std::optional<TransformationMatrix> spaceTransform;
+    if (m_space)
+        spaceTransform = m_space->nativeOrigin();
+    if (!spaceTransform)
+        spaceTransform = TransformationMatrix();
+    else if (!spaceTransform->isInvertible())
+        return;
+
+    auto transformInLocalSpace = m_transform ? *spaceTransform->inverse() * m_transform->rawTransform() : *spaceTransform->inverse();
+    TransformationMatrix::Decomposed4Type decomposed;
+    if (!transformInLocalSpace.decompose4(decomposed))
+        return;
+
+    scopeExit.release();
+    m_poseInLocalSpace.position = { static_cast<float>(decomposed.translateX), static_cast<float>(decomposed.translateY), static_cast<float>(decomposed.translateZ) };
+    m_poseInLocalSpace.orientation = { static_cast<float>(decomposed.quaternion.x), static_cast<float>(decomposed.quaternion.y), static_cast<float>(decomposed.quaternion.z), static_cast<float>(decomposed.quaternion.w) };
+}
+
+PlatformXR::DeviceLayer XREquirectLayer::endFrame()
+{
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    PlatformXR::DeviceLayer layerData;
+    if (needsRedraw())
+        m_backing->endFrame(layerData);
+
+    layerData.handle = m_backing->handle();
+    layerData.visible = true;
+
+    if (needsRedraw())
+        recomputePose();
+
+    fillInCommonDeviceLayerData(layerData);
+
+    layerData.equirectLayerData = {
+        .radius = m_radius,
+        .centralHorizontalAngle = m_centralHorizontalAngle,
+        .upperVerticalAngle = m_upperVerticalAngle,
+        .lowerVerticalAngle = m_lowerVerticalAngle,
+        .poseInLocalSpace = m_poseInLocalSpace,
+    };
+    return layerData;
+#else
+    return PlatformXR::DeviceLayer { };
+#endif
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/XREquirectLayer.h
+++ b/Source/WebCore/Modules/webxr/XREquirectLayer.h
@@ -27,38 +27,60 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "ExceptionOr.h"
 #include "XRCompositionLayer.h"
+#include "XREquirectLayerInit.h"
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
 
 namespace WebCore {
 
 class WebXRRigidTransform;
+class WebXRSession;
 class WebXRSpace;
+class XRLayerBacking;
 
 // https://immersive-web.github.io/layers/#xrequirectlayertype
 class XREquirectLayer : public XRCompositionLayer {
+    WTF_MAKE_TZONE_ALLOCATED(XREquirectLayer);
 public:
+    static Ref<XREquirectLayer> create(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XREquirectLayerInit& init)
+    {
+        return adoptRef(*new XREquirectLayer(scriptExecutionContext, session, WTF::move(backing), init));
+    }
+
     virtual ~XREquirectLayer();
 
-    const WebXRSpace& space() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setSpace(WebXRSpace&) { RELEASE_ASSERT_NOT_REACHED(); }
-    const WebXRRigidTransform& transform() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setTransform(WebXRRigidTransform&) { RELEASE_ASSERT_NOT_REACHED(); }
+    const WebXRSpace& space() const;
+    void setSpace(WebXRSpace&);
+    const WebXRRigidTransform& transform() const;
+    void setTransform(WebXRRigidTransform&);
 
-    float radius() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setRadius(float) { RELEASE_ASSERT_NOT_REACHED(); }
-    float centralHorizontalAngle() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setCentralHorizontalAngle(float) { RELEASE_ASSERT_NOT_REACHED(); }
-    float upperVerticalAngle() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setUpperVerticalAngle(float) { RELEASE_ASSERT_NOT_REACHED(); }
-    float lowerVerticalAngle() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setLowerVerticalAngle(float) { RELEASE_ASSERT_NOT_REACHED(); }
+    float radius() const { return m_radius; }
+    void setRadius(float radius) { m_radius = radius; setNeedsRedraw(true); }
+    float centralHorizontalAngle() const { return m_centralHorizontalAngle; }
+    void setCentralHorizontalAngle(float angle) { m_centralHorizontalAngle = angle; setNeedsRedraw(true); }
+    float upperVerticalAngle() const { return m_upperVerticalAngle; }
+    void setUpperVerticalAngle(float angle) { m_upperVerticalAngle = angle; setNeedsRedraw(true); }
+    float lowerVerticalAngle() const { return m_lowerVerticalAngle; }
+    void setLowerVerticalAngle(float angle) { m_lowerVerticalAngle = angle; setNeedsRedraw(true); }
 
 private:
+    XREquirectLayer(ScriptExecutionContext&, WebXRSession&, Ref<XRLayerBacking>&&, const XREquirectLayerInit&);
     bool isXREquirectLayer() const final { return true; }
+    void recomputePose();
+
+    RefPtr<WebXRSpace> m_space;
+    RefPtr<WebXRRigidTransform> m_transform;
+    float m_radius;
+    float m_centralHorizontalAngle;
+    float m_upperVerticalAngle;
+    float m_lowerVerticalAngle;
+    PlatformXR::FrameData::Pose m_poseInLocalSpace;
 
     // WebXRLayer.
-    [[noreturn]] void startFrame(PlatformXR::FrameData&) final { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] PlatformXR::DeviceLayer endFrame() final { RELEASE_ASSERT_NOT_REACHED(); }
+    void startFrame(PlatformXR::FrameData&) final;
+    PlatformXR::DeviceLayer endFrame() final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -34,14 +34,18 @@
 #include "WebGLOpaqueTexture.h"
 #include "WebGLRenderingContext.h"
 #include "WebGLRenderingContextBase.h"
+#include "WebXRReferenceSpace.h"
 #include "WebXRSession.h"
 #include "WebXRView.h"
 #include "WebXRViewport.h"
+#include "XREquirectLayer.h"
+#include "XREquirectLayerInit.h"
 #include "XRLayerLayout.h"
 #include "XRProjectionLayer.h"
 #include "XRProjectionLayerInit.h"
 #include "XRQuadLayer.h"
 #include "XRQuadLayerInit.h"
+#include "XRWebGLEquirectLayerBacking.h"
 #include "XRWebGLProjectionLayerBacking.h"
 #include "XRWebGLQuadLayerBacking.h"
 #include "XRWebGLSubImage.h"
@@ -329,6 +333,32 @@ static ExceptionOr<void> checkCanSetSpace(const WebXRSpace& space, const WebXRSe
     return { };
 }
 
+ExceptionOr<void> XRWebGLBinding::validateCompositionLayerInitParameters(const XRLayerInit& init) const
+{
+    if (init.layout == XRLayerLayout::Default)
+        return Exception { ExceptionCode::TypeError, "Default layout is not supported for non projection layers."_s };
+
+    // The following checks are really part of the allocate textures algorithm, but we prefer to early fail here
+    // as the allocation happens lazily when getSubImage() is called.
+    if (init.mipLevels < 1)
+        return Exception { ExceptionCode::InvalidStateError, "Mip levels lower than 1 are invalid."_s };
+    if (init.mipLevels > 1) {
+        auto isPowerOfTwo = [](uint32_t n) {
+            return !(n & (n - 1));
+        };
+        if (!isPowerOfTwo(init.viewPixelWidth) || !isPowerOfTwo(init.viewPixelHeight))
+            return Exception { ExceptionCode::InvalidStateError, "Mip levels greater than 1 are not supported for non power of 2 textures."_s };
+    }
+
+    if (!colorFormatIsSupportedForNonProjectionLayer(init.colorFormat))
+        return Exception { ExceptionCode::NotSupportedError, "Unsupported texture format."_s };
+
+    if (init.depthFormat && !depthFormatIsSupportedForNonProjectionLayer(*init.depthFormat))
+        return Exception { ExceptionCode::NotSupportedError, "Unsupported texture depth format."_s };
+
+    return { };
+}
+
 ExceptionOr<Ref<XRQuadLayer>> XRWebGLBinding::createQuadLayer(ScriptExecutionContext& scriptExecutionContext, const XRQuadLayerInit& init)
 {
     if (!m_session->supportsFeature(PlatformXR::SessionFeature::Layers))
@@ -342,29 +372,9 @@ ExceptionOr<Ref<XRQuadLayer>> XRWebGLBinding::createQuadLayer(ScriptExecutionCon
             if (baseContext->isContextLost())
                 return Exception { ExceptionCode::InvalidStateError, "Cannot create a quad layer with a lost WebGL context"_s };
 
-            if (init.layout == XRLayerLayout::Default)
-                return Exception { ExceptionCode::TypeError, "Default layout is not supported for quad layers."_s };
-
-            // The following three checks are really part of the allocate textures algorithm, but we need to fail early here
-            // as the allocation happens lazily when getSubImage() is called.
-            if (!colorFormatIsSupportedForNonProjectionLayer(init.colorFormat))
-                return Exception { ExceptionCode::NotSupportedError, "Unsupported texture format."_s };
-
-            if (init.mipLevels < 1)
-                return Exception { ExceptionCode::InvalidStateError, "Mip levels lower than 1 are invalid."_s };
-            if (init.mipLevels > 1) {
-                auto isPowerOfTwo = [](uint32_t n) {
-                    return !(n & (n - 1));
-                };
-                if (!isPowerOfTwo(init.viewPixelWidth) || !isPowerOfTwo(init.viewPixelHeight))
-                    return Exception { ExceptionCode::InvalidStateError, "Mip levels greater than 1 are not supported for non power of 2 textures."_s };
-
-            }
-
-            // The following check is really part of the allocate depth textures algorithm, but we need to fail early for the quad layer case
-            // as the allocation happens lazily when getSubImage() is called.
-            if (init.depthFormat && !depthFormatIsSupportedForNonProjectionLayer(*init.depthFormat))
-                return Exception { ExceptionCode::NotSupportedError, "Unsupported texture depth format."_s };
+            auto validateInitResult = validateCompositionLayerInitParameters(init);
+            if (validateInitResult.hasException())
+                return validateInitResult.releaseException();
 
             auto createBackingResult = XRWebGLQuadLayerBacking::create(m_session, baseContext, init);
             if (createBackingResult.hasException())
@@ -517,6 +527,57 @@ ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateDepthTex
             if (textures.isEmpty())
                 return Exception { ExceptionCode::OperationError };
             return textures;
+        },
+        [](std::monostate) {
+            ASSERT_NOT_REACHED();
+            return Exception { ExceptionCode::OperationError, "Could not get a WebGL rendering context."_s };
+        }
+    );
+}
+
+ExceptionOr<Ref<XREquirectLayer>> XRWebGLBinding::createEquirectLayer(ScriptExecutionContext& scriptExecutionContext, const XREquirectLayerInit& init)
+{
+    if (!m_session->supportsFeature(PlatformXR::SessionFeature::Layers))
+        return Exception { ExceptionCode::NotSupportedError, "Layers are not supported by the session."_s };
+
+    if (m_session->ended())
+        return Exception { ExceptionCode::InvalidStateError, "Cannot create an equirect layer with an XRSession that has ended."_s };
+
+    return WTF::switchOn(m_context,
+        [&](const Ref<WebGLRenderingContextBase>& baseContext) -> ExceptionOr<Ref<XREquirectLayer>> {
+            if (baseContext->isContextLost())
+                return Exception { ExceptionCode::InvalidStateError, "Cannot create an equirect layer with a lost WebGL context"_s };
+
+            if (!init.space->isReferenceSpace())
+                return Exception { ExceptionCode::TypeError, "The space is not a reference space."_s };
+
+            if (downcast<WebXRReferenceSpace>(init.space)->type() == XRReferenceSpaceType::Viewer)
+                return Exception { ExceptionCode::TypeError, "Viewer space is not allowed for equirect layers."_s };
+
+            auto validateInitResult = validateCompositionLayerInitParameters(init);
+            if (validateInitResult.hasException())
+                return validateInitResult.releaseException();
+
+            auto createBackingResult = XRWebGLEquirectLayerBacking::create(m_session, baseContext, init);
+            if (createBackingResult.hasException())
+                return createBackingResult.releaseException();
+            Ref backing = createBackingResult.releaseReturnValue();
+
+            auto checkSpaceResult = checkCanSetSpace(init.space.get(), m_session);
+            if (checkSpaceResult.hasException())
+                return checkSpaceResult.releaseException();
+
+            Ref layer = XREquirectLayer::create(scriptExecutionContext, m_session, WTF::move(backing), init);
+            initializeCompositionLayer(layer.get());
+
+            auto layoutResult = determineLayout(init.textureType, init.layout);
+            if (layoutResult.hasException())
+                return layoutResult.releaseException();
+            auto layout = layoutResult.releaseReturnValue();
+            layer->setLayout(layout);
+            layer->setNeedsRedraw(true);
+
+            return layer;
         },
         [](std::monostate) {
             ASSERT_NOT_REACHED();

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.h
@@ -78,7 +78,7 @@ public:
     ExceptionOr<Ref<XRProjectionLayer>> createProjectionLayer(ScriptExecutionContext&, const XRProjectionLayerInit&);
     ExceptionOr<Ref<XRQuadLayer>> createQuadLayer(ScriptExecutionContext&, const XRQuadLayerInit&);
     ExceptionOr<Ref<XRCylinderLayer>> createCylinderLayer(const XRCylinderLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
-    ExceptionOr<Ref<XREquirectLayer>> createEquirectLayer(const XREquirectLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
+    ExceptionOr<Ref<XREquirectLayer>> createEquirectLayer(ScriptExecutionContext&, const XREquirectLayerInit&);
     ExceptionOr<Ref<XRCubeLayer>> createCubeLayer(const XRCubeLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     Ref<WebXRViewport> initializeViewport(IntSize, XRLayerLayout, int offset, int num);
@@ -95,6 +95,7 @@ private:
     bool depthFormatIsSupportedForProjectionLayer(GCGLenum) const;
     bool colorFormatIsSupportedForNonProjectionLayer(GCGLenum) const;
     bool depthFormatIsSupportedForNonProjectionLayer(GCGLenum) const;
+    ExceptionOr<void> validateCompositionLayerInitParameters(const XRLayerInit&) const;
     ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateColorTexturesForProjectionLayer(XRProjectionLayer&, XRTextureType, GCGLenum textureFormat, double scaleFactor);
     ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateDepthTexturesForProjectionLayer(XRProjectionLayer&, XRTextureType, GCGLenum textureFormat, double scaleFactor);
     ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateColorTexturesForLayer(XRCompositionLayer&, XRTextureType, const XRLayerInit&);

--- a/Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "XRWebGLEquirectLayerBacking.h"
+
+#if ENABLE(WEBXR_LAYERS)
+
+#include "WebXRSession.h"
+#include "WebXRWebGLLayer.h"
+#include "WebXRWebGLSwapchain.h"
+#include "XREquirectLayerInit.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLEquirectLayerBacking);
+
+ExceptionOr<Ref<XRWebGLEquirectLayerBacking>> XRWebGLEquirectLayerBacking::create(WebXRSession& session, WebGLRenderingContextBase& context, const XREquirectLayerInit& init)
+{
+    auto device = session.device();
+    if (!device)
+        return Exception { ExceptionCode::OperationError, "Cannot create an equirect layer without a valid device."_s };
+
+    auto computeEquirectLayerData = [](XREquirectLayerInit init) -> std::pair<IntSize, PlatformXR::LayerLayout> {
+        switch (init.layout) {
+        case XRLayerLayout::Mono:
+            return { IntSize { static_cast<int>(init.viewPixelWidth), static_cast<int>(init.viewPixelHeight) }, PlatformXR::LayerLayout::Mono };
+        case XRLayerLayout::Stereo:
+        case XRLayerLayout::StereoLeftRight:
+            return { IntSize { static_cast<int>(init.viewPixelWidth * 2), static_cast<int>(init.viewPixelHeight) }, PlatformXR::LayerLayout::StereoLeftRight };
+        case XRLayerLayout::StereoTopBottom:
+            return { IntSize { static_cast<int>(init.viewPixelWidth), static_cast<int>(init.viewPixelHeight * 2) }, PlatformXR::LayerLayout::StereoTopBottom };
+        default:
+        case XRLayerLayout::Default:
+            ASSERT_NOT_REACHED_WITH_MESSAGE("Default layout is not supported for non-projection Layers");
+            return { IntSize(), PlatformXR::LayerLayout::Mono };
+        };
+    };
+
+    auto [ equirectLayerSize, equirectLayerLayout ] = computeEquirectLayerData(init);
+
+    auto layerInfo = device->createEquirectLayer(equirectLayerSize, equirectLayerLayout);
+    if (!layerInfo)
+        return Exception { ExceptionCode::OperationError, "Unable to create an equirect layer."_s };
+
+    auto colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, init.colorFormat, init.clearOnAccess, layerInfo->numImages);
+    if (!colorSwapchain)
+        return Exception { ExceptionCode::OperationError, "Failed to create a WebGL swapchain."_s };
+
+    return adoptRef(*new XRWebGLEquirectLayerBacking(layerInfo->handle, WTF::move(colorSwapchain), nullptr, init));
+}
+
+XRWebGLEquirectLayerBacking::XRWebGLEquirectLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XREquirectLayerInit& init)
+    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain))
+    , m_init(init)
+{
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,25 +23,33 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-typedef (WebGLRenderingContext or WebGL2RenderingContext) WebXRWebGLRenderingContext;
+#pragma once
 
-// https://immersive-web.github.io/layers/#XRWebGLBindingtype
-[
-    Conditional=WEBXR_LAYERS,
-    EnabledBySetting=WebXRLayersAPIEnabled,
-    Exposed=Window
-] interface XRWebGLBinding {
-    constructor(WebXRSession session, WebXRWebGLRenderingContext context);
+#if ENABLE(WEBXR_LAYERS)
 
-    readonly attribute double nativeProjectionScaleFactor;
-    readonly attribute boolean usesDepthValues;
+#include "XREquirectLayerInit.h"
+#include "XRWebGLLayerBacking.h"
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
-    [CallWith=CurrentScriptExecutionContext] XRProjectionLayer createProjectionLayer(optional XRProjectionLayerInit init = {});
-    [CallWith=CurrentScriptExecutionContext] XRQuadLayer createQuadLayer(optional XRQuadLayerInit init = {});
-    XRCylinderLayer createCylinderLayer(optional XRCylinderLayerInit init = {});
-    [CallWith=CurrentScriptExecutionContext] XREquirectLayer createEquirectLayer(optional XREquirectLayerInit init = {});
-    XRCubeLayer createCubeLayer(optional XRCubeLayerInit init = {});
+namespace WebCore {
 
-    XRWebGLSubImage getSubImage(XRCompositionLayer layer, WebXRFrame frame, optional XREye eye = "none");
-    XRWebGLSubImage getViewSubImage(XRProjectionLayer layer, WebXRView view);
+class WebGLRenderingContextBase;
+class WebXRWebGLSwapchain;
+class WebXRSession;
+
+class XRWebGLEquirectLayerBacking : public XRWebGLLayerBacking {
+    WTF_MAKE_TZONE_ALLOCATED(XRWebGLEquirectLayerBacking);
+public:
+    static ExceptionOr<Ref<XRWebGLEquirectLayerBacking>> create(WebXRSession&, WebGLRenderingContextBase&, const XREquirectLayerInit&);
+
+private:
+    XRWebGLEquirectLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XREquirectLayerInit&);
+
+    XREquirectLayerInit m_init;
 };
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -581,6 +581,7 @@ Modules/webxr/WebXRRay.cpp
 Modules/webxr/XRReferenceSpaceEvent.cpp
 Modules/webxr/XRSessionEvent.cpp
 Modules/webxr/XRSubImage.cpp
+Modules/webxr/XRWebGLEquirectLayerBacking.cpp
 Modules/webxr/XRWebGLLayerBacking.cpp
 Modules/webxr/XRWebGLProjectionLayerBacking.cpp
 Modules/webxr/XRWebGLQuadLayerBacking.cpp

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -512,6 +512,14 @@ struct DeviceLayer {
         FrameData::Pose poseInLocalSpace;
     };
     std::optional<QuadLayerData> quadLayerData;
+    struct EquirectLayerData {
+        float radius;
+        float centralHorizontalAngle;
+        float upperVerticalAngle;
+        float lowerVerticalAngle;
+        FrameData::Pose poseInLocalSpace;
+    };
+    std::optional<EquirectLayerData> equirectLayerData;
 #endif
 };
 
@@ -555,6 +563,7 @@ public:
     virtual std::optional<LayerInfo> createLayerProjection(uint32_t width, uint32_t height, bool alpha) = 0;
 #if ENABLE(WEBXR_LAYERS)
     virtual std::optional<LayerInfo> createQuadLayer(WebCore::IntSize, LayerLayout) = 0;
+    virtual std::optional<LayerInfo> createEquirectLayer(WebCore::IntSize, LayerLayout) = 0;
 #endif
     virtual void deleteLayer(LayerHandle) = 0;
 

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -319,12 +319,22 @@ std::optional<PlatformXR::LayerInfo> SimulatedXRDevice::createLayerProjection(ui
 }
 
 #if ENABLE(WEBXR_LAYERS)
-std::optional<PlatformXR::LayerInfo> SimulatedXRDevice::createQuadLayer(IntSize size, PlatformXR::LayerLayout)
+std::optional<PlatformXR::LayerInfo> SimulatedXRDevice::createCompositionLayer(IntSize size)
 {
     auto handle = createLayer(size);
     if (!handle)
         return std::nullopt;
     return PlatformXR::LayerInfo { *handle, 1 };
+}
+
+std::optional<PlatformXR::LayerInfo> SimulatedXRDevice::createQuadLayer(IntSize size, PlatformXR::LayerLayout)
+{
+    return createCompositionLayer(size);
+}
+
+std::optional<PlatformXR::LayerInfo> SimulatedXRDevice::createEquirectLayer(IntSize size, PlatformXR::LayerLayout)
+{
+    return createCompositionLayer(size);
 }
 #endif
 

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -108,7 +108,9 @@ private:
     std::optional<PlatformXR::LayerHandle> createLayer(IntSize);
     std::optional<PlatformXR::LayerInfo> createLayerProjection(uint32_t width, uint32_t height, bool alpha) final;
 #if ENABLE(WEBXR_LAYERS)
+    std::optional<PlatformXR::LayerInfo> createCompositionLayer(IntSize);
     std::optional<PlatformXR::LayerInfo> createQuadLayer(IntSize, PlatformXR::LayerLayout) final;
+    std::optional<PlatformXR::LayerInfo> createEquirectLayer(IntSize, PlatformXR::LayerLayout) final;
 #endif
     void deleteLayer(PlatformXR::LayerHandle) final;
 #if ENABLE(WEBXR_HIT_TEST)

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -306,6 +306,15 @@ header: <WebCore/PlatformXR.h>
 };
 
 header: <WebCore/PlatformXR.h>
+[Nested] struct PlatformXR::DeviceLayer::EquirectLayerData {
+    float radius;
+    float centralHorizontalAngle;
+    float upperVerticalAngle;
+    float lowerVerticalAngle;
+    PlatformXR::FrameData::Pose poseInLocalSpace;
+};
+
+header: <WebCore/PlatformXR.h>
 [CustomHeader] struct PlatformXR::DeviceLayer {
     PlatformXR::LayerHandle handle;
     bool visible;
@@ -315,6 +324,7 @@ header: <WebCore/PlatformXR.h>
     bool blendTextureSourceAlpha;
     bool forceMonoPresentation;
     std::optional<PlatformXR::DeviceLayer::QuadLayerData> quadLayerData;
+    std::optional<PlatformXR::DeviceLayer::EquirectLayerData> equirectLayerData;
 #endif
 };
 #endif

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -148,6 +148,12 @@ std::optional<PlatformXR::LayerInfo> XRDeviceProxy::createQuadLayer(WebCore::Int
     RefPtr xrSystem = m_xrSystem.get();
     return xrSystem ? xrSystem->createQuadLayer(size, layout) : std::nullopt;
 }
+
+std::optional<PlatformXR::LayerInfo> XRDeviceProxy::createEquirectLayer(WebCore::IntSize size, PlatformXR::LayerLayout layout)
+{
+    RefPtr xrSystem = m_xrSystem.get();
+    return xrSystem ? xrSystem->createEquirectLayer(size, layout) : std::nullopt;
+}
 #endif
 
 void XRDeviceProxy::submitFrame(Vector<PlatformXR::DeviceLayer>&& layers)

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.h
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.h
@@ -68,6 +68,7 @@ private:
     std::optional<PlatformXR::LayerInfo> createLayerProjection(uint32_t, uint32_t, bool) final;
 #if ENABLE(WEBXR_LAYERS)
     std::optional<PlatformXR::LayerInfo> createQuadLayer(WebCore::IntSize, PlatformXR::LayerLayout) final;
+    std::optional<PlatformXR::LayerInfo> createEquirectLayer(WebCore::IntSize, PlatformXR::LayerLayout) final;
 #endif
     void deleteLayer(PlatformXR::LayerHandle) override { };
     void submitFrame(Vector<PlatformXR::DeviceLayer>&&) final;

--- a/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
@@ -72,8 +72,11 @@ public:
 #endif
 
 #if ENABLE(WEBXR_LAYERS)
+    // FIXME: Make these pure virtual once Apple internal implements correctly
     using CreateQuadCallback = CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>;
-    virtual void createQuadLayer(WebCore::IntSize, PlatformXR::LayerLayout, CreateQuadCallback&&) = 0;
+    virtual void createQuadLayer(WebCore::IntSize, PlatformXR::LayerLayout, CreateQuadCallback&&) { };
+    using CreateEquirectCallback = CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>;
+    virtual void createEquirectLayer(WebCore::IntSize, PlatformXR::LayerLayout, CreateEquirectCallback&&) { };
 #endif
 
     // Session creation/termination.

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -450,6 +450,12 @@ void PlatformXRSystem::createQuadLayer(IPC::Connection&, WebCore::IntSize, Platf
     ASSERT_NOT_REACHED_WITH_MESSAGE("VisionOS does not support Quad layers yet");
     reply(std::nullopt);
 }
+
+void PlatformXRSystem::createEquirectLayer(IPC::Connection&, WebCore::IntSize, PlatformXR::LayerLayout, CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>&& reply)
+{
+    ASSERT_NOT_REACHED_WITH_MESSAGE("VisionOS does not support Equirect layers yet");
+    reply(std::nullopt);
+}
 #endif // ENABLE(WEBXR_LAYERS) && PLATFORM(VISION)
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -106,9 +106,12 @@ private:
 #endif
 #if ENABLE(WEBXR_LAYERS)
 #if !USE(OPENXR) && !defined(NDEBUG)
-    [[noreturn]]
+#define XR_NORETURN [[noreturn]]
+#else
+#define XR_NORETURN
 #endif
-    void NODELETE createQuadLayer(IPC::Connection&, WebCore::IntSize, PlatformXR::LayerLayout, CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>&&);
+    XR_NORETURN void NODELETE createQuadLayer(IPC::Connection&, WebCore::IntSize, PlatformXR::LayerLayout, CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>&&);
+    XR_NORETURN void NODELETE createEquirectLayer(IPC::Connection&, WebCore::IntSize, PlatformXR::LayerLayout, CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>&&);
 #endif
 #if ENABLE(WEBXR_HIT_TEST)
     void requestHitTestSource(const PlatformXR::HitTestOptions&, CompletionHandler<void(Expected<PlatformXR::HitTestSource, WebCore::ExceptionData>)>&&);

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
@@ -43,6 +43,7 @@ messages -> PlatformXRSystem {
 #endif
 #if ENABLE(WEBXR_LAYERS)
     CreateQuadLayer(WebCore::IntSize size, PlatformXR::LayerLayout layout) -> (struct std::optional<PlatformXR::LayerInfo> info) Synchronous
+    CreateEquirectLayer(WebCore::IntSize size, PlatformXR::LayerLayout layout) -> (struct std::optional<PlatformXR::LayerInfo> info) Synchronous
 #endif
 #if !USE(OPENXR)
     SubmitFrame()

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -557,6 +557,143 @@ Vector<XrCompositionLayerBaseHeader*> OpenXRQuadLayer::endFrame(const PlatformXR
     return layerHeaders;
 }
 
+#if defined(XR_KHR_composition_layer_equirect2)
+
+std::unique_ptr<OpenXREquirectLayer> OpenXREquirectLayer::create(std::unique_ptr<OpenXRSwapchain>&& swapchain, PlatformXR::LayerLayout layout)
+{
+    return std::unique_ptr<OpenXREquirectLayer>(new OpenXREquirectLayer(makeUniqueRefFromNonNullUniquePtr(WTF::move(swapchain)), layout));
+}
+
+OpenXREquirectLayer::OpenXREquirectLayer(UniqueRef<OpenXRSwapchain>&& swapchain, PlatformXR::LayerLayout layout)
+    : OpenXRLayer(WTF::move(swapchain))
+    , m_layout(layout)
+{
+    m_layers.resize(layout == PlatformXR::LayerLayout::Mono ? 1 : 2);
+    m_layers.fill(createOpenXRStruct<XrCompositionLayerEquirect2KHR, XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR>());
+    int xOffset = 0;
+    int yOffset = 0;
+    int subImageWidth = layout == PlatformXR::LayerLayout::StereoLeftRight ? m_swapchain->width() / 2 : m_swapchain->width();
+    int subImageHeight = layout == PlatformXR::LayerLayout::StereoTopBottom ? m_swapchain->height() / 2 : m_swapchain->height();
+    XrExtent2Di subImageExtent = { subImageWidth, subImageHeight };
+    for (auto& xrLayer : m_layers) {
+        xrLayer.subImage.swapchain = m_swapchain->swapchain();
+        xrLayer.subImage.imageRect.offset = { xOffset, yOffset };
+        xrLayer.subImage.imageRect.extent = subImageExtent;
+        xrLayer.subImage.imageArrayIndex = 0;
+
+        xOffset += layout == PlatformXR::LayerLayout::StereoLeftRight ? subImageWidth : 0;
+        yOffset += layout == PlatformXR::LayerLayout::StereoTopBottom ? subImageHeight : 0;
+    }
+}
+
+std::optional<PlatformXR::FrameData::LayerData> OpenXREquirectLayer::startFrame()
+{
+    auto texture = m_swapchain->acquireImage();
+    if (!texture)
+        return std::nullopt;
+
+    auto addResult = m_exportedTextures.add(*texture, m_nextReusableTextureIndex);
+    bool needsExport = addResult.isNewEntry;
+
+    PlatformXR::FrameData::LayerData layerData;
+    layerData.renderingFrameIndex = m_renderingFrameIndex++;
+    layerData.textureData = {
+        .reusableTextureIndex = addResult.iterator->value,
+        .colorTexture = { },
+        .depthStencilBuffer = { },
+    };
+
+    if (!needsExport)
+        return layerData;
+    m_nextReusableTextureIndex++;
+
+    auto externalTexture = exportOpenXRTexture(*texture);
+    if (!externalTexture)
+        return std::nullopt;
+
+    layerData.textureData->colorTexture = WTF::move(externalTexture.value());
+
+    layerData.layerSetup = {
+        .physicalSize = { { { static_cast<uint16_t>(m_swapchain->width()), static_cast<uint16_t>(m_swapchain->height()) } } },
+        .viewports = { },
+        .foveationRateMapDesc = { }
+    };
+
+    return layerData;
+}
+
+Vector<XrCompositionLayerBaseHeader*> OpenXREquirectLayer::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
+{
+    if (!m_swapchain->acquiredTexture()) {
+        LOG_ERROR("OpenXREquirectLayer::endFrame called without a valid acquired texture");
+        return { };
+    }
+
+#if OS(ANDROID) || USE(GBM)
+    if (needsBlitTexture()) {
+        if (!m_fbosForBlitting[0])
+            glGenFramebuffers(m_fbosForBlitting.size(), m_fbosForBlitting.data());
+        blitTexture();
+    }
+#endif
+
+    auto eyeVisibility = [](bool isLeftEye, bool isMonoPresentation) {
+        if (isMonoPresentation)
+            return XR_EYE_VISIBILITY_BOTH;
+        return isLeftEye ? XR_EYE_VISIBILITY_LEFT : XR_EYE_VISIBILITY_RIGHT;
+    };
+    auto flags = layer.blendTextureSourceAlpha ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0;
+
+    auto isLeftEyeIndex = [layout = m_layout](int layerIndex) {
+        switch (layout) {
+        case PlatformXR::LayerLayout::Mono:
+        case PlatformXR::LayerLayout::StereoLeftRight:
+            return !layerIndex;
+        case PlatformXR::LayerLayout::StereoTopBottom:
+#if defined(XR_USE_GRAPHICS_API_OPENGL_ES) || defined(XR_USE_GRAPHICS_API_OPENGL)
+            return layerIndex == 1;
+#elif defined(XR_USE_GRAPHICS_API_VULKAN)
+            return !layerIndex;
+#endif
+        default:
+            ASSERT_NOT_REACHED_WITH_MESSAGE("Unrecognized layout for equirect layer");
+            return false;
+        };
+    };
+
+    const auto numLayers = m_layers.size();
+    Vector<XrCompositionLayerBaseHeader*> layerHeaders;
+    layerHeaders.reserveCapacity(numLayers);
+
+    bool isMonoPresentation = layer.forceMonoPresentation || m_layout == PlatformXR::LayerLayout::Mono;
+    for (size_t i = 0; i < numLayers; ++i) {
+        if (isMonoPresentation && !isLeftEyeIndex(i))
+            continue;
+
+        auto& xrLayer = m_layers[i];
+        xrLayer.layerFlags = flags;
+        xrLayer.eyeVisibility = eyeVisibility(isLeftEyeIndex(i), isMonoPresentation);
+        xrLayer.space = space;
+
+        ASSERT(layer.equirectLayerData);
+        auto& equirectData = *layer.equirectLayerData;
+        xrLayer.pose.position = { equirectData.poseInLocalSpace.position.x(), equirectData.poseInLocalSpace.position.y(), equirectData.poseInLocalSpace.position.z() };
+        xrLayer.pose.orientation = { equirectData.poseInLocalSpace.orientation.x, equirectData.poseInLocalSpace.orientation.y, equirectData.poseInLocalSpace.orientation.z, equirectData.poseInLocalSpace.orientation.w };
+        xrLayer.radius = equirectData.radius;
+        xrLayer.centralHorizontalAngle = equirectData.centralHorizontalAngle;
+        xrLayer.upperVerticalAngle = equirectData.upperVerticalAngle;
+        xrLayer.lowerVerticalAngle = equirectData.lowerVerticalAngle;
+
+        layerHeaders.append(reinterpret_cast<XrCompositionLayerBaseHeader*>(&xrLayer));
+    }
+
+    m_swapchain->releaseImage();
+
+    return layerHeaders;
+}
+
+#endif
+
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
@@ -115,6 +115,23 @@ private:
     PlatformXR::LayerLayout m_layout;
 };
 
+#if defined(XR_KHR_composition_layer_equirect2)
+class OpenXREquirectLayer final: public OpenXRLayer  {
+    WTF_MAKE_TZONE_ALLOCATED(OpenXREquirectLayer);
+    WTF_MAKE_NONCOPYABLE(OpenXREquirectLayer);
+public:
+    static std::unique_ptr<OpenXREquirectLayer> create(std::unique_ptr<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
+private:
+    explicit OpenXREquirectLayer(UniqueRef<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
+
+    std::optional<PlatformXR::FrameData::LayerData> startFrame() final;
+    Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) final;
+
+    Vector<XrCompositionLayerEquirect2KHR> m_layers;
+    PlatformXR::LayerLayout m_layout;
+};
+#endif
+
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -295,6 +295,66 @@ void OpenXRCoordinator::createQuadLayer(WebCore::IntSize size, PlatformXR::Layer
             });
         });
 }
+
+void OpenXRCoordinator::createEquirectLayer(WebCore::IntSize size, PlatformXR::LayerLayout layout, CreateEquirectCallback&& reply)
+{
+#if defined(XR_KHR_composition_layer_equirect2)
+    if (!OpenXRExtensions::singleton().isExtensionSupported(XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME ""_span)) {
+        RELEASE_LOG(XR, "OpenXRCoordinator: equirect layer extension not supported");
+        reply(std::nullopt);
+        return;
+    }
+
+    WTF::switchOn(m_state,
+        [&](Idle&) { reply(std::nullopt); },
+        [&](Active& active) {
+            active.renderQueue->dispatch([this, size, layout, completionHandler = WTF::move(reply)] mutable {
+                if (!collectSwapchainFormatsIfNeeded()) {
+                    RELEASE_LOG(XR, "OpenXRCoordinator: no supported swapchain formats");
+                    callOnMainRunLoop([completion = WTF::move(completionHandler)] mutable {
+                        completion(std::nullopt);
+                    });
+                    return;
+                }
+
+                bool alpha = false;
+                auto swapchain = createSwapchain(size.width(), size.height(), alpha);
+                if (!swapchain) {
+                    RELEASE_LOG(XR, "OpenXRCoordinator: failed to create swapchain");
+                    callOnMainRunLoop([completion = WTF::move(completionHandler)] mutable {
+                        completion(std::nullopt);
+                    });
+                    return;
+                }
+
+                LOG(XR, "Created swapchain for equirect layer with size %dx%d and format %ld", size.width(), size.height(), swapchain->format());
+                auto imageCount = swapchain->imageCount();
+                if (auto layer = OpenXREquirectLayer::create(WTF::move(swapchain), layout)) {
+#if USE(GBM)
+                    if (m_gbmDevice)
+                        layer->setGBMDevice(m_gbmDevice);
+#endif
+                    auto layerHandle = m_nextLayerHandle++;
+                    m_layers.add(layerHandle, WTF::move(layer));
+                    PlatformXR::LayerInfo layerInfo { layerHandle, imageCount };
+                    callOnMainRunLoop([completion = WTF::move(completionHandler), info = layerInfo] mutable {
+                        completion(info);
+                    });
+                } else {
+                    RELEASE_LOG(XR, "OpenXRCoordinator: failed to create equirect layer");
+                    callOnMainRunLoop([completion = WTF::move(completionHandler)] mutable {
+                        completion(std::nullopt);
+                    });
+                }
+            });
+        });
+#else
+    UNUSED_PARAM(size);
+    UNUSED_PARAM(layout);
+    RELEASE_LOG(XR, "OpenXRCoordinator: equirect layer not supported (XR_KHR_composition_layer_equirect2 not defined)");
+    reply(std::nullopt);
+#endif
+}
 #endif // ENABLE(WEBXR_LAYERS)
 
 void OpenXRCoordinator::startSession(WebPageProxy& page, WeakPtr<PlatformXRCoordinatorSessionEventClient>&& sessionEventClient, const WebCore::SecurityOriginData&, PlatformXR::SessionMode sessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&)
@@ -630,6 +690,10 @@ void OpenXRCoordinator::createInstance()
         extensions.append(const_cast<char*>(XR_ANDROID_RAYCAST_EXTENSION_NAME));
 #endif
 #endif
+#endif
+#if defined(XR_KHR_composition_layer_equirect2)
+    if (OpenXRExtensions::singleton().isExtensionSupported(XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME ""_span))
+        extensions.append(const_cast<char*>(XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME));
 #endif
 
     XrInstanceCreateInfo createInfo = createOpenXRStruct<XrInstanceCreateInfo, XR_TYPE_INSTANCE_CREATE_INFO >();

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -59,6 +59,7 @@ public:
 
 #if ENABLE(WEBXR_LAYERS)
     void createQuadLayer(WebCore::IntSize, PlatformXR::LayerLayout, CreateQuadCallback&&) override;
+    void createEquirectLayer(WebCore::IntSize, PlatformXR::LayerLayout, CreateEquirectCallback&&) override;
 #endif
 
     void startSession(WebPageProxy&, WeakPtr<PlatformXRCoordinatorSessionEventClient>&&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&) override;

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXRSystemOpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXRSystemOpenXR.cpp
@@ -70,6 +70,21 @@ void PlatformXRSystem::createQuadLayer(IPC::Connection&, WebCore::IntSize size, 
     else
         reply(std::nullopt);
 }
+
+void PlatformXRSystem::createEquirectLayer(IPC::Connection&, WebCore::IntSize size, PlatformXR::LayerLayout layout, CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>&& reply)
+{
+    ASSERT(RunLoop::isMain());
+
+    RefPtr page = m_page.get();
+    if (!page) {
+        reply(std::nullopt);
+        return;
+    }
+    if (auto* xrCoordinator = PlatformXRSystem::xrCoordinator())
+        xrCoordinator->createEquirectLayer(size, layout, WTF::move(reply));
+    else
+        reply(std::nullopt);
+}
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
@@ -129,6 +129,15 @@ std::optional<PlatformXR::LayerInfo> PlatformXRSystemProxy::createQuadLayer(WebC
     auto [layerInfo] = result.takeReply();
     return layerInfo;
 }
+
+std::optional<PlatformXR::LayerInfo> PlatformXRSystemProxy::createEquirectLayer(WebCore::IntSize size, PlatformXR::LayerLayout layout)
+{
+    auto result = protect(m_page)->sendSync(Messages::PlatformXRSystem::CreateEquirectLayer(size, layout));
+    if (!result.succeeded())
+        return std::nullopt;
+    auto [layerInfo] = result.takeReply();
+    return layerInfo;
+}
 #endif
 
 #if USE(OPENXR)

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -59,6 +59,7 @@ public:
     std::optional<PlatformXR::LayerInfo> createLayerProjection(uint32_t, uint32_t, bool);
 #if ENABLE(WEBXR_LAYERS)
     std::optional<PlatformXR::LayerInfo> createQuadLayer(WebCore::IntSize, PlatformXR::LayerLayout);
+    std::optional<PlatformXR::LayerInfo> createEquirectLayer(WebCore::IntSize, PlatformXR::LayerLayout);
 #endif
 #if USE(OPENXR)
     void submitFrame(Vector<PlatformXR::DeviceLayer>&&);

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2440,7 +2440,7 @@ def check_spacing(file_extension, clean_lines, line_number, file_state, error):
     # 'delete []' or 'new char * []'. Objective-C can't follow this rule
     # because of method calls.
     if file_extension != 'mm' and file_extension != 'm':
-        if search(r'\w\s+\[', line) and not search(r'(delete|return|auto)\s+\[', line) and not search(r'\s+\[\[(likely|unlikely)\]\]', line):
+        if search(r'\w\s+\[', line) and not search(r'(delete|return|auto)\s+\[', line) and not search(r'\s+\[\[(likely|unlikely|noreturn)\]\]', line):
             error(line_number, 'whitespace/brackets', 5,
                   'Extra space before [.')
 

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -2394,6 +2394,8 @@ class CppStyleTest(CppStyleTestBase):
         self.assert_lint('        m_taskFunction = [callee, method, arguments...] {', '')
         self.assert_lint('int main(int argc, char* agrv [])', 'Extra space before [.  [whitespace/brackets] [5]')
         self.assert_lint('    str [strLength] = \'\\0\';', 'Extra space before [.  [whitespace/brackets] [5]')
+        self.assert_lint('define FOO [[noreturn]];', '')
+        self.assert_lint('define FOO [[return]];', 'Extra space before [.  [whitespace/brackets] [5]')
 
     def test_cpp_lambda_functions(self):
         self.assert_lint('        [&] (Type argument) {', '')


### PR DESCRIPTION
#### 59e13430ba6a62f57fa7583742a1e7f356332f9d
<pre>
[WebXR][OpenXR] Support Equirect layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=312168">https://bugs.webkit.org/show_bug.cgi?id=312168</a>

Reviewed by Dan Glastonbury.

This implements the required changes to create equirect layers on UIProcess
side and share them with the WebProcess so that web authors could use
them in their WebXR experiences.

This includes not only mono equirect layers (same image in both eyes) but
also top-bottom and left-to-right which are also supported. Authors can
even force a stereo layer to be presented as a mono layer at any point
in time, something that is also supported.

As in the case of the quad and projection layers, texture arrays are not
supported yet but they&apos;ll be eventually added.

The only platform implementation supporting the equirect layer will
initially be the OpenXR one which supports the equirect layer via
the XR_KHR_composition_layer_equirect2 extension. Special code had to be added
for the top-bottom cases to support different graphics libraries that
might treat the Y-axis direction in different ways (OpenGL vs Vulkan).

For the case of Apple platforms we had to add some code that will be
eventually removed but that is needed in order not to break Apple
internal systems. That change required also fine tunning the style rule
checkers for spaces before brackets.

No new tests required as the API to create the equirect layers is already
being tested by current tests.

* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
(WebCore::WebXRWebGLLayer::endFrame):
* Source/WebCore/Modules/webxr/XREquirectLayer.cpp:
(WebCore::XREquirectLayer::XREquirectLayer):
(WebCore::XREquirectLayer::space const):
(WebCore::XREquirectLayer::setSpace):
(WebCore::XREquirectLayer::transform const):
(WebCore::XREquirectLayer::setTransform):
(WebCore::XREquirectLayer::startFrame):
(WebCore::XREquirectLayer::recomputePose):
(WebCore::XREquirectLayer::endFrame):
* Source/WebCore/Modules/webxr/XREquirectLayer.h:
(WebCore::XREquirectLayer::create):
(WebCore::XREquirectLayer::radius const):
(WebCore::XREquirectLayer::setRadius):
(WebCore::XREquirectLayer::centralHorizontalAngle const):
(WebCore::XREquirectLayer::setCentralHorizontalAngle):
(WebCore::XREquirectLayer::upperVerticalAngle const):
(WebCore::XREquirectLayer::setUpperVerticalAngle):
(WebCore::XREquirectLayer::lowerVerticalAngle const):
(WebCore::XREquirectLayer::setLowerVerticalAngle):
(WebCore::XREquirectLayer::space const): Deleted.
(WebCore::XREquirectLayer::setSpace): Deleted.
(WebCore::XREquirectLayer::transform const): Deleted.
(WebCore::XREquirectLayer::setTransform): Deleted.
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
(WebCore::XRWebGLBinding::validateCompositionLayerInitParameters const):
(WebCore::XRWebGLBinding::createQuadLayer):
(WebCore::XRWebGLBinding::createEquirectLayer):
* Source/WebCore/Modules/webxr/XRWebGLBinding.h:
(WebCore::XRWebGLBinding::createEquirectLayer): Deleted.
* Source/WebCore/Modules/webxr/XRWebGLBinding.idl:
* Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.cpp: Added.
(WebCore::XRWebGLEquirectLayerBacking::create):
(WebCore::XRWebGLEquirectLayerBacking::XRWebGLEquirectLayerBacking):
* Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.h: Copied from Source/WebCore/Modules/webxr/XREquirectLayer.cpp.
* Source/WebCore/Sources.txt:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::createCompositionLayer):
(WebCore::SimulatedXRDevice::createQuadLayer):
(WebCore::SimulatedXRDevice::createEquirectLayer):
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::createEquirectLayer):
* Source/WebKit/Shared/XR/XRDeviceProxy.h:
* Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h:
(WebKit::PlatformXRCoordinator::createQuadLayer):
(WebKit::PlatformXRCoordinator::createEquirectLayer):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::createEquirectLayer):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in:
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp:
(WebKit::OpenXREquirectLayer::create):
(WebKit::OpenXREquirectLayer::OpenXREquirectLayer):
(WebKit::OpenXREquirectLayer::startFrame):
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::createEquirectLayer):
(WebKit::OpenXRCoordinator::createInstance):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:
* Source/WebKit/UIProcess/XR/openxr/PlatformXRSystemOpenXR.cpp:
(WebKit::PlatformXRSystem::createEquirectLayer):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:
(WebKit::PlatformXRSystemProxy::createEquirectLayer):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h:
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_spacing):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTest):

Canonical link: <a href="https://commits.webkit.org/312072@main">https://commits.webkit.org/312072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9377a7a80428cce7a716b58e95af9cc865bebb7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122770 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86157 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103440 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/157826 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24088 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22477 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15106 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169825 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15570 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130958 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31621 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131072 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35537 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31567 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141959 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89445 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18765 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31078 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97092 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30598 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30871 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->