### PR TITLE
[Mac] Add support for screen reserved

### DIFF
--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
@@ -298,4 +298,8 @@ SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBaseObjectGetVTable,
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMDerivedObjectCreate, OSStatus, (CFAllocatorRef allocator, const CMBaseVTable* vTable, CMBaseClassID classID, CMBaseObjectRef* baseObject), (allocator, vTable, classID, baseObject), PAL_EXPORT)
 #endif // PLATFORM(MAC)
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/CoreMediaSoftLinkAdditions.cpp>)
+#import <WebKitAdditions/CoreMediaSoftLinkAdditions.cpp>
+#endif
+
 #endif // USE(AVFOUNDATION)

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
@@ -564,6 +564,10 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMDerivedObjectCreate, OSStatus, (
 
 #endif // PLATFORM(MAC)
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/CoreMediaSoftLinkAdditions.h>)
+#import <WebKitAdditions/CoreMediaSoftLinkAdditions.h>
+#endif
+
 #endif // USE(AVFOUNDATION)
 
 #endif // !__has_feature(modules)

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -128,6 +128,7 @@
 #include "RenderVideo.h"
 #include "RenderView.h"
 #include "ResourceLoadInfo.h"
+#include "ScreenProperties.h"
 #include "ScriptController.h"
 #include "ScriptDisallowedScope.h"
 #include "ScriptExecutionContextInlines.h"
@@ -672,10 +673,19 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     , m_remote(RemotePlayback::create(*this))
 #endif
+    , m_screenPropertiesChangedObserver { ScreenPropertiesChangedObserver::create([weakThis = WeakPtr { *this }] (PlatformDisplayID displayId) {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->screenPropertiesChanged(displayId);
+    }) }
 {
     RefPtr page = document.page();
     m_shouldAudioPlaybackRequireUserGesture = page && page->requiresUserGestureForAudioPlayback() && !processingUserGestureForMedia();
     m_shouldVideoPlaybackRequireUserGesture = page && page->requiresUserGestureForVideoPlayback() && !processingUserGestureForMedia();
+
+#if PLATFORM(MAC)
+    if (auto data = screenData(primaryScreenDisplayID()))
+        m_screenReserved = data->reserved;
+#endif
 
     allMediaElements().add(*this);
 
@@ -919,6 +929,7 @@ void HTMLMediaElement::registerWithDocument(Document& document)
 #endif
 
     document.addAudioProducer(*this);
+    document.addScreenPropertiesChangedObserver(m_screenPropertiesChangedObserver);
 }
 
 void HTMLMediaElement::unregisterWithDocument(Document& document)
@@ -8250,6 +8261,10 @@ void HTMLMediaElement::createMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     player->setViewportVisibility(viewportVisibility());
     player->setInFullscreenOrPictureInPicture(isInFullscreenOrPictureInPicture());
 
+#if PLATFORM(MAC)
+    player->setScreenReserved(m_screenReserved);
+#endif
+
     schedulePlaybackControlsManagerUpdate();
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(ENCRYPTED_MEDIA)
     updateShouldContinueAfterNeedKey();
@@ -10469,6 +10484,28 @@ void HTMLMediaElement::rebuildMediaEngineForWirelessPlayback()
 }
 
 #endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+
+void HTMLMediaElement::screenPropertiesChanged(PlatformDisplayID displayID)
+{
+    setPreferredDynamicRangeMode(preferredDynamicRangeMode(protect(document().view()).get()));
+#if PLATFORM(MAC)
+    if (auto data = screenData(displayID))
+        setScreenReserved(data->reserved);
+#else
+    UNUSED_PARAM(displayID);
+#endif
+}
+
+#if PLATFORM(MAC)
+void HTMLMediaElement::setScreenReserved(bool reserved)
+{
+    if (m_screenReserved == reserved)
+        return;
+    m_screenReserved = reserved;
+    if (RefPtr player = m_player)
+        player->setScreenReserved(reserved);
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -138,6 +138,7 @@ class RemotePlayback;
 
 using CueInterval = PODInterval<MediaTime, TextTrackCue*>;
 using CueList = Vector<CueInterval>;
+using PlatformDisplayID = uint32_t;
 
 using MediaProvider = Variant<
 #if ENABLE(MEDIA_STREAM)
@@ -1194,6 +1195,11 @@ private:
     void rebuildMediaEngineForWirelessPlayback();
 #endif
 
+    void screenPropertiesChanged(PlatformDisplayID);
+#if PLATFORM(MAC)
+    void setScreenReserved(bool);
+#endif
+
     Timer m_progressEventTimer;
     Timer m_playbackProgressTimer;
     Timer m_scanTimer;
@@ -1510,6 +1516,13 @@ private:
     RefPtr<AggregateMessageClientForTesting> m_internalMessageClient;
 
     bool m_forceStereoDecoding { false };
+
+    using ScreenPropertiesChangedObserver = Observer<void(PlatformDisplayID)>;
+    Ref<ScreenPropertiesChangedObserver> m_screenPropertiesChangedObserver;
+
+#if PLATFORM(MAC)
+    bool m_screenReserved { false };
+#endif
 };
 
 String convertEnumerationToString(HTMLMediaElement::AutoplayEventPlaybackState);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1755,12 +1755,6 @@ void Page::setDeviceScaleFactor(float scaleFactor)
 
 void Page::screenPropertiesDidChange(bool affectsStyle)
 {
-#if ENABLE(VIDEO)
-    auto mode = preferredDynamicRangeMode(protect(protect(mainFrame())->virtualView()).get());
-    forEachMediaElement([mode] (auto& element) {
-        element.setPreferredDynamicRangeMode(mode);
-    });
-#endif
 #if HAVE(SUPPORT_HDR_DISPLAY)
     updateDisplayEDRHeadroom();
 #endif

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -67,6 +67,10 @@ struct ScreenData {
     float scaleFactor { 1 };
 #endif
 
+#if PLATFORM(MAC)
+    bool reserved { false };
+#endif
+
     bool operator==(const ScreenData&) const = default;
 };
 

--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -128,6 +128,7 @@ public:
     virtual Ref<MediaTimePromise> prepareToSeek(const MediaTime&) = 0;
     virtual Ref<GenericPromise> finishSeek(const MediaTime&) = 0;
     virtual bool seeking() const = 0;
+    virtual void setScreenReserved(bool) = 0;
 };
 
 struct SamplesRendererTrackIdentifierType;

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -2122,6 +2122,16 @@ MediaPlaybackTargetType MediaPlayer::playbackTargetType() const
 }
 #endif
 
+#if PLATFORM(MAC)
+void MediaPlayer::setScreenReserved(bool reserved)
+{
+    if (m_screenReserved == reserved)
+        return;
+    m_screenReserved = reserved;
+    protect(m_private)->screenReservedChanged(reserved);
+}
+#endif
+
 String convertEnumerationToString(MediaPlayer::ReadyState enumerationValue)
 {
     static const std::array<NeverDestroyed<String>, 5> values {

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -818,6 +818,11 @@ public:
 
     void elementIdChanged(const String&) const;
 
+#if PLATFORM(MAC)
+    void setScreenReserved(bool);
+    bool screenReserved() { return m_screenReserved; }
+#endif
+
 private:
     MediaPlayer(MediaPlayerClient&);
     MediaPlayer(MediaPlayerClient&, MediaPlayerEnums::MediaEngineIdentifier);
@@ -890,6 +895,10 @@ private:
 #endif
 
     WeakPtr<MessageClientForTesting> m_internalMessageClient;
+
+#if PLATFORM(MAC)
+    bool m_screenReserved { false };
+#endif
 };
 
 class MediaPlayerFactory : public CanMakeWeakPtr<MediaPlayerFactory>, public CanMakeCheckedPtr<MediaPlayerFactory> {

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -397,6 +397,10 @@ public:
 
     static WEBCORE_EXPORT RefPtr<ShareableBitmap> bitmapFromImage(NativeImage&);
 
+#if PLATFORM(MAC)
+    virtual void screenReservedChanged(bool) { }
+#endif
+
 protected:
     mutable PlatformTimeRanges m_seekable;
     bool m_shouldCheckHardwareSupport { false };

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -105,6 +105,7 @@ public:
     Ref<GenericPromise> finishSeek(const MediaTime&) final;
     void notifyEffectiveRateChanged(Function<void(double)>&&) final;
     bool seeking() const final;
+    void setScreenReserved(bool) final;
 
     // AudioInterface
     void setVolume(float) final;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -69,6 +69,12 @@
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/AVSampleBufferRenderSynchronizerAdditions.mm>)
+#import <WebKitAdditions/AVSampleBufferRenderSynchronizerAdditions.mm>
+#else
+static void setSynchronizerScreenReserved(AVSampleBufferRenderSynchronizer *, bool) { }
+#endif
+
 @interface AVSampleBufferDisplayLayer (Staging_100128644)
 @property (assign, nonatomic) BOOL preventsAutomaticBackgroundingDuringVideoPlayback;
 @end
@@ -994,6 +1000,11 @@ void AudioVideoRendererAVFObjC::destroyAudioRenderers()
 bool AudioVideoRendererAVFObjC::seeking() const
 {
     return m_seekState != SeekCompleted;
+}
+
+void AudioVideoRendererAVFObjC::setScreenReserved(bool reserved)
+{
+    setSynchronizerScreenReserved(m_synchronizer, reserved);
 }
 
 MediaTime AudioVideoRendererAVFObjC::clampTimeToLastSeekTime(const MediaTime& time) const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -410,6 +410,10 @@ private:
     void updateLayerAttachment();
     bool shouldAttachLayerToPlayer();
 
+#if PLATFORM(MAC)
+    void screenReservedChanged(bool) final;
+#endif
+
     RetainPtr<AVURLAsset> m_avAsset;
     RetainPtr<AVPlayer> m_avPlayer;
     RetainPtr<AVPlayerItem> m_avPlayerItem;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -142,6 +142,14 @@
 
 #import <pal/cocoa/MediaToolboxSoftLink.h>
 
+#if PLATFORM(MAC)
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/AVPlayerAdditions.mm>)
+#import <WebKitAdditions/AVPlayerAdditions.mm>
+#else
+static void setPlayerScreenReserved(AVPlayer *, bool) { }
+#endif
+#endif
+
 // Note: This must be defined before our SOFT_LINK macros:
 @class AVMediaSelectionOption;
 @interface AVMediaSelectionOption (OutOfBandExtensions)
@@ -1162,6 +1170,10 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
         INFO_LOG(LOGIDENTIFIER, "Setting videoTarget");
         [m_avPlayer addVideoTarget:m_videoTarget];
     }
+#endif
+
+#if PLATFORM(MAC)
+    setPlayerScreenReserved(m_avPlayer.get(), player->screenReserved());
 #endif
 
     if (m_isGatheringVideoFrameMetadata)
@@ -4319,6 +4331,14 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldAttachLayerToPlayer()
 
     return true;
 }
+
+#if PLATFORM(MAC)
+void MediaPlayerPrivateAVFoundationObjC::screenReservedChanged(bool reserved)
+{
+    setPlayerScreenReserved(m_avPlayer.get(), reserved);
+}
+#endif
+
 
 NSArray* assetMetadataKeyNames()
 {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -326,6 +326,10 @@ private:
     void cancelPendingSeek();
     void completeSeek(const MediaTime&);
 
+#if PLATFORM(MAC)
+    void screenReservedChanged(bool) final;
+#endif
+
     // Remote layer support
     WebCore::HostingContext hostingContext() const final;
     void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&) final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -120,6 +120,10 @@ MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC(Media
     , m_renderer(createRenderer(*this, player.clientIdentifier(), m_playerIdentifier))
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+
+#if PLATFORM(MAC)
+    m_renderer->setScreenReserved(player.screenReserved());
+#endif
 }
 
 MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC()
@@ -1467,6 +1471,13 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setVideoLayerSizeFenced(const WebCore
 {
     m_renderer->setVideoLayerSizeFenced(size, WTF::move(sendRightAnnotated));
 }
+
+#if PLATFORM(MAC)
+void MediaPlayerPrivateMediaSourceAVFObjC::screenReservedChanged(bool reserved)
+{
+    m_renderer->setScreenReserved(reserved);
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -47,6 +47,12 @@
 #import <pal/cocoa/MediaToolboxSoftLink.h>
 #endif
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/PlatformScreenAdditions.mm>)
+#import <WebKitAdditions/PlatformScreenAdditions.mm>
+#else
+#define COLLECT_SCREEN_RESERVED
+#endif
+
 namespace WebCore {
 
 // These functions scale between screen and page coordinates because JavaScript/DOM operations
@@ -181,6 +187,8 @@ ScreenProperties collectScreenProperties()
         screenData.maxEDRHeadroom = [screen maximumPotentialExtendedDynamicRangeColorComponentValue];
         screenData.currentEDRHeadroom = [screen maximumExtendedDynamicRangeColorComponentValue];
 #endif
+
+        COLLECT_SCREEN_RESERVED;
 
         screenProperties.screenDataMap.set(displayID, WTF::move(screenData));
         if (!screenProperties.primaryDisplayID)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -403,6 +403,12 @@ void RemoteAudioVideoRendererProxyManager::finishSeek(RemoteAudioVideoRendererId
     });
 }
 
+void RemoteAudioVideoRendererProxyManager::setScreenReserved(RemoteAudioVideoRendererIdentifier identifier, bool reserved)
+{
+    if (RefPtr renderer = rendererFor(identifier))
+        renderer->setScreenReserved(reserved);
+}
+
 void RemoteAudioVideoRendererProxyManager::setVolume(RemoteAudioVideoRendererIdentifier identifier, float volume)
 {
     if (RefPtr renderer = rendererFor(identifier))

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -119,6 +119,7 @@ private:
     void stall(RemoteAudioVideoRendererIdentifier);
     void prepareToSeek(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
     void finishSeek(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(GenericPromise::Result&&)>&&);
+    void setScreenReserved(RemoteAudioVideoRendererIdentifier, bool);
 
     // AudioInterface
     void setVolume(RemoteAudioVideoRendererIdentifier, float);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -60,6 +60,7 @@ messages -> RemoteAudioVideoRendererProxyManager {
     Stall(WebKit::RemoteAudioVideoRendererIdentifier identifier)
     PrepareToSeek(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime seekTime) -> (Expected<MediaTime, WebCore::PlatformMediaError> result)
     FinishSeek(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime seekTime) -> (GenericPromise::Result result)
+    SetScreenReserved(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool reserved)
 
     SetVolume(WebKit::RemoteAudioVideoRendererIdentifier identifier, float volume)
     SetMuted(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool muted)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -1411,6 +1411,13 @@ void RemoteMediaPlayerProxy::sendInternalMessage(const WebCore::MessageForTestin
     protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::SendInternalMessage { message }, m_id);
 }
 
+#if PLATFORM(MAC)
+void RemoteMediaPlayerProxy::screenReservedChanged(bool reserved)
+{
+    protect(m_player)->setScreenReserved(reserved);
+}
+#endif
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -403,6 +403,10 @@ private:
     void setHasMessageClientForTesting(bool);
     void sendInternalMessage(const WebCore::MessageForTesting&) final;
 
+#if PLATFORM(MAC)
+    void screenReservedChanged(bool);
+#endif
+
 #if !RELEASE_LOG_DISABLED
     const Logger& mediaPlayerLogger() final { return m_logger; }
     uint64_t mediaPlayerLogIdentifier() { return m_configuration.logIdentifier; }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -163,6 +163,10 @@ messages -> RemoteMediaPlayerProxy {
     SetSoundStageSize(enum:uint8_t WebCore::MediaPlayerSoundStageSize value)
 
     SetHasMessageClientForTesting(bool value)
+
+#if PLATFORM(MAC)
+    ScreenReservedChanged(bool value)
+#endif
 }
 
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2406,6 +2406,9 @@ header: <WebCore/ScreenProperties.h>
 #if PLATFORM(MAC) || PLATFORM(IOS_FAMILY)
     float scaleFactor;
 #endif
+#if PLATFORM(MAC)
+    bool reserved;
+#endif
 };
 
 #if HAVE(SUPPORT_HDR_DISPLAY)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -535,6 +535,13 @@ bool AudioVideoRendererRemote::seeking() const
     return m_seeking;
 }
 
+void AudioVideoRendererRemote::setScreenReserved(bool reserved)
+{
+    ensureOnDispatcherWithConnection([reserved](auto& renderer, auto& connection) {
+        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetScreenReserved(renderer.m_identifier, reserved), 0);
+    });
+}
+
 void AudioVideoRendererRemote::setPreferences(VideoRendererPreferences preferences)
 {
     ensureOnDispatcherWithConnection([preferences](auto& renderer, auto& connection) {

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -150,6 +150,7 @@ private:
     Ref<WebCore::MediaTimePromise> prepareToSeek(const MediaTime&) final;
     Ref<GenericPromise> finishSeek(const MediaTime&) final;
     bool seeking() const final;
+    void setScreenReserved(bool) final;
 
     void setPreferences(WebCore::VideoRendererPreferences) final;
     void setHasProtectedVideoContent(bool) final;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1909,6 +1909,13 @@ void MediaPlayerPrivateRemote::destroyResourceLoader(RemoteMediaResourceLoaderId
     m_mediaResourceLoaders.remove(identifier);
 }
 
+#if PLATFORM(MAC)
+void MediaPlayerPrivateRemote::screenReservedChanged(bool reserved)
+{
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::ScreenReservedChanged(reserved), m_id);
+}
+#endif
+
 void MediaPlayerPrivateRemote::gpuProcessConnectionDidClose()
 {
     assertIsMainRunLoop();

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -217,6 +217,10 @@ public:
     MediaTime currentTime() const final;
     MediaTime currentOrPendingSeekTime() const final;
 
+#if PLATFORM(MAC)
+    void screenReservedChanged(bool) final;
+#endif
+
     void gpuProcessConnectionDidClose();
 
 private:


### PR DESCRIPTION
#### e6d1b2643f990587a3263f7a196b5130f886384c
<pre>
[Mac] Add support for screen reserved
<a href="https://rdar.apple.com/175197574">rdar://175197574</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312822">https://bugs.webkit.org/show_bug.cgi?id=312822</a>

Reviewed by Eric Carlson.

Pass screen reserved down from the UI process all the way to the renderers.

* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp:
* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::registerWithDocument):
(WebCore::HTMLMediaElement::screenPropertiesChanged):
(WebCore::HTMLMediaElement::setScreenReserved):
(WebCore::m_remote): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::screenPropertiesDidChange):
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::setScreenReserved):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::screenReservedChanged):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(setSynchronizerScreenReserved):
(WebCore::AudioVideoRendererAVFObjC::setScreenReserved):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(setPlayerScreenReserved):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::screenReservedChanged):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::m_renderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::screenReservedChanged):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::collectScreenProperties):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::setScreenReserved):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::screenReservedChanged):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::setScreenReserved):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::screenReservedChanged):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/311815@main">https://commits.webkit.org/311815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aff5058fd5a8f636ec4a4c250e3d1e0376b95709

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158064 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166892 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31403 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122410 "Found 19 new test failures: fast/dom/crash-moving-subtree-between-documents.html fast/events/event-handler-detached-document-dispatchEvent.html fast/media/template-hidden.html imported/blink/fullscreen/full-screen-detached-document.html imported/blink/media/track/media-element-move-to-new-document-assert.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-insert-into-iframe.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-move-to-other-document.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-appendChild-to-inactive-document-crash.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-play-in-inactive-document-crash.html imported/w3c/web-platform-tests/html/semantics/forms/the-label-element/clicking-interactive-content.html ... (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24695 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103079 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14665 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169382 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14736 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21380 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130581 "Found 20 new test failures: fast/dom/crash-moving-subtree-between-documents.html fast/events/event-handler-detached-document-dispatchEvent.html fast/media/template-hidden.html imported/blink/fullscreen/full-screen-detached-document.html imported/blink/media/track/media-element-move-to-new-document-assert.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-insert-into-iframe.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-move-to-other-document.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-appendChild-to-inactive-document-crash.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-play-in-inactive-document-crash.html imported/w3c/web-platform-tests/html/semantics/forms/the-label-element/clicking-interactive-content.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31147 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26129 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130696 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35400 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141551 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88981 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25432 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18357 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30637 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96170 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30158 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30388 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30285 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->