### PR TITLE
[win] Enable `MemoryPressureHandlerWin` and Implement low memory watcher

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -264,9 +264,13 @@ private:
     Configuration m_configuration;
 
 #if OS(WINDOWS)
+    friend VOID CALLBACK lowMemoryNotificationCallback(PVOID, BOOLEAN);
     void windowsMeasurementTimerFired();
+    void windowsLowMemoryNotificationFired();
+    void beginWaitingForLowMemoryNotification();
     RunLoop::Timer m_windowsMeasurementTimer;
     Win32Handle m_lowMemoryHandle;
+    HANDLE m_lowMemoryWaitHandle { nullptr };
 #endif
 
 #if (OS(LINUX) || OS(FREEBSD) || OS(HAIKU) || OS(QNX)) && !OS(ANDROID)

--- a/Source/WTF/wtf/win/MemoryPressureHandlerWin.cpp
+++ b/Source/WTF/wtf/win/MemoryPressureHandlerWin.cpp
@@ -27,6 +27,8 @@
 #include <wtf/MemoryPressureHandler.h>
 
 #include <psapi.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WTF {
@@ -36,13 +38,45 @@ void MemoryPressureHandler::platformInitialize()
     m_lowMemoryHandle = Win32Handle::adopt(::CreateMemoryResourceNotification(LowMemoryResourceNotification));
 }
 
+VOID CALLBACK lowMemoryNotificationCallback(PVOID context, BOOLEAN)
+{
+    callOnMainThread([handler = static_cast<MemoryPressureHandler*>(context)] {
+        handler->windowsLowMemoryNotificationFired();
+    });
+}
+
+void MemoryPressureHandler::beginWaitingForLowMemoryNotification()
+{
+    if (m_lowMemoryWaitHandle)
+        return;
+
+    if (!::RegisterWaitForSingleObject(&m_lowMemoryWaitHandle, m_lowMemoryHandle.get(), lowMemoryNotificationCallback, this, INFINITE, WT_EXECUTEONLYONCE))
+        m_lowMemoryWaitHandle = nullptr;
+}
+
+void MemoryPressureHandler::windowsLowMemoryNotificationFired()
+{
+    m_lowMemoryWaitHandle = nullptr;
+
+    if (!m_installed || !m_lowMemoryHandle)
+        return;
+
+    BOOL memoryLow;
+
+    if (QueryMemoryResourceNotification(m_lowMemoryHandle.get(), &memoryLow) && memoryLow) {
+        setMemoryPressureStatus(SystemMemoryPressureStatus::Critical);
+        releaseMemory(Critical::Yes);
+    }
+    beginWaitingForLowMemoryNotification();
+}
+
 void MemoryPressureHandler::windowsMeasurementTimerFired()
 {
     setMemoryPressureStatus(SystemMemoryPressureStatus::Normal);
 
     BOOL memoryLow;
 
-    if (QueryMemoryResourceNotification(m_lowMemoryHandle.get(), &memoryLow) && memoryLow) {
+    if (m_lowMemoryHandle && QueryMemoryResourceNotification(m_lowMemoryHandle.get(), &memoryLow) && memoryLow) {
         setMemoryPressureStatus(SystemMemoryPressureStatus::Critical);
         releaseMemory(Critical::Yes);
         return;
@@ -68,11 +102,14 @@ void MemoryPressureHandler::windowsMeasurementTimerFired()
 
 void MemoryPressureHandler::platformReleaseMemory(Critical)
 {
+    WTF::releaseFastMallocFreeMemory();
 }
 
 void MemoryPressureHandler::install()
 {
+    platformInitialize();
     m_installed = true;
+    beginWaitingForLowMemoryNotification();
     m_windowsMeasurementTimer.startRepeating(60_s);
 }
 
@@ -82,6 +119,10 @@ void MemoryPressureHandler::uninstall()
         return;
 
     m_windowsMeasurementTimer.stop();
+    if (m_lowMemoryWaitHandle) {
+        ::UnregisterWaitEx(m_lowMemoryWaitHandle, INVALID_HANDLE_VALUE);
+        m_lowMemoryWaitHandle = nullptr;
+    }
     m_installed = false;
 }
 

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -41,6 +41,7 @@ list(APPEND WebKit_SOURCES
     UIProcess/DefaultUndoController.cpp
     UIProcess/LegacySessionStateCodingNone.cpp
     UIProcess/WebGrammarDetail.cpp
+    UIProcess/WebMemoryPressureHandler.cpp
     UIProcess/WebViewportAttributes.cpp
 
     UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp

--- a/Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "WebProcessPool.h"
 
+#include "WebMemoryPressureHandler.h"
 #include "WebProcessCreationParameters.h"
 #include <WebCore/NotImplemented.h>
 
@@ -63,6 +64,8 @@ static void initializeRemoteInspectorServer(StringView address)
 
 void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
 {
+    WebKit::installMemoryPressureHandler();
+
 #if ENABLE(REMOTE_INSPECTOR)
     if (const char* address = getenv("WEBKIT_INSPECTOR_SERVER"))
         initializeRemoteInspectorServer(StringView::fromLatin1(address));


### PR DESCRIPTION
#### dc311bb8313d5b2aac0e817007a024b38ce6e2c2
<pre>
[win] Enable `MemoryPressureHandlerWin` and Implement low memory watcher
<a href="https://bugs.webkit.org/show_bug.cgi?id=297533">https://bugs.webkit.org/show_bug.cgi?id=297533</a>

Reviewed by Don Olmstead.

Enable the memory pressure handler on Windows by calling
WebKit::installMemoryPressureHandler() from
WebProcessPool::platformInitialize().

Implement a low memory watcher that is invoked by a callback when
the system is under memory pressure.

Canonical link: <a href="https://commits.webkit.org/313270@main">https://commits.webkit.org/313270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ced1d61cec866c9d2c7c3ea7f4005021e0c820d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118919 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126090 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145956 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106668 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27479 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26007 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.SelectAllTextInEmbedHostedPDF (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19112 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173916 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23313 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21229 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134398 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134397 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36291 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145482 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/97867 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28930 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22315 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194874 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35117 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102869 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50362 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34619 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->