### PR TITLE
Fix the case of two adjacent placeholders for the i18n replacement logic

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
@@ -313,7 +313,7 @@ String WebExtensionLocalization::stringByReplacingNamedPlaceholdersInString(Stri
 
         localizedString = makeStringByReplacingAll(localizedString, originalKey, localizedReplacement);
 
-        index += localizedReplacement.length();
+        index += std::max(0, static_cast<int>(localizedReplacement.length()) - 1);
     }
 
     return localizedString;
@@ -350,7 +350,7 @@ String WebExtensionLocalization::stringByReplacingPositionalPlaceholdersInString
         if (!matchLength)
             break;
 
-        index += replacement.length();
+        index += std::max(0, static_cast<int>(replacement.length()) - 1);
     }
 
     return localizedString;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm
@@ -473,6 +473,17 @@ TEST(WKWebExtensionAPILocalization, Placeholders)
                 },
             },
         },
+        @"key12": @{
+            messageKey: @"$prefix$$suffix$",
+            placeholdersKey: @{
+                @"prefix": @{
+                    placeholderDictionaryContentKey: @"$1",
+                },
+                @"suffix": @{
+                    placeholderDictionaryContentKey: @"$2",
+                },
+            },
+        },
     };
 
     auto *backgroundScript = Util::constructScript(@[
@@ -491,6 +502,7 @@ TEST(WKWebExtensionAPILocalization, Placeholders)
         @"browser.test.assertEq(browser.i18n.getMessage('key9', placeholders), 'v3')",
         @"browser.test.assertEq(browser.i18n.getMessage('key10', placeholders), 'v3.4版')",
         @"browser.test.assertEq(browser.i18n.getMessage('key11', placeholders), '3 4')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key12', placeholders), '34')",
 
         [NSString stringWithFormat:@"placeholders = %@", Util::constructJSArrayOfStrings(@[ @"irrelevant", @"argument value" ])],
         @"browser.test.assertEq(browser.i18n.getMessage('key5', placeholders), ' and argument value')",


### PR DESCRIPTION
#### 9d2313b02b23d7fe95b3e3f11f3e4f6ce2a8a74a
<pre>
Fix the case of two adjacent placeholders for the i18n replacement logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=312967">https://bugs.webkit.org/show_bug.cgi?id=312967</a>

Reviewed by Timothy Hatcher.

The regex (?:[^$]|^)(\$NAME\$) requires a non-$ guard character immediately before each placeholder unless the placeholder is at the beginning of a string. Advancing by replacement.length() - 1 keeps the last inserted char within the search window, letting it serve as the guard for an immediately following placeholder.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm

* Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp:
(WebKit::WebExtensionLocalization::stringByReplacingNamedPlaceholdersInString):
(WebKit::WebExtensionLocalization::stringByReplacingPositionalPlaceholdersInString):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, Placeholders)):

Canonical link: <a href="https://commits.webkit.org/311769@main">https://commits.webkit.org/311769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bf5aa3c241624805c0839eb3dbb39278b8eb606

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166733 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111988 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122278 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85855 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24570 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141809 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102944 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23626 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14506 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133308 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169223 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14208 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130454 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130568 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141406 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88787 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24011 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25304 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18212 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95617 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29999 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->