### PR TITLE
[CMake] Fix iOS CMake build for bmalloc

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -26,6 +26,7 @@ set(bmalloc_SOURCES
     bmalloc/Mutex.cpp
     bmalloc/TZoneHeap.cpp
     bmalloc/TZoneHeapManager.cpp
+    bmalloc/VMAllocate.cpp
     bmalloc/bmalloc.cpp
 
     libpas/src/libpas/bmalloc_heap.c
@@ -619,7 +620,7 @@ if (USE_MIMALLOC)
     )
 endif ()
 
-if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+if (APPLE)
     list(APPEND bmalloc_SOURCES
         bmalloc/TZoneLog.cpp
     )

--- a/Source/bmalloc/PlatformCocoa.cmake
+++ b/Source/bmalloc/PlatformCocoa.cmake
@@ -1,0 +1,14 @@
+list(APPEND bmalloc_PUBLIC_HEADERS
+    Configurations/module.modulemap
+)
+
+list(APPEND bmalloc_PRIVATE_DEFINITIONS PAS_BMALLOC_HIDDEN=1)
+
+list(APPEND bmalloc_SOURCES
+    bmalloc/ProcessCheck.mm
+)
+
+find_library(FOUNDATION_LIBRARY Foundation)
+list(APPEND bmalloc_LIBRARIES ${FOUNDATION_LIBRARY})
+
+target_compile_options(bmalloc PRIVATE -fno-threadsafe-statics)

--- a/Source/bmalloc/PlatformIOS.cmake
+++ b/Source/bmalloc/PlatformIOS.cmake
@@ -1,0 +1,11 @@
+include(PlatformCocoa.cmake)
+
+add_definitions(-DBPLATFORM_IOS=1)
+add_definitions(-DBPLATFORM_IOS_FAMILY=1)
+add_definitions(-DBPLATFORM_COCOA=1)
+
+add_definitions(-DPAS_PLATFORM_IOS=1)
+add_definitions(-DPAS_PLATFORM_IOS_FAMILY=1)
+add_definitions(-DPAS_PLATFORM_COCOA=1)
+
+list(APPEND bmalloc_COMPILE_OPTIONS $<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-O3>)

--- a/Source/bmalloc/PlatformMac.cmake
+++ b/Source/bmalloc/PlatformMac.cmake
@@ -1,16 +1,3 @@
+include(PlatformCocoa.cmake)
+
 add_definitions(-DBPLATFORM_MAC=1)
-
-list(APPEND bmalloc_PRIVATE_DEFINITIONS PAS_BMALLOC_HIDDEN=1)
-
-list(APPEND bmalloc_PUBLIC_HEADERS
-    Configurations/module.modulemap
-)
-
-list(APPEND bmalloc_SOURCES
-    bmalloc/ProcessCheck.mm
-)
-
-# ProcessCheck.mm uses Foundation (NSBundle, NSProcessInfo).
-# bmalloc is an OBJECT library so framework deps must be explicit.
-find_library(FOUNDATION_LIBRARY Foundation)
-list(APPEND bmalloc_LIBRARIES ${FOUNDATION_LIBRARY})


### PR DESCRIPTION
#### 557fcb31d1f14385e4c38d6afe3791a8b5eb9d36
<pre>
[CMake] Fix iOS CMake build for bmalloc
<a href="https://bugs.webkit.org/show_bug.cgi?id=312910">https://bugs.webkit.org/show_bug.cgi?id=312910</a>
&lt;<a href="https://rdar.apple.com/problem/175263649">rdar://problem/175263649</a>&gt;

Reviewed by BJ Burg and Yusuke Suzuki.

Add iOS platform configuration for bmalloc and extract shared Cocoa logic
into PlatformCocoa.cmake. The shared file contains ProcessCheck.mm,
Foundation framework linkage, and the module map header that both platforms
need. PlatformIOS.cmake adds BPLATFORM_IOS and PAS_PLATFORM_IOS definitions,
os_unfair_lock inline support on internal SDKs, and -O3 optimization.

* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/PlatformCocoa.cmake: Added.
* Source/bmalloc/PlatformIOS.cmake: Added.
* Source/bmalloc/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/312578@main">https://commits.webkit.org/312578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1a5298326611aa33bc9bf75a1c372cf93c5b184

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169322 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33892 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163377 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26627 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104980 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17041 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/152475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171800 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/21256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23502 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33566 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132660 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143657 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95332 "Built successfully") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24402 "Failed to push commit to Webkit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27262 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192818 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33060 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49652 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32560 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32804 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32708 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->