### PR TITLE
HTMLEntityParser: minor code quality improvements

### DIFF
--- a/Source/WebCore/html/parser/HTMLEntityParser.cpp
+++ b/Source/WebCore/html/parser/HTMLEntityParser.cpp
@@ -70,7 +70,7 @@ constexpr DecodedHTMLEntity::DecodedHTMLEntity(ConstructNotEnoughCharactersType)
 
 static constexpr DecodedHTMLEntity NODELETE makeEntity(char32_t character)
 {
-    if (character <= 0 || character > UCHAR_MAX_VALUE || U_IS_SURROGATE(character))
+    if (!character || character > UCHAR_MAX_VALUE || U_IS_SURROGATE(character))
         return { replacementCharacter };
     if ((character & ~0x1F) != 0x80) {
         if (U_IS_BMP(character)) {

--- a/Source/WebCore/html/parser/HTMLEntitySearch.cpp
+++ b/Source/WebCore/html/parser/HTMLEntitySearch.cpp
@@ -39,13 +39,14 @@ HTMLEntitySearch::HTMLEntitySearch()
 
 HTMLEntitySearch::CompareResult HTMLEntitySearch::compare(const HTMLEntityTableEntry* entry, char16_t nextCharacter) const
 {
+    auto name = entry->nameCharacters();
     char16_t entryNextCharacter;
-    if (entry->nameLengthExcludingSemicolon < m_currentLength + 1) {
-        if (!entry->nameIncludesTrailingSemicolon || entry->nameLengthExcludingSemicolon < m_currentLength)
+    if (m_currentLength >= name.size()) {
+        if (!entry->nameIncludesTrailingSemicolon || m_currentLength > name.size())
             return Before;
         entryNextCharacter = ';';
     } else
-        entryNextCharacter = entry->nameCharacters()[m_currentLength];
+        entryNextCharacter = name[m_currentLength];
     if (entryNextCharacter == nextCharacter)
         return Prefix;
     return entryNextCharacter < nextCharacter ? Before : After;

--- a/Source/WebCore/html/parser/create-html-entity-table
+++ b/Source/WebCore/html/parser/create-html-entity-table
@@ -191,7 +191,7 @@ output_file.write("""});
 
 std::span<const char> HTMLEntityTableEntry::nameCharacters() const
 {
-    return staticEntityStringStorage.span().subspan(nameCharactersOffset);
+    return staticEntityStringStorage.span().subspan(nameCharactersOffset, nameLengthExcludingSemicolon);
 }
 
 std::span<const HTMLEntityTableEntry> HTMLEntityTable::entriesStartingWith(char16_t c)


### PR DESCRIPTION
#### 76f8c0b5884b64dc4e0e891f309192449b8ec57f
<pre>
HTMLEntityParser: minor code quality improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=312874">https://bugs.webkit.org/show_bug.cgi?id=312874</a>

Reviewed by Anne van Kesteren.

Two small improvements to the HTML entity parser:
  - In makeEntity(char32_t), replace `character &lt;= 0` with `!character`
    since char32_t is unsigned, making the intent clearer.
  - Bound the span returned by HTMLEntityTableEntry::nameCharacters() to
    nameLengthExcludingSemicolon characters instead of extending to the end
    of the entire string storage. Update HTMLEntitySearch::compare() to use
    the span&apos;s size for bounds checking instead of accessing the bitfield
    directly.

* Source/WebCore/html/parser/HTMLEntityParser.cpp:
(WebCore::makeEntity):
* Source/WebCore/html/parser/HTMLEntitySearch.cpp:
(WebCore::HTMLEntitySearch::compare const):
* Source/WebCore/html/parser/create-html-entity-table:

Canonical link: <a href="https://commits.webkit.org/311738@main">https://commits.webkit.org/311738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3da1f3e6af803e75fa08bc856bc40fec76647d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111780 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122103 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85753 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102772 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23447 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21730 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14293 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169011 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13563 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130270 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130387 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35347 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30719 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141213 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88557 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25174 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18018 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30271 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94749 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29792 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30022 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29919 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->