### PR TITLE
Fix BBQ constant folding for integer div/rem with INT_MIN and -1

### DIFF
--- a/JSTests/wasm/stress/int-div-rem-constant-folding.js
+++ b/JSTests/wasm/stress/int-div-rem-constant-folding.js
@@ -1,0 +1,76 @@
+import * as assert from "../assert.js";
+import { instantiate } from "../wabt-wrapper.js";
+
+// Test constant folding of integer div/rem with INT_MIN / -1 edge cases.
+// Operations other than signed division should not throw an overflow trap
+
+let wat = `
+(module
+  (func (export "i32_div_s") (result i32)
+    i32.const -2147483648
+    i32.const -1
+    i32.div_s
+  )
+  (func (export "i64_div_s") (result i64)
+    i64.const -9223372036854775808
+    i64.const -1
+    i64.div_s
+  )
+  (func (export "i32_rem_s") (result i32)
+    i32.const -2147483648
+    i32.const -1
+    i32.rem_s
+  )
+  (func (export "i64_rem_s") (result i64)
+    i64.const -9223372036854775808
+    i64.const -1
+    i64.rem_s
+  )
+  (func (export "i32_div_u") (result i32)
+    i32.const -2147483648
+    i32.const -1
+    i32.div_u
+  )
+  (func (export "i64_div_u") (result i64)
+    i64.const -9223372036854775808
+    i64.const -1
+    i64.div_u
+  )
+  (func (export "i32_rem_u") (result i32)
+    i32.const -2147483648
+    i32.const -1
+    i32.rem_u
+  )
+  (func (export "i64_rem_u") (result i64)
+    i64.const -9223372036854775808
+    i64.const -1
+    i64.rem_u
+  )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat);
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        // div_s(INT_MIN, -1) must trap (integer overflow)
+        assert.throws(() => instance.exports.i32_div_s(), WebAssembly.RuntimeError, "Integer overflow");
+        assert.throws(() => instance.exports.i64_div_s(), WebAssembly.RuntimeError, "Integer overflow");
+
+        // INT_MIN % -1 == 0 (no overflow trap for rem_s)
+        assert.eq(instance.exports.i32_rem_s(), 0);
+        assert.eq(instance.exports.i64_rem_s(), 0n);
+
+        // Unsigned: 0x80000000 / 0xFFFFFFFF == 0
+        assert.eq(instance.exports.i32_div_u(), 0);
+        // Unsigned: 0x8000000000000000 / 0xFFFFFFFFFFFFFFFF == 0
+        assert.eq(instance.exports.i64_div_u(), 0n);
+
+        // Unsigned: 0x80000000 % 0xFFFFFFFF == 0x80000000 (returned as signed: -2147483648)
+        assert.eq(instance.exports.i32_rem_u(), -2147483648);
+        // Unsigned: 0x8000000000000000 % 0xFFFFFFFFFFFFFFFF == 0x8000000000000000
+        assert.eq(instance.exports.i64_rem_u(), -9223372036854775808n);
+    }
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -2075,19 +2075,24 @@ void BBQJIT::recordJumpToThrowException(ExceptionType type, const JumpList& jump
     m_exceptions[static_cast<unsigned>(type)].append(jumps);
 }
 
-template<typename IntType>
+template<typename IntType, BBQJIT::ConstantDivOverflow overflow>
 Value BBQJIT::checkConstantDivision(const Value& lhs, const Value& rhs)
 {
     constexpr bool is32 = sizeof(IntType) == 4;
-    if (!(is32 ? int64_t(rhs.asI32()) : rhs.asI64())) {
+    int64_t lhsValue = is32 ? int64_t(lhs.asI32()) : lhs.asI64();
+    int64_t rhsValue = is32 ? int64_t(rhs.asI32()) : rhs.asI64();
+
+    if (!rhsValue) {
         emitThrowException(ExceptionType::DivisionByZero);
         return is32 ? Value::fromI32(1) : Value::fromI64(1);
     }
-    if ((is32 ? int64_t(rhs.asI32()) : rhs.asI64()) == -1
-        && (is32 ? int64_t(lhs.asI32()) : lhs.asI64()) == std::numeric_limits<IntType>::min()
-        && std::is_signed<IntType>()) {
-        emitThrowException(ExceptionType::IntegerOverflow);
-        return is32 ? Value::fromI32(1) : Value::fromI64(1);
+    if constexpr (std::is_signed_v<IntType>) {
+        if (lhsValue == std::numeric_limits<IntType>::min() && rhsValue == -1) {
+            if constexpr (overflow == ConstantDivOverflow::CanOverflow)
+                emitThrowException(ExceptionType::IntegerOverflow);
+            // Wasm rem_s(INT_MIN, -1) is defined to return 0; substitute divisor to avoid C++ UB.
+            return is32 ? Value::fromI32(1) : Value::fromI64(1);
+        }
     }
     return rhs;
 }
@@ -2098,7 +2103,7 @@ Value BBQJIT::checkConstantDivision(const Value& lhs, const Value& rhs)
     EMIT_BINARY(
         "I32DivS", TypeKind::I32,
         BLOCK(
-            Value::fromI32(lhs.asI32() / checkConstantDivision<int32_t>(lhs, rhs).asI32())
+            Value::fromI32(lhs.asI32() / checkConstantDivision<int32_t, ConstantDivOverflow::CanOverflow>(lhs, rhs).asI32())
         ),
         BLOCK(
             emitModOrDiv<int32_t, false>(lhs, lhsLocation, rhs, rhsLocation, result, resultLocation);
@@ -2115,7 +2120,7 @@ Value BBQJIT::checkConstantDivision(const Value& lhs, const Value& rhs)
     EMIT_BINARY(
         "I64DivS", TypeKind::I64,
         BLOCK(
-            Value::fromI64(lhs.asI64() / checkConstantDivision<int64_t>(lhs, rhs).asI64())
+            Value::fromI64(lhs.asI64() / checkConstantDivision<int64_t, ConstantDivOverflow::CanOverflow>(lhs, rhs).asI64())
         ),
         BLOCK(
             emitModOrDiv<int64_t, false>(lhs, lhsLocation, rhs, rhsLocation, result, resultLocation);
@@ -2132,7 +2137,7 @@ Value BBQJIT::checkConstantDivision(const Value& lhs, const Value& rhs)
     EMIT_BINARY(
         "I32DivU", TypeKind::I32,
         BLOCK(
-            Value::fromI32(static_cast<uint32_t>(lhs.asI32()) / static_cast<uint32_t>(checkConstantDivision<int32_t>(lhs, rhs).asI32()))
+            Value::fromI32(static_cast<uint32_t>(lhs.asI32()) / static_cast<uint32_t>(checkConstantDivision<uint32_t>(lhs, rhs).asI32()))
         ),
         BLOCK(
             emitModOrDiv<uint32_t, false>(lhs, lhsLocation, rhs, rhsLocation, result, resultLocation);
@@ -2149,7 +2154,7 @@ Value BBQJIT::checkConstantDivision(const Value& lhs, const Value& rhs)
     EMIT_BINARY(
         "I64DivU", TypeKind::I64,
         BLOCK(
-            Value::fromI64(static_cast<uint64_t>(lhs.asI64()) / static_cast<uint64_t>(checkConstantDivision<int64_t>(lhs, rhs).asI64()))
+            Value::fromI64(static_cast<uint64_t>(lhs.asI64()) / static_cast<uint64_t>(checkConstantDivision<uint64_t>(lhs, rhs).asI64()))
         ),
         BLOCK(
             emitModOrDiv<uint64_t, false>(lhs, lhsLocation, rhs, rhsLocation, result, resultLocation);
@@ -2200,7 +2205,7 @@ Value BBQJIT::checkConstantDivision(const Value& lhs, const Value& rhs)
     EMIT_BINARY(
         "I32RemU", TypeKind::I32,
         BLOCK(
-            Value::fromI32(static_cast<uint32_t>(lhs.asI32()) % static_cast<uint32_t>(checkConstantDivision<int32_t>(lhs, rhs).asI32()))
+            Value::fromI32(static_cast<uint32_t>(lhs.asI32()) % static_cast<uint32_t>(checkConstantDivision<uint32_t>(lhs, rhs).asI32()))
         ),
         BLOCK(
             emitModOrDiv<uint32_t, true>(lhs, lhsLocation, rhs, rhsLocation, result, resultLocation);
@@ -2217,7 +2222,7 @@ Value BBQJIT::checkConstantDivision(const Value& lhs, const Value& rhs)
     EMIT_BINARY(
         "I64RemU", TypeKind::I64,
         BLOCK(
-            Value::fromI64(static_cast<uint64_t>(lhs.asI64()) % static_cast<uint64_t>(checkConstantDivision<int64_t>(lhs, rhs).asI64()))
+            Value::fromI64(static_cast<uint64_t>(lhs.asI64()) % static_cast<uint64_t>(checkConstantDivision<uint64_t>(lhs, rhs).asI64()))
         ),
         BLOCK(
             emitModOrDiv<uint64_t, true>(lhs, lhsLocation, rhs, rhsLocation, result, resultLocation);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1649,7 +1649,10 @@ public:
     template<typename IntType, bool IsMod>
     void emitModOrDiv(Value& lhs, Location lhsLocation, Value& rhs, Location rhsLocation, Value& result, Location resultLocation);
 
-    template<typename IntType>
+    // signed INT_MIN / -1 is the only integer div/rem that can overflow.
+    enum class ConstantDivOverflow { CanOverflow, CannotOverflow };
+
+    template<typename IntType, ConstantDivOverflow = ConstantDivOverflow::CannotOverflow>
     Value checkConstantDivision(const Value& lhs, const Value& rhs);
 
     [[nodiscard]] PartialResult addI32DivS(Value lhs, Value rhs, Value& result);


### PR DESCRIPTION
#### 787be9470e19a8f703bc17d0e73ba7e7bb24d237
<pre>
Fix BBQ constant folding for integer div/rem with INT_MIN and -1
<a href="https://bugs.webkit.org/show_bug.cgi?id=312682">https://bugs.webkit.org/show_bug.cgi?id=312682</a>
<a href="https://rdar.apple.com/175122462">rdar://175122462</a>

Reviewed by Dan Hecht.

BBQ currently emits an integer overflow trap for integer div/rem
operations where the operands are INT_MIN and -1. This is only valid for
signed division since unsigned division and modulo cannot overflow. This
patch changes checkConstantDivision to no longer emit a trap in the
cases of unsigned div and all rem instructions.

Test: JSTests/wasm/stress/int-div-rem-constant-folding.js

* JSTests/wasm/stress/int-div-rem-constant-folding.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::checkConstantDivision):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32DivS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64DivS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32DivU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64DivU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32RemU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64RemU):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:

Canonical link: <a href="https://commits.webkit.org/311898@main">https://commits.webkit.org/311898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21bef74a94874f021cce36f5792c4e2b9e190eb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112138 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122400 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85929 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141959 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103069 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23743 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22055 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14656 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150106 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169373 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18890 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14727 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21374 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130574 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130689 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35446 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141545 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88972 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25420 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18351 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190184 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96161 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48825 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30149 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30379 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30276 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->