### PR TITLE
[YARR] Reject dangling hyphen in class set under `/v` flag

### DIFF
--- a/JSTests/stress/regexp-v-flag-dangling-hyphen.js
+++ b/JSTests/stress/regexp-v-flag-dangling-hyphen.js
@@ -1,0 +1,34 @@
+function shouldThrowSyntaxError(source) {
+    let error = null;
+    try {
+        new RegExp(source, "v");
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof SyntaxError))
+        throw new Error(`Expected SyntaxError for /${source}/v but got ${error}`);
+}
+
+function shouldNotThrow(source) {
+    new RegExp(source, "v");
+}
+
+// In /v mode, '-' is a ClassSetSyntaxCharacter and is only legal between two
+// ClassSetCharacters as part of a ClassSetRange. A bare or trailing '-' with
+// no right-hand side must be rejected.
+shouldThrowSyntaxError("[a-]");
+shouldThrowSyntaxError("[\\d-]");
+shouldThrowSyntaxError("[\\w-]");
+shouldThrowSyntaxError("[a-z\\d-]");
+shouldThrowSyntaxError("[\\p{ASCII}-]");
+shouldThrowSyntaxError("[a-[b]]");
+shouldThrowSyntaxError("[\\d-[b]]");
+
+// These should still parse.
+shouldNotThrow("[a-z]");
+shouldNotThrow("[a\\-]");
+shouldNotThrow("[\\-a]");
+shouldNotThrow("[a--b]");
+shouldNotThrow("[a&&b]");
+shouldNotThrow("[\\w--\\d]");
+shouldNotThrow("[\\d\\-a]");

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -537,7 +537,8 @@ private:
             if (m_state == ClassSetConstructionState::CachedCharacter) {
                 m_delegate.atomCharacterClassAtom(m_character);
                 m_state = ClassSetConstructionState::Empty;
-            }
+            } else if (m_state == ClassSetConstructionState::CachedCharacterHyphen || m_state == ClassSetConstructionState::AfterCharacterClassHyphen)
+                m_errorCode = ErrorCode::InvalidClassSetCharacter;
         }
 
         void afterSetOperand()
@@ -757,10 +758,7 @@ private:
         {
             if (m_state == ClassSetConstructionState::CachedCharacter)
                 m_delegate.atomCharacterClassAtom(m_character);
-            else if (m_state == ClassSetConstructionState::CachedCharacterHyphen) {
-                m_delegate.atomCharacterClassAtom(m_character);
-                m_delegate.atomCharacterClassAtom('-');
-            } else if (m_state == ClassSetConstructionState::AfterSetOperator)
+            else if (m_state == ClassSetConstructionState::CachedCharacterHyphen || m_state == ClassSetConstructionState::AfterCharacterClassHyphen || m_state == ClassSetConstructionState::AfterSetOperator)
                 m_errorCode = ErrorCode::InvalidClassSetCharacter;
 
             if (isInverted() && m_mayContainStrings)


### PR DESCRIPTION
#### 1088aa8bd9981b871a451fa77b336383025ab347
<pre>
[YARR] Reject dangling hyphen in class set under `/v` flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=312948">https://bugs.webkit.org/show_bug.cgi?id=312948</a>

Reviewed by Yusuke Suzuki.

In UnicodeSets mode (/v), &apos;-&apos; is a ClassSetSyntaxCharacter and is only
legal between two ClassSetCharacters as part of a ClassSetRange. A bare
or trailing &apos;-&apos; with no right-hand side (e.g. /[a-]/v, /[\d-]/v) must be
rejected, but JSC was incorrectly accepting them by emitting both the
cached character and a literal &apos;-&apos;.

This patch makes ClassSetParserDelegate raise InvalidClassSetCharacter
in flushCachedCharacterIfNeeded() and end() when CachedCharacterHyphen
or AfterCharacterClassHyphen state is reached, since both represent an
incomplete ClassSetRange.

Test: JSTests/stress/regexp-v-flag-dangling-hyphen.js

* JSTests/stress/regexp-v-flag-dangling-hyphen.js: Added.
(shouldThrowSyntaxError):
(shouldNotThrow):
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::ClassSetParserDelegate::flushCachedCharacterIfNeeded):
(JSC::Yarr::Parser::ClassSetParserDelegate::end):

Canonical link: <a href="https://commits.webkit.org/311999@main">https://commits.webkit.org/311999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d74b77b367d32e5fdcfd05a2bb3ef0bcaaac6f80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166700 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111954 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122248 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85834 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102914 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23594 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21888 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14473 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149923 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169190 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18707 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14000 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130420 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130534 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35501 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141374 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88745 "Hash d74b77b3 for PR 63288 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25274 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18180 "Passed tests") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190001 "Hash d74b77b3 for PR 63288 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30445 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95380 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/190001 "Hash d74b77b3 for PR 63288 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29966 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->