### PR TITLE
[:has() perf] Limit invalidation traversal with scope selector

### DIFF
--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
@@ -10,4 +10,6 @@
   Traversal count: 3
 :has(:is(.trigger + .other)) with compound peer .c6
   Traversal count: 7
+:has(.trigger) non-subject with scope-bounded traversal .c7
+  Traversal count: 14
 

--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
@@ -14,6 +14,8 @@
 .c5:has(+ .trigger) { color: green; }
 /* :has() with :is() wrapping */
 .c6:has(:is(.trigger + .other)) > .target { color: green; }
+/* Non-subject :has() with descendant — scope-bounded traversal */
+.c7:has(.trigger) .target { color: green; }
 </style>
 <script>
 if (window.testRunner)
@@ -104,6 +106,12 @@ runTest(":has(:is(.trigger + .other)) with compound peer .c6", "c6", function(co
     var trigger = document.createElement("div");
     trigger.className = "trigger";
     container.insertBefore(trigger, container.querySelector(".other"));
+}, true);
+
+runTest(":has(.trigger) non-subject with scope-bounded traversal .c7", "c7", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.appendChild(trigger);
 }, true);
 </script>
 </body>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2262,7 +2262,7 @@ webkit.org/b/288133 imported/w3c/web-platform-tests/scroll-to-text-fragment/find
 
 webkit.org/b/287990 [ Sonoma+ ] fast/canvas/webgl/drawingbuffer-test.html [ Pass Failure ]
 
-webkit.org/b/260320 imported/w3c/web-platform-tests/css/selectors/invalidation/nth-child-in-shadow-root.html [ ImageOnlyFailure ]
+webkit.org/b/260320 imported/w3c/web-platform-tests/css/selectors/invalidation/nth-child-in-shadow-root.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/289275 media/media-garbage-collection.html [ Pass Failure Timeout ]
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1538,32 +1538,71 @@ std::optional<Style::PseudoElementIdentifier> CSSSelectorParser::parsePseudoElem
     }
 }
 
-CSSSelectorList CSSSelectorParser::makeHasArgumentReplacingScope(const CSSSelector& hasArgument, const CSSSelector& hasPseudoClass)
-{
-    // Collect compound peers of :has() (other simple selectors in the same compound, excluding :has() itself).
+struct HasCompoundContext {
     Vector<const CSSSelector*> compoundPeers;
+    CSSSelector::Relation compoundRelation;
+    const CSSSelector* leftStart { nullptr };
+};
+
+static std::optional<HasCompoundContext> collectHasCompoundContext(const CSSSelector& hasPseudoClass)
+{
+    HasCompoundContext context;
     for (auto* selector = hasPseudoClass.lastInCompound(); selector; selector = selector->precedingInCompound()) {
         if (selector != &hasPseudoClass)
-            compoundPeers.append(selector);
+            context.compoundPeers.append(selector);
     }
-
-    if (compoundPeers.isEmpty())
-        return CSSSelectorList::makeCopyingComplexSelector(hasArgument);
+    if (context.compoundPeers.isEmpty())
+        return { };
 
     auto* firstInCompound = hasPseudoClass.firstInCompound();
-    auto compoundRelation = firstInCompound->relation();
-    auto* leftStart = firstInCompound->precedingInComplexSelector();
+    context.compoundRelation = firstInCompound->relation();
+    context.leftStart = firstInCompound->precedingInComplexSelector();
+    return context;
+}
 
-    auto appendSelector = [](MutableCSSSelectorList& result, MutableCSSSelector*& leftmost, std::unique_ptr<MutableCSSSelector> selector) {
-        if (!leftmost) {
-            result.append(WTF::move(selector));
-            leftmost = result.last().get();
-        } else {
-            leftmost->setPrecedingInComplexSelector(WTF::move(selector));
-            leftmost = leftmost->precedingInComplexSelector();
-        }
-    };
+static void appendSelector(MutableCSSSelectorList& result, MutableCSSSelector*& leftmost, std::unique_ptr<MutableCSSSelector> selector)
+{
+    if (!leftmost) {
+        result.append(WTF::move(selector));
+        leftmost = result.last().get();
+    } else {
+        leftmost->setPrecedingInComplexSelector(WTF::move(selector));
+        leftmost = leftmost->precedingInComplexSelector();
+    }
+}
 
+static CSSSelectorList buildScopeSelector(const HasCompoundContext& context)
+{
+    MutableCSSSelector* leftmost = nullptr;
+    MutableCSSSelectorList result;
+
+    for (auto* peer : context.compoundPeers) {
+        auto mutableSelector = makeUnique<MutableCSSSelector>(*peer, MutableCSSSelector::SimpleSelector);
+        mutableSelector->setRelation(peer->relation());
+        appendSelector(result, leftmost, WTF::move(mutableSelector));
+    }
+
+    leftmost->setRelation(context.compoundRelation);
+
+    for (auto* selector = context.leftStart; selector; selector = selector->precedingInComplexSelector()) {
+        auto mutableSelector = makeUnique<MutableCSSSelector>(*selector, MutableCSSSelector::SimpleSelector);
+        mutableSelector->setRelation(selector->relation());
+        appendSelector(result, leftmost, WTF::move(mutableSelector));
+    }
+
+    return CSSSelectorList { WTF::move(result) };
+}
+
+CSSSelectorList CSSSelectorParser::makeHasScopeSelector(const CSSSelector& hasPseudoClass)
+{
+    auto context = collectHasCompoundContext(hasPseudoClass);
+    if (!context)
+        return { };
+    return buildScopeSelector(*context);
+}
+
+CSSSelectorList CSSSelectorParser::makeHasArgumentWithScope(const CSSSelector& hasArgument, const CSSSelector& scopeSelector)
+{
     MutableCSSSelector* leftmost = nullptr;
     MutableCSSSelectorList result;
 
@@ -1576,18 +1615,8 @@ CSSSelectorList CSSSelectorParser::makeHasArgumentReplacingScope(const CSSSelect
         appendSelector(result, leftmost, WTF::move(mutableSelector));
     }
 
-    // Copy compound peers.
-    for (auto* peer : compoundPeers) {
-        auto mutableSelector = makeUnique<MutableCSSSelector>(*peer, MutableCSSSelector::SimpleSelector);
-        mutableSelector->setRelation(peer->relation());
-        appendSelector(result, leftmost, WTF::move(mutableSelector));
-    }
-
-    // The leftmost peer adopts the compound's combinator to the left side.
-    leftmost->setRelation(compoundRelation);
-
-    // Copy remaining left-side selectors.
-    for (auto* selector = leftStart; selector; selector = selector->precedingInComplexSelector()) {
+    // Append scope selector.
+    for (auto* selector = &scopeSelector; selector; selector = selector->precedingInComplexSelector()) {
         auto mutableSelector = makeUnique<MutableCSSSelector>(*selector, MutableCSSSelector::SimpleSelector);
         mutableSelector->setRelation(selector->relation());
         appendSelector(result, leftmost, WTF::move(mutableSelector));

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -59,7 +59,8 @@ public:
 
     static bool supportsComplexSelector(CSSParserTokenRange, const CSSSelectorParserContext&);
     static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList, bool parentRuleIsScope = false);
-    static CSSSelectorList makeHasArgumentReplacingScope(const CSSSelector& hasArgument, const CSSSelector& hasPseudoClass);
+    static CSSSelectorList makeHasScopeSelector(const CSSSelector& hasPseudoClass);
+    static CSSSelectorList makeHasArgumentWithScope(const CSSSelector& hasArgument, const CSSSelector& scopeSelector);
     static std::optional<Style::PseudoElementIdentifier> parsePseudoElement(const String&, const CSSSelectorParserContext&);
 
 private:

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -101,9 +101,10 @@ RuleFeature::RuleFeature(const RuleData& ruleData, MatchElement matchElement, Is
 {
 }
 
-RuleFeatureWithInvalidationSelector::RuleFeatureWithInvalidationSelector(const RuleData& data, MatchElement matchElement, IsNegation isNegation, CSSSelectorList&& invalidationSelector)
+RuleFeatureWithInvalidationSelector::RuleFeatureWithInvalidationSelector(const RuleData& data, MatchElement matchElement, IsNegation isNegation, CSSSelectorList&& invalidationSelector, CSSSelectorList&& scopeSelector)
     : RuleFeature(data, matchElement, isNegation)
     , invalidationSelector(WTF::move(invalidationSelector))
+    , scopeSelector(WTF::move(scopeSelector))
 {
 }
 
@@ -473,7 +474,8 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
             ruleData,
             matchElement,
             isNegation,
-            CSSSelectorParser::makeHasArgumentReplacingScope(*selector, *hasPseudoClass)
+            CSSSelectorList::makeCopyingComplexSelector(*selector),
+            CSSSelectorParser::makeHasScopeSelector(*hasPseudoClass)
         });
 
         if (doesBreakScope == DoesBreakScope::Yes)

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -105,9 +105,10 @@ struct RuleFeature : public RuleAndSelector {
 static_assert(sizeof(RuleFeature) <= 16, "RuleFeature is a frequently allocated object. Keep it small.");
 
 struct RuleFeatureWithInvalidationSelector : public RuleFeature {
-    RuleFeatureWithInvalidationSelector(const RuleData&, MatchElement, IsNegation, CSSSelectorList&& invalidationSelector);
+    RuleFeatureWithInvalidationSelector(const RuleData&, MatchElement, IsNegation, CSSSelectorList&& invalidationSelector, CSSSelectorList&& scopeSelector = { });
 
     CSSSelectorList invalidationSelector;
+    CSSSelectorList scopeSelector;
 };
 #pragma pack(pop)
 

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -54,6 +54,7 @@ using CascadeLayerPriority = uint16_t;
 struct RuleSetAndNegation {
     RefPtr<const RuleSet> ruleSet;
     IsNegation isNegation { IsNegation::No };
+    const CSSSelectorList* scopeSelector { nullptr };
 };
 using InvalidationRuleSetVector = Vector<RuleSetAndNegation, 1>;
 

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -32,6 +32,7 @@
 #include "ElementRuleCollector.h"
 #include "HTMLSlotElement.h"
 #include "RuleSetBuilder.h"
+#include "SelectorChecker.h"
 #include "SelectorMatchingState.h"
 #include "ShadowRoot.h"
 #include "StyleResolver.h"
@@ -405,7 +406,35 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
             }
             return;
         }
-        // FIXME: The remaining non-subject :has() cases could be made more precise with two-step invalidation.
+        if (matchElement.relation == Relation::Ancestor && hasRelation == HasRelation::Descendant) {
+            // .foo:has(.changed) .subject — find outermost ancestor matching any scope selector (.foo) to bound traversal.
+            auto scopeElement = [&] -> RefPtr<Element> {
+                Vector<Element*, 16> ancestors;
+                for (RefPtr ancestor = element.parentElement(); ancestor; ancestor = ancestor->parentElement())
+                    ancestors.append(ancestor.get());
+                SelectorChecker selectorChecker(element.document());
+                SelectorChecker::CheckingContext checkingContext(SelectorChecker::Mode::StyleInvalidation);
+                for (RefPtr ancestor : ancestors | std::views::reverse) {
+                    for (auto& ruleSet : m_ruleSets) {
+                        if (!ruleSet.scopeSelector)
+                            return element.document().documentElement();
+                        for (auto& selector : *ruleSet.scopeSelector) {
+                            if (selectorChecker.match(selector, *ancestor, checkingContext))
+                                return ancestor;
+                        }
+                    }
+                }
+                return element.document().documentElement();
+            }();
+
+            if (scopeElement) {
+                SelectorMatchingState selectorMatchingState;
+                invalidateStyleForDescendants(*scopeElement, &selectorMatchingState);
+                return;
+            }
+        }
+        // Remaining non-subject :has() cases fall back to full document traversal.
+
         SelectorMatchingState selectorMatchingState;
         invalidateStyleForDescendants(*element.document().documentElement(), &selectorMatchingState);
         return;
@@ -532,16 +561,18 @@ void Invalidator::invalidateInShadowTreeIfNeeded(Element& element)
 
 void Invalidator::addToMatchElementRuleSets(Invalidator::MatchElementRuleSets& matchElementRuleSets, const InvalidationRuleSet& invalidationRuleSet)
 {
+    auto& scopeSelector = invalidationRuleSet.scopeSelector;
     matchElementRuleSets.ensure(invalidationRuleSet.matchElement, [] {
         return InvalidationRuleSetVector { };
-    }).iterator->value.append({ invalidationRuleSet.ruleSet.copyRef(), IsNegation::No });
+    }).iterator->value.append({ invalidationRuleSet.ruleSet.copyRef(), IsNegation::No, scopeSelector.isEmpty() ? nullptr : &scopeSelector });
 }
 
 void Invalidator::addToMatchElementRuleSetsRespectingNegation(Invalidator::MatchElementRuleSets& matchElementRuleSets, const InvalidationRuleSet& invalidationRuleSet)
 {
+    auto& scopeSelector = invalidationRuleSet.scopeSelector;
     matchElementRuleSets.ensure(invalidationRuleSet.matchElement, [] {
         return InvalidationRuleSetVector { };
-    }).iterator->value.append({ invalidationRuleSet.ruleSet.copyRef(), invalidationRuleSet.isNegation });
+    }).iterator->value.append({ invalidationRuleSet.ruleSet.copyRef(), invalidationRuleSet.isNegation, scopeSelector.isEmpty() ? nullptr : &scopeSelector });
 }
 
 void Invalidator::invalidateWithMatchElementRuleSets(Element& element, const MatchElementRuleSets& matchElementRuleSets)

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -30,6 +30,7 @@
 #include "StyleScopeRuleSets.h"
 
 #include "CSSPropertyParser.h"
+#include "CSSSelectorParser.h"
 #include "CSSStyleSheet.h"
 #include "CSSViewTransitionRule.h"
 #include "DeclarationOrigin.h"
@@ -317,6 +318,7 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
             MatchElement matchElement;
             IsNegation isNegation;
             const CSSSelectorList* invalidationSelector { nullptr };
+            const CSSSelectorList* scopeSelector { nullptr };
 
             unsigned hash() const
             {
@@ -324,13 +326,16 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
                 add(hasher, matchElement.relation, matchElement.hasRelation, isNegation);
                 if (invalidationSelector)
                     add(hasher, *invalidationSelector);
+                if (scopeSelector)
+                    add(hasher, *scopeSelector);
                 return hasher.hash();
             }
             bool operator==(const RuleSetKey& other) const
             {
                 return matchElement == other.matchElement
                     && isNegation == other.isNegation
-                    && arePointingToEqualData(invalidationSelector, other.invalidationSelector);
+                    && arePointingToEqualData(invalidationSelector, other.invalidationSelector)
+                    && arePointingToEqualData(scopeSelector, other.scopeSelector);
             }
         };
 
@@ -339,7 +344,7 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
         for (auto& feature : *features) {
             auto key = [&] {
                 if constexpr (std::is_same_v<typename RuleFeatureVectorType::ValueType, RuleFeatureWithInvalidationSelector>)
-                    return GenericHashKey<RuleSetKey> { { feature.matchElement, feature.isNegation, &feature.invalidationSelector } };
+                    return GenericHashKey<RuleSetKey> { { feature.matchElement, feature.isNegation, &feature.invalidationSelector, &feature.scopeSelector } };
                 else
                     return GenericHashKey<RuleSetKey> { { feature.matchElement, feature.isNegation } };
             }();
@@ -354,11 +359,19 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
         return makeUnique<Vector<InvalidationRuleSet>>(WTF::map(ruleSetMap, [](auto& entry) {
             auto& key = entry.key.key();
             entry.value->shrinkToFit();
+            auto invalidationSelector = [&] {
+                if (key.invalidationSelector && key.scopeSelector && !key.scopeSelector->isEmpty())
+                    return CSSSelectorParser::makeHasArgumentWithScope(key.invalidationSelector->first(), key.scopeSelector->first());
+                if (key.invalidationSelector)
+                    return CSSSelectorList { *key.invalidationSelector };
+                return CSSSelectorList { };
+            }();
             return InvalidationRuleSet {
                 WTF::move(entry.value),
-                key.invalidationSelector ? *key.invalidationSelector : CSSSelectorList { },
+                WTF::move(invalidationSelector),
                 key.matchElement,
-                key.isNegation
+                key.isNegation,
+                key.scopeSelector ? *key.scopeSelector : CSSSelectorList { }
             };
         }));
     }).iterator->value.get();

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -55,6 +55,9 @@ struct InvalidationRuleSet {
     CSSSelectorList invalidationSelectors;
     MatchElement matchElement;
     IsNegation isNegation;
+    // For non-subject :has(), a selector matching the :has() scope element.
+    // Used to bound the invalidation traversal to the scope element's subtree.
+    CSSSelectorList scopeSelector;
 };
 
 enum class SelectorsForStyleAttribute : uint8_t { None, SubjectPositionOnly, NonSubjectPosition };


### PR DESCRIPTION
#### 245943e53c92260358ae98799c107126fa07a6ca
<pre>
[:has() perf] Limit invalidation traversal with scope selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=312866">https://bugs.webkit.org/show_bug.cgi?id=312866</a>
<a href="https://rdar.apple.com/175233639">rdar://175233639</a>

Reviewed by Alan Baradlay.

For a selector like

.foo:has(.bar) .baz

we know that any potentially affected element for .bar change is in .foo subtree. By saving and using the
the scope selector (&quot;.foo&quot; here) we can limit invalidation traversal to the minimal subtree.

* LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt:
* LayoutTests/fast/selectors/has-invalidation-traversal-size.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::collectHasCompoundContext):
(WebCore::appendSelector):
(WebCore::buildScopeSelector):
(WebCore::CSSSelectorParser::makeHasScopeSelector):
(WebCore::CSSSelectorParser::makeHasArgumentWithScope):
(WebCore::CSSSelectorParser::makeHasArgumentReplacingScope): Deleted.
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureWithInvalidationSelector::RuleFeatureWithInvalidationSelector):
(WebCore::Style::RuleFeatureSet::collectFeatures):

Save the scope selector to RuleFeature.
Since we are passing the scope selector we don&apos;t need to resolve the invalidation selectors against the scope here,
we can do it at RuleSet building time.

* Source/WebCore/style/RuleFeature.h:
(WebCore::Style::RuleFeatureWithInvalidationSelector::RuleFeatureWithInvalidationSelector):
* Source/WebCore/style/RuleSet.h:
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):

In Ancestor/Descendant case use the scope selector to find the scope element and traverse that subtree only.

(WebCore::Style::Invalidator::addToMatchElementRuleSets):
(WebCore::Style::Invalidator::addToMatchElementRuleSetsRespectingNegation):
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ensureInvalidationRuleSets):

Include the scope selector to InvalidationRuleSet.
Resolve the invalidation selector scopes.

* Source/WebCore/style/StyleScopeRuleSets.h:

Canonical link: <a href="https://commits.webkit.org/311702@main">https://commits.webkit.org/311702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87bf97124350d9c2149320d606750e2afbf6b55b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166557 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122134 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24415 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102803 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14328 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169046 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13641 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21073 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130301 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130418 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/35327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141245 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88600 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18050 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30306 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94925 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29827 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30057 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29954 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->