### PR TITLE
[WPE] Android build not compatible with texture based AcceleratedSurface

### DIFF
--- a/Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in
+++ b/Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in
@@ -26,7 +26,9 @@
     ExceptionForEnabledBy
 ]
 messages -> AcceleratedBackingStore {
+#if USE(GBM)
     DidCreateDMABufBuffer(uint64_t id, WebCore::DMABufBufferAttributes dmaBufAttributes, WebKit::RendererBufferFormat::Usage usage)
+#endif
     DidCreateSHMBuffer(uint64_t id, WebCore::ShareableBitmapHandle handle)
 
 #if OS(ANDROID)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -466,6 +466,7 @@ void AcceleratedSurface::RenderTargetSHMImage::didRenderFrame()
     glReadPixels(0, 0, m_bitmap->size().width(), m_bitmap->size().height(), GL_BGRA, GL_UNSIGNED_BYTE, m_bitmap->mutableSpan().data());
 }
 
+#if USE(GBM)
 std::unique_ptr<AcceleratedSurface::RenderTarget> AcceleratedSurface::RenderTargetTexture::create(AcceleratedSurface& surface, const IntSize& size)
 {
     auto texture = BitmapTexture::create(size);
@@ -522,7 +523,7 @@ AcceleratedSurface::RenderTargetTexture::RenderTargetTexture(AcceleratedSurface&
 }
 
 AcceleratedSurface::RenderTargetTexture::~RenderTargetTexture() = default;
-
+#endif // USE(GBM)
 #endif // PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
 
 #if USE(WPE_RENDERER)
@@ -605,9 +606,11 @@ AcceleratedSurface::SwapChain::SwapChain(AcceleratedSurface& surface)
     switch (display.type()) {
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
     case PlatformDisplay::Type::Surfaceless:
+#if USE(GBM)
         if (display.eglExtensions().MESA_image_dma_buf_export && WebProcess::singleton().rendererBufferTransportMode().contains(RendererBufferTransportMode::Hardware))
             m_type = Type::Texture;
         else
+#endif
             m_type = Type::SharedMemory;
         break;
 #if USE(GBM)
@@ -764,8 +767,10 @@ std::unique_ptr<AcceleratedSurface::RenderTarget> AcceleratedSurface::SwapChain:
     case Type::EGLImage:
         return RenderTargetEGLImage::create(m_surface.get(), m_size, m_bufferFormat);
 #endif
+#if USE(GBM)
     case Type::Texture:
         return RenderTargetTexture::create(m_surface.get(), m_size);
+#endif
     case Type::SharedMemory:
         return RenderTargetSHMImage::create(m_surface.get(), m_size);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -273,7 +273,7 @@ private:
         static std::unique_ptr<RenderTarget> create(AcceleratedSurface&, const WebCore::IntSize&, const BufferFormat&);
 #if OS(ANDROID)
         RenderTargetEGLImage(AcceleratedSurface&, const WebCore::IntSize&, EGLImage, RefPtr<AHardwareBuffer>&&);
-#else
+#elif USE(GBM)
         RenderTargetEGLImage(AcceleratedSurface&, const WebCore::IntSize&, EGLImage, WebCore::DMABufBufferAttributes&&, RendererBufferFormat::Usage);
 #endif
         ~RenderTargetEGLImage();
@@ -303,6 +303,7 @@ private:
         RefPtr<WebCore::BitmapTexture> m_texture;
     };
 
+#if USE(GBM)
     class RenderTargetTexture final : public RenderTargetShareableBuffer {
     public:
         static std::unique_ptr<RenderTarget> create(AcceleratedSurface&, const WebCore::IntSize&);
@@ -314,6 +315,7 @@ private:
 
         Ref<WebCore::BitmapTexture> m_texture;
     };
+#endif
 #endif // PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
 
 #if USE(WPE_RENDERER)
@@ -346,7 +348,9 @@ private:
             EGLImage,
 #endif
             SharedMemory,
+#if USE(GBM)
             Texture,
+#endif // !OS(ANDROID)
 #endif
 #if USE(WPE_RENDERER)
             WPEBackend


### PR DESCRIPTION
#### 48c4f6ff72e643fb298439f72c22da6e95f1d011
<pre>
[WPE] Android build not compatible with texture based AcceleratedSurface
<a href="https://bugs.webkit.org/show_bug.cgi?id=312895">https://bugs.webkit.org/show_bug.cgi?id=312895</a>

Reviewed by NOBODY (OOPS!).

Usages of DMABuf should be guarded by USE(GBM). Recent changes in
AcceleratedSurfaces were breaking those builds in which USE_GBM=0
because in those cases the DMABuf structs are not defined.

No new tests as this is a build fix.

* Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::SwapChain::SwapChain):
(WebKit::AcceleratedSurface::SwapChain::createTarget const):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48c4f6ff72e643fb298439f72c22da6e95f1d011

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167350 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112605 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122782 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86160 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103452 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24098 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22491 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133785 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169840 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15585 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130969 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131083 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141973 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89475 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25779 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18779 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31093 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97107 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->