### PR TITLE
Surfaces should not be marked volatile while preparing for display

### DIFF
--- a/LayoutTests/ipc/mark-surfaces-volatile-during-prepare-for-display-expected.txt
+++ b/LayoutTests/ipc/mark-surfaces-volatile-during-prepare-for-display-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/mark-surfaces-volatile-during-prepare-for-display.html
+++ b/LayoutTests/ipc/mark-surfaces-volatile-during-prepare-for-display.html
@@ -1,0 +1,97 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<!doctype html>
+<p>This test passes if WebKit does not crash.</p>
+<script src="../resources/ipc.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+async function runTest() {
+    if (!window.IPC) {
+        testRunner.notifyDone();
+        return;
+    }
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const streamConnection = CoreIPC.newStreamConnection();
+    const renderingBackendIdentifier = randomIPCID();
+
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+        renderingBackendIdentifier: renderingBackendIdentifier,
+        connectionHandle: streamConnection
+    });
+
+    const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+    const didInitializeReply = streamConnection.connection.waitForMessage(
+        renderingBackendIdentifier,
+        IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name,
+        1
+    );
+    streamConnection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+
+    const imageBufferSetIdentifier = randomIPCID();
+    const graphicsContextIdentifier = randomIPCID();
+
+    remoteRenderingBackend.CreateImageBufferSet({
+        identifier: imageBufferSetIdentifier,
+        contextIdentifier: graphicsContextIdentifier,
+    });
+
+    const remoteImageBufferSet = streamConnection.newInterface("RemoteImageBufferSet", imageBufferSetIdentifier);
+    const remoteGraphicsContext = streamConnection.newInterface("RemoteGraphicsContext", graphicsContextIdentifier);
+
+    remoteImageBufferSet.UpdateConfiguration({
+        configuration: {
+            logicalSize: { width: 128, height: 128 },
+            resolutionScale: 1.0,
+            colorSpace: {
+                serializableColorSpace: {
+                    alias: {
+                        optionalValue: {
+                            m_cgColorSpace: {
+                                alias: {
+                                    variantType: 'WebCore::ColorSpace',
+                                    variant: 19
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            contentsFormat: 1,
+            bufferFormat: { pixelFormat: 2, useLosslessCompression: 0 },
+            renderingMode: 1,
+            renderingPurpose: 3,
+        },
+    });
+
+    remoteRenderingBackend.PrepareImageBufferSetsForDisplaySync({
+        swapBuffersInput: [{
+            remoteBufferSet: imageBufferSetIdentifier,
+            dirtyRegion: { data: { m_segments: [], m_spans: [] } },
+            supportsPartialRepaint: false,
+            hasEmptyDirtyRegion: false,
+            requiresClearedPixels: false,
+        }],
+    });
+
+    remoteRenderingBackend.MarkSurfacesVolatile({
+        requestIdentifier: randomIPCID(),
+        renderingResourceIdentifiers: [[imageBufferSetIdentifier, 1]],
+        forcePurge: false,
+    });
+
+    remoteGraphicsContext.SetShouldAntialias({
+        shouldAntialias: true
+    });
+
+    streamConnection.connection.invalidate();
+    testRunner.notifyDone();
+}
+
+runTest();
+</script>

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
@@ -65,6 +65,8 @@ public:
 
     bool makeBuffersVolatile(OptionSet<BufferInSetType> requestedBuffers, OptionSet<BufferInSetType>& volatileBuffers, bool forcePurge);
 
+    bool isPreparingForDisplay() const { return m_context.get(); }
+
 private:
     RemoteImageBufferSet(ImageBufferSetIdentifier, RemoteGraphicsContextIdentifier, RemoteRenderingBackend&);
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -629,6 +629,7 @@ void RemoteRenderingBackend::markSurfacesVolatile(MarkSurfacesAsVolatileRequestI
         RefPtr<RemoteImageBufferSet> remoteImageBufferSet = m_remoteImageBufferSets.get(identifier.first);
 
         MESSAGE_CHECK(remoteImageBufferSet, "BufferSet is being marked volatile before being created");
+        MESSAGE_CHECK(!remoteImageBufferSet->isPreparingForDisplay(), "BufferSet is being marked volatile while preparing for display");
 
         OptionSet<BufferInSetType> volatileBuffers;
         if (!remoteImageBufferSet->makeBuffersVolatile(identifier.second, volatileBuffers, forcePurge))


### PR DESCRIPTION
#### 325e4cb39ee10789836fc6406654495276b815a8
<pre>
Surfaces should not be marked volatile while preparing for display
<a href="https://bugs.webkit.org/show_bug.cgi?id=307138">https://bugs.webkit.org/show_bug.cgi?id=307138</a>
<a href="https://rdar.apple.com/167565825">rdar://167565825</a>

Reviewed by Kimmo Kinnunen.

The WebProcess can send MarkSurfacesVolatile while prepareBufferForDisplay is still active on the GPU Process.
This is semantically invalid.

MarkSurfacesVolatile calls makeBuffersVolatile, which calls releaseGraphicsContext() on each image buffer — destroying the graphics
context that prepareBufferForDisplay is actively using through m_context. This leads to a dangling reference.

The only concerning path here is the makeBuffersVolatile()-&gt;releaseGraphicsContext() path.
Since RemoteImageBufferGraphicsContext holds a strong reference to the context&apos;s ImageBuffer,
other paths releasing the ImageBuffer and ImageBuffer destructor paths are not of concern.
And WebProcess only local paths to releaseGraphicsContext() are also not of concern.

To fix, we add a MESSAGE_CHECK to reject when markSurfacesVolatile is called while drawing is ongoing.

Test: ipc/mark-surfaces-volatile-during-prepare-for-display.html

* LayoutTests/ipc/mark-surfaces-volatile-during-prepare-for-display-expected.txt: Added.
* LayoutTests/ipc/mark-surfaces-volatile-during-prepare-for-display.html: Added.
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h:
(WebKit::RemoteImageBufferSet::isPreparingForDisplay const):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::markSurfacesVolatile):

Originally-landed-as: 305413.309@safari-7624-branch (939a2f7876f3). <a href="https://rdar.apple.com/173968798">rdar://173968798</a>
Canonical link: <a href="https://commits.webkit.org/311872@main">https://commits.webkit.org/311872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a0a4eefe1a24843aca43cd1aac6da5b4972288f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111864 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122174 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85793 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102843 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23511 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21802 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14377 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169095 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13803 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21115 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130340 "Found 1 new test failure: ipc/mark-surfaces-volatile-during-prepare-for-display.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130457 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141287 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88651 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25214 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18093 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30355 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95124 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29876 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30106 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->