### PR TITLE
Use JSValueInWrappedObject::set() instead of setWeakly() when value is visited during GC

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -277,7 +277,7 @@ void AudioWorkletProcessor::buildJSArguments(VM& vm, JSGlobalObject& globalObjec
     if (!success) {
         auto* array = constructFrozenJSArray(vm, globalObject, inputs, ShouldPopulateWithBusData::Yes);
         RETURN_IF_EXCEPTION(scope, void());
-        m_jsInputs.setWeakly(globalObject, array);
+        m_jsInputs.set(globalObject, wrapper(), array);
     }
     args.append(m_jsInputs.getValue());
 
@@ -286,14 +286,14 @@ void AudioWorkletProcessor::buildJSArguments(VM& vm, JSGlobalObject& globalObjec
     if (!success) {
         auto* array = constructFrozenJSArray(vm, globalObject, outputs, ShouldPopulateWithBusData::No);
         RETURN_IF_EXCEPTION(scope, void());
-        m_jsOutputs.setWeakly(globalObject, array);
+        m_jsOutputs.set(globalObject, wrapper(), array);
     }
     args.append(m_jsOutputs.getValue());
 
     success = copyDataFromParameterMapToJSObject(vm, globalObject, paramValuesMap, toJSObject(m_jsParamValues));
     RETURN_IF_EXCEPTION(scope, void());
     if (!success)
-        m_jsParamValues.setWeakly(globalObject, constructFrozenKeyValueObject(vm, globalObject, paramValuesMap));
+        m_jsParamValues.set(globalObject, wrapper(), constructFrozenKeyValueObject(vm, globalObject, paramValuesMap));
 
     args.append(m_jsParamValues.getValue());
 }

--- a/Source/WebCore/bindings/js/JSValueInWrappedObjectInlines.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObjectInlines.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <JavaScriptCore/HeapCellInlines.h>
+#include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSCJSValueStructure.h>
 #include <JavaScriptCore/SlotVisitorInlines.h>
 #include <JavaScriptCore/WeakInlines.h>
@@ -104,14 +105,16 @@ inline void JSValueInWrappedObject::setWeakly(RefPtr<DOMWrapperWorld>&& world, J
 inline void JSValueInWrappedObject::set(JSC::JSGlobalObject& globalObject, const JSC::JSCell* owner, JSC::JSValue value)
 {
     setValueInternal(value);
-    globalObject.vm().writeBarrier(owner, value);
+    if (owner)
+        globalObject.vm().writeBarrier(owner, value);
     setWorld(globalObject);
 }
 
 inline void JSValueInWrappedObject::set(RefPtr<DOMWrapperWorld>&& world, JSC::VM& vm, const JSC::JSCell* owner, JSC::JSValue value)
 {
     setValueInternal(value);
-    vm.writeBarrier(owner, value);
+    if (owner)
+        vm.writeBarrier(owner, value);
     setWorld(WTF::move(world));
 }
 

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -176,10 +176,8 @@ void AbortSignal::markAborted(JSC::JSGlobalObject& globalObject, JSC::JSValue re
     m_aborted = true;
     m_sourceSignals.clear();
 
-    // FIXME: This code is wrong: we should emit a write-barrier. Otherwise, GC can collect it.
-    // https://bugs.webkit.org/show_bug.cgi?id=236353
     ASSERT(reason);
-    m_reason.setWeakly(globalObject, reason);
+    m_reason.set(globalObject, wrapper(), reason);
 }
 
 void AbortSignal::runAbortSteps()

--- a/Source/WebCore/dom/CustomEvent.cpp
+++ b/Source/WebCore/dom/CustomEvent.cpp
@@ -66,9 +66,7 @@ void CustomEvent::initCustomEvent(JSC::JSGlobalObject& globalObject, const AtomS
 
     initEvent(type, canBubble, cancelable);
 
-    // FIXME: This code is wrong: we should emit a write-barrier. Otherwise, GC can collect it.
-    // https://bugs.webkit.org/show_bug.cgi?id=236353
-    m_detail.setWeakly(globalObject, detail);
+    m_detail.set(globalObject, wrapper(), detail);
     m_cachedDetail.clear();
 }
 

--- a/Source/WebCore/dom/InternalObserver.h
+++ b/Source/WebCore/dom/InternalObserver.h
@@ -27,6 +27,7 @@
 
 #include "ActiveDOMObject.h"
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 
 namespace JSC {
 class AbstractSlotVisitor;
@@ -34,6 +35,8 @@ class JSValue;
 } // namespace JSC
 
 namespace WebCore {
+
+class Subscriber;
 
 class InternalObserver : public ActiveDOMObject, public RefCounted<InternalObserver> {
 public:
@@ -52,6 +55,9 @@ public:
 
     virtual void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor&) const = 0;
 
+    void setSubscriber(Subscriber& subscriber) { m_subscriber = subscriber; }
+    Subscriber* subscriber() const { return m_subscriber.get(); }
+
 protected:
     bool m_active { true };
 
@@ -63,6 +69,9 @@ protected:
     // ActiveDOMObject
     void stop() override { }
     bool virtualHasPendingActivity() const override { return m_active; }
+
+private:
+    WeakPtr<Subscriber> m_subscriber;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverLast.cpp
+++ b/Source/WebCore/dom/InternalObserverLast.cpp
@@ -37,6 +37,7 @@
 #include "JSValueInWrappedObjectInlines.h"
 #include "Observable.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include "SubscribeOptions.h"
 #include "Subscriber.h"
 #include "SubscriberCallback.h"
@@ -62,7 +63,8 @@ private:
         auto* globalObject = context->globalObject();
         if (!globalObject)
             return;
-        m_lastValue.setWeakly(*globalObject, value);
+        auto* owner = subscriber() ? subscriber()->wrapper() : nullptr;
+        m_lastValue.set(*globalObject, owner, value);
     }
 
     void error(JSC::JSValue value) final

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -37,6 +37,7 @@
 #include "Observable.h"
 #include "ReducerCallback.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include "SubscribeOptions.h"
 #include "Subscriber.h"
 #include "SubscriberCallback.h"
@@ -61,7 +62,8 @@ private:
 
         if (!m_accumulator) {
             m_index++;
-            m_accumulator.setWeakly(*globalObject, value);
+            auto* owner = subscriber() ? subscriber()->wrapper() : nullptr;
+            m_accumulator.set(*globalObject, owner, value);
             return;
         }
 
@@ -80,8 +82,10 @@ private:
             Ref { m_signal }->signalAbort(value);
         }
 
-        if (result.type() == CallbackResultType::Success)
-            m_accumulator.setWeakly(*globalObject, result.releaseReturnValue());
+        if (result.type() == CallbackResultType::Success) {
+            auto* owner = subscriber() ? subscriber()->wrapper() : nullptr;
+            m_accumulator.set(*globalObject, owner, result.releaseReturnValue());
+        }
     }
 
     void error(JSC::JSValue value) final
@@ -114,8 +118,9 @@ private:
         , m_promise(WTF::move(promise))
     {
         if (!initialValue.isUndefined()) [[unlikely]] {
+            auto* owner = subscriber() ? subscriber()->wrapper() : nullptr;
             if (auto* globalObject = context.globalObject())
-                m_accumulator.setWeakly(*globalObject, initialValue);
+                m_accumulator.set(*globalObject, owner, initialValue);
         }
     }
 

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -50,6 +50,7 @@ Subscriber::Subscriber(ScriptExecutionContext& context, Ref<InternalObserver>&& 
     , m_observer(observer)
     , m_options(options)
 {
+    m_observer->setSubscriber(*this);
     relaxAdoptionRequirement();
     followSignal(m_signal);
     if (RefPtr signal = options.signal)

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -61,7 +61,7 @@ NavigateEvent::NavigateEvent(JSC::JSGlobalObject& globalObject, const AtomString
     , m_abortController(abortController)
 {
     Locker<JSC::JSLock> locker(commonVM().apiLock());
-    m_info.setWeakly(globalObject, init.info);
+    m_info.set(globalObject, wrapper(), init.info);
 }
 
 NavigateEvent::NavigateEvent(RefPtr<DOMWrapperWorld>&& world, const AtomString& type, Init&& init, EventIsTrusted isTrusted, AbortController* abortController)


### PR DESCRIPTION
#### b5c5cdb996bdf3d80f21a280a555d709de46980b
<pre>
Use JSValueInWrappedObject::set() instead of setWeakly() when value is visited during GC
<a href="https://bugs.webkit.org/show_bug.cgi?id=236353">https://bugs.webkit.org/show_bug.cgi?id=236353</a>
<a href="https://rdar.apple.com/89012493">rdar://89012493</a>

Reviewed by Yusuke Suzuki.

JSValueInWrappedObject.h documents that setWeakly() must not be used when
the value will be visited via visitAdditionalChildrenInGCThread, because
the GC may prematurely collect the value without a write barrier. Use
set() instead, which calls setWeakly() followed by a write barrier.

For InternalObserverReduce and InternalObserverLast, added a
WeakPtr&lt;Subscriber&gt; back-reference on InternalObserver so the observer
can obtain the JSSubscriber wrapper to use as the write barrier owner.

* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
(WebCore::AudioWorkletProcessor::buildJSArguments):
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::markAborted):
* Source/WebCore/dom/CustomEvent.cpp:
(WebCore::CustomEvent::initCustomEvent):
* Source/WebCore/dom/InternalObserver.h:
(WebCore::InternalObserver::setSubscriber):
(WebCore::InternalObserver::subscriber const):
* Source/WebCore/dom/InternalObserverLast.cpp:
* Source/WebCore/dom/InternalObserverReduce.cpp:
* Source/WebCore/dom/Subscriber.cpp:
(WebCore::Subscriber::Subscriber):
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::NavigateEvent):

Canonical link: <a href="https://commits.webkit.org/311842@main">https://commits.webkit.org/311842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b96309d8abe888a7fa6aade4b3c3759ba724d49b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112041 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122326 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85878 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102993 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23672 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14559 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169276 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14454 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21282 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130500 "Found 1 new test failure: media/media-vp8-webm.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26176 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130614 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35413 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141453 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88863 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18259 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30531 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95887 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30052 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30282 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30179 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->