### PR TITLE
HTMLParserScheduler resume timer should not fire while parser yield tokens are active

### DIFF
--- a/Source/WebCore/html/parser/HTMLParserScheduler.cpp
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.cpp
@@ -105,6 +105,11 @@ void HTMLParserScheduler::continueNextChunkTimerFired()
     ASSERT(!m_suspended);
     ASSERT(m_parser);
 
+    // If yield tokens are active, don't resume parsing. didEndYieldingParser()
+    // will schedule a new resume when the tokens are released.
+    if (m_documentHasActiveParserYieldTokens)
+        return;
+
     // FIXME: The timer class should handle timer priorities instead of this code.
     // If a layout is scheduled, wait again to let the layout timer run first.
     if (m_parser->document()->isLayoutPending()) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenPlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenPlugIn.mm
@@ -62,6 +62,12 @@
         --_numberOfTokensToTakeAfterComittingLoad;
 }
 
+- (void)releaseAndRetakeDocumentParserToken
+{
+    [self releaseDocumentParserToken];
+    [self takeDocumentParserTokenAfterCommittingLoad];
+}
+
 - (void)webProcessPlugInBrowserContextController:(WKWebProcessPlugInBrowserContextController *)controller didCommitLoadForFrame:(WKWebProcessPlugInFrame *)frame
 {
     _loadCommitted = YES;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenTests.h
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenTests.h
@@ -33,4 +33,5 @@
 @protocol ParserYieldTokenTestBundle <NSObject>
 - (void)takeDocumentParserTokenAfterCommittingLoad;
 - (void)releaseDocumentParserToken;
+- (void)releaseAndRetakeDocumentParserToken;
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenTests.mm
@@ -133,6 +133,32 @@ TEST(ParserYieldTokenTests, TakeMultipleParserYieldTokens)
         [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantPast]];
 }
 
+TEST(ParserYieldTokenTests, ReleaseAndRetakeYieldTokenDoesNotCrash)
+{
+    auto webView = [ParserYieldTokenTestWebView webView];
+    [[webView bundle] takeDocumentParserTokenAfterCommittingLoad];
+    [webView loadTestPageNamed:@"simple"];
+
+    waitForDelay(0.5_s);
+    EXPECT_FALSE([webView finishedDocumentLoad]);
+    EXPECT_FALSE([webView finishedLoad]);
+
+    // Release and immediately retake the yield token. This causes
+    // didEndYieldingParser to schedule a 0s resume timer, and then
+    // didBeginYieldingParser to set yield tokens active again. When the
+    // timer fires, the parser must not assert or busy-loop.
+    [[webView bundle] releaseAndRetakeDocumentParserToken];
+
+    waitForDelay(0.5_s);
+    EXPECT_FALSE([webView finishedDocumentLoad]);
+    EXPECT_FALSE([webView finishedLoad]);
+
+    [[webView bundle] releaseDocumentParserToken];
+
+    while (![webView finishedLoad] || ![webView finishedDocumentLoad])
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantPast]];
+}
+
 TEST(ParserYieldTokenTests, DeferredScriptExecutesBeforeDocumentLoadWhenTakingParserYieldToken)
 {
     auto webView = [ParserYieldTokenTestWebView webView];


### PR DESCRIPTION
#### 2cce60119e858731f8018bdb692ea20843133c37
<pre>
HTMLParserScheduler resume timer should not fire while parser yield tokens are active
<a href="https://bugs.webkit.org/show_bug.cgi?id=312867">https://bugs.webkit.org/show_bug.cgi?id=312867</a>

Reviewed by Ryosuke Niwa.

When a DocumentParserYieldToken is released and immediately retaken,
didEndYieldingParser() schedules a 0s resume timer, and then
didBeginYieldingParser() sets yield tokens active again. When the timer
fires, continueNextChunkTimerFired() calls pumpTokenizer() which asserts
!isScheduledForResume() — but that returns true because yield tokens are
active, causing an assertion failure. In release builds, this leads to a
busy-loop through the event loop until the yield tokens are cleared.

Fix this by checking m_documentHasActiveParserYieldTokens in
continueNextChunkTimerFired() and returning early, letting
didEndYieldingParser() handle scheduling the resume when tokens are
eventually released.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenPlugIn.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenTests.h
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenTests.mm

* Source/WebCore/html/parser/HTMLParserScheduler.cpp:
(WebCore::HTMLParserScheduler::continueNextChunkTimerFired):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenPlugIn.mm:
(-[ParserYieldTokenPlugIn releaseAndRetakeDocumentParserToken]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenTests.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenTests.mm:
(TEST(ParserYieldTokenTests, ReleaseAndRetakeYieldTokenDoesNotCrash)):

Canonical link: <a href="https://commits.webkit.org/311753@main">https://commits.webkit.org/311753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf4bb91d427cdb00f2f388640dc0b345e8e0f647

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111764 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122089 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85751 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102758 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23431 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21715 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14277 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168995 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13532 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130258 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130375 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35358 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141211 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88541 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25172 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18016 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30255 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94720 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29776 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30006 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29903 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->