### PR TITLE
AX: Some places in accessibility traverse through VisiblePositions without checking progress was made, meaning we can loop forever

### DIFF
--- a/LayoutTests/accessibility/left-right-line-range-display-table-in-flex-expected.txt
+++ b/LayoutTests/accessibility/left-right-line-range-display-table-in-flex-expected.txt
@@ -1,0 +1,9 @@
+This test ensures that requesting a left or right line range for a text marker inside a display:table span within a flex container does not hang.
+
+PASS: did not hang.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+FOOO Inc
+FOOO:NYSE

--- a/LayoutTests/accessibility/left-right-line-range-display-table-in-flex.html
+++ b/LayoutTests/accessibility/left-right-line-range-display-table-in-flex.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+.container {
+    display: flex;
+    justify-content: space-between;
+}
+.container .title {
+    font-size: inherit;
+    margin: 0;
+}
+.container .name { display: table; }
+</style>
+</head>
+<body>
+
+<div class="container">
+    <h1 id="heading" class="title"><span class="name">FOOO Inc</span> <span class="exchange">FOOO:NYSE</span></h1>
+</div>
+
+<script>
+var output = "This test ensures that requesting a left or right line range for a text marker inside a display:table span within a flex container does not hang.\n\n";
+
+if (window.accessibilityController) {
+    var heading = accessibilityController.accessibleElementById("heading");
+    var range = heading.textMarkerRangeForElement(heading);
+    var start = heading.startTextMarkerForTextMarkerRange(range);
+    var end = heading.endTextMarkerForTextMarkerRange(range);
+
+    heading.leftLineTextMarkerRangeForTextMarker(start);
+    heading.leftLineTextMarkerRangeForTextMarker(end);
+    heading.rightLineTextMarkerRangeForTextMarker(start);
+    heading.rightLineTextMarkerRangeForTextMarker(end);
+    output += "PASS: did not hang.\n";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -977,6 +977,7 @@ accessibility/insert-text-into-password-field.html [ Skip ]
 accessibility/native-label-geometry-with-aria-labelledby.html [ Skip ]
 
 # These test a Cocoa-only API.
+accessibility/left-right-line-range-display-table-in-flex.html [ Skip ]
 accessibility/line-range-display-table-in-flex.html [ Skip ]
 accessibility/mixed-contenteditable-visible-character-range-hang.html [ Skip ]
 accessibility/mixed-contenteditable-double-br-visible-character-range-hang.html [ Skip ]

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -4347,6 +4347,11 @@ CharacterOffset AXObjectCache::characterOffsetFromVisiblePosition(const VisibleP
         // can return a previous position, resulting in us looping infinitely. Iterating solely through
         // |nextVisuallyDistinctCandidate|s should guarantee forward progress.
         currentPosition = nextVisuallyDistinctCandidate(currentPosition, SkipDisplayContents::No);
+        if (currentPosition == previousPosition) {
+            // |nextVisuallyDistinctCandidate|s should guarantee forward progress, so this should be unreachable.
+            AX_ASSERT_NOT_REACHED();
+            break;
+        }
         visiblePosition = VisiblePosition(currentPosition, visiblePosition.affinity());
 
         characterOffset++;
@@ -4960,8 +4965,14 @@ CharacterOffset AXObjectCache::characterOffsetForBounds(const IntRect& rect, boo
         if (rect.contains(absoluteCaretBoundsForCharacterOffset(previousCharOffset).center()))
             return previousCharOffset;
 
+        auto priorNextCharOffset = nextCharOffset;
+        auto priorPreviousCharOffset = previousCharOffset;
         nextCharOffset = nextCharacterOffset(nextCharOffset, false);
         previousCharOffset = previousCharacterOffset(previousCharOffset, false);
+        if (nextCharOffset.isEqual(priorNextCharOffset) && previousCharOffset.isEqual(priorPreviousCharOffset)) {
+            // Without this break, we would loop infinitely.
+            break;
+        }
     }
 
     return CharacterOffset();

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1747,8 +1747,10 @@ static VisiblePosition updateAXLineStartForVisiblePosition(const VisiblePosition
     VisiblePosition startPosition = visiblePosition;
     while (true) {
         tempPosition = startPosition.previous();
-        if (tempPosition.isNull())
+        if (tempPosition.isNull() || tempPosition == startPosition) {
+            // Without the tempPosition == startPosition check, we would loop infinitely.
             break;
+        }
         Position p = tempPosition.deepEquivalent();
         CheckedPtr renderer = p.deprecatedNode()->renderer();
         if (!renderer || (renderer->isRenderBlock() && !p.deprecatedEditingOffset()))
@@ -1780,7 +1782,12 @@ VisiblePositionRange AccessibilityObject::leftLineVisiblePositionRange(const Vis
     // This check will reposition the marker before the floating object, to ensure we get a line start.
     if (startPosition.isNull()) {
         while (startPosition.isNull() && prevVisiblePos.isNotNull()) {
+            auto previousPosition = prevVisiblePos;
             prevVisiblePos = prevVisiblePos.previous();
+            if (prevVisiblePos == previousPosition) {
+                // Without this break, we would loop infinitely.
+                break;
+            }
             startPosition = startOfLine(prevVisiblePos);
         }
     } else
@@ -1815,7 +1822,12 @@ VisiblePositionRange AccessibilityObject::rightLineVisiblePositionRange(const Vi
     // return null for position by a floating object, since floating object doesn't really belong to any line.
     // This check will reposition the marker after the floating object, to ensure we get a line end.
     while (endPosition.isNull() && nextVisiblePos.isNotNull()) {
+        auto previousPosition = nextVisiblePos;
         nextVisiblePos = nextVisiblePos.next();
+        if (nextVisiblePos == previousPosition) {
+            // Without this break, we would loop infinitely.
+            break;
+        }
         endPosition = endOfLine(nextVisiblePos);
     }
 


### PR DESCRIPTION
#### 57b2f8d4bbd70e2365abb9e3d96aadf525a20b86
<pre>
AX: Some places in accessibility traverse through VisiblePositions without checking progress was made, meaning we can loop forever
<a href="https://bugs.webkit.org/show_bug.cgi?id=312932">https://bugs.webkit.org/show_bug.cgi?id=312932</a>
<a href="https://rdar.apple.com/175280603">rdar://175280603</a>

Reviewed by Joshua Hoffman.

In 311153@main we fixed three while-loops in AccessibilityObject.cpp where
VisiblePosition::next() or previous() could return the same position, causing
an infinite loop and permanently hanging the main-thread. This change applies
the same defensive pattern to five additional loops that have the same vulnerability:

1. leftLineVisiblePositionRange: previous() loop without progress check
2. rightLineVisiblePositionRange: next() loop without progress check
3. updateAXLineStartForVisiblePosition: while(true) with previous() and no
 stuck-position guard
4. characterOffsetFromVisiblePosition: nextVisuallyDistinctCandidate loop
 with no guard despite comments acknowledging the risk
5. characterOffsetForBounds: bidirectional CharacterOffset iteration with no
 stuck-position check

* LayoutTests/accessibility/left-right-line-range-display-table-in-flex-expected.txt: Added.
* LayoutTests/accessibility/left-right-line-range-display-table-in-flex.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::characterOffsetFromVisiblePosition):
(WebCore::AXObjectCache::characterOffsetForBounds):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::updateAXLineStartForVisiblePosition):
(WebCore::AccessibilityObject::leftLineVisiblePositionRange const):
(WebCore::AccessibilityObject::rightLineVisiblePositionRange const):

Canonical link: <a href="https://commits.webkit.org/311749@main">https://commits.webkit.org/311749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3ff0effc2979cde602a96416c3430ac778fc4fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111884 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122194 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102863 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23530 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14397 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169115 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13850 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130362 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130479 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35354 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30823 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141300 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88671 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25228 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18106 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30375 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95182 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29896 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30126 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30023 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->