### PR TITLE
[WPE][GTK] Initialize Vulkan in a way that will allow sharing allocated buffers with OpenGL

### DIFF
--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -179,3 +179,14 @@ endif ()
 if (USE_LIBSECRET)
     list(APPEND WebCore_PRIVATE_LIBRARIES Secret::Secret)
 endif ()
+
+if (USE_VULKAN)
+    list(APPEND WebCore_PRIVATE_LIBRARIES volk::volk)
+    list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
+        "${WEBCORE_DIR}/platform/graphics/vulkan"
+    )
+    list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+        platform/graphics/vulkan/VulkanTypes.h
+        platform/graphics/vulkan/VulkanUtilities.h
+    )
+endif ()

--- a/Source/WebCore/PlatformWPE.cmake
+++ b/Source/WebCore/PlatformWPE.cmake
@@ -153,6 +153,17 @@ if (ENABLE_GAMEPAD)
     )
 endif ()
 
+if (USE_VULKAN)
+    list(APPEND WebCore_PRIVATE_LIBRARIES volk::volk)
+    list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
+        "${WEBCORE_DIR}/platform/graphics/vulkan"
+    )
+    list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+        platform/graphics/vulkan/VulkanTypes.h
+        platform/graphics/vulkan/VulkanUtilities.h
+    )
+endif ()
+
 # This sets the maximum amount of memory that BitmapTexturePool can hold before being more
 # aggressive trying to release the unused textures.
 # Use a big value as the default size limit (80MB, enough for ten 1920x1080 layers).

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -89,6 +89,9 @@ platform/graphics/glib/SystemFontDatabaseGLib.cpp
 
 platform/graphics/opentype/OpenTypeVerticalData.cpp
 
+platform/graphics/vulkan/VulkanTypes.cpp
+platform/graphics/vulkan/VulkanUtilities.cpp
+
 platform/graphics/x11/XErrorTrapper.cpp @no-unify
 
 platform/gtk/LocalizedStringsGtk.cpp

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -97,6 +97,9 @@ platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
 
 platform/graphics/opentype/OpenTypeVerticalData.cpp
 
+platform/graphics/vulkan/VulkanTypes.cpp
+platform/graphics/vulkan/VulkanUtilities.cpp
+
 platform/libwpe/PlatformKeyboardEventLibWPE.cpp
 platform/libwpe/PlatformPasteboardLibWPE.cpp
 

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -200,6 +200,7 @@ namespace WebCore {
     M(WebRTCStats) \
     M(Worker) \
     M(XR) \
+    M(Vulkan) \
     M(WheelEventTestMonitor) \
 
 #undef DECLARE_LOG_CHANNEL

--- a/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "VulkanTypes.h"
+
+#if USE(VULKAN)
+#include "Logging.h"
+#include "VulkanUtilities.h"
+#include <wtf/text/CStringView.h>
+
+namespace WebCore {
+namespace Vulkan {
+
+ApplicationInfo::ApplicationInfo(const char* applicationName, uint32_t apiVersion)
+{
+    m_inner.pApplicationName = applicationName;
+    m_inner.apiVersion = apiVersion;
+}
+
+InstanceCreateInfo::InstanceCreateInfo(const ApplicationInfo& applicationInfo, std::span<const char* const> enabledLayers, std::span<const char* const> enabledExtensions)
+{
+    m_inner.pApplicationInfo = applicationInfo.ptr();
+
+    m_inner.enabledLayerCount = enabledLayers.size();
+    m_inner.ppEnabledLayerNames = enabledLayers.data();
+
+    m_inner.enabledExtensionCount = enabledExtensions.size();
+    m_inner.ppEnabledExtensionNames = enabledExtensions.data();
+}
+
+void PhysicalDevice::fillProperties(PhysicalDeviceProperties& properties) const
+{
+    vkGetPhysicalDeviceProperties2(m_inner, properties.ptr());
+}
+
+const Vector<VkLayerProperties>& Instance::availableLayers()
+{
+    static const auto layerProperties = ([]() -> Vector<VkLayerProperties> {
+        uint32_t layerCount;
+        if (auto result = vkEnumerateInstanceLayerProperties(&layerCount, nullptr); result != VK_SUCCESS) {
+            RELEASE_LOG_ERROR(Vulkan, "Cannot enumerate instance layers: %s", resultString(result));
+            return { };
+        }
+
+        Vector<VkLayerProperties> result(layerCount);
+        auto resultSpan = result.mutableSpan();
+        ASSERT(resultSpan.size() == layerCount);
+
+        if (auto result = vkEnumerateInstanceLayerProperties(&layerCount, resultSpan.data()); result != VK_SUCCESS) {
+            RELEASE_LOG_ERROR(Vulkan, "Cannot enumerate instance layers: %s", resultString(result));
+            return { };
+        }
+
+        for (const auto& item : result)
+            RELEASE_LOG_DEBUG(Vulkan, "Available layer: %s (spec %" PRIu32 ", version %" PRIu32 ")", item.layerName, item.specVersion, item.implementationVersion);
+
+        return result;
+    })();
+    return layerProperties;
+}
+
+bool Instance::hasLayers(std::span<const char* const> layerNames)
+{
+    return std::ranges::all_of(layerNames, [](auto* layerName) -> bool {
+        return availableLayers().containsIf([layerName](const auto& layer) -> bool {
+            return CStringView::unsafeFromUTF8(layerName) == CStringView::unsafeFromUTF8(layer.layerName);
+        });
+    });
+}
+
+bool Instance::hasLayer(const char* const layerName)
+{
+    std::array<const char* const, 1> layerNames = { layerName };
+    return hasLayers(std::span(layerNames));
+}
+
+Result<Vector<VkExtensionProperties>> Instance::availableExtensions(const char* layerName)
+{
+    uint32_t extensionCount;
+    if (auto result = vkEnumerateInstanceExtensionProperties(layerName, &extensionCount, nullptr); result != VK_SUCCESS)
+        return makeUnexpected(result);
+
+    Vector<VkExtensionProperties> result(extensionCount);
+    auto resultSpan = result.mutableSpan();
+    ASSERT(resultSpan.size() == extensionCount);
+
+    if (auto result = vkEnumerateInstanceExtensionProperties(layerName, &extensionCount, resultSpan.data()); result != VK_SUCCESS)
+        return makeUnexpected(result);
+
+    return result;
+}
+
+bool Instance::hasExtensions(const Vector<VkExtensionProperties>& availableExtensions, std::span<const char* const> extensionNames)
+{
+    return std::ranges::all_of(extensionNames, [&availableExtensions](auto* extensionName) -> bool {
+        return availableExtensions.containsIf([extensionName](const auto& extension) -> bool {
+            return CStringView::unsafeFromUTF8(extensionName) == CStringView::unsafeFromUTF8(extension.extensionName);
+        });
+    });
+}
+
+bool Instance::hasExtension(const Vector<VkExtensionProperties>& availableExtensions, const char* const extensionName)
+{
+    std::array<const char* const, 1> extensionNames = { extensionName };
+    return hasExtensions(availableExtensions, std::span(extensionNames));
+}
+
+bool Instance::hasExtensions(std::span<const char* const> extensionNames, const char* layerName)
+{
+    if (auto extensions = availableExtensions(layerName))
+        return hasExtensions(*extensions, extensionNames);
+    return false;
+}
+
+bool Instance::hasExtension(const char* const extensionName, const char *layerName)
+{
+    std::array<const char* const, 1> extensionNames = { extensionName };
+    return hasExtensions(std::span(extensionNames), layerName);
+}
+
+Instance Instance::s_sharedInstance { nullptr };
+
+void Instance::setSharedInstance(Instance&& instance)
+{
+    if (s_sharedInstance.m_inner)
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Attempted to reset already initialized Vulkan shared instance");
+    s_sharedInstance = WTF::move(instance);
+}
+
+Instance* Instance::sharedInstanceIfExists()
+{
+    return s_sharedInstance.m_inner ? &s_sharedInstance : nullptr;
+}
+
+Instance& Instance::sharedInstance()
+{
+    if (!s_sharedInstance.m_inner) [[unlikely]]
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Attempted to use Vulkan shared instance before its initialization");
+    return s_sharedInstance;
+}
+
+Result<Instance> Instance::create(const InstanceCreateInfo& creationInfo)
+{
+    VkInstance instance;
+    if (auto result = vkCreateInstance(creationInfo.ptr(), nullptr, &instance); result != VK_SUCCESS)
+        return makeUnexpected(result);
+
+    volkLoadInstanceOnly(instance);
+    return Instance(instance);
+}
+
+Instance::~Instance()
+{
+#ifdef VK_EXT_debug_utils
+    if (m_debugMessenger)
+        vkDestroyDebugUtilsMessengerEXT(m_inner, m_debugMessenger, nullptr);
+#endif // VK_EXT_debug_utils
+
+    if (m_inner)
+        vkDestroyInstance(m_inner, nullptr);
+}
+
+Result<Vector<PhysicalDevice>> Instance::availableDevices() const
+{
+    uint32_t deviceCount;
+    if (auto result = vkEnumeratePhysicalDevices(m_inner, &deviceCount, nullptr); result != VK_SUCCESS)
+        return makeUnexpected(result);
+
+    Vector<PhysicalDevice> devices(deviceCount);
+    static_assert(sizeof(PhysicalDevice) == sizeof(VkPhysicalDevice));
+    auto devicesSpan = spanReinterpretCast<VkPhysicalDevice>(devices.mutableSpan());
+    ASSERT(devicesSpan.size() == deviceCount);
+    if (auto result = vkEnumeratePhysicalDevices(m_inner, &deviceCount, devicesSpan.data()); result != VK_SUCCESS)
+        return makeUnexpected(result);
+
+    return devices;
+}
+
+#ifdef VK_EXT_debug_utils
+struct DebugUtilsMessengerCreateInfo : Structure<VkDebugUtilsMessengerCreateInfoEXT, VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT> {
+};
+
+static VkBool32 debugUtilsMessengerHandleMessage(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes, const VkDebugUtilsMessengerCallbackDataEXT* data, void*)
+{
+    ASSERT(data->pMessage);
+
+    const WTFLogLevel logLevel = [messageSeverity] {
+        switch (messageSeverity) {
+        case VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT:
+            return WTFLogLevel::Error;
+        case VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT:
+            return WTFLogLevel::Info;
+        case VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT:
+            return WTFLogLevel::Warning;
+        case VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT:
+            return WTFLogLevel::Debug;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    }();
+
+    StringBuilder messageTypeString;
+    if (messageTypes & VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT)
+        messageTypeString.append("General, "_s);
+    if (messageTypes & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)
+        messageTypeString.append("Validation, "_s);
+    if (messageTypes & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)
+        messageTypeString.append("Performance, "_s);
+    RELEASE_ASSERT(messageTypeString.length() > 2);
+    messageTypeString.shrink(messageTypeString.length() - 2);
+
+    if (data->pMessageIdName)
+        RELEASE_LOG_WITH_LEVEL(Vulkan, logLevel, "[%s: %s] %s", data->pMessageIdName, messageTypeString.toString().utf8().data(), data->pMessage);
+    else
+        RELEASE_LOG_WITH_LEVEL(Vulkan, logLevel, "[%s] %s", messageTypeString.toString().utf8().data(), data->pMessage);
+
+    return VK_FALSE;
+}
+
+VkResult Instance::installDebugMessenger()
+{
+    if (m_debugMessenger)
+        return VK_SUCCESS;
+
+    DebugUtilsMessengerCreateInfo createInfo;
+    createInfo->pfnUserCallback = debugUtilsMessengerHandleMessage;
+    createInfo->messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+    createInfo->messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+    if (LOG_CHANNEL(Vulkan).level >= WTFLogLevel::Info)
+        createInfo->messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+    if (LOG_CHANNEL(Vulkan).level >= WTFLogLevel::Warning)
+        createInfo->messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+    if (LOG_CHANNEL(Vulkan).level >= WTFLogLevel::Debug)
+        createInfo->messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
+
+    return vkCreateDebugUtilsMessengerEXT(m_inner, createInfo.ptr(), nullptr, &m_debugMessenger);
+}
+#else
+VkResult Instance::installDebugMessenger() const
+{
+    return VK_ERROR_EXTENSION_NOT_PRESENT;
+}
+#endif // VK_EXT_debug_utils
+
+} // namespace Vulkan
+} // namespace WebCore
+
+#endif // USE(VULKAN)

--- a/Source/WebCore/platform/graphics/vulkan/VulkanTypes.h
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanTypes.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(VULKAN)
+#include <expected>
+#include <volk.h>
+#include <wtf/Noncopyable.h>
+
+namespace WebCore {
+namespace Vulkan {
+
+template <typename Type>
+using Result = std::expected<Type, VkResult>;
+
+template <typename VulkanType>
+struct BaseStruct {
+    WTF_MAKE_NONCOPYABLE(BaseStruct)
+
+    using Base = BaseStruct<VulkanType>;
+
+    BaseStruct()
+    {
+        zeroBytes(m_inner);
+    }
+
+    BaseStruct(VulkanType&& inner)
+        : m_inner(WTF::move(inner))
+    {
+    }
+
+    ~BaseStruct() = default;
+
+    BaseStruct(BaseStruct&& other)
+        : BaseStruct()
+    {
+        std::swap(m_inner, other.m_inner);
+    }
+
+    BaseStruct& operator=(BaseStruct&& other)
+    {
+        if (this != &other) [[likely]]
+            std::swap(m_inner, other.m_inner);
+        return *this;
+    }
+
+    const VulkanType* LIFETIME_BOUND ptr() const { return &m_inner; }
+    VulkanType* LIFETIME_BOUND ptr() { return &m_inner; }
+
+protected:
+    VulkanType m_inner;
+};
+
+template <typename VulkanType, VkStructureType vulkanStructureType>
+struct Structure : BaseStruct<VulkanType> {
+    using Type = VulkanType;
+    using Base = BaseStruct<VulkanType>;
+
+    static constexpr VkStructureType typeCode = vulkanStructureType;
+
+    Structure()
+    {
+        this->m_inner.sType = typeCode;
+    }
+
+    Structure(VulkanType&& inner)
+        : Base(WTF::move(inner))
+    {
+        ASSERT(this->m_inner.sType == typeCode);
+    }
+
+    Structure(Structure&& other)
+        : Structure(WTF::move(other.m_inner))
+    {
+    }
+
+    // Create another structure, make it the "next" to this, and return it.
+    // This enables the following handy idiom to create chained Structure
+    // subtype instances:
+    //
+    //   struct A : Structure<...> { };
+    //   struct B : Structure<...> { };
+    //   struct C : Structure<...> { };
+    //
+    //   A first;
+    //   auto second = first.next<B>();
+    //   auto third = second.next<C>();
+    //
+    // Then the resulting chain of structures is: first -> second -> third.
+    //
+    template <typename OtherType, typename... Args>
+    requires std::derived_from<OtherType, Structure<typename OtherType::Type, OtherType::typeCode>>
+    [[nodiscard]] OtherType next(Args&&... params)
+    {
+        OtherType nextStructure { std::forward<Args>(params)... };
+        this->m_inner.pNext = nextStructure.ptr();
+        return nextStructure;
+    }
+
+    const VulkanType* LIFETIME_BOUND operator->() const { return this->ptr(); }
+    VulkanType* LIFETIME_BOUND operator->() { return this->ptr(); }
+};
+
+struct ApplicationInfo : Structure<VkApplicationInfo, VK_STRUCTURE_TYPE_APPLICATION_INFO> {
+    ApplicationInfo(const String& applicationName, uint32_t apiVersion = VK_API_VERSION_1_3)
+        : ApplicationInfo(applicationName.utf8().data(), apiVersion)
+    {
+    }
+
+private:
+    ApplicationInfo(const char* applicationName, uint32_t apiVersion);
+};
+
+struct InstanceCreateInfo : Structure<VkInstanceCreateInfo, VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO> {
+    InstanceCreateInfo(const ApplicationInfo& applicationInfo LIFETIME_BOUND, std::span<const char* const> enabledLayers LIFETIME_BOUND = { }, std::span<const char* const> enabledExtensions LIFETIME_BOUND = { });
+};
+
+struct PhysicalDeviceProperties : Structure<VkPhysicalDeviceProperties2, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2> {
+    const VkPhysicalDeviceProperties* LIFETIME_BOUND operator->() const { return &m_inner.properties; }
+    VkPhysicalDeviceProperties* LIFETIME_BOUND operator->() { return &m_inner.properties; }
+};
+
+struct PhysicalDeviceDRMProperties : Structure<VkPhysicalDeviceDrmPropertiesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT> {
+};
+
+struct PhysicalDevice : BaseStruct<VkPhysicalDevice> {
+    void fillProperties(PhysicalDeviceProperties&) const;
+};
+
+struct Instance : BaseStruct<VkInstance> {
+    [[nodiscard]] static const Vector<VkLayerProperties>& availableLayers();
+    [[nodiscard]] static bool hasLayers(std::span<const char* const> layerNames);
+    [[nodiscard]] static bool hasLayer(const char* const layerName);
+
+    [[nodiscard]] static Result<Vector<VkExtensionProperties>> availableExtensions(const char* layerName = nullptr);
+    [[nodiscard]] static bool hasExtensions(const Vector<VkExtensionProperties>&, std::span<const char* const> extensionNames);
+    [[nodiscard]] static bool hasExtension(const Vector<VkExtensionProperties>&, const char* const extensionName);
+    [[nodiscard]] static bool hasExtensions(std::span<const char* const> extensionNames, const char* layerName = nullptr);
+    [[nodiscard]] static bool hasExtension(const char* const extensionName, const char* layerName = nullptr);
+
+    static void setSharedInstance(Instance&&);
+    [[nodiscard]] static Instance* sharedInstanceIfExists();
+    [[nodiscard]] static Instance& sharedInstance();
+
+    [[nodiscard]] static Result<Instance> create(const InstanceCreateInfo&);
+    ~Instance();
+
+    Instance(Instance&& other)
+        : Base()
+    {
+        *this = WTF::move(other);
+    }
+
+    Instance& operator=(Instance&& other)
+    {
+        if (this != &other) {
+            std::swap(m_inner, other.m_inner);
+#ifdef VK_EXT_debug_utils
+            std::swap(m_debugMessenger, other.m_debugMessenger);
+#endif
+        }
+        return *this;
+    }
+
+    [[nodiscard]] Result<Vector<PhysicalDevice>> availableDevices() const;
+    [[nodiscard]] VkResult installDebugMessenger();
+
+private:
+    Instance(VkInstance inner)
+        : Base(WTF::move(inner))
+    {
+    }
+
+    static Instance s_sharedInstance;
+
+#ifdef VK_EXT_debug_utils
+    VkDebugUtilsMessengerEXT m_debugMessenger { nullptr };
+#endif
+};
+
+} // namespace Vulkan
+} // namespace WebCore
+
+#endif // USE(VULKAN)

--- a/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "VulkanUtilities.h"
+
+#if USE(VULKAN)
+#include "Logging.h"
+#include <wtf/RuntimeApplicationChecks.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/Vector.h>
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
+
+#if USE(GLIB)
+#include "ApplicationGLib.h"
+#endif
+
+#ifndef VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME
+#define VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME "VK_KHR_external_memory_capabilities"
+#endif
+
+namespace WebCore {
+namespace Vulkan {
+
+const char* resultString(VkResult result)
+{
+    switch (result) {
+    case VK_SUCCESS:
+        return "SUCCESS";
+    case VK_NOT_READY:
+        return "NOT_READY";
+    case VK_TIMEOUT:
+        return "TIMEOUT";
+    case VK_EVENT_SET:
+        return "EVENT_SET";
+    case VK_EVENT_RESET:
+        return "EVENT_RESET";
+    case VK_INCOMPLETE:
+        return "INCOMPLETE";
+    case VK_ERROR_OUT_OF_HOST_MEMORY:
+        return "ERROR_OUT_OF_HOST_MEMORY";
+    case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+        return "ERROR_OUT_OF_DEVICE_MEMORY";
+    case VK_ERROR_INITIALIZATION_FAILED:
+        return "ERROR_INITIALIZATION_FAILED";
+    case VK_ERROR_DEVICE_LOST:
+        return "ERROR_DEVICE_LOST";
+    case VK_ERROR_MEMORY_MAP_FAILED:
+        return "ERROR_MEMORY_MAP_FAILED";
+    case VK_ERROR_LAYER_NOT_PRESENT:
+        return "ERROR_LAYER_NOT_PRESENT";
+    case VK_ERROR_EXTENSION_NOT_PRESENT:
+        return "ERROR_EXTENSION_NOT_PRESENT";
+    case VK_ERROR_FEATURE_NOT_PRESENT:
+        return "ERROR_FEATURE_NOT_PRESENT";
+    case VK_ERROR_INCOMPATIBLE_DRIVER:
+        return "ERROR_INCOMPATIBLE_DRIVER";
+    case VK_ERROR_TOO_MANY_OBJECTS:
+        return "ERROR_TOO_MANY_OBJECTS";
+    case VK_ERROR_FORMAT_NOT_SUPPORTED:
+        return "ERROR_FORMAT_NOT_SUPPORTED";
+    case VK_ERROR_FRAGMENTED_POOL:
+        return "ERROR_FRAGMENTED_POOL";
+    case VK_ERROR_UNKNOWN:
+        return "ERROR_UNKNOWN";
+    case VK_ERROR_OUT_OF_POOL_MEMORY:
+        return "ERROR_OUT_OF_POOL_MEMORY";
+    case VK_ERROR_INVALID_EXTERNAL_HANDLE:
+        return "ERROR_INVALID_EXTERNAL_HANDLE";
+    case VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS:
+        return "ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS";
+    case VK_ERROR_FRAGMENTATION:
+        return "ERROR_FRAGMENTATION";
+    case VK_PIPELINE_COMPILE_REQUIRED:
+        return "PIPELINE_COMPILE_REQUIRED";
+#ifdef VK_EXT_global_priority
+    case VK_ERROR_NOT_PERMITTED_EXT:
+        return "ERROR_NOT_PERMITTED_EXT";
+#endif
+#ifdef VK_KHR_surface
+    case VK_ERROR_SURFACE_LOST_KHR:
+        return "ERROR_SURFACE_LOST_KHR";
+    case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
+        return "ERROR_NATIVE_WINDOW_IN_USE_KHR";
+#endif
+#ifdef VK_KHR_swapchain
+    case VK_SUBOPTIMAL_KHR:
+        return "SUBOPTIMAL_KHR";
+    case VK_ERROR_OUT_OF_DATE_KHR:
+        return "ERROR_OUT_OF_DATE_KHR";
+#endif
+#ifdef VK_KHR_display_swapchain
+    case VK_ERROR_INCOMPATIBLE_DISPLAY_KHR:
+        return "ERROR_INCOMPATIBLE_DISPLAY_KHR";
+#endif
+#ifdef VK_NV_glsl_shader
+    case VK_ERROR_INVALID_SHADER_NV:
+        return "ERROR_INVALID_SHADER_NV";
+#endif
+#ifdef VK_KHR_video_queue
+    case VK_ERROR_IMAGE_USAGE_NOT_SUPPORTED_KHR:
+        return "ERROR_IMAGE_USAGE_NOT_SUPPORTED_KHR";
+    case VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR:
+        return "ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR";
+    case VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR:
+        return "ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR";
+    case VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR:
+        return "ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR";
+    case VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR:
+        return "ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR";
+    case VK_ERROR_VIDEO_STD_VERSION_NOT_SUPPORTED_KHR:
+        return "ERROR_VIDEO_STD_VERSION_NOT_SUPPORTED_KHR";
+#endif
+#ifdef VK_EXT_image_drm_format_modifier
+    case VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT:
+        return "ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT";
+#endif
+#ifdef VK_EXT_full_screen_exclusive
+    case VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT:
+        return "ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT";
+#endif
+#ifdef VK_KHR_deferred_host_operations
+    case VK_THREAD_IDLE_KHR:
+        return "THREAD_IDLE_KHR";
+    case VK_THREAD_DONE_KHR:
+        return "THREAD_DONE_KHR";
+    case VK_OPERATION_DEFERRED_KHR:
+        return "OPERATION_DEFERRED_KHR";
+    case VK_OPERATION_NOT_DEFERRED_KHR:
+        return "OPERATION_NOT_DEFERRED_KHR";
+#endif
+#ifdef VK_KHR_video_encode_queue
+    case VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR:
+        return "ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR";
+#endif
+#ifdef VK_EXT_image_compression_control
+    case VK_ERROR_COMPRESSION_EXHAUSTED_EXT:
+        return "ERROR_COMPRESSION_EXHAUSTED_EXT";
+#endif
+#ifdef VK_EXT_shader_object
+    case VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT:
+        return "ERROR_INCOMPATIBLE_SHADER_BINARY_EXT";
+#endif
+#ifdef VK_EXT_debug_report
+    case VK_ERROR_VALIDATION_FAILED_EXT:
+        return "ERROR_VALIDATION_FAILED_EXT";
+#endif
+    default:
+        return "UNKNOWN";
+    }
+}
+
+void initializeIfNeeded()
+{
+    if (Instance::sharedInstanceIfExists())
+        return;
+
+    if (auto result = volkInitialize(); result != VK_SUCCESS) {
+        RELEASE_LOG(Vulkan, "Vulkan initialization failed: %s (runtime libraries missing?)", resultString(result));
+        return;
+    }
+
+    if (!Instance::hasExtension(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME)) {
+        RELEASE_LOG_ERROR(Vulkan, "Required extension %s not present", VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
+        return;
+    }
+
+    Vector<const char*> layerNames;
+    Vector<const char*> extensionNames {
+        VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
+    };
+
+#ifdef VK_EXT_debug_utils
+    bool shouldInstallDebugMessenger = false;
+#endif // VK_EXT_debug_utils
+
+    if (LOG_CHANNEL(Vulkan).state != WTFLogChannelState::Off) [[unlikely]] {
+        static constexpr auto validationLayerName = "VK_LAYER_KHRONOS_validation";
+        if (Instance::hasLayer(validationLayerName)) {
+            layerNames.append(validationLayerName);
+
+#ifdef VK_EXT_debug_utils
+            if ((shouldInstallDebugMessenger = Instance::hasExtension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME)))
+                extensionNames.append(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+            else
+                RELEASE_LOG_ERROR(Vulkan, "VK_EXT_debug_utils not available, logging may be incomplete");
+#endif // VK_EXT_debug_utils
+        } else
+            RELEASE_LOG_ERROR(Vulkan, "Cannot enable debug/logging support: validation layers not present");
+
+        StringBuilder formattedLayerList;
+        if (layerNames.size()) {
+            formattedLayerList.append(":"_s);
+            for (const auto* name : layerNames)
+                formattedLayerList.append(" "_s, CStringView::unsafeFromUTF8(name));
+        }
+        RELEASE_LOG_DEBUG(Vulkan, "Requesting %zu layers%s", layerNames.size(), formattedLayerList.toString().utf8().data());
+
+        StringBuilder formattedExtensionList;
+        if (extensionNames.size()) {
+            formattedExtensionList.append(":"_s);
+            for (const auto* name : extensionNames)
+                formattedExtensionList.append(" "_s, CStringView::unsafeFromUTF8(name));
+        }
+        RELEASE_LOG_DEBUG(Vulkan, "Requesting %zu extensions%s", extensionNames.size(), formattedExtensionList.toString().utf8().data());
+    }
+
+#if USE(GLIB)
+    const String applicationName = makeString(getApplicationID(), '.', processTypeDescription(processType()));
+#else
+    const String applicationName = makeString("WebKit."_s, processTypeDescription(processType()));
+#endif
+
+    auto instance = Instance::create({ { applicationName }, layerNames.span(), extensionNames.span() });
+    if (!instance) {
+        RELEASE_LOG_ERROR(Vulkan, "Cannot create instance: %s (%d)", resultString(instance), instance.error());
+        return;
+    }
+
+#ifdef VK_EXT_debug_utils
+    if (shouldInstallDebugMessenger) {
+        if (auto result = instance->installDebugMessenger(); result != VK_SUCCESS)
+            RELEASE_LOG_ERROR(Vulkan, "Cannot create debug messenger, logging may be incomplete: %s (%d)", resultString(result), result);
+    }
+#endif // VK_EXT_debug_utils
+
+    // TODO: For now we only enumerate devices, choose one that matches the OpenGL device in use.
+    auto devices = instance->availableDevices();
+    for (auto& deviceInfo : *devices) {
+        PhysicalDeviceProperties properties;
+        auto drmProperties = properties.next<PhysicalDeviceDRMProperties>();
+        deviceInfo.fillProperties(properties);
+
+        RELEASE_LOG(Vulkan, "=== Device: %s ===", properties->deviceName);
+        RELEASE_LOG(Vulkan, "API version: %d.%d.%d", VK_VERSION_MAJOR(properties->apiVersion),
+            VK_VERSION_MINOR(properties->apiVersion), VK_VERSION_PATCH(properties->apiVersion));
+        RELEASE_LOG(Vulkan, "Vendor ID: %#" PRIx32, properties->vendorID);
+        RELEASE_LOG(Vulkan, "Device ID: %#" PRIx32, properties->deviceID);
+
+        RELEASE_LOG(Vulkan, "DRM primary: %s", drmProperties->hasPrimary ? "yes" : "no");
+        if (drmProperties->hasPrimary)
+            RELEASE_LOG(Vulkan, "  - Node: major=%" PRIi64 ", minor=%" PRIi64, drmProperties->primaryMajor, drmProperties->primaryMinor);
+        RELEASE_LOG(Vulkan, "DRM render: %s", drmProperties->hasRender ? "yes" : "no");
+        if (drmProperties->hasRender)
+            RELEASE_LOG(Vulkan, "  - Node: major=%" PRIi64 ", minor=%" PRIi64, drmProperties->renderMajor, drmProperties->renderMinor);
+    }
+
+    Instance::setSharedInstance(WTF::move(*instance));
+}
+
+} // namespace Vulkan
+} // namespace WebCore
+
+#endif // USE(VULKAN)

--- a/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.h
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(VULKAN)
+#include "VulkanTypes.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+namespace Vulkan {
+
+[[nodiscard]] const char* resultString(VkResult);
+
+template <typename Type>
+[[nodiscard]] const char* resultString(const Result<Type>& result)
+{
+    return resultString(result.error_or(VK_SUCCESS));
+}
+
+void initializeIfNeeded();
+
+} // namespace Vulkan
+} // namespace WebCore
+
+#endif // USE(VULKAN)

--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -180,6 +180,7 @@ extern "C" {
     M(ViewportSizing) \
     M(VirtualMemory) \
     M(VisibleRects) \
+    M(Vulkan) \
     M(WebAuthn) \
     M(WebGL) \
     M(WebRTC) \

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1171,6 +1171,7 @@ RefPtr<GraphicsContextGL> WebChromeClient::createGraphicsContextGL(const Graphic
 {
 #if PLATFORM(GTK)
     WebProcess::singleton().initializePlatformDisplayIfNeeded();
+    WebProcess::singleton().initializeVulkanIfNeeded();
 #endif
 #if ENABLE(GPU_PROCESS)
     if (WebProcess::singleton().shouldUseRemoteRenderingForWebGL()) {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
@@ -115,8 +115,10 @@ void DrawingAreaCoordinatedGraphics::updatePreferences(const WebPreferencesStore
     Ref page = *m_webPage->corePage();
     Settings& settings = page->settings();
 #if PLATFORM(GTK)
-    if (settings.hardwareAccelerationEnabled())
+    if (settings.hardwareAccelerationEnabled()) {
         WebProcess::singleton().initializePlatformDisplayIfNeeded();
+        WebProcess::singleton().initializeVulkanIfNeeded();
+    }
 #endif
     settings.setForceCompositingMode(store.getBoolValueForKey(WebPreferencesKey::forceCompositingModeKey()));
     // Fixed position elements need to be composited and create stacking contexts

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -522,7 +522,8 @@ public:
     const OptionSet<AvailableInputDevices>& availableInputDevices() const LIFETIME_BOUND { return m_availableInputDevices; }
     std::optional<AvailableInputDevices> primaryPointingDevice() const;
     void setAvailableInputDevices(OptionSet<AvailableInputDevices>);
-#endif // PLATFORM(WPE)
+    void initializeVulkanIfNeeded();
+#endif // PLATFORM(GTK) || PLATFORM(WPE)
 
     String mediaKeysStorageDirectory() const { return m_mediaKeysStorageDirectory; }
     FileSystem::Salt mediaKeysStorageSalt() const { return m_mediaKeysStorageSalt; }

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -90,6 +90,11 @@
 #include <WebCore/AccessibilityAtspi.h>
 #endif
 
+#if USE(VULKAN)
+#include <WebCore/VulkanUtilities.h>
+#include <wtf/text/CStringView.h>
+#endif
+
 #define RELEASE_LOG_SESSION_ID (m_sessionID ? m_sessionID->toUInt64() : 0)
 #define WEBPROCESS_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [sessionID=%" PRIu64 "] WebProcess::" fmt, this, RELEASE_LOG_SESSION_ID, ##__VA_ARGS__)
 #define WEBPROCESS_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [sessionID=%" PRIu64 "] WebProcess::" fmt, this, RELEASE_LOG_SESSION_ID, ##__VA_ARGS__)
@@ -180,8 +185,28 @@ void WebProcess::initializePlatformDisplayIfNeeded() const
     CRASH();
 }
 
+void WebProcess::initializeVulkanIfNeeded()
+{
+#if USE(VULKAN)
+    bool useVulkan = false;
+    if (const auto envValue = CStringView::unsafeFromUTF8(getenv("WEBKIT_VULKAN_ENABLED")))
+        useVulkan = (envValue == "1"_s && envValue != "0"_s);
+
+    if (!useVulkan)
+        return;
+
+    Vulkan::initializeIfNeeded();
+#endif
+}
+
 void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& parameters)
 {
+    if (!parameters.applicationID.isEmpty())
+        WebCore::setApplicationID(parameters.applicationID);
+
+    if (!parameters.applicationName.isEmpty())
+        WebCore::setApplicationName(parameters.applicationName);
+
     const char* enableCPURendering = getenv("WEBKIT_SKIA_ENABLE_CPU_RENDERING");
     IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     if (enableCPURendering && strcmp(enableCPURendering, "0"))
@@ -211,7 +236,8 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 #else
     initializePlatformDisplayIfNeeded();
 #endif
-#endif
+    initializeVulkanIfNeeded();
+#endif // PLATFORM(WPE)
 
     m_availableInputDevices = parameters.availableInputDevices;
 
@@ -221,12 +247,6 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 
     if (parameters.memoryPressureHandlerConfiguration)
         MemoryPressureHandler::singleton().setConfiguration(WTF::move(*parameters.memoryPressureHandlerConfiguration));
-
-    if (!parameters.applicationID.isEmpty())
-        WebCore::setApplicationID(parameters.applicationID);
-
-    if (!parameters.applicationName.isEmpty())
-        WebCore::setApplicationName(parameters.applicationName);
 
 #if ENABLE(REMOTE_INSPECTOR)
     if (!parameters.inspectorServerAddress.isNull())

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -59,6 +59,7 @@ WEBKIT_OPTION_DEFINE(USE_LIBHYPHEN "Whether to enable the default automatic hyph
 WEBKIT_OPTION_DEFINE(USE_LIBSECRET "Whether to enable the persistent credential storage using libsecret." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_SKIA_OPENTYPE_SVG "Whether to use the Skia built-in support for OpenType SVG fonts." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_SYSTEM_SYSPROF_CAPTURE "Whether to use a system-provided libsysprof-capture" PUBLIC ON)
+WEBKIT_OPTION_DEFINE(USE_VULKAN "Whether to build support to use Vulkan." PUBLIC ${DEVELOPER_MODE})
 WEBKIT_OPTION_DEFINE(ENABLE_JSC_RESTRICTED_OPTIONS_BY_DEFAULT "Whether to enable dangerous development options in JSC by default." PRIVATE OFF)
 
 WEBKIT_OPTION_DEPEND(ENABLE_DOCUMENTATION ENABLE_INTROSPECTION)
@@ -376,6 +377,13 @@ if (USE_LIBHYPHEN)
     find_package(Hyphen)
     if (NOT Hyphen_FOUND)
        message(FATAL_ERROR "libhyphen is needed for USE_LIBHYPHEN.")
+    endif ()
+endif ()
+
+if (USE_VULKAN)
+    find_package(volk CONFIG)
+    if (NOT TARGET volk::volk OR NOT TARGET volk::volk_headers)
+        message(FATAL_ERROR "Volk is required for USE_VULKAN")
     endif ()
 endif ()
 

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -114,6 +114,7 @@ WEBKIT_OPTION_DEFINE(USE_LIBBACKTRACE "Whether to enable usage of libbacktrace."
 WEBKIT_OPTION_DEFINE(USE_LIBDRM "Whether to enable usage of libdrm." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_LIBHYPHEN "Whether to enable the default automatic hyphenation implementation." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_SKIA_OPENTYPE_SVG "Whether to use the Skia built-in support for OpenType SVG fonts." PUBLIC ON)
+WEBKIT_OPTION_DEFINE(USE_VULKAN "Whether to build support to use Vulkan." PUBLIC ${ENABLE_DEVELOPER_MODE})
 
 # Private options specific to the WPE port.
 WEBKIT_OPTION_DEFINE(USE_EXTERNAL_HOLEPUNCH "Whether to enable external holepunch" PRIVATE OFF)
@@ -247,6 +248,13 @@ if (USE_LIBHYPHEN)
     find_package(Hyphen)
     if (NOT Hyphen_FOUND)
        message(FATAL_ERROR "libhyphen is needed for USE_LIBHYPHEN.")
+    endif ()
+endif ()
+
+if (USE_VULKAN)
+    find_package(volk CONFIG)
+    if (NOT TARGET volk::volk OR NOT TARGET volk::volk_headers)
+        message(FATAL_ERROR "Volk is required for USE_VULKAN")
     endif ()
 endif ()
 


### PR DESCRIPTION
#### 5bc4ddb9f31fb9002336127c75a643786f1d7b56
<pre>
[WPE][GTK] Initialize Vulkan in a way that will allow sharing allocated buffers with OpenGL
<a href="https://bugs.webkit.org/show_bug.cgi?id=312992">https://bugs.webkit.org/show_bug.cgi?id=312992</a>

Reviewed by Nikolas Zimmermann.

This imports the needed CMake bits to detect and use Volk, which is a
Vulkan loader that works in a way similar to Epoxy. This way it is not
required at runtime to have Vulkan installed, and the built WebKit
library does not depend on a fixed version of libvulkan.

The rest of the patch is adding scaffolding for dealing with Vulkan
types in a more idiomatic and type-safe way, reusing C++ types from
WTF, and includes initialization code for the Vulkan context in the
WebProcess.

Follow-up patches will wire device selection, and buffer allocation.

* Source/WebCore/PlatformGTK.cmake:
* Source/WebCore/PlatformWPE.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/Logging.h:
* Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp: Added.
(WebCore::Vulkan::ApplicationInfo::ApplicationInfo):
(WebCore::Vulkan::InstanceCreateInfo::InstanceCreateInfo):
(WebCore::Vulkan::PhysicalDevice::fillProperties const):
(WebCore::Vulkan::Instance::availableLayers):
(WebCore::Vulkan::Instance::hasLayers):
(WebCore::Vulkan::Instance::hasLayer):
(WebCore::Vulkan::Instance::availableExtensions):
(WebCore::Vulkan::Instance::hasExtensions):
(WebCore::Vulkan::Instance::hasExtension):
(WebCore::Vulkan::Instance::setSharedInstance):
(WebCore::Vulkan::Instance::sharedInstanceIfExists):
(WebCore::Vulkan::Instance::sharedInstance):
(WebCore::Vulkan::Instance::create):
(WebCore::Vulkan::Instance::~Instance):
(WebCore::Vulkan::Instance::availableDevices const):
(WebCore::Vulkan::debugUtilsMessengerHandleMessage):
(WebCore::Vulkan::Instance::installDebugMessenger):
(WebCore::Vulkan::Instance::installDebugMessenger const):
* Source/WebCore/platform/graphics/vulkan/VulkanTypes.h: Added.
(WebCore::Vulkan::BaseStruct::BaseStruct):
(WebCore::Vulkan::BaseStruct::operator=):
(WebCore::Vulkan::BaseStruct::ptr const):
(WebCore::Vulkan::BaseStruct::ptr):
(WebCore::Vulkan::Structure::Structure):
(WebCore::Vulkan::Structure::next):
(WebCore::Vulkan::Structure::operator-&gt; const):
(WebCore::Vulkan::Structure::operator-&gt;):
(WebCore::Vulkan::ApplicationInfo::ApplicationInfo):
(WebCore::Vulkan::InstanceCreateInfo::InstanceCreateInfo):
(WebCore::Vulkan::PhysicalDeviceProperties::operator-&gt; const):
(WebCore::Vulkan::PhysicalDeviceProperties::operator-&gt;):
(WebCore::Vulkan::Instance::Instance):
(WebCore::Vulkan::Instance::operator=):
* Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp: Added.
(WebCore::Vulkan::resultString):
(WebCore::Vulkan::initializeIfNeeded):
* Source/WebCore/platform/graphics/vulkan/VulkanUtilities.h: Added.
(WebCore::Vulkan::resultString):
* Source/WebKit/Platform/Logging.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createGraphicsContextGL const):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::updatePreferences):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::initializeVulkanIfNeeded):
(WebKit::WebProcess::platformInitializeWebProcess):
* Source/cmake/OptionsGTK.cmake:
* Source/cmake/OptionsWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/312614@main">https://commits.webkit.org/312614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b10d0588bcc42ce0a425342b241c60e40f922724

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34023 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/27124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169453 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34023 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26744 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105104 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17172 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/152606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/21979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171932 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/21387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18714 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/23619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33697 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28392 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132783 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35877 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33681 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/143774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95477 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/27378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192949 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/100317 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49687 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32691 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32935 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->