### PR TITLE
[BBQ] floating point min/max handle negative zero incorrectly

### DIFF
--- a/JSTests/wasm/stress/fmin-fmax-constant-fold.js
+++ b/JSTests/wasm/stress/fmin-fmax-constant-fold.js
@@ -1,0 +1,117 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// Test constant folding of f32/f64 min/max with edge cases that the spec tests
+// don't cover (spec tests pass values as parameters, never as inline constants).
+
+let wat = `
+(module
+    ;; Signed zeros
+    (func (export "f32_min_pos_neg_zero") (result f32) f32.const 0.0   f32.const -0.0  f32.min)
+    (func (export "f32_min_neg_pos_zero") (result f32) f32.const -0.0  f32.const 0.0   f32.min)
+    (func (export "f32_max_pos_neg_zero") (result f32) f32.const 0.0   f32.const -0.0  f32.max)
+    (func (export "f32_max_neg_pos_zero") (result f32) f32.const -0.0  f32.const 0.0   f32.max)
+    (func (export "f64_min_pos_neg_zero") (result f64) f64.const 0.0   f64.const -0.0  f64.min)
+    (func (export "f64_min_neg_pos_zero") (result f64) f64.const -0.0  f64.const 0.0   f64.min)
+    (func (export "f64_max_pos_neg_zero") (result f64) f64.const 0.0   f64.const -0.0  f64.max)
+    (func (export "f64_max_neg_pos_zero") (result f64) f64.const -0.0  f64.const 0.0   f64.max)
+
+    ;; NaN propagation
+    (func (export "f32_min_nan_one")  (result f32) f32.const nan    f32.const 1.0  f32.min)
+    (func (export "f32_min_one_nan")  (result f32) f32.const 1.0    f32.const nan  f32.min)
+    (func (export "f32_max_nan_one")  (result f32) f32.const nan    f32.const 1.0  f32.max)
+    (func (export "f32_max_one_nan")  (result f32) f32.const 1.0    f32.const nan  f32.max)
+    (func (export "f64_min_nan_one")  (result f64) f64.const nan    f64.const 1.0  f64.min)
+    (func (export "f64_min_one_nan")  (result f64) f64.const 1.0    f64.const nan  f64.min)
+    (func (export "f64_max_nan_one")  (result f64) f64.const nan    f64.const 1.0  f64.max)
+    (func (export "f64_max_one_nan")  (result f64) f64.const 1.0    f64.const nan  f64.max)
+
+    ;; Both NaN
+    (func (export "f32_min_nan_nan") (result f32) f32.const nan f32.const nan f32.min)
+    (func (export "f32_max_nan_nan") (result f32) f32.const nan f32.const nan f32.max)
+    (func (export "f64_min_nan_nan") (result f64) f64.const nan f64.const nan f64.min)
+    (func (export "f64_max_nan_nan") (result f64) f64.const nan f64.const nan f64.max)
+
+    ;; Denormals (smallest subnormal)
+    (func (export "f32_min_denorm") (result f32) f32.const 0x1p-149 f32.const -0x1p-149 f32.min)
+    (func (export "f32_max_denorm") (result f32) f32.const -0x1p-149 f32.const 0x1p-149 f32.max)
+    (func (export "f64_min_denorm") (result f64) f64.const 0x1p-1074 f64.const -0x1p-1074 f64.min)
+    (func (export "f64_max_denorm") (result f64) f64.const -0x1p-1074 f64.const 0x1p-1074 f64.max)
+
+    ;; Infinity
+    (func (export "f32_min_inf")     (result f32) f32.const inf  f32.const -inf f32.min)
+    (func (export "f32_max_inf")     (result f32) f32.const -inf f32.const inf  f32.max)
+    (func (export "f32_min_inf_one") (result f32) f32.const inf  f32.const 1.0  f32.min)
+    (func (export "f32_max_inf_one") (result f32) f32.const -inf f32.const 1.0  f32.max)
+    (func (export "f64_min_inf")     (result f64) f64.const inf  f64.const -inf f64.min)
+    (func (export "f64_max_inf")     (result f64) f64.const -inf f64.const inf  f64.max)
+
+    ;; NaN with infinity
+    (func (export "f32_min_nan_inf") (result f32) f32.const nan f32.const inf f32.min)
+    (func (export "f32_max_nan_inf") (result f32) f32.const nan f32.const -inf f32.max)
+    (func (export "f64_min_nan_inf") (result f64) f64.const nan f64.const inf f64.min)
+    (func (export "f64_max_nan_inf") (result f64) f64.const nan f64.const -inf f64.max)
+
+    ;; Normal values
+    (func (export "f32_min_normal") (result f32) f32.const 3.14 f32.const 2.72 f32.min)
+    (func (export "f32_max_normal") (result f32) f32.const 3.14 f32.const 2.72 f32.max)
+    (func (export "f64_min_normal") (result f64) f64.const 3.14 f64.const 2.72 f64.min)
+    (func (export "f64_max_normal") (result f64) f64.const 3.14 f64.const 2.72 f64.max)
+)
+`;
+
+let instance = await instantiate(wat);
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    // Signed zeros: min should return -0, max should return +0
+    assert.eq(instance.exports.f32_min_pos_neg_zero(), -0.0);
+    assert.eq(instance.exports.f32_min_neg_pos_zero(), -0.0);
+    assert.eq(instance.exports.f32_max_pos_neg_zero(), 0.0);
+    assert.eq(instance.exports.f32_max_neg_pos_zero(), 0.0);
+    assert.eq(instance.exports.f64_min_pos_neg_zero(), -0.0);
+    assert.eq(instance.exports.f64_min_neg_pos_zero(), -0.0);
+    assert.eq(instance.exports.f64_max_pos_neg_zero(), 0.0);
+    assert.eq(instance.exports.f64_max_neg_pos_zero(), 0.0);
+
+    // NaN propagation: any NaN operand produces NaN
+    assert.eq(instance.exports.f32_min_nan_one(), NaN);
+    assert.eq(instance.exports.f32_min_one_nan(), NaN);
+    assert.eq(instance.exports.f32_max_nan_one(), NaN);
+    assert.eq(instance.exports.f32_max_one_nan(), NaN);
+    assert.eq(instance.exports.f64_min_nan_one(), NaN);
+    assert.eq(instance.exports.f64_min_one_nan(), NaN);
+    assert.eq(instance.exports.f64_max_nan_one(), NaN);
+    assert.eq(instance.exports.f64_max_one_nan(), NaN);
+
+    // Both NaN
+    assert.eq(instance.exports.f32_min_nan_nan(), NaN);
+    assert.eq(instance.exports.f32_max_nan_nan(), NaN);
+    assert.eq(instance.exports.f64_min_nan_nan(), NaN);
+    assert.eq(instance.exports.f64_max_nan_nan(), NaN);
+
+    // Denormals
+    assert.eq(instance.exports.f32_min_denorm(), -Math.fround(Math.pow(2, -149)));
+    assert.eq(instance.exports.f32_max_denorm(), Math.fround(Math.pow(2, -149)));
+    assert.eq(instance.exports.f64_min_denorm(), -Math.pow(2, -1074));
+    assert.eq(instance.exports.f64_max_denorm(), Math.pow(2, -1074));
+
+    // Infinity
+    assert.eq(instance.exports.f32_min_inf(), -Infinity);
+    assert.eq(instance.exports.f32_max_inf(), Infinity);
+    assert.eq(instance.exports.f32_min_inf_one(), 1.0);
+    assert.eq(instance.exports.f32_max_inf_one(), 1.0);
+    assert.eq(instance.exports.f64_min_inf(), -Infinity);
+    assert.eq(instance.exports.f64_max_inf(), Infinity);
+
+    // NaN with infinity
+    assert.eq(instance.exports.f32_min_nan_inf(), NaN);
+    assert.eq(instance.exports.f32_max_nan_inf(), NaN);
+    assert.eq(instance.exports.f64_min_nan_inf(), NaN);
+    assert.eq(instance.exports.f64_max_nan_inf(), NaN);
+
+    // Normal values
+    assert.eq(instance.exports.f32_min_normal(), Math.fround(2.72));
+    assert.eq(instance.exports.f32_max_normal(), Math.fround(3.14));
+    assert.eq(instance.exports.f64_min_normal(), 2.72);
+    assert.eq(instance.exports.f64_max_normal(), 3.14);
+}

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 
+#include "MathCommon.h"
 #include "PCToCodeOriginMap.h"
 #include "SimpleRegisterAllocator.h"
 #include "WasmCallingConvention.h"
@@ -1677,17 +1678,12 @@ public:
     void emitFloatingPointMinOrMax(FPRReg left, FPRReg right, FPRReg result);
 
     template<MinOrMax IsMinOrMax, typename FloatType>
-    constexpr FloatType computeFloatingPointMinOrMax(FloatType left, FloatType right)
+    FloatType computeFloatingPointMinOrMax(FloatType left, FloatType right)
     {
-        if (std::isnan(left))
-            return left;
-        if (std::isnan(right))
-            return right;
-
         if constexpr (IsMinOrMax == MinOrMax::Min)
-            return std::min<FloatType>(left, right);
+            return Math::fMin<FloatType>(left, right);
         else
-            return std::max<FloatType>(left, right);
+            return Math::fMax<FloatType>(left, right);
     }
 
     [[nodiscard]] PartialResult addF32Min(Value lhs, Value rhs, Value& result);


### PR DESCRIPTION
#### a03517078f7e2286420e5b0091cf78469a444695
<pre>
[BBQ] floating point min/max handle negative zero incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=312689">https://bugs.webkit.org/show_bug.cgi?id=312689</a>
<a href="https://rdar.apple.com/175122289">rdar://175122289</a>

Reviewed by Dan Hecht.

The BBQ JIT&apos;s computeFloatingPointMinOrMax used std::min/std::max for
constant folding f32.min, f32.max, f64.min, and f64.max. Because
+0.0 == -0.0 in IEEE 754, std::min/std::max return the first argument
when operands are equal, producing the wrong sign for opposite-sign
zeros. This differed from IPInt and OMG&apos;s results for the same
operation.

Replace with Math::fMin/fMax from MathCommon.h which already handle
both NaN propagation and opposite-sign zeros correctly.

Test: JSTests/wasm/stress/fmin-fmax-constant-fold.js
Canonical link: <a href="https://commits.webkit.org/311790@main">https://commits.webkit.org/311790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca23566f676ab7f8c7746a6317683ce9dfa8e7b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31357 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/24550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166848 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/31494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31359 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160978 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/31494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/103046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/31494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/14621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150071 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/31494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/19717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169338 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18855 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/14692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/31103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/130669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/31041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/141511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/88937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24020 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/31041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190149 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/30593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/96126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/48813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/30114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->