### PR TITLE
[OpenXR] Missing OpenXR loader initialization for Android

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -53,6 +53,7 @@
 #include <dlfcn.h>
 using WPEAndroidRuntimeGetJavaVMFunction = JavaVM* (*)();
 using WPEAndroidRuntimeGetActivityFunction = jobject (*)();
+using WPEAndroidRuntimeGetApplicationContextFunction = jobject (*)();
 #undef jobject
 #endif
 
@@ -567,6 +568,40 @@ void OpenXRCoordinator::createInstance()
     ASSERT(RunLoop::isMain());
     ASSERT(m_instance == XR_NULL_HANDLE);
 
+#if OS(ANDROID)
+    static WPEAndroidRuntimeGetJavaVMFunction s_wpeAndroidRuntimeGetJavaVM =
+        reinterpret_cast<WPEAndroidRuntimeGetJavaVMFunction>(dlsym(RTLD_DEFAULT, "wpe_android_runtime_get_current_java_vm"));
+    if (!s_wpeAndroidRuntimeGetJavaVM) [[unlikely]] {
+        RELEASE_LOG_ERROR(XR, "Cannot resolve wpe_android_runtime_get_current_java_vm(): %s.", dlerror());
+        return;
+    }
+
+    static WPEAndroidRuntimeGetActivityFunction s_wpeAndroidRuntimeGetActivity =
+        reinterpret_cast<WPEAndroidRuntimeGetActivityFunction>(dlsym(RTLD_DEFAULT, "wpe_android_runtime_get_current_activity"));
+    if (!s_wpeAndroidRuntimeGetActivity) [[unlikely]] {
+        RELEASE_LOG_ERROR(XR, "Cannot resolve wpe_android_runtime_get_current_activity(): %s.", dlerror());
+        return;
+    }
+
+    static WPEAndroidRuntimeGetApplicationContextFunction s_wpeAndroidRuntimeGetApplicationContext =
+        reinterpret_cast<WPEAndroidRuntimeGetApplicationContextFunction>(dlsym(RTLD_DEFAULT, "wpe_android_runtime_get_application_context"));
+    if (!s_wpeAndroidRuntimeGetApplicationContext) [[unlikely]] {
+        RELEASE_LOG_ERROR(XR, "Cannot resolve wpe_android_runtime_get_application_context(): %s.", dlerror());
+        return;
+    }
+
+    // Setup the OpenXR loader for Android. This MUST be done before calling any OpenXR method (except xrGetInstanceProcAddr).
+    PFN_xrInitializeLoaderKHR initializeLoaderKHR;
+    CHECK_XRCMD(xrGetInstanceProcAddr(nullptr, "xrInitializeLoaderKHR", reinterpret_cast<PFN_xrVoidFunction*>(&initializeLoaderKHR)));
+    XrLoaderInitInfoAndroidKHR loaderData;
+    zeroBytes(loaderData);
+    loaderData.type = XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR;
+    loaderData.next = nullptr;
+    loaderData.applicationVM = s_wpeAndroidRuntimeGetJavaVM();
+    loaderData.applicationContext = s_wpeAndroidRuntimeGetApplicationContext();
+    initializeLoaderKHR(reinterpret_cast<XrLoaderInitInfoBaseHeaderKHR*>(&loaderData));
+#endif
+
     Vector<char *> extensions;
 #if defined(XR_USE_PLATFORM_EGL)
     if (OpenXRExtensions::singleton().isExtensionSupported(XR_MNDX_EGL_ENABLE_EXTENSION_NAME ""_span))
@@ -604,20 +639,6 @@ void OpenXRCoordinator::createInstance()
     createInfo.enabledExtensionNames = extensions.mutableSpan().data();
 
 #if OS(ANDROID)
-    static WPEAndroidRuntimeGetJavaVMFunction s_wpeAndroidRuntimeGetJavaVM =
-        reinterpret_cast<WPEAndroidRuntimeGetJavaVMFunction>(dlsym(RTLD_DEFAULT, "wpe_android_runtime_get_current_java_vm"));
-    if (!s_wpeAndroidRuntimeGetJavaVM) [[unlikely]] {
-        RELEASE_LOG_ERROR(XR, "Cannot resolve wpe_android_runtime_get_current_java_vm(): %s.", dlerror());
-        return;
-    }
-
-    static WPEAndroidRuntimeGetActivityFunction s_wpeAndroidRuntimeGetActivity =
-        reinterpret_cast<WPEAndroidRuntimeGetActivityFunction>(dlsym(RTLD_DEFAULT, "wpe_android_runtime_get_current_activity"));
-    if (!s_wpeAndroidRuntimeGetActivity) [[unlikely]] {
-        RELEASE_LOG_ERROR(XR, "Cannot resolve wpe_android_runtime_get_current_activity(): %s.", dlerror());
-        return;
-    }
-
     auto java = createOpenXRStruct<XrInstanceCreateInfoAndroidKHR, XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR>();
     java.applicationVM = s_wpeAndroidRuntimeGetJavaVM();
     java.applicationActivity = s_wpeAndroidRuntimeGetActivity();


### PR DESCRIPTION
#### ef3ccf8c385bab01cae9c31344aa7ee237d0222c
<pre>
[OpenXR] Missing OpenXR loader initialization for Android
<a href="https://bugs.webkit.org/show_bug.cgi?id=312881">https://bugs.webkit.org/show_bug.cgi?id=312881</a>

Reviewed by Adrian Perez de Castro.

Desktop clients do not generally need to do anything special with
regard to the OpenXR Loader. They just need to locate it in well defined
paths and us it. Unfortunately that is not as easy for Android apps.
They have to fill in a XrLoaderInitInfoAndroidKHR structure with some
data (like pointers to the JavaVM or the application context) in order
to properly initialize the loader.

Apart from filling in that structure we&apos;re moving the code around
because this initialization MUST be done before any call to OpenXR. The
current code was incorrectly trying to initialize the OpenXR extensions
first, resulting in multiple failures before failing to create a
session.

It depends on new API added to wpe-android in
<a href="https://github.com/Igalia/wpe-android/pull/254">https://github.com/Igalia/wpe-android/pull/254</a>

No new tests as this is required for proper OpenXR runtime
initialization in device which is not testable ATM.

* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::createInstance):

Canonical link: <a href="https://commits.webkit.org/311678@main">https://commits.webkit.org/311678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3caff71fcac66dfbc3b0e28d0ae1c78c2ab833f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166533 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122114 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24401 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102783 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14304 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169022 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13586 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130282 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130399 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35308 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141227 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88571 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18032 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30282 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94771 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29803 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30033 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->