### PR TITLE
Implement 'dirtiness' for HTMLOptionElement

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-selected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-selected-expected.txt
@@ -1,5 +1,5 @@
 
 PASS not dirty
-FAIL dirty, selected assert_equals: expected true but got false
-FAIL dirty, not selected assert_equals: expected false but got true
+PASS dirty, selected
+PASS dirty, not selected
 

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -413,9 +413,8 @@ void HTMLOptionElement::attributeChanged(const QualifiedName& name, const AtomSt
         Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClass::Default, !newValue.isNull());
         m_isDefault = !newValue.isNull();
 
-        // FIXME: WebKit still need to implement 'dirtiness'. See: https://bugs.webkit.org/show_bug.cgi?id=258073
         // https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-selectedness
-        if (oldValue.isNull() != newValue.isNull())
+        if (oldValue.isNull() != newValue.isNull() && !m_isDirty)
             setSelected(!newValue.isNull());
         break;
     }
@@ -459,6 +458,26 @@ void HTMLOptionElement::setSelected(bool selected)
 
     if (RefPtr select = ownerSelectElement())
         select->optionSelectionStateChanged(*this, selected);
+}
+
+bool HTMLOptionElement::selectedForBindings() const
+{
+    return selected();
+}
+
+void HTMLOptionElement::setSelectedForBindings(bool selected)
+{
+    bool wasSelected = m_isSelected;
+    setSelected(selected);
+
+    // https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-dirtiness
+    // The spec says dirtiness becomes true unconditionally. However, for web
+    // compatibility, don't set dirtiness if the option is owned by a select
+    // element and selectedness did not actually change.
+    if (ownerSelectElement() && wasSelected == m_isSelected)
+        return;
+
+    m_isDirty = true;
 }
 
 void HTMLOptionElement::setSelectedState(bool selected, AllowStyleInvalidation allowStyleInvalidation)

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -57,6 +57,9 @@ public:
     WEBCORE_EXPORT bool selected(AllowStyleInvalidation = AllowStyleInvalidation::Yes) const;
     WEBCORE_EXPORT void setSelected(bool);
 
+    bool selectedForBindings() const;
+    void setSelectedForBindings(bool);
+
     WEBCORE_EXPORT HTMLSelectElement* NODELETE ownerSelectElement() const;
     bool belongsToBaseAppearancePicker() const;
 
@@ -71,6 +74,8 @@ public:
 
     void setSelectedState(bool, AllowStyleInvalidation = AllowStyleInvalidation::Yes);
     bool selectedWithoutUpdate() const { return m_isSelected; }
+
+    void setDirty(bool dirty) { m_isDirty = dirty; }
 
     void cloneIntoSelectedContent(HTMLSelectedContentElement&);
 
@@ -104,6 +109,7 @@ private:
     bool m_disabled { false };
     bool m_isSelected { false };
     bool m_isDefault { false };
+    bool m_isDirty { false };
     bool m_shadowTreeNeedsUpdate { false };
     WeakPtr<HTMLSelectElement, WeakPtrImplWithEventTargetData> m_ownerSelect;
     WeakPtr<HTMLSpanElement, WeakPtrImplWithEventTargetData> m_labelContainer;

--- a/Source/WebCore/html/HTMLOptionElement.idl
+++ b/Source/WebCore/html/HTMLOptionElement.idl
@@ -28,7 +28,7 @@
     [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString label;
     [CEReactions=NotNeeded, Reflect="selected"] attribute boolean defaultSelected;
-    attribute boolean selected;
+    [ImplementedAs=selectedForBindings] attribute boolean selected;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString value;
 
     [CEReactions=Needed] attribute DOMString text;

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1532,6 +1532,8 @@ void HTMLSelectElement::reset()
         if (!option)
             continue;
 
+        option->setDirty(false);
+
         if (option->hasAttributeWithoutSynchronization(selectedAttr)) {
             if (selectedOption && !m_multiple)
                 selectedOption->setSelectedState(false);


### PR DESCRIPTION
#### 300656133429cb9c46126d3ce5829eac61957b10
<pre>
Implement &apos;dirtiness&apos; for HTMLOptionElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=312876">https://bugs.webkit.org/show_bug.cgi?id=312876</a>

Reviewed by Anne van Kesteren.

The HTML spec defines a &apos;dirtiness&apos; concept for option elements: once
option.selected is set via the IDL (JavaScript), the option becomes
&quot;dirty&quot; and subsequent changes to the selected content attribute should
not affect selectedness. This was missing in WebKit, causing two WPT
test failures.

Spec: <a href="https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-dirtiness">https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-dirtiness</a>

The implementation follows Blink&apos;s approach: use ImplementedAs in the
IDL to separate the JS binding setter (which sets the dirty flag) from
the internal setSelected() method (which does not). In attributeChanged,
the selected attribute only updates selectedness when the option is not
dirty. Form reset clears the dirty flag.

For web compatibility, dirtiness is not set when the option is owned
by a select element and the selectedness did not actually change. This
matches Blink behavior (<a href="https://crbug.com/570367).">https://crbug.com/570367).</a>

No new tests, rebaselined existing WPT test. This test was already passing
in both Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-selected-expected.txt:
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::attributeChanged):
(WebCore::HTMLOptionElement::selectedForBindings const):
(WebCore::HTMLOptionElement::setSelectedForBindings):
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebCore/html/HTMLOptionElement.idl:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::reset):

Canonical link: <a href="https://commits.webkit.org/311746@main">https://commits.webkit.org/311746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91219e1a967908d240f7e81f9c7791374d92ad8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31040 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24233 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Running compile-webkit-without-change") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111785 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122109 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85757 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102778 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23456 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21737 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14298 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133136 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19428 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169016 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13571 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130277 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25807 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130394 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35352 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141222 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88562 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18027 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94757 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29797 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30027 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29924 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->