### PR TITLE
WKMouseTrackingObserver should do a hit test before forwarding mouse event

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -229,6 +229,20 @@ static NSString * const WKMediaExitFullScreenItem = @"WKMediaExitFullScreenItem"
 
 @implementation WKMouseTrackingObserver {
     WeakPtr<WebKit::WebViewImpl> _impl;
+    BOOL _viewIsTopmostAtLastMouseLocation;
+}
+
+- (BOOL)updateViewIsTopmostAtMouseLocation:(NSEvent *)event
+{
+    CheckedPtr impl = _impl.get();
+    if (!impl)
+        return NO;
+
+    RetainPtr view = impl->view();
+    RetainPtr hitView = [[view window].contentView hitTest:[[view window].contentView.superview convertPoint:event.locationInWindow fromView:nil]];
+
+    _viewIsTopmostAtLastMouseLocation = [hitView isDescendantOf:view.get()];
+    return _viewIsTopmostAtLastMouseLocation;
 }
 
 - (instancetype)initWithViewImpl:(WebKit::WebViewImpl&)impl
@@ -240,19 +254,22 @@ static NSString * const WKMediaExitFullScreenItem = @"WKMediaExitFullScreenItem"
 
 - (void)mouseMoved:(NSEvent *)event
 {
-    if (CheckedPtr impl = _impl.get())
+    CheckedPtr impl = _impl.get();
+    if (impl && [self updateViewIsTopmostAtMouseLocation:event])
         impl->mouseMoved(event);
 }
 
 - (void)mouseEntered:(NSEvent *)event
 {
-    if (CheckedPtr impl = _impl.get())
+    CheckedPtr impl = _impl.get();
+    if (impl && [self updateViewIsTopmostAtMouseLocation:event])
         impl->mouseEntered(event);
 }
 
 - (void)mouseExited:(NSEvent *)event
 {
-    if (CheckedPtr impl = _impl.get())
+    CheckedPtr impl = _impl.get();
+    if (impl && _viewIsTopmostAtLastMouseLocation)
         impl->mouseExited(event);
 }
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
@@ -260,6 +260,7 @@ class Color;
 - (void)wheelEventAtPoint:(CGPoint)pointInWindow wheelDelta:(CGSize)delta phase:(CGScrollPhase)phase momentumPhase:(CGMomentumScrollPhase)momentumPhase;
 - (BOOL)acceptsFirstMouseAtPoint:(NSPoint)pointInWindow;
 - (NSWindow *)hostWindow;
+- (NSEvent *)_mouseEventWithType:(NSEventType)type atLocation:(NSPoint)pointInWindow;
 - (void)typeCharacter:(char)character modifiers:(NSEventModifierFlags)modifiers;
 - (void)sendKey:(NSString *)characters code:(unsigned short)keyCode isDown:(BOOL)isDown modifiers:(NSEventModifierFlags)modifiers;
 - (void)setEventTimestampOffset:(NSTimeInterval)offset;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MouseEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MouseEventTests.mm
@@ -447,6 +447,190 @@ TEST(MouseEventTests, AutoscrollOnMouseDragBelowWindow)
     EXPECT_GT(scrollY, 0);
 }
 
+static NSString *overlappingWebViewsHTML = @"<!DOCTYPE html>"
+    "<html><head><style>body, html { margin: 0; width: 100%; height: 100%; } #target { width: 100%; height: 100%; }</style></head>"
+    "<body><div id='target'></div><script>"
+    "    let moveCount = 0;"
+    "    let enterCount = 0;"
+    "    let leaveCount = 0;"
+    "    let target = document.getElementById('target');"
+    "    target.addEventListener('mousemove', () => moveCount++);"
+    "    target.addEventListener('mouseenter', () => enterCount++);"
+    "    target.addEventListener('mouseleave', () => leaveCount++);"
+    "</script></body></html>";
+
+static auto setupOverlappingWebViews()
+{
+    RetainPtr bottomWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [bottomWebView synchronouslyLoadHTMLString:overlappingWebViewsHTML];
+    [bottomWebView evaluateJavaScript:@"document.body.style.backgroundColor = 'blue'" completionHandler:nil];
+
+    RetainPtr topWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(200, 0, 200, 200)]);
+    [topWebView synchronouslyLoadHTMLString:overlappingWebViewsHTML];
+    [topWebView evaluateJavaScript:@"document.body.style.backgroundColor = 'red'" completionHandler:nil];
+    [[bottomWebView window].contentView addSubview:topWebView.get()];
+
+    auto findTrackingAreaObserver = [](TestWKWebView *webView) -> id {
+        for (NSTrackingArea *area in [webView trackingAreas]) {
+            if (area.options & NSTrackingMouseMoved)
+                return area.owner;
+        }
+        return nil;
+    };
+
+    RetainPtr<id> bottomObserver = findTrackingAreaObserver(bottomWebView.get());
+    RetainPtr<id> topObserver = findTrackingAreaObserver(topWebView.get());
+
+    return std::make_tuple(bottomWebView, topWebView, bottomObserver, topObserver);
+}
+
+static void checkMouseEventCounts(TestWKWebView *view, int expectedMouseMoveCount, int expectedMouseEnterCount, int expectedMouseLeaveCount)
+{
+    [view waitForPendingMouseEvents];
+
+    EXPECT_EQ([[view objectByEvaluatingJavaScript:@"moveCount"] intValue], expectedMouseMoveCount);
+    EXPECT_EQ([[view objectByEvaluatingJavaScript:@"enterCount"] intValue], expectedMouseEnterCount);
+    EXPECT_EQ([[view objectByEvaluatingJavaScript:@"leaveCount"] intValue], expectedMouseLeaveCount);
+}
+
+TEST(MouseEventTests, OverlappingWebViewsTopViewReceivesMouseMove)
+{
+    auto [bottomWebView, topWebView, bottomObserver, topObserver] = setupOverlappingWebViews();
+
+    RetainPtr event = [bottomWebView _mouseEventWithType:NSEventTypeMouseMoved atLocation:NSMakePoint(300, 100)];
+    [bottomObserver mouseMoved:event.get()];
+    [topObserver mouseMoved:event.get()];
+
+    checkMouseEventCounts(bottomWebView, 0, 0, 0);
+    checkMouseEventCounts(topWebView, 1, 1, 0);
+}
+
+TEST(MouseEventTests, OverlappingWebViewsBottomViewReceivesMouseMove)
+{
+    auto [bottomWebView, topWebView, bottomObserver, topObserver] = setupOverlappingWebViews();
+
+    RetainPtr event = [bottomWebView _mouseEventWithType:NSEventTypeMouseMoved atLocation:NSMakePoint(100, 200)];
+    [bottomObserver mouseMoved:event.get()];
+    [topObserver mouseMoved:event.get()];
+
+    checkMouseEventCounts(bottomWebView, 1, 1, 0);
+    checkMouseEventCounts(topWebView, 0, 0, 0);
+}
+
+TEST(MouseEventTests, OverlappingWebViewsTopViewReceivesMouseEnterAndMouseExit)
+{
+    auto [bottomWebView, topWebView, bottomObserver, topObserver] = setupOverlappingWebViews();
+
+    RetainPtr enterTopViewEvent = [bottomWebView _mouseEventWithType:NSEventTypeMouseEntered atLocation:NSMakePoint(300, 100)];
+
+    [bottomObserver mouseEntered:enterTopViewEvent.get()];
+    [topObserver mouseEntered:enterTopViewEvent.get()];
+
+    checkMouseEventCounts(bottomWebView, 0, 0, 0);
+    checkMouseEventCounts(topWebView, 1, 1, 0);
+
+    RetainPtr exitTopViewEvent = [bottomWebView _mouseEventWithType:NSEventTypeMouseExited atLocation:NSMakePoint(500, 100)];
+
+    [bottomObserver mouseExited:exitTopViewEvent.get()];
+    [topObserver mouseExited:exitTopViewEvent.get()];
+
+    checkMouseEventCounts(bottomWebView, 0, 0, 0);
+    checkMouseEventCounts(topWebView, 1, 1, 1);
+}
+
+TEST(MouseEventTests, OverlappingWebViewsBottomViewReceivesMouseEnterAndMouseExit)
+{
+    auto [bottomWebView, topWebView, bottomObserver, topObserver] = setupOverlappingWebViews();
+
+    RetainPtr enterBottomViewEvent = [bottomWebView _mouseEventWithType:NSEventTypeMouseEntered atLocation:NSMakePoint(300, 300)];
+
+    [bottomObserver mouseEntered:enterBottomViewEvent.get()];
+    [topObserver mouseEntered:enterBottomViewEvent.get()];
+
+    checkMouseEventCounts(bottomWebView, 1, 1, 0);
+    checkMouseEventCounts(topWebView, 0, 0, 0);
+
+    RetainPtr exitBottomViewEvent = [bottomWebView _mouseEventWithType:NSEventTypeMouseExited atLocation:NSMakePoint(300, 500)];
+
+    [bottomObserver mouseExited:exitBottomViewEvent.get()];
+    [topObserver mouseExited:exitBottomViewEvent.get()];
+
+    checkMouseEventCounts(bottomWebView, 1, 1, 1);
+    checkMouseEventCounts(topWebView, 0, 0, 0);
+}
+
+TEST(MouseEventTests, OverlappingWebViewsTopAndBottomViewsReceiveMouseEnterAndMouseExit)
+{
+    auto [bottomWebView, topWebView, bottomObserver, topObserver] = setupOverlappingWebViews();
+
+    RetainPtr enterBottomViewEvent = [bottomWebView _mouseEventWithType:NSEventTypeMouseEntered atLocation:NSMakePoint(300, 300)];
+
+    [bottomObserver mouseEntered:enterBottomViewEvent.get()];
+    [topObserver mouseEntered:enterBottomViewEvent.get()];
+
+    checkMouseEventCounts(bottomWebView, 1, 1, 0);
+    checkMouseEventCounts(topWebView, 0, 0, 0);
+
+    RetainPtr enterTopViewEvent = [bottomWebView _mouseEventWithType:NSEventTypeMouseEntered atLocation:NSMakePoint(300, 100)];
+
+    [bottomObserver mouseEntered:enterTopViewEvent.get()];
+    [topObserver mouseEntered:enterTopViewEvent.get()];
+
+    checkMouseEventCounts(bottomWebView, 1, 1, 0);
+    checkMouseEventCounts(topWebView, 1, 1, 0);
+
+    RetainPtr moveOnBottomViewEvent = [bottomWebView _mouseEventWithType:NSEventTypeMouseMoved atLocation:NSMakePoint(300, 300)];
+
+    [bottomObserver mouseMoved:moveOnBottomViewEvent.get()];
+
+    RetainPtr exitTopViewEvent = [bottomWebView _mouseEventWithType:NSEventTypeMouseExited atLocation:NSMakePoint(300, 300)];
+
+    [topObserver mouseExited:exitTopViewEvent.get()];
+
+    checkMouseEventCounts(bottomWebView, 2, 1, 0);
+    checkMouseEventCounts(topWebView, 1, 1, 1);
+
+    RetainPtr exitBottomViewEvent = [bottomWebView _mouseEventWithType:NSEventTypeMouseExited atLocation:NSMakePoint(300, 500)];
+
+    [bottomObserver mouseExited:exitBottomViewEvent.get()];
+    [topObserver mouseExited:exitBottomViewEvent.get()];
+
+    checkMouseEventCounts(bottomWebView, 2, 1, 1);
+    checkMouseEventCounts(topWebView, 1, 1, 1);
+}
+
+TEST(MouseEventTests, MouseMoveNotForwardedWhenCoveredByOverlay)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView synchronouslyLoadHTMLString:@"<body><script>"
+        "let moveCount = 0;"
+        "addEventListener('mousemove', () => moveCount++);"
+        "</script></body>"];
+
+    RetainPtr overlay = adoptNS([[NSView alloc] initWithFrame:NSMakeRect(200, 0, 200, 400)]);
+    [[webView superview] addSubview:overlay.get() positioned:NSWindowAbove relativeTo:webView.get()];
+
+    auto findTrackingAreaObserver = [](TestWKWebView *view) -> id {
+        for (NSTrackingArea *area in [view trackingAreas]) {
+            if (area.options & NSTrackingMouseMoved)
+                return area.owner;
+        }
+        return nil;
+    };
+
+    RetainPtr<id> observer = findTrackingAreaObserver(webView.get());
+
+    RetainPtr eventOnOverlay = [webView _mouseEventWithType:NSEventTypeMouseMoved atLocation:NSMakePoint(300, 200)];
+    [observer mouseMoved:eventOnOverlay.get()];
+    [webView waitForPendingMouseEvents];
+    EXPECT_EQ([[webView objectByEvaluatingJavaScript:@"moveCount"] intValue], 0);
+
+    RetainPtr eventOnWebView = [webView _mouseEventWithType:NSEventTypeMouseMoved atLocation:NSMakePoint(100, 200)];
+    [observer mouseMoved:eventOnWebView.get()];
+    [webView waitForPendingMouseEvents];
+    EXPECT_GE([[webView objectByEvaluatingJavaScript:@"moveCount"] intValue], 1);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 67fc22ee94fb75cf572cb11d84271e8f1e912226
<pre>
WKMouseTrackingObserver should do a hit test before forwarding mouse event
<a href="https://bugs.webkit.org/show_bug.cgi?id=312923">https://bugs.webkit.org/show_bug.cgi?id=312923</a>
<a href="https://rdar.apple.com/175269276">rdar://175269276</a>

Reviewed by Abrar Rahman Protyasha.

WKMouseTrackingObserver should only forward a mouse move event to WebViewImpl if the
web view is the topmost view at the event&apos;s mouse location. This is the first step
to eventually deprecate the _ignoresMouseMoveEvents SPI. Clients will not need
to ask a web view to ignore mouse events because the mouse events will not
be forwarded in the first place if the web view is not the topmost view.

Inside -[mouseMoved:event] and -[mouseEntered:event], WKMouseTrackingObserver should
update _viewIsTopmostAtLastMouseLocation. We need to keep track of whether this was
the topmost view at the last known mouse location in order to determine whether to
forward mouseExited in the future. The mouseExited event only tells us the new location,
which is necessarily outside of the view, therefore we must keep track of whether the
view was previously topmost.

Added API tests OverlappingWebViewsTopViewReceivesMouseMove, OverlappingWebViewsBottomViewReceivesMouseMove,
OverlappingWebViewsTopViewReceivesMouseEnterAndMouseExit, OverlappingWebViewsBottomViewReceivesMouseEnterAndMouseExit,
OverlappingWebViewsTopAndBottomViewsReceiveMouseEnterAndMouseExit,
and MouseMoveNotForwardedWhenCoveredByOverlay.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKMouseTrackingObserver updateViewIsTopmostAtMouseLocation:]):
(-[WKMouseTrackingObserver mouseMoved:]):
(-[WKMouseTrackingObserver mouseEntered:]):
(-[WKMouseTrackingObserver mouseExited:]):
* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MouseEventTests.mm:
(TestWebKitAPI::setupOverlappingWebViews):
(TestWebKitAPI::checkMouseEventCounts):
(TestWebKitAPI::TEST(MouseEventTests, OverlappingWebViewsTopViewReceivesMouseMove)):
(TestWebKitAPI::TEST(MouseEventTests, OverlappingWebViewsBottomViewReceivesMouseMove)):
(TestWebKitAPI::TEST(MouseEventTests, OverlappingWebViewsTopViewReceivesMouseEnterAndMouseExit)):
(TestWebKitAPI::TEST(MouseEventTests, OverlappingWebViewsBottomViewReceivesMouseEnterAndMouseExit)):
(TestWebKitAPI::TEST(MouseEventTests, OverlappingWebViewsTopAndBottomViewsReceiveMouseEnterAndMouseExit)):
(TestWebKitAPI::TEST(MouseEventTests, MouseMoveNotForwardedWhenCoveredByOverlay)):

Canonical link: <a href="https://commits.webkit.org/312201@main">https://commits.webkit.org/312201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ee5ac135da0163f6efc35d319c1442e8e430fc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113154 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b4f2b3b-25ec-4236-989e-03e847136fc4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123236 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86531 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/853bf579-1540-4b6b-ad6d-c180eaa3e655) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103902 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6925f6e4-0967-467d-b8c3-68bf4955639e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24567 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22983 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15672 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170392 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16134 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131425 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131537 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142468 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90181 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24234 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26247 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19277 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97656 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31162 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31435 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31317 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->