### PR TITLE
REGRESSION(311234@main): Partially revert "[Skia] Add deferred texture binding support for dma-buf backed GPU atlas textures"

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -66,35 +66,14 @@ RefPtr<SkiaGPUAtlas> SkiaGPUAtlas::create(const SkiaImageAtlasLayout& layout, Re
 
     RELEASE_ASSERT(atlasSize == atlasTexture->size());
 
-    ASSERT_IMPLIES(atlasTexture->usesDeferredTextureBinding(), !atlasTexture->id());
-
-    GrBackendTexture backendTexture;
-    if (!atlasTexture->usesDeferredTextureBinding()) {
-        backendTexture = atlasTexture->createSkiaBackendTexture();
-        if (!backendTexture.isValid())
-            return nullptr;
-    }
+    auto backendTexture = atlasTexture->createSkiaBackendTexture();
+    if (!backendTexture.isValid())
+        return nullptr;
 
     return adoptRef(*new SkiaGPUAtlas(WTF::move(atlasTexture), WTF::move(backendTexture), layout, atlasSize));
 }
 
-bool SkiaGPUAtlas::ensureBackendTexture()
-{
-    if (!m_atlasTexture->usesDeferredTextureBinding())
-        return m_backendTexture.isValid();
-
-#if USE(GBM)
-    if (!m_atlasTexture->id()) {
-        if (!m_atlasTexture->bindDMABufToTexture())
-            return false;
-        m_backendTexture = m_atlasTexture->createSkiaBackendTexture();
-    }
-#endif
-
-    return m_backendTexture.isValid();
-}
-
-bool SkiaGPUAtlas::uploadImages()
+void SkiaGPUAtlas::uploadImages()
 {
     Vector<uint8_t> conversionBuffer;
 
@@ -130,7 +109,7 @@ bool SkiaGPUAtlas::uploadImages()
                     gpuBuffer->updateContents(*writeScope, pixels->first, entry.atlasRect, pixels->second);
             }
 
-            return true;
+            return;
         }
     }
 #endif
@@ -140,8 +119,6 @@ bool SkiaGPUAtlas::uploadImages()
         if (auto pixels = pixelDataInSRGB(entry.rasterImage))
             m_atlasTexture->updateContents(pixels->first, entry.atlasRect, IntPoint::zero(), pixels->second, PixelFormat::BGRA8);
     }
-
-    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
@@ -47,7 +47,7 @@ class SkiaImageAtlasLayout;
 using ImageToRectMap = HashMap<const SkImage*, SkRect>;
 
 // GPU atlas that uploads raster images into a BitmapTexture.
-// Uses MemoryMappedGPUBuffer directly for DMA-buf (GBM) path and
+// Uses MemoryMappedGPUBuffer directly for dma-buf (GBM) path and
 // BitmapTexture::updateContents() for GL fallback.
 class SkiaGPUAtlas : public ThreadSafeRefCounted<SkiaGPUAtlas, WTF::DestructionThread::Main> {
     WTF_MAKE_TZONE_ALLOCATED(SkiaGPUAtlas);
@@ -55,15 +55,10 @@ class SkiaGPUAtlas : public ThreadSafeRefCounted<SkiaGPUAtlas, WTF::DestructionT
 public:
     static RefPtr<SkiaGPUAtlas> create(const SkiaImageAtlasLayout&, Ref<BitmapTexture>&&);
 
-    // Upload images into the atlas texture. Can run from any thread for DMA-buf backed textures.
-    bool uploadImages();
+    // Upload images into the atlas texture. Can run from any thread for dma-buf backed textures.
+    void uploadImages();
 
     virtual ~SkiaGPUAtlas();
-
-    // Ensures the EGLImage and GrBackendTexture are created. For dma-buf backed textures
-    // with deferred binding, this must be called after the upload is complete — typically
-    // from the upload work queue thread, before signaling the upload condition.
-    bool ensureBackendTexture();
 
     const GrBackendTexture& backendTexture() const LIFETIME_BOUND { return m_backendTexture; }
     const ImageToRectMap& imageToRect() const LIFETIME_BOUND { return m_imageToRect; }

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -125,7 +125,7 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::createBuffer(RenderingMode render
     return CoordinatedUnacceleratedTileBuffer::create(size, contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha);
 }
 
-RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout& layout, AtlasUploadCondition& uploadCondition)
+RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout& layout, AtlasUploadCondition& uploadCondition, bool& needsUploadFence)
 {
     const auto& atlasSize = layout.atlasSize();
 
@@ -134,13 +134,13 @@ RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout&
 #if USE(GBM)
     if (shouldUseDMABufAtlasTextures()) {
         isDMABufBackedTexture = true;
-        textureFlags.add({ BitmapTexture::Flags::BackedByDMABuf, BitmapTexture::Flags::ForceLinearBuffer, BitmapTexture::Flags::DeferTextureBinding });
+        textureFlags.add({ BitmapTexture::Flags::BackedByDMABuf, BitmapTexture::Flags::ForceLinearBuffer });
     }
 #endif
 
     // Verify the texture actually has DMA-buf backing. BitmapTexture silently
-    // falls back to GL if DMA-buf allocation fails, and we must use the
-    // synchronous GL upload path instead of the DMA-buf work queue path.
+    // falls back to GL if DMA-buf allocation fails, but we must not dispatch
+    // GL operations to the upload worker thread (which has no GL context).
     auto texture = BitmapTexturePool::singleton().acquireTexture(atlasSize, textureFlags);
 #if USE(GBM)
     if (!texture->memoryMappedGPUBuffer())
@@ -152,37 +152,18 @@ RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout&
         return nullptr;
 
     // GL path: upload synchronously.
-    if (!isDMABufBackedTexture) {
+    if (!isDMABufBackedTexture) [[unlikely]] {
         atlas->uploadImages();
+        needsUploadFence = true;
         return atlas;
     }
 
     // DMA-buf path: create atlas without uploading, dispatch pixel writes to worker.
-    // After uploading, bind the dma-buf to an EGLImage + GL texture on this single
-    // thread, so replay workers only need to rewrap the SkImage for their context.
     if (!m_uploadWorkQueue)
         m_uploadWorkQueue = WorkQueue::create("AtlasUpload"_s);
     uploadCondition.addPending();
     m_uploadWorkQueue->dispatch([atlas = Ref { *atlas }, condition = Ref { uploadCondition }]() mutable {
         atlas->uploadImages();
-
-        // Use a lightweight GL context (no GrDirectContext / Skia GPU backend)
-        // since we only need raw GL calls for EGLImage texture binding.
-        static thread_local auto glContext = GLContext::createOffscreen(PlatformDisplay::sharedDisplay());
-        if (!glContext || !glContext->makeContextCurrent()) {
-            WTFLogAlways("ERROR: Failed to create/activate GL context on atlas upload thread. Aborting ..."); // NOLINT
-            CRASH();
-        }
-
-        if (!atlas->ensureBackendTexture()) {
-            WTFLogAlways("ERROR: Failed to bind DMA-buf to GL texture on atlas upload thread. Aborting ..."); // NOLINT
-            CRASH();
-        }
-
-        // Flush GL commands so the texture object state (EGLImage binding)
-        // is visible to replay worker contexts in the same share group.
-        glFlush();
-
         condition->signal();
     });
     return atlas;
@@ -266,11 +247,8 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
 
             bool needsUploadFence = false;
             for (const auto& layout : result->atlasLayouts()) {
-                if (auto atlas = createAtlas(layout.get(), uploadCondition.get())) {
-                    if (!atlas->atlasTexture().usesDeferredTextureBinding())
-                        needsUploadFence = true;
+                if (auto atlas = createAtlas(layout.get(), uploadCondition.get(), needsUploadFence))
                     gpuAtlases.append(atlas.releaseNonNull());
-                }
             }
 
             if (!gpuAtlases.isEmpty()) {
@@ -285,9 +263,8 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
                     result->setGPUAtlases(WTF::move(gpuAtlases), WTF::move(uploadCondition));
                 }
 
-                // Flush and fence for the GL upload fallback path, where
+                // Flush and fence only for the GL upload path, where
                 // BitmapTexture::updateContents() issues GL upload commands.
-                // Not needed on the DMA-buf path where uploading is CPU-side (memory-mapped).
                 if (needsUploadFence)
                     result->setUploadFence(SkiaUtilities::flushAndSubmitWithFence(grContext));
             }

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -69,7 +69,7 @@ public:
 private:
     Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
-    RefPtr<SkiaGPUAtlas> createAtlas(const SkiaImageAtlasLayout&, AtlasUploadCondition&);
+    RefPtr<SkiaGPUAtlas> createAtlas(const SkiaImageAtlasLayout&, AtlasUploadCondition&, bool& needsUploadFence);
     bool tryReuseCachedAtlases(SkiaRecordingResult&, unsigned fingerprint);
 
     RefPtr<WorkerPool> m_paintingWorkerPool;

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
@@ -39,8 +39,7 @@ SkiaReplayCanvas::SkiaReplayCanvas(const IntSize& size, const RefPtr<SkiaRecordi
     , m_recording(recording)
 {
     // Create atlas wrappers from pre-prepared GPU atlases.
-    // GPU atlases were uploaded (and texture-bound) before signaling the upload condition;
-    // we just rewrap the SkImage for this worker's GrDirectContext.
+    // GPU atlases were uploaded on main thread; we just rewrap for this worker's context.
     if (m_recording && m_recording->hasGPUAtlases()) {
         auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
         if (!glContext || !glContext->makeContextCurrent())

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -126,13 +126,6 @@ BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
 
         m_memoryMappedGPUBuffer = MemoryMappedGPUBuffer::create(m_size, bufferFlags);
 
-        // Defer EGLImage/GL texture creation until after CPU writes into the
-        // mapped buffer complete, so the GPU only sees final DMA-buf contents.
-        if (m_memoryMappedGPUBuffer && usesDeferredTextureBinding()) {
-            glBindTexture(m_renderTarget, boundTexture);
-            return;
-        }
-
         // Proceed as usual with GL texture creation if the dma-buf creation failed.
         // as we only want to allocate the dma-buf, but neither map it, nor create a texture now - but when we
         // need it (from the thread that needs it!).
@@ -144,7 +137,6 @@ BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
         m_flags.remove(Flags::BackedByDMABuf);
         m_flags.remove(Flags::ForceLinearBuffer);
         m_flags.remove(Flags::ForceVivanteSuperTiledBuffer);
-        m_flags.remove(Flags::DeferTextureBinding);
     }
 #endif
 
@@ -206,20 +198,6 @@ bool BitmapTexture::allocateTextureFromMemoryMappedGPUBuffer()
     return false;
 }
 
-bool BitmapTexture::bindDMABufToTexture()
-{
-    ASSERT(usesDeferredTextureBinding());
-    ASSERT(!m_id);
-
-    GLint boundTexture = 0;
-    glGetIntegerv(m_binding, &boundTexture);
-
-    bool result = allocateTextureFromMemoryMappedGPUBuffer();
-
-    glBindTexture(m_renderTarget, boundTexture);
-    return result;
-}
-
 BitmapTexture::BitmapTexture(EGLImage image, const IntSize& size, OptionSet<Flags> flags)
     : m_flags(flags)
     , m_size(size)
@@ -262,13 +240,6 @@ void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
 #if USE(GBM)
     // We don't support switching from dmabuf backing to regular textures -- there is no use-case for that scenario.
     RELEASE_ASSERT(m_flags.contains(Flags::BackedByDMABuf) == flags.contains(Flags::BackedByDMABuf));
-
-    // When DeferTextureBinding is requested, destroy the existing GL texture so that
-    // a fresh EGLImage will be created.
-    if (flags.contains(Flags::DeferTextureBinding) && m_id) {
-        glDeleteTextures(1, &m_id);
-        m_id = 0;
-    }
 #endif
 
     m_flags = flags;
@@ -316,8 +287,7 @@ void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
         // Recreate MemoryMappedGPUBuffer with new size.
         m_memoryMappedGPUBuffer = MemoryMappedGPUBuffer::create(m_size, m_memoryMappedGPUBuffer->flags());
 
-        // Defer texture binding if requested -- bindDMABufToTexture() will create the EGLImage later.
-        if (usesDeferredTextureBinding() || allocateTextureFromMemoryMappedGPUBuffer()) {
+        if (allocateTextureFromMemoryMappedGPUBuffer()) {
             glBindTexture(m_renderTarget, boundTexture);
             return;
         }

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -62,18 +62,17 @@ enum class TextureMapperFlags : uint16_t;
 
 class BitmapTexture final : public ThreadSafeRefCounted<BitmapTexture> {
 public:
-    enum class Flags : uint16_t {
+    enum class Flags : uint8_t {
         SupportsAlpha = 1 << 0,
         DepthBuffer = 1 << 1,
 #if USE(GBM)
         BackedByDMABuf = 1 << 2,
         ForceLinearBuffer = 1 << 3,
         ForceVivanteSuperTiledBuffer = 1 << 4,
-        DeferTextureBinding = 1 << 5,
 #endif
-        UseBGRALayout = 1 << 6,
-        NearestFiltering = 1 << 7,
-        ExternalOESRenderTarget = 1 << 8,
+        UseBGRALayout = 1 << 5,
+        NearestFiltering = 1 << 6,
+        ExternalOESRenderTarget = 1 << 7,
     };
 
     static Ref<BitmapTexture> create(const IntSize& size, OptionSet<Flags> flags = { })
@@ -94,15 +93,6 @@ public:
     size_t sizeInBytes() const;
     OptionSet<Flags> flags() const { return m_flags; }
     bool isOpaque() const { return !m_flags.contains(Flags::SupportsAlpha); }
-
-    bool usesDeferredTextureBinding() const
-    {
-#if USE(GBM)
-        return m_flags.contains(Flags::DeferTextureBinding);
-#else
-        return false;
-#endif
-    }
 
     void bindAsSurface();
     void initializeStencil();
@@ -132,7 +122,6 @@ public:
 
 #if USE(GBM)
     MemoryMappedGPUBuffer* memoryMappedGPUBuffer() const LIFETIME_BOUND { return m_memoryMappedGPUBuffer.get(); }
-    bool bindDMABufToTexture();
     IntSize allocatedSize() const;
 #else
     IntSize allocatedSize() const { return m_size; }


### PR DESCRIPTION
#### 8ff337c2222fb6769053edda9df223a414656ff7
<pre>
REGRESSION(311234@main): Partially revert &quot;[Skia] Add deferred texture binding support for dma-buf backed GPU atlas textures&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=312971">https://bugs.webkit.org/show_bug.cgi?id=312971</a>

Reviewed by Carlos Garcia Campos.

This partially reverts 311234@main, keeping only the &quot;avoid upload
fence&quot; in dma-buf upload code path change and a BitmapTexture specific
fix to remove the LinearTexture/VivanteSuperTiledTexture related flags
if dma-buf support backing support is not available.

The original patch caused a peformance regression in MotionMark/Images,
due to the glFlush() usage in the upload thread, necessary to support
deferred texture binding, but the feature itself didn&apos;t fix the
rendering glitches observed on particular configurations, so revert that
logic.

* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
(WebCore::SkiaGPUAtlas::create):
(WebCore::SkiaGPUAtlas::uploadImages):
(WebCore::SkiaGPUAtlas::ensureBackendTexture): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h:
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::createAtlas):
(WebCore::SkiaPaintingEngine::record):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp:
(WebCore::SkiaReplayCanvas::SkiaReplayCanvas):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::reset):
(WebCore::BitmapTexture::bindDMABufToTexture): Deleted.
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:

Canonical link: <a href="https://commits.webkit.org/311760@main">https://commits.webkit.org/311760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb6869cca7321cd9ec03c60d2383cfe4b0fcad1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166746 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122292 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24582 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102962 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14519 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169236 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14248 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130465 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130579 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35363 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30939 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141416 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88802 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18222 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30491 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95670 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30242 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->