### PR TITLE
check-for-inappropriate-objc-class-names reports false positives due to linker-generated helper functions

### DIFF
--- a/Tools/Scripts/check-for-inappropriate-objc-class-names
+++ b/Tools/Scripts/check-for-inappropriate-objc-class-names
@@ -59,17 +59,20 @@ my $pattern = "^(" . join('|', @allowedPrefixes) . ")";
 my $sawError = 0;
 
 if (!defined $executablePathAge || !defined $buildTimestampAge || $executablePathAge < $buildTimestampAge || $scriptAge < $buildTimestampAge) {
-    if (!open NM, "(nm -Ujp '$executablePath' | sed 's/^/STDOUT:/') 2>&1 |") {
-        print "ERROR: Could not open $executablePath\n";
+    if (!open NM, "(nm -Ump '$executablePath' | grep -v __TEXT | sed 's/^/STDOUT:/') 2>&1 |") {
+        print "error: Could not open $executablePath\n";
         $sawError = 1;
         next;
     }
     my @badNames;
     while (<NM>) {
         if (/^STDOUT:/) {
-            next unless /^STDOUT:_OBJC_CLASS_\$_/;
+            next unless /^STDOUT:.+_OBJC_CLASS_\$_.+$/;
             chomp;
-            my $className = substr($_, 21);
+            s/\([^\)]+\)//g;
+            s/^.+_OBJC_CLASS_\$_//;
+            s/\ .*$//;
+            my $className = $_;
             push(@badNames, $className) unless $className =~ /$pattern/;
         } else {
             print STDERR if $_ ne "nm: no name list\n";
@@ -106,15 +109,15 @@ if (!defined $executablePathAge || !defined $buildTimestampAge || $executablePat
         my $shortName = $executablePath;
         $shortName =~ s/.*\///;
 
-        print "ERROR: $shortName defines one or more Objective-C classes with inappropriate names. ($executablePath)\n";
+        print "error: $shortName defines one or more Objective-C classes with inappropriate names. ($executablePath)\n";
         for my $className (@badNames) {
-            print "ERROR: Inappropriate Objective-C class name: $className.\n";
+            print "error: Inappropriate Objective-C class name: $className.\n";
         }
 
         if (@allowedPrefixes > 1) {
-            print "ERROR: Objective-C class names in $target must have one of these prefixes: " . join(", ", map('"' . $_ . '"', @allowedPrefixes)) . ".\n";
+            print "error: Objective-C class names in $target must have one of these prefixes: " . join(", ", map('"' . $_ . '"', @allowedPrefixes)) . ".\n";
         } else {
-            print "ERROR: Objective-C class names in $target must have the prefix \"" . $allowedPrefixes[0] . "\".\n";
+            print "error: Objective-C class names in $target must have the prefix \"" . $allowedPrefixes[0] . "\".\n";
         }
 
         $sawError = 1;


### PR DESCRIPTION
#### 3c85d58466e8b26669d3e73291a297f42f662cca
<pre>
check-for-inappropriate-objc-class-names reports false positives due to linker-generated helper functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=312947">https://bugs.webkit.org/show_bug.cgi?id=312947</a>
<a href="https://rdar.apple.com/175271158">rdar://175271158</a>

Reviewed by Richard Robinson.

When delay-init linking an Objective-C class, the linker can now generate a helper function
with a name of the format &quot;_OBJC_CLASS_$_TheClassName$loadHelper_x8&quot;. This causes failures
from our check-for-inappropriate-objc-class-names script, which detects that symbol as an
Objective-C class named &quot;TheClassName$loadHelper_x8&quot;.

Prevent this by excluding all symbols from the __TEXT segment when considering Objective-C
class names, since the metadata for classes (i.e. any content that would ever legitimately
produce issues) is placed into other sections.

While I was in the area, I also changed the output formatting to print &apos;error:&apos; in
lowercase since Xcode knows how to surface such prefixed lines as separate errors rather
than burying that output in the build transcript.

* Tools/Scripts/check-for-inappropriate-objc-class-names:
    Augment the `nm` invocation to print the full mach-o info about the symbols so that
    the segment is included in the output. That then requires updates to the name
    extraction to account for the fact that the line now contains more text than just the
    symbol name.

Canonical link: <a href="https://commits.webkit.org/311750@main">https://commits.webkit.org/311750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a45d945e505a8c43088837c7c06622e5775efc92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166714 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122259 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24548 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102925 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14487 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169204 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21219 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30969 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130547 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35355 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141390 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88760 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25284 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18196 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30459 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29980 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30210 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30107 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->