### PR TITLE
'git webkit pr' should support running from any branch (not just main)

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -120,10 +120,9 @@ class Branch(Command):
         return None
 
     @classmethod
-    def main(cls, args, repository, why=None, redact=False, target_remote='fork', **kwargs):
-        if not isinstance(repository, local.Git):
-            sys.stderr.write("Can only 'branch' on a native Git repository\n")
-            return 1
+    def ensure_issue(cls, args, repository, why=None, redact=False):
+        if not args.issue:
+            args.issue = repository.config().get('branch.{}.bug'.format(repository.branch))
 
         if not args.issue:
             if Tracker.instance() and getattr(args, 'update_issue', True):
@@ -150,7 +149,6 @@ class Branch(Command):
                     Tracker.instance().credentials(required=True, validate=True)
                 description = Terminal.input('Issue description: ')
 
-                # Asking for a radar here will prevent race conditions with the bug importer
                 needs_radar = any([isinstance(tracker, radar.Tracker) and tracker.radarclient() for tracker in Tracker._trackers])
                 radar_cc_default = repository.config().get('webkitscmpy.cc-radar', 'true') == 'true'
                 if not getattr(args, 'defaults', None) and needs_radar and not isinstance(Tracker.instance(), radar.Tracker):
@@ -176,7 +174,7 @@ class Branch(Command):
                 )
                 if not issue:
                     sys.stderr.write('Failed to create new issue\n')
-                    return 1
+                    return None, 1
                 print("Created '{}'".format(issue))
                 if issue and issue.title and not redact and not issue.redacted and not issue.tracker.hide_title:
                     args.issue = cls.to_branch_name(issue.title)
@@ -191,7 +189,20 @@ class Branch(Command):
             args._title = issue.title
         if issue:
             args._bug_urls = Commit.bug_urls(issue)
-        elif not (repository or local.Scm).DEV_BRANCHES.match(args.issue):
+
+        return issue, 0
+
+    @classmethod
+    def main(cls, args, repository, why=None, redact=False, target_remote='fork', **kwargs):
+        if not isinstance(repository, local.Git):
+            sys.stderr.write("Can only 'branch' on a native Git repository\n")
+            return 1
+
+        issue, result = cls.ensure_issue(args, repository, why=why, redact=redact)
+        if result:
+            return result
+
+        if not issue and not (repository or local.Scm).DEV_BRANCHES.match(args.issue):
             # Support creating a branch from PR or revert when update_issue is False
             args.issue = cls.to_branch_name(args.issue)
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -160,16 +160,17 @@ class PullRequest(Command):
         # Then, see if we already have a commit associated with this branch we need to modify
         has_commit = repository.commit(include_log=False, include_identifier=False).branch == repository.branch and repository.branch != repository.default_branch
         if not modified and has_commit:
-            log.info('Using committed changes...')
-            return 0
+            if not getattr(args, '_bug_urls', None) or os.environ.get('COMMIT_MESSAGE_REVERT'):
+                log.info('Using committed changes...')
+                return 0
 
         bug_urls = getattr(args, '_bug_urls', None) or ''
         if isinstance(bug_urls, (list, tuple)):
             bug_urls = '\n'.join(bug_urls)
 
         # Otherwise, we need to create a commit
-        will_amend = has_commit and args.technique == 'overwrite'
-        if not modified:
+        will_amend = has_commit and (args.technique == 'overwrite' or bool(getattr(args, '_bug_urls', None)))
+        if not modified and not will_amend:
             sys.stderr.write('No modified files\n')
             return 1
         log.info('Amending commit...' if will_amend else 'Creating commit...')
@@ -195,6 +196,22 @@ class PullRequest(Command):
             title = commits[0].message.splitlines()[0] if commits[0].message else '???'
         title = title.rstrip().lstrip()
         return title[:-5].rstrip() if title.endswith('(Part') else title
+
+    @classmethod
+    def issue_from_commits(cls, repository, source_remote, branch_point):
+        head = repository.commit(include_log=True, include_identifier=False)
+        if run([
+            repository.executable(), 'merge-base', '--is-ancestor',
+            head.hash, 'remotes/{}/{}'.format(source_remote, branch_point.branch),
+        ], capture_output=True, cwd=repository.root_path).returncode:
+            if head.issues:
+                return head.issues[0].link
+            revert_message = os.environ.get('COMMIT_MESSAGE_REVERT', '')
+            for line in revert_message.splitlines():
+                issue = Tracker.from_string(line)
+                if issue:
+                    return issue.link
+        return None
 
     @classmethod
     def check_pull_request_args(cls, repository, args):
@@ -261,13 +278,7 @@ class PullRequest(Command):
 
         if not repository.is_suitable_branch_for_pull_request(repository.branch, source_remote):
             if not args.issue:
-                head = repository.commit(include_log=True, include_identifier=False)
-                if run([
-                    repository.executable(), 'merge-base', '--is-ancestor',
-                    head.hash, 'remotes/{}/{}'.format(source_remote, branch_point.branch),
-                ], capture_output=True, cwd=repository.root_path).returncode:
-                    if head.issues:
-                        args.issue = head.issues[0].link
+                args.issue = cls.issue_from_commits(repository, source_remote, branch_point)
 
             if Branch.main(
                 args, repository,
@@ -299,6 +310,23 @@ class PullRequest(Command):
             if not issue.tracker.hide_title:
                 args._title = issue.title
             args._bug_urls = Commit.bug_urls(issue)
+
+        elif not args.issue and getattr(args, 'update_issue', True) and Tracker.instance():
+            args.issue = cls.issue_from_commits(repository, source_remote, branch_point)
+            if not args.issue:
+                issue, result = Branch.ensure_issue(args, repository, redact=source_remote != repository.default_remote)
+                if result:
+                    return None
+
+                bug_urls = getattr(args, '_bug_urls', None) or ''
+                if isinstance(bug_urls, (list, tuple)):
+                    bug_urls = '\n'.join(bug_urls)
+                title = getattr(args, '_title', None) or ''
+                cls.write_branch_variables(
+                    repository, repository.branch,
+                    title=title,
+                    bug=bug_urls,
+                )
 
         if not repository.config().get('remote.{}.url'.format(source_remote)):
             sys.stderr.write("'{}' is not a remote in this repository\n".format(source_remote))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -991,6 +991,92 @@ No pre-PR checks to run""")
             ],
         )
 
+    def test_github_existing_branch_bugzilla(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(
+                projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(
+                self.BUGZILLA.split('://')[-1],
+                projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+                environment=Environment(
+                    BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                    BUGS_EXAMPLE_COM_PASSWORD='password',
+                )), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)],
+        ), mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn(), MockTerminal.input('https://bugs.example.com/show_bug.cgi?id=1'):
+
+            repo.commits['eng/pr-branch'] = [
+                repo.commits[repo.default_branch][-1],
+                Commit(
+                    hash='06de5d56554e693db72313f4ca1fb969c30b8ccb',
+                    branch='eng/pr-branch',
+                    author=dict(name='Tim Contributor', emails=['tcontributor@example.com']),
+                    identifier="5.1@eng/pr-branch",
+                    timestamp=int(time.time()),
+                    message='[Testing] Existing commit'
+                )
+            ]
+            repo.head = repo.commits['eng/pr-branch'][-1]
+            repo.staged['added.txt'] = 'added'
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history', '--commit'),
+                path=self.path,
+            ))
+
+            self.assertEqual(
+                Tracker.instance().issue(1).comments[-1].content,
+                'Pull request: https://github.example.com/WebKit/WebKit/pull/1',
+            )
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Enter issue URL or title of new issue: \n"
+            "Created 'PR 1 | Example issue 1'!\n"
+            "Posted pull request link to https://bugs.example.com/show_bug.cgi?id=1\n"
+            "https://github.example.com/WebKit/WebKit/pull/1\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_github_existing_branch_no_staged_changes(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(
+                projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(
+                self.BUGZILLA.split('://')[-1],
+                projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+                environment=Environment(
+                    BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                    BUGS_EXAMPLE_COM_PASSWORD='password',
+                )), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)],
+        ), mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn(), MockTerminal.input('https://bugs.example.com/show_bug.cgi?id=1'):
+
+            repo.commits['eng/pr-branch'] = [
+                repo.commits[repo.default_branch][-1],
+                Commit(
+                    hash='06de5d56554e693db72313f4ca1fb969c30b8ccb',
+                    branch='eng/pr-branch',
+                    author=dict(name='Tim Contributor', emails=['tcontributor@example.com']),
+                    identifier="5.1@eng/pr-branch",
+                    timestamp=int(time.time()),
+                    message='[Testing] Existing commit'
+                )
+            ]
+            repo.head = repo.commits['eng/pr-branch'][-1]
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history', '--commit'),
+                path=self.path,
+            ))
+
+            self.assertEqual(
+                Tracker.instance().issue(1).comments[-1].content,
+                'Pull request: https://github.example.com/WebKit/WebKit/pull/1',
+            )
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+
     def test_github_branch_number(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(
                 projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(


### PR DESCRIPTION
#### af6725a1fa1dc3afbd1fbd5f592b31ff32d0d80d
<pre>
&apos;git webkit pr&apos; should support running from any branch (not just main)
<a href="https://bugs.webkit.org/show_bug.cgi?id=312930">https://bugs.webkit.org/show_bug.cgi?id=312930</a>
<a href="https://rdar.apple.com/175277222">rdar://175277222</a>

Reviewed by Jonathan Bedard.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.ensure_issue): Factored out a helper function for use below.

(Branch):
(Branch.main): Call the helper function.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_commit): Update the commit message to include the
bug title and URL whenever we create a commit, since branch-based
workflows won&apos;t have taken that step yet.

(PullRequest):
(PullRequest.issue_from_commits): Factored out a helper function for use below.

(PullRequest.pull_request_branch_point): This is most of the fix: If we&apos;re on
a branch already but we don&apos;t have an issue filed yet, now&apos;s the time to file it.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
Test the on branch with local changes case and the on branch with an existing
commit case.

Canonical link: <a href="https://commits.webkit.org/311983@main">https://commits.webkit.org/311983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dc6af0c4c8e668537c2d3955bc1b0f78b73efb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111967 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122258 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85842 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24550 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141788 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionContext.TopLevelThrowInModuleBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102924 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/157206 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23606 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21899 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14485 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169202 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130432 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/157282 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30967 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130546 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141387 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88758 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24113 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25285 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18193 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30457 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29978 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30208 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->