### PR TITLE
WebGL provoking vertex with uint16 primitive restart causes GPU OOB access

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5455,6 +5455,8 @@ webkit.org/b/313511 media/media-source/media-source-real-overlapping-dts.html [ 
 
 [ Debug ] imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior.html [ Pass Failure ]
 
+webkit.org/b/305531 webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash.html [ Skip ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8671,3 +8671,6 @@ imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-co
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-touch-scroll.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-self-invoke.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadowhost-focus-navigation.html [ Skip ]
+
+# rdar://168334716 (MTLCompilerService crashes when Metal Shader Validation is enabled on iOS Simulator)
+webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash.html [ Skip ]

--- a/LayoutTests/webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash-expected.txt
+++ b/LayoutTests/webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash.
+
+

--- a/LayoutTests/webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash.html
+++ b/LayoutTests/webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash.html
@@ -1,0 +1,91 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<p>PASS if no crash.</p>
+<canvas id="canvas" width="256" height="256"></canvas>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl2');
+const ext = gl.getExtension('WEBGL_provoking_vertex');
+
+const vertexShaderSource = `#version 300 es
+    in vec2 position;
+    flat out int color;
+    void main() {
+        gl_Position = vec4(position, 0.0, 1.0);
+        color = gl_VertexID;
+    }
+`;
+
+const fragmentShaderSource = `#version 300 es
+    precision mediump float;
+    flat in int color;
+    out vec4 fragColor;
+    void main() {
+        fragColor = vec4(float(color) / 10.0, 0.0, 0.0, 1.0);
+    }
+`;
+
+const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+gl.shaderSource(vertexShader, vertexShaderSource);
+gl.compileShader(vertexShader);
+
+const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+gl.shaderSource(fragmentShader, fragmentShaderSource);
+gl.compileShader(fragmentShader);
+
+const program = gl.createProgram();
+gl.attachShader(program, vertexShader);
+gl.attachShader(program, fragmentShader);
+gl.linkProgram(program);
+gl.useProgram(program);
+
+ext.provokingVertexWEBGL(0x8E4E);
+
+const vertices = new Float32Array([
+    -0.9, -0.9,  // 0
+    -0.5, -0.9,  // 1
+    -0.9, -0.5,  // 2
+    -0.5, -0.5,  // 3
+     0.5, -0.9,  // 4
+     0.9, -0.9,  // 5
+     0.5, -0.5,  // 6
+]);
+
+const vbo = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+
+const positionLoc = gl.getAttribLocation(program, 'position');
+gl.enableVertexAttribArray(positionLoc);
+gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
+
+// Index buffer with restart marker
+const indices = new Uint16Array([
+    0, 1, 2, 3,     // First strip
+    0xFFFF,         // Restart marker
+    4, 5, 6         // Second strip
+]);
+
+const ibo = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+
+// This triggers the bug
+gl.drawElements(gl.TRIANGLE_STRIP, 8, gl.UNSIGNED_SHORT, 0);
+gl.finish();
+
+// Wait for Metal completion handlers to report crash
+setTimeout(() => {
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 300);
+</script>
+</body>
+</html>

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_internal_shaders_autogen.metal
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_internal_shaders_autogen.metal
@@ -2549,10 +2549,10 @@ constant bool outIndexBufferIsUint16 = (((fixIndexBufferKey >> 2U) & 0x03U) == 2
 constant bool outIndexBufferIsUint32 = (((fixIndexBufferKey >> 2U) & 0x03U) == 3U);
 constant bool doPrimRestart = (fixIndexBufferKey & 0x00100U);
 constant uint fixIndexBufferMode = (fixIndexBufferKey >> 4U) & 0x0FU;
+constant uint restartIndex = indexBufferIsUint16 ? 0xFFFF : 0xFFFFFFFF;
 static inline uint readIdx(
                            const device ushort *indexBufferUint16,
                            const device uint *indexBufferUint32,
-                           const uint restartIndex,
                            const uint indexCount,
                            uint idx,
                            thread bool &foundRestart,
@@ -2588,7 +2588,6 @@ static inline void outputPrimitive(
                                    const device uint *indexBufferUint32,
                                    device ushort *outIndexBufferUint16,
                                    device uint *outIndexBufferUint32,
-                                   const uint restartIndex,
                                    const uint indexCount,
                                    thread uint &baseIndex,
                                    uint onIndex,
@@ -2602,7 +2601,7 @@ static inline void outputPrimitive(
     {
         case 0x00U:
         {
-            auto tmpIndex = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex, foundRestart, indexThatRestartedFirst);
             if(foundRestart)
             {
                 baseIndex = indexThatRestartedFirst + 1;
@@ -2613,8 +2612,8 @@ static inline void outputPrimitive(
         break;
         case 0x01U:
         {
-            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
             if(foundRestart)
             {
                 baseIndex = indexThatRestartedFirst + 1;
@@ -2635,8 +2634,8 @@ static inline void outputPrimitive(
         break;
         case 0x03U:
         {
-            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
             if(foundRestart)
             {
                 baseIndex = indexThatRestartedFirst + 1;
@@ -2656,9 +2655,9 @@ static inline void outputPrimitive(
         break;
         case 0x04U:
         {
-            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex2 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 2, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex2 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 2, foundRestart, indexThatRestartedFirst);
             if(foundRestart)
             {
                 baseIndex = indexThatRestartedFirst + 1;
@@ -2682,9 +2681,9 @@ static inline void outputPrimitive(
         case 0x05U:
         {
             uint isOdd = ((onIndex - baseIndex) & 1);
-            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 0 + isOdd, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 1 - isOdd, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex2 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 2, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 0 + isOdd, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 1 - isOdd, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex2 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 2, foundRestart, indexThatRestartedFirst);
             if(foundRestart)
             {
                 baseIndex = indexThatRestartedFirst + 1;
@@ -2726,7 +2725,6 @@ kernel void fixIndexBuffer(
                            constant uint &primCount [[ buffer(3) ]],
                            uint prim [[thread_position_in_grid]])
 {
-    constexpr uint restartIndex = 0xFFFFFFFF;
     uint baseIndex = 0;
     uint onIndex = onIndex;
     uint onOutIndex = onOutIndex;
@@ -2755,7 +2753,7 @@ kernel void fixIndexBuffer(
                 onOutIndex = prim * 3;
                 break;
         }
-        outputPrimitive(indexBufferUint16, indexBufferUint32, outIndexBufferUint16, outIndexBufferUint32, restartIndex, indexCount, baseIndex, onIndex, onOutIndex);
+        outputPrimitive(indexBufferUint16, indexBufferUint32, outIndexBufferUint16, outIndexBufferUint32, indexCount, baseIndex, onIndex, onOutIndex);
     }
 }
 static inline void generatePrimitive(

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_internal_shaders_src_autogen.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_internal_shaders_src_autogen.h
@@ -2550,10 +2550,10 @@ constant bool outIndexBufferIsUint16 = (((fixIndexBufferKey >> 2U) & 0x03U) == 2
 constant bool outIndexBufferIsUint32 = (((fixIndexBufferKey >> 2U) & 0x03U) == 3U);
 constant bool doPrimRestart = (fixIndexBufferKey & 0x00100U);
 constant uint fixIndexBufferMode = (fixIndexBufferKey >> 4U) & 0x0FU;
+constant uint restartIndex = indexBufferIsUint16 ? 0xFFFF : 0xFFFFFFFF;
 static inline uint readIdx(
                            const device ushort *indexBufferUint16,
                            const device uint *indexBufferUint32,
-                           const uint restartIndex,
                            const uint indexCount,
                            uint idx,
                            thread bool &foundRestart,
@@ -2589,7 +2589,6 @@ static inline void outputPrimitive(
                                    const device uint *indexBufferUint32,
                                    device ushort *outIndexBufferUint16,
                                    device uint *outIndexBufferUint32,
-                                   const uint restartIndex,
                                    const uint indexCount,
                                    thread uint &baseIndex,
                                    uint onIndex,
@@ -2603,7 +2602,7 @@ static inline void outputPrimitive(
     {
         case 0x00U:
         {
-            auto tmpIndex = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex, foundRestart, indexThatRestartedFirst);
             if(foundRestart)
             {
                 baseIndex = indexThatRestartedFirst + 1;
@@ -2614,8 +2613,8 @@ static inline void outputPrimitive(
         break;
         case 0x01U:
         {
-            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
             if(foundRestart)
             {
                 baseIndex = indexThatRestartedFirst + 1;
@@ -2636,8 +2635,8 @@ static inline void outputPrimitive(
         break;
         case 0x03U:
         {
-            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
             if(foundRestart)
             {
                 baseIndex = indexThatRestartedFirst + 1;
@@ -2657,9 +2656,9 @@ static inline void outputPrimitive(
         break;
         case 0x04U:
         {
-            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex2 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 2, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 0, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 1, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex2 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 2, foundRestart, indexThatRestartedFirst);
             if(foundRestart)
             {
                 baseIndex = indexThatRestartedFirst + 1;
@@ -2683,9 +2682,9 @@ static inline void outputPrimitive(
         case 0x05U:
         {
             uint isOdd = ((onIndex - baseIndex) & 1);
-            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 0 + isOdd, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 1 - isOdd, foundRestart, indexThatRestartedFirst);
-            auto tmpIndex2 = readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, onIndex + 2, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex0 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 0 + isOdd, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex1 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 1 - isOdd, foundRestart, indexThatRestartedFirst);
+            auto tmpIndex2 = readIdx(indexBufferUint16, indexBufferUint32, indexCount, onIndex + 2, foundRestart, indexThatRestartedFirst);
             if(foundRestart)
             {
                 baseIndex = indexThatRestartedFirst + 1;
@@ -2727,7 +2726,6 @@ kernel void fixIndexBuffer(
                            constant uint &primCount [[ buffer(3) ]],
                            uint prim [[thread_position_in_grid]])
 {
-    constexpr uint restartIndex = 0xFFFFFFFF;
     uint baseIndex = 0;
     uint onIndex = onIndex;
     uint onOutIndex = onOutIndex;
@@ -2756,7 +2754,7 @@ kernel void fixIndexBuffer(
                 onOutIndex = prim * 3;
                 break;
         }
-        outputPrimitive(indexBufferUint16, indexBufferUint32, outIndexBufferUint16, outIndexBufferUint32, restartIndex, indexCount, baseIndex, onIndex, onOutIndex);
+        outputPrimitive(indexBufferUint16, indexBufferUint32, outIndexBufferUint16, outIndexBufferUint32, indexCount, baseIndex, onIndex, onOutIndex);
     }
 }
 static inline void generatePrimitive(

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/rewrite_indices.metal
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/rewrite_indices.metal
@@ -18,12 +18,12 @@ constant bool outIndexBufferIsUint16 = (((fixIndexBufferKey >> MtlFixIndexBuffer
 constant bool outIndexBufferIsUint32 = (((fixIndexBufferKey >> MtlFixIndexBufferKeyOutShift) & MtlFixIndexBufferKeyTypeMask) == MtlFixIndexBufferKeyUint32);
 constant bool doPrimRestart = (fixIndexBufferKey & MtlFixIndexBufferKeyPrimRestart);
 constant uint fixIndexBufferMode = (fixIndexBufferKey >> MtlFixIndexBufferKeyModeShift) & MtlFixIndexBufferKeyModeMask;
+constant uint restartIndex = indexBufferIsUint16 ? 0xFFFF : 0xFFFFFFFF;
 
 
 static inline uint readIdx(
                            const device ushort *indexBufferUint16,
                            const device uint   *indexBufferUint32,
-                           const uint restartIndex,
                            const uint indexCount,
                            uint idx,
                            thread bool &foundRestart,
@@ -60,7 +60,6 @@ static inline void outputPrimitive(
                                    const device uint   *indexBufferUint32,
                                    device ushort *outIndexBufferUint16,
                                    device uint   *outIndexBufferUint32,
-                                   const uint restartIndex,
                                    const uint indexCount,
                                    thread uint &baseIndex,
                                    uint onIndex,
@@ -70,7 +69,7 @@ static inline void outputPrimitive(
     if(baseIndex > onIndex) return; // skipped indices while processing
     bool foundRestart = false;
     uint indexThatRestartedFirst = 0;
-#define READ_IDX(_idx) readIdx(indexBufferUint16, indexBufferUint32, restartIndex, indexCount, _idx, foundRestart, indexThatRestartedFirst)
+#define READ_IDX(_idx) readIdx(indexBufferUint16, indexBufferUint32, indexCount, _idx, foundRestart, indexThatRestartedFirst)
 #define WRITE_IDX(_idx, _val) \
 ({ \
     if(outIndexBufferIsUint16) \
@@ -222,7 +221,6 @@ kernel void fixIndexBuffer(
                            constant uint &primCount [[ buffer(3) ]],
                            uint prim [[thread_position_in_grid]])
 {
-    constexpr uint restartIndex = 0xFFFFFFFF; // unused
     uint baseIndex = 0;
     uint onIndex = onIndex;
     uint onOutIndex = onOutIndex;
@@ -251,7 +249,7 @@ kernel void fixIndexBuffer(
                 onOutIndex = prim * 3;
                 break;
         }
-        outputPrimitive(indexBufferUint16, indexBufferUint32, outIndexBufferUint16, outIndexBufferUint32, restartIndex, indexCount, baseIndex, onIndex, onOutIndex);
+        outputPrimitive(indexBufferUint16, indexBufferUint32, outIndexBufferUint16, outIndexBufferUint32, indexCount, baseIndex, onIndex, onOutIndex);
     }
 }
 


### PR DESCRIPTION
#### e298509a76abafc3a886a7c567f031cf62451cc0
<pre>
WebGL provoking vertex with uint16 primitive restart causes GPU OOB access
<a href="https://bugs.webkit.org/show_bug.cgi?id=305531">https://bugs.webkit.org/show_bug.cgi?id=305531</a>
<a href="https://rdar.apple.com/167631804">rdar://167631804</a>

Reviewed by Mike Wyrzykowski.

The fixIndexBuffer Metal compute kernel uses a hardcoded restart index of 0xFFFFFFFF,
which is only correct for uint32 indices. For uint16 indices, the primitive restart marker is 0xFFFF.
So when provoking vertex is used and we need to process the uint16 index buffer with primitive restart
enabled, the shader fails to recognize the restart markers, causing the restart marker to be used as a valid
index resulting in an OOB GPU buffer access.

Fix by selecting the type-appropriate restart index based on indexBufferIsUint16.

Test: webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash.html

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash-expected.txt: Added.
* LayoutTests/webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash.html: Added.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_internal_shaders_autogen.metal:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_internal_shaders_src_autogen.h:
(readIdx):
(outputPrimitive):
(fixIndexBuffer):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/rewrite_indices.metal:

Originally-landed-as: 305413.88@safari-7624-branch (b2f04087d62a). <a href="https://rdar.apple.com/173968824">rdar://173968824</a>
Canonical link: <a href="https://commits.webkit.org/312243@main">https://commits.webkit.org/312243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67f8f8f8f2d0f75809a51cab0b1bcd05af71060c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159343 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/32771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/32839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/32758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/168175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162300 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/32839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/32839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/32758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/32839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/170667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/170667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/32758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/170667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/142701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24250 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/31915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->