### PR TITLE
REGRESSION(311380@main): Video disappears after tab switch

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -67,11 +67,11 @@ public:
     ~AudioVideoRendererAVFObjC();
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
-    void setPreferences(VideoRendererPreferences) final;
+    WEBCORE_EXPORT void setPreferences(VideoRendererPreferences) final;
     void setHasProtectedVideoContent(bool) final;
 
     // TracksRendererInterface
-    std::optional<TrackIdentifier> addTrack(TrackType) final;
+    WEBCORE_EXPORT std::optional<TrackIdentifier> addTrack(TrackType) final;
     void removeTrack(TrackIdentifier) final;
 
     void enqueueSample(TrackIdentifier, Ref<MediaSample>&&, std::optional<MediaTime>) final;
@@ -120,11 +120,11 @@ public:
     void setIsVisible(bool);
     void setPresentationSize(const IntSize&) final;
     void setShouldMaintainAspectRatio(bool) final;
-    void renderingCanBeAcceleratedChanged(bool) final;
+    WEBCORE_EXPORT void renderingCanBeAcceleratedChanged(bool) final;
     void contentBoxRectChanged(const LayoutRect&) final;
     void notifyFirstFrameAvailable(Function<void()>&&) final;
     void notifyWhenHasAvailableVideoFrame(Function<void(const MediaTime&, double)>&&) final;
-    void notifyWhenRequiresFlushToResume(Function<void()>&&) final;
+    WEBCORE_EXPORT void notifyWhenRequiresFlushToResume(Function<void()>&&) final;
     void notifyRenderingModeChanged(Function<void()>&&) final;
     void expectMinimumUpcomingPresentationTime(const MediaTime&) final;
     void notifySizeChanged(Function<void(const MediaTime&, FloatSize)>&&) final;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -1468,9 +1468,12 @@ Ref<GenericPromise> AudioVideoRendererAVFObjC::stageVideoRenderer(WebSampleBuffe
     }
 
     bool videoTrackChangeOnly = !m_previousRendererConfiguration.hasVideoTrack && newConfiguration.hasVideoTrack;
-    bool flushRequired = std::exchange(m_previousRendererConfiguration, newConfiguration) != newConfiguration && !videoTrackChangeOnly;
+    bool configurationChanged = std::exchange(m_previousRendererConfiguration, newConfiguration) != newConfiguration;
+    bool hasVideoRenderer = videoRenderer && videoRenderer->renderer();
+    bool switchingFromRenderless = renderer && !hasVideoRenderer && !isUsingDecompressionSession();
+    bool flushRequired = (configurationChanged || switchingFromRenderless) && !videoTrackChangeOnly;
     m_readyToRequestVideoData = !flushRequired;
-    ALWAYS_LOG(LOGIDENTIFIER, "renderer: ", !!renderer, " videoTrackChangeOnly: ", videoTrackChangeOnly, " flushRequired: ", flushRequired);
+    ALWAYS_LOG(LOGIDENTIFIER, "renderer: ", !!renderer, " videoTrackChangeOnly: ", videoTrackChangeOnly, " configurationChanged: ", configurationChanged, " switchingFromRenderless: ", switchingFromRenderless, " flushRequired: ", flushRequired);
 
     return videoRenderer->changeRenderer(renderer)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, rendererToExpire = WTF::move(rendererToExpire), flushRequired]() {
         RefPtr protectedThis = weakThis.get();

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -705,6 +705,7 @@
 				WebCore/CBORValueTest.cpp,
 				WebCore/CBORWriterTest.cpp,
 				WebCore/cocoa/AudioStreamDescriptionCocoa.mm,
+				WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm,
 				WebCore/cocoa/AVFoundationSoftLinkTest.mm,
 				WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp,
 				WebCore/cocoa/CaptionPreferencesTests.mm,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if USE(AVFOUNDATION)
+
+#include "Helpers/PlatformUtilities.h"
+#include <WebCore/AudioVideoRendererAVFObjC.h>
+#include <WebCore/MediaPlayerEnums.h>
+#include <WebCore/TrackInfo.h>
+#include <wtf/Logger.h>
+
+using namespace WebCore;
+
+namespace TestWebKitAPI {
+
+class AudioVideoRendererAVFObjCTest : public testing::Test {
+public:
+    void SetUp() final
+    {
+        Ref logger = Logger::create(this);
+        renderer = AudioVideoRendererAVFObjC::create(logger, 0);
+        renderer->setPreferences({ VideoRendererPreference::PrefersDecompressionSession });
+        renderer->notifyWhenRequiresFlushToResume([this] {
+            ++flushToResumeCount;
+        });
+        renderer->addTrack(TrackInfo::TrackType::Video);
+    }
+
+    void TearDown() final
+    {
+        renderer = nullptr;
+    }
+
+    RefPtr<AudioVideoRendererAVFObjC> renderer;
+    int flushToResumeCount { 0 };
+};
+
+TEST_F(AudioVideoRendererAVFObjCTest, FlushToResumeOnVisibilityRestore)
+{
+    renderer->renderingCanBeAcceleratedChanged(true);
+    Util::runFor(0.1_s);
+    EXPECT_EQ(flushToResumeCount, 0);
+
+    renderer->renderingCanBeAcceleratedChanged(false);
+    Util::runFor(0.1_s);
+    EXPECT_EQ(flushToResumeCount, 0);
+
+    renderer->renderingCanBeAcceleratedChanged(true);
+    bool callbackFired = Util::waitFor([this] {
+        return flushToResumeCount > 0;
+    });
+    EXPECT_TRUE(callbackFired);
+    EXPECT_EQ(flushToResumeCount, 1);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // USE(AVFOUNDATION)


### PR DESCRIPTION
#### 2cd16cbf3e9b17bf07f9c76125393cc15d464b95
<pre>
REGRESSION(311380@main): Video disappears after tab switch
<a href="https://rdar.apple.com/175257980">rdar://175257980</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312968">https://bugs.webkit.org/show_bug.cgi?id=312968</a>

Reviewed by Jean-Yves Avenard.

When tearing down and recreating a video renderer, ensure a flush occurs if needed, causing
the SourceBuffer to provide media data for the current playback position.

Tests: Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm

* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::stageVideoRenderer):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm: Added.
(TestWebKitAPI::TEST_F(AudioVideoRendererAVFObjCTest, FlushToResumeOnVisibilityRestore)):

Canonical link: <a href="https://commits.webkit.org/311771@main">https://commits.webkit.org/311771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4524e67c3f131f5fc3ba480091ea82a2cab4bb86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166744 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111999 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122288 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85859 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102954 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23634 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14517 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169234 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14244 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130463 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130577 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35373 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88800 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25313 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18218 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30489 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95666 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30010 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30240 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30137 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->