### PR TITLE
ANGLE: Metal: TransformFeedbackTest.RenderOnceChangeXfbBufferRenderAgain fails validation

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -681,6 +681,9 @@
 		7BED4E072F98E33B00A240A7 /* GLSLValidationTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BED4E002F98E33B00A240A7 /* GLSLValidationTest.cpp */; };
 		7BED4E0B2F98E35C00A240A7 /* CompilerTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BED4E0A2F98E35C00A240A7 /* CompilerTest.cpp */; };
 		7BED4E0C2F98E35C00A240A7 /* CompilerTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BED4E092F98E35C00A240A7 /* CompilerTest.h */; };
+		7BED5BE82F99F81200A240A7 /* TransformFeedback_unittest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BED5BE72F99F81200A240A7 /* TransformFeedback_unittest.cpp */; };
+		7BED6F852F99FE0700A240A7 /* FrameCapture_mock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFD0029227449D1D002BE3BC /* FrameCapture_mock.cpp */; };
+		7BED6F862F99FE2E00A240A7 /* serialize_mock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A2C67022923766600FEDF46 /* serialize_mock.cpp */; };
 		7BF554C42C81EF29002B101E /* libtranslator.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BF5549B2C81EDE0002B101E /* libtranslator.a */; };
 		7BF554C52C81EF4D002B101E /* TranslatorFuzzer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF554A02C81EE51002B101E /* TranslatorFuzzer.cpp */; };
 		7BF554CD2C81F028002B101E /* TranslatorFuzzer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF554A02C81EE51002B101E /* TranslatorFuzzer.cpp */; };
@@ -2220,6 +2223,7 @@
 		7BED4E002F98E33B00A240A7 /* GLSLValidationTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GLSLValidationTest.cpp; sourceTree = "<group>"; };
 		7BED4E092F98E35C00A240A7 /* CompilerTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompilerTest.h; sourceTree = "<group>"; };
 		7BED4E0A2F98E35C00A240A7 /* CompilerTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CompilerTest.cpp; sourceTree = "<group>"; };
+		7BED5BE72F99F81200A240A7 /* TransformFeedback_unittest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TransformFeedback_unittest.cpp; sourceTree = "<group>"; };
 		7BF5549B2C81EDE0002B101E /* libtranslator.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libtranslator.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		7BF554A02C81EE51002B101E /* TranslatorFuzzer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TranslatorFuzzer.cpp; path = WebKit/TranslatorFuzzer.cpp; sourceTree = "<group>"; };
 		7BF554A12C81EE77002B101E /* TranslatorFuzzerCoverage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = TranslatorFuzzerCoverage.mm; path = WebKit/TranslatorFuzzerCoverage.mm; sourceTree = "<group>"; };
@@ -3225,6 +3229,7 @@
 				A30307142305F7C3002DA972 /* trace.h */,
 				5C1DBDC31B0438D300235552 /* TransformFeedback.cpp */,
 				5C1DBDC41B0438D300235552 /* TransformFeedback.h */,
+				7BED5BE72F99F81200A240A7 /* TransformFeedback_unittest.cpp */,
 				5C1DBDC51B0438D300235552 /* Uniform.cpp */,
 				5C1DBDC61B0438D300235552 /* Uniform.h */,
 				5C1DBDC71B0438D300235552 /* validationEGL.cpp */,
@@ -6285,6 +6290,7 @@
 				7BFAF8ED2DE6EDE400327F7F /* FixedQueue_unittest.cpp in Sources */,
 				7BFAF8E02DE6EDE400327F7F /* FixedVector_unittest.cpp in Sources */,
 				7BFAF8812DE6ECA700327F7F /* FloatLex_test.cpp in Sources */,
+				7BED6F852F99FE0700A240A7 /* FrameCapture_mock.cpp in Sources */,
 				7B8C091A2F84EC49007E37DE /* GPUTestConfig.cpp in Sources */,
 				7B8C091B2F84EC83007E37DE /* GPUTestExpectationsParser.cpp in Sources */,
 				7BFAF8E52DE6EDE400327F7F /* hash_utils_unittest.cpp in Sources */,
@@ -6299,12 +6305,14 @@
 				7BFAF8E62DE6EDE400327F7F /* Optional_unittest.cpp in Sources */,
 				7B8C091C2F84EC9D007E37DE /* OSWindow.cpp in Sources */,
 				7BFAF8F02DE6EDE400327F7F /* PoolAlloc_unittest.cpp in Sources */,
+				7BED6F862F99FE2E00A240A7 /* serialize_mock.cpp in Sources */,
 				7BFAF8F12DE6EDE400327F7F /* SimpleMutex_unittest.cpp in Sources */,
 				7BFAF8E12DE6EDE400327F7F /* span_unittest.cpp in Sources */,
 				7BFAF8E42DE6EDE400327F7F /* string_utils_unittest.cpp in Sources */,
 				7BFAF8E32DE6EDE400327F7F /* system_utils_unittest.cpp in Sources */,
 				7BFAF8F32DE6EE4500327F7F /* SystemInfo_unittest.cpp in Sources */,
 				7B8C09152F84EAB1007E37DE /* TestSuite.cpp in Sources */,
+				7BED5BE82F99F81200A240A7 /* TransformFeedback_unittest.cpp in Sources */,
 				7BFAF8C12DE6ECA700327F7F /* Type_test.cpp in Sources */,
 				7BFAF8BB2DE6ECA700327F7F /* VariablePacker_test.cpp in Sources */,
 				7BFAF8E22DE6EDE400327F7F /* vector_utils_unittest.cpp in Sources */,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/Buffer.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Buffer.cpp
@@ -555,7 +555,9 @@ void Buffer::onStateChange(const Context *context, angle::SubjectMessage message
 
     // Apply the change directly on current context's current vertex array. All other vertex arrays
     // requires a buffer rebind in order to pick up the change.
-    context->onBufferChanged(this, message,
+    bool isUsedInTransformFeedback = mState.mTransformFeedbackGenericBindingCount > 0 ||
+                                     mState.mTransformFeedbackIndexedBindingCount > 0;
+    context->onBufferChanged(this, message, isUsedInTransformFeedback,
                              mVertexArrayBufferBindingMaskAndContext.getBufferBindingMask(context));
 }
 
@@ -567,7 +569,10 @@ void Buffer::onContentsChange(const Context *context)
         static_cast<Texture *>(contentsObserver.observer)->onBufferContentsChange();
     }
 
+    bool isUsedInTransformFeedback = mState.mTransformFeedbackGenericBindingCount > 0 ||
+                                     mState.mTransformFeedbackIndexedBindingCount > 0;
     context->onBufferChanged(this, angle::SubjectMessage::ContentsChanged,
+                             isUsedInTransformFeedback,
                              mVertexArrayBufferBindingMaskAndContext.getBufferBindingMask(context));
 }
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp
@@ -10219,6 +10219,18 @@ void Context::onProgramPipelineDestroy(const ProgramPipeline *programPipeline) c
     mState.mProgramPipelineManager->recycleHandle(programPipeline->id());
 }
 
+void Context::invalidateTransformFeedbackCapacities(const Buffer *buffer) const
+{
+    for (auto pair : UnsafeResourceMapIter(mTransformFeedbackMap))
+    {
+        TransformFeedback *tf = pair.second;
+        if (tf != nullptr && tf->isBufferBound(buffer->id()))
+        {
+            tf->invalidateVertexCapacity();
+        }
+    }
+}
+
 // ErrorSet implementation.
 ErrorSet::ErrorSet(Debug *debug,
                    const angle::FrontendFeatures &frontendFeatures,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/Context.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Context.h
@@ -957,6 +957,7 @@ class Context final : public egl::LabeledObject, angle::NonCopyable, public angl
     void onSwapChainImageChanged() const { mDefaultFramebuffer->onSwapChainImageChanged(); }
     void onBufferChanged(const Buffer *buffer,
                          const angle::SubjectMessage message,
+                         bool isUsedInTransformFeedback,
                          VertexArrayBufferBindingMask vertexArrayBufferBindingMask) const
     {
         // Notify current vertex array of the buffer changed. Note that other vertex arrays of this
@@ -967,6 +968,10 @@ class Context final : public egl::LabeledObject, angle::NonCopyable, public angl
             ASSERT(mState.mVertexArray != nullptr);
             mState.mVertexArray->onBufferChanged(this, buffer, message,
                                                  vertexArrayBufferBindingMask);
+        }
+        if (isUsedInTransformFeedback && message == angle::SubjectMessage::SubjectChanged)
+        {
+            invalidateTransformFeedbackCapacities(buffer);
         }
     }
 
@@ -1052,6 +1057,7 @@ class Context final : public egl::LabeledObject, angle::NonCopyable, public angl
     void updateActiveAttribsMaskIfNeeded() const;
 
     void endTilingImplicit();
+    void invalidateTransformFeedbackCapacities(const Buffer *buffer) const;
 
     State mState;
     bool mShared;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/TransformFeedback.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/TransformFeedback.cpp
@@ -52,7 +52,6 @@ TransformFeedbackState::TransformFeedbackState(size_t maxIndexedBuffers)
       mPrimitiveMode(PrimitiveMode::InvalidEnum),
       mPaused(false),
       mVerticesDrawn(0),
-      mVertexCapacity(0),
       mProgram(nullptr),
       mIndexedBuffers(maxIndexedBuffers)
 {}
@@ -149,7 +148,6 @@ angle::Result TransformFeedback::begin(const Context *context,
     mState.mPaused        = false;
     mState.mVerticesDrawn = 0;
     bindProgram(context, program);
-    recomputeVertexCapacity(context);
     return angle::Result::Continue;
 }
 
@@ -160,7 +158,7 @@ angle::Result TransformFeedback::end(const Context *context)
     mState.mPrimitiveMode  = PrimitiveMode::InvalidEnum;
     mState.mPaused         = false;
     mState.mVerticesDrawn  = 0;
-    mState.mVertexCapacity = 0;
+    mState.mVertexCapacity = std::nullopt;
     if (mState.mProgram)
     {
         mState.mProgram->release(context);
@@ -180,7 +178,6 @@ angle::Result TransformFeedback::resume(const Context *context)
 {
     ANGLE_TRY(mImplementation->resume(context));
     mState.mPaused = false;
-    recomputeVertexCapacity(context);
     return angle::Result::Continue;
 }
 
@@ -194,9 +191,10 @@ PrimitiveMode TransformFeedback::getPrimitiveMode() const
     return mState.mPrimitiveMode;
 }
 
-bool TransformFeedback::checkBufferSpaceForDraw(const GLsizei *counts,
+bool TransformFeedback::checkBufferSpaceForDraw(const Context *context,
+                                                const GLsizei *counts,
                                                 const GLsizei *primcounts,
-                                                GLsizei drawcount) const
+                                                GLsizei drawcount)
 {
     auto vertices = angle::CheckedNumeric<GLsizeiptr>(mState.mVerticesDrawn);
     for (GLsizei drawID = 0; drawID < drawcount; ++drawID)
@@ -205,7 +203,32 @@ bool TransformFeedback::checkBufferSpaceForDraw(const GLsizei *counts,
         GLsizei count     = ANGLE_UNSAFE_BUFFERS(counts[drawID]);
         vertices += GetVerticesNeededForDraw(mState.mPrimitiveMode, count, primcount);
     }
-    return vertices.IsValid() && vertices.ValueOrDie() <= mState.mVertexCapacity;
+
+    if (!mState.mVertexCapacity.has_value())
+    {
+        const ProgramExecutable *programExecutable = context->getState().getLinkedProgramExecutable(context);
+        if (programExecutable)
+        {
+            // Compute the number of vertices we can draw before overflowing the bound buffers.
+            auto strides = programExecutable->getTransformFeedbackStrides();
+            ASSERT(strides.size() <= mState.mIndexedBuffers.size() && !strides.empty());
+            GLsizeiptr minCapacity = std::numeric_limits<GLsizeiptr>::max();
+            for (size_t index = 0; index < strides.size(); index++)
+            {
+                GLsizeiptr capacity =
+                    GetBoundBufferAvailableSize(mState.mIndexedBuffers[index]) / strides[index];
+                minCapacity = std::min(minCapacity, capacity);
+            }
+            mState.mVertexCapacity = minCapacity;
+        }
+        else
+        {
+            UNREACHABLE();
+            mState.mVertexCapacity = 0;
+        }
+    }
+
+    return vertices.IsValid() && vertices.ValueOrDie() <= *mState.mVertexCapacity;
 }
 
 void TransformFeedback::onVerticesDrawn(const Context *context, GLsizei count, GLsizei primcount)
@@ -238,32 +261,6 @@ void TransformFeedback::bindProgram(const Context *context, Program *program)
         {
             mState.mProgram->addRef();
         }
-    }
-}
-
-void TransformFeedback::recomputeVertexCapacity(const Context *context)
-{
-    // In one of the angle_unittests - "TransformFeedbackTest.SideEffectsOfStartAndStop"
-    // there is a code path where <context> is a nullptr, account for that possibility.
-    const ProgramExecutable *programExecutable =
-        context ? context->getState().getLinkedProgramExecutable(context) : nullptr;
-    if (programExecutable)
-    {
-        // Compute the number of vertices we can draw before overflowing the bound buffers.
-        auto strides = programExecutable->getTransformFeedbackStrides();
-        ASSERT(strides.size() <= mState.mIndexedBuffers.size() && !strides.empty());
-        GLsizeiptr minCapacity = std::numeric_limits<GLsizeiptr>::max();
-        for (size_t index = 0; index < strides.size(); index++)
-        {
-            GLsizeiptr capacity =
-                GetBoundBufferAvailableSize(mState.mIndexedBuffers[index]) / strides[index];
-            minCapacity = std::min(minCapacity, capacity);
-        }
-        mState.mVertexCapacity = minCapacity;
-    }
-    else
-    {
-        mState.mVertexCapacity = 0;
     }
 }
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/TransformFeedback.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/TransformFeedback.h
@@ -14,6 +14,7 @@
 #include "libANGLE/Debug.h"
 
 #include "angle_gl.h"
+#include <optional>
 
 namespace rx
 {
@@ -50,7 +51,7 @@ class TransformFeedbackState final : angle::NonCopyable
     PrimitiveMode mPrimitiveMode;
     bool mPaused;
     GLsizeiptr mVerticesDrawn;
-    GLsizeiptr mVertexCapacity;
+    std::optional<GLsizeiptr> mVertexCapacity;
 
     Program *mProgram;
 
@@ -78,9 +79,10 @@ class TransformFeedback final : public RefCountObject<TransformFeedbackID>, publ
     PrimitiveMode getPrimitiveMode() const;
     // Validates that the vertices produced by a draw call will fit in the bound transform feedback
     // buffers. primcounts may be nullptr for non-instanced draw calls.
-    bool checkBufferSpaceForDraw(const GLsizei *counts,
+    bool checkBufferSpaceForDraw(const Context *context,
+                                 const GLsizei *counts,
                                  const GLsizei *primcounts,
-                                 GLsizei drawcount) const;
+                                 GLsizei drawcount);
     // This must be called after each draw call when transform feedback is enabled to keep track of
     // how many vertices have been written to the buffers. This information is needed by
     // checkBufferSpaceForDraw because each draw call appends vertices to the buffers starting just
@@ -107,6 +109,7 @@ class TransformFeedback final : public RefCountObject<TransformFeedbackID>, publ
     // Returns true if the buffer is bound to any of the indexed binding points in this transform
     // feedback.
     bool isBufferBound(BufferID bufferID) const;
+    void invalidateVertexCapacity() { mState.mVertexCapacity = std::nullopt; }
 
     angle::Result detachBuffer(const Context *context, BufferID bufferID);
 
@@ -116,7 +119,6 @@ class TransformFeedback final : public RefCountObject<TransformFeedbackID>, publ
 
   private:
     void bindProgram(const Context *context, Program *program);
-    void recomputeVertexCapacity(const Context *context);
 
     TransformFeedbackState mState;
     rx::TransformFeedbackImpl *mImplementation;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp
@@ -1536,7 +1536,7 @@ bool ValidateDrawArraysTransformFeedbackBufferSize(const Context *context,
     {
         const State &state                      = context->getState();
         TransformFeedback *curTransformFeedback = state.getCurrentTransformFeedback();
-        if (!curTransformFeedback->checkBufferSpaceForDraw(counts, primcounts, drawcount))
+        if (!curTransformFeedback->checkBufferSpaceForDraw(context, counts, primcounts, drawcount))
         {
             ANGLE_VALIDATION_ERROR(GL_INVALID_OPERATION, err::kTransformFeedbackBufferTooSmall);
             return false;

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/TransformFeedbackTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/TransformFeedbackTest.cpp
@@ -782,9 +782,7 @@ TEST_P(TransformFeedbackTest, BlitWhileRecordingDoesNotContribute)
 }
 
 // Test that XFB does not allow writing more vertices than fit in the bound buffers.
-// TODO(jmadill): Enable this test after fixing the last case where the buffer size changes after
-// calling glBeginTransformFeedback.
-TEST_P(TransformFeedbackTest, DISABLED_TooSmallBuffers)
+TEST_P(TransformFeedbackTest, TooSmallBuffers)
 {
     glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
     glClear(GL_COLOR_BUFFER_BIT);
@@ -4441,13 +4439,21 @@ TEST_P(TransformFeedbackTest, RenderOnceChangeXfbBufferRenderAgain)
     // Break the render pass
     EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::red);
 
-    // Redefine the transform feedback buffer
-    glBufferData(GL_TRANSFORM_FEEDBACK_BUFFER, 40, nullptr, GL_DYNAMIC_READ);
+    // Redefine the transform feedback buffer: a draw fits to 96 bytes.
+    glBufferData(GL_TRANSFORM_FEEDBACK_BUFFER, 96 * 2, nullptr, GL_DYNAMIC_READ);
 
     // Start a new render pass
     drawQuad(drawColor, essl3_shaders::PositionAttrib(), 0.5f);
+    EXPECT_GL_NO_ERROR();
+
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::red);
+
+    glBufferData(GL_TRANSFORM_FEEDBACK_BUFFER, 40, nullptr, GL_DYNAMIC_READ);
+    drawQuad(drawColor, essl3_shaders::PositionAttrib(), 0.5f);
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
 
     glEndTransformFeedback();
+    EXPECT_GL_NO_ERROR();
 }
 
 // Test bufferData call and transform feedback.


### PR DESCRIPTION
#### 7e67d72fd8ad22a6976516aa50109d511ad802b8
<pre>
ANGLE: Metal: TransformFeedbackTest.RenderOnceChangeXfbBufferRenderAgain fails validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=312988">https://bugs.webkit.org/show_bug.cgi?id=312988</a>
<a href="https://rdar.apple.com/175334405">rdar://175334405</a>

Reviewed by Dan Glastonbury.

TransformFeedbackTest.RenderOnceChangeXfbBufferRenderAgain would draw
the second draw with too small transform feedback buffer.
This should generate INVALID_OPERATION, but didn&apos;t.

Implement the feature by invalidating the vertex capacity of the
transform feedback buffer when the buffer is updated. Recalculate
the capacity upon the draw call validation check.

WebGL does not use this feature, as updating the buffer is disallowed
by WebGL specification. However, the validation failure would make
running the ANGLEEnd2EndTests inconventient on Metal, as the tests
stop when the process crashes.

Enable TransformFeedback_unittest in WebKit build.

* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
* Source/ThirdParty/ANGLE/src/libANGLE/Buffer.cpp:
(gl::Buffer::onStateChange):
(gl::Buffer::onContentsChange):
* Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp:
(gl::Context::invalidateTransformFeedbackCapacities const):
* Source/ThirdParty/ANGLE/src/libANGLE/Context.h:
* Source/ThirdParty/ANGLE/src/libANGLE/TransformFeedback.cpp:
(gl::TransformFeedbackState::TransformFeedbackState):
(gl::TransformFeedback::begin):
(gl::TransformFeedback::end):
(gl::TransformFeedback::resume):
(gl::TransformFeedback::checkBufferSpaceForDraw):
(gl::TransformFeedback::checkBufferSpaceForDraw const): Deleted.
(gl::TransformFeedback::recomputeVertexCapacity): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/TransformFeedback.h:
* Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp:
(gl::ValidateDrawArraysTransformFeedbackBufferSize):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/TransformFeedbackTest.cpp:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/VertexAttributeTest.cpp:

Canonical link: <a href="https://commits.webkit.org/311839@main">https://commits.webkit.org/311839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91ac6e8bef194b998850c8d764567bcb28ed1b18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167052 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112306 "Build is in progress. Recent messages:") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122534 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/112306 "Build is in progress. Recent messages:") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24804 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103203 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14824 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169541 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130716 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31306 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130831 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35412 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141696 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89140 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25539 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30796 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30317 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30547 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30444 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->