### PR TITLE
[LBSE] Add svg-transform-scale-with-and-without-layer.html

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5482,6 +5482,8 @@ webkit.org/b/313039 imported/w3c/web-platform-tests/speculation-rules/prefetch/n
 webkit.org/b/313056 fullscreen/full-screen-enter-while-exiting-fully.html [ Pass Timeout ]
 webkit.org/b/313058 media/media-vp8-webm.html [ Pass Timeout ImageOnlyFailure ]
 
+webkit.org/b/312985 svg/transforms/svg-transform-scale-with-and-without-layer.html [ ImageOnlyFailure ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/svg/transforms/svg-transform-scale-with-and-without-layer-expected.html
+++ b/LayoutTests/svg/transforms/svg-transform-scale-with-and-without-layer-expected.html
@@ -1,0 +1,9 @@
+<html>
+<body style="margin: 0">
+<!-- Expected: two half-size circles, green at (50,50) and blue at (150,50) -->
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+    <circle cx="50" cy="50" r="40" fill="green"/>
+    <circle cx="150" cy="50" r="40" fill="blue" style="opacity: 0.99"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/transforms/svg-transform-scale-with-and-without-layer.html
+++ b/LayoutTests/svg/transforms/svg-transform-scale-with-and-without-layer.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=1; totalPixels=80" />
+</head>
+<body style="margin: 0">
+<!-- Test that SVG transform="scale(0.5)" renders identically with and without a RenderLayer -->
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+    <!-- Left: scale(0.5) WITHOUT a layer (no compositing trigger) -->
+    <circle cx="100" cy="100" r="80" fill="green" transform="scale(0.5)"/>
+
+    <!-- Right: scale(0.5) WITH a layer (opacity triggers layer creation) -->
+    <circle cx="300" cy="100" r="80" fill="blue" transform="scale(0.5)" style="opacity: 0.99"/>
+</svg>
+</body>
+</html>


### PR DESCRIPTION
#### f8a07e3bf427c4fa427a47a6f46b6b36ad2a38b6
<pre>
[LBSE] Add svg-transform-scale-with-and-without-layer.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=312985">https://bugs.webkit.org/show_bug.cgi?id=312985</a>

Reviewed by Nikolas Zimmermann.

Add a test to verify that a SVG transform renders with and without a RenderLayer.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/svg/transforms/svg-transform-scale-with-and-without-layer-expected.html: Added.
* LayoutTests/svg/transforms/svg-transform-scale-with-and-without-layer.html: Added.

Canonical link: <a href="https://commits.webkit.org/311853@main">https://commits.webkit.org/311853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62dd91291d3fe027bb6875253cef1c90ccd85720

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167057 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122535 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24808 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103204 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14829 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169546 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130719 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31311 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130834 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35422 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141702 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89145 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18508 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30801 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->