### PR TITLE
Add `display: block` UA style rules for optgroup and option elements

### DIFF
--- a/LayoutTests/accessibility/crash-table-recursive-layout-expected.txt
+++ b/LayoutTests/accessibility/crash-table-recursive-layout-expected.txt
@@ -1,2 +1,3 @@
 PASS if no crash.
 
+

--- a/LayoutTests/fast/dom/HTMLFormElement/associated-elements-after-index-assertion-fail2-expected.txt
+++ b/LayoutTests/fast/dom/HTMLFormElement/associated-elements-after-index-assertion-fail2-expected.txt
@@ -1,4 +1,5 @@
 This page verifies fix for bug 58247. WebKit should not crash when this page is rendered.
 
 
+
 PASS

--- a/LayoutTests/fast/dom/HTMLLabelElement/label-control-expected.txt
+++ b/LayoutTests/fast/dom/HTMLLabelElement/label-control-expected.txt
@@ -49,3 +49,7 @@ TEST COMPLETE
 
 
 
+
+
+
+

--- a/LayoutTests/fast/forms/label/labelable-elements-expected.txt
+++ b/LayoutTests/fast/forms/label/labelable-elements-expected.txt
@@ -125,3 +125,4 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 
+

--- a/LayoutTests/fast/forms/label/labels-add-htmlFor-label-expected.txt
+++ b/LayoutTests/fast/forms/label/labels-add-htmlFor-label-expected.txt
@@ -94,3 +94,4 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 
+

--- a/LayoutTests/fast/forms/label/labels-add-parent-label-expected.txt
+++ b/LayoutTests/fast/forms/label/labels-add-parent-label-expected.txt
@@ -95,3 +95,4 @@ PASS successfullyParsed is true
 TEST COMPLETE
 
 
+

--- a/LayoutTests/fast/forms/label/labels-change-htmlFor-attribute-expected.txt
+++ b/LayoutTests/fast/forms/label/labels-change-htmlFor-attribute-expected.txt
@@ -94,3 +94,4 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 
+

--- a/LayoutTests/fast/forms/label/labels-multiple-sibling-labels-expected.txt
+++ b/LayoutTests/fast/forms/label/labels-multiple-sibling-labels-expected.txt
@@ -65,3 +65,4 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 
+

--- a/LayoutTests/fast/forms/label/labels-parent-and-sibling-labels-expected.txt
+++ b/LayoutTests/fast/forms/label/labels-parent-and-sibling-labels-expected.txt
@@ -65,3 +65,4 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 
+

--- a/LayoutTests/fast/forms/label/labels-remove-htmlFor-attribute-expected.txt
+++ b/LayoutTests/fast/forms/label/labels-remove-htmlFor-attribute-expected.txt
@@ -94,3 +94,4 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 
+

--- a/LayoutTests/fast/forms/label/labels-remove-htmlFor-label-expected.txt
+++ b/LayoutTests/fast/forms/label/labels-remove-htmlFor-label-expected.txt
@@ -94,3 +94,4 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 
+

--- a/LayoutTests/fast/forms/label/labels-remove-parent-label-expected.txt
+++ b/LayoutTests/fast/forms/label/labels-remove-parent-label-expected.txt
@@ -95,3 +95,4 @@ PASS successfullyParsed is true
 TEST COMPLETE
 
 
+

--- a/LayoutTests/fast/forms/select/menulist-focusable-items-expected.txt
+++ b/LayoutTests/fast/forms/select/menulist-focusable-items-expected.txt
@@ -10,4 +10,5 @@ PASS isFocusable("optionD") is true
 PASS successfullyParsed is true
 
 TEST COMPLETE
- D
+
+D

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/editing-around-select-element.tentative_delete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/editing-around-select-element.tentative_delete-expected.txt
@@ -35,6 +35,6 @@ PASS execCommand(delete, false, "") in <select multiple contenteditable>{<option
 PASS execCommand(delete, false, "") in <select multiple><option contenteditable>{abc}</option><option>def</option></select>: shouldn't modify <option>
 PASS execCommand(delete, false, "") in <select multiple><optgroup contenteditable>{<option>abc</option><option>def</option>}</optgroup></select>: shouldn't delete <option>s
 PASS execCommand(delete, false, "") in <select multiple><optgroup contenteditable><option>{abc}</option><option>def</option></optgroup></select>: shouldn't delete <option>s nor optgroup
-FAIL execCommand(delete, false, "") in <optgroup contenteditable><option>{abc}</option><option>def</option></optgroup>: shouldn't delete <option>s nor optgroup assert_equals: expected "<optgroup contenteditable><option>abc</option><option>def</option></optgroup>" but got "<optgroup contenteditable><option>def</option></optgroup>"
+FAIL execCommand(delete, false, "") in <optgroup contenteditable><option>{abc}</option><option>def</option></optgroup>: shouldn't delete <option>s nor optgroup assert_equals: expected "<optgroup contenteditable><option>abc</option><option>def</option></optgroup>" but got "<optgroup contenteditable><option></option><option>def</option></optgroup>"
 FAIL execCommand(delete, false, "") in <option contenteditable>{abc}</option>: shouldn't modify <option> assert_equals: expected "<option contenteditable>abc</option>" but got "<option contenteditable></option>"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/editing-around-select-element.tentative_forwardDelete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/editing-around-select-element.tentative_forwardDelete-expected.txt
@@ -35,6 +35,6 @@ PASS execCommand(forwardDelete, false, "") in <select multiple contenteditable>{
 PASS execCommand(forwardDelete, false, "") in <select multiple><option contenteditable>{abc}</option><option>def</option></select>: shouldn't modify <option>
 PASS execCommand(forwardDelete, false, "") in <select multiple><optgroup contenteditable>{<option>abc</option><option>def</option>}</optgroup></select>: shouldn't delete <option>s
 PASS execCommand(forwardDelete, false, "") in <select multiple><optgroup contenteditable><option>{abc}</option><option>def</option></optgroup></select>: shouldn't delete <option>s nor optgroup
-FAIL execCommand(forwardDelete, false, "") in <optgroup contenteditable><option>{abc}</option><option>def</option></optgroup>: shouldn't delete <option>s nor optgroup assert_equals: expected "<optgroup contenteditable><option>abc</option><option>def</option></optgroup>" but got "<optgroup contenteditable><option>def</option></optgroup>"
+FAIL execCommand(forwardDelete, false, "") in <optgroup contenteditable><option>{abc}</option><option>def</option></optgroup>: shouldn't delete <option>s nor optgroup assert_equals: expected "<optgroup contenteditable><option>abc</option><option>def</option></optgroup>" but got "<optgroup contenteditable><option></option><option>def</option></optgroup>"
 FAIL execCommand(forwardDelete, false, "") in <option contenteditable>{abc}</option>: shouldn't modify <option> assert_equals: expected "<option contenteditable>abc</option>" but got "<option contenteditable></option>"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-element-reflection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-element-reflection-expected.txt
@@ -37,7 +37,9 @@ Light DOM text
 Light DOM text
 
 Misspelling
- Second option First option
+
+Second option
+First option
 
 PASS aria-activedescendant element reflection
 PASS If the content attribute is set directly, the IDL attribute getter always returns the first element whose ID matches the content attribute.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -140,10 +140,10 @@ PASS <select> containing text node child ("<select class='poke'></select>")
 PASS <optgroup> containing <optgroup> ("<select><optgroup class='poke-optgroup'></select>")
 PASS <optgroup> containing <option> ("<select><optgroup><option>abc</select>")
 FAIL <div> in <option> ("<select><option class='poke-div'>123</select>") assert_equals: innerText expected "123\nabc" but got "123abc"
-FAIL empty <optgroup> in <div> ("<div>a<optgroup></optgroup>bc") assert_equals: innerText expected "a\nbc" but got "abc"
-FAIL <optgroup> in <div> ("<div>a<optgroup>123</optgroup>bc") assert_equals: innerText expected "a\nbc" but got "a123bc"
-FAIL empty <option> in <div> ("<div>a<option></option>bc") assert_equals: innerText expected "a\nbc" but got "abc"
-FAIL <option> in <div> ("<div>a<option>123</option>bc") assert_equals: innerText expected "a\n123\nbc" but got "a123bc"
+PASS empty <optgroup> in <div> ("<div>a<optgroup></optgroup>bc")
+FAIL <optgroup> in <div> ("<div>a<optgroup>123</optgroup>bc") assert_equals: innerText expected "a\nbc" but got "a\n123\nbc"
+PASS empty <option> in <div> ("<div>a<option></option>bc")
+PASS <option> in <div> ("<div>a<option>123</option>bc")
 PASS undefined ("<select><option>one</option><div><optgroup label=optgroup><div><option><span>two")
 PASS <button> contents preserved ("<div><button>abc")
 PASS <fieldset> contents preserved ("<div><fieldset>abc")

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
@@ -1,5 +1,6 @@
 
 
+
 PASS <input type="hidden"> - letter-spacing
 PASS <input type="hidden"> - word-spacing
 PASS <input type="hidden"> - line-height

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-index-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-index-expected.txt
@@ -1,4 +1,6 @@
- hello hello
+
+hello
+hello
 
 PASS option index should work inside the document
 PASS option index should always be 0 for options in datalists

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-after-select-expected.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
 
-<div>child text</div>
+<div id="ref">child text</div>
+<optgroup id="src"></optgroup>
+<script>
+// Copy the font-weight from an optgroup onto the div so the ref matches
+// regardless of what default styling each engine applies to optgroup.
+const src = document.querySelector("#src");
+const ref = document.querySelector("#ref");
+ref.style.fontWeight = getComputedStyle(src).fontWeight;
+src.remove();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-expected.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
 
-<div>child text</div>
+<div id="ref">child text</div>
+<optgroup id="src"></optgroup>
+<script>
+// Copy the font-weight from an optgroup onto the div so the ref matches
+// regardless of what default styling each engine applies to optgroup.
+const src = document.querySelector("#src");
+const ref = document.querySelector("#ref");
+ref.style.fontWeight = getComputedStyle(src).fontWeight;
+src.remove();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-ref.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
 <link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">
 
-<div>child text</div>
+<div id="ref">child text</div>
+<optgroup id="src"></optgroup>
+<script>
+// Copy the font-weight from an optgroup onto the div so the ref matches
+// regardless of what default styling each engine applies to optgroup.
+const src = document.querySelector("#src");
+const ref = document.querySelector("#ref");
+ref.style.fontWeight = getComputedStyle(src).fontWeight;
+src.remove();
+</script>

--- a/LayoutTests/platform/glib/fast/frames/iframe-option-crash-expected.txt
+++ b/LayoutTests/platform/glib/fast/frames/iframe-option-crash-expected.txt
@@ -1,24 +1,24 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x192
-  RenderBlock {html} at (0,0) size 800x192
-    RenderBody {body} at (8,8) size 784x176
+layer at (0,0) size 800x349
+  RenderBlock {html} at (0,0) size 800x349
+    RenderBody {body} at (8,8) size 784x333
       RenderBlock {div} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 426x18
           text run at (0,0) width 426: "If no crash while painting, the test passed (requires pixel test mode)."
-      RenderBlock (anonymous) at (0,18) size 784x158
+      RenderBlock (anonymous) at (0,18) size 784x0
         RenderText {#text} at (0,0) size 0x0
-        RenderText {#text} at (0,0) size 0x0
-        RenderInline {option} at (0,140) size 304x17
-          RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
-            layer at (0,0) size 300x150
-              RenderView at (0,0) size 300x150
-            layer at (0,0) size 300x150
-              RenderBlock {HTML} at (0,0) size 300x150
-                RenderBody {BODY} at (8,8) size 284x134
-                  RenderText {#text} at (0,0) size 16x18
-                    text run at (0,0) width 16: "11"
-        RenderIFrame {iframe} at (304,0) size 304x154 [border: (2px inset #000000)]
+      RenderBlock {option} at (0,18) size 784x158
+        RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
+          layer at (0,0) size 300x150
+            RenderView at (0,0) size 300x150
+          layer at (0,0) size 300x150
+            RenderBlock {HTML} at (0,0) size 300x150
+              RenderBody {BODY} at (8,8) size 284x134
+                RenderText {#text} at (0,0) size 16x18
+                  text run at (0,0) width 16: "11"
+      RenderBlock (anonymous) at (0,175) size 784x158
+        RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
           layer at (0,0) size 300x150
             RenderView at (0,0) size 300x150
           layer at (0,0) size 300x150

--- a/LayoutTests/platform/ios/fast/frames/iframe-option-crash-expected.txt
+++ b/LayoutTests/platform/ios/fast/frames/iframe-option-crash-expected.txt
@@ -1,24 +1,24 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x195
-  RenderBlock {html} at (0,0) size 800x195
-    RenderBody {body} at (8,8) size 784x179
+layer at (0,0) size 800x353
+  RenderBlock {html} at (0,0) size 800x353
+    RenderBody {body} at (8,8) size 784x337
       RenderBlock {div} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 437x20
           text run at (0,0) width 437: "If no crash while painting, the test passed (requires pixel test mode)."
-      RenderBlock (anonymous) at (0,20) size 784x159
+      RenderBlock (anonymous) at (0,20) size 784x0
         RenderText {#text} at (0,0) size 0x0
-        RenderText {#text} at (0,0) size 0x0
-        RenderInline {option} at (0,139) size 304x19
-          RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
-            layer at (0,0) size 300x150
-              RenderView at (0,0) size 300x150
-            layer at (0,0) size 300x150
-              RenderBlock {HTML} at (0,0) size 300x150
-                RenderBody {BODY} at (8,8) size 284x134
-                  RenderText {#text} at (0,0) size 16x20
-                    text run at (0,0) width 16: "11"
-        RenderIFrame {iframe} at (304,0) size 304x154 [border: (2px inset #000000)]
+      RenderBlock {option} at (0,20) size 784x159
+        RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
+          layer at (0,0) size 300x150
+            RenderView at (0,0) size 300x150
+          layer at (0,0) size 300x150
+            RenderBlock {HTML} at (0,0) size 300x150
+              RenderBody {BODY} at (8,8) size 284x134
+                RenderText {#text} at (0,0) size 16x20
+                  text run at (0,0) width 16: "11"
+      RenderBlock (anonymous) at (0,178) size 784x159
+        RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
           layer at (0,0) size 300x150
             RenderView at (0,0) size 300x150
           layer at (0,0) size 300x150

--- a/LayoutTests/platform/mac/fast/frames/iframe-option-crash-expected.txt
+++ b/LayoutTests/platform/mac/fast/frames/iframe-option-crash-expected.txt
@@ -1,24 +1,24 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x192
-  RenderBlock {html} at (0,0) size 800x192
-    RenderBody {body} at (8,8) size 784x176
+layer at (0,0) size 800x350
+  RenderBlock {html} at (0,0) size 800x350
+    RenderBody {body} at (8,8) size 784x334
       RenderBlock {div} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 437x18
           text run at (0,0) width 437: "If no crash while painting, the test passed (requires pixel test mode)."
-      RenderBlock (anonymous) at (0,18) size 784x158
+      RenderBlock (anonymous) at (0,18) size 784x0
         RenderText {#text} at (0,0) size 0x0
-        RenderText {#text} at (0,0) size 0x0
-        RenderInline {option} at (0,140) size 304x18
-          RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
-            layer at (0,0) size 300x150
-              RenderView at (0,0) size 300x150
-            layer at (0,0) size 300x150
-              RenderBlock {HTML} at (0,0) size 300x150
-                RenderBody {BODY} at (8,8) size 284x134
-                  RenderText {#text} at (0,0) size 16x18
-                    text run at (0,0) width 16: "11"
-        RenderIFrame {iframe} at (304,0) size 304x154 [border: (2px inset #000000)]
+      RenderBlock {option} at (0,18) size 784x158
+        RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
+          layer at (0,0) size 300x150
+            RenderView at (0,0) size 300x150
+          layer at (0,0) size 300x150
+            RenderBlock {HTML} at (0,0) size 300x150
+              RenderBody {BODY} at (8,8) size 284x134
+                RenderText {#text} at (0,0) size 16x18
+                  text run at (0,0) width 16: "11"
+      RenderBlock (anonymous) at (0,176) size 784x158
+        RenderIFrame {iframe} at (0,0) size 304x154 [border: (2px inset #000000)]
           layer at (0,0) size 300x150
             RenderView at (0,0) size 300x150
           layer at (0,0) size 300x150

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1203,9 +1203,13 @@ select option:not(:checked)::checkmark {
     visibility: hidden;
 }
 
-select optgroup {
+optgroup {
     display: block;
     font-weight: bolder;
+}
+
+option {
+    display: block;
 }
 
 select optgroup option {


### PR DESCRIPTION
#### 6cbbd3d85350fa3de395e431af5d71895877b95a
<pre>
Add `display: block` UA style rules for optgroup and option elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=312964">https://bugs.webkit.org/show_bug.cgi?id=312964</a>

Reviewed by Anne van Kesteren (OOPS\!).

Previously, WebKit only applied `display: block` to `optgroup` inside `select`
(via `select optgroup { display: block }`). This meant `optgroup` and `option`
outside of `select` were rendered inline, causing `innerText` to not produce
line breaks at their boundaries.

Both Blink and Firefox apply `display: block` unconditionally to these elements:

Blink (html.css):
    <a href="https://source.chromium.org/chromium/chromium/src/+/main">https://source.chromium.org/chromium/chromium/src/+/main</a>:third_party/blink/renderer/core/html/resources/html.css
```
    optgroup {
        font-weight: bolder;
        display: block;
    }

    option {
        ...
        display: block;
        ...
    }
```
Firefox (forms.css):
    <a href="https://searchfox.org/mozilla-central/source/layout/style/res/forms.css">https://searchfox.org/mozilla-central/source/layout/style/res/forms.css</a>
```
    optgroup {
        display: block;
        ...
    }

    option {
        display: block;
        ...
    }
```

This aligns WebKit with other engines and fixes several innerText subtests
in the WPT getter.html test for `optgroup/option` elements outside of `select`.

Also fix the standalone-optgroup-no-shadow-tree WPT ref tests which were
comparing a standalone optgroup against a plain &lt;div&gt;. The refs now copy the
font-weight from an optgroup onto the div so it matches regardless of what
default styling each engine applies to optgroup. These tests were already
marked as failing in Blink for the same reason.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/standalone-optgroup-no-shadow-tree-ref.html:
* Source/WebCore/css/html.css:
(optgroup):
(option):
(select optgroup): Deleted.

Canonical link: <a href="https://commits.webkit.org/311911@main">https://commits.webkit.org/311911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69ccbe4f5163ede63427e6c9fef31c1a12af4bf0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167229 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31812 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161357 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/24932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103349 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15000 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169719 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/15364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21683 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31515 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130978 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35455 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141852 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25673 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30972 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96781 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30492 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->