### PR TITLE
parseHTMLFloatingPointNumberValue should return fallback value on parse failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-meter-element/meter-leading-plus-sign-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-meter-element/meter-leading-plus-sign-expected.txt
@@ -1,0 +1,16 @@
+Meter element: leading plus sign in content attributes
+
+
+PASS value with leading '+' should parse as 5
+PASS max with leading '+' should parse as 10
+PASS min with leading '+' should parse as 1
+PASS low with leading '+' should parse as 2
+PASS high with leading '+' should parse as 8
+PASS optimum with leading '+' should parse as 6
+PASS value '+3.14' should parse as 3.14
+PASS setAttribute with leading '+' should parse correctly
+PASS bare '+' for max should use default value 1
+PASS bare '-' for max should use default value 1
+PASS bare '.' for max should use default value 1
+PASS '+-5' for max should use default value 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-meter-element/meter-leading-plus-sign.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-meter-element/meter-leading-plus-sign.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>The meter element: parsing floating-point number values with leading plus sign</title>
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-floating-point-number-values">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-meter-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <h1>Meter element: leading plus sign in content attributes</h1>
+    <div id="log"></div>
+    <div style="display: none;">
+      <meter id="meter_plus_value" value="+5" min="0" max="10"></meter>
+      <meter id="meter_plus_max" value="5" min="0" max="+10"></meter>
+      <meter id="meter_plus_min" value="5" min="+1" max="10"></meter>
+      <meter id="meter_plus_low" value="5" min="0" max="10" low="+2"></meter>
+      <meter id="meter_plus_high" value="5" min="0" max="10" high="+8"></meter>
+      <meter id="meter_plus_optimum" value="5" min="0" max="10" optimum="+6"></meter>
+      <meter id="meter_plus_decimal" value="+3.14" min="0" max="10"></meter>
+      <meter id="meter_bare_plus_max" max="+"></meter>
+      <meter id="meter_bare_minus_max" max="-"></meter>
+      <meter id="meter_bare_dot_max" max="."></meter>
+      <meter id="meter_plus_minus_max" max="+-5"></meter>
+    </div>
+    <script>
+      // The HTML spec "rules for parsing floating-point number values" (step 9)
+      // says a leading U+002B PLUS SIGN (+) should be accepted and skipped.
+
+      test(function() {
+        assert_equals(document.getElementById("meter_plus_value").value, 5);
+      }, "value with leading '+' should parse as 5");
+
+      test(function() {
+        assert_equals(document.getElementById("meter_plus_max").max, 10);
+      }, "max with leading '+' should parse as 10");
+
+      test(function() {
+        assert_equals(document.getElementById("meter_plus_min").min, 1);
+      }, "min with leading '+' should parse as 1");
+
+      test(function() {
+        assert_equals(document.getElementById("meter_plus_low").low, 2);
+      }, "low with leading '+' should parse as 2");
+
+      test(function() {
+        assert_equals(document.getElementById("meter_plus_high").high, 8);
+      }, "high with leading '+' should parse as 8");
+
+      test(function() {
+        assert_equals(document.getElementById("meter_plus_optimum").optimum, 6);
+      }, "optimum with leading '+' should parse as 6");
+
+      test(function() {
+        assert_equals(document.getElementById("meter_plus_decimal").value, 3.14);
+      }, "value '+3.14' should parse as 3.14");
+
+      test(function() {
+        var meter = document.createElement("meter");
+        meter.setAttribute("min", "0");
+        meter.setAttribute("max", "+10");
+        meter.setAttribute("value", "+5");
+        assert_equals(meter.max, 10, "max");
+        assert_equals(meter.value, 5, "value");
+      }, "setAttribute with leading '+' should parse correctly");
+
+      // Bare '+', '-', '.' are parse errors per the spec (step 10: after
+      // consuming the sign, if position is past the end of input or not at
+      // a '.' or ASCII digit, return an error). The meter element should
+      // use its default/fallback values.
+
+      test(function() {
+        assert_equals(document.getElementById("meter_bare_plus_max").max, 1);
+      }, "bare '+' for max should use default value 1");
+
+      test(function() {
+        assert_equals(document.getElementById("meter_bare_minus_max").max, 1);
+      }, "bare '-' for max should use default value 1");
+
+      test(function() {
+        assert_equals(document.getElementById("meter_bare_dot_max").max, 1);
+      }, "bare '.' for max should use default value 1");
+
+      test(function() {
+        assert_equals(document.getElementById("meter_plus_minus_max").max, 1);
+      }, "'+-5' for max should use default value 1");
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/html/parser/HTMLParserIdioms.cpp
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.cpp
@@ -256,6 +256,9 @@ static double parseHTMLFloatingPointNumberValueInternal(std::span<const Characte
     size_t parsedLength;
     double number = parseDouble(position.first(length - leadingSpacesLength), parsedLength);
 
+    if (!parsedLength)
+        return fallbackValue;
+
     // The following expression converts -0 to +0.
     return number ? number : 0;
 }


### PR DESCRIPTION
#### 91fe69be48d69ab36edafc1848089a15d33a4288
<pre>
parseHTMLFloatingPointNumberValue should return fallback value on parse failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=312869">https://bugs.webkit.org/show_bug.cgi?id=312869</a>

Reviewed by Anne van Kesteren.

parseHTMLFloatingPointNumberValueInternal never checked parsedLength after
calling parseDouble, so when parsing failed entirely (e.g. for bare &quot;+&quot;,
&quot;-&quot;, or &quot;.&quot;), it returned 0 instead of the caller-provided fallback value.

Fix by checking parsedLength and returning the fallback value on parse
failure. Note that parseDouble (backed by fast_float::from_chars) already
accepts leading &apos;+&apos; via the allow_leading_plus flag, so no special
handling of &apos;+&apos; is needed.

Test: imported/w3c/web-platform-tests/html/semantics/forms/the-meter-element/meter-leading-plus-sign.html

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-meter-element/meter-leading-plus-sign-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-meter-element/meter-leading-plus-sign.html: Added.
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::parseHTMLFloatingPointNumberValueInternal):

Canonical link: <a href="https://commits.webkit.org/311735@main">https://commits.webkit.org/311735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42feb9afff0d14dc81247da374171b70d3125f1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111797 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122122 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85764 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102791 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23462 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21749 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14310 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169028 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13599 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130290 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35340 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88579 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18038 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94793 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29809 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30039 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29936 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->