### PR TITLE
[visionOS] Support negative playbackRate in <model>

### DIFF
--- a/LayoutTests/model-element/model-element-animations-loop-expected.txt
+++ b/LayoutTests/model-element/model-element-animations-loop-expected.txt
@@ -1,4 +1,6 @@
 
 PASS <model> with loop=false should stop after reaching its duration
+PASS <model> with negative playbackRate and loop=false should stop after seeking near the beginning
 PASS <model> with loop=true should loop and continue playing after reaching its duration
+PASS <model> with negative playbackRate and loop=true should loop and continue playing after reaching the beginning
 

--- a/LayoutTests/model-element/model-element-animations-loop.html
+++ b/LayoutTests/model-element/model-element-animations-loop.html
@@ -23,12 +23,35 @@ promise_test(async t => {
     const [model, source] = createModelAndSource(t, "resources/stopwatch-60s.usdz");
     await model.ready;
 
+    model.playbackRate = -100;
+    await model.play();
+    model.currentTime = 0.5;
+    await sleepForSeconds(0.8);
+    assert_true(model.paused, "Model animation is paused after animation finishes without looping with negative rate and seek");
+}, `<model> with negative playbackRate and loop=false should stop after seeking near the beginning`);
+
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/stopwatch-60s.usdz");
+    await model.ready;
+
     model.loop = true;
     await model.play();
     model.currentTime = model.duration - 0.01;
     await sleepForSeconds(0.2);
     assert_false(model.paused, "Model animation should keep playing after animation finishes with looping");
 }, `<model> with loop=true should loop and continue playing after reaching its duration`);
+
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/stopwatch-60s.usdz");
+    await model.ready;
+
+    model.loop = true;
+    model.playbackRate = -10;
+    await model.play();
+    model.currentTime = 0.01;
+    await sleepForSeconds(0.2);
+    assert_false(model.paused, "Model animation should keep playing after reaching beginning with negative rate and looping");
+}, `<model> with negative playbackRate and loop=true should loop and continue playing after reaching the beginning`);
 
 </script>
 </body>

--- a/LayoutTests/model-element/model-element-animations-playback-expected.txt
+++ b/LayoutTests/model-element/model-element-animations-playback-expected.txt
@@ -4,4 +4,5 @@ PASS <model> source with no animation should fail play action
 PASS <model> source with animation should be able to play/pause with expected paused states afterwards
 PASS <model> source with autoplay=true should play on load
 PASS Paused <model> should stay paused after changing autoplay=true
+PASS <model> should accept negative playbackRate and play/pause normally
 

--- a/LayoutTests/model-element/model-element-animations-playback.html
+++ b/LayoutTests/model-element/model-element-animations-playback.html
@@ -56,5 +56,17 @@ promise_test(async t => {
     assert_true(model.paused);
 }, `Paused <model> should stay paused after changing autoplay=true`);
 
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/stopwatch-60s.usdz");
+    await model.ready;
+
+    model.playbackRate = -5;
+    assert_equals(model.playbackRate, -5, "playbackRate should accept negative values");
+    await model.play();
+    assert_false(model.paused, "model.paused should be false after playing with negative rate");
+    await model.pause();
+    assert_true(model.paused, "model.paused should be true after pausing with negative rate");
+}, `<model> should accept negative playbackRate and play/pause normally`);
+
 </script>
 </body>

--- a/Source/WebCore/Modules/model-element/ModelPlayerAnimationState.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayerAnimationState.cpp
@@ -86,8 +86,7 @@ std::optional<double> ModelPlayerAnimationState::effectivePlaybackRate() const
 
 void ModelPlayerAnimationState::setPlaybackRate(double playbackRate)
 {
-    // FIXME (280081): Support negative playback rate
-    m_effectivePlaybackRate = fmax(playbackRate, 0);
+    m_effectivePlaybackRate = playbackRate;
 }
 
 std::optional<Seconds> ModelPlayerAnimationState::lastCachedCurrentTime() const
@@ -117,6 +116,8 @@ Seconds ModelPlayerAnimationState::currentTime() const
     Seconds estimatedCurrentTime = lastCachedCurrentTime + animationTimePassed;
     if (estimatedCurrentTime > m_duration)
         estimatedCurrentTime = m_loop ? estimatedCurrentTime % m_duration : m_duration;
+    else if (estimatedCurrentTime < 0_s)
+        estimatedCurrentTime = m_loop ? m_duration + (estimatedCurrentTime % m_duration) : 0_s;
     return estimatedCurrentTime;
 }
 

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
@@ -168,8 +168,7 @@ extension WKRKEntity {
             animationPlaybackController?.speed ?? backingPlaybackRate
         }
         set {
-            // FIXME (280081): Support negative playback rate
-            backingPlaybackRate = max(newValue, 0)
+            backingPlaybackRate = newValue
             guard let animationPlaybackController else {
                 return
             }

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -385,8 +385,7 @@ void ModelProcessModelPlayer::setLoop(bool loop)
 
 void ModelProcessModelPlayer::setPlaybackRate(double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
 {
-    // FIXME (280081): Support negative playback rate
-    m_requestedPlaybackRate = fmax(playbackRate, 0);
+    m_requestedPlaybackRate = playbackRate;
     sendWithAsyncReply(Messages::ModelProcessModelPlayerProxy::SetPlaybackRate(m_requestedPlaybackRate), WTF::move(completionHandler));
 }
 


### PR DESCRIPTION
#### 92591db4ec9b22d73f9fb31f949bd15182aac08c
<pre>
[visionOS] Support negative playbackRate in &lt;model&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=280081">https://bugs.webkit.org/show_bug.cgi?id=280081</a>
<a href="https://rdar.apple.com/136346356">rdar://136346356</a>

Reviewed by Mike Wyrzykowski.

Remove clamps that prevented negative playbackRate value.
Add layout tests for negative rate play/pause and negative rate looping.

* LayoutTests/model-element/model-element-animations-loop-expected.txt:
* LayoutTests/model-element/model-element-animations-loop.html:
* LayoutTests/model-element/model-element-animations-playback-expected.txt:
* LayoutTests/model-element/model-element-animations-playback.html:
* Source/WebCore/Modules/model-element/ModelPlayerAnimationState.cpp:
(WebCore::ModelPlayerAnimationState::setPlaybackRate):
(WebCore::ModelPlayerAnimationState::currentTime const):
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift:
(WKRKEntity.playbackRate):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::setPlaybackRate):

Canonical link: <a href="https://commits.webkit.org/311747@main">https://commits.webkit.org/311747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc825b1b4bcbceba7a3dd1c30ceae8e80fdb9bc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111879 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122188 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102857 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23526 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14392 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169110 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13837 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21138 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130356 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35353 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88666 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25243 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18116 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95172 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29891 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30121 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30018 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->