### PR TITLE
[JSC] `Intl.DateTimeFormat#resolvedOptions().timeZone` should return "+00:00" for zero-offset time zones

### DIFF
--- a/JSTests/stress/intl-datetimeformat-offset-timezone-zero.js
+++ b/JSTests/stress/intl-datetimeformat-offset-timezone-zero.js
@@ -1,0 +1,12 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+shouldBe(new Intl.DateTimeFormat(undefined, { timeZone: "+00:00" }).resolvedOptions().timeZone, "+00:00");
+shouldBe(new Intl.DateTimeFormat(undefined, { timeZone: "-00:00" }).resolvedOptions().timeZone, "+00:00");
+shouldBe(new Intl.DateTimeFormat(undefined, { timeZone: "+00" }).resolvedOptions().timeZone, "+00:00");
+shouldBe(new Intl.DateTimeFormat(undefined, { timeZone: "-00" }).resolvedOptions().timeZone, "+00:00");
+shouldBe(new Intl.DateTimeFormat(undefined, { timeZone: "+0000" }).resolvedOptions().timeZone, "+00:00");
+shouldBe(new Intl.DateTimeFormat(undefined, { timeZone: "UTC" }).resolvedOptions().timeZone, "UTC");
+shouldBe(new Intl.DateTimeFormat(undefined, { timeZone: "+03:00" }).resolvedOptions().timeZone, "+03:00");

--- a/JSTests/stress/temporal-timezone.js
+++ b/JSTests/stress/temporal-timezone.js
@@ -64,7 +64,7 @@ for (let text of failures) {
     }, RangeError);
 }
 
-shouldBe(new Temporal.TimeZone("+00:00").id, `UTC`);
+shouldBe(new Temporal.TimeZone("+00:00").id, `+00:00`);
 shouldBe(new Temporal.TimeZone("+01:00").id, `+01:00`);
 shouldBe(new Temporal.TimeZone("+01:59").id, `+01:59`);
 shouldBe(new Temporal.TimeZone("-01:59").id, `-01:59`);

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -2086,8 +2086,6 @@ String TimeZone::toString() const
 {
     if (isID())
         return intlTimeZoneIDToString(m_id);
-    if (!m_offset)
-        return intlTimeZoneIDToString(utcTimeZoneID());
     return ISO8601::formatTimeZoneOffsetString(m_offset);
 }
 

--- a/Source/JavaScriptCore/runtime/JSCTimeZone.h
+++ b/Source/JavaScriptCore/runtime/JSCTimeZone.h
@@ -58,16 +58,15 @@ public:
     }
 
     static TimeZone fromID(TimeZoneID id) { return TimeZone(id, 0); }
-    static TimeZone fromUTCOffset(int64_t offsetNanoseconds) { return TimeZone(utcTimeZoneID(), offsetNanoseconds); }
+    static TimeZone fromUTCOffset(int64_t offsetNanoseconds) { return TimeZone(offsetSentinelID, offsetNanoseconds); }
 
-    bool isUTCOffset() const { return m_id == utcTimeZoneID(); }
+    bool isUTCOffset() const { return m_id == offsetSentinelID; }
     bool isID() const { return !isUTCOffset(); }
 
     TimeZoneID id() const { ASSERT(isID()); return m_id; }
     int64_t utcOffsetNanoseconds() const { ASSERT(isUTCOffset()); return m_offset; }
 
-    // IANA primary identifier for non-UTC named zones, "UTC" for offset 0, or formatted
-    // "+HH:MM[:SS[.fff...]]" for non-zero UTC offsets.
+    // IANA primary identifier for named zones, or formatted "+HH:MM[:SS[.fff...]]" for UTC offsets.
     JS_EXPORT_PRIVATE String toString() const;
 
     // ICU accepts named identifiers as-is, and offsets only in "GMT+HHMM" form.
@@ -76,6 +75,9 @@ public:
     friend bool operator==(const TimeZone&, const TimeZone&) = default;
 
 private:
+    // A TimeZoneID is an index into intlAvailableTimeZones() so it can never reach this value.
+    static constexpr TimeZoneID offsetSentinelID = std::numeric_limits<TimeZoneID>::max();
+
     constexpr TimeZone(TimeZoneID id, int64_t offset) : m_id(id), m_offset(offset) { }
 
     TimeZoneID m_id { };


### PR DESCRIPTION
#### fed503a77519d94ab56ddcc5ed64fb9b259748d4
<pre>
[JSC] `Intl.DateTimeFormat#resolvedOptions().timeZone` should return &quot;+00:00&quot; for zero-offset time zones
<a href="https://bugs.webkit.org/show_bug.cgi?id=312872">https://bugs.webkit.org/show_bug.cgi?id=312872</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/311604@main">311604@main</a> introduced JSC::TimeZone which stored utcTimeZoneID() in m_id
for offset-based time zones and used `m_id == utcTimeZoneID()` to detect
them. As a result, TimeZone::fromUTCOffset(0) and
TimeZone::fromID(utcTimeZoneID()) produced the identical state and
toString() returned &quot;UTC&quot; for both, so
`new Intl.DateTimeFormat(undefined, {timeZone: &apos;+00:00&apos;}).resolvedOptions().timeZone`
returned &quot;UTC&quot; instead of &quot;+00:00&quot;, violating ECMA-402
FormatOffsetTimeZoneIdentifier and regressing
test262/intl402/DateTimeFormat/prototype/resolvedOptions/offset-timezone-change.js.
It also meant TimeZone::fromID(utcTimeZoneID()) reported isID() == false
and would assert in id().

This patch uses a dedicated sentinel TimeZoneID for offset-based time
zones so they can be distinguished from the named &quot;UTC&quot; zone, and lets
toString() emit &quot;+00:00&quot; for a zero offset.

Test: JSTests/stress/intl-datetimeformat-offset-timezone-zero.js

* JSTests/stress/intl-datetimeformat-offset-timezone-zero.js: Added.
(shouldBe):
* JSTests/stress/temporal-timezone.js:
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::TimeZone::toString const):
* Source/JavaScriptCore/runtime/JSCTimeZone.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fed503a77519d94ab56ddcc5ed64fb9b259748d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166519 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31034 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160653 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/24392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14290 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/149746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/19420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169008 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18530 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/13558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21041 "Build is in progress. Recent messages:") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/130390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/141214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/189823 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30268 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/94743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/48752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29789 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30019 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/29916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->