### PR TITLE
[LBSE] Add svg/dom-paint-order

### DIFF
--- a/LayoutTests/svg/dom-paint-order/deep-nesting-with-transforms-expected.html
+++ b/LayoutTests/svg/dom-paint-order/deep-nesting-with-transforms-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Reference: HTML divs replicating the deep nesting with transforms.
+     Outer SVG is 400x200 viewBox 1:1.
+     Left group: translate(10,10), right group: translate(200,10).
+     Rotated rects use transform-origin mapped to their group's local origin. -->
+<div style="position: absolute; overflow: hidden; width: 400px; height: 200px;">
+  <!-- Background rect (5,5) 390x190 -->
+  <div style="position: absolute; left: 5px; top: 5px; width: 390px; height: 190px; background: #f8f9fa; border-radius: 5px;"></div>
+
+  <!-- Left group: translate(10,10) — group origin at page (10,10) -->
+  <div style="position: absolute; left: 10px; top: 10px; width: 170px; height: 170px; background: #dee2e6; border-radius: 3px;"></div>
+  <div style="position: absolute; left: 20px; top: 20px; width: 80px; height: 80px; background: #ff6b6b;"></div>
+  <div style="position: absolute; left: 60px; top: 40px; width: 80px; height: 80px; background: #51cf66; transform: rotate(-5deg); transform-origin: -50px -30px;"></div>
+  <div style="position: absolute; left: 20px; top: 80px; width: 80px; height: 80px; background: #339af0;"></div>
+  <div style="position: absolute; left: 60px; top: 100px; width: 80px; height: 80px; background: #fcc419; transform: rotate(5deg); transform-origin: -50px -90px;"></div>
+
+  <!-- Right group: translate(200,10) — group origin at page (200,10) -->
+  <div style="position: absolute; left: 200px; top: 10px; width: 170px; height: 170px; background: #e9ecef; border-radius: 3px;"></div>
+  <div style="position: absolute; left: 210px; top: 20px; width: 80px; height: 80px; background: #845ef7;"></div>
+  <div style="position: absolute; left: 250px; top: 40px; width: 80px; height: 80px; background: #20c997; transform: rotate(-3deg); transform-origin: -50px -30px;"></div>
+  <div style="position: absolute; left: 210px; top: 80px; width: 80px; height: 80px; background: #f06595;"></div>
+  <div style="position: absolute; left: 250px; top: 100px; width: 80px; height: 80px; background: #fab005; transform: rotate(3deg); transform-origin: -50px -90px;"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/deep-nesting-with-transforms.html
+++ b/LayoutTests/svg/dom-paint-order/deep-nesting-with-transforms.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="deep-nesting-with-transforms-expected.html">
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-64" />
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Tests deeply nested containers where transforms exist at various levels,
+     creating layers at different depths. Non-layer children at each level
+     must interleave correctly with their layered siblings.
+     Shapes deliberately overlap so paint order is visually verifiable. -->
+<svg width="400" height="200" viewBox="0 0 400 200">
+  <g>
+    <rect x="5" y="5" width="390" height="190" fill="#f8f9fa" rx="5"/>
+
+    <g style="transform: translate(10px, 10px);">
+      <rect x="0" y="0" width="170" height="170" fill="#dee2e6" rx="3"/>
+
+      <g>
+        <rect x="10" y="10" width="80" height="80" fill="#ff6b6b"/>
+        <rect x="50" y="30" width="80" height="80" fill="#51cf66" style="transform: rotate(-5deg);"/>
+        <rect x="10" y="70" width="80" height="80" fill="#339af0"/>
+        <rect x="50" y="90" width="80" height="80" fill="#fcc419" style="transform: rotate(5deg);"/>
+      </g>
+    </g>
+
+    <g style="transform: translate(200px, 10px);">
+      <rect x="0" y="0" width="170" height="170" fill="#e9ecef" rx="3"/>
+      <rect x="10" y="10" width="80" height="80" fill="#845ef7"/>
+      <rect x="50" y="30" width="80" height="80" fill="#20c997" style="transform: rotate(-3deg);"/>
+      <rect x="10" y="70" width="80" height="80" fill="#f06595"/>
+      <rect x="50" y="90" width="80" height="80" fill="#fab005" style="transform: rotate(3deg);"/>
+    </g>
+  </g>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/foreignobject-interleaving-expected.html
+++ b/LayoutTests/svg/dom-paint-order/foreignobject-interleaving-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Reference: HTML divs replicating the foreignObject interleaving test.
+     Outer SVG is 400x200 viewBox 1:1. -->
+<div style="position: absolute; overflow: hidden; width: 400px; height: 200px; background: #f0f0f0;">
+  <!-- circle cx=80 cy=100 r=60 → bbox (20,40) 120x120 -->
+  <div style="position: absolute; left: 20px; top: 40px; width: 120px; height: 120px; background: #e74c3c; border-radius: 50%;"></div>
+  <!-- foreignObject (120,30) 160x140 -->
+  <div style="position: absolute; left: 120px; top: 30px; width: 160px; height: 140px; background: rgba(52, 152, 219, 0.8);"></div>
+  <!-- circle cx=320 cy=100 r=60 → bbox (260,40) 120x120 -->
+  <div style="position: absolute; left: 260px; top: 40px; width: 120px; height: 120px; background: #2ecc71; border-radius: 50%;"></div>
+  <!-- rect (260,60) 80x80 rotate(10deg), origin at SVG (0,0) -->
+  <div style="position: absolute; left: 260px; top: 60px; width: 80px; height: 80px; background: rgba(155, 89, 182, 0.7); transform: rotate(10deg); transform-origin: -260px -60px;"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/foreignobject-interleaving.html
+++ b/LayoutTests/svg/dom-paint-order/foreignobject-interleaving.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="foreignobject-interleaving-expected.html">
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Tests that foreignObject with HTML content paints in correct DOM order
+     relative to SVG siblings, including transformed layer siblings. -->
+<svg width="400" height="200" viewBox="0 0 400 200">
+  <rect x="0" y="0" width="400" height="200" fill="#f0f0f0"/>
+
+  <!-- Non-layer SVG shape -->
+  <circle cx="80" cy="100" r="60" fill="#e74c3c"/>
+
+  <!-- foreignObject with HTML content -->
+  <foreignObject x="120" y="30" width="160" height="140">
+    <div xmlns="http://www.w3.org/1999/xhtml"
+         style="background: rgba(52, 152, 219, 0.8); width: 160px; height: 140px;"></div>
+  </foreignObject>
+
+  <!-- Non-layer SVG shape after foreignObject -->
+  <circle cx="320" cy="100" r="60" fill="#2ecc71"/>
+
+  <!-- Transformed SVG rect (creates layer) -->
+  <rect x="260" y="60" width="80" height="80" fill="rgba(155, 89, 182, 0.7)"
+        style="transform: rotate(10deg);"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/nested-group-split-containers-expected.html
+++ b/LayoutTests/svg/dom-paint-order/nested-group-split-containers-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Reference: same visual result painted in DOM order (flat, no grouping). -->
+<svg width="400" height="200" viewBox="0 0 400 200">
+  <rect x="10" y="20" width="90" height="90" fill="#e74c3c"/>
+  <rect x="50" y="40" width="90" height="90" fill="#3498db" style="transform: scale(0.95);"/>
+  <circle cx="155" cy="70" r="45" fill="#2ecc71"/>
+  <circle cx="185" cy="85" r="45" fill="#9b59b6" style="transform: rotate(5deg);"/>
+  <ellipse cx="230" cy="65" rx="50" ry="40" fill="#f39c12"/>
+  <rect x="255" y="30" width="90" height="90" fill="#1abc9c"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/nested-group-split-containers.html
+++ b/LayoutTests/svg/dom-paint-order/nested-group-split-containers.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="nested-group-split-containers-expected.html">
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Tests that non-layered <g> containers with layered descendants are properly
+     "split" so that their children interleave with layers in DOM order.
+     This exercises the split container logic in collectSVGChildrenInDOMOrder.
+     Shapes deliberately overlap so paint order is visually verifiable. -->
+<svg width="400" height="200" viewBox="0 0 400 200">
+  <g>
+    <!-- Non-layer child of outer group -->
+    <rect x="10" y="20" width="90" height="90" fill="#e74c3c"/>
+
+    <!-- Layer child (CSS transform) overlapping the red rect -->
+    <rect x="50" y="40" width="90" height="90" fill="#3498db" style="transform: scale(0.95);"/>
+
+    <!-- Inner group: another split container with layered descendants -->
+    <g>
+      <!-- Non-layer child overlapping the blue rect -->
+      <circle cx="155" cy="70" r="45" fill="#2ecc71"/>
+
+      <!-- Layer child overlapping the green circle -->
+      <circle cx="185" cy="85" r="45" fill="#9b59b6" style="transform: rotate(5deg);"/>
+
+      <!-- Non-layer child overlapping the purple circle -->
+      <ellipse cx="230" cy="65" rx="50" ry="40" fill="#f39c12"/>
+    </g>
+
+    <!-- Non-layer child after inner group, overlapping the orange ellipse -->
+    <rect x="255" y="30" width="90" height="90" fill="#1abc9c"/>
+  </g>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/nested-svg-viewbox-paint-order-expected.html
+++ b/LayoutTests/svg/dom-paint-order/nested-svg-viewbox-paint-order-expected.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Reference: HTML divs replicating the nested SVG viewBox paint order.
+     First nested SVG: x=20 y=20 160x160, viewBox 0 0 100 100, scale=1.6
+     Second nested SVG: x=200 y=20 160x160, viewBox 0 0 200 200, scale=0.8 -->
+
+<!-- Outer background -->
+<div style="position: absolute; overflow: hidden; width: 400px; height: 200px; background: #fafafa;">
+
+  <!-- First nested viewport: offset (20,20), scale 1.6x -->
+  <div style="position: absolute; left: 20px; top: 20px; width: 160px; height: 160px; overflow: hidden;">
+    <!-- rect 0,0 100x100 → 0,0 160x160 -->
+    <div style="position: absolute; left: 0; top: 0; width: 160px; height: 160px; background: #e8f5e9;"></div>
+    <!-- circle cx=30 cy=30 r=25 → bbox (5,5,50,50) → (8,8) 80x80 -->
+    <div style="position: absolute; left: 8px; top: 8px; width: 80px; height: 80px; background: #4caf50; border-radius: 50%;"></div>
+    <!-- circle cx=70 cy=70 r=25 scale(0.8) → bbox (45,45,50,50) → (72,72) 80x80, origin at container (0,0) -->
+    <div style="position: absolute; left: 72px; top: 72px; width: 80px; height: 80px; background: #81c784; border-radius: 50%; transform: scale(0.8); transform-origin: -72px -72px;"></div>
+    <!-- rect 10,60 30x30 → (16,96) 48x48 -->
+    <div style="position: absolute; left: 16px; top: 96px; width: 48px; height: 48px; background: #388e3c;"></div>
+  </div>
+
+  <!-- Second nested viewport: offset (200,20), scale 0.8x -->
+  <div style="position: absolute; left: 200px; top: 20px; width: 160px; height: 160px; overflow: hidden;">
+    <!-- rect 0,0 200x200 → 0,0 160x160 -->
+    <div style="position: absolute; left: 0; top: 0; width: 160px; height: 160px; background: #e3f2fd;"></div>
+    <!-- rect 10,10 80x80 → (8,8) 64x64 -->
+    <div style="position: absolute; left: 8px; top: 8px; width: 64px; height: 64px; background: #1976d2;"></div>
+    <!-- rect 50,50 80x80 rotate(10deg) → (40,40) 64x64, origin at container (0,0) -->
+    <div style="position: absolute; left: 40px; top: 40px; width: 64px; height: 64px; background: #42a5f5; transform: rotate(10deg); transform-origin: -40px -40px;"></div>
+    <!-- rect 100,10 80x80 → (80,8) 64x64 -->
+    <div style="position: absolute; left: 80px; top: 8px; width: 64px; height: 64px; background: #90caf9;"></div>
+    <!-- rect 60,100 80x80 → (48,80) 64x64 -->
+    <div style="position: absolute; left: 48px; top: 80px; width: 64px; height: 64px; background: #0d47a1;"></div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/nested-svg-viewbox-paint-order.html
+++ b/LayoutTests/svg/dom-paint-order/nested-svg-viewbox-paint-order.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="nested-svg-viewbox-paint-order-expected.html">
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Tests that nested <svg> elements with viewBox transforms correctly
+     paint their children in DOM order, including transformed children
+     (which create layers) interleaved with non-layer children. -->
+<svg width="400" height="200" viewBox="0 0 400 200">
+  <rect width="400" height="200" fill="#fafafa"/>
+
+  <!-- Nested SVG with viewBox creating a supplemental layer transform -->
+  <svg x="20" y="20" width="160" height="160" viewBox="0 0 100 100" overflow="hidden">
+    <rect width="100" height="100" fill="#e8f5e9"/>
+    <circle cx="30" cy="30" r="25" fill="#4caf50"/>
+    <!-- Transformed circle creates a layer, interleaved with non-layer siblings -->
+    <circle cx="70" cy="70" r="25" fill="#81c784" style="transform: scale(0.8);"/>
+    <rect x="10" y="60" width="30" height="30" fill="#388e3c"/>
+  </svg>
+
+  <!-- Another nested SVG with different viewBox scale -->
+  <svg x="200" y="20" width="160" height="160" viewBox="0 0 200 200" overflow="hidden">
+    <rect width="200" height="200" fill="#e3f2fd"/>
+
+    <!-- Non-layer group with layered descendants (split container) -->
+    <g>
+      <rect x="10" y="10" width="80" height="80" fill="#1976d2"/>
+      <!-- Transformed rect creates a layer inside the group -->
+      <rect x="50" y="50" width="80" height="80" fill="#42a5f5" style="transform: rotate(10deg);"/>
+      <rect x="100" y="10" width="80" height="80" fill="#90caf9"/>
+    </g>
+
+    <rect x="60" y="100" width="80" height="80" fill="#0d47a1"/>
+  </svg>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/transformed-layer-interleaving-expected.html
+++ b/LayoutTests/svg/dom-paint-order/transformed-layer-interleaving-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Reference: plain HTML divs in DOM order matching expected stacking. -->
+<div style="position: absolute; overflow: hidden; width: 400px; height: 200px;">
+  <div style="position: absolute; left: 50px; top: 30px; width: 120px; height: 120px; background: orange;"></div>
+  <div style="position: absolute; left: 100px; top: 50px; width: 120px; height: 120px; background: purple; transform: rotate(15deg); transform-origin: -100px -50px;"></div>
+  <div style="position: absolute; left: 220px; top: 60px; width: 80px; height: 80px; background: cyan;"></div>
+  <div style="position: absolute; left: 240px; top: 50px; width: 120px; height: 120px; background: gold;"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/transformed-layer-interleaving.html
+++ b/LayoutTests/svg/dom-paint-order/transformed-layer-interleaving.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="transformed-layer-interleaving-expected.html">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=0-5" />
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Tests that CSS-transformed and SVG-transformed elements (which create layers)
+     interleave correctly with non-layer siblings in DOM order. -->
+<svg width="400" height="200">
+  <!-- Non-layer child -->
+  <rect x="50" y="30" width="120" height="120" fill="orange"/>
+
+  <!-- CSS transform -> creates layer, paints after orange in DOM order -->
+  <rect x="100" y="50" width="120" height="120" fill="purple" style="transform: rotate(15deg);"/>
+
+  <!-- Non-layer child, paints after purple in DOM order -->
+  <rect x="220" y="60" width="80" height="80" fill="cyan"/>
+
+  <!-- SVG transform attribute -> creates layer, paints last in DOM order -->
+  <rect x="200" y="30" width="120" height="120" fill="gold" transform="translate(40, 20)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/z-index-interleaving-expected.html
+++ b/LayoutTests/svg/dom-paint-order/z-index-interleaving-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Reference: rects painted in expected visual stacking order (back to front). -->
+<svg width="300" height="200" viewBox="0 0 300 200">
+  <rect x="40" y="20" width="100" height="100" fill="blue"/>
+  <rect x="70" y="40" width="100" height="100" fill="red"/>
+  <rect x="100" y="60" width="100" height="100" fill="green"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/z-index-interleaving.html
+++ b/LayoutTests/svg/dom-paint-order/z-index-interleaving.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<link rel="match" href="z-index-interleaving-expected.html">
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Tests that SVG elements with z-index paint in correct z-order,
+     interleaving layered (z-indexed) and non-layered children. -->
+<svg width="300" height="200" viewBox="0 0 300 200">
+  <!-- z-index: 1 — should be on top of everything -->
+  <rect x="100" y="60" width="100" height="100" fill="green" style="z-index: 1;"/>
+
+  <!-- No z-index — non-layer child, effective z-index 0 -->
+  <rect x="70" y="40" width="100" height="100" fill="red"/>
+
+  <!-- z-index: -1 — should be behind everything -->
+  <rect x="40" y="20" width="100" height="100" fill="blue" style="z-index: -1;"/>
+</svg>
+</body>
+</html>


### PR DESCRIPTION
#### b17a2c3864f76e056947ce64a569cc6bdc7bd34b
<pre>
[LBSE] Add svg/dom-paint-order
<a href="https://bugs.webkit.org/show_bug.cgi?id=312993">https://bugs.webkit.org/show_bug.cgi?id=312993</a>

Reviewed by Nikolas Zimmermann.

Add tests to verify (visually) paint order of SVG content in various situations, testing combinations
of layer and non-layer children, transforms, explicit z-index, foreignObject, etc.

* LayoutTests/svg/dom-paint-order/deep-nesting-with-transforms-expected.html: Added.
* LayoutTests/svg/dom-paint-order/deep-nesting-with-transforms.html: Added.
* LayoutTests/svg/dom-paint-order/foreignobject-interleaving-expected.html: Added.
* LayoutTests/svg/dom-paint-order/foreignobject-interleaving.html: Added.
* LayoutTests/svg/dom-paint-order/nested-group-split-containers-expected.html: Added.
* LayoutTests/svg/dom-paint-order/nested-group-split-containers.html: Added.
* LayoutTests/svg/dom-paint-order/nested-svg-viewbox-paint-order-expected.html: Added.
* LayoutTests/svg/dom-paint-order/nested-svg-viewbox-paint-order.html: Added.
* LayoutTests/svg/dom-paint-order/transformed-layer-interleaving-expected.html: Added.
* LayoutTests/svg/dom-paint-order/transformed-layer-interleaving.html: Added.
* LayoutTests/svg/dom-paint-order/z-index-interleaving-expected.html: Added.
* LayoutTests/svg/dom-paint-order/z-index-interleaving.html: Added.

Canonical link: <a href="https://commits.webkit.org/311845@main">https://commits.webkit.org/311845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a66813b96bd2a9c236ee1d24b61d277ca15476a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112048 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122331 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85883 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102998 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23679 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14566 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169283 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130505 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31048 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130619 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35415 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88871 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25355 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18264 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30538 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->