### PR TITLE
Early-level WIP: Local Network Access

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -140,11 +140,12 @@ static IPAddressSpace updateTargetAddressSpaceIfNeeded(IPAddressSpace currentAdd
     if (host.isEmpty())
         return currentAddressSpace;
 
-    if (WebCore::isLocalIPAddressSpace(url))
-        return IPAddressSpace::Local;
+    auto space = WebCore::determineIPAddressSpace(url);
+    if (space != IPAddressSpace::Public)
+        return space;
 
     if (host.endsWithIgnoringASCIICase(".local"_s))
-        return IPAddressSpace::Local;
+        return IPAddressSpace::Private;
 
     return currentAddressSpace;
 }

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
@@ -26,8 +26,11 @@
 #include "config.h"
 #include "IPAddressSpace.h"
 
+#include "DNS.h"
+#include <arpa/inet.h>
 #include <array>
 #include <cstdio>
+#include <netinet/in.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
@@ -48,17 +51,17 @@ IPAddressSpace determineIPAddressSpace(const URL& url)
 
     // Handle IPv6 addresses (check for colon to distinguish from IPv4)
     if (host.contains(':')) {
-        // ::1/128 - IPv6 Local - loopback
+        // ::1/128 - IPv6 loopback
         if (host == "::1")
             return IPAddressSpace::Local;
 
-        // fc00::/7 - Unique Loopback - local
+        // fc00::/7 - Unique Local Address - private
         if (host.startsWith("fc"_s) || host.startsWith("fd"_s))
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Private;
 
-        // fe80::/10 - Link-Loopback Unicast - local
+        // fe80::/10 - Link-Local Unicast - private
         if (host.startsWith("fe8"_s) || host.startsWith("fe9"_s) || host.startsWith("fea"_s) || host.startsWith("feb"_s))
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Private;
         // ::ffff: - IPv4 Mapped IPv6 Addresses - format for parsing by IPv4 Algorithm.
         if (host.startsWith("::ffff:"_s)) {
             host = host.substring(7);
@@ -104,42 +107,134 @@ IPAddressSpace determineIPAddressSpace(const URL& url)
 
         // Check IPv4 address blocks according to spec table:
 
-        // 127.0.0.0/8 - IPv4 Loopback - loopback
+        // 127.0.0.0/8 - IPv4 Loopback - local
         if (parts[0] == 127)
             return IPAddressSpace::Local;
 
-        // 10.0.0.0/8 - Local Use - local
+        // 10.0.0.0/8 - Private Use - private
         if (parts[0] == 10)
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Private;
 
-        // 100.64.0.0/10 - Carrier-Grade NAT - local
+        // 100.64.0.0/10 - Carrier-Grade NAT - private
         if (parts[0] == 100 && (parts[1] & 0xC0) == 64)
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Private;
 
-        // 172.16.0.0/12 - Local Use - local
+        // 172.16.0.0/12 - Private Use - private
         if (parts[0] == 172 && (parts[1] & 0xF0) == 16)
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Private;
 
-        // 192.168.0.0/16 - Local Use - local
+        // 192.168.0.0/16 - Private Use - private
         if (parts[0] == 192 && parts[1] == 168)
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Private;
 
-        // 198.18.0.0/15 - Benchmarking - local
+        // 198.18.0.0/15 - Benchmarking - private
         if (parts[0] == 198 && (parts[1] & 0xFE) == 18)
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Private;
 
-        // 169.254.0.0/16 - Link Local - local
+        // 169.254.0.0/16 - Link Local - private
         if (parts[0] == 169 && parts[1] == 254)
-            return IPAddressSpace::Local;
+            return IPAddressSpace::Private;
 
         return IPAddressSpace::Public;
     }
     return IPAddressSpace::Public;
 }
 
+static IPAddressSpace determineIPv4AddressSpace(const struct in_addr& addr)
+{
+    uint32_t ip = ntohl(addr.s_addr);
+    uint8_t first = ip >> 24;
+    uint8_t second = (ip >> 16) & 0xFF;
+
+    // 127.0.0.0/8 - loopback
+    if (first == 127)
+        return IPAddressSpace::Local;
+
+    // 10.0.0.0/8
+    if (first == 10)
+        return IPAddressSpace::Private;
+
+    // 100.64.0.0/10
+    if (first == 100 && (second & 0xC0) == 64)
+        return IPAddressSpace::Private;
+
+    // 172.16.0.0/12
+    if (first == 172 && (second & 0xF0) == 16)
+        return IPAddressSpace::Private;
+
+    // 192.168.0.0/16
+    if (first == 192 && second == 168)
+        return IPAddressSpace::Private;
+
+    // 198.18.0.0/15
+    if (first == 198 && (second & 0xFE) == 18)
+        return IPAddressSpace::Private;
+
+    // 169.254.0.0/16
+    if (first == 169 && second == 254)
+        return IPAddressSpace::Private;
+
+    return IPAddressSpace::Public;
+}
+
+static IPAddressSpace determineIPv6AddressSpace(const struct in6_addr& addr)
+{
+    // ::1/128 - loopback
+    if (IN6_IS_ADDR_LOOPBACK(&addr))
+        return IPAddressSpace::Local;
+
+    // ::ffff:0:0/96 - IPv4-mapped
+    if (IN6_IS_ADDR_V4MAPPED(&addr)) {
+        struct in_addr v4addr;
+        uint32_t mapped = (static_cast<uint32_t>(addr.s6_addr[12]) << 24)
+            | (static_cast<uint32_t>(addr.s6_addr[13]) << 16)
+            | (static_cast<uint32_t>(addr.s6_addr[14]) << 8)
+            | static_cast<uint32_t>(addr.s6_addr[15]);
+        v4addr.s_addr = htonl(mapped);
+        return determineIPv4AddressSpace(v4addr);
+    }
+
+    auto byte0 = addr.s6_addr[0];
+    auto byte1 = addr.s6_addr[1];
+
+    // fc00::/7 - Unique Local Address
+    if ((byte0 & 0xFE) == 0xFC)
+        return IPAddressSpace::Private;
+
+    // fe80::/10 - Link-Local
+    if (byte0 == 0xFE && (byte1 & 0xC0) == 0x80)
+        return IPAddressSpace::Private;
+
+    return IPAddressSpace::Public;
+}
+
+IPAddressSpace determineIPAddressSpace(const IPAddress& address)
+{
+    if (address.isIPv4())
+        return determineIPv4AddressSpace(address.ipv4Address());
+    if (address.isIPv6())
+        return determineIPv6AddressSpace(address.ipv6Address());
+    return IPAddressSpace::Public;
+}
+
+bool isLocalIPAddressSpace(IPAddressSpace space)
+{
+    return space == IPAddressSpace::Private || space == IPAddressSpace::Local;
+}
+
 bool isLocalIPAddressSpace(const URL& url)
 {
-    return determineIPAddressSpace(url) == IPAddressSpace::Local;
+    auto space = determineIPAddressSpace(url);
+    return space == IPAddressSpace::Private || space == IPAddressSpace::Local;
+}
+
+bool isPrivateNetworkRequest(IPAddressSpace source, IPAddressSpace target)
+{
+    if (source == IPAddressSpace::Public && target != IPAddressSpace::Public)
+        return true;
+    if (source == IPAddressSpace::Private && target == IPAddressSpace::Local)
+        return true;
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.h
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.h
@@ -27,14 +27,20 @@
 
 namespace WebCore {
 
-enum class IPAddressSpace : bool {
+class IPAddress;
+
+enum class IPAddressSpace : uint8_t {
     Public,
+    Private,
     Local
 };
 
 WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
+WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const IPAddress&);
 
 WEBCORE_EXPORT bool isLocalIPAddressSpace(IPAddressSpace);
 WEBCORE_EXPORT bool isLocalIPAddressSpace(const WTF::URL&);
+
+WEBCORE_EXPORT bool isPrivateNetworkRequest(IPAddressSpace source, IPAddressSpace target);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.idl
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.idl
@@ -23,4 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
- enum IPAddressSpace { "public", "local" };
+ enum IPAddressSpace { "public", "private", "local" };

--- a/Source/WebCore/Modules/permissions/PermissionName.h
+++ b/Source/WebCore/Modules/permissions/PermissionName.h
@@ -35,6 +35,7 @@ enum class PermissionName : uint8_t {
     DisplayCapture,
     Geolocation,
     Gyroscope,
+    LocalNetwork,
     Magnetometer,
     Microphone,
     Midi,

--- a/Source/WebCore/Modules/permissions/PermissionName.idl
+++ b/Source/WebCore/Modules/permissions/PermissionName.idl
@@ -34,6 +34,7 @@ enum PermissionName {
     "display-capture",
     "geolocation",
     "gyroscope",
+    "local-network",
     "magnetometer",
     "microphone",
     "midi",

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -116,6 +116,8 @@ std::optional<PermissionName> Permissions::toPermissionName(const String& name)
         return PermissionName::Camera;
     if (name == "geolocation"_s)
         return PermissionName::Geolocation;
+    if (name == "local-network"_s)
+        return PermissionName::LocalNetwork;
     if (name == "microphone"_s)
         return PermissionName::Microphone;
     if (name == "notifications"_s)

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -87,7 +87,7 @@ void updateRequestForAccessControl(ResourceRequest& request, SecurityOrigin& sec
     request.setHTTPOrigin(securityOrigin.toString());
 }
 
-ResourceRequest createAccessControlPreflightRequest(const ResourceRequest& request, SecurityOrigin& securityOrigin, const String& referrer, bool includeFetchMetadata)
+ResourceRequest createAccessControlPreflightRequest(const ResourceRequest& request, SecurityOrigin& securityOrigin, const String& referrer, bool includeFetchMetadata, bool isPrivateNetworkRequest)
 {
     ResourceRequest preflightRequest { URL { request.url() } };
     static const double platformDefaultTimeout = 0;
@@ -126,6 +126,9 @@ ResourceRequest createAccessControlPreflightRequest(const ResourceRequest& reque
         if (!headerBuffer.isEmpty())
             preflightRequest.setHTTPHeaderField(HTTPHeaderName::AccessControlRequestHeaders, headerBuffer.toString());
     }
+
+    if (isPrivateNetworkRequest)
+        preflightRequest.setHTTPHeaderField(HTTPHeaderName::AccessControlRequestPrivateNetwork, "true"_s);
 
     if (includeFetchMetadata) {
         Ref requestOrigin = SecurityOrigin::create(request.url());
@@ -296,7 +299,7 @@ Expected<void, String> passesAccessControlCheck(const ResourceResponse& response
     return { };
 }
 
-Expected<void, String> validatePreflightResponse(PAL::SessionID sessionID, const ResourceRequest& request, const ResourceResponse& response, StoredCredentialsPolicy storedCredentialsPolicy, const SecurityOrigin& topOrigin, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler* checkDisabler)
+Expected<void, String> validatePreflightResponse(PAL::SessionID sessionID, const ResourceRequest& request, const ResourceResponse& response, StoredCredentialsPolicy storedCredentialsPolicy, const SecurityOrigin& topOrigin, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler* checkDisabler, bool isPrivateNetworkRequest, bool* privateNetworkAllowed)
 {
     if (!response.isSuccessful())
         return makeUnexpected(makeString("Preflight response is not successful. Status code: "_s, response.httpStatusCode()));
@@ -304,6 +307,11 @@ Expected<void, String> validatePreflightResponse(PAL::SessionID sessionID, const
     auto accessControlCheckResult = passesAccessControlCheck(response, storedCredentialsPolicy, securityOrigin, checkDisabler);
     if (!accessControlCheckResult)
         return accessControlCheckResult;
+
+    if (isPrivateNetworkRequest && privateNetworkAllowed) {
+        const String& allowPrivateNetwork = response.httpHeaderField(HTTPHeaderName::AccessControlAllowPrivateNetwork);
+        *privateNetworkAllowed = (allowPrivateNetwork == "true"_s);
+    }
 
     auto result = CrossOriginPreflightResultCacheItem::create(storedCredentialsPolicy, response);
     if (!result.has_value())

--- a/Source/WebCore/loader/CrossOriginAccessControl.h
+++ b/Source/WebCore/loader/CrossOriginAccessControl.h
@@ -60,7 +60,7 @@ void updateRequestReferrer(ResourceRequest&, ReferrerPolicy, const URL&, const O
     
 WEBCORE_EXPORT void updateRequestForAccessControl(ResourceRequest&, SecurityOrigin&, StoredCredentialsPolicy);
 
-WEBCORE_EXPORT ResourceRequest createAccessControlPreflightRequest(const ResourceRequest&, SecurityOrigin&, const String&, bool includeFetchMetadata);
+WEBCORE_EXPORT ResourceRequest createAccessControlPreflightRequest(const ResourceRequest&, SecurityOrigin&, const String&, bool includeFetchMetadata, bool isPrivateNetworkRequest = false);
 enum class SameOriginFlag : bool { No, Yes };
 CachedResourceRequest createPotentialAccessControlRequest(ResourceRequest&&, ResourceLoaderOptions&&, Document&, const String& crossOriginAttribute, SameOriginFlag = SameOriginFlag::No);
 
@@ -88,7 +88,7 @@ private:
 };
 
 WEBCORE_EXPORT Expected<void, String> passesAccessControlCheck(const ResourceResponse&, StoredCredentialsPolicy, const SecurityOrigin&, const CrossOriginAccessControlCheckDisabler*);
-WEBCORE_EXPORT Expected<void, String> validatePreflightResponse(PAL::SessionID, const ResourceRequest&, const ResourceResponse&, StoredCredentialsPolicy, const SecurityOrigin& topOrigin, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler*);
+WEBCORE_EXPORT Expected<void, String> validatePreflightResponse(PAL::SessionID, const ResourceRequest&, const ResourceResponse&, StoredCredentialsPolicy, const SecurityOrigin& topOrigin, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler*, bool isPrivateNetworkRequest = false, bool* privateNetworkAllowed = nullptr);
 
 enum class ForNavigation : bool { No, Yes };
 WEBCORE_EXPORT std::optional<ResourceError> validateCrossOriginResourcePolicy(CrossOriginEmbedderPolicyValue, const SecurityOrigin&, const URL&, const ResourceResponse&, ForNavigation, const OriginAccessPatterns&);

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -82,12 +82,16 @@ void CrossOriginPreflightChecker::validatePreflightResponse(DocumentThreadableLo
         return;
     }
 
-    auto result = WebCore::validatePreflightResponse(page->sessionID(), request, response, loader.options().storedCredentialsPolicy, loader.topOrigin(), loader.securityOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
+    bool privateNetworkAllowed = false;
+    auto result = WebCore::validatePreflightResponse(page->sessionID(), request, response, loader.options().storedCredentialsPolicy, loader.topOrigin(), loader.securityOrigin(), &CrossOriginAccessControlCheckDisabler::singleton(), loader.m_isPrivateNetworkRequest, &privateNetworkAllowed);
     if (!result) {
         loader.document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, result.error());
         loader.preflightFailure(identifier, ResourceError(errorDomainWebKitInternal, 0, request.url(), result.error(), ResourceError::Type::AccessControl));
         return;
     }
+
+    if (loader.m_isPrivateNetworkRequest && !privateNetworkAllowed)
+        loader.document().addConsoleMessage(MessageSource::Security, MessageLevel::Warning, "The server did not respond with Access-Control-Allow-Private-Network: true. This will be required in a future release."_s);
 
     // FIXME: <https://webkit.org/b/164889> Web Inspector: Show Preflight Request information in inspector
     // This is only showing success preflight requests and responses but we should show network events
@@ -140,7 +144,7 @@ void CrossOriginPreflightChecker::startPreflight()
     options.initiatorContext = loader->options().initiatorContext;
 
     bool includeFetchMetadata = !loader->document().quirks().shouldDisableFetchMetadata();
-    CachedResourceRequest preflightRequest(createAccessControlPreflightRequest(m_request, loader->securityOrigin(), loader->referrer(), includeFetchMetadata), options);
+    CachedResourceRequest preflightRequest(createAccessControlPreflightRequest(m_request, loader->securityOrigin(), loader->referrer(), includeFetchMetadata, loader->m_isPrivateNetworkRequest), options);
     preflightRequest.setInitiatorType(AtomString { loader->options().initiatorType });
 
     ASSERT(!m_resource);
@@ -158,7 +162,7 @@ void CrossOriginPreflightChecker::doPreflight(DocumentThreadableLoader& loader, 
         return;
 
     bool includeFetchMetadata = !loader.document().quirks().shouldDisableFetchMetadata();
-    ResourceRequest preflightRequest = createAccessControlPreflightRequest(request, loader.securityOrigin(), loader.referrer(), includeFetchMetadata);
+    ResourceRequest preflightRequest = createAccessControlPreflightRequest(request, loader.securityOrigin(), loader.referrer(), includeFetchMetadata, loader.m_isPrivateNetworkRequest);
     ResourceError error;
     ResourceResponse response;
     RefPtr<SharedBuffer> data;

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -45,6 +45,7 @@
 #include "DocumentView.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
+#include "IPAddressSpace.h"
 #include "InspectorInstrumentation.h"
 #include "InspectorNetworkAgent.h"
 #include "LegacySchemeRegistry.h"
@@ -202,7 +203,10 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequest(ResourceRequest&& re
 {
     ASSERT(m_options.mode == FetchOptions::Mode::Cors);
 
-    if ((m_options.preflightPolicy == PreflightPolicy::Consider && isSimpleCrossOriginAccessRequest(request.httpMethod(), request.httpHeaderFields())) || m_options.preflightPolicy == PreflightPolicy::Prevent || shouldPerformSecurityChecks()) {
+    if (m_document->settings().localNetworkAccessEnabled() && !m_isPrivateNetworkRequest)
+        m_privateNetworkAccessRetryRequest = request;
+
+    if ((m_options.preflightPolicy == PreflightPolicy::Consider && isSimpleCrossOriginAccessRequest(request.httpMethod(), request.httpHeaderFields()) && !m_isPrivateNetworkRequest) || m_options.preflightPolicy == PreflightPolicy::Prevent || shouldPerformSecurityChecks()) {
         if (checkURLSchemeAsCORSEnabled(request.url()))
             makeSimpleCrossOriginAccessRequest(WTF::move(request));
     } else {
@@ -220,10 +224,13 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequest(ResourceRequest&& re
             return;
 
         m_simpleRequest = false;
-        if (RefPtr page = document->page(); page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), document->clientOrigin(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields()))
-            preflightSuccess(WTF::move(request));
-        else
-            makeCrossOriginAccessRequestWithPreflight(WTF::move(request));
+        if (!m_isPrivateNetworkRequest) {
+            if (RefPtr page = document->page(); page && CrossOriginPreflightResultCache::singleton().canSkipPreflight(page->sessionID(), document->clientOrigin(), request.url(), m_options.storedCredentialsPolicy, request.httpMethod(), request.httpHeaderFields())) {
+                preflightSuccess(WTF::move(request));
+                return;
+            }
+        }
+        makeCrossOriginAccessRequestWithPreflight(WTF::move(request));
     }
 }
 
@@ -242,6 +249,10 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequestWithPreflight(Resourc
         Ref preflightChecker = CrossOriginPreflightChecker::create(*this, WTF::move(request));
         m_preflightChecker = preflightChecker.copyRef();
         preflightChecker->startPreflight();
+        return;
+    }
+    if (m_isPrivateNetworkRequest) {
+        logErrorAndFail(ResourceError(errorDomainWebKitInternal, 0, request.url(), "Synchronous local network access is not allowed"_s, ResourceError::Type::AccessControl));
         return;
     }
     CrossOriginPreflightChecker::doPreflight(*this, WTF::move(request));
@@ -385,6 +396,19 @@ void DocumentThreadableLoader::dataSent(CachedResource& resource, unsigned long 
 void DocumentThreadableLoader::responseReceived(const CachedResource& resource, const ResourceResponse& response, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT_UNUSED(resource, &resource == m_resource);
+
+    if (m_privateNetworkAccessRetryRequest && m_document->settings().localNetworkAccessEnabled()
+        && isPrivateNetworkRequest(m_document->ipAddressSpace(), response.ipAddressSpace())) {
+        clearResource();
+        auto retryRequest = *std::exchange(m_privateNetworkAccessRetryRequest, std::nullopt);
+        if (completionHandler)
+            completionHandler();
+        m_isPrivateNetworkRequest = true;
+        m_simpleRequest = false;
+        makeCrossOriginAccessRequestWithPreflight(WTF::move(retryRequest));
+        return;
+    }
+
     ResourceResponse responseWithCorrectFragmentIdentifier;
     if (response.source() != ResourceResponse::Source::ServiceWorker && response.url().fragmentIdentifier() != m_responseURL.fragmentIdentifier()) {
         responseWithCorrectFragmentIdentifier = response;

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -33,6 +33,7 @@
 
 #include "ContentSecurityPolicy.h"
 #include "CrossOriginPreflightChecker.h"
+#include "IPAddressSpace.h"
 #include "LoaderMalloc.h"
 #include "ResourceLoaderIdentifier.h"
 #include "ResourceResponse.h"
@@ -146,6 +147,8 @@ class CachedRawResource;
 
         ShouldLogError m_shouldLogError;
         std::optional<ResourceRequest> m_bypassingPreflightForServiceWorkerRequest;
+        bool m_isPrivateNetworkRequest { false };
+        std::optional<ResourceRequest> m_privateNetworkAccessRetryRequest;
     };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -139,7 +139,9 @@ bool MixedContentChecker::shouldBlockRequest(Frame& frame, const URL& url, IsUpg
 
     if (!isMixedContent(frame, url))
         return false;
-    if ((LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol()) || shouldTreatAsPotentiallyTrustworthy(url)) && isUpgradable == IsUpgradable::Yes)
+    if (shouldTreatAsPotentiallyTrustworthy(url))
+        return false;
+    if (LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol()) && isUpgradable == IsUpgradable::Yes)
         return false;
     frame.reportMixedContentViolation(true, url);
     return true;

--- a/Source/WebCore/platform/network/HTTPHeaderNames.in
+++ b/Source/WebCore/platform/network/HTTPHeaderNames.in
@@ -32,10 +32,12 @@ Access-Control-Allow-Credentials
 Access-Control-Allow-Headers
 Access-Control-Allow-Methods
 Access-Control-Allow-Origin
+Access-Control-Allow-Private-Network
 Access-Control-Expose-Headers
 Access-Control-Max-Age
 Access-Control-Request-Headers
 Access-Control-Request-Method
+Access-Control-Request-Private-Network
 Age
 Authorization
 Cache-Control

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-enum class IPAddressSpace : bool;
+enum class IPAddressSpace : uint8_t;
 
 enum class ResourceRequestCachePolicy : uint8_t {
     UseProtocolCachePolicy, // normal load, equivalent to fetch "default" cache mode.

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -63,7 +63,7 @@ enum class WasPrivateRelayed : bool { No, Yes };
 static constexpr unsigned bitWidthOfWasPrivateRelayed = 1;
 static_assert(static_cast<unsigned>(WasPrivateRelayed::Yes) <= ((1U << bitWidthOfWasPrivateRelayed) - 1));
 
-static constexpr unsigned bitWidthOfIPAddressSpace = 1;
+static constexpr unsigned bitWidthOfIPAddressSpace = 2;
 static_assert(static_cast<unsigned>(IPAddressSpace::Local) <= ((1U << bitWidthOfIPAddressSpace) - 1));
 
 enum class ResourceResponseBaseType : uint8_t { Basic, Cors, Default, Error, Opaque, Opaqueredirect };
@@ -155,7 +155,7 @@ public:
     void setProxyName(String&& proxyName) { m_proxyName = WTF::move(proxyName); }
     const String& proxyName() const LIFETIME_BOUND { return m_proxyName; }
 
-    IPAddressSpace ipAddressSpace() { return m_ipAddressSpace; }
+    IPAddressSpace ipAddressSpace() const { return m_ipAddressSpace; }
     void setIPAddressSpace(IPAddressSpace ipAddressSpace) { m_ipAddressSpace = ipAddressSpace; }
 
     // These functions return parsed values of the corresponding response headers.

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -32,6 +32,7 @@
 #include "NetworkLoadParameters.h"
 #include "NetworkProcess.h"
 #include "NetworkSession.h"
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceRequest.h>
@@ -185,6 +186,8 @@ void NetworkDataTask::didReceiveResponse(ResourceResponse&& response, Negotiated
         response.setUsedLegacyTLS(UsedLegacyTLS::Yes);
     if (privateRelayed == PrivateRelayed::Yes)
         response.setWasPrivateRelayed(WasPrivateRelayed::Yes);
+    if (resolvedIPAddress)
+        response.setIPAddressSpace(determineIPAddressSpace(*resolvedIPAddress));
 
     if (RefPtr client = m_client.get())
         client->didReceiveResponse(WTF::move(response), negotiatedLegacyTLS, privateRelayed, WTF::move(completionHandler));

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -34,6 +34,7 @@
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/FetchOptions.h>
 #include <WebCore/FetchingWorkerIdentifier.h>
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/NavigationRequester.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
@@ -98,6 +99,7 @@ struct NetworkResourceLoadParameters {
     std::optional<WebCore::FrameIdentifier> parentFrameID { };
     bool crossOriginAccessControlCheckEnabled { true };
     URL documentURL { };
+    WebCore::IPAddressSpace clientIPAddressSpace { WebCore::IPAddressSpace::Public };
 
     bool isCrossOriginOpenerPolicyEnabled { false };
     bool isClearSiteDataHeaderEnabled { false };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -77,8 +77,9 @@ enum class WebKit::NavigatingToAppBoundDomain : bool;
     bool pageHasResourceLoadClient;
     std::optional<WebCore::FrameIdentifier> parentFrameID;
     bool crossOriginAccessControlCheckEnabled;
-    
+
     URL documentURL;
+    WebCore::IPAddressSpace clientIPAddressSpace;
 
     bool isCrossOriginOpenerPolicyEnabled;
     bool isClearSiteDataHeaderEnabled;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -67,6 +67,7 @@
 #include <WebCore/DiagnosticLoggingKeys.h>
 #include <WebCore/HTTPParsers.h>
 #include <WebCore/HTTPStatusCodes.h>
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/LinkHeader.h>
 #include <WebCore/NetworkLoadMetrics.h>
@@ -1053,6 +1054,32 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
         if (m_isKeptAlive) {
             LOADER_RELEASE_LOG("didReceiveResponse: Ignoring response because of keepalive option");
             return completionHandler(PolicyAction::Ignore);
+        }
+
+        if (!isMainResource() && isPrivateNetworkRequest(m_parameters.clientIPAddressSpace, m_response.ipAddressSpace())) {
+            auto& currentRequest = m_networkLoad ? m_networkLoad->currentRequest() : originalRequest();
+            bool isPreflightRequest = currentRequest.httpHeaderField(HTTPHeaderName::AccessControlRequestPrivateNetwork) == "true"_s;
+            if (!isPreflightRequest && !m_privateNetworkAccessGranted) {
+                LOADER_RELEASE_LOG("didReceiveResponse: Pausing load for private network access permission");
+                m_responseCompletionHandler = WTF::move(completionHandler);
+                connectionToWebProcess().networkProcess().parentProcessConnection()->sendWithAsyncReply(
+                    Messages::NetworkProcessProxy::RequestLocalNetworkAccessPermission(webPageProxyID()),
+                    [this, protectedThis = Ref { *this }](bool granted) {
+                        if (granted) {
+                            m_privateNetworkAccessGranted = true;
+                            continueDidReceiveResponse();
+                        } else {
+                            LOADER_RELEASE_LOG_ERROR("didReceiveResponse: Private network access denied by user");
+                            if (m_responseCompletionHandler)
+                                m_responseCompletionHandler(PolicyAction::Ignore);
+                            RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }, url = m_response.url()] {
+                                if (protectedThis->m_networkLoad)
+                                    protectedThis->didFailLoading(ResourceError { errorDomainWebKitInternal, 0, url, "User denied local network access"_s, ResourceError::Type::AccessControl });
+                            });
+                        }
+                    });
+                return;
+            }
         }
 
         LOADER_RELEASE_LOG("didReceiveResponse: Using response");

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -334,6 +334,7 @@ private:
     RefPtr<NetworkLoadChecker> m_networkLoadChecker;
     bool m_shouldRestartLoad { false };
     ResponseCompletionHandler m_responseCompletionHandler;
+    bool m_privateNetworkAccessGranted { false };
     bool m_shouldCaptureExtraNetworkLoadMetrics { false };
     bool m_isKeptAlive { false };
     std::unique_ptr<EarlyHintsResourceLoader> m_earlyHintsResourceLoader;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -105,7 +105,11 @@ enum class WebCore::IDBTransactionMode : uint8_t {
     Versionchange
 };
 
-enum class WebCore::IPAddressSpace : bool;
+enum class WebCore::IPAddressSpace : uint8_t {
+    Public,
+    Private,
+    Local
+};
 
 #if ENABLE(MEDIA_SESSION)
 header: <WebCore/MediaSessionPlaybackState.h>
@@ -168,6 +172,7 @@ enum class WebCore::PermissionName : uint8_t {
     DisplayCapture,
     Geolocation,
     Gyroscope,
+    LocalNetwork,
     Magnetometer,
     Microphone,
     Midi,

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -157,6 +157,7 @@ public:
     virtual void decidePolicyForUserMediaPermissionRequest(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, SecurityOrigin&, SecurityOrigin&, WebKit::UserMediaPermissionRequestProxy&);
     virtual void decidePolicyForScreenCaptureUnmuting(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, WebKit::FrameInfoData&&, SecurityOrigin&, SecurityOrigin&, CompletionHandler<void(bool isAllowed)>&& completionHandler) { completionHandler(false); }
     virtual void decidePolicyForNotificationPermissionRequest(WebKit::WebPageProxy&, SecurityOrigin&, CompletionHandler<void(bool allowed)>&& completionHandler) { completionHandler(false); }
+    virtual void decidePolicyForLocalNetworkAccessPermissionRequest(WebKit::WebPageProxy&, const WebCore::SecurityOriginData&, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(false); }
     virtual void requestStorageAccessConfirm(WebKit::WebPageProxy&, WebKit::WebFrameProxy*, const WebCore::RegistrableDomain& requestingDomain, const WebCore::RegistrableDomain& currentDomain, std::optional<WebCore::OrganizationStorageAccessPromptQuirk>&&, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(true); }
     virtual void addMessageToConsoleForTesting(WebKit::WebPageProxy&, WTF::String&&) { }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
@@ -301,6 +301,14 @@ WK_SWIFT_UI_ACTOR
  */
 - (void)webView:(WKWebView *)webView requestGeolocationPermissionForOrigin:(WKSecurityOrigin*)origin initiatedByFrame:(WKFrameInfo *)frame decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKPermissionDecision decision))decisionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+/*! @abstract Called when a web view requests access to the local network.
+ @param webView The web view requesting local network access.
+ @param origin The origin of the web content requesting local network access.
+ @param frame The frame that initiated the request.
+ @param decisionHandler The decision handler to call once the app has made its decision.
+ */
+- (void)webView:(WKWebView *)webView requestLocalNetworkAccessPermissionForOrigin:(WKSecurityOrigin *)origin decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKPermissionDecision decision))decisionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST && __IPHONE_OS_VERSION_MIN_REQUIRED >= 180400
 
 /*! @abstract Tells the delegate when the keyboard delivers an input suggestion.

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -137,6 +137,8 @@ static RetainPtr<NSString> alertMessageText(MediaPermissionReason reason, const 
         SUPPRESS_UNRETAINED_ARG return adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"“%@” Would Like to Access Motion and Orientation", @"Message for requesting access to the device motion and orientation"), visibleOrigin.get()]);
     case MediaPermissionReason::Geolocation:
         SUPPRESS_UNRETAINED_ARG return adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to use your current location?", @"Message for geolocation prompt"), visibleOrigin.get()]);
+    case MediaPermissionReason::LocalNetworkAccess:
+        SUPPRESS_UNRETAINED_ARG return adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow \u201C%@\u201D to access your local network?", @"Message for local network access prompt"), visibleOrigin.get()]);
     case MediaPermissionReason::SpeechRecognition:
         SUPPRESS_UNRETAINED_ARG return adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"Allow “%@” to capture your audio and use it for speech recognition?", @"Message for spechrecognition prompt"), visibleDomain(origin.host()).get()]);
     }
@@ -155,6 +157,8 @@ static RetainPtr<NSString> allowButtonText(MediaPermissionReason reason)
         return WEB_UI_STRING_KEY(@"Allow", "Allow (device motion and orientation access)", @"Button title in Device Orientation Permission API prompt").createNSString();
     case MediaPermissionReason::Geolocation:
         return WEB_UI_STRING_KEY(@"Allow", "Allow (geolocation)", @"Allow button title in geolocation prompt").createNSString();
+    case MediaPermissionReason::LocalNetworkAccess:
+        return WEB_UI_STRING_KEY(@"Allow", "Allow (local network access)", @"Allow button title in local network access prompt").createNSString();
     case MediaPermissionReason::SpeechRecognition:
         return WEB_UI_STRING_KEY(@"Allow", "Allow (speechrecognition)", @"Allow button title in speech recognition prompt").createNSString();
     }
@@ -173,6 +177,8 @@ static RetainPtr<NSString> doNotAllowButtonText(MediaPermissionReason reason)
         return WEB_UI_STRING_KEY(@"Cancel", "Cancel (device motion and orientation access)", @"Button title in Device Orientation Permission API prompt").createNSString();
     case MediaPermissionReason::Geolocation:
         return WEB_UI_STRING_KEY(@"Don’t Allow", "Don’t Allow (geolocation)", @"Disallow button title in geolocation prompt").createNSString();
+    case MediaPermissionReason::LocalNetworkAccess:
+        return WEB_UI_STRING_KEY(@"Don't Allow", "Don't Allow (local network access)", @"Disallow button title in local network access prompt").createNSString();
     case MediaPermissionReason::SpeechRecognition:
         return WEB_UI_STRING_KEY(@"Don’t Allow", "Don’t Allow (speechrecognition)", @"Disallow button title in speech recognition prompt").createNSString();
     }

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -117,6 +117,7 @@ private:
         bool takeFocus(WebPageProxy*, WKFocusDirection) final;
         void handleAutoplayEvent(WebPageProxy&, WebCore::AutoplayEvent, OptionSet<WebCore::AutoplayEventFlags>) final;
         void decidePolicyForNotificationPermissionRequest(WebPageProxy&, API::SecurityOrigin&, CompletionHandler<void(bool allowed)>&&) final;
+        void decidePolicyForLocalNetworkAccessPermissionRequest(WebPageProxy&, const WebCore::SecurityOriginData&, CompletionHandler<void(bool)>&&) final;
         bool focusFromServiceWorker(WebKit::WebPageProxy&) final;
         bool runOpenPanel(WebPageProxy&, WebFrameProxy*, FrameInfoData&&, API::OpenPanelParameters*, WebOpenPanelResultListenerProxy*) final;
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
@@ -325,6 +326,7 @@ private:
         bool webViewSupportedXRSessionFeatures : 1;
 #endif
         bool webViewRequestNotificationPermissionForSecurityOriginDecisionHandler : 1;
+        bool webViewRequestLocalNetworkAccessPermissionForOriginDecisionHandler : 1;
         bool webViewUpdatedAppBadge : 1;
         bool webViewDidAdjustVisibilityWithSelectors : 1;
 

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -248,6 +248,8 @@ void UIDelegate::setDelegate(id<WKUIDelegate> delegate)
 
     m_delegateMethods.webViewRequestNotificationPermissionForSecurityOriginDecisionHandler = [delegate respondsToSelector:@selector(_webView:requestNotificationPermissionForSecurityOrigin:decisionHandler:)];
 
+    m_delegateMethods.webViewRequestLocalNetworkAccessPermissionForOriginDecisionHandler = [delegate respondsToSelector:@selector(webView:requestLocalNetworkAccessPermissionForOrigin:decisionHandler:)];
+
     m_delegateMethods.webViewUpdatedAppBadge = [delegate respondsToSelector:@selector(_webView:updatedAppBadge:fromSecurityOrigin:)];
 
     m_delegateMethods.webViewDidAdjustVisibilityWithSelectors = [delegate respondsToSelector:@selector(_webView:didAdjustVisibilityWithSelectors:)];
@@ -622,6 +624,36 @@ void UIDelegate::UIClient::decidePolicyForGeolocationPermissionRequest(WebKit::W
         checker->didCallCompletionHandler();
         completionHandler(result);
     }).get()];
+}
+
+void UIDelegate::UIClient::decidePolicyForLocalNetworkAccessPermissionRequest(WebKit::WebPageProxy& page, const WebCore::SecurityOriginData& originData, CompletionHandler<void(bool)>&& completionHandler)
+{
+    RefPtr uiDelegate = m_uiDelegate.get();
+    if (!uiDelegate || !uiDelegate->m_delegateMethods.webViewRequestLocalNetworkAccessPermissionForOriginDecisionHandler) {
+        alertForPermission(page, MediaPermissionReason::LocalNetworkAccess, originData, WTF::move(completionHandler));
+        return;
+    }
+
+    RetainPtr delegate = uiDelegate->m_delegate.get();
+    if (!delegate)
+        return completionHandler(false);
+
+    auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:requestLocalNetworkAccessPermissionForOrigin:decisionHandler:));
+    auto decisionHandler = makeBlockPtr([completionHandler = WTF::move(completionHandler), checker = WTF::move(checker)](WKPermissionDecision decision) mutable {
+        if (checker->completionHandlerHasBeenCalled())
+            return;
+        checker->didCallCompletionHandler();
+        switch (decision) {
+        case WKPermissionDecisionPrompt:
+        case WKPermissionDecisionDeny:
+            completionHandler(false);
+            break;
+        case WKPermissionDecisionGrant:
+            completionHandler(true);
+            break;
+        }
+    });
+    [delegate webView:uiDelegate->m_webView.get().get() requestLocalNetworkAccessPermissionForOrigin:wrapper(API::SecurityOrigin::create(originData)).get() decisionHandler:decisionHandler.get()];
 }
 
 void UIDelegate::UIClient::didResignInputElementStrongPasswordAppearance(WebPageProxy&, API::Object* userInfo)

--- a/Source/WebKit/UIProcess/MediaPermissionUtilities.h
+++ b/Source/WebKit/UIProcess/MediaPermissionUtilities.h
@@ -58,6 +58,7 @@ enum class MediaPermissionReason {
     Microphone,
     DeviceOrientation,
     Geolocation,
+    LocalNetworkAccess,
     SpeechRecognition,
     ScreenCapture
 };

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -694,6 +694,17 @@ void NetworkProcessProxy::resourceLoadDidCompleteWithError(WebPageProxyIdentifie
     page->resourceLoadDidCompleteWithError(WTF::move(loadInfo), WTF::move(response), WTF::move(error));
 }
 
+void NetworkProcessProxy::requestLocalNetworkAccessPermission(WebPageProxyIdentifier pageID, CompletionHandler<void(bool)>&& completionHandler)
+{
+    RefPtr page = WebProcessProxy::webPage(pageID);
+    if (!page) {
+        completionHandler(false);
+        return;
+    }
+
+    page->requestLocalNetworkAccessPermissionFromNetworkProcess(WTF::move(completionHandler));
+}
+
 void NetworkProcessProxy::didAllowPrivateTokenUsageByThirdPartyForTesting(PAL::SessionID sessionID, bool wasAllowed, URL&& resourceURL)
 {
     if (RefPtr store = websiteDataStoreFromSessionID(sessionID))

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -281,6 +281,8 @@ public:
     void resourceLoadDidReceiveResponse(WebPageProxyIdentifier, ResourceLoadInfo&&, WebCore::ResourceResponse&&);
     void resourceLoadDidCompleteWithError(WebPageProxyIdentifier, ResourceLoadInfo&&, WebCore::ResourceResponse&&, WebCore::ResourceError&&);
 
+    void requestLocalNetworkAccessPermission(WebPageProxyIdentifier, CompletionHandler<void(bool)>&&);
+
     void didAllowPrivateTokenUsageByThirdPartyForTesting(PAL::SessionID, bool wasAllowed, URL&&);
 
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -75,6 +75,8 @@ messages -> NetworkProcessProxy WantsDispatchMessage {
     ResourceLoadDidReceiveResponse(WebKit::WebPageProxyIdentifier pageIdentifier, struct WebKit::ResourceLoadInfo resourceLoadInfo, WebCore::ResourceResponse response)
     ResourceLoadDidCompleteWithError(WebKit::WebPageProxyIdentifier pageIdentifier, struct WebKit::ResourceLoadInfo resourceLoadInfo, WebCore::ResourceResponse response, WebCore::ResourceError error)
 
+    RequestLocalNetworkAccessPermission(WebKit::WebPageProxyIdentifier pageIdentifier) -> (bool granted)
+
     DidAllowPrivateTokenUsageByThirdPartyForTesting(PAL::SessionID sessionID, bool wasAllowed, URL resourceURL)
     
     TriggerBrowsingContextGroupSwitchForNavigation(WebKit::WebPageProxyIdentifier pageIdentifier, WebCore::NavigationIdentifier navigationID, enum:uint8_t WebCore::BrowsingContextGroupSwitchDecision browsingContextGroupSwitchDecision, WebCore::Site responseSite, WebKit::NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume) -> (bool success)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13555,6 +13555,7 @@ bool WebPageProxy::shouldAlwaysPromptForPermission(PermissionName permissionName
     // These are not persistent permissions.
     case PermissionName::BackgroundFetch:
     case PermissionName::DisplayCapture:
+    case PermissionName::LocalNetwork:
     case PermissionName::ScreenWakeLock:
     case PermissionName::SpeakerSelection:
     case PermissionName::StorageAccess:
@@ -14095,6 +14096,36 @@ void WebPageProxy::requestNotificationPermission(const String& originString, Com
         if (allowed && protectedThis)
             protectedThis->pageWillLikelyUseNotifications();
         completionHandler(allowed);
+    });
+}
+
+void WebPageProxy::requestLocalNetworkAccessPermissionFromNetworkProcess(CompletionHandler<void(bool)>&& completionHandler)
+{
+    Ref securityOrigin = WebCore::SecurityOrigin::create(pageLoadState().activeURL());
+    auto originData = securityOrigin->data();
+
+    auto cachedResult = m_localNetworkAccessPermissions.find(originData);
+    if (cachedResult != m_localNetworkAccessPermissions.end()) {
+        completionHandler(cachedResult->value);
+        return;
+    }
+
+    auto& pendingHandlers = m_pendingLocalNetworkAccessRequests.ensure(originData, [] {
+        return Vector<CompletionHandler<void(bool)>> { };
+    }).iterator->value;
+    pendingHandlers.append(WTF::move(completionHandler));
+
+    if (pendingHandlers.size() > 1)
+        return;
+
+    m_uiClient->decidePolicyForLocalNetworkAccessPermissionRequest(*this, originData, [weakThis = WeakPtr { *this }, originData](bool granted) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        protectedThis->m_localNetworkAccessPermissions.set(originData, granted);
+        auto handlers = protectedThis->m_pendingLocalNetworkAccessRequests.take(originData);
+        for (auto& handler : handlers)
+            handler(granted);
     });
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -29,6 +29,7 @@
 // Use forward declarations and WebPageProxyInternals.h instead.
 #include "APIObject.h"
 #include "MessageReceiver.h"
+#include <WebCore/SecurityOriginData.h>
 #include <wtf/ApproximateTime.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
@@ -743,6 +744,8 @@ class WebPageProxy final : public API::ObjectImpl<API::Object::Type::Page>, publ
 public:
     static Ref<WebPageProxy> create(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     virtual ~WebPageProxy();
+
+    void requestLocalNetworkAccessPermissionFromNetworkProcess(CompletionHandler<void(bool)>&&);
 
     void ref() const final { API::ObjectImpl<API::Object::Type::Page>::ref(); }
     void deref() const final { API::ObjectImpl<API::Object::Type::Page>::deref(); }
@@ -3690,6 +3693,8 @@ private:
     std::unique_ptr<API::IconLoadingClient> m_iconLoadingClient;
     std::unique_ptr<API::FormClient> m_formClient;
     std::unique_ptr<API::UIClient> m_uiClient;
+    HashMap<WebCore::SecurityOriginData, bool> m_localNetworkAccessPermissions;
+    HashMap<WebCore::SecurityOriginData, Vector<CompletionHandler<void(bool)>>> m_pendingLocalNetworkAccessRequests;
     std::unique_ptr<API::FindClient> m_findClient;
     std::unique_ptr<API::FindMatchesClient> m_findMatchesClient;
     std::unique_ptr<API::DiagnosticLoggingClient> m_diagnosticLoggingClient;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -398,6 +398,7 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
 
     if (RefPtr document = frame->document()) {
         parameters.crossOriginEmbedderPolicy = document->crossOriginEmbedderPolicy();
+        parameters.clientIPAddressSpace = document->ipAddressSpace();
         parameters.isClearSiteDataHeaderEnabled = document->settings().clearSiteDataHTTPHeaderEnabled();
         parameters.isClearSiteDataExecutionContextEnabled = document->settings().clearSiteDataExecutionContextsSupportEnabled();
         parameters.mayBlockNetworkRequest = (!isMainFrameNavigation && document->settings().scriptTrackingPrivacyNetworkRequestBlockingLatchEnabled()) ?

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
@@ -42,26 +42,26 @@ TEST(IPAddressSpace, IPv4Loopback)
 // Test IPv4 private address ranges
 TEST(IPAddressSpace, IPv4PrivateAddresses)
 {
-    // 10.0.0.0/8 - Local Use
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://10.0.0.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://10.255.255.255/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://10.192.168.1:443/"_s)), WebCore::IPAddressSpace::Local);
+    // 10.0.0.0/8 - Private Use
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://10.0.0.1/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://10.255.255.255/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://10.192.168.1:443/"_s)), WebCore::IPAddressSpace::Private);
 
-    // 172.16.0.0/12 - Local Use
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.16.0.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.31.255.255/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://172.20.1.2:8443/"_s)), WebCore::IPAddressSpace::Local);
+    // 172.16.0.0/12 - Private Use
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.16.0.1/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.31.255.255/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://172.20.1.2:8443/"_s)), WebCore::IPAddressSpace::Private);
 
-    // Edge cases - should NOT be local
+    // Edge cases - should NOT be private
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.15.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.32.0.1/"_s)), WebCore::IPAddressSpace::Public);
 
-    // 192.168.0.0/16 - Local Use
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.168.0.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.168.255.255/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://192.168.1.100:8080/"_s)), WebCore::IPAddressSpace::Local);
+    // 192.168.0.0/16 - Private Use
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.168.0.1/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.168.255.255/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://192.168.1.100:8080/"_s)), WebCore::IPAddressSpace::Private);
 
-    // Edge cases - should NOT be local
+    // Edge cases - should NOT be private
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.167.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.169.0.1/"_s)), WebCore::IPAddressSpace::Public);
 }
@@ -69,11 +69,11 @@ TEST(IPAddressSpace, IPv4PrivateAddresses)
 // Test Carrier-Grade NAT addresses (100.64.0.0/10)
 TEST(IPAddressSpace, IPv4CarrierGradeNAT)
 {
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.64.0.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.127.255.255/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://100.100.100.100:443/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.64.0.1/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.127.255.255/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://100.100.100.100:443/"_s)), WebCore::IPAddressSpace::Private);
 
-    // Edge cases - should NOT be local
+    // Edge cases - should NOT be private
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.63.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.128.0.1/"_s)), WebCore::IPAddressSpace::Public);
 }
@@ -81,11 +81,11 @@ TEST(IPAddressSpace, IPv4CarrierGradeNAT)
 // Test Link Local addresses (169.254.0.0/16)
 TEST(IPAddressSpace, IPv4LinkLocal)
 {
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://169.254.0.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://169.254.255.255/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://169.254.1.1:8080/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://169.254.0.1/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://169.254.255.255/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://169.254.1.1:8080/"_s)), WebCore::IPAddressSpace::Private);
 
-    // Edge cases - should NOT be local
+    // Edge cases - should NOT be private
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://169.253.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://169.255.0.1/"_s)), WebCore::IPAddressSpace::Public);
 }
@@ -93,11 +93,11 @@ TEST(IPAddressSpace, IPv4LinkLocal)
 // Test Benchmarking addresses (198.18.0.0/15)
 TEST(IPAddressSpace, IPv4Benchmarking)
 {
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.18.0.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://198.18.100.50:443/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.18.0.1/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://198.18.100.50:443/"_s)), WebCore::IPAddressSpace::Private);
 
-    // Edge cases - should NOT be local
+    // Edge cases - should NOT be private
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.17.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.20.0.1/"_s)), WebCore::IPAddressSpace::Public);
 }
@@ -122,12 +122,12 @@ TEST(IPAddressSpace, IPv6Loopback)
 // Test IPv6 Unique Local addresses (fc00::/7)
 TEST(IPAddressSpace, IPv6UniqueLocal)
 {
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fc00::1]/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fd00::1]/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[fcff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:443/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:8080/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fc00::1]/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fd00::1]/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[fcff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:443/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:8080/"_s)), WebCore::IPAddressSpace::Private);
 
-    // Edge cases - should NOT be local
+    // Edge cases - should NOT be private
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fbff::1]/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fe00::1]/"_s)), WebCore::IPAddressSpace::Public);
 }
@@ -135,13 +135,13 @@ TEST(IPAddressSpace, IPv6UniqueLocal)
 // Test IPv6 Link-Local addresses (fe80::/10)
 TEST(IPAddressSpace, IPv6LinkLocal)
 {
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fe80::1]/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fe90::1]/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fea0::1]/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[feb0::1]/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:8080/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fe80::1]/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fe90::1]/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fea0::1]/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[feb0::1]/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:8080/"_s)), WebCore::IPAddressSpace::Private);
 
-    // Edge cases - should NOT be local
+    // Edge cases - should NOT be private
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fe7f::1]/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fec0::1]/"_s)), WebCore::IPAddressSpace::Public);
 }
@@ -151,9 +151,9 @@ TEST(IPAddressSpace, IPv6MappedIPv4DottedDecimal)
 {
     // Local IPv4 addresses mapped to IPv6
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:127.0.0.1]/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:10.0.0.1]/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:192.168.1.1]/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::ffff:172.16.0.1]:443/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:10.0.0.1]/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:192.168.1.1]/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::ffff:172.16.0.1]:443/"_s)), WebCore::IPAddressSpace::Private);
 
     // Public IPv4 addresses mapped to IPv6
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:8.8.8.8]/"_s)), WebCore::IPAddressSpace::Public);
@@ -164,16 +164,16 @@ TEST(IPAddressSpace, IPv6MappedIPv4DottedDecimal)
 TEST(IPAddressSpace, IPv6MappedIPv4HexNotation)
 {
     // 127.0.0.1 = 0x7f000001 -> c0a8:101 represents 192.168.1.1
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:c0a8:101]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:c0a8:101]/"_s)), WebCore::IPAddressSpace::Private);
 
     // 10.0.0.1 = 0x0a000001
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:a00:1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:a00:1]/"_s)), WebCore::IPAddressSpace::Private);
 
     // 8.8.8.8 = 0x08080808
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:808:808]/"_s)), WebCore::IPAddressSpace::Public);
 
     // 172.16.0.1 = 0xac100001
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::ffff:ac10:1]:443/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::ffff:ac10:1]:443/"_s)), WebCore::IPAddressSpace::Private);
 }
 
 // Test IPv6 public addresses
@@ -234,16 +234,16 @@ TEST(IPAddressSpace, UtilityFunctions)
 TEST(IPAddressSpace, DifferentURLSchemes)
 {
     // HTTP and HTTPS
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.168.1.1/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://192.168.1.1/"_s)), WebCore::IPAddressSpace::Private);
 
     // Other schemes
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("ftp://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("ws://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("wss://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("ftp://192.168.1.1/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("ws://192.168.1.1/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("wss://192.168.1.1/"_s)), WebCore::IPAddressSpace::Private);
 
     // Custom schemes
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("custom://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("custom://192.168.1.1/"_s)), WebCore::IPAddressSpace::Private);
 
     // Public addresses with different schemes
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://8.8.8.8/"_s)), WebCore::IPAddressSpace::Public);
@@ -255,9 +255,9 @@ TEST(IPAddressSpace, URLsWithPorts)
 {
     // Local addresses with various ports
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1:8080/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://192.168.1.1:443/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://192.168.1.1:443/"_s)), WebCore::IPAddressSpace::Private);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::1]:3000/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[fc00::1]:8443/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[fc00::1]:8443/"_s)), WebCore::IPAddressSpace::Private);
 
     // Public addresses with ports
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://8.8.8.8:53/"_s)), WebCore::IPAddressSpace::Public);
@@ -268,22 +268,43 @@ TEST(IPAddressSpace, URLsWithPorts)
 TEST(IPAddressSpace, IPv4BoundaryConditions)
 {
     // Test exact boundaries for 172.16.0.0/12
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.16.0.0/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.31.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.16.0.0/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.31.255.255/"_s)), WebCore::IPAddressSpace::Private);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.15.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.32.0.0/"_s)), WebCore::IPAddressSpace::Public);
 
     // Test exact boundaries for 100.64.0.0/10
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.64.0.0/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.127.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.64.0.0/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.127.255.255/"_s)), WebCore::IPAddressSpace::Private);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.63.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.128.0.0/"_s)), WebCore::IPAddressSpace::Public);
 
     // Test exact boundaries for 198.18.0.0/15
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.18.0.0/"_s)), WebCore::IPAddressSpace::Local);
-    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.18.0.0/"_s)), WebCore::IPAddressSpace::Private);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Private);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.17.255.255/"_s)), WebCore::IPAddressSpace::Public);
     EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.20.0.0/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test isPrivateNetworkRequest
+TEST(IPAddressSpace, IsPrivateNetworkRequest)
+{
+    // Public -> Private = private network request
+    EXPECT_TRUE(WebCore::isPrivateNetworkRequest(WebCore::IPAddressSpace::Public, WebCore::IPAddressSpace::Private));
+    // Public -> Local = private network request
+    EXPECT_TRUE(WebCore::isPrivateNetworkRequest(WebCore::IPAddressSpace::Public, WebCore::IPAddressSpace::Local));
+    // Private -> Local = private network request
+    EXPECT_TRUE(WebCore::isPrivateNetworkRequest(WebCore::IPAddressSpace::Private, WebCore::IPAddressSpace::Local));
+
+    // Same-space requests are NOT private network requests
+    EXPECT_FALSE(WebCore::isPrivateNetworkRequest(WebCore::IPAddressSpace::Public, WebCore::IPAddressSpace::Public));
+    EXPECT_FALSE(WebCore::isPrivateNetworkRequest(WebCore::IPAddressSpace::Private, WebCore::IPAddressSpace::Private));
+    EXPECT_FALSE(WebCore::isPrivateNetworkRequest(WebCore::IPAddressSpace::Local, WebCore::IPAddressSpace::Local));
+
+    // More-public target is NOT a private network request
+    EXPECT_FALSE(WebCore::isPrivateNetworkRequest(WebCore::IPAddressSpace::Private, WebCore::IPAddressSpace::Public));
+    EXPECT_FALSE(WebCore::isPrivateNetworkRequest(WebCore::IPAddressSpace::Local, WebCore::IPAddressSpace::Public));
+    EXPECT_FALSE(WebCore::isPrivateNetworkRequest(WebCore::IPAddressSpace::Local, WebCore::IPAddressSpace::Private));
 }
 
 }


### PR DESCRIPTION
#### 2dbdc3d8ad11027a512d51baecd4757831bee2c8
<pre>
Early-level WIP: Local Network Access
<a href="https://bugs.webkit.org/show_bug.cgi?id=312940">https://bugs.webkit.org/show_bug.cgi?id=312940</a>
<a href="https://rdar.apple.com/175293096">rdar://175293096</a>

Reviewed by NOBODY (OOPS!).

Test: Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp

* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::updateTargetAddressSpaceIfNeeded):
* Source/WebCore/Modules/fetch/IPAddressSpace.cpp:
(WebCore::determineIPAddressSpace):
(WebCore::determineIPv4AddressSpace):
(WebCore::determineIPv6AddressSpace):
(WebCore::isLocalIPAddressSpace):
(WebCore::isPrivateNetworkRequest):
* Source/WebCore/Modules/fetch/IPAddressSpace.h:
* Source/WebCore/Modules/fetch/IPAddressSpace.idl:
* Source/WebCore/Modules/permissions/PermissionName.h:
* Source/WebCore/Modules/permissions/PermissionName.idl:
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::Permissions::toPermissionName):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::createAccessControlPreflightRequest):
(WebCore::validatePreflightResponse):
* Source/WebCore/loader/CrossOriginAccessControl.h:
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::validatePreflightResponse):
(WebCore::CrossOriginPreflightChecker::startPreflight):
(WebCore::CrossOriginPreflightChecker::doPreflight):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::makeCrossOriginAccessRequest):
(WebCore::DocumentThreadableLoader::makeCrossOriginAccessRequestWithPreflight):
(WebCore::DocumentThreadableLoader::responseReceived):
(WebCore::DocumentThreadableLoader::preflightSuccess):
* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::MixedContentChecker::shouldBlockRequest):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::requestLocalNetworkAccessPermission):
* Source/WebCore/platform/network/HTTPHeaderNames.in:
* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::RequestData::RequestData):
(WebCore::ResourceRequestBase::isPrivateNetworkAccessAllowed const):
(WebCore::ResourceRequestBase::setIsPrivateNetworkAccessAllowed):
* Source/WebCore/platform/network/ResourceResponseBase.h:
(WebCore::ResourceResponseBase::ipAddressSpace const):
(WebCore::ResourceResponseBase::ipAddressSpace): Deleted.
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::didReceiveResponse):
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::decidePolicyForLocalNetworkAccessPermissionRequest):
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::alertMessageText):
(WebKit::allowButtonText):
(WebKit::doNotAllowButtonText):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::setDelegate):
(WebKit::UIDelegate::UIClient::decidePolicyForLocalNetworkAccessPermissionRequest):
* Source/WebKit/UIProcess/MediaPermissionUtilities.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::shouldAlwaysPromptForPermission const):
(WebKit::WebPageProxy::requestLocalNetworkAccessPermission):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::requestLocalNetworkAccessPermission):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::requestLocalNetworkAccessPermission):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp:
(TestWebKitAPI::TEST(IPAddressSpace, IPv4PrivateAddresses)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv4CarrierGradeNAT)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv4LinkLocal)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv4Benchmarking)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6UniqueLocal)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6LinkLocal)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6MappedIPv4DottedDecimal)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6MappedIPv4HexNotation)):
(TestWebKitAPI::TEST(IPAddressSpace, DifferentURLSchemes)):
(TestWebKitAPI::TEST(IPAddressSpace, URLsWithPorts)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv4BoundaryConditions)):
(TestWebKitAPI::TEST(IPAddressSpace, IsPrivateNetworkRequest)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4663e2ea2f60408f1ec5400f727656cd47ea86f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157917 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166745 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112000 "Hash 4663e2ea for PR 63281 does not build (failure)") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31256 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122291 "Found 25 new test failures: http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/proper-open-window-upgrades-UpgradeMixedContent.html http/tests/security/mixedContent/import-insecure-script-in-iframe-UpgradeMixedContent.html http/tests/security/mixedContent/insecure-css-in-iframe.html http/tests/security/mixedContent/insecure-css-in-main-frame.html http/tests/security/mixedContent/insecure-executable-css-with-secure-cookies-UpgradeMixedContent.html http/tests/security/mixedContent/insecure-iframe-in-iframe.html http/tests/security/mixedContent/insecure-iframe-in-main-frame-UpgradeMixedContent.html http/tests/security/mixedContent/insecure-iframe-in-sandboxed-iframe-UpgradeMixedContent.html http/tests/security/mixedContent/insecure-script-in-data-iframe-in-main-frame-blocked.html http/tests/security/mixedContent/insecure-script-in-iframe.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/112000 "Hash 4663e2ea for PR 63281 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160875 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24581 "Found 60 new test failures: fast/backgrounds/background-repeat-long-scroll.html http/tests/media/audio-load-loadeddata.html http/tests/site-isolation/mediastream/getDisplayMedia-starts.html http/tests/site-isolation/mediastream/getUserMedia-audio-starts.html http/tests/site-isolation/mediastream/getUserMedia-video-starts.html http/tests/ssl/media-stream/get-user-media-different-host.html http/tests/ssl/media-stream/get-user-media-nested.html http/tests/ssl/media-stream/get-user-media-secure-connection.html http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable-gpuprocess.html http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141824 "Found 130 new API test failures: TestWebKitAPI.ServiceWorkers.ThrottleCrash, TestWebKitAPI.WebTransport.WorkerAfterNetworkProcessCrash, TestWebKitAPI.ServiceWorkers.SWProcessConnectionCreation, TestWebKitAPI.ServiceWorker.OpenWindowWebsiteDataStoreDelegate, TestWebKitAPI.PushAPI.firePushEventDataStoreDelegate, TestWebKitAPI.ServiceWorker.openWindowWithoutDelegate, TestWebKitAPI.ServiceWorkers.InProcessServiceWorker, TestWebKitAPI.ServiceWorkers.LoadData, TestWebKitAPI.ServiceWorkers.FetchAfterRestoreFromDisk, TestWebKitAPI.SiteIsolation.IframeImageTranslation ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102957 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23637 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/BlobURL/cross-partition-worker-creation.https.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21934 "Found 132 new API test failures: TestWebKitAPI.ServiceWorkers.ThrottleCrash, TestWebKitAPI.WebTransport.WorkerAfterNetworkProcessCrash, TestWebKitAPI.ServiceWorkers.SWProcessConnectionCreation, TestWebKitAPI.ServiceWorker.OpenWindowWebsiteDataStoreDelegate, TestWebKitAPI.PushAPI.firePushEventDataStoreDelegate, TestWebKitAPI.ResourceLoadDelegate.BeaconAndSyncXHR, TestWebKitAPI.ServiceWorker.openWindowWithoutDelegate, TestWebKitAPI.ServiceWorkers.InProcessServiceWorker, TestWebKitAPI.ServiceWorkers.LoadData, TestWebKitAPI.ServiceWorkers.FetchAfterRestoreFromDisk ... (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14518 "Hash 4663e2ea for PR 63281 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133319 "Found 92 new API test failures: TestWebKitAPI.ServiceWorkers.ThrottleCrash, TestWebKitAPI.WebTransport.WorkerAfterNetworkProcessCrash, TestWebKitAPI.ServiceWorker.OpenWindowWebsiteDataStoreDelegate, TestWebKitAPI.PushAPI.firePushEventDataStoreDelegate, TestWebKitAPI.Badging.DedicatedWorker, TestWebKitAPI.ServiceWorker.openWindowWithoutDelegate, TestWebKitAPI.AdvancedPrivacyProtections.DoNotHideReferrerInPopupWindow, TestWebKitAPI.ServiceWorkers.InProcessServiceWorker, TestWebKitAPI.ServiceWorkers.LoadData, TestWebKitAPI.AppPrivacyReport.NonAppInitiatedRequestWithServiceWorkerSoftUpdate ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169235 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14246 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21249 "Found 60 new test failures: fast/preloader/image-data-url.html http/tests/IndexedDB/collect-IDB-objects.https.html http/tests/IndexedDB/idbindex-getAllRecords-prev-private.html http/tests/accessibility/focus-text-field-in-iframe.html http/tests/cache-storage/cache-clearing-all.https.html http/tests/cache-storage/cache-clearing-origin.https.html http/tests/cache/disk-cache/disk-cache-302-status-code.html http/tests/cache/disk-cache/disk-cache-307-status-code.html http/tests/cache/disk-cache/disk-cache-404-status-code.html http/tests/cache/disk-cache/disk-cache-disable.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130466 "Found 29 new test failures: http/tests/inspector/network/loadResource-insecure-resource-UpgradeMixedContent.html http/tests/navigation/ping-attribute/anchor-cross-origin-from-https-UpgradeMixedContent.html http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html http/tests/navigation/ping-attribute/secure-anchor-cross-origin-UpgradeMixedContent.html http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/proper-open-window-upgrades-UpgradeMixedContent.html http/tests/security/mixedContent/import-insecure-script-in-iframe-UpgradeMixedContent.html http/tests/security/mixedContent/insecure-css-in-iframe.html http/tests/security/mixedContent/insecure-css-in-main-frame.html http/tests/security/mixedContent/insecure-executable-css-with-secure-cookies-UpgradeMixedContent.html http/tests/security/mixedContent/insecure-iframe-in-iframe.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31000 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26000 "Found 60 new test failures: accessibility/mac/input-replacevalue-userinfo.html fast/preloader/image-data-url.html http/tests/IndexedDB/collect-IDB-objects.https.html http/tests/IndexedDB/idbindex-getAllRecords-prev-private.html http/tests/accessibility/focus-text-field-in-iframe.html http/tests/cache-storage/cache-clearing-origin.https.html http/tests/cache/disk-cache/disk-cache-302-status-code.html http/tests/cache/disk-cache/disk-cache-307-status-code.html http/tests/cache/disk-cache/disk-cache-404-status-code.html http/tests/cache/disk-cache/disk-cache-fragments.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130580 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141420 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88801 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25321 "Found 60 new test failures: http/tests/iframe-monitor/blob-resource.html http/tests/iframe-monitor/cached-resource.html http/tests/iframe-monitor/compressed-resource.html http/tests/iframe-monitor/dark-mode.html http/tests/iframe-monitor/data-url-resource.html http/tests/iframe-monitor/eligibility.html http/tests/iframe-monitor/iframe-unload.html http/tests/iframe-monitor/just-use-eligible-subresource.html http/tests/iframe-monitor/throttler.html http/tests/iframe-monitor/workers/service-worker-not-count-twice.html ... (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18226 "Found 60 new test failures: compositing/geometry/layer-position-after-removing-perspective.html fast/preloader/image-data-url.html http/tests/IndexedDB/collect-IDB-objects.https.html http/tests/IndexedDB/idbindex-getAllRecords-prev-private.html http/tests/accessibility/focus-text-field-in-iframe.html http/tests/cache-storage/cache-clearing-all.https.html http/tests/cache-storage/cache-clearing-origin.https.html http/tests/cache/disk-cache/disk-cache-302-status-code.html http/tests/cache/disk-cache/disk-cache-307-status-code.html http/tests/cache/disk-cache/disk-cache-404-status-code.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30490 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95668 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30011 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30241 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30138 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->