### PR TITLE
[CMake] Fix ANGLE for iOS CMake build

### DIFF
--- a/Source/ThirdParty/ANGLE/CMakeLists.txt
+++ b/Source/ThirdParty/ANGLE/CMakeLists.txt
@@ -1,10 +1,12 @@
 set_property(DIRECTORY . PROPERTY FOLDER "ANGLE")
 
 if (APPLE)
-    set(is_mac TRUE)
-    # GLESv2.cmake:131 (converted from ANGLE's gn) gates system_utils_{apple,posix,mac}.cpp on
-    # is_apple (gn's naming), but this shim only set is_mac. 25 undefined angle::* at link.
     set(is_apple TRUE)
+    if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
+        set(is_ios TRUE)
+    else ()
+        set(is_mac TRUE)
+    endif ()
 elseif (WIN32)
     set(is_win TRUE)
     set(angle_enable_d3d9 TRUE)

--- a/Source/ThirdParty/ANGLE/PlatformCocoa.cmake
+++ b/Source/ThirdParty/ANGLE/PlatformCocoa.cmake
@@ -1,0 +1,25 @@
+find_library(COREGRAPHICS_LIBRARY CoreGraphics)
+find_library(FOUNDATION_LIBRARY Foundation)
+find_library(IOSURFACE_LIBRARY IOSurface)
+find_library(METAL_LIBRARY Metal)
+find_package(ZLIB REQUIRED)
+
+list(APPEND ANGLE_SOURCES
+    ${metal_backend_sources}
+
+    ${angle_translator_lib_msl_sources}
+
+    ${libangle_mac_sources}
+    ${libangle_gpu_info_util_sources}
+)
+
+list(APPEND ANGLE_DEFINITIONS
+    ANGLE_ENABLE_METAL
+)
+
+list(APPEND ANGLEGLESv2_LIBRARIES
+    ${COREGRAPHICS_LIBRARY}
+    ${FOUNDATION_LIBRARY}
+    ${IOSURFACE_LIBRARY}
+    ${METAL_LIBRARY}
+)

--- a/Source/ThirdParty/ANGLE/PlatformIOS.cmake
+++ b/Source/ThirdParty/ANGLE/PlatformIOS.cmake
@@ -1,0 +1,18 @@
+include(PlatformCocoa.cmake)
+
+find_library(QUARTZCORE_LIBRARY QuartzCore)
+
+list(REMOVE_ITEM ANGLE_SOURCES
+    src/common/gl/cgl/FunctionsCGL.cpp
+    src/common/gl/cgl/FunctionsCGL.h
+    src/common/system_utils_mac.cpp
+)
+
+list(APPEND ANGLE_SOURCES
+    ${libangle_gpu_info_util_ios_sources}
+    src/libANGLE/renderer/driver_utils_ios.mm
+)
+
+list(APPEND ANGLEGLESv2_LIBRARIES
+    ${QUARTZCORE_LIBRARY}
+)

--- a/Source/ThirdParty/ANGLE/PlatformMac.cmake
+++ b/Source/ThirdParty/ANGLE/PlatformMac.cmake
@@ -1,30 +1,13 @@
-find_library(COREGRAPHICS_LIBRARY CoreGraphics)
-find_library(FOUNDATION_LIBRARY Foundation)
+include(PlatformCocoa.cmake)
+
 find_library(IOKIT_LIBRARY IOKit)
-find_library(IOSURFACE_LIBRARY IOSurface)
-find_library(METAL_LIBRARY Metal)
 find_library(QUARTZ_LIBRARY Quartz)
-find_package(ZLIB REQUIRED)
 
 list(APPEND ANGLE_SOURCES
-    ${metal_backend_sources}
-
-    ${angle_translator_lib_msl_sources}
-
     ${libangle_gpu_info_util_mac_sources}
-    ${libangle_gpu_info_util_sources}
-    ${libangle_mac_sources}
-)
-
-list(APPEND ANGLE_DEFINITIONS
-    ANGLE_ENABLE_METAL
 )
 
 list(APPEND ANGLEGLESv2_LIBRARIES
-    ${COREGRAPHICS_LIBRARY}
-    ${FOUNDATION_LIBRARY}
     ${IOKIT_LIBRARY}
-    ${IOSURFACE_LIBRARY}
-    ${METAL_LIBRARY}
     ${QUARTZ_LIBRARY}
 )


### PR DESCRIPTION
#### 6aaadbd23fbe7e3d6b9f687f9c26ce18755d1ce3
<pre>
[CMake] Fix ANGLE for iOS CMake build
<a href="https://bugs.webkit.org/show_bug.cgi?id=312913">https://bugs.webkit.org/show_bug.cgi?id=312913</a>
&lt;<a href="https://rdar.apple.com/problem/175263596">rdar://problem/175263596</a>&gt;

Reviewed by BJ Burg.

Add iOS platform configuration for ANGLE and extract shared Cocoa logic into
PlatformCocoa.cmake. The shared file contains Metal backend sources, MSL
translator sources, and CoreGraphics/Foundation/IOSurface/Metal framework
linkage common to both platforms. PlatformIOS.cmake adds QuartzCore linkage,
iOS GPU info utilities, and driver_utils_ios.mm. PlatformMac.cmake retains
IOKit/Quartz linkage and Mac GPU info utilities.

* Source/ThirdParty/ANGLE/CMakeLists.txt:
* Source/ThirdParty/ANGLE/PlatformCocoa.cmake: Added.
* Source/ThirdParty/ANGLE/PlatformIOS.cmake: Added.
* Source/ThirdParty/ANGLE/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/312571@main">https://commits.webkit.org/312571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/877522361e9b929895842fe55d9e4e2914f005aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169325 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e72651cd-2c9c-4ec1-8adc-ec3931dea348) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33895 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163380 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104983 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2793f5b-9eb0-4a53-a419-f8b514eae783) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17044 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171803 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33569 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132664 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143653 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24405 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27263 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33063 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32563 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32807 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32711 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->