### PR TITLE
CSS preload scanner should resolve relative @import URLs against the base element URL

### DIFF
--- a/LayoutTests/http/tests/preload/css-import-base-tag-expected.txt
+++ b/LayoutTests/http/tests/preload/css-import-base-tag-expected.txt
@@ -1,0 +1,10 @@
+Test that the preload scanner correctly resolves relative @import URLs in CSS against a base tag
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.isPreloaded('http://127.0.0.1:8000/preload/resources/base-tag-import.css'); is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/preload/css-import-base-tag.html
+++ b/LayoutTests/http/tests/preload/css-import-base-tag.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+    <script>
+        if (window.internals)
+            internals.clearMemoryCache();
+    </script>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=100&test=css-import-base-tag"></script>
+</head>
+<body>
+<script>
+description("Test that the preload scanner correctly resolves relative @import URLs in CSS against a base tag");
+    if (window.internals)
+        shouldBeTrue("internals.isPreloaded('http://127.0.0.1:8000/preload/resources/base-tag-import.css');");
+</script>
+<base href="http://127.0.0.1:8000/preload/resources/foo.html">
+<style>
+@import "base-tag-import.css";
+</style>
+</body>
+</html>

--- a/LayoutTests/http/tests/preload/resources/base-tag-import.css
+++ b/LayoutTests/http/tests/preload/resources/base-tag-import.css
@@ -1,0 +1,1 @@
+body { background: green; }

--- a/Source/WebCore/html/parser/CSSPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.cpp
@@ -48,10 +48,11 @@ void CSSPreloadScanner::reset()
     m_ruleValue.clear();
 }
 
-void CSSPreloadScanner::scan(const HTMLToken::DataVector& data, PreloadRequestStream& requests)
+void CSSPreloadScanner::scan(const HTMLToken::DataVector& data, PreloadRequestStream& requests, const URL& predictedBaseElementURL)
 {
     ASSERT(!m_requests);
     SetForScope change(m_requests, &requests);
+    m_predictedBaseElementURL = predictedBaseElementURL;
 
     for (char16_t c : data) {
         if (m_state == DoneParsingImportRules)
@@ -241,9 +242,8 @@ void CSSPreloadScanner::emitRule()
         String url = parseCSSStringOrURL(m_ruleValue.span());
         StringView conditions(m_ruleConditions.span());
         if (!url.isEmpty() && hasValidImportConditions(conditions)) {
-            URL baseElementURL; // FIXME: This should be passed in from the HTMLPreloadScanner via scan(): without it we will get relative URLs wrong.
             // FIXME: Should this be including the charset in the preload request?
-            m_requests->append(makeUnique<PreloadRequest>("css"_s, url, baseElementURL, CachedResource::Type::CSSStyleSheet, String(), ScriptType::Classic, ReferrerPolicy::EmptyString));
+            m_requests->append(makeUnique<PreloadRequest>("css"_s, url, m_predictedBaseElementURL, CachedResource::Type::CSSStyleSheet, String(), ScriptType::Classic, ReferrerPolicy::EmptyString));
         }
         m_state = Initial;
     } else if (equalLettersIgnoringASCIICase(rule, "charset"_s))

--- a/Source/WebCore/html/parser/CSSPreloadScanner.h
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.h
@@ -40,7 +40,7 @@ public:
 
     void reset();
 
-    void scan(const HTMLToken::DataVector&, PreloadRequestStream&);
+    void scan(const HTMLToken::DataVector&, PreloadRequestStream&, const URL& predictedBaseElementURL = URL());
 
 private:
     enum State {
@@ -68,6 +68,7 @@ private:
 
     // Only non-zero during scan()
     PreloadRequestStream* m_requests;
+    URL m_predictedBaseElementURL;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -464,7 +464,7 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
     case HTMLToken::Type::Character:
         if (!m_inStyle)
             return;
-        m_cssScanner.scan(token.characters(), requests);
+        m_cssScanner.scan(token.characters(), requests, m_predictedBaseElementURL);
         return;
 
     case HTMLToken::Type::EndTag: {


### PR DESCRIPTION
#### c81d6b6e4ae114456d148ff231fca1f92d720565
<pre>
CSS preload scanner should resolve relative @import URLs against the base element URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=312880">https://bugs.webkit.org/show_bug.cgi?id=312880</a>

Reviewed by Anne van Kesteren.

The HTMLPreloadScanner already tracks the predicted base element URL
from &lt;base&gt; tags and passes it when creating preload requests for
images, scripts, and stylesheets. However, the CSSPreloadScanner was
not receiving this URL, so relative @import URLs were resolved against
an empty base URL. This fell back to document.baseURL() which may not
yet reflect &lt;base&gt; tags the preload scanner has already seen, since the
main parser runs behind the preload scanner.

Fix this by passing m_predictedBaseElementURL through to
CSSPreloadScanner::scan() and using it when creating PreloadRequests
for @import rules.

Test: http/tests/preload/css-import-base-tag.html

* LayoutTests/http/tests/preload/css-import-base-tag-expected.txt: Added.
* LayoutTests/http/tests/preload/css-import-base-tag.html: Added.
* LayoutTests/http/tests/preload/resources/base-tag-import.css: Added.
(body):
* Source/WebCore/html/parser/CSSPreloadScanner.cpp:
(WebCore::CSSPreloadScanner::scan):
(WebCore::CSSPreloadScanner::emitRule):
* Source/WebCore/html/parser/CSSPreloadScanner.h:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::scan):

Canonical link: <a href="https://commits.webkit.org/311744@main">https://commits.webkit.org/311744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f953827679ca8f72855f3ee08b53cd4b25e6e119

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111788 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122112 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85759 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102781 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23454 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21740 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14301 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169019 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13579 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130280 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30789 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130397 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35350 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30727 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88565 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25180 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18030 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30279 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94763 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29800 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30030 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29927 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->