### PR TITLE
[:has() perf] Compute scope selector for :has() nested in logical pseudo-class

### DIFF
--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
@@ -12,4 +12,10 @@
   Traversal count: 7
 :has(.trigger) non-subject with scope-bounded traversal .c7
   Traversal count: 14
+:not(:has(.trigger)) inside :not() with compound peer .c8
+  Traversal count: 14
+:is(:has(.trigger)) inside :is() with compound peer .c9
+  Traversal count: 14
+:is(.other :has(.trigger)) inside :is() with complex selector and compound peer .c10
+  Traversal count: 14
 

--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
@@ -16,6 +16,12 @@
 .c6:has(:is(.trigger + .other)) > .target { color: green; }
 /* Non-subject :has() with descendant — scope-bounded traversal */
 .c7:has(.trigger) .target { color: green; }
+/* :has() inside :not() with compound peer */
+.c8:not(:has(.trigger)) .target { color: green; }
+/* :has() inside :is() with compound peer */
+.c9:is(:has(.trigger)) .target { color: green; }
+/* :has() inside :is() with complex selector and compound peer */
+.c10:is(.other :has(.trigger)) .target { color: green; }
 </style>
 <script>
 if (window.testRunner)
@@ -113,6 +119,25 @@ runTest(":has(.trigger) non-subject with scope-bounded traversal .c7", "c7", fun
     trigger.className = "trigger";
     container.appendChild(trigger);
 }, true);
+
+runTest(":not(:has(.trigger)) inside :not() with compound peer .c8", "c8", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.appendChild(trigger);
+}, true);
+
+runTest(":is(:has(.trigger)) inside :is() with compound peer .c9", "c9", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.appendChild(trigger);
+}, true);
+
+runTest(":is(.other :has(.trigger)) inside :is() with complex selector and compound peer .c10", "c10", function(container) {
+    var trigger = document.createElement("div");
+    trigger.className = "trigger";
+    container.appendChild(trigger);
+}, true);
+</script>
 </script>
 </body>
 </html>

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -233,31 +233,44 @@ static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, co
     return matchElement;
 }
 
-DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& selectorFeatures, const CSSSelector& firstSelector, MatchElement matchElement, IsNegation isNegation, CanBreakScope allComponentsCanBreakScope)
+struct RuleFeatureSet::RecursiveCollectionContext {
+    MatchElement matchElement { MatchElement::Relation::Subject, { } };
+    IsNegation isNegation { IsNegation::No };
+    CanBreakScope canBreakScope { CanBreakScope::No };
+    const CSSSelector* outerCompoundSelector { nullptr };
+};
+
+void RuleFeatureSet::collectFeaturesFromSelector(SelectorFeatures& selectorFeatures, const CSSSelector& selector, MatchElement matchElement)
 {
+    recursivelyCollectFeaturesFromSelector(selectorFeatures, selector, { matchElement });
+}
+
+DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& selectorFeatures, const CSSSelector& firstSelector, const RecursiveCollectionContext& context)
+{
+    auto matchElement = context.matchElement;
     auto doesBreakScope = DoesBreakScope::No;
     const CSSSelector* selector = &firstSelector;
     while (true) {
-        auto canBreakScope = allComponentsCanBreakScope;
+        auto canBreakScope = context.canBreakScope;
         if (selector->match() == CSSSelector::Match::Id) {
             idsInRules.add(selector->value());
             if (matchElement.relation == MatchElement::Relation::Parent || matchElement.relation == MatchElement::Relation::Ancestor)
                 idsMatchingAncestorsInRules.add(selector->value());
             else if (matchElement.hasRelation || matchElement.relation == MatchElement::Relation::AnySibling || matchElement.relation == MatchElement::Relation::Host || matchElement.relation == MatchElement::Relation::HostChild)
-                selectorFeatures.ids.append({ selector, matchElement, isNegation });
+                selectorFeatures.ids.append({ selector, matchElement, context.isNegation });
         } else if (selector->match() == CSSSelector::Match::Class)
-            selectorFeatures.classes.append({ selector, matchElement, isNegation });
+            selectorFeatures.classes.append({ selector, matchElement, context.isNegation });
         else if (selector->isAttributeSelector()) {
             attributeLowercaseLocalNamesInRules.add(selector->attribute().localNameLowercase());
             attributeLocalNamesInRules.add(selector->attribute().localName());
-            selectorFeatures.attributes.append({ selector, matchElement, isNegation });
+            selectorFeatures.attributes.append({ selector, matchElement, context.isNegation });
         } else if (selector->match() == CSSSelector::Match::PseudoElement) {
             // Don't put anything here as selectors that differ by pseudo-element only are collected only once.
             // Pseudo-elements are handled in collectPseudoElementFeatures.
         } else if (selector->match() == CSSSelector::Match::PseudoClass) {
             bool isLogicalCombination = isLogicalCombinationPseudoClass(selector->pseudoClass());
             if (!isLogicalCombination)
-                selectorFeatures.pseudoClasses.append({ selector, matchElement, isNegation });
+                selectorFeatures.pseudoClasses.append({ selector, matchElement, context.isNegation });
 
             // Check for the :has(:is(foo bar)) case. In this case `foo` can match elements outside the :has() scope.
             if (isLogicalCombination && matchElement.hasRelation)
@@ -265,16 +278,28 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
         }
 
         if (const CSSSelectorList* selectorList = selector->selectorList()) {
-            auto subSelectorIsNegation = isNegation;
+            auto subSelectorIsNegation = context.isNegation;
             if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Not)
-                subSelectorIsNegation = isNegation == IsNegation::No ? IsNegation::Yes : IsNegation::No;
+                subSelectorIsNegation = context.isNegation == IsNegation::No ? IsNegation::Yes : IsNegation::No;
 
             for (auto& subSelector : *selectorList) {
                 auto subResult = computeSubSelectorMatchElement(matchElement, *selector, subSelector);
-                auto pseudoClassDoesBreakScope = recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, subResult, subSelectorIsNegation, canBreakScope);
 
-                if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Has)
-                    selectorFeatures.hasPseudoClasses.append({ &subSelector, subResult, isNegation, pseudoClassDoesBreakScope, selector });
+                RecursiveCollectionContext subContext { subResult, subSelectorIsNegation, canBreakScope, context.outerCompoundSelector };
+
+                // When entering a logical combination (not :has() itself), record the outer compound
+                // so nested :has() can use it for scope selector extraction.
+                if (selector->match() == CSSSelector::Match::PseudoClass && isLogicalCombinationPseudoClass(selector->pseudoClass()) && selector->pseudoClass() != CSSSelector::PseudoClass::Has) {
+                    if (!subContext.outerCompoundSelector)
+                        subContext.outerCompoundSelector = selector;
+                }
+
+                auto pseudoClassDoesBreakScope = recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, subContext);
+
+                if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Has) {
+                    auto scopeSource = context.outerCompoundSelector ? context.outerCompoundSelector : selector;
+                    selectorFeatures.hasPseudoClasses.append({ &subSelector, subResult, context.isNegation, pseudoClassDoesBreakScope, scopeSource });
+                }
 
                 if (pseudoClassDoesBreakScope == DoesBreakScope::Yes)
                     doesBreakScope = DoesBreakScope::Yes;
@@ -290,7 +315,7 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
         // Detect scope-breaking inside :has() arguments.
         // When inside :has() and a logical combinator like :is() allows scope breaking,
         // combinators can reach outside the :has() scope.
-        if (matchElement.hasRelation && *matchElement.hasRelation != MatchElement::HasRelation::ScopeBreaking && allComponentsCanBreakScope == CanBreakScope::Yes) {
+        if (matchElement.hasRelation && *matchElement.hasRelation != MatchElement::HasRelation::ScopeBreaking && context.canBreakScope == CanBreakScope::Yes) {
             if (relation == CSSSelector::Relation::DescendantSpace || relation == CSSSelector::Relation::Child) {
                 // For :has(> :is(.x > .y)), the child combinator inside :is() is still scoped to the direct child's tree.
                 // Only mark as scope-breaking if the has argument isn't a direct child, or the combinator is a descendant space.
@@ -374,7 +399,7 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
     auto& selector = ruleData.selector();
     bool firstSeen = collectionContext.selectorDeduplicationSet.add({ selector }).isNewEntry;
     if (firstSeen)
-        recursivelyCollectFeaturesFromSelector(selectorFeatures, selector);
+        collectFeaturesFromSelector(selectorFeatures, selector);
 
     if (ruleData.canMatchPseudoElement())
         collectPseudoElementFeatures(ruleData);
@@ -383,8 +408,8 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
         auto collectSelectorList = [&] (const auto& selectorList) {
             if (!selectorList.isEmpty()) {
                 for (auto& subSelector : selectorList) {
-                    recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, { MatchElement::Relation::Ancestor, { } });
-                    recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, { MatchElement::Relation::Subject, { } });
+                    collectFeaturesFromSelector(selectorFeatures, subSelector, { MatchElement::Relation::Ancestor, { } });
+                    collectFeaturesFromSelector(selectorFeatures, subSelector, { MatchElement::Relation::Subject, { } });
                 }
             }
         };

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -176,7 +176,9 @@ private:
         Vector<InvalidationFeature> pseudoClasses;
         Vector<HasInvalidationFeature> hasPseudoClasses;
     };
-    DoesBreakScope recursivelyCollectFeaturesFromSelector(SelectorFeatures&, const CSSSelector&, MatchElement = { MatchElement::Relation::Subject, { } }, IsNegation = IsNegation::No, CanBreakScope = CanBreakScope::No);
+    struct RecursiveCollectionContext;
+    void collectFeaturesFromSelector(SelectorFeatures&, const CSSSelector&, MatchElement = { MatchElement::Relation::Subject, { } });
+    DoesBreakScope recursivelyCollectFeaturesFromSelector(SelectorFeatures&, const CSSSelector&, const RecursiveCollectionContext&);
     void NODELETE collectPseudoElementFeatures(const RuleData&);
 };
 


### PR DESCRIPTION
#### 48505dc2500727a503310fcc9ae95a292bb2c4ba
<pre>
[:has() perf] Compute scope selector for :has() nested in logical pseudo-class
<a href="https://bugs.webkit.org/show_bug.cgi?id=312979">https://bugs.webkit.org/show_bug.cgi?id=312979</a>
<a href="https://rdar.apple.com/175323086">rdar://175323086</a>

Reviewed by Alan Baradlay.

Better invalidation for cases like

.foo:not(:has(.bar)) .baz

* LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt:
* LayoutTests/fast/selectors/has-invalidation-traversal-size.html:
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::collectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):

Factor the parameters into a struct.
Track the outermost selector and use that as the scope selector.

(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/style/RuleFeature.h:
(WebCore::Style::RuleFeatureSet::collectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector): Deleted.

Canonical link: <a href="https://commits.webkit.org/311797@main">https://commits.webkit.org/311797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b7755c7e527e56a5c4d7255d3bfc21753b7cd14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166843 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122377 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24662 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103044 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14616 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169333 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14687 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130551 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31098 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130666 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35386 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141507 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88932 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18313 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30588 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96121 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30109 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30339 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30236 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->