### PR TITLE
[Regression 310415@main] linkedin.com: Videos stop playing after few seconds and audio lost

### DIFF
--- a/LayoutTests/media/media-source/media-source-seek-to-zero-then-play-expected.txt
+++ b/LayoutTests/media/media-source/media-source-seek-to-zero-then-play-expected.txt
@@ -1,0 +1,22 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(sourceBuffer.appendWindowEnd = 0.3)
+Appended first segment with window [0, 0.3)
+RUN(video.currentTime = 0)
+EVENT(seeked)
+First seek to 0 completed
+RUN(video.currentTime = 0)
+EVENT(seeked)
+Second seek to 0 completed
+RUN(sourceBuffer.appendWindowEnd = 0.6)
+Re-appended first segment with window [0, 0.6)
+RUN(video.play())
+EVENT(playing)
+EXPECTED (video frame rendered past 0.3s) OK
+RUN(video.pause())
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-seek-to-zero-then-play.html
+++ b/LayoutTests/media/media-source/media-source-seek-to-zero-then-play.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="timeout" content="long">
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Ensure that video does not stall and that video frames' time continue increasing when seeking to the same location twice.
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    var MediaSource = self.ManagedMediaSource || self.MediaSource;
+    var source;
+    var sourceBuffer;
+    var loader;
+
+    async function start() {
+        findMediaElement();
+
+        loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+        await loaderPromise(loader);
+
+        source = new MediaSource();
+
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+
+        run('sourceBuffer = source.addSourceBuffer(loader.type())');
+        run('sourceBuffer.appendBuffer(loader.initSegment())');
+        await waitFor(sourceBuffer, 'update');
+
+        // Append first segment with window [0, 0.3) to limit pre-enqueued data.
+        run('sourceBuffer.appendWindowEnd = 0.3');
+        sourceBuffer.appendBuffer(loader.mediaSegment(0));
+        await waitFor(sourceBuffer, 'update', true);
+        consoleWrite('Appended first segment with window [0, 0.3)');
+
+        // First seek to 0.
+        run('video.currentTime = 0');
+        await waitFor(video, 'seeked');
+        consoleWrite('First seek to 0 completed');
+
+        // Second seek to 0: synchronizer already at 0.
+        run('video.currentTime = 0');
+        await waitFor(video, 'seeked');
+        consoleWrite('Second seek to 0 completed');
+
+        // Remove window restriction and re-append the first segment, capped at 0.6s.
+        // With bug 312859, provideMediaData is blocked so samples past 0.3s never
+        // reach the renderer.
+        run('sourceBuffer.appendWindowEnd = 0.6');
+        sourceBuffer.appendBuffer(loader.mediaSegment(0));
+        await waitFor(sourceBuffer, 'update', true);
+        consoleWrite('Re-appended first segment with window [0, 0.6)');
+        source.endOfStream();
+
+        // Play and check that a video frame past 0.3s is actually rendered.
+        // With the bug, video frames were frozen so requestVideoFrameCallback
+        // never reported a frame past 0.3s.
+        run('video.play()');
+        await waitFor(video, 'playing');
+
+        const gotFrame = await new Promise(resolve => {
+            const timeout = setTimeout(() => resolve(false), 5000);
+            function check(now, metadata) {
+                if (metadata.mediaTime > 0.3) {
+                    clearTimeout(timeout);
+                    resolve(true);
+                    return;
+                }
+                video.requestVideoFrameCallback(check);
+            }
+            video.requestVideoFrameCallback(check);
+        });
+
+        if (gotFrame)
+            consoleWrite('EXPECTED (video frame rendered past 0.3s) OK');
+        else
+            consoleWrite('EXPECTED (video frame rendered past 0.3s) FAIL');
+
+        run('video.pause()');
+        endTest();
+    }
+    </script>
+</head>
+<body onload="start()">
+    <video disableRemotePlayback></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -597,6 +597,8 @@ webkit.org/b/298491 media/media-vp9-reschange-webm.html [ Timeout ]
 webkit.org/b/307141 media/media-source/media-source-seek-and-play.html [ Failure Pass ]
 webkit.org/b/307141 media/media-source/media-controller-media-source-play-then-pause.html [ Failure Pass ]
 
+webkit.org/b/312871 media/media-source/media-source-seek-to-zero-then-play.html [ Failure ]
+
 # NOTIFICATION_EVENT tests
 http/tests/workers/service/shownotification-allowed-document.html [ Pass ]
 http/tests/workers/service/shownotification-invalid-data.html [ Pass ]

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -100,9 +100,15 @@ MediaTime MediaSourcePrivate::duration() const
 Ref<MediaTimePromise> MediaSourcePrivate::waitForTarget(const SeekTarget& target)
 {
     assertIsMainThread();
-    m_reenqueuePending = true;
-    if (RefPtr client = this->client())
-        return client->waitForTarget(target);
+    if (RefPtr client = this->client()) {
+        m_reenqueuePending = true;
+        return client->waitForTarget(target)->whenSettled(RunLoop::currentSingleton(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
+            RefPtr protectedThis = weakThis.get();
+            if (!result && protectedThis)
+                protectedThis->m_reenqueuePending = false;
+            return MediaTimePromise::createAndSettle(WTF::move(result));
+        });
+    }
     return MediaTimePromise::createAndReject(PlatformMediaError::ClientDisconnected);
 }
 

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -107,6 +107,7 @@ public:
     Ref<MediaTimePromise> waitForTarget(const SeekTarget&);
     Ref<GenericPromise> reenqueueMediaForTime(const MediaTime&);
     bool isReenqueuePending() const { return m_reenqueuePending; }
+    void clearReenqueuePending() { m_reenqueuePending = false; }
 
     virtual void setTimeFudgeFactor(const MediaTime& fudgeFactor) { m_timeFudgeFactor = fudgeFactor; }
     MediaTime timeFudgeFactor() const { return m_timeFudgeFactor; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -587,6 +587,8 @@ void MediaPlayerPrivateMediaSourceAVFObjC::continueSeek(const MediaTime& seekTim
             protectedThis->reenqueueMediaForTimeAndFinishSeek(seekTime);
             return;
         }
+        if (RefPtr mediaSourcePrivate = protectedThis->m_mediaSourcePrivate)
+            mediaSourcePrivate->clearReenqueuePending();
         protectedThis->completeSeek(*result);
     })->track(m_rendererPrepareSeekRequest);
 }


### PR DESCRIPTION
#### 1fc19c74dd82e8f75e5a55b6d7116ad4d21e9f0d
<pre>
[Regression 310415@main] linkedin.com: Videos stop playing after few seconds and audio lost
<a href="https://bugs.webkit.org/show_bug.cgi?id=312859">https://bugs.webkit.org/show_bug.cgi?id=312859</a>
<a href="https://rdar.apple.com/174966899">rdar://174966899</a>

Reviewed by Jer Noble.

MediaSourcePrivate::waitForTarget() sets m_reenqueuePending = true.
It was normally cleared by reenqueueMediaForTime(). However, when prepareToSeek()
returned a non-indefinite time (meaning the synchronizer was already at the target position),
continueSeek() took a fast path that called completeSeek() directly, skipping
reenqueueMediaForTime() entirely.
This left m_reenqueuePending stuck as true. Since SourceBufferPrivate::provideMediaData()
bailed early when isReenqueuePending() was true, no new samples ever reached the
renderer after that point.

Test: media/media-source/media-source-seek-to-zero-then-play.html

* LayoutTests/media/media-source/media-source-seek-to-zero-then-play-expected.txt: Added.
* LayoutTests/media/media-source/media-source-seek-to-zero-then-play.html: Added.
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::waitForTarget):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::continueSeek):

Canonical link: <a href="https://commits.webkit.org/311698@main">https://commits.webkit.org/311698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0df63bc8ba637d70e14d7b771881b15386971492

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157694 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166518 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122100 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102769 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14289 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169007 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13554 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130268 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35324 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88553 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18017 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Passed layout tests; 8 flakes") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94741 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30018 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29915 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->