### PR TITLE
[YARR] Fix YarrJIT SIGBUS from sibling-alt frame slot aliasing

### DIFF
--- a/JSTests/stress/regexp-jit-sibling-alt-frame-slot-collision.js
+++ b/JSTests/stress/regexp-jit-sibling-alt-frame-slot-collision.js
@@ -1,0 +1,36 @@
+//@ runDefault
+
+function shouldBe(actual, expected, message) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(message + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+// Regression tests for YarrJIT frame-slot aliasing between sibling alternatives
+// that mix BackTrackInfoParenthesesOnce (PAC-signed return address) and
+// BackTrackInfoParentheses (parenContextHead cleared on backtrack).
+// Prior to the fix, these patterns SIGBUSed via failed PAC authentication.
+
+(function() {
+    shouldBe(/(a*(|)|()*)*b/.exec("aa"), null, "original repro with 'aa'");
+    shouldBe(/(a*(|)|()*)*b/.exec("aab"), ["aab", "aa", "", null], "original repro with 'aab'");
+})();
+
+(function() {
+    shouldBe(/(a+(|)|()*)*b/.exec("aa"), null, "a+ variant with 'aa'");
+})();
+
+(function() {
+    shouldBe(/(a*(|)|(a)*)*b/.exec("aa"), null, "nested Once inside alt 1 with 'aa'");
+})();
+
+(function() {
+    // Extra nesting makes the inner (|) land at a higher frame location, avoiding
+    // the collision; this test guards against over-aggressive bail-outs.
+    shouldBe(/(a*((|))|()*)*b/.exec("aab"), ["aab", "aa", "", "", null], "extra nesting still matches");
+})();
+
+(function() {
+    // ()+ has a non-zero minimum, which already triggered a separate JIT bail-out.
+    // Keep it here as a control that the surrounding paths still work.
+    shouldBe(/(a*(|)|()+)*b/.exec("aa"), null, "()+ variant");
+})();

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1909,15 +1909,18 @@ public:
         if ((disjunction != m_pattern.m_body) && (disjunction->m_alternatives.size() > 1))
             initialCallFrameSize += YarrStackSpaceForBackTrackInfoAlternative;
 
+        bool shareOffsets = (disjunction == m_pattern.m_body);
+
         unsigned minimumInputSize = UINT_MAX;
         unsigned maximumCallFrameSize = 0;
         bool hasFixedSize = true;
         ErrorCode error = ErrorCode::NoError;
 
+        unsigned perAlternativeInitial = initialCallFrameSize;
         for (unsigned alt = 0; alt < disjunction->m_alternatives.size(); ++alt) {
             PatternAlternative* alternative = disjunction->m_alternatives[alt].get();
             unsigned currentAlternativeCallFrameSize;
-            error = setupAlternativeOffsets(alternative, initialCallFrameSize, initialInputPosition, currentAlternativeCallFrameSize);
+            error = setupAlternativeOffsets(alternative, perAlternativeInitial, initialInputPosition, currentAlternativeCallFrameSize);
             if (hasError(error))
                 return error;
             minimumInputSize = std::min(minimumInputSize, alternative->m_minimumSize);
@@ -1925,8 +1928,10 @@ public:
             hasFixedSize &= alternative->m_hasFixedSize;
             if (alternative->m_minimumSize > INT_MAX)
                 m_pattern.m_containsUnsignedLengthPattern = true;
+            if (!shareOffsets)
+                perAlternativeInitial = currentAlternativeCallFrameSize;
         }
-        
+
         ASSERT(maximumCallFrameSize >= initialCallFrameSize);
 
         disjunction->m_hasFixedSize = hasFixedSize;


### PR DESCRIPTION
#### 7c8c020f78cee3786a371746d985d79b0750134b
<pre>
[YARR] Fix YarrJIT SIGBUS from sibling-alt frame slot aliasing
<a href="https://bugs.webkit.org/show_bug.cgi?id=312976">https://bugs.webkit.org/show_bug.cgi?id=312976</a>
<a href="https://rdar.apple.com/175322483">rdar://175322483</a>

Reviewed by Sosuke Suzuki.

In /(a*(|)|()*)*b/.exec(&quot;aa&quot;), sibling alternatives of a nested
disjunction share a starting frame offset. But
clearParenContextHeadSlotsInRange clears parenContextHeadIndex slots
regardless of whether it is used differently in the different alternative.

Let&apos;s make things much simpler. This patch stops sharing frame slots
between multiple alternatives and just monotonically increasing the
slots. This is simply bound by the pattern, and it assigns unique frame
slot throughout the pattern, which makes a lot of handlings simpler in
particular when using ParenContext.

Test: JSTests/stress/regexp-jit-sibling-alt-frame-slot-collision.js

* JSTests/stress/regexp-jit-sibling-alt-frame-slot-collision.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::setupDisjunctionOffsets):

Canonical link: <a href="https://commits.webkit.org/311786@main">https://commits.webkit.org/311786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8423f4155321fd5560433ecb78f4c942e78a35ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112013 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122303 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85864 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102970 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23649 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14531 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149981 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133331 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169248 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18765 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14276 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130476 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130590 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141428 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88818 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24017 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25328 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18234 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190059 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30503 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95706 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48799 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30024 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30254 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30151 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->