### PR TITLE
AX: aria-relevant="text" not handled properly when setting/replacing text

### DIFF
--- a/LayoutTests/accessibility/mac/live-regions/live-region-relevant-text-non-atomic-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-relevant-text-non-atomic-expected.txt
@@ -1,0 +1,14 @@
+This tests that aria-relevant=text properly announces when setting textContent on a live region.
+
+Received announcement request:
+AnnouncementKey: New Content{
+    AXLanguage = en;
+}
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+New Content

--- a/LayoutTests/accessibility/mac/live-regions/live-region-relevant-text-non-atomic.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-relevant-text-non-atomic.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div id="text-region" aria-live="polite" aria-relevant="text">Initial text</div>
+
+<script>
+var output = "This tests that aria-relevant=text properly announces when setting textContent on a live region.\n\n";
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAnnouncementUserInfo(userInfo);
+        output += `\n`;
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("text-region");
+
+    document.getElementById("text-region").textContent = "New Content";
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXAnnouncementTypes.h
+++ b/Source/WebCore/accessibility/AXAnnouncementTypes.h
@@ -52,6 +52,7 @@ struct LiveRegionObject {
     String text;
     String language;
     HashSet<AXID> descendants; // For atomic regions only, to track additions/removals of descendants.
+    bool isTextContent { false };
 };
 
 struct LiveRegionSnapshot {

--- a/Source/WebCore/accessibility/AXLiveRegionManager.cpp
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.cpp
@@ -216,7 +216,7 @@ LiveRegionSnapshot AXLiveRegionManager::buildLiveRegionSnapshot(AccessibilityObj
         }
 
         if (shouldIncludeInSnapshot(object))
-            snapshot.objects.append({ object.objectID(), object.announcementText(), object.languageIncludingAncestors(), { } });
+            snapshot.objects.append({ object.objectID(), object.announcementText(), object.languageIncludingAncestors(), { }, object.isStaticText() });
         else {
             for (auto& child : object.unignoredChildren())
                 buildObjectList(downcast<AccessibilityObject>(child.get()));
@@ -329,7 +329,6 @@ AttributedString AXLiveRegionManager::computeAnnouncement(const LiveRegionSnapsh
     StringBuilder stringBuilder;
     Vector<std::pair<AttributedString::Range, HashMap<String, AttributedString::AttributeValue>>> attributes;
 
-    bool reachedCharacterLimit = false;
     size_t characterCount = 0;
 
     HashSet<AXID> spokenObjects = { };
@@ -368,38 +367,29 @@ AttributedString AXLiveRegionManager::computeAnnouncement(const LiveRegionSnapsh
         spokenObjects.add(object.objectID);
     };
 
-    if (hasAdditions && !diff.added.isEmpty()) {
-        for (auto& object : diff.added) {
-            appendStringAndLanguage(object);
-
-            if (characterCount > maximumAnnouncementLength) {
-                reachedCharacterLimit = true;
+    auto announceObjects = [&](const Vector<LiveRegionObject>& objects, IsLiveRegionRemoval isRemoval = IsLiveRegionRemoval::No, bool textContentOnly = false) {
+        for (auto& object : objects) {
+            if (characterCount > maximumAnnouncementLength)
                 break;
-            }
+            if (textContentOnly && !object.isTextContent)
+                continue;
+            appendStringAndLanguage(object, isRemoval);
         }
-    }
+    };
 
-    if (!reachedCharacterLimit && hasRemovals && !diff.removed.isEmpty()) {
-        for (auto& object : diff.removed) {
-            appendStringAndLanguage(object, IsLiveRegionRemoval::Yes);
+    // "additions" announces all new nodes. "text" without "additions" announces only added text
+    // nodes (e.g. textContent/innerText replacement creates new text nodes, not element additions).
+    // When both are set, "additions" already covers text nodes so the text-only path is skipped.
+    if (hasAdditions)
+        announceObjects(diff.added);
+    else if (hasText)
+        announceObjects(diff.added, IsLiveRegionRemoval::No, /* textContentOnly */ true);
 
-            if (characterCount > maximumAnnouncementLength) {
-                reachedCharacterLimit = true;
-                break;
-            }
-        }
-    }
+    if (hasRemovals)
+        announceObjects(diff.removed, IsLiveRegionRemoval::Yes);
 
-    if (!reachedCharacterLimit && hasText && !diff.changed.isEmpty()) {
-        for (auto& object : diff.changed) {
-            appendStringAndLanguage(object);
-
-            if (characterCount > maximumAnnouncementLength) {
-                reachedCharacterLimit = true;
-                break;
-            }
-        }
-    }
+    if (hasText)
+        announceObjects(diff.changed);
 
     auto string = stringBuilder.toString();
     return AttributedString { WTF::move(string), WTF::move(attributes), std::nullopt };


### PR DESCRIPTION
#### 10a8504cca5e55437034047473438581b15de069
<pre>
AX: aria-relevant=&quot;text&quot; not handled properly when setting/replacing text
<a href="https://bugs.webkit.org/show_bug.cgi?id=312958">https://bugs.webkit.org/show_bug.cgi?id=312958</a>
<a href="https://rdar.apple.com/165656891">rdar://165656891</a>

Reviewed by Tyler Wilcock.

When text is replaced/set using APIs like innerText/textContent, the node can get regenerated, leading
to a new accessibility object being created. This causes those nodes to be considered &quot;additions&quot;. In
the previous logic, that meant those elements wouldn&apos;t be announced for aria-relevant=text regions.

The fix for this is to consider additions that are text content to be text changes. If aria-relevant=
additions, this supersedes this and includes all content.

Test: accessibility/mac/live-regions/live-region-relevant-text-non-atomic.html

* LayoutTests/accessibility/mac/live-regions/live-region-relevant-text-non-atomic-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-relevant-text-non-atomic.html: Added.
* Source/WebCore/accessibility/AXAnnouncementTypes.h:
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::buildLiveRegionSnapshot const):
(WebCore::AXLiveRegionManager::computeAnnouncement const):

Canonical link: <a href="https://commits.webkit.org/311778@main">https://commits.webkit.org/311778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f3d3796c2fcb01a120250b9abb87a20c4398e6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166719 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111974 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159762 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122265 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85849 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102931 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23611 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21906 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14492 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169209 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14095 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130439 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130553 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35377 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88765 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18199 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30464 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95508 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29985 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30215 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30112 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->