### PR TITLE
Fix immersive state consistency during rapid request/exit cycles

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -345,8 +345,10 @@ RenderPtr<RenderElement> HTMLModelElement::createElementRenderer(RenderStyle&& s
 void HTMLModelElement::didAttachRenderers()
 {
 #if ENABLE(MODEL_PROCESS)
-    if (RefPtr page = document().page())
+    if (RefPtr page = document().page()) {
         page->incrementModelElementCount();
+        m_didIncrementModelElementCount = true;
+    }
 #endif
 
     if (!m_shouldCreateModelPlayerUponRendererAttachment)
@@ -359,8 +361,9 @@ void HTMLModelElement::didAttachRenderers()
 void HTMLModelElement::willDetachRenderers()
 {
 #if ENABLE(MODEL_PROCESS)
-    if (RefPtr page = document().page())
+    if (RefPtr page = document().page(); m_didIncrementModelElementCount && page)
         page->decrementModelElementCount();
+    m_didIncrementModelElementCount = false;
 #endif
 }
 
@@ -826,6 +829,10 @@ bool HTMLModelElement::canSetEntityTransform() const
 
 bool HTMLModelElement::supportsStageModeInteraction() const
 {
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    if (m_detachedForImmersive)
+        return false;
+#endif
     return canSetEntityTransform();
 }
 
@@ -1590,18 +1597,23 @@ void HTMLModelElement::exitImmersivePresentation(CompletionHandler<void()>&& com
         return;
     }
 
-    modelPlayer->exitImmersivePresentation([weakThis = WeakPtr { *this }, completion = WTF::move(completion)] mutable {
+    auto generation = m_immersiveDetachGeneration;
+    modelPlayer->exitImmersivePresentation([weakThis = WeakPtr { *this }, generation, completion = WTF::move(completion)] mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completion();
 
-        protectedThis->setDetachedForImmersive(false);
+        // Only reset if no new request has re-armed the flag since this exit started.
+        if (protectedThis->m_immersiveDetachGeneration == generation)
+            protectedThis->setDetachedForImmersive(false);
         completion();
     });
 }
 
 void HTMLModelElement::setDetachedForImmersive(bool detachedForImmersive)
 {
+    if (detachedForImmersive)
+        ++m_immersiveDetachGeneration;
     m_detachedForImmersive = detachedForImmersive;
     visibilityStateChanged();
     invalidateStyleAndLayerComposition();

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -341,6 +341,9 @@ private:
     bool m_isDragging { false };
     bool m_shouldCreateModelPlayerUponRendererAttachment { false };
     bool m_isIntersectingViewport { false };
+#if ENABLE(MODEL_PROCESS)
+    bool m_didIncrementModelElementCount { false };
+#endif
 
     RefPtr<ModelPlayer> m_modelPlayer;
     EventLoopTimerHandle m_loadModelTimer;
@@ -369,6 +372,7 @@ private:
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     bool m_detachedForImmersive { false };
+    unsigned m_immersiveDetachGeneration { 0 };
     void setDetachedForImmersive(bool);
 
     Vector<CompletionHandler<void(ExceptionOr<RefPtr<ModelPlayer>>)>> m_modelPlayerCreationCallbacks;

--- a/Source/WebCore/dom/DocumentImmersive.cpp
+++ b/Source/WebCore/dom/DocumentImmersive.cpp
@@ -102,6 +102,12 @@ void DocumentImmersive::requestImmersive(HTMLModelElement* element, CompletionHa
     if (RefPtr window = document().window(); !window || !window->consumeTransientActivation())
         return handleImmersiveError(element, "Cannot request immersive without transient activation."_s, EmitErrorEvent::Yes, ExceptionCode::TypeError, WTF::move(completionHandler));
 
+    if (immersiveElement() == element && !m_pendingExitImmersive)
+        return completionHandler({ });
+
+    if (m_pendingImmersiveElement == element)
+        return completionHandler(Exception { ExceptionCode::AbortError, "Immersive request aborted by a pending immersive request."_s });
+
     cancelActiveRequest([weakElement = WeakPtr { *element }, weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
         RefPtr protectedThis = weakThis.get();
         RefPtr protectedElement = weakElement.get();
@@ -134,6 +140,15 @@ void DocumentImmersive::requestImmersive(HTMLModelElement* element, CompletionHa
 
 void DocumentImmersive::exitImmersive(CompletionHandler<void(ExceptionOr<void>)>&& completionHandler)
 {
+    if (m_pendingExitImmersive) {
+        // Invalidate and cancel any current immersive request
+        cancelActiveRequest([] { });
+        m_pendingImmersiveElement = nullptr;
+        releaseDeferredRequest();
+
+        return completionHandler(Exception { ExceptionCode::AbortError, "Immersive exit aborted by a pending exit request."_s });
+    }
+
     cancelActiveRequest([weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
@@ -167,12 +182,9 @@ void DocumentImmersive::exitImmersive(CompletionHandler<void(ExceptionOr<void>)>
 
                 protectedThis->updateElementIsImmersive(protectedElement.get(), false);
                 protectedThis->m_immersiveElement = nullptr;
+                protectedThis->m_pendingExitImmersive = false;
 
-                if (protectedThis->m_pendingExitCompletionHandler) {
-                    auto pendingHandler = std::exchange(protectedThis->m_pendingExitCompletionHandler, { });
-                    pendingHandler();
-                }
-
+                protectedThis->releaseDeferredRequest();
                 completionHandler({ });
             });
         });
@@ -252,6 +264,12 @@ std::optional<Exception> DocumentImmersive::isRequestOutdated(HTMLModelElement* 
     return std::nullopt;
 }
 
+void DocumentImmersive::releaseDeferredRequest()
+{
+    if (auto handler = std::exchange(m_deferredRequestHandler, { }))
+        handler();
+}
+
 void DocumentImmersive::cancelActiveRequest(CompletionHandler<void()>&& completionHandler)
 {
     m_activeRequest.stage = ActiveRequest::Stage::None;
@@ -289,6 +307,24 @@ void DocumentImmersive::createModelPlayerForImmersive(Ref<HTMLModelElement>&& el
 {
     m_activeRequest.stage = ActiveRequest::Stage::ModelPlayer;
 
+    if (m_pendingExitImmersive) {
+        releaseDeferredRequest();
+
+        m_deferredRequestHandler = [weakElement = WeakPtr { element }, weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
+            RefPtr protectedThis = weakThis.get();
+            RefPtr protectedElement = weakElement.get();
+
+            if (!protectedThis || !protectedElement)
+                return completionHandler(Exception { ExceptionCode::AbortError });
+
+            if (auto error = protectedThis->isRequestOutdated(protectedElement.get(), ActiveRequest::Stage::ModelPlayer))
+                return protectedThis->handleImmersiveError(protectedElement.get(), error->message(), EmitErrorEvent::Yes, error->code(), WTF::move(completionHandler));
+
+            protectedThis->createModelPlayerForImmersive(protectedElement.releaseNonNull(), WTF::move(completionHandler));
+        };
+        return;
+    }
+
     element->ensureImmersivePresentation([weakElement = WeakPtr { element }, weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](auto result) mutable {
         RefPtr protectedThis = weakThis.get();
         RefPtr protectedElement = weakElement.get();
@@ -306,29 +342,6 @@ void DocumentImmersive::createModelPlayerForImmersive(Ref<HTMLModelElement>&& el
             return protectedThis->handleImmersiveError(protectedElement.get(), exception.message(), EmitErrorEvent::Yes, exception.code(), WTF::move(completionHandler));
         }
 
-        if (protectedThis->m_pendingExitImmersive) {
-            if (protectedThis->m_pendingExitCompletionHandler) {
-                auto previousRequestHandler = std::exchange(protectedThis->m_pendingExitCompletionHandler, { });
-                previousRequestHandler();
-            }
-
-            auto contextID = result.releaseReturnValue();
-            protectedThis->m_pendingExitCompletionHandler = [weakThis, weakElement, contextID, completionHandler = WTF::move(completionHandler)]() mutable {
-                RefPtr protectedThis = weakThis.get();
-                RefPtr protectedElement = weakElement.get();
-
-                if (!protectedThis || !protectedElement)
-                    return completionHandler(Exception { ExceptionCode::AbortError });
-
-                if (auto error = protectedThis->isRequestOutdated(protectedElement.get(), ActiveRequest::Stage::ModelPlayer)) {
-                    protectedElement->exitImmersivePresentation([] { });
-                    return protectedThis->handleImmersiveError(protectedElement.get(), error->message(), EmitErrorEvent::Yes, error->code(), WTF::move(completionHandler));
-                }
-
-                protectedThis->presentImmersiveElement(protectedElement.releaseNonNull(), contextID, WTF::move(completionHandler));
-            };
-            return;
-        }
         protectedThis->presentImmersiveElement(protectedElement.releaseNonNull(), result.releaseReturnValue(), WTF::move(completionHandler));
     });
 }
@@ -353,7 +366,7 @@ void DocumentImmersive::presentImmersiveElement(Ref<HTMLModelElement>&& element,
 
         // We exit the immersive presentation of the old element only after we finished presenting the new element.
         // This is because the old element can remain visible during this transition.
-        if (RefPtr protectedOldElement = weakOldElement.get()) {
+        if (RefPtr protectedOldElement = weakOldElement.get(); protectedOldElement && protectedOldElement != protectedElement) {
             protectedOldElement->exitImmersivePresentation([] { });
             if (protectedThis)
                 protectedThis->updateElementIsImmersive(protectedOldElement.get(), false);
@@ -440,11 +453,7 @@ void DocumentImmersive::clear()
     m_immersiveElement = nullptr;
     m_pendingExitImmersive = false;
 
-    if (m_pendingExitCompletionHandler) {
-        auto handler = std::exchange(m_pendingExitCompletionHandler, { });
-        handler();
-    }
-
+    releaseDeferredRequest();
     clearPendingEvents();
 }
 

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -81,7 +81,8 @@ private:
 
     WeakPtr<HTMLModelElement, WeakPtrImplWithEventTargetData> m_pendingImmersiveElement;
     bool m_pendingExitImmersive { false };
-    CompletionHandler<void()> m_pendingExitCompletionHandler;
+    CompletionHandler<void()> m_deferredRequestHandler;
+    void releaseDeferredRequest();
 
     struct ActiveRequest {
         enum class Stage : uint8_t { None, Permission, ModelPlayer, Presentation };


### PR DESCRIPTION
#### 28bd6e3983d38c89aab9ce30480c59c817136d42
<pre>
Fix immersive state consistency during rapid request/exit cycles
<a href="https://bugs.webkit.org/show_bug.cgi?id=312882">https://bugs.webkit.org/show_bug.cgi?id=312882</a>
<a href="https://rdar.apple.com/175242589">rdar://175242589</a>

Reviewed by Mike Wyrzykowski.

Some race conditions caused m_detachedForImmersive, m_immersiveElement,
and the :immersive pseudo-class to desynchronize from the client&apos;s immersive
presentation state during rapid requestImmersive/exitImmersive cycles.

Reject duplicate requestImmersive calls for the same element directly instead
of going through handleImmersiveError, which would clear m_pendingImmersiveElement
and m_activeRequest for the in-flight request. Reject duplicate exitImmersive calls
when an exit is already in flight to prevent parallel exit flows from racing.

Defer ensureImmersivePresentation behind a pending exit to avoid conflicting
model player IPCs that invalidate the immersive context. Guard
exitImmersivePresentation&apos;s async callback with a generation counter to prevent
stale exit callbacks from resetting m_detachedForImmersive after a new request
re-armed it. Skip old element cleanup in presentImmersiveElement when old and
new elements are the same.

Also fix a pre-existing crash in decrementModelElementCount when
willDetachRenderers is called on a model element whose parent was display:none,
meaning didAttachRenderers was never called and the count was never incremented.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::didAttachRenderers):
Track whether the model element count was incremented so willDetachRenderers can skip the decrement.
(WebCore::HTMLModelElement::willDetachRenderers):
Only decrement if didAttachRenderers actually incremented, preventing a negative count crash when
the element&apos;s parent was display:none.
(WebCore::HTMLModelElement::supportsStageModeInteraction const):
Return false when detached for immersive to prevent stage mode interaction during immersive transitions.
(WebCore::HTMLModelElement::exitImmersivePresentation):
Capture m_immersiveDetachGeneration before the async IPC and only reset
m_detachedForImmersive if the generation still matches.
(WebCore::HTMLModelElement::setDetachedForImmersive):
Increment the generation counter when entering the detached state.

* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::requestImmersive):
Resolve immediately if already immersive with no exit pending. Reject duplicate
same-element requests directly without going through handleImmersiveError to
avoid clearing in-flight request state.
(WebCore::DocumentImmersive::exitImmersive):
Reject if an exit is already in flight, cancelling any active request and
releasing any deferred request handler. Reset m_pendingExitImmersive before firing
the deferred request handler so it sees correct state.
(WebCore::DocumentImmersive::releaseDeferredRequest):
Extracted helper to fire and clear m_deferredRequestHandler.
(WebCore::DocumentImmersive::createModelPlayerForImmersive):
Defer the entire model player setup behind a pending exit to avoid sending conflicting
ensureImmersivePresentation/exitImmersivePresentation IPCs on the same model
player.
(WebCore::DocumentImmersive::presentImmersiveElement):
Skip old element cleanup when old and new elements are the same to avoid tearing
down state that was just set up.
(WebCore::DocumentImmersive::clear):

* Source/WebCore/dom/DocumentImmersive.h:

Canonical link: <a href="https://commits.webkit.org/311684@main">https://commits.webkit.org/311684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c92428b48b0c76931ae202372f068cb4226e9a7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166531 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122113 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24399 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102782 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14302 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169020 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13582 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21053 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130281 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130398 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35311 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141226 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88569 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18031 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30280 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94766 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29801 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->