### PR TITLE
[Site Isolation] Web Inspector: Fix Runtime layout tests for cross-origin frame targets

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe-expected.txt
@@ -1,11 +1,11 @@
 Test that Runtime.evaluate and callFunctionOn work correctly in cross-origin iframes under site isolation.
 
 
+
 == Running test suite: SiteIsolation.Runtime.CrossOriginEvaluate
 -- Running test case: SiteIsolation.Runtime.CrossOrigin.FrameTargetCreated
-PASS: Added target should have Frame type.
 PASS: Cross-origin frame target should have a RuntimeAgent.
-PASS: Cross-origin frame target should eventually have an ExecutionContext.
+PASS: Cross-origin frame target should have an ExecutionContext.
 
 -- Running test case: SiteIsolation.Runtime.CrossOrigin.EvaluatePassphrase
 PASS: Cross-origin frame should have passphrase 'cross-origin-secret'.
@@ -22,7 +22,4 @@ PASS: Creating object in cross-origin frame should not throw.
 PASS: Created object should have an objectId.
 PASS: callFunctionOn should return the object's key value.
 PASS: callFunctionOn should not throw.
-
--- Running test case: SiteIsolation.Runtime.CrossOrigin.RemoveIframe
-PASS: Removed target should have Frame type.
 

--- a/LayoutTests/http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe.html
@@ -4,39 +4,23 @@
 <script>
     var passphrase = "main-page-value";
 
-    let iframe;
-
-    function addCrossOriginIFrame() {
-        let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
-        iframe = document.createElement("iframe");
-        iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/runtime/resources/frame-with-passphrase.html`;
-        document.body.appendChild(iframe);
-    }
-
-    function removeCrossOriginIFrame() {
-        iframe.remove();
-    }
-
     function test() {
         let suite = InspectorTest.createAsyncSuite("SiteIsolation.Runtime.CrossOriginEvaluate");
 
+        let crossOriginTarget;
+
         suite.addTestCase({
             name: "SiteIsolation.Runtime.CrossOrigin.FrameTargetCreated",
-            description: "Adding a cross-origin iframe should create a frame target with an execution context.",
+            description: "The static cross-origin iframe should have a frame target with an execution context.",
             async test() {
-                let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
-                InspectorTest.evaluateInPage("addCrossOriginIFrame()");
-                let event = await targetAddedPromise;
-                let target = event.data.target;
+                let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+                let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+                let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+                crossOriginTarget = frameTargets.find((t) => t !== mainFrameTarget);
 
-                InspectorTest.assert(target instanceof WI.FrameTarget);
-                InspectorTest.expectEqual(target.type, WI.TargetType.Frame, "Added target should have Frame type.");
-                InspectorTest.expectNotNull(target.RuntimeAgent, "Cross-origin frame target should have a RuntimeAgent.");
-
-                // The execution context arrives asynchronously after the target is added.
-                if (!target.executionContext)
-                    await target.awaitEvent(WI.FrameTarget.Event.PageExecutionContextChanged);
-                InspectorTest.expectNotNull(target.executionContext, "Cross-origin frame target should eventually have an ExecutionContext.");
+                InspectorTest.assert(crossOriginTarget instanceof WI.FrameTarget);
+                InspectorTest.expectNotNull(crossOriginTarget.RuntimeAgent, "Cross-origin frame target should have a RuntimeAgent.");
+                InspectorTest.expectNotNull(crossOriginTarget.executionContext, "Cross-origin frame target should have an ExecutionContext.");
             }
         });
 
@@ -44,9 +28,6 @@
             name: "SiteIsolation.Runtime.CrossOrigin.EvaluatePassphrase",
             description: "Evaluating in the cross-origin frame should return values from that frame's context.",
             async test() {
-                let frameTargets = WI.targets.filter((t) => t instanceof WI.FrameTarget);
-                let crossOriginTarget = frameTargets[frameTargets.length - 1];
-
                 let passphraseValue = await waitForExpressionInTarget(crossOriginTarget, "window.passphrase");
                 InspectorTest.expectEqual(passphraseValue, "cross-origin-secret", "Cross-origin frame should have passphrase 'cross-origin-secret'.");
 
@@ -61,9 +42,6 @@
             name: "SiteIsolation.Runtime.CrossOrigin.EvaluateHostname",
             description: "Evaluating document.location.hostname should return the cross-origin hostname.",
             async test() {
-                let frameTargets = WI.targets.filter((t) => t instanceof WI.FrameTarget);
-                let crossOriginTarget = frameTargets[frameTargets.length - 1];
-
                 let frameHostname = await waitForExpressionInTarget(crossOriginTarget, "document.location.hostname");
                 let pageResponse = await WI.pageTarget.RuntimeAgent.evaluate.invoke({ expression: "document.location.hostname", objectGroup: "test", returnByValue: true });
 
@@ -77,9 +55,6 @@
             name: "SiteIsolation.Runtime.CrossOrigin.CallFunctionOn",
             description: "callFunctionOn should work with objects created in the cross-origin frame's context.",
             async test() {
-                let frameTargets = WI.targets.filter((t) => t instanceof WI.FrameTarget);
-                let crossOriginTarget = frameTargets[frameTargets.length - 1];
-
                 let createResponse = await crossOriginTarget.RuntimeAgent.evaluate.invoke({ expression: "({key: 'from-cross-origin'})", objectGroup: "test" });
                 InspectorTest.expectThat(!createResponse.wasThrown, "Creating object in cross-origin frame should not throw.");
                 InspectorTest.expectNotNull(createResponse.result.objectId, "Created object should have an objectId.");
@@ -94,24 +69,11 @@
             }
         });
 
-        suite.addTestCase({
-            name: "SiteIsolation.Runtime.CrossOrigin.RemoveIframe",
-            description: "Removing the cross-origin iframe should remove the frame target.",
-            async test() {
-                let targetRemovedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetRemoved);
-                InspectorTest.evaluateInPage("removeCrossOriginIFrame()");
-                let event = await targetRemovedPromise;
-                let target = event.data.target;
-
-                InspectorTest.assert(target instanceof WI.FrameTarget);
-                InspectorTest.expectEqual(target.type, WI.TargetType.Frame, "Removed target should have Frame type.");
-            }
-        });
-
         suite.runTestCasesAndFinish();
     }
 </script>
 
 <body onload="runTest()">
     <p>Test that Runtime.evaluate and callFunctionOn work correctly in cross-origin iframes under site isolation.</p>
+    <iframe src="http://localhost:8000/site-isolation/inspector/runtime/resources/frame-with-passphrase.html"></iframe>
 </body>

--- a/LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target-expected.txt
@@ -1,9 +1,10 @@
 Test that Runtime.executionContextCreated events are correctly dispatched for frame targets under site isolation.
 
 
+
 == Running test suite: SiteIsolation.Runtime.ExecutionContextCreated
--- Running test case: SiteIsolation.Runtime.ExecutionContextCreated.OnFrameTargetAdded
-PASS: Should receive an ExecutionContext from the event.
+-- Running test case: SiteIsolation.Runtime.ExecutionContextCreated.StaticIframe
+PASS: Should have an ExecutionContext.
 PASS: ExecutionContext should have a positive numeric id.
 PASS: ExecutionContext should have a name string.
 ExecutionContext type: normal
@@ -19,4 +20,7 @@ PASS: Should have at least 2 frame targets (main frame + cross-origin iframe).
 PASS: Execution context id should be unique.
 PASS: Execution context id should be unique.
 PASS: Should have at least 2 unique context ids.
+
+-- Running test case: SiteIsolation.Runtime.ExecutionContextCreated.DynamicIframeReceivesContext
+PASS: Dynamically added cross-origin iframe should have an ExecutionContext.
 

--- a/LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html
@@ -1,4 +1,6 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
 <script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
 <script>
 function addCrossOriginIFrame() {
     let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
@@ -10,27 +12,19 @@ function addCrossOriginIFrame() {
 function test() {
     let suite = InspectorTest.createAsyncSuite("SiteIsolation.Runtime.ExecutionContextCreated");
 
+    let crossOriginTarget;
+
     suite.addTestCase({
-        name: "SiteIsolation.Runtime.ExecutionContextCreated.OnFrameTargetAdded",
-        description: "A new frame target should receive an executionContextCreated event with correct structure.",
+        name: "SiteIsolation.Runtime.ExecutionContextCreated.StaticIframe",
+        description: "The static cross-origin iframe's frame target should have an execution context with correct structure.",
         async test() {
-            let contextPromise = new Promise((resolve) => {
-                WI.targetManager.singleFireEventListener(WI.TargetManager.Event.TargetAdded, (targetEvent) => {
-                    let target = targetEvent.data.target;
-                    if (!(target instanceof WI.FrameTarget))
-                        return;
+            let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+            let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+            let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+            crossOriginTarget = frameTargets.find((t) => t !== mainFrameTarget);
 
-                    target.singleFireEventListener(WI.FrameTarget.Event.ExecutionContextAdded, (contextEvent) => {
-                        resolve({target, context: contextEvent.data.context});
-                    });
-                });
-            });
-
-            InspectorTest.evaluateInPage("addCrossOriginIFrame()");
-
-            let {target, context} = await contextPromise;
-
-            InspectorTest.expectNotNull(context, "Should receive an ExecutionContext from the event.");
+            let context = crossOriginTarget.executionContext;
+            InspectorTest.expectNotNull(context, "Should have an ExecutionContext.");
             InspectorTest.expectThat(typeof context.id === "number" && context.id > 0, "ExecutionContext should have a positive numeric id.");
             InspectorTest.expectThat(typeof context.name === "string", "ExecutionContext should have a name string.");
             InspectorTest.log(`ExecutionContext type: ${String(context.type)}`);
@@ -39,12 +33,8 @@ function test() {
 
     suite.addTestCase({
         name: "SiteIsolation.Runtime.ExecutionContextCreated.ContextIsUsable",
-        description: "The execution context from the event should be usable for evaluation.",
+        description: "The execution context should be usable for evaluation.",
         async test() {
-            let frameTargets = WI.targets.filter((t) => t instanceof WI.FrameTarget);
-            let crossOriginTarget = frameTargets[frameTargets.length - 1];
-            InspectorTest.assert(crossOriginTarget, "Should have a cross-origin frame target.");
-
             InspectorTest.expectNotNull(crossOriginTarget.executionContext, "Frame target should have a page execution context.");
 
             let response = await crossOriginTarget.RuntimeAgent.evaluate.invoke({
@@ -79,10 +69,27 @@ function test() {
         }
     });
 
+    suite.addTestCase({
+        name: "SiteIsolation.Runtime.ExecutionContextCreated.DynamicIframeReceivesContext",
+        description: "A dynamically added cross-origin iframe should also receive an execution context.",
+        async test() {
+            let committedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+            InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+            let event = await committedPromise;
+            let dynamicTarget = event.data.target;
+
+            InspectorTest.assert(dynamicTarget instanceof WI.FrameTarget);
+            if (!dynamicTarget.executionContext)
+                await dynamicTarget.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded);
+            InspectorTest.expectNotNull(dynamicTarget.executionContext, "Dynamically added cross-origin iframe should have an ExecutionContext.");
+        }
+    });
+
     suite.runTestCasesAndFinish();
 }
 </script>
 
 <body onload="runTest()">
 <p>Test that Runtime.executionContextCreated events are correctly dispatched for frame targets under site isolation.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/runtime/resources/frame-with-passphrase.html"></iframe>
 </body>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2413,6 +2413,9 @@ webkit.org/b/307889 http/tests/multipart/multipart-async-image.html [ Pass Failu
 webkit.org/b/310302 imported/w3c/web-platform-tests/uievents/mouse/mouse_boundary_events_on_image_map.html [ Pass Failure ]
 
 # FIXME <https://webkit.org/b/311136>: Additional work needed to pass these tests
+http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Skip ]
+http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Skip ]
+http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Skip ]
 http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe.html [ Failure Crash ]
 http/tests/site-isolation/inspector/runtime/execution-context-from-frame-target.html [ Failure ]
 http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html [ Failure ]


### PR DESCRIPTION
#### 79442d49cf75d2d5e5b6325e3af7cb98da990684
<pre>
[Site Isolation] Web Inspector: Fix Runtime layout tests for cross-origin frame targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=311136">https://bugs.webkit.org/show_bug.cgi?id=311136</a>
<a href="https://rdar.apple.com/173722617">rdar://173722617</a>

Reviewed by Qianlang Chen.

These tests were failing because they dynamically created cross-origin
iframes and used TargetAdded to acquire the frame target. Under site
isolation, this resolved with the initial about:blank target instead
of the committed cross-origin target. The about:blank target never
receives an execution context since reportExecutionContextCreation()
skips the initial empty document.

Also fixed evaluate-in-cross-origin-iframe.html which referenced
WI.FrameTarget.Event.PageExecutionContextChanged — an event that
only exists on WI.Frame, not WI.FrameTarget, causing awaitEvent to
wait on undefined and time out.

Switched to static cross-origin iframes declared in the test HTML.
By the time onload fires, the provisional target lifecycle has
completed and the committed frame target is already available with
its execution context set. Uses fetchDocumentURLsForTargets to
identify the cross-origin target.

* LayoutTests/http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe.html:
* LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/311959@main">https://commits.webkit.org/311959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7764847832793cdca9839bd1357e6f8cce4403c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112415 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122627 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86066 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103311 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23943 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22321 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14933 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169652 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130812 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130926 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35479 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141792 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89269 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25624 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18598 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30905 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30425 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30698 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30579 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->