### PR TITLE
ANGLE: Metal: ImageTestMetal.OverrideMetalTextureInternalFormatIncompatibleFormat fails validation

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/gen_mtl_format_table.py
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/gen_mtl_format_table.py
@@ -98,7 +98,10 @@ void FormatTable::initNativeFormatCapsAutogen(const DisplayMtl *display)
     bool supportDepthStencilAutoResolve = supportDepthAutoResolve && supportStencilAutoResolve;
 
     // Source: https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
-    {metal_format_caps}
+    // clang-format off
+{metal_format_caps}
+    // clang-format on
+
 }}
 
 }}  // namespace mtl
@@ -219,6 +222,64 @@ def maybe_add_deprecation_warning_supression(is_deprecated_pixel_format,
 # Returns a bool indicating whether `pixel_format` has been deprecated in iOS 18.0+.
 def is_format_deprecated(pixel_format):
     return 'MTLPixelFormatPVRTC_RGB' in pixel_format
+
+
+def is_format_compressed(mtl_format):
+    name = mtl_format.replace('MTLPixelFormat', '')
+    return any(name.startswith(prefix) for prefix in ['BC', 'ETC', 'EAC', 'PVRTC', 'ASTC'])
+
+
+def get_mtl_format_info(mtl_format):
+    """Extract channel count and pixel byte size from an MTLPixelFormat name.
+
+    For depth/stencil formats, returns channels=0 with the correct pixel byte size.
+    Examples:
+        MTLPixelFormatRGBA32Float       -> (4, 16, 4)  # 4 channels, 4 bytes each, alignment 4
+        MTLPixelFormatRG16Float         -> (2, 4, 2)   # 2 channels, 2 bytes each, alignment 2
+        MTLPixelFormatR8Unorm           -> (1, 1, 1)   # 1 channel, 1 byte, alignment 1
+        MTLPixelFormatDepth32Float      -> (0, 4, 4)   # depth, 4 bytes, alignment 4
+        MTLPixelFormatDepth16Unorm      -> (0, 2, 2)   # depth, 2 bytes, alignment 2
+        MTLPixelFormatStencil8          -> (0, 1, 1)   # stencil, 1 byte, alignment 1
+        MTLPixelFormatDepth32Float_Stencil8 -> (0, 5, 4) # depth+stencil, 5 bytes, alignment 4
+    """
+    name = mtl_format.replace('MTLPixelFormat', '')
+
+    if name == 'Invalid':
+        return 0, 0, 0
+
+    base_name = name.replace('_sRGB', '')
+
+    predefined_formats = {
+        'Depth32Float': (0, 4, 4),
+        'Depth16Unorm': (0, 2, 2),
+        'Stencil8': (0, 1, 1),
+        'Depth32Float_Stencil8': (0, 5, 4), # "When using this format, some Metal device objects allocate 64-bits per pixel."
+        'Depth24Unorm_Stencil8': (0, 4, 4),
+        'BGR10A2Unorm': (4, 4, 4),
+        'RGB10A2Unorm': (4, 4, 4),
+        'RGB10A2Uint': (4, 4, 4),
+        'RG11B10Float': (3, 4, 4),
+        'RGB9E5Float': (3, 4, 4),
+        'B5G6R5Unorm': (3, 2, 2),
+        'A1BGR5Unorm': (4, 2, 2),
+        'ABGR4Unorm': (4, 2, 2),
+        'BGR5A1Unorm': (4, 2, 2),
+    }
+    predefined = predefined_formats.get(base_name)
+    if predefined:
+        return predefined
+
+    # Regular formats: [channels][bits][type]
+    # e.g. R8Unorm, RG16Float, RGBA32Uint, BGRA8Unorm, A8Unorm
+    m = re.match(r'^(A|RGBA|BGRA|BGR|RGB|RG|R)(\d+)(Unorm|Snorm|Uint|Sint|Float)$', base_name)
+    assert m
+
+    channels = len(m.group(1))
+    bits = int(m.group(2))
+    bytes_per_channel = bits // 8
+    pixel_bytes = channels * bytes_per_channel
+    alignment = pixel_bytes // channels
+    return channels, pixel_bytes, alignment
 
 # NOTE(hqle): This is a modified version of the get_vertex_copy_function() function in
 # src/libANGLE/renderer/angle_format.py
@@ -720,22 +781,36 @@ def gen_mtl_format_caps_init_string(map_image):
     ios_specific_caps = map_image['caps_ios_specific']
     caps_init_str = ''
 
-    def cap_to_param(caps, key):
-        return '/** ' + key + '*/ ' + caps.get(key, 'false')
-
     def caps_to_cpp(caps_table):
         init_str = ''
         # Tracks whether the pixel format family being added to `init_str` is deprecated.
         section_contains_deprecated_format = False
         for mtl_format in sorted(caps_table.keys()):
+            if is_format_compressed(mtl_format):
+                compressed = 'true'
+                pixel_bytes = 0
+                pixel_bytes_msaa = 0
+                channels = 0
+                alignment = 0
+            else:
+                compressed = 'false'
+                channels, pixel_bytes, alignment = get_mtl_format_info(mtl_format)
+                pixel_bytes_msaa = pixel_bytes
+
             caps = caps_table[mtl_format]
-            filterable = cap_to_param(caps, 'filterable')
-            writable = cap_to_param(caps, 'writable')
-            colorRenderable = cap_to_param(caps, 'colorRenderable')
-            depthRenderable = cap_to_param(caps, 'depthRenderable')
-            blendable = cap_to_param(caps, 'blendable')
-            multisample = cap_to_param(caps, 'multisample')
-            resolve = cap_to_param(caps, 'resolve')
+
+            filterable = caps.get('filterable', 'false')
+            writable = caps.get('writable', 'false')
+            color_renderable = caps.get('colorRenderable', 'false')
+            depth_renderable = caps.get('depthRenderable', 'false')
+            blendable = caps.get('blendable', 'false')
+            multisample = caps.get('multisample', 'false')
+            resolve = caps.get('resolve', 'false')
+            compressed = caps.get('compressed', compressed)
+            pixel_bytes = caps.get('pixelBytes', pixel_bytes)
+            pixel_bytes_msaa = caps.get('pixelBytes', pixel_bytes_msaa)
+            channels = caps.get('channels', channels)
+            alignment = caps.get('alignment', alignment)
 
             # Add deprecation warnings around MTLPixelFormatPVRTC_* enums.
             format_is_deprecated = is_format_deprecated(mtl_format)
@@ -743,9 +818,21 @@ def gen_mtl_format_caps_init_string(map_image):
                 format_is_deprecated, section_contains_deprecated_format)
             section_contains_deprecated_format = format_is_deprecated
 
-            init_str += "    setFormatCaps({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7});\n\n".format(
-                mtl_format, filterable, writable, blendable, multisample, resolve, colorRenderable,
-                depthRenderable)
+            init_str += f"""    setFormatCaps({mtl_format},
+                  {{
+                      .filterable      = {filterable},
+                      .writable        = {writable},
+                      .colorRenderable = {color_renderable},
+                      .depthRenderable = {depth_renderable},
+                      .blendable       = {blendable},
+                      .multisample     = {multisample},
+                      .resolve         = {resolve},
+                      .compressed      = {compressed},
+                      .pixelBytes      = {pixel_bytes},
+                      .pixelBytesMSAA  = {pixel_bytes},
+                      .channels        = {channels},
+                      .alignment       = {alignment}
+                  }});\n"""
 
         return init_str
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_table_autogen.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_table_autogen.mm
@@ -3850,635 +3850,1988 @@ void FormatTable::initNativeFormatCapsAutogen(const DisplayMtl *display)
     bool supportDepthStencilAutoResolve = supportDepthAutoResolve && supportStencilAutoResolve;
 
     // Source: https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
-    setFormatCaps(MTLPixelFormatA8Unorm, /** filterable*/ true, /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatBGR10A2Unorm, /** filterable*/ true,
-                  /** writable*/ display->supportsEitherGPUFamily(3, 1), /** blendable*/ true,
-                  /** multisample*/ true, /** resolve*/ true, /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatBGRA8Unorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true, /** resolve*/ true,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatBGRA8Unorm_sRGB, /** filterable*/ true,
-                  /** writable*/ display->supportsAppleGPUFamily(2) && !display->isSimulator(),
-                  /** blendable*/ true, /** multisample*/ true, /** resolve*/ true,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
+    // clang-format off
+    setFormatCaps(MTLPixelFormatA8Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 1,
+                      .pixelBytesMSAA  = 1,
+                      .channels        = 1,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatBGR10A2Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = display->supportsEitherGPUFamily(3, 1),
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 4,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatBGRA8Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 4,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatBGRA8Unorm_sRGB,
+                  {
+                      .filterable      = true,
+                      .writable        = display->supportsAppleGPUFamily(2) && !display->isSimulator(),
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 4,
+                      .alignment       = 1
+                  });
     setFormatCaps(MTLPixelFormatDepth32Float,
-                  /** filterable*/ display->supports32BitFloatFiltering(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ true,
-                  /** resolve*/ supportDepthAutoResolve, /** colorRenderable*/ false,
-                  /** depthRenderable*/ true);
-
+                  {
+                      .filterable      = display->supports32BitFloatFiltering(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = true,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = supportDepthAutoResolve,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 0,
+                      .alignment       = 4
+                  });
     setFormatCaps(MTLPixelFormatDepth32Float_Stencil8,
-                  /** filterable*/ display->supports32BitFloatFiltering(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ true,
-                  /** resolve*/ supportDepthStencilAutoResolve, /** colorRenderable*/ false,
-                  /** depthRenderable*/ true);
-
-    setFormatCaps(MTLPixelFormatR16Float, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true, /** resolve*/ true,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatR16Sint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatR16Snorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true,
-                  /** resolve*/ display->supportsMacGPUFamily(1), /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatR16Uint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatR16Unorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true,
-                  /** resolve*/ display->supportsMacGPUFamily(1), /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(
-        MTLPixelFormatR32Float,
-        /** filterable*/ display->supportsMacGPUFamily(1) ||
-            (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
-        /** writable*/ true, /** blendable*/ true, /** multisample*/ true,
-        /** resolve*/ display->supportsMacGPUFamily(1) ||
-            (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
-        /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatR32Sint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ display->supportsMacGPUFamily(1),
-                  /** resolve*/ false, /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatR32Uint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ display->supportsMacGPUFamily(1),
-                  /** resolve*/ false, /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatR8Sint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatR8Snorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true,
-                  /** resolve*/ display->supportsEitherGPUFamily(2, 1), /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatR8Uint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatR8Unorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true, /** resolve*/ true,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG11B10Float, /** filterable*/ true,
-                  /** writable*/ display->supportsEitherGPUFamily(3, 1), /** blendable*/ true,
-                  /** multisample*/ true, /** resolve*/ true, /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG16Float, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true, /** resolve*/ true,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG16Sint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG16Snorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true,
-                  /** resolve*/ display->supportsMacGPUFamily(1), /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG16Uint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG16Unorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true,
-                  /** resolve*/ display->supportsMacGPUFamily(1), /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(
-        MTLPixelFormatRG32Float,
-        /** filterable*/ display->supportsMacGPUFamily(1) ||
-            (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
-        /** writable*/ true, /** blendable*/ true,
-        /** multisample*/ display->supportsEitherGPUFamily(7, 1),
-        /** resolve*/ display->supportsMacGPUFamily(1) ||
-            (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
-        /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG32Sint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ display->supportsEitherGPUFamily(7, 1),
-                  /** resolve*/ false, /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG32Uint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ display->supportsEitherGPUFamily(7, 1),
-                  /** resolve*/ false, /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG8Sint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG8Snorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true,
-                  /** resolve*/ display->supportsEitherGPUFamily(2, 1), /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG8Uint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG8Unorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true, /** resolve*/ true,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGB10A2Uint, /** filterable*/ false,
-                  /** writable*/ display->supportsEitherGPUFamily(3, 1), /** blendable*/ false,
-                  /** multisample*/ true, /** resolve*/ false, /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGB10A2Unorm, /** filterable*/ true,
-                  /** writable*/ display->supportsEitherGPUFamily(3, 1), /** blendable*/ true,
-                  /** multisample*/ true, /** resolve*/ true, /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(
-        MTLPixelFormatRGB9E5Float, /** filterable*/ true,
-        /** writable*/ display->supportsAppleGPUFamily(3),
-        /** blendable*/ display->supportsAppleGPUFamily(1),
-        /** multisample*/ display->supportsAppleGPUFamily(1),
-        /** resolve*/ display->supportsAppleGPUFamily(1),
-        /** colorRenderable*/ display->supportsAppleGPUFamily(1) && !display->isSimulator(),
-        /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA16Float, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true, /** resolve*/ true,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA16Sint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA16Snorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true,
-                  /** resolve*/ display->supportsMacGPUFamily(1), /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA16Uint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA16Unorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true,
-                  /** resolve*/ display->supportsMacGPUFamily(1), /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(
-        MTLPixelFormatRGBA32Float,
-        /** filterable*/ display->supportsMacGPUFamily(1) ||
-            (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
-        /** writable*/ true,
-        /** blendable*/ display->supportsMacGPUFamily(1) ||
-            (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
-        /** multisample*/ display->supportsEitherGPUFamily(7, 1),
-        /** resolve*/ display->supportsMacGPUFamily(1) ||
-            (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
-        /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA32Sint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ display->supportsMacGPUFamily(1),
-                  /** resolve*/ false, /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA32Uint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ display->supportsMacGPUFamily(1),
-                  /** resolve*/ false, /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA8Sint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA8Snorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true,
-                  /** resolve*/ display->supportsEitherGPUFamily(2, 1), /** colorRenderable*/ true,
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA8Uint, /** filterable*/ false, /** writable*/ true,
-                  /** blendable*/ false, /** multisample*/ true, /** resolve*/ false,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA8Unorm, /** filterable*/ true, /** writable*/ true,
-                  /** blendable*/ true, /** multisample*/ true, /** resolve*/ true,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRGBA8Unorm_sRGB, /** filterable*/ true,
-                  /** writable*/ display->supportsAppleGPUFamily(2) && !display->isSimulator(),
-                  /** blendable*/ true, /** multisample*/ true, /** resolve*/ true,
-                  /** colorRenderable*/ true, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatStencil8, /** filterable*/ false, /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ true,
-                  /** resolve*/ supportStencilAutoResolve, /** colorRenderable*/ false,
-                  /** depthRenderable*/ true);
-
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST ||                       \
-    (TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400) || \
+                  {
+                      .filterable      = display->supports32BitFloatFiltering(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = true,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = supportDepthStencilAutoResolve,
+                      .compressed      = false,
+                      .pixelBytes      = 5,
+                      .pixelBytesMSAA  = 5,
+                      .channels        = 0,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatR16Float,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 1,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatR16Sint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 1,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatR16Snorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = display->supportsMacGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 1,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatR16Uint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 1,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatR16Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = display->supportsMacGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 1,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatR32Float,
+                  {
+                      .filterable      = display->supportsMacGPUFamily(1) || (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = display->supportsMacGPUFamily(1) || (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 1,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatR32Sint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = display->supportsMacGPUFamily(1),
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 1,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatR32Uint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = display->supportsMacGPUFamily(1),
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 1,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatR8Sint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 1,
+                      .pixelBytesMSAA  = 1,
+                      .channels        = 1,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatR8Snorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = display->supportsEitherGPUFamily(2, 1),
+                      .compressed      = false,
+                      .pixelBytes      = 1,
+                      .pixelBytesMSAA  = 1,
+                      .channels        = 1,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatR8Uint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 1,
+                      .pixelBytesMSAA  = 1,
+                      .channels        = 1,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatR8Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 1,
+                      .pixelBytesMSAA  = 1,
+                      .channels        = 1,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatRG11B10Float,
+                  {
+                      .filterable      = true,
+                      .writable        = display->supportsEitherGPUFamily(3, 1),
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 3,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatRG16Float,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 2,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatRG16Sint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 2,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatRG16Snorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = display->supportsMacGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 2,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatRG16Uint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 2,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatRG16Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = display->supportsMacGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 2,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatRG32Float,
+                  {
+                      .filterable      = display->supportsMacGPUFamily(1) || (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = display->supportsEitherGPUFamily(7, 1),
+                      .resolve         = display->supportsMacGPUFamily(1) || (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
+                      .compressed      = false,
+                      .pixelBytes      = 8,
+                      .pixelBytesMSAA  = 8,
+                      .channels        = 2,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatRG32Sint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = display->supportsEitherGPUFamily(7, 1),
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 8,
+                      .pixelBytesMSAA  = 8,
+                      .channels        = 2,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatRG32Uint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = display->supportsEitherGPUFamily(7, 1),
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 8,
+                      .pixelBytesMSAA  = 8,
+                      .channels        = 2,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatRG8Sint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 2,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatRG8Snorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = display->supportsEitherGPUFamily(2, 1),
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 2,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatRG8Uint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 2,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatRG8Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 2,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatRGB10A2Uint,
+                  {
+                      .filterable      = false,
+                      .writable        = display->supportsEitherGPUFamily(3, 1),
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 4,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatRGB10A2Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = display->supportsEitherGPUFamily(3, 1),
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 4,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatRGB9E5Float,
+                  {
+                      .filterable      = true,
+                      .writable        = display->supportsAppleGPUFamily(3),
+                      .colorRenderable = display->supportsAppleGPUFamily(1) && !display->isSimulator(),
+                      .depthRenderable = false,
+                      .blendable       = display->supportsAppleGPUFamily(1),
+                      .multisample     = display->supportsAppleGPUFamily(1),
+                      .resolve         = display->supportsAppleGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 3,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatRGBA16Float,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 8,
+                      .pixelBytesMSAA  = 8,
+                      .channels        = 4,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatRGBA16Sint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 8,
+                      .pixelBytesMSAA  = 8,
+                      .channels        = 4,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatRGBA16Snorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = display->supportsMacGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 8,
+                      .pixelBytesMSAA  = 8,
+                      .channels        = 4,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatRGBA16Uint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 8,
+                      .pixelBytesMSAA  = 8,
+                      .channels        = 4,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatRGBA16Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = display->supportsMacGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 8,
+                      .pixelBytesMSAA  = 8,
+                      .channels        = 4,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatRGBA32Float,
+                  {
+                      .filterable      = display->supportsMacGPUFamily(1) || (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = display->supportsMacGPUFamily(1) || (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
+                      .multisample     = display->supportsEitherGPUFamily(7, 1),
+                      .resolve         = display->supportsMacGPUFamily(1) || (display->supportsAppleGPUFamily(7) && display->supports32BitFloatFiltering()),
+                      .compressed      = false,
+                      .pixelBytes      = 16,
+                      .pixelBytesMSAA  = 16,
+                      .channels        = 4,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatRGBA32Sint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = display->supportsMacGPUFamily(1),
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 16,
+                      .pixelBytesMSAA  = 16,
+                      .channels        = 4,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatRGBA32Uint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = display->supportsMacGPUFamily(1),
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 16,
+                      .pixelBytesMSAA  = 16,
+                      .channels        = 4,
+                      .alignment       = 4
+                  });
+    setFormatCaps(MTLPixelFormatRGBA8Sint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 4,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatRGBA8Snorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = display->supportsEitherGPUFamily(2, 1),
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 4,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatRGBA8Uint,
+                  {
+                      .filterable      = false,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = false,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 4,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatRGBA8Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = true,
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 4,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatRGBA8Unorm_sRGB,
+                  {
+                      .filterable      = true,
+                      .writable        = display->supportsAppleGPUFamily(2) && !display->isSimulator(),
+                      .colorRenderable = true,
+                      .depthRenderable = false,
+                      .blendable       = true,
+                      .multisample     = true,
+                      .resolve         = true,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 4,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatStencil8,
+                  {
+                      .filterable      = false,
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = true,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = supportStencilAutoResolve,
+                      .compressed      = false,
+                      .pixelBytes      = 1,
+                      .pixelBytesMSAA  = 1,
+                      .channels        = 0,
+                      .alignment       = 1
+                  });
+#if TARGET_OS_OSX || TARGET_OS_MACCATALYST ||\
+    (TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400) ||\
     (TARGET_OS_TV && __TV_OS_VERSION_MAX_ALLOWED >= 160400) || TARGET_OS_VISION
-    setFormatCaps(MTLPixelFormatBC1_RGBA, /** filterable*/ display->supportsBCTextureCompression(),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+    setFormatCaps(MTLPixelFormatBC1_RGBA,
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatBC1_RGBA_sRGB,
-                  /** filterable*/ display->supportsBCTextureCompression(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatBC2_RGBA, /** filterable*/ display->supportsBCTextureCompression(),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatBC2_RGBA,
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatBC2_RGBA_sRGB,
-                  /** filterable*/ display->supportsBCTextureCompression(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatBC3_RGBA, /** filterable*/ display->supportsBCTextureCompression(),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatBC3_RGBA,
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatBC3_RGBA_sRGB,
-                  /** filterable*/ display->supportsBCTextureCompression(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatBC4_RSnorm,
-                  /** filterable*/ display->supportsBCTextureCompression(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatBC4_RUnorm,
-                  /** filterable*/ display->supportsBCTextureCompression(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatBC5_RGSnorm,
-                  /** filterable*/ display->supportsBCTextureCompression(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatBC5_RGUnorm,
-                  /** filterable*/ display->supportsBCTextureCompression(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatBC6H_RGBFloat,
-                  /** filterable*/ display->supportsBCTextureCompression(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatBC6H_RGBUfloat,
-                  /** filterable*/ display->supportsBCTextureCompression(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatBC7_RGBAUnorm,
-                  /** filterable*/ display->supportsBCTextureCompression(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatBC7_RGBAUnorm_sRGB,
-                  /** filterable*/ display->supportsBCTextureCompression(), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsBCTextureCompression(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
 #endif  // BC formats
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST
-    setFormatCaps(MTLPixelFormatDepth16Unorm, /** filterable*/ true, /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ true,
-                  /** resolve*/ supportDepthAutoResolve, /** colorRenderable*/ false,
-                  /** depthRenderable*/ true);
-
+    setFormatCaps(MTLPixelFormatDepth16Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = true,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = supportDepthAutoResolve,
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 0,
+                      .alignment       = 2
+                  });
     setFormatCaps(MTLPixelFormatDepth24Unorm_Stencil8,
-                  /** filterable*/ display->supportsMacGPUFamily(1) &&
-                      display->supportsDepth24Stencil8PixelFormat(),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ true,
-                  /** resolve*/ supportDepthStencilAutoResolve, /** colorRenderable*/ false,
-                  /** depthRenderable*/ display->supportsMacGPUFamily(1) &&
-                      display->supportsDepth24Stencil8PixelFormat());
-
+                  {
+                      .filterable      = display->supportsMacGPUFamily(1) && display->supportsDepth24Stencil8PixelFormat(),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = display->supportsMacGPUFamily(1) && display->supportsDepth24Stencil8PixelFormat(),
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = supportDepthStencilAutoResolve,
+                      .compressed      = false,
+                      .pixelBytes      = 4,
+                      .pixelBytesMSAA  = 4,
+                      .channels        = 0,
+                      .alignment       = 4
+                  });
 #endif  // TARGET_OS_OSX || TARGET_OS_MACCATALYST
 #if (TARGET_OS_IPHONE && !TARGET_OS_MACCATALYST) || \
     (TARGET_OS_OSX && (__MAC_OS_X_VERSION_MAX_ALLOWED >= 110000))
-    setFormatCaps(MTLPixelFormatA1BGR5Unorm, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ display->supportsAppleGPUFamily(1),
-                  /** multisample*/ display->supportsAppleGPUFamily(1),
-                  /** resolve*/ display->supportsAppleGPUFamily(1),
-                  /** colorRenderable*/ display->supportsAppleGPUFamily(1),
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatABGR4Unorm, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ display->supportsAppleGPUFamily(1),
-                  /** multisample*/ display->supportsAppleGPUFamily(1),
-                  /** resolve*/ display->supportsAppleGPUFamily(1),
-                  /** colorRenderable*/ display->supportsAppleGPUFamily(1),
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_10x10_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+    setFormatCaps(MTLPixelFormatA1BGR5Unorm,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = display->supportsAppleGPUFamily(1),
+                      .depthRenderable = false,
+                      .blendable       = display->supportsAppleGPUFamily(1),
+                      .multisample     = display->supportsAppleGPUFamily(1),
+                      .resolve         = display->supportsAppleGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 4,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatABGR4Unorm,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = display->supportsAppleGPUFamily(1),
+                      .depthRenderable = false,
+                      .blendable       = display->supportsAppleGPUFamily(1),
+                      .multisample     = display->supportsAppleGPUFamily(1),
+                      .resolve         = display->supportsAppleGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 4,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatASTC_10x10_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatASTC_10x10_sRGB,
-                  /** filterable*/ display->supportsAppleGPUFamily(2), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_10x5_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_10x5_sRGB, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_10x6_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_10x6_sRGB, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_10x8_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_10x8_sRGB, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_12x10_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_10x5_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_10x5_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_10x6_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_10x6_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_10x8_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_10x8_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_12x10_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatASTC_12x10_sRGB,
-                  /** filterable*/ display->supportsAppleGPUFamily(2), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_12x12_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_12x12_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatASTC_12x12_sRGB,
-                  /** filterable*/ display->supportsAppleGPUFamily(2), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_4x4_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_4x4_sRGB, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_5x4_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_5x4_sRGB, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_5x5_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_5x5_sRGB, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_6x5_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_6x5_sRGB, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_6x6_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_6x6_sRGB, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_8x5_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_8x5_sRGB, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_8x6_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_8x6_sRGB, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_8x8_LDR, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_8x8_sRGB, /** filterable*/ display->supportsAppleGPUFamily(2),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatB5G6R5Unorm, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ display->supportsAppleGPUFamily(1),
-                  /** multisample*/ display->supportsAppleGPUFamily(1),
-                  /** resolve*/ display->supportsAppleGPUFamily(1),
-                  /** colorRenderable*/ display->supportsAppleGPUFamily(1),
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatBGR5A1Unorm, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ display->supportsAppleGPUFamily(1),
-                  /** multisample*/ display->supportsAppleGPUFamily(1),
-                  /** resolve*/ display->supportsAppleGPUFamily(1),
-                  /** colorRenderable*/ display->supportsAppleGPUFamily(1),
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatDepth16Unorm, /** filterable*/ true, /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ true,
-                  /** resolve*/ supportDepthAutoResolve, /** colorRenderable*/ false,
-                  /** depthRenderable*/ true);
-
-    setFormatCaps(MTLPixelFormatEAC_R11Snorm, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatEAC_R11Unorm, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatEAC_RG11Snorm, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatEAC_RG11Unorm, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatEAC_RGBA8, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatEAC_RGBA8_sRGB, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatETC2_RGB8, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatETC2_RGB8A1, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_4x4_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_4x4_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_5x4_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_5x4_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_5x5_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_5x5_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_6x5_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_6x5_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_6x6_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_6x6_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_8x5_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_8x5_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_8x6_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_8x6_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_8x8_LDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_8x8_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(2),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatB5G6R5Unorm,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = display->supportsAppleGPUFamily(1),
+                      .depthRenderable = false,
+                      .blendable       = display->supportsAppleGPUFamily(1),
+                      .multisample     = display->supportsAppleGPUFamily(1),
+                      .resolve         = display->supportsAppleGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 3,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatBGR5A1Unorm,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = display->supportsAppleGPUFamily(1),
+                      .depthRenderable = false,
+                      .blendable       = display->supportsAppleGPUFamily(1),
+                      .multisample     = display->supportsAppleGPUFamily(1),
+                      .resolve         = display->supportsAppleGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 4,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatDepth16Unorm,
+                  {
+                      .filterable      = true,
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = true,
+                      .blendable       = false,
+                      .multisample     = true,
+                      .resolve         = supportDepthAutoResolve,
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 0,
+                      .alignment       = 2
+                  });
+    setFormatCaps(MTLPixelFormatEAC_R11Snorm,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatEAC_R11Unorm,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatEAC_RG11Snorm,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatEAC_RG11Unorm,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatEAC_RGBA8,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatEAC_RGBA8_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatETC2_RGB8,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatETC2_RGB8A1,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatETC2_RGB8A1_sRGB,
-                  /** filterable*/ display->supportsAppleGPUFamily(1), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatETC2_RGB8_sRGB, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatETC2_RGB8_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     setFormatCaps(MTLPixelFormatPVRTC_RGBA_2BPP,
-                  /** filterable*/ display->supportsAppleGPUFamily(1), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatPVRTC_RGBA_2BPP_sRGB,
-                  /** filterable*/ display->supportsAppleGPUFamily(1), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatPVRTC_RGBA_4BPP,
-                  /** filterable*/ display->supportsAppleGPUFamily(1), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatPVRTC_RGBA_4BPP_sRGB,
-                  /** filterable*/ display->supportsAppleGPUFamily(1), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatPVRTC_RGB_2BPP, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatPVRTC_RGB_2BPP,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatPVRTC_RGB_2BPP_sRGB,
-                  /** filterable*/ display->supportsAppleGPUFamily(1), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatPVRTC_RGB_4BPP, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatPVRTC_RGB_4BPP,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
     setFormatCaps(MTLPixelFormatPVRTC_RGB_4BPP_sRGB,
-                  /** filterable*/ display->supportsAppleGPUFamily(1), /** writable*/ false,
-                  /** blendable*/ false, /** multisample*/ false, /** resolve*/ false,
-                  /** colorRenderable*/ false, /** depthRenderable*/ false);
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+#pragma clang diagnostic pop
+    setFormatCaps(MTLPixelFormatR8Unorm_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = display->supportsAppleGPUFamily(2),
+                      .colorRenderable = display->supportsAppleGPUFamily(1),
+                      .depthRenderable = false,
+                      .blendable       = display->supportsAppleGPUFamily(1),
+                      .multisample     = display->supportsAppleGPUFamily(1),
+                      .resolve         = display->supportsAppleGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 1,
+                      .pixelBytesMSAA  = 1,
+                      .channels        = 1,
+                      .alignment       = 1
+                  });
+    setFormatCaps(MTLPixelFormatRG8Unorm_sRGB,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(1),
+                      .writable        = display->supportsAppleGPUFamily(2),
+                      .colorRenderable = display->supportsAppleGPUFamily(1),
+                      .depthRenderable = false,
+                      .blendable       = display->supportsAppleGPUFamily(1),
+                      .multisample     = display->supportsAppleGPUFamily(1),
+                      .resolve         = display->supportsAppleGPUFamily(1),
+                      .compressed      = false,
+                      .pixelBytes      = 2,
+                      .pixelBytesMSAA  = 2,
+                      .channels        = 2,
+                      .alignment       = 1
+                  });
+#if TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_VISION
+    setFormatCaps(MTLPixelFormatASTC_10x10_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_10x5_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_10x6_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_10x8_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_12x10_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_12x12_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_4x4_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_5x4_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_5x5_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_6x5_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_6x6_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_8x5_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_8x6_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+    setFormatCaps(MTLPixelFormatASTC_8x8_HDR,
+                  {
+                      .filterable      = display->supportsAppleGPUFamily(6),
+                      .writable        = false,
+                      .colorRenderable = false,
+                      .depthRenderable = false,
+                      .blendable       = false,
+                      .multisample     = false,
+                      .resolve         = false,
+                      .compressed      = true,
+                      .pixelBytes      = 0,
+                      .pixelBytesMSAA  = 0,
+                      .channels        = 0,
+                      .alignment       = 0
+                  });
+#endif // TARGET_OS_IOS || mac 11.0+ || TARGET_OS_VISION
+#endif // TARGET_OS_IPHONE && !TARGET_OS_MACCATALYST || mac 11.0+
 
-#    pragma clang diagnostic pop
-    setFormatCaps(MTLPixelFormatR8Unorm_sRGB, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ display->supportsAppleGPUFamily(2),
-                  /** blendable*/ display->supportsAppleGPUFamily(1),
-                  /** multisample*/ display->supportsAppleGPUFamily(1),
-                  /** resolve*/ display->supportsAppleGPUFamily(1),
-                  /** colorRenderable*/ display->supportsAppleGPUFamily(1),
-                  /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatRG8Unorm_sRGB, /** filterable*/ display->supportsAppleGPUFamily(1),
-                  /** writable*/ display->supportsAppleGPUFamily(2),
-                  /** blendable*/ display->supportsAppleGPUFamily(1),
-                  /** multisample*/ display->supportsAppleGPUFamily(1),
-                  /** resolve*/ display->supportsAppleGPUFamily(1),
-                  /** colorRenderable*/ display->supportsAppleGPUFamily(1),
-                  /** depthRenderable*/ false);
-
-#    if TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_VISION
-    setFormatCaps(MTLPixelFormatASTC_10x10_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_10x5_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_10x6_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_10x8_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_12x10_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_12x12_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_4x4_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_5x4_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_5x5_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_6x5_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_6x6_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_8x5_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_8x6_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-    setFormatCaps(MTLPixelFormatASTC_8x8_HDR, /** filterable*/ display->supportsAppleGPUFamily(6),
-                  /** writable*/ false, /** blendable*/ false, /** multisample*/ false,
-                  /** resolve*/ false, /** colorRenderable*/ false, /** depthRenderable*/ false);
-
-#    endif  // TARGET_OS_IOS || mac 11.0+ || TARGET_OS_VISION
-#endif      // TARGET_OS_IPHONE && !TARGET_OS_MACCATALYST || mac 11.0+
+    // clang-format on
 }
 
 }  // namespace mtl

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.h
@@ -154,45 +154,7 @@ class FormatTable final : angle::NonCopyable
     void initNativeFormatCapsAutogen(const DisplayMtl *display);
     void initNativeFormatCaps(const DisplayMtl *display);
 
-    void setFormatCaps(MTLPixelFormat formatId,
-                       bool filterable,
-                       bool writable,
-                       bool blendable,
-                       bool multisample,
-                       bool resolve,
-                       bool colorRenderable);
-
-    void setFormatCaps(MTLPixelFormat formatId,
-                       bool filterable,
-                       bool writable,
-                       bool blendable,
-                       bool multisample,
-                       bool resolve,
-                       bool colorRenderable,
-                       NSUInteger bytesPerChannel,
-                       NSUInteger channels);
-
-    void setFormatCaps(MTLPixelFormat formatId,
-                       bool filterable,
-                       bool writable,
-                       bool blendable,
-                       bool multisample,
-                       bool resolve,
-                       bool colorRenderable,
-                       bool depthRenderable);
-
-    void setFormatCaps(MTLPixelFormat formatId,
-                       bool filterable,
-                       bool writable,
-                       bool blendable,
-                       bool multisample,
-                       bool resolve,
-                       bool colorRenderable,
-                       bool depthRenderable,
-                       NSUInteger bytesPerChannel,
-                       NSUInteger channels);
-
-    void setCompressedFormatCaps(MTLPixelFormat formatId, bool filterable);
+    void setFormatCaps(MTLPixelFormat formatId, const FormatCaps &caps);
 
     void adjustFormatCapsForDevice(const mtl::ContextDevice &device,
                                    MTLPixelFormat id,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.mm
@@ -272,71 +272,9 @@ const VertexFormat &FormatTable::getVertexFormat(angle::FormatID angleFormatId,
     return mVertexFormatTables[tableIdx][static_cast<size_t>(angleFormatId)];
 }
 
-void FormatTable::setFormatCaps(MTLPixelFormat formatId,
-                                bool filterable,
-                                bool writable,
-                                bool blendable,
-                                bool multisample,
-                                bool resolve,
-                                bool colorRenderable)
+void FormatTable::setFormatCaps(MTLPixelFormat formatId, const FormatCaps &caps)
 {
-    setFormatCaps(formatId, filterable, writable, blendable, multisample, resolve, colorRenderable,
-                  false, 0);
-}
-void FormatTable::setFormatCaps(MTLPixelFormat formatId,
-                                bool filterable,
-                                bool writable,
-                                bool blendable,
-                                bool multisample,
-                                bool resolve,
-                                bool colorRenderable,
-                                NSUInteger pixelBytes,
-                                NSUInteger channels)
-{
-    setFormatCaps(formatId, filterable, writable, blendable, multisample, resolve, colorRenderable,
-                  false, pixelBytes, channels);
-}
-
-void FormatTable::setFormatCaps(MTLPixelFormat formatId,
-                                bool filterable,
-                                bool writable,
-                                bool blendable,
-                                bool multisample,
-                                bool resolve,
-                                bool colorRenderable,
-                                bool depthRenderable)
-{
-    setFormatCaps(formatId, filterable, writable, blendable, multisample, resolve, colorRenderable,
-                  depthRenderable, 0, 0);
-}
-void FormatTable::setFormatCaps(MTLPixelFormat id,
-                                bool filterable,
-                                bool writable,
-                                bool blendable,
-                                bool multisample,
-                                bool resolve,
-                                bool colorRenderable,
-                                bool depthRenderable,
-                                NSUInteger pixelBytes,
-                                NSUInteger channels)
-{
-    mNativePixelFormatCapsTable[id].filterable      = filterable;
-    mNativePixelFormatCapsTable[id].writable        = writable;
-    mNativePixelFormatCapsTable[id].colorRenderable = colorRenderable;
-    mNativePixelFormatCapsTable[id].depthRenderable = depthRenderable;
-    mNativePixelFormatCapsTable[id].blendable       = blendable;
-    mNativePixelFormatCapsTable[id].multisample     = multisample;
-    mNativePixelFormatCapsTable[id].resolve         = resolve;
-    mNativePixelFormatCapsTable[id].pixelBytes      = pixelBytes;
-    mNativePixelFormatCapsTable[id].pixelBytesMSAA  = pixelBytes;
-    mNativePixelFormatCapsTable[id].channels        = channels;
-    if (channels != 0)
-        mNativePixelFormatCapsTable[id].alignment = MAX(pixelBytes / channels, 1U);
-}
-
-void FormatTable::setCompressedFormatCaps(MTLPixelFormat formatId, bool filterable)
-{
-    setFormatCaps(formatId, filterable, false, false, false, false, false, false);
+    mNativePixelFormatCapsTable[formatId] = caps;
 }
 
 void FormatTable::adjustFormatCapsForDevice(const mtl::ContextDevice &device,


### PR DESCRIPTION
#### af29d7b1edd959d5d505be847d20f4693c1b3c04
<pre>
ANGLE: Metal: ImageTestMetal.OverrideMetalTextureInternalFormatIncompatibleFormat fails validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=312875">https://bugs.webkit.org/show_bug.cgi?id=312875</a>
<a href="https://rdar.apple.com/175238170">rdar://175238170</a>

Reviewed by Dan Glastonbury.

Format::isViewCompatible(const Format &amp;srcFormat)  would compare
    if (srcFormat.caps.channels != caps.channels) ..
    if (srcFormat.caps.pixelBytes != caps.pixelBytes) ..

These properties were not populated at all.
Make the generator extract the info from MTLPixelFormatXXX names.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/gen_mtl_format_table.py:
(is_format_deprecated):
(is_format_compressed):
(get_mtl_format_channels_and_bytes):
(gen_mtl_format_caps_init_string):
(gen_mtl_format_caps_init_string.caps_to_cpp):
(gen_mtl_format_caps_init_string.cap_to_param): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_table_autogen.mm:
(rx::mtl::FormatTable::initNativeFormatCapsAutogen):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.mm:
(rx::mtl::FormatTable::setFormatCaps):
(rx::mtl::FormatTable::setCompressedFormatCaps): Deleted.

Canonical link: <a href="https://commits.webkit.org/311827@main">https://commits.webkit.org/311827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/183dcd8cc0c931daff8c82aba913bdad24d657ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166774 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112029 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122318 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85871 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102985 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23666 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21962 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14547 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169264 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130492 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130606 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35409 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141446 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88848 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25344 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18252 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30519 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30040 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30270 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30167 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->