### PR TITLE
[Site Isolation] Fix http/tests/security/XFrameOptions/x-frame-options-ancestors-same-origin-deny.html

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -199,7 +199,6 @@ http/tests/resourceLoadStatistics/exemptDomains/managed-domains-cookieEnabled.ht
 http/tests/resourceLoadStatistics/exemptDomains/third-party-cookie-blocking.html [ Failure ]
 http/tests/resourceLoadStatistics/omit-document-referrer-nested-third-party-iframe-ephemeral.html [ Failure ]
 http/tests/resourceLoadStatistics/omit-document-referrer-third-party-iframe-ephemeral.html [ Failure ]
-http/tests/security/XFrameOptions/x-frame-options-ancestors-same-origin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-multiple-headers-sameorigin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-parent-same-origin-deny.html [ Failure ]
 http/tests/security/allow-top-level-navigations-by-third-party-iframes-with-previous-user-activation.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -210,7 +210,6 @@ http/tests/privateClickMeasurement/store-private-click-measurement-nested.html [
 http/tests/resourceLoadStatistics/omit-document-referrer-nested-third-party-iframe-ephemeral.html [ Failure ]
 http/tests/resourceLoadStatistics/omit-document-referrer-third-party-iframe-ephemeral.html [ Failure ]
 http/tests/resourceLoadStatistics/user-interaction-in-cross-origin-sub-frame.html [ Failure ]
-http/tests/security/XFrameOptions/x-frame-options-ancestors-same-origin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-multiple-headers-sameorigin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-parent-same-origin-deny.html [ Failure ]
 http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Pass ]

--- a/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
@@ -47,22 +47,19 @@ void printErrorMessageForFrame(LocalFrame* frame, const String& message)
     frame->document()->window()->printErrorMessage(message);
 }
 
-// FIXME: Refactor to share code with LocalDOMWindow::crossDomainAccessErrorMessage.
-static String remoteFrameAccessError(JSC::JSGlobalObject* lexicalGlobalObject)
+static String remoteFrameAccessError(JSC::JSGlobalObject* lexicalGlobalObject, DOMWindow& targetWindow)
 {
-    RefPtr remoteWindow = dynamicDowncast<RemoteDOMWindow>(asJSDOMWindow(lexicalGlobalObject)->wrapped());
-    Ref activeOrigin = remoteWindow ? remoteWindow->frame()->frameDocumentSecurityOriginOrOpaque() : activeDOMWindow(*lexicalGlobalObject).document()->securityOrigin();
-    return makeString("Blocked a frame with origin \""_s, activeOrigin->toString(), "\" from accessing a cross-origin frame. Protocols, domains, and ports must match."_s);
+    return targetWindow.crossDomainAccessErrorMessage(activeDOMWindow(*lexicalGlobalObject), IncludeTargetOrigin::No);
 }
 
 // FIXME: Refactor to share more code with canAccessDocument.
-static void reportErrorAccessingRemoteFrame(JSC::JSGlobalObject* lexicalGlobalObject, SecurityReportingOption reportingOption)
+static void reportErrorAccessingRemoteFrame(JSC::JSGlobalObject* lexicalGlobalObject, DOMWindow& targetWindow, SecurityReportingOption reportingOption)
 {
     switch (reportingOption) {
     case ThrowSecurityError: {
         VM& vm = lexicalGlobalObject->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
-        throwSecurityError(*lexicalGlobalObject, scope, remoteFrameAccessError(lexicalGlobalObject));
+        throwSecurityError(*lexicalGlobalObject, scope, remoteFrameAccessError(lexicalGlobalObject, targetWindow));
         break;
     }
     case LogSecurityError:
@@ -156,7 +153,7 @@ bool BindingSecurity::shouldAllowAccessToDOMWindow(JSC::JSGlobalObject* lexicalG
 {
     auto* localWindow = dynamicDowncast<LocalDOMWindow>(window);
     if (window && !localWindow) {
-        reportErrorAccessingRemoteFrame(lexicalGlobalObject, reportingOption);
+        reportErrorAccessingRemoteFrame(lexicalGlobalObject, *window, reportingOption);
         return false;
     }
     return shouldAllowAccessToDOMWindow(lexicalGlobalObject, localWindow, reportingOption);
@@ -166,7 +163,7 @@ bool BindingSecurity::shouldAllowAccessToDOMWindow(JSC::JSGlobalObject& lexicalG
 {
     auto* localWindow = dynamicDowncast<LocalDOMWindow>(window);
     if (window && !localWindow) {
-        message = remoteFrameAccessError(&lexicalGlobalObject);
+        message = remoteFrameAccessError(&lexicalGlobalObject, *window);
         return false;
     }
     return shouldAllowAccessToDOMWindow(lexicalGlobalObject, localWindow, message);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8386,6 +8386,20 @@ void Document::inheritPolicyContainerFrom(const PolicyContainer& policyContainer
     SecurityContext::inheritPolicyContainerFrom(policyContainer);
 }
 
+void Document::enforceSandboxFlags(SandboxFlags flags, SandboxFlagsSource source)
+{
+    bool wasSandboxedOrigin = isSandboxed(SandboxFlag::Origin);
+    SecurityContext::enforceSandboxFlags(flags, source);
+
+    if (m_frame && settings().siteIsolationEnabled()) {
+        bool sandboxedStateDidChange = wasSandboxedOrigin != isSandboxed(SandboxFlag::Origin);
+        if (!sandboxedStateDidChange)
+            return;
+
+        m_frame->loader().client().broadcastFrameDocumentIsSandboxedOriginToOtherProcesses(isSandboxed(SandboxFlag::Origin));
+    }
+}
+
 // https://html.spec.whatwg.org/#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name (Step 8.2)
 bool Document::shouldForceNoOpenerBasedOnCOOP() const
 {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1423,6 +1423,7 @@ public:
     void initContentSecurityPolicy();
 
     void inheritPolicyContainerFrom(const PolicyContainer&) final;
+    void enforceSandboxFlags(SandboxFlags, SandboxFlagsSource = SandboxFlagsSource::Other) final;
 
     void updateURLForPushOrReplaceState(const URL&);
     void statePopped(Ref<SerializedScriptValue>&&);

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -58,7 +58,7 @@ public:
     bool isSecureTransitionTo(const URL&) const;
 
     enum class SandboxFlagsSource : bool { CSP, Other };
-    void enforceSandboxFlags(SandboxFlags, SandboxFlagsSource = SandboxFlagsSource::Other);
+    virtual void enforceSandboxFlags(SandboxFlags, SandboxFlagsSource = SandboxFlagsSource::Other);
 
     bool isSandboxed(SandboxFlag flag) const { return m_sandboxFlags.contains(flag); }
 

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -977,17 +977,17 @@ String DOMWindow::crossDomainAccessErrorMessage(const LocalDOMWindow& activeWind
     URL activeURL = activeWindow.document()->url();
     RefPtr<const SecurityOrigin> remoteFrameSecurityOrigin = (m_type == DOMWindowType::Remote) ? remoteFrame->frameDocumentSecurityOriginOrOpaque() : RefPtr<const SecurityOrigin>();
     URL targetURL = localDocument ? localDocument->url() : remoteFrameSecurityOrigin->toURL();
-    bool localSandboxed = (localDocument && localDocument->isSandboxed(SandboxFlag::Origin));
+    bool targetSandboxed = localDocument ? localDocument->isSandboxed(SandboxFlag::Origin) : (remoteFrame && remoteFrame->frameDocumentIsSandboxedOrigin());
 
-    if (localSandboxed || activeWindow.document()->isSandboxed(SandboxFlag::Origin)) {
+    if (targetSandboxed || activeWindow.document()->isSandboxed(SandboxFlag::Origin)) {
         if (includeTargetOrigin == IncludeTargetOrigin::Yes)
             message = makeString("Blocked a frame at \""_s, SecurityOrigin::create(activeURL).get().toString(), "\" from accessing a frame at \""_s, SecurityOrigin::create(targetURL).get().toString(), "\". "_s);
         else
             message = makeString("Blocked a frame at \""_s, SecurityOrigin::create(activeURL).get().toString(), "\" from accessing a cross-origin frame. "_s);
 
-        if (localSandboxed && activeWindow.document()->isSandboxed(SandboxFlag::Origin))
+        if (targetSandboxed && activeWindow.document()->isSandboxed(SandboxFlag::Origin))
             return makeString("Sandbox access violation: "_s, message, " Both frames are sandboxed and lack the \"allow-same-origin\" flag."_s);
-        if (localSandboxed)
+        if (targetSandboxed)
             return makeString("Sandbox access violation: "_s, message, " The frame being accessed is sandboxed and lacks the \"allow-same-origin\" flag."_s);
         return makeString("Sandbox access violation: "_s, message, " The frame requesting access is sandboxed and lacks the \"allow-same-origin\" flag."_s);
     }

--- a/Source/WebCore/page/FrameTreeSyncData.in
+++ b/Source/WebCore/page/FrameTreeSyncData.in
@@ -29,6 +29,7 @@
 FrameCanCreatePaymentSession : bool
 FrameDocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [Headers=<WebCore/SecurityOrigin.h>]
 FrameDocumentSecurityPolicy : std::optional<WebCore::DocumentSecurityPolicy> [Headers=<WebCore/DocumentSecurityPolicy.h>]
+FrameDocumentIsSandboxedOrigin : bool
 FrameURLProtocol : String [Headers=<wtf/text/WTFString.h>]
 FrameRect : WebCore::IntRect [Headers=<WebCore/IntRect.h>]
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -208,6 +208,11 @@ std::optional<DocumentSecurityPolicy> RemoteFrame::frameDocumentSecurityPolicy()
     return frameTreeSyncData().frameDocumentSecurityPolicy;
 }
 
+bool RemoteFrame::frameDocumentIsSandboxedOrigin() const
+{
+    return frameTreeSyncData().frameDocumentIsSandboxedOrigin;
+}
+
 String RemoteFrame::frameURLProtocol() const
 {
     return frameTreeSyncData().frameURLProtocol;

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -96,6 +96,7 @@ public:
 
     String debugDescription() const final;
     const SecurityOrigin& frameDocumentSecurityOriginOrOpaque() const;
+    bool frameDocumentIsSandboxedOrigin() const;
 
 private:
     WEBCORE_EXPORT explicit RemoteFrame(Page&, ClientCreator&&, FrameIdentifier, HTMLFrameOwnerElement*, Frame* parent, Markable<LayerHostingContextIdentifier>, Frame* opener, Ref<FrameTreeSyncData>&&, AddToFrameTree = AddToFrameTree::Yes);

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -747,7 +747,7 @@ Ref<FrameTreeSyncData> WebFrameProxy::calculateFrameTreeSyncData() const
     bool isSecureForPaymentSession = false;
 #endif
 
-    return FrameTreeSyncData::create(isSecureForPaymentSession, securityOrigin(), m_documentSecurityPolicy, url().protocol().toString(), IntRect { }, LayoutRect { }, HashMap<FrameIdentifier, RemoteFrameLayoutInfo> { });
+    return FrameTreeSyncData::create(isSecureForPaymentSession, securityOrigin(), m_documentSecurityPolicy, m_effectiveSandboxFlags.contains(WebCore::SandboxFlag::Origin), url().protocol().toString(), IntRect { }, LayoutRect { }, HashMap<FrameIdentifier, RemoteFrameLayoutInfo> { });
 }
 
 Ref<SecurityOrigin> WebFrameProxy::securityOrigin() const


### PR DESCRIPTION
#### cbe41ae4841f2bb4621cf826de137e51664e3f02
<pre>
[Site Isolation] Fix http/tests/security/XFrameOptions/x-frame-options-ancestors-same-origin-deny.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=312937">https://bugs.webkit.org/show_bug.cgi?id=312937</a>
<a href="https://rdar.apple.com/175291706">rdar://175291706</a>

Reviewed by Sihui Liu.

When a cross-origin subframe is blocked by X-Frame-Options with site isolation,
the SecurityError changed from a sandbox-specific message to a generic
cross-origin error.

When X-Frame-Options blocks a load, DocumentLoader::loadErrorDocument()
replaces the frame&apos;s content with an empty document and calls
enforceSandboxFlags(SandboxFlag::Origin). This makes the document&apos;s security
origin opaque so it can&apos;t match any other origin.
Without site isolation, when JavaScript tries to access the blocked frame&apos;s
contentWindow, the security check sees the sandboxed document and produces:
&quot;Sandbox access violation: ...The frame being accessed is sandboxed and lacks
the &apos;allow-same-origin&apos; flag.&quot;

This patch adds FrameDocumentIsSandboxedOrigin to FrameTreeSyncData.in
so allow-same-origin sandbox state syncs across processes.
The origin sandbox state is broadcasted to other processes
from a new function, Document::enforceSandboxFlags,
which overrides SecurityContext::enforceSandboxFlags.
I chose to synchronize the sandbox origin state here since
enforceSandboxFlags is called from the following call sites:
1. when a document is sandboxed via the &quot;sandbox&quot; HTML attribute
        (from Document::initSecurityContext),
2. when a load is blocked by X-Frame-Options headers (this test)
        (from DocumentLoader::loadErrorDocument)
3. when CSP headers update the sandbox state
        (from ContentSecurityPolicy::applyPolicyToScriptExecutionContext
        which calls enforceSandboxFlags on a ScriptExecutionContext which
        is guarded by is&lt;Document&gt; so it ends up at Document::enforceSandboxFlags)

This patch updates DOMWindow::crossDomainAccessErrorMessage to check
RemoteFrame::frameDocumentIsSandboxedOrigin(), which produces the
sandbox-specific message for both Local and Remote frames.

This patch also updates JSDOMBindingSecurity::remoteFrameAccessError
to share code with DOMWindow::crossDomainAccessErrorMessage
to avoid duplicating the sandbox checks.

This patch fixes http/tests/security/XFrameOptions/x-frame-options-ancestors-same-origin-deny.html

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp:
(WebCore::remoteFrameAccessError):
(WebCore::reportErrorAccessingRemoteFrame):
(WebCore::BindingSecurity::shouldAllowAccessToDOMWindow):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::enforceSandboxFlags):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/SecurityContext.h:
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::crossDomainAccessErrorMessage):
* Source/WebCore/page/FrameTreeSyncData.in:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::frameDocumentIsSandboxedOrigin const):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::calculateFrameTreeSyncData const):

Canonical link: <a href="https://commits.webkit.org/313507@main">https://commits.webkit.org/313507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a37e05c4da8fc2ea33fe1226b9bac5923a00299

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171763 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119271 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126393 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89013 "17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146315 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106970 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27787 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26319 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19463 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174267 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21790 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134707 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134702 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98380 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24855 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29232 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22676 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103509 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34970 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/699 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35215 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->