### PR TITLE
ANGLE: Metal: Texture2DTestES3.TexImageFormatMismatch fails validation

### DIFF
--- a/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_expectations.txt
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_expectations.txt
@@ -524,6 +524,10 @@
 351275980 MAC METAL : GLSLTest_ES3.DynamicIndexingOfSwizzledLValuesShouldWork2/* = SKIP
 351275980 IOS METAL : GLSLTest_ES3.DynamicIndexingOfSwizzledLValuesShouldWork2/* = SKIP
 
+// Validation failure. Correctly handled in WebGL.
+0 MAC METAL : Texture2DTestES3.TexImageFormatMismatch/ES3_Metal* = SKIP
+0 IOS METAL : Texture2DTestES3.TexImageFormatMismatch/ES3_Metal* = SKIP
+
 // D3D
 42264944 WIN D3D9 : GLSLValidationTest.HandleExcessiveLoopBug/* = SKIP
 42264653 WIN D3D11 : GLSLTestLoops.*ContinueInSwitch/* = SKIP

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/TextureTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/TextureTest.cpp
@@ -17767,7 +17767,7 @@ TEST_P(Texture2DTestES3, LargeTextureOverflow)
 }
 
 // Create an integer format texture but specify a FLOAT sampler. OpenGL
-// tolerates this but it causes a Vulkan validation error.
+// tolerates this but it causes a Vulkan and Metal validation error.
 TEST_P(Texture2DTestES3, TexImageFormatMismatch)
 {
     GLint textureUnit = 2;

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
@@ -7162,6 +7162,73 @@ TEST_P(WebGL2CompatibilityTest, PrimitiveRestartIndexAfterToggleIsError)
     EXPECT_GL_ERROR(GL_INVALID_OPERATION);
 }
 
+// Create an integer format texture but specify a FLOAT sampler. In WebGL,
+// unlike OpenGL, this must generate INVALID_OPERATION at draw time.
+// Also verify that with a matching float texture, the draw succeeds and
+// produces the expected output.
+// Modeled after TEST_P(Texture2DTestES3, TexImageFormatMismatch).
+TEST_P(WebGL2CompatibilityTest, TexImageFormatMismatch)
+{
+    constexpr char kVS[] =
+        R"(#version 300 es
+in vec4 a_position;
+out vec2 v_texCoord;
+void main()
+{
+    gl_Position = a_position;
+    v_texCoord = (a_position.xy * 0.5) + 0.5;
+})";
+
+    constexpr char kFS[] =
+        R"(#version 300 es
+precision highp float;
+uniform highp sampler2D tex;
+in vec2 v_texCoord;
+out vec4 fragColor;
+void main()
+{
+    fragColor = texture(tex, v_texCoord);
+})";
+
+    ANGLE_GL_PROGRAM(program, kVS, kFS);
+
+    GLint texLocation = glGetUniformLocation(program, "tex");
+    ASSERT_NE(-1, texLocation);
+
+    glUseProgram(program);
+
+    glUniform1i(texLocation, 0);
+
+    // First, verify that a matching float-format texture works and draws correctly.
+    GLTexture tex;
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+    std::vector<GLColor> greenData(8 * 8, GLColor::green);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 8, 8, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                    greenData.data());
+    ASSERT_GL_NO_ERROR();
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, tex);
+
+    // Drawing with a matching sampler/texture format must succeed.
+    drawQuad(program, "a_position", 0.5f, 1.0f, true);
+    ASSERT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
+
+    // In WebGL, drawing with a sampler/texture format mismatch must fail.
+    GLubyte texData[8 * 8 * 2] = {};
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_R16UI, 8, 8, 0, GL_RED_INTEGER, GL_UNSIGNED_SHORT,
+                    texData);
+    ASSERT_GL_NO_ERROR();
+
+    drawQuad(program, "a_position", 0.5f, 1.0f, true);
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+}
+
 ANGLE_INSTANTIATE_TEST_ES2_AND_ES3(WebGLCompatibilityTest);
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(WebGL2CompatibilityTest);


### PR DESCRIPTION
#### c0e61f9064f2e8ef33a4ed76c5e5e05d490498b1
<pre>
ANGLE: Metal: Texture2DTestES3.TexImageFormatMismatch fails validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=312877">https://bugs.webkit.org/show_bug.cgi?id=312877</a>
<a href="https://rdar.apple.com/175240759">rdar://175240759</a>

Reviewed by Dan Glastonbury.

Skip the test, it&apos;s a known unimplemented failure: OpenGL allows
sampling integer textures with float samplers.
This is disallowed in WebGL. Add the test to WebGLCompatibilityTest to
ensure the rule is implemented.

* Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_expectations.txt:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/TextureTest.cpp:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp:

Canonical link: <a href="https://commits.webkit.org/311754@main">https://commits.webkit.org/311754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8957f915d24efde6cf73486cb179d2f3f5d05eac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111786 "Built successfully") | ⏳ 🛠 ios-apple 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31176 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Running compile-webkit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122110 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85758 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141613 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102779 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23452 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21738 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14299 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169017 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130278 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130395 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35359 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141223 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88563 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25179 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18028 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30277 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29798 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29925 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->