### PR TITLE
[LBSE] Always call updateLayerTransform() even when renderer has no layer

### DIFF
--- a/Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h
+++ b/Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020, 2021, 2022 Igalia S.L.
+ * Copyright (C) 2020, 2021, 2022, 2026 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -24,25 +24,26 @@
 
 namespace WebCore {
 
+// FIXME: This class should be renamed, as well as 'updateLayerTransform', since LBSE uses it also for non-layered use-cases.
 class SVGLayerTransformUpdater {
     WTF_MAKE_NONCOPYABLE(SVGLayerTransformUpdater);
 public:
     SVGLayerTransformUpdater(RenderLayerModelObject& renderer)
         : m_renderer(renderer)
     {
-        if (!m_renderer->hasLayer())
-            return;
+        if (m_renderer->hasLayer()) {
+            m_transformReferenceBox = m_renderer->transformReferenceBoxRect();
+            m_layerTransform = m_renderer->layerTransform();
+        }
 
-        m_transformReferenceBox = m_renderer->transformReferenceBoxRect();
-        m_layerTransform = m_renderer->layerTransform();
-
+        // Always call updateLayerTransform(), even without a layer. SVG renderers
+        // (e.g. RenderSVGViewportContainer) compute supplemental transforms (viewBox,
+        // zoom, pan) in their override, which are needed by applyTransform() during painting.
         m_renderer->updateLayerTransform();
     }
 
     ~SVGLayerTransformUpdater()
     {
-        if (!m_renderer->hasLayer())
-            return;
         if (m_renderer->transformReferenceBoxRect() == m_transformReferenceBox)
             return;
 


### PR DESCRIPTION
#### 43998c639fbe817d966dab86bbb215db9dc65ab3
<pre>
[LBSE] Always call updateLayerTransform() even when renderer has no layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=312984">https://bugs.webkit.org/show_bug.cgi?id=312984</a>

Reviewed by Rob Buis.

SVGLayerTransformUpdater bailed out early when the renderer had no layer,
skipping updateLayerTransform(). Some SVG renderers (e.g. RenderSVGViewportContainer)
compute supplemental transforms (viewBox, zoom, pan) in their updateLayerTransform()
override that are required by applyTransform() during painting, regardless of
whether the renderer is layer-backed.

Covered by existing tests, once conditional-layer creation is enabled for LBSE.

* Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h:
(WebCore::SVGLayerTransformUpdater::SVGLayerTransformUpdater):
(WebCore::SVGLayerTransformUpdater::~SVGLayerTransformUpdater):

Canonical link: <a href="https://commits.webkit.org/311763@main">https://commits.webkit.org/311763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8474dd33e94cdb86f9c5c7877041394c2ff11756

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166772 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31283 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122317 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24609 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102984 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14545 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169262 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14363 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21273 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130491 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130605 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88845 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24009 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25342 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18250 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30517 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95799 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30038 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->