### PR TITLE
Avoid repeated calls to elementNameForTag() in HTMLTreeBuilder::processEndTagForInCell()

### DIFF
--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -1921,18 +1921,20 @@ void HTMLTreeBuilder::processEndTagForInCell(AtomHTMLToken&& token)
     ASSERT(token.type() == HTMLToken::Type::EndTag);
     switch (token.tagName()) {
     case TagName::th:
-    case TagName::td:
-        if (!m_tree.openElements().inTableScope(elementNameForTag(Namespace::HTML, token.tagName()))) {
+    case TagName::td: {
+        auto elementName = elementNameForTag(Namespace::HTML, token.tagName());
+        if (!m_tree.openElements().inTableScope(elementName)) {
             parseError(token);
             return;
         }
         m_tree.generateImpliedEndTags();
-        if (m_tree.currentStackItem().elementName() != elementNameForTag(Namespace::HTML, token.tagName()))
+        if (m_tree.currentStackItem().elementName() != elementName)
             parseError(token);
-        m_tree.openElements().popUntilPopped(elementNameForTag(Namespace::HTML, token.tagName()));
+        m_tree.openElements().popUntilPopped(elementName);
         m_tree.activeFormattingElements().clearToLastMarker();
         m_insertionMode = InsertionMode::InRow;
         return;
+    }
     case TagName::body:
     case TagName::caption:
     case TagName::col:
@@ -2004,16 +2006,18 @@ void HTMLTreeBuilder::processEndTagForInBody(AtomHTMLToken&& token)
     case TagName::search:
     case TagName::section:
     case TagName::summary:
-    case TagName::ul:
-        if (!m_tree.openElements().inScope(elementNameForTag(Namespace::HTML, token.tagName()))) {
+    case TagName::ul: {
+        auto elementName = elementNameForTag(Namespace::HTML, token.tagName());
+        if (!m_tree.openElements().inScope(elementName)) {
             parseError(token);
             return;
         }
         m_tree.generateImpliedEndTags();
-        if (m_tree.currentStackItem().elementName() != elementNameForTag(Namespace::HTML, token.tagName()))
+        if (m_tree.currentStackItem().elementName() != elementName)
             parseError(token);
-        m_tree.openElements().popUntilPopped(elementNameForTag(Namespace::HTML, token.tagName()));
+        m_tree.openElements().popUntilPopped(elementName);
         return;
+    }
     case TagName::form:
         if (!isParsingTemplateContents()) {
             RefPtr<Element> formElement = m_tree.takeForm();
@@ -2060,16 +2064,18 @@ void HTMLTreeBuilder::processEndTagForInBody(AtomHTMLToken&& token)
         m_tree.openElements().popUntilPopped(HTML::li);
         return;
     case TagName::dd:
-    case TagName::dt:
-        if (!m_tree.openElements().inScope(elementNameForTag(Namespace::HTML, token.tagName()))) {
+    case TagName::dt: {
+        auto elementName = elementNameForTag(Namespace::HTML, token.tagName());
+        if (!m_tree.openElements().inScope(elementName)) {
             parseError(token);
             return;
         }
-        m_tree.generateImpliedEndTagsWithExclusion(elementNameForTag(Namespace::HTML, token.tagName()));
-        if (m_tree.currentStackItem().elementName() != elementNameForTag(Namespace::HTML, token.tagName()))
+        m_tree.generateImpliedEndTagsWithExclusion(elementName);
+        if (m_tree.currentStackItem().elementName() != elementName)
             parseError(token);
-        m_tree.openElements().popUntilPopped(elementNameForTag(Namespace::HTML, token.tagName()));
+        m_tree.openElements().popUntilPopped(elementName);
         return;
+    }
     case TagName::h1:
     case TagName::h2:
     case TagName::h3:
@@ -2103,17 +2109,19 @@ void HTMLTreeBuilder::processEndTagForInBody(AtomHTMLToken&& token)
         return;
     case TagName::applet:
     case TagName::marquee:
-    case TagName::object:
-        if (!m_tree.openElements().inScope(elementNameForTag(Namespace::HTML, token.tagName()))) {
+    case TagName::object: {
+        auto elementName = elementNameForTag(Namespace::HTML, token.tagName());
+        if (!m_tree.openElements().inScope(elementName)) {
             parseError(token);
             return;
         }
         m_tree.generateImpliedEndTags();
-        if (m_tree.currentStackItem().elementName() != elementNameForTag(Namespace::HTML, token.tagName()))
+        if (m_tree.currentStackItem().elementName() != elementName)
             parseError(token);
-        m_tree.openElements().popUntilPopped(elementNameForTag(Namespace::HTML, token.tagName()));
+        m_tree.openElements().popUntilPopped(elementName);
         m_tree.activeFormattingElements().clearToLastMarker();
         return;
+    }
     case TagName::br:
         parseError(token);
         processFakeStartTag(TagName::br);


### PR DESCRIPTION
#### c46c45fa01204974ea0e91685d7fa0a3f5fb3503
<pre>
Avoid repeated calls to elementNameForTag() in HTMLTreeBuilder::processEndTagForInCell()
<a href="https://bugs.webkit.org/show_bug.cgi?id=312860">https://bugs.webkit.org/show_bug.cgi?id=312860</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processEndTagForInCell):
(WebCore::HTMLTreeBuilder::processEndTagForInBody):

Canonical link: <a href="https://commits.webkit.org/311671@main">https://commits.webkit.org/311671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8db87a483262a1e0221905eef610b4b63b608466

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166495 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122081 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102750 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14266 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168984 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13509 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130249 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25778 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130366 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35304 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141196 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88530 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18001 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30244 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94693 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29765 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29995 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29892 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->