### PR TITLE
Log warning messages to the console if a page with a responsive meta viewport scrolls horizontally

### DIFF
--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: This page has a responsive meta viewport tag. The page content is wider than the viewport but resizing causes the page overflow to be worse.
 This test verifies that the shrink-to-fit-content heuristic doesn't induce more horizontal scrolling than we would otherwise have. To run the test manually, load the page and check that the bar almost entirely fits within the viewport, with no more than 480px of horizontal scrolling (on a 320px-wide device) and 20px of scrolling (on a 810px-wide device).
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow-expected.txt
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: This page has a responsive meta viewport tag. The page content is wider than the viewport. The page will be scaled to fit.
 This test verifies that the shrink-to-fit-content heuristic prevents horizontal scrolling by shrinking the page, even when a page specifies a responsive viewport. To run the test manually, load the page and check that the bar entirely fits within the viewport, and the page is not horizontally scrollable.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7773,6 +7773,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
     frame->setFirstLayerTreeTransactionIDAfterDidCommitLoad(firstTransactionIDAfterDidCommitLoad);
     cancelPotentialTapInFrame(*frame);
 #endif
+
     resetFocusedElementForFrame(frame);
 
     if (frame->isMainFrame())
@@ -7782,6 +7783,10 @@ void WebPage::didCommitLoad(WebFrame* frame)
 
     if (!frame->isRootFrame())
         return;
+
+#if ENABLE(VIEWPORT_RESIZING)
+    m_lastShrinkToFitLayoutWidth = 0;
+#endif
 
     if (RefPtr drawingArea = m_drawingArea)
         drawingArea->sendEnterAcceleratedCompositingModeIfNeeded();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2788,6 +2788,10 @@ private:
     String m_userAgent;
     bool m_hasCustomUserAgent { false };
 
+#if ENABLE(VIEWPORT_RESIZING)
+    int m_lastShrinkToFitLayoutWidth { 0 };
+#endif
+
 #if ENABLE(TILED_CA_DRAWING_AREA)
     DrawingAreaType m_drawingAreaType;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3350,12 +3350,23 @@ void WebPage::shrinkToFitContent(ZoomToInitialScale zoomToInitialScale)
 
     m_viewportConfiguration.setIsKnownToLayOutWiderThanViewport(true);
     double originalMinimumDeviceWidth = m_viewportConfiguration.minimumEffectiveDeviceWidth();
-    if (changeMinimumEffectiveDeviceWidth(std::min(maximumExpandedLayoutWidth, originalContentWidth)) && view->contentsWidth() - scaledViewWidth() > originalHorizontalOverflowAmount) {
-        changeMinimumEffectiveDeviceWidth(originalMinimumDeviceWidth);
-        m_viewportConfiguration.setIsKnownToLayOutWiderThanViewport(false);
+
+    bool didChangeMinimumEffectiveDeviceWidth = changeMinimumEffectiveDeviceWidth(std::min(maximumExpandedLayoutWidth, originalContentWidth));
+
+    if (didChangeMinimumEffectiveDeviceWidth) {
+        bool hasResponsiveMetaViewportTag = m_viewportConfiguration.viewportArguments().widthWasExplicit && m_viewportConfiguration.viewportArguments().width == ViewportArguments::ValueDeviceWidth;
+
+        if (view->contentsWidth() - scaledViewWidth() > originalHorizontalOverflowAmount) {
+            changeMinimumEffectiveDeviceWidth(originalMinimumDeviceWidth);
+            m_viewportConfiguration.setIsKnownToLayOutWiderThanViewport(false);
+            if (hasResponsiveMetaViewportTag && m_viewportConfiguration.layoutWidth() != m_lastShrinkToFitLayoutWidth)
+                mainDocument->addConsoleMessage(MessageSource::Rendering, MessageLevel::Warning, "This page has a responsive meta viewport tag. The page content is wider than the viewport but resizing causes the page overflow to be worse."_s);
+        } else if (hasResponsiveMetaViewportTag && m_viewportConfiguration.layoutWidth() != m_lastShrinkToFitLayoutWidth)
+            mainDocument->addConsoleMessage(MessageSource::Rendering, MessageLevel::Warning, "This page has a responsive meta viewport tag. The page content is wider than the viewport. The page will be scaled to fit."_s);
     }
 
-    // FIXME (197429): Consider additionally logging an error message to the console if a responsive meta viewport tag was used.
+    m_lastShrinkToFitLayoutWidth = m_viewportConfiguration.layoutWidth();
+
     RELEASE_LOG(ViewportSizing, "Shrink-to-fit: content width %d => %d; layout width %d => %d", originalContentWidth, view->contentsWidth(), originalLayoutWidth, m_viewportConfiguration.layoutWidth());
     viewportConfigurationChanged(zoomToInitialScale);
 }


### PR DESCRIPTION
#### 14fb97b18b24bfafb8ca4e01ef2f0a76aec8e006
<pre>
Log warning messages to the console if a page with a responsive meta viewport scrolls horizontally
<a href="https://bugs.webkit.org/show_bug.cgi?id=197429">https://bugs.webkit.org/show_bug.cgi?id=197429</a>
<a href="https://rdar.apple.com/175292678">rdar://175292678</a>

Reviewed by Richard Robinson, Lily Spiniolas, and Aditya Keerthi.

Fixed a FIXME by adding console warning messages when a
responsive meta viewport was used.

To prevent extra logs, only give a warning message if the width
changed. This is tracked by m_lastShrinkToFitLayoutWidth, which
is used to compare if the width is different from before.

Update test results since they include the new console warnings.

* LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt:
* LayoutTests/fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow-expected.txt:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCommitLoad):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::shrinkToFitContent):

Canonical link: <a href="https://commits.webkit.org/311964@main">https://commits.webkit.org/311964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99e53ea13e6eb3e885085a79266ef3e589f7f118

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112553 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122735 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86137 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103405 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24048 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15069 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169788 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15500 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130924 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31584 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131038 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89405 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24106 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25729 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18729 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31041 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96942 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30561 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30834 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30715 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->