### PR TITLE
Avoid updating UI-side layer positions for no-op transactions

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -302,6 +302,7 @@ void ScrollingTree::traverseScrollingTreeRecursive(ScrollingTreeNode& node, NOES
 
 void ScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode& node, ScrollingLayerPositionAction)
 {
+    setNeedsApplyLayerPositions();
     if (node.isRootNode())
         setMainFrameScrollPosition(node.currentScrollPosition());
 }
@@ -458,6 +459,7 @@ bool ScrollingTree::commitTreeStateInternal(std::unique_ptr<ScrollingStateTree>&
     }
 
     didCommitTree();
+    setNeedsApplyLayerPositions();
 
     return succeeded;
 }
@@ -586,6 +588,9 @@ void ScrollingTree::removeAllNodes()
 void ScrollingTree::applyLayerPositions()
 {
     Locker locker { m_treeLock };
+
+    if (!m_needsApplyLayerPositions.exchange(false))
+        return;
 
     applyLayerPositionsInternal();
 }

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -125,6 +125,7 @@ public:
     bool commitTreeStateInternal(std::unique_ptr<ScrollingStateTree>&&, std::optional<LayerHostingContextIdentifier>) WTF_REQUIRES_LOCK(m_treeLock);
 
     WEBCORE_EXPORT virtual void applyLayerPositions();
+    void setNeedsApplyLayerPositions() { m_needsApplyLayerPositions = true; }
 
     virtual Ref<ScrollingTreeNode> createScrollingTreeNode(ScrollingNodeType, ScrollingNodeID) = 0;
     
@@ -393,6 +394,7 @@ protected:
 private:
     ThreadSafeWeakHashSet<ScrollingTreeNode> m_fixedOrStickyNodes;
     std::atomic<bool> m_isHandlingProgrammaticScroll { false };
+    std::atomic<bool> m_needsApplyLayerPositions { false };
     bool m_isMonitoringWheelEvents { false };
     bool m_scrollingPerformanceTestingEnabled { false };
     bool m_overlayScrollbarsEnabled { false };


### PR DESCRIPTION
#### 8ff9ee25d0ec06f7173aa827b6bf4307ffe400b8
<pre>
Avoid updating UI-side layer positions for no-op transactions
<a href="https://bugs.webkit.org/show_bug.cgi?id=312959">https://bugs.webkit.org/show_bug.cgi?id=312959</a>
<a href="https://rdar.apple.com/175308880">rdar://175308880</a>

Reviewed by Brent Fulgham.

Currently, after every RemoteLayerTree commit that is received by the UI process,
we call `applyScrollingTreeLayerPositionsAfterCommit()`, which traverses the scrolling
tree and updates CALayer positions.

If the transaction contains no scrolling tree changes, then this is not necessary;
`applyLayerPositions()` only needs to be called after a scrolling tree state change,
or after a user scroll.

Track this state via `ScrollingTree::m_needsApplyLayerPositions()`, and set the flag
under `commitTreeState()` and `scrollingTreeNodeDidScroll()`. It&apos;s the `commitTreeState(()`
call that&apos;s skipped when `stateTree-&gt;hasChangedProperties()` is false.

This should be a minor power saving.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::scrollingTreeNodeDidScroll):
(WebCore::ScrollingTree::commitTreeStateInternal):
(WebCore::ScrollingTree::applyLayerPositions):
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::setNeedsApplyLayerPositions):

Canonical link: <a href="https://commits.webkit.org/311816@main">https://commits.webkit.org/311816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50ea6df49b582384ffdf4e95886ff03a85951a6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166829 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112084 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122361 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85903 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103028 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23705 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14602 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169319 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14673 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130535 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130650 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35401 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141493 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88918 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18299 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30574 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96107 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30095 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30325 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->