### PR TITLE
WPT testcase for deselectAll() on SVGSVGElement Interface

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-deselectAll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-deselectAll-expected.txt
@@ -1,0 +1,13 @@
+Selectable text
+Inner text
+HTML paragraph text
+
+
+PASS deselectAll exists on outermost svg element
+PASS deselectAll exists on inner svg element
+PASS deselectAll() does not throw when nothing is selected
+PASS deselectAll() clears selection of SVG text content
+PASS deselectAll() clears selection of HTML content outside the svg
+PASS deselectAll() on inner svg clears the document selection
+PASS deselectAll() results in a collapsed selection
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-deselectAll.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-deselectAll.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<title>SVGSVGElement.deselectAll()</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__deselectAll">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="outer" width="200" height="200">
+  <text id="svgtext" x="10" y="50">Selectable text</text>
+  <svg id="inner" width="100" height="100">
+    <text id="innertext" x="10" y="50">Inner text</text>
+  </svg>
+</svg>
+<p id="htmltext">HTML paragraph text</p>
+<script>
+const outer = document.getElementById("outer");
+const inner = document.getElementById("inner");
+const svgtext = document.getElementById("svgtext");
+const innertext = document.getElementById("innertext");
+const htmltext = document.getElementById("htmltext");
+
+test(function() {
+  assert_equals(typeof outer.deselectAll, "function",
+    "deselectAll must be a function");
+}, "deselectAll exists on outermost svg element");
+
+test(function() {
+  assert_equals(typeof inner.deselectAll, "function",
+    "deselectAll must be a function on inner svg");
+}, "deselectAll exists on inner svg element");
+
+test(function() {
+  outer.deselectAll();
+}, "deselectAll() does not throw when nothing is selected");
+
+test(function() {
+  const sel = window.getSelection();
+  const range = document.createRange();
+  range.selectNodeContents(svgtext);
+  sel.removeAllRanges();
+  sel.addRange(range);
+  assert_greater_than(sel.rangeCount, 0,
+    "precondition: text must be selected");
+
+  outer.deselectAll();
+
+  assert_equals(sel.rangeCount, 0,
+    "deselectAll must remove all ranges from the selection");
+}, "deselectAll() clears selection of SVG text content");
+
+test(function() {
+  const sel = window.getSelection();
+  const range = document.createRange();
+  range.selectNodeContents(htmltext);
+  sel.removeAllRanges();
+  sel.addRange(range);
+  assert_greater_than(sel.rangeCount, 0,
+    "precondition: HTML text must be selected");
+
+  outer.deselectAll();
+
+  assert_equals(sel.rangeCount, 0,
+    "deselectAll must clear selections even outside the SVG subtree");
+}, "deselectAll() clears selection of HTML content outside the svg");
+
+test(function() {
+  const sel = window.getSelection();
+  const range = document.createRange();
+  range.selectNodeContents(svgtext);
+  sel.removeAllRanges();
+  sel.addRange(range);
+  assert_greater_than(sel.rangeCount, 0,
+    "precondition: text must be selected");
+
+  inner.deselectAll();
+
+  assert_equals(sel.rangeCount, 0,
+    "deselectAll on inner svg must also clear the document selection");
+}, "deselectAll() on inner svg clears the document selection");
+
+test(function() {
+  const sel = window.getSelection();
+  const range = document.createRange();
+  range.selectNodeContents(svgtext);
+  sel.removeAllRanges();
+  sel.addRange(range);
+
+  outer.deselectAll();
+
+  assert_true(sel.isCollapsed,
+    "after deselectAll, selection must be collapsed");
+}, "deselectAll() results in a collapsed selection");
+</script>


### PR DESCRIPTION
#### 6c9f1125938c5ce5f3baddd92e98e26fa1343133
<pre>
WPT testcase for deselectAll() on SVGSVGElement Interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=312961">https://bugs.webkit.org/show_bug.cgi?id=312961</a>
<a href="https://rdar.apple.com/175311669">rdar://175311669</a>

Reviewed by Dan Glastonbury.

This adds a missing WPT test for deselectAll on SVGSVGElement Interface.
see <a href="https://github.com/w3c/svgwg/issues/1095">https://github.com/w3c/svgwg/issues/1095</a>

Test: imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-deselectAll.html

* LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-deselectAll-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-deselectAll.html: Added.

Canonical link: <a href="https://commits.webkit.org/311752@main">https://commits.webkit.org/311752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b77ef3210888b26a2c2b637fed39e8e84ca252a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166724 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122271 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24561 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102937 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14497 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169214 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130445 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/157294 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30979 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25979 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130559 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141401 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88772 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25296 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18207 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30469 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29990 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30220 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30117 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->