### PR TITLE
Implement connectedMoveCallback()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/custom-element-move-reactions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/custom-element-move-reactions-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL the disconnected/connected callbacks should be called when no other callback is defined assert_array_equals: lengths differ, expected array ["disconnected", "connected"] length 2, got [] length 0
-FAIL the element should stay connected during the callbacks assert_array_equals: lengths differ, expected array [true, true] length 2, got [] length 0
-FAIL When connectedMoveCallback is defined, it is called instead of disconnectedCallback/connectedCallback assert_array_equals: lengths differ, expected array ["connectedMove"] length 1, got [] length 0
-FAIL Reactions to atomic move are called in order of element, not in order of operation assert_array_equals: lengths differ, expected array ["outer disconnected", "outer connected", "inner disconnected", "inner connected"] length 4, got [] length 0
-FAIL When connectedCallback is not defined, no crash assert_array_equals: lengths differ, expected array ["disconnected"] length 1, got [] length 0
-FAIL When disconnectedCallback is not defined, no crash assert_array_equals: lengths differ, expected array ["connected"] length 1, got [] length 0
+PASS the disconnected/connected callbacks should be called when no other callback is defined
+PASS the element should stay connected during the callbacks
+PASS When connectedMoveCallback is defined, it is called instead of disconnectedCallback/connectedCallback
+PASS Reactions to atomic move are called in order of element, not in order of operation
+PASS When connectedCallback is not defined, no crash
+PASS When disconnectedCallback is not defined, no crash
 

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -346,6 +346,16 @@ void JSCustomElementInterface::invokeDisconnectedCallback(Element& element)
     invokeCallback(element, m_disconnectedCallback.get(), [](JSC::JSGlobalObject*, JSDOMGlobalObject*, JSC::MarkedArgumentBuffer&) { });
 }
 
+void JSCustomElementInterface::setConnectedMoveCallback(JSC::JSObject* callback)
+{
+    m_connectedMoveCallback = callback;
+}
+
+void JSCustomElementInterface::invokeConnectedMoveCallback(Element& element)
+{
+    invokeCallback(element, m_connectedMoveCallback.get(), [](JSC::JSGlobalObject*, JSDOMGlobalObject*, JSC::MarkedArgumentBuffer&) { });
+}
+
 void JSCustomElementInterface::setAdoptedCallback(JSC::JSObject* callback)
 {
     m_adoptedCallback = callback;

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.h
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.h
@@ -79,6 +79,10 @@ public:
     bool hasDisconnectedCallback() const { return !!m_disconnectedCallback; }
     void invokeDisconnectedCallback(Element&);
 
+    void setConnectedMoveCallback(JSC::JSObject*);
+    bool hasConnectedMoveCallback() const { return !!m_connectedMoveCallback; }
+    void invokeConnectedMoveCallback(Element&);
+
     void setAdoptedCallback(JSC::JSObject*);
     bool hasAdoptedCallback() const { return !!m_adoptedCallback; }
     void invokeAdoptedCallback(Element&, Document& oldDocument, Document& newDocument);
@@ -136,6 +140,7 @@ private:
     JSC::Weak<JSC::JSObject> m_constructor;
     JSC::Weak<JSC::JSObject> m_connectedCallback;
     JSC::Weak<JSC::JSObject> m_disconnectedCallback;
+    JSC::Weak<JSC::JSObject> m_connectedMoveCallback;
     JSC::Weak<JSC::JSObject> m_adoptedCallback;
     JSC::Weak<JSC::JSObject> m_attributeChangedCallback;
     JSC::Weak<JSC::JSObject> m_formAssociatedCallback;

--- a/Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp
@@ -35,6 +35,7 @@
 #include "JSDOMConvertSequences.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMPromiseDeferred.h"
+#include "Settings.h"
 #include <wtf/SetForScope.h>
 
 
@@ -139,6 +140,15 @@ JSValue JSCustomElementRegistry::define(JSGlobalObject& lexicalGlobalObject, Cal
     if (disconnectedCallback)
         elementInterface->setDisconnectedCallback(disconnectedCallback);
     RETURN_IF_EXCEPTION(scope, { });
+
+    RefPtr document = dynamicDowncast<Document>(registry.scriptExecutionContext());
+    bool moveBeforeEnabled = document && document->settings().moveBeforeEnabled();
+    if (moveBeforeEnabled) {
+        auto* connectedMoveCallback = getCustomElementCallback(lexicalGlobalObject, prototypeObject, Identifier::fromString(vm, "connectedMoveCallback"_s));
+        if (connectedMoveCallback)
+            elementInterface->setConnectedMoveCallback(connectedMoveCallback);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
 
     auto* adoptedCallback = getCustomElementCallback(lexicalGlobalObject, prototypeObject, Identifier::fromString(vm, "adoptedCallback"_s));
     if (adoptedCallback)

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -31,6 +31,7 @@
 #include "CommonAtomStrings.h"
 #include "CommonVM.h"
 #include "ContainerNodeAlgorithms.h"
+#include "CustomElementReactionQueue.h"
 #include "DocumentInlines.h"
 #include "DocumentQuirks.h"
 #include "Editor.h"
@@ -1460,7 +1461,12 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
         }
     }
 
-    // FIXME(281223): Implement the rest of this function.
+    if (isConnected()) {
+        for (RefPtr inclusiveDescendant = &node; inclusiveDescendant; inclusiveDescendant = NodeTraversal::next(*inclusiveDescendant, &node)) {
+            if (RefPtr element = dynamicDowncast<Element>(*inclusiveDescendant); element && element->isDefinedCustomElement())
+                CustomElementReactionQueue::enqueueConnectedMoveCallbackIfNeeded(*element);
+        }
+    }
 
     return { };
 }

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -79,6 +79,10 @@ inline void CustomElementReactionQueueItem::invoke(Element& element, JSCustomEle
         ASSERT(!m_payload.has_value());
         elementInterface.invokeDisconnectedCallback(element);
         break;
+    case Type::ConnectedMove:
+        ASSERT(!m_payload.has_value());
+        elementInterface.invokeConnectedMoveCallback(element);
+        break;
     case Type::Adopted: {
         ASSERT(m_payload.has_value() && std::holds_alternative<AdoptedPayload>(m_payload.value()));
         auto& payload = std::get<AdoptedPayload>(m_payload.value());
@@ -184,6 +188,26 @@ void CustomElementReactionQueue::enqueueDisconnectedCallbackIfNeeded(Element& el
         return;
     queue->m_items.append(Item::Type::Disconnected);
     enqueueElementOnAppropriateElementQueue(element);
+}
+
+void CustomElementReactionQueue::enqueueConnectedMoveCallbackIfNeeded(Element& element)
+{
+    ASSERT(CustomElementReactionDisallowedScope::isReactionAllowed());
+    ASSERT(element.isDefinedCustomElement());
+    ASSERT(element.document().refCount() > 0);
+    ASSERT(element.reactionQueue());
+    CheckedRef queue = *element.reactionQueue();
+    if (queue->m_interface->hasConnectedMoveCallback()) {
+        queue->m_items.append(Item::Type::ConnectedMove);
+        enqueueElementOnAppropriateElementQueue(element);
+        return;
+    }
+    if (queue->m_interface->hasDisconnectedCallback())
+        queue->m_items.append(Item::Type::Disconnected);
+    if (queue->m_interface->hasConnectedCallback())
+        queue->m_items.append(Item::Type::Connected);
+    if (!queue->m_items.isEmpty())
+        enqueueElementOnAppropriateElementQueue(element);
 }
 
 void CustomElementReactionQueue::enqueueAdoptedCallbackIfNeeded(Element& element, Document& oldDocument, Document& newDocument)

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -60,6 +60,7 @@ public:
         ElementUpgrade,
         Connected,
         Disconnected,
+        ConnectedMove,
         Adopted,
         AttributeChanged,
         FormAssociated,
@@ -129,6 +130,7 @@ public:
     static void tryToUpgradeElement(Element&);
     static void enqueueConnectedCallbackIfNeeded(Element&);
     static void enqueueDisconnectedCallbackIfNeeded(Element&);
+    static void enqueueConnectedMoveCallbackIfNeeded(Element&);
     static void enqueueAdoptedCallbackIfNeeded(Element&, Document& oldDocument, Document& newDocument);
     static void enqueueAttributeChangedCallbackIfNeeded(Element&, const QualifiedName&, const AtomString& oldValue, const AtomString& newValue);
     static void enqueueFormAssociatedCallbackIfNeeded(Element&, HTMLFormElement*);


### PR DESCRIPTION
#### 891c9fe4a79afebb292de1f8f96322724b573107
<pre>
Implement connectedMoveCallback()
<a href="https://bugs.webkit.org/show_bug.cgi?id=312983">https://bugs.webkit.org/show_bug.cgi?id=312983</a>

Reviewed by Ryosuke Niwa.

Adds the connectedMoveCallback() to custom elements, and calls it as part of moveBefore().

This is behind the MoveBeforeEnabled flag.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/custom-element-move-reactions-expected.txt:
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::setConnectedMoveCallback):
(WebCore::JSCustomElementInterface::invokeConnectedMoveCallback):
* Source/WebCore/bindings/js/JSCustomElementInterface.h:
(WebCore::JSCustomElementInterface::hasConnectedMoveCallback const):
* Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp:
(WebCore::JSCustomElementRegistry::define):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::moveBefore):
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueueItem::invoke):
(WebCore::CustomElementReactionQueue::enqueueConnectedMoveCallbackIfNeeded):
* Source/WebCore/dom/CustomElementReactionQueue.h:

Canonical link: <a href="https://commits.webkit.org/311850@main">https://commits.webkit.org/311850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6f4ef3efcdd3a6422314d80597523d751b4685f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167056 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122536 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24811 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103205 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14828 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169545 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14899 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21529 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130720 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31310 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130835 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35421 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141700 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89144 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25543 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18506 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30800 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96333 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30321 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->