### PR TITLE
[LBSE] Add more compositing tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8198,3 +8198,8 @@ imported/w3c/web-platform-tests/svg/text/reftests/textpath-side-005.svg [ ImageO
 
 webkit.org/b/312264 imported/w3c/web-platform-tests/css/cssom-view/interrupt-hidden-smooth-scroll.html [ Pass Failure ]
 
+# webkit.org/b/308565 LBSE specific compositing tests
+svg/compositing/foreground-layer-composited-html-in-foreignobject-between-rects.html [ ImageOnlyFailure ]
+svg/compositing/foreground-layer-composited-svg-rect-and-foreignobject-interleaved.html [ ImageOnlyFailure ]
+svg/compositing/foreground-layer-mixed-svg-and-foreignobject-composited.html [ ImageOnlyFailure ]
+svg/compositing/foreground-layer-multiple-foreignobjects-composited.html [ ImageOnlyFailure ]

--- a/LayoutTests/svg/compositing/foreground-layer-all-children-composited-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-all-children-composited-expected.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect x="110" y="10" width="80" height="80" fill="green"/>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-all-children-composited.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-all-children-composited.svg
@@ -1,0 +1,9 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: All children are composited.
+         No non-composited content exists, so neither primary nor foreground layer
+         has anything to paint. All painting happens via composited child layers. -->
+    <rect style="will-change: transform" x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect style="will-change: transform" x="110" y="10" width="80" height="80" fill="green"/>
+    <rect style="will-change: transform" x="210" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-group-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-group-expected.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <g>
+        <rect x="110" y="10" width="80" height="80" fill="green"/>
+        <circle cx="250" cy="50" r="40" fill="lime"/>
+    </g>
+    <rect x="300" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-group.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-group.svg
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: A <g> element that is composited (will-change on the group).
+         Non-composited content before and after the composited group must paint. -->
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <g style="will-change: transform">
+        <rect x="110" y="10" width="80" height="80" fill="green"/>
+        <circle cx="250" cy="50" r="40" fill="lime"/>
+    </g>
+    <rect x="300" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-html-in-foreignobject-between-rects-expected.html
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-html-in-foreignobject-between-rects-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 400px; height: 200px; }
+</style>
+</head>
+<body>
+<svg viewBox="0 0 400 200">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <foreignObject x="110" y="10" width="80" height="80">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="width: 80px; height: 80px; background: green;"></div>
+    </foreignObject>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-html-in-foreignobject-between-rects.html
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-html-in-foreignobject-between-rects.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-100" />
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 400px; height: 200px; }
+</style>
+</head>
+<body>
+<!-- Test: A composited HTML div inside foreignObject between non-composited SVG rects.
+     The will-change on the div makes the foreignObject subtree composited.
+     All SVG rects (before and after) must paint correctly. -->
+<svg viewBox="0 0 400 200">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <foreignObject x="110" y="10" width="80" height="80">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="will-change: transform; width: 80px; height: 80px; background: green;"></div>
+    </foreignObject>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-rect-with-svg-transform-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-rect-with-svg-transform-expected.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect transform="translate(50,50)" x="50" y="50" width="80" height="80" fill="green"/>
+    <rect x="200" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-rect-with-svg-transform.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-rect-with-svg-transform.svg
@@ -1,0 +1,8 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Composited child with an SVG transform attribute.
+         The SVG transform should be preserved correctly. -->
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect style="will-change: transform" transform="translate(50,50)" x="50" y="50" width="80" height="80" fill="green"/>
+    <rect x="200" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-svg-rect-and-foreignobject-interleaved-expected.html
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-svg-rect-and-foreignobject-interleaved-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 400px; height: 200px; }
+</style>
+</head>
+<body>
+<svg viewBox="0 0 400 200">
+    <rect x="10" y="10" width="40" height="40" fill="blue"/>
+    <rect x="60" y="10" width="40" height="40" fill="green"/>
+    <rect x="110" y="10" width="40" height="40" fill="red"/>
+    <foreignObject x="160" y="10" width="40" height="40">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="width: 40px; height: 40px; background: orange;"></div>
+    </foreignObject>
+    <rect x="210" y="10" width="40" height="40" fill="purple"/>
+    <rect x="260" y="10" width="40" height="40" fill="cyan"/>
+    <rect x="310" y="10" width="40" height="40" fill="magenta"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-svg-rect-and-foreignobject-interleaved.html
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-svg-rect-and-foreignobject-interleaved.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-100" />
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 400px; height: 200px; }
+</style>
+</head>
+<body>
+<!-- Test: Interleaved composited SVG rects and composited foreignObjects,
+     with non-composited content between each. This is the most complex scenario
+     combining both compositing code paths. -->
+<svg viewBox="0 0 400 200">
+    <rect x="10" y="10" width="40" height="40" fill="blue"/>
+    <rect style="will-change: transform" x="60" y="10" width="40" height="40" fill="green"/>
+    <rect x="110" y="10" width="40" height="40" fill="red"/>
+    <foreignObject x="160" y="10" width="40" height="40">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="will-change: transform; width: 40px; height: 40px; background: orange;"></div>
+    </foreignObject>
+    <rect x="210" y="10" width="40" height="40" fill="purple"/>
+    <rect style="will-change: transform" x="260" y="10" width="40" height="40" fill="cyan"/>
+    <rect x="310" y="10" width="40" height="40" fill="magenta"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-transformed-group-between-rects-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-transformed-group-between-rects-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <g transform="translate(20,20)">
+        <rect x="90" y="0" width="80" height="80" fill="green"/>
+    </g>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-transformed-group-between-rects.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-transformed-group-between-rects.svg
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: A composited, transformed group sandwiched between non-composited rects.
+         Tests that SVG transforms on composited groups don't break paint order. -->
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <g style="will-change: transform" transform="translate(20,20)">
+        <rect x="90" y="0" width="80" height="80" fill="green"/>
+    </g>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-with-css-transform-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-with-css-transform-expected.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect style="transform: rotate(15deg);" x="130" y="30" width="80" height="80" fill="green"/>
+    <rect x="250" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-with-css-transform.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-with-css-transform.svg
@@ -1,0 +1,8 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Composited child using CSS transform (not SVG transform attribute).
+         will-change triggers compositing; CSS transform applies a visual rotation. -->
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect style="will-change: transform; transform: rotate(15deg)" x="130" y="30" width="80" height="80" fill="green"/>
+    <rect x="250" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-with-opacity-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-with-opacity-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect style="opacity: 0.5" x="110" y="10" width="80" height="80" fill="green"/>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+    <rect style="opacity: 0.8" x="110" y="110" width="80" height="80" fill="orange"/>
+    <rect x="210" y="110" width="80" height="80" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-with-opacity.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-with-opacity.svg
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Composited children with opacity.
+         Opacity < 1 creates a stacking context and interacts with compositing.
+         Non-composited children between composited ones must still paint. -->
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect style="will-change: transform; opacity: 0.5" x="110" y="10" width="80" height="80" fill="green"/>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+    <rect style="will-change: transform; opacity: 0.8" x="110" y="110" width="80" height="80" fill="orange"/>
+    <rect x="210" y="110" width="80" height="80" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-with-z-index-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-with-z-index-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect x="110" y="10" width="80" height="80" fill="green"/>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+    <rect x="10" y="120" width="80" height="80" fill="purple"/>
+    <rect x="60" y="60" width="80" height="80" fill="orange"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-composited-with-z-index.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-composited-with-z-index.svg
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Composited children with explicit z-index values.
+         z-index creates stacking contexts which interact with compositing. -->
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect style="will-change: transform; z-index: 1" x="110" y="10" width="80" height="80" fill="green"/>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+    <rect style="will-change: transform; z-index: 2" x="60" y="60" width="80" height="80" fill="orange"/>
+    <rect x="10" y="120" width="80" height="80" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-consecutive-composited-children-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-consecutive-composited-children-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="50" height="50" fill="blue"/>
+    <rect x="70" y="10" width="50" height="50" fill="green"/>
+    <rect x="130" y="10" width="50" height="50" fill="red"/>
+    <rect x="190" y="10" width="50" height="50" fill="orange"/>
+    <rect x="250" y="10" width="50" height="50" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-consecutive-composited-children.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-consecutive-composited-children.svg
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Multiple consecutive composited children with no non-composited content between.
+         Only non-composited content at the edges (before first and after last). -->
+    <rect x="10" y="10" width="50" height="50" fill="blue"/>
+    <rect style="will-change: transform" x="70" y="10" width="50" height="50" fill="green"/>
+    <rect style="will-change: transform" x="130" y="10" width="50" height="50" fill="red"/>
+    <rect style="will-change: transform" x="190" y="10" width="50" height="50" fill="orange"/>
+    <rect x="250" y="10" width="50" height="50" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-content-between-composited-children-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-content-between-composited-children-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="60" height="60" fill="blue"/>
+    <rect x="80" y="10" width="60" height="60" fill="green"/>
+    <rect x="150" y="10" width="60" height="60" fill="red"/>
+    <rect x="220" y="10" width="60" height="60" fill="orange"/>
+    <rect x="290" y="10" width="60" height="60" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-content-between-composited-children.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-content-between-composited-children.svg
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Non-composited content between two composited children.
+         This is the key bug scenario: rect C must not be skipped.
+         A=non-composited, B=composited, C=non-composited, D=composited, E=non-composited -->
+    <rect x="10" y="10" width="60" height="60" fill="blue"/>
+    <rect style="will-change: transform" x="80" y="10" width="60" height="60" fill="green"/>
+    <rect x="150" y="10" width="60" height="60" fill="red"/>
+    <rect style="will-change: transform" x="220" y="10" width="60" height="60" fill="orange"/>
+    <rect x="290" y="10" width="60" height="60" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-first-child-composited-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-first-child-composited-expected.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="green"/>
+    <rect x="110" y="10" width="80" height="80" fill="blue"/>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-first-child-composited.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-first-child-composited.svg
@@ -1,0 +1,9 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: First child is composited, rest are not.
+         Primary layer paints nothing (no children before first composited),
+         foreground layer paints the trailing non-composited children. -->
+    <rect style="will-change: transform" x="10" y="10" width="80" height="80" fill="green"/>
+    <rect x="110" y="10" width="80" height="80" fill="blue"/>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-last-child-composited-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-last-child-composited-expected.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect x="110" y="10" width="80" height="80" fill="red"/>
+    <rect x="210" y="10" width="80" height="80" fill="green"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-last-child-composited.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-last-child-composited.svg
@@ -1,0 +1,9 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Last child is composited, rest are not.
+         Primary layer paints all non-composited children (they're all before the composited child),
+         foreground layer paints nothing (no children after last composited). -->
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect x="110" y="10" width="80" height="80" fill="red"/>
+    <rect style="will-change: transform" x="210" y="10" width="80" height="80" fill="green"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-mixed-composited-elements-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-mixed-composited-elements-expected.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="50" height="50" fill="blue"/>
+    <rect x="70" y="10" width="50" height="50" fill="green"/>
+    <circle cx="155" cy="35" r="25" fill="red"/>
+    <circle cx="215" cy="35" r="25" fill="orange"/>
+    <rect x="250" y="10" width="50" height="50" fill="purple"/>
+    <g>
+        <rect x="310" y="10" width="50" height="50" fill="cyan"/>
+    </g>
+    <rect x="10" y="80" width="50" height="50" fill="magenta"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-mixed-composited-elements.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-mixed-composited-elements.svg
@@ -1,0 +1,14 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Mixed composited element types: rect, circle, and group.
+         All non-composited content between them must paint. -->
+    <rect x="10" y="10" width="50" height="50" fill="blue"/>
+    <rect style="will-change: transform" x="70" y="10" width="50" height="50" fill="green"/>
+    <circle cx="155" cy="35" r="25" fill="red"/>
+    <circle style="will-change: transform" cx="215" cy="35" r="25" fill="orange"/>
+    <rect x="250" y="10" width="50" height="50" fill="purple"/>
+    <g style="will-change: transform">
+        <rect x="310" y="10" width="50" height="50" fill="cyan"/>
+    </g>
+    <rect x="10" y="80" width="50" height="50" fill="magenta"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-mixed-svg-and-foreignobject-composited-expected.html
+++ b/LayoutTests/svg/compositing/foreground-layer-mixed-svg-and-foreignobject-composited-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 400px; height: 200px; }
+</style>
+</head>
+<body>
+<svg viewBox="0 0 400 200">
+    <rect x="10" y="10" width="50" height="50" fill="blue"/>
+    <rect x="70" y="10" width="50" height="50" fill="green"/>
+    <rect x="130" y="10" width="50" height="50" fill="red"/>
+    <foreignObject x="190" y="10" width="50" height="50">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="width: 50px; height: 50px; background: orange;"></div>
+    </foreignObject>
+    <rect x="250" y="10" width="50" height="50" fill="purple"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/foreground-layer-mixed-svg-and-foreignobject-composited.html
+++ b/LayoutTests/svg/compositing/foreground-layer-mixed-svg-and-foreignobject-composited.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-100" />
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 400px; height: 200px; }
+</style>
+</head>
+<body>
+<!-- Test: Mix of composited SVG elements and composited HTML inside foreignObject.
+     Both compositing mechanisms coexist with non-composited content between them. -->
+<svg viewBox="0 0 400 200">
+    <rect x="10" y="10" width="50" height="50" fill="blue"/>
+    <rect style="will-change: transform" x="70" y="10" width="50" height="50" fill="green"/>
+    <rect x="130" y="10" width="50" height="50" fill="red"/>
+    <foreignObject x="190" y="10" width="50" height="50">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="will-change: transform; width: 50px; height: 50px; background: orange;"></div>
+    </foreignObject>
+    <rect x="250" y="10" width="50" height="50" fill="purple"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/foreground-layer-multiple-foreignobjects-composited-expected.html
+++ b/LayoutTests/svg/compositing/foreground-layer-multiple-foreignobjects-composited-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 400px; height: 200px; }
+</style>
+</head>
+<body>
+<svg viewBox="0 0 400 200">
+    <rect x="10" y="10" width="50" height="50" fill="blue"/>
+    <foreignObject x="70" y="10" width="50" height="50">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="width: 50px; height: 50px; background: green;"></div>
+    </foreignObject>
+    <rect x="130" y="10" width="50" height="50" fill="red"/>
+    <foreignObject x="190" y="10" width="50" height="50">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="width: 50px; height: 50px; background: orange;"></div>
+    </foreignObject>
+    <rect x="250" y="10" width="50" height="50" fill="purple"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/foreground-layer-multiple-foreignobjects-composited.html
+++ b/LayoutTests/svg/compositing/foreground-layer-multiple-foreignobjects-composited.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-100" />
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 400px; height: 200px; }
+</style>
+</head>
+<body>
+<!-- Test: Multiple foreignObject elements with composited HTML content,
+     with non-composited SVG rects between them. Tests the gap scenario
+     with foreignObject-based compositing. -->
+<svg viewBox="0 0 400 200">
+    <rect x="10" y="10" width="50" height="50" fill="blue"/>
+    <foreignObject x="70" y="10" width="50" height="50">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="will-change: transform; width: 50px; height: 50px; background: green;"></div>
+    </foreignObject>
+    <rect x="130" y="10" width="50" height="50" fill="red"/>
+    <foreignObject x="190" y="10" width="50" height="50">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="will-change: transform; width: 50px; height: 50px; background: orange;"></div>
+    </foreignObject>
+    <rect x="250" y="10" width="50" height="50" fill="purple"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/foreground-layer-nested-group-with-composited-child-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-nested-group-with-composited-child-expected.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <g>
+        <rect x="110" y="10" width="80" height="80" fill="red"/>
+        <rect x="210" y="10" width="80" height="80" fill="green"/>
+        <rect x="310" y="10" width="80" height="80" fill="orange"/>
+    </g>
+    <rect x="10" y="110" width="80" height="80" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-nested-group-with-composited-child.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-nested-group-with-composited-child.svg
@@ -1,0 +1,13 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: A non-composited group containing a composited child.
+         The group itself is not composited, but it contains a composited rect.
+         This tests the parent SVG container's foreground layer splitting. -->
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <g>
+        <rect x="110" y="10" width="80" height="80" fill="red"/>
+        <rect style="will-change: transform" x="210" y="10" width="80" height="80" fill="green"/>
+        <rect x="310" y="10" width="80" height="80" fill="orange"/>
+    </g>
+    <rect x="10" y="110" width="80" height="80" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-no-composited-children-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-no-composited-children-expected.svg
@@ -1,0 +1,6 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect x="110" y="10" width="80" height="80" fill="green"/>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-no-composited-children.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-no-composited-children.svg
@@ -1,0 +1,8 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: No composited children at all (baseline).
+         All content paints in the primary layer, no foreground layer is created. -->
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect x="110" y="10" width="80" height="80" fill="green"/>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-noncomposited-overlapping-later-composited-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-noncomposited-overlapping-later-composited-expected.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="green"/>
+    <rect x="150" y="50" width="100" height="100" fill="red"/>
+    <rect x="200" y="80" width="80" height="80" fill="blue"/>
+    <rect x="310" y="10" width="60" height="60" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-noncomposited-overlapping-later-composited.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-noncomposited-overlapping-later-composited.svg
@@ -1,0 +1,14 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Non-composited child overlapping only a LATER composited sibling.
+         C (red) overlaps D (blue, composited) but not B (green, composited).
+         DOM order: B, C, D - so C should be above B but below D.
+         The overlap promotion mechanism should ideally promote C to composited,
+         but since it processes layers sequentially, C may not be promoted.
+         In that case, C ends up in the foreground layer above D.
+         This is the same limitation HTML compositing has. -->
+    <rect style="will-change: transform" x="10" y="10" width="80" height="80" fill="green"/>
+    <rect x="150" y="50" width="100" height="100" fill="red"/>
+    <rect style="will-change: transform" x="200" y="80" width="80" height="80" fill="blue"/>
+    <rect x="310" y="10" width="60" height="60" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-only-composited-child-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-only-composited-child-expected.svg
@@ -1,0 +1,4 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="100" y="100" width="200" height="200" fill="green"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-only-composited-child.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-only-composited-child.svg
@@ -1,0 +1,7 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Only one child and it is composited (edge case).
+         Primary layer paints nothing, foreground layer paints nothing,
+         all painting is done by the single composited child layer. -->
+    <rect style="will-change: transform" x="100" y="100" width="200" height="200" fill="green"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-overlapping-composited-children-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-overlapping-composited-children-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect x="50" y="50" width="100" height="100" fill="green" fill-opacity="0.7"/>
+    <rect x="100" y="30" width="60" height="60" fill="red" fill-opacity="0.7"/>
+    <rect x="120" y="80" width="100" height="100" fill="orange" fill-opacity="0.7"/>
+    <rect x="250" y="10" width="80" height="80" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-overlapping-composited-children.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-overlapping-composited-children.svg
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Two composited children that overlap, with a non-composited child between them.
+         The overlap promotion mechanism should handle compositing correctness.
+         The non-composited rect between them must still be painted. -->
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect style="will-change: transform" x="50" y="50" width="100" height="100" fill="green" fill-opacity="0.7"/>
+    <rect x="100" y="30" width="60" height="60" fill="red" fill-opacity="0.7"/>
+    <rect style="will-change: transform" x="120" y="80" width="100" height="100" fill="orange" fill-opacity="0.7"/>
+    <rect x="250" y="10" width="80" height="80" fill="purple"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-single-composited-child-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-single-composited-child-expected.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect x="110" y="10" width="80" height="80" fill="green"/>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-single-composited-child.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-single-composited-child.svg
@@ -1,0 +1,9 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Single composited child with non-composited siblings before and after.
+         The non-composited rect before should be in the primary layer,
+         the non-composited rect after should be in the foreground layer. -->
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+    <rect style="will-change: transform" x="110" y="10" width="80" height="80" fill="green"/>
+    <rect x="210" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-three-composited-children-expected.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-three-composited-children-expected.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <rect x="10" y="10" width="40" height="40" fill="blue"/>
+    <rect x="60" y="10" width="40" height="40" fill="green"/>
+    <rect x="110" y="10" width="40" height="40" fill="red"/>
+    <rect x="160" y="10" width="40" height="40" fill="orange"/>
+    <rect x="210" y="10" width="40" height="40" fill="purple"/>
+    <rect x="260" y="10" width="40" height="40" fill="cyan"/>
+    <rect x="310" y="10" width="40" height="40" fill="magenta"/>
+</svg>

--- a/LayoutTests/svg/compositing/foreground-layer-three-composited-children.svg
+++ b/LayoutTests/svg/compositing/foreground-layer-three-composited-children.svg
@@ -1,0 +1,12 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <!-- Test: Three composited children with non-composited content between each.
+         All non-composited rects must be painted. -->
+    <rect x="10" y="10" width="40" height="40" fill="blue"/>
+    <rect style="will-change: transform" x="60" y="10" width="40" height="40" fill="green"/>
+    <rect x="110" y="10" width="40" height="40" fill="red"/>
+    <rect style="will-change: transform" x="160" y="10" width="40" height="40" fill="orange"/>
+    <rect x="210" y="10" width="40" height="40" fill="purple"/>
+    <rect style="will-change: transform" x="260" y="10" width="40" height="40" fill="cyan"/>
+    <rect x="310" y="10" width="40" height="40" fill="magenta"/>
+</svg>


### PR DESCRIPTION
#### 6d7499c6a698ecab5e7e00d609fa722a8384f479
<pre>
[LBSE] Add more compositing tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=312995">https://bugs.webkit.org/show_bug.cgi?id=312995</a>

Reviewed by Nikolas Zimmermann.

Add various new tests to verify various compositing scenarios including foreignObject, opacity etc.

* LayoutTests/TestExpectations:
* LayoutTests/svg/compositing/foreground-layer-all-children-composited-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-all-children-composited.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-group-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-group.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-html-in-foreignobject-between-rects-expected.html: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-html-in-foreignobject-between-rects.html: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-rect-with-svg-transform-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-rect-with-svg-transform.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-svg-rect-and-foreignobject-interleaved-expected.html: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-svg-rect-and-foreignobject-interleaved.html: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-transformed-group-between-rects-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-transformed-group-between-rects.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-with-css-transform-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-with-css-transform.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-with-opacity-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-with-opacity.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-with-z-index-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-composited-with-z-index.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-consecutive-composited-children-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-consecutive-composited-children.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-content-between-composited-children-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-content-between-composited-children.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-first-child-composited-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-first-child-composited.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-last-child-composited-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-last-child-composited.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-mixed-composited-elements-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-mixed-composited-elements.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-mixed-svg-and-foreignobject-composited-expected.html: Added.
* LayoutTests/svg/compositing/foreground-layer-mixed-svg-and-foreignobject-composited.html: Added.
* LayoutTests/svg/compositing/foreground-layer-multiple-foreignobjects-composited-expected.html: Added.
* LayoutTests/svg/compositing/foreground-layer-multiple-foreignobjects-composited.html: Added.
* LayoutTests/svg/compositing/foreground-layer-nested-group-with-composited-child-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-nested-group-with-composited-child.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-no-composited-children-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-no-composited-children.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-noncomposited-overlapping-later-composited-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-noncomposited-overlapping-later-composited.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-only-composited-child-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-only-composited-child.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-overlapping-composited-children-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-overlapping-composited-children.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-single-composited-child-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-single-composited-child.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-three-composited-children-expected.svg: Added.
* LayoutTests/svg/compositing/foreground-layer-three-composited-children.svg: Added.

Canonical link: <a href="https://commits.webkit.org/311846@main">https://commits.webkit.org/311846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de4d764d74a1ee776a77cde2e5fd3ca268badd1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112058 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122339 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85887 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103006 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23683 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14576 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133366 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169293 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130513 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130628 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35417 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141474 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88889 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25375 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18280 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30548 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30069 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30196 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->