### PR TITLE
[JSC] Lower `BitAnd(SShr(x, lsb), mask)` to `ubfx` for ARM64

### DIFF
--- a/JSTests/microbenchmarks/arithmetic-shift-and-mask.js
+++ b/JSTests/microbenchmarks/arithmetic-shift-and-mask.js
@@ -1,0 +1,18 @@
+function test(pixel)
+{
+    var r = (pixel >> 24) & 0xff;
+    var g = (pixel >> 16) & 0xff;
+    var b = (pixel >> 8) & 0xff;
+    var a = pixel & 0xff;
+    return r + g + b + a;
+}
+noInline(test);
+
+var result = 0;
+for (var i = 0; i < 5e6; ++i) {
+    result += test(0x12345678);
+    result += test(0x87654321 | 0);
+}
+
+if (result !== 3060000000)
+    throw new Error("bad result: " + result);

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -3957,28 +3957,13 @@ private:
             Value* left = m_value->child(0);
             Value* right = m_value->child(1);
 
-            if (right->isInt(0xff)) {
-                appendUnOp<ZeroExtend8To32, ZeroExtend8To32>(left);
-                return;
-            }
-
-            if (right->isInt(0xffff)) {
-                appendUnOp<ZeroExtend16To32, ZeroExtend16To32>(left);
-                return;
-            }
-
-            if (right->isInt64(0xffffffff) || right->isInt32(0xffffffff)) {
-                appendUnOp<Move32, Move32>(left);
-                return;
-            }
-
-            // UBFX Pattern: dest = (src >> lsb) & mask 
+            // UBFX Pattern: dest = (src >> lsb) & mask
             // Where: mask = (1 << width) - 1
             auto tryAppendUBFX = [&] () -> bool {
                 Air::Opcode opcode = opcodeForType(ExtractUnsignedBitfield32, ExtractUnsignedBitfield64, m_value->type());
-                if (!isValidForm(opcode, Arg::Tmp, Arg::Imm, Arg::Imm, Arg::Tmp)) 
+                if (!isValidForm(opcode, Arg::Tmp, Arg::Imm, Arg::Imm, Arg::Tmp))
                     return false;
-                if (left->opcode() != ZShr)
+                if (left->opcode() != ZShr && left->opcode() != SShr)
                     return false;
 
                 Value* srcValue = left->child(0);
@@ -4002,6 +3987,21 @@ private:
 
             if (tryAppendUBFX())
                 return;
+
+            if (right->isInt(0xff)) {
+                appendUnOp<ZeroExtend8To32, ZeroExtend8To32>(left);
+                return;
+            }
+
+            if (right->isInt(0xffff)) {
+                appendUnOp<ZeroExtend16To32, ZeroExtend16To32>(left);
+                return;
+            }
+
+            if (right->isInt64(0xffffffff) || right->isInt32(0xffffffff)) {
+                appendUnOp<Move32, Move32>(left);
+                return;
+            }
 
             // BIC Pattern: d = n & (m ^ -1)
             auto tryAppendBIC = [&] (Value* left, Value* right) -> bool {

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -602,6 +602,8 @@ void testUbfx32ShiftAnd();
 void testUbfx32AndShift();
 void testUbfx64ShiftAnd();
 void testUbfx64AndShift();
+void testUbfx32ArithmeticShiftAnd();
+void testUbfx64ArithmeticShiftAnd();
 void testUbfiz32AndShiftValueMask();
 void testUbfiz32AndShiftMaskValue();
 void testUbfiz32ShiftAnd();

--- a/Source/JavaScriptCore/b3/testb3_2.cpp
+++ b/Source/JavaScriptCore/b3/testb3_2.cpp
@@ -3938,6 +3938,94 @@ void testUbfx64AndShift()
     }
 }
 
+void testUbfx32ArithmeticShiftAnd()
+{
+    // Test Pattern: (src >> lsb) & mask with arithmetic shift.
+    if (JSC::Options::defaultB3OptLevel() < 2)
+        return;
+    Vector<int32_t> srcs = { 0, 1, -1, 0x76543210, static_cast<int32_t>(0xfedcba98) };
+    Vector<uint32_t> lsbs = { 1, 8, 14, 30 };
+    Vector<uint32_t> widths = { 30, 8, 17, 1 };
+
+    auto test = [&] (uint32_t lsb, uint32_t mask, bool expectUbfx) {
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<int32_t>(proc, root);
+
+        Value* srcValue = arguments[0];
+        Value* lsbValue = root->appendNew<Const32Value>(proc, Origin(), lsb);
+        Value* maskValue = root->appendNew<Const32Value>(proc, Origin(), mask);
+
+        Value* left = root->appendNew<Value>(proc, SShr, Origin(), srcValue, lsbValue);
+        root->appendNewControlValue(
+            proc, Return, Origin(),
+            root->appendNew<Value>(proc, BitAnd, Origin(), left, maskValue));
+
+        auto code = compileProc(proc);
+        if (isARM64()) {
+            if (expectUbfx)
+                checkUsesInstruction(*code, "ubfx");
+            else
+                checkDoesNotUseInstruction(*code, "ubfx");
+        }
+        for (auto src : srcs)
+            CHECK_EQ(invoke<int32_t>(*code, src), ((src >> lsb) & static_cast<int32_t>(mask)));
+    };
+
+    auto generateMask = [&] (uint32_t width) -> uint32_t {
+        return (1U << width) - 1U;
+    };
+
+    for (size_t i = 0; i < lsbs.size(); ++i)
+        test(lsbs.at(i), generateMask(widths.at(i)), true);
+
+    // lsb + width > 32: mask reaches sign bits, must not use ubfx.
+    test(8, generateMask(25), false);
+}
+
+void testUbfx64ArithmeticShiftAnd()
+{
+    if (JSC::Options::defaultB3OptLevel() < 2)
+        return;
+    Vector<int64_t> srcs = { 0, 1, -1, 0x123456789abcdef0LL, static_cast<int64_t>(0xfedcba9876543210ULL) };
+    Vector<uint64_t> lsbs = { 1, 8, 30, 62 };
+    Vector<uint64_t> widths = { 62, 8, 33, 1 };
+
+    auto test = [&] (uint64_t lsb, uint64_t mask, bool expectUbfx) {
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<int64_t>(proc, root);
+
+        Value* srcValue = arguments[0];
+        Value* lsbValue = root->appendNew<Const32Value>(proc, Origin(), lsb);
+        Value* maskValue = root->appendNew<Const64Value>(proc, Origin(), mask);
+
+        Value* left = root->appendNew<Value>(proc, SShr, Origin(), srcValue, lsbValue);
+        root->appendNewControlValue(
+            proc, Return, Origin(),
+            root->appendNew<Value>(proc, BitAnd, Origin(), left, maskValue));
+
+        auto code = compileProc(proc);
+        if (isARM64()) {
+            if (expectUbfx)
+                checkUsesInstruction(*code, "ubfx");
+            else
+                checkDoesNotUseInstruction(*code, "ubfx");
+        }
+        for (auto src : srcs)
+            CHECK_EQ(invoke<int64_t>(*code, src), ((src >> lsb) & static_cast<int64_t>(mask)));
+    };
+
+    auto generateMask = [&] (uint64_t width) -> uint64_t {
+        return (1ULL << width) - 1ULL;
+    };
+
+    for (size_t i = 0; i < lsbs.size(); ++i)
+        test(lsbs.at(i), generateMask(widths.at(i)), true);
+
+    test(8, generateMask(57), false);
+}
+
 void testUbfiz32AndShiftValueMask()
 {
     // Test Pattern: d = (n & mask) << lsb 
@@ -7728,6 +7816,8 @@ void addBitTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& ta
     RUN(testUbfx32AndShift());
     RUN(testUbfx64ShiftAnd());
     RUN(testUbfx64AndShift());
+    RUN(testUbfx32ArithmeticShiftAnd());
+    RUN(testUbfx64ArithmeticShiftAnd());
     RUN(testUbfiz32AndShiftValueMask());
     RUN(testUbfiz32AndShiftMaskValue());
     RUN(testUbfiz32ShiftAnd());


### PR DESCRIPTION
#### b8d759043c8880de7528a5acecc3207b8e79d9c8
<pre>
[JSC] Lower `BitAnd(SShr(x, lsb), mask)` to `ubfx` for ARM64
<a href="https://bugs.webkit.org/show_bug.cgi?id=312963">https://bugs.webkit.org/show_bug.cgi?id=312963</a>

Reviewed by Yusuke Suzuki.

tryAppendUBFX previously matched only BitAnd(ZShr, mask). Extend it to
also accept SShr (arithmetic right shift). This is safe because the
existing lsb + width &lt;= datasize guard ensures the mask never reaches
the sign-extension bits introduced by the arithmetic shift, so ubfx
(which zero-extends) produces the identical result.

Also move tryAppendUBFX before the 0xff/0xffff/0xffffffff zero-extend
special cases so that the common pixel-unpacking pattern
(pixel &gt;&gt; N) &amp; 0xff is not stolen by ZeroExtend8To32 and instead
collapses into a single ubfx. Non-shift BitAnd(x, 0xff) still falls
through to the existing zero-extend path, and x86_64 is unaffected
since ExtractUnsignedBitfield* has no valid form there.

This mirrors a recent V8 change that reported ~2% on JetStream3
gaussian-blur: <a href="https://chromium-review.googlesource.com/c/v8/v8/+/7768219">https://chromium-review.googlesource.com/c/v8/v8/+/7768219</a>

FTL codegen for `((p&gt;&gt;24)&amp;0xff)+((p&gt;&gt;16)&amp;0xff)+((p&gt;&gt;8)&amp;0xff)+(p&amp;0xff)`:

Before:
    asr   w2, w0, #0x18
    and   w2, w2, #0xff
    asr   w3, w0, #0x10
    and   w3, w3, #0xff
    asr   w4, w0, #0x8
    and   w4, w4, #0xff
    and   w0, w0, #0xff
    add   w2, w2, w3
    add   w0, w4, w0
    add   w0, w2, w0

After:
    lsr   w2, w0, #0x18
    ubfx  w3, w0, #0x10, #0x8
    ubfx  w4, w0, #0x8, #0x8
    and   w0, w0, #0xff
    add   w2, w2, w3
    add   w0, w4, w0
    add   w0, w2, w0

Microbenchmark (Apple Silicon):

                                   TipOfTree                  Patched

arithmetic-shift-and-mask       19.0037+-0.2975           18.6483+-0.0836      might be 1.0191x faster

Tests: JSTests/microbenchmarks/arithmetic-shift-and-mask.js
       Source/JavaScriptCore/b3/testb3_2.cpp

* JSTests/microbenchmarks/arithmetic-shift-and-mask.js: Added.
(test):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_2.cpp:
(testUbfx32ArithmeticShiftAnd):
(testUbfx64ArithmeticShiftAnd):
(addBitTests):

Canonical link: <a href="https://commits.webkit.org/311756@main">https://commits.webkit.org/311756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8a2b34e0e58aac2f2e3f95431db32611d477de2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166726 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122273 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24564 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102939 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21915 "Build is in progress. Recent messages:") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14499 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149949 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169216 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18733 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14168 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130447 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130561 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35360 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141399 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88774 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25299 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18205 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190027 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95581 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48793 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29992 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30222 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->