### PR TITLE
[GStreamer][glib] Fix GRefPtr adaptations

### DIFF
--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -109,16 +109,20 @@ public:
     GRefPtr(T* ptr /* (transfer floating) */)
         : m_ptr(RefDerefTraits::refIfNotNull(ptr))
     {
+        // After invoking refIfNotNull, ptr must no longer be floating.
+        ASSERT(!m_ptr || !RefDerefTraits::isFloating(m_ptr));
     }
 
     GRefPtr(const GRefPtr& o)
         : m_ptr(RefDerefTraits::refIfNotNull(o.m_ptr))
     {
+        ASSERT(!m_ptr || !RefDerefTraits::isFloating(m_ptr));
     }
 
     GRefPtr(GRefPtr&& o)
         : m_ptr(o.leakRef())
     {
+        ASSERT(!m_ptr || !RefDerefTraits::isFloating(m_ptr));
     }
 
     ~GRefPtr()
@@ -128,6 +132,8 @@ public:
 
     void clear()
     {
+        // Before dereferencing, the pointer must not be floating.
+        ASSERT(!m_ptr || !RefDerefTraits::isFloating(m_ptr));
         RefDerefTraits::derefIfNotNull(std::exchange(m_ptr, nullptr));
     }
 
@@ -314,6 +320,43 @@ template<typename P> struct HashTraits<GRefPtr<P>> : SimpleClassHashTraits<GRefP
             return false; \
         } \
     };
+
+#if ASSERT_ENABLED
+#define WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(typeName, refFunc, derefFunc, isFloatingFunc, shouldBeFloatingOnCreation) \
+    template<> struct GRefPtrDefaultRefDerefTraits<typeName> { \
+        static inline typeName* refIfNotNull(typeName* ptr) \
+        { \
+            if (!ptr) [[unlikely]] \
+                return nullptr; \
+            bool wasFloating = isFloatingFunc(ptr); \
+            refFunc(ptr); \
+            ASSERT(!isFloatingFunc(ptr)); \
+            if constexpr (shouldBeFloatingOnCreation) { \
+                if (G_IS_OBJECT(ptr)) { \
+                    if (G_OBJECT(ptr)->ref_count <= 1) \
+                        ASSERT(wasFloating); \
+                    else \
+                        ASSERT(!wasFloating); \
+                } \
+            } else \
+                ASSERT(!wasFloating); \
+            return ptr; \
+        } \
+        static inline void derefIfNotNull(typeName* ptr) \
+        { \
+            if (ptr) [[likely]] \
+                derefFunc(ptr); \
+        } \
+        static inline bool isFloating(typeName* ptr) \
+        { \
+            if (ptr) [[likely]] \
+                return isFloatingFunc(ptr); \
+            return false; \
+        } \
+    };
+#else
+#define WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(typeName, refFunc, derefFunc, isFloatingFunc, shouldBeFloatingOnCreation) WTF_DEFINE_GREF_TRAITS_INLINE(typeName, refFunc, derefFunc, isFloatingFunc)
+#endif
 
 WTF_DECLARE_GREF_TRAITS(GDBusNodeInfo, WTF_EXPORT_PRIVATE)
 WTF_DECLARE_GREF_TRAITS(GResource)

--- a/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
@@ -46,6 +46,7 @@ typedef struct _GstWebRTCRTPTransceiver GstWebRTCRTPTransceiver;
 typedef struct _GstRTPHeaderExtension GstRTPHeaderExtension;
 typedef struct _GstWebRTCICE GstWebRTCICE;
 typedef struct _GstWebRTCICEStream GstWebRTCICEStream;
+typedef struct _GstWebRTCSCTPTransport GstWebRTCSCTPTransport;
 
 #endif // USE(GSTREAMER_WEBRTC)
 
@@ -65,15 +66,15 @@ WTF_DEFINE_GREF_TRAITS_INLINE(GstBufferPool, gst_object_ref_sink, gst_object_unr
 WTF_DEFINE_GREF_TRAITS_INLINE(WebKitVideoSink, gst_object_ref_sink, gst_object_unref, g_object_is_floating)
 WTF_DEFINE_GREF_TRAITS_INLINE(WebKitWebSrc, gst_object_ref_sink, gst_object_unref, g_object_is_floating)
 
-WTF_DEFINE_GREF_TRAITS_INLINE(GstObject, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstStream, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstStreamCollection, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstClock, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstDeviceMonitor, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstDeviceProvider, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstDeviceProviderFactory, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstDevice, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstTracer, gst_object_ref, gst_object_unref, g_object_is_floating)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstObject, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstStream, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstStreamCollection, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstClock, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstDeviceMonitor, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstDeviceProvider, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstDeviceProviderFactory, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstDevice, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstTracer, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
 
 WTF_DEFINE_GREF_TRAITS_INLINE(GstCaps, gst_caps_ref, gst_caps_unref)
 WTF_DEFINE_GREF_TRAITS_INLINE(GstContext, gst_context_ref, gst_context_unref)
@@ -97,14 +98,21 @@ WTF_DECLARE_GREF_TRAITS(GstEGLImage)
 #endif
 
 #if USE(GSTREAMER_WEBRTC)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstWebRTCRTPReceiver, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstWebRTCRTPSender, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstWebRTCRTPTransceiver, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstWebRTCDTLSTransport, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstWebRTCICETransport, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstWebRTCICEStream, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstRTPHeaderExtension, gst_object_ref, gst_object_unref, g_object_is_floating)
-WTF_DEFINE_GREF_TRAITS_INLINE(GstWebRTCICE, gst_object_ref, gst_object_unref, g_object_is_floating)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstWebRTCRTPReceiver, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstWebRTCRTPSender, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstWebRTCRTPTransceiver, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+#if GST_CHECK_VERSION(1, 28, 1)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstWebRTCDTLSTransport, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstWebRTCICETransport, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstWebRTCSCTPTransport, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+#else
+WTF_DEFINE_GREF_TRAITS_INLINE(GstWebRTCDTLSTransport, gst_object_ref, gst_object_unref)
+WTF_DEFINE_GREF_TRAITS_INLINE(GstWebRTCICETransport, gst_object_ref, gst_object_unref)
+WTF_DEFINE_GREF_TRAITS_INLINE(GstWebRTCSCTPTransport, gst_object_ref, gst_object_unref)
+#endif
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstWebRTCICEStream, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstRTPHeaderExtension, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
+WTF_DEFINE_GREF_TRAITS_INLINE_ASSERT_ON_FLOATING_REF(GstWebRTCICE, gst_object_ref_sink, gst_object_unref, g_object_is_floating, true)
 
 WTF_DEFINE_GREF_TRAITS_INLINE(GstPromise, gst_promise_ref, gst_promise_unref)
 


### PR DESCRIPTION
#### 30862078b4ff7558c70b683d6cbc47d7405cbe1a
<pre>
[GStreamer][glib] Fix GRefPtr adaptations
<a href="https://bugs.webkit.org/show_bug.cgi?id=312978">https://bugs.webkit.org/show_bug.cgi?id=312978</a>

Reviewed by Philippe Normand.

There were inconsitencies in how we managed some GStreamer types with
floating references. Now we added a checked version for debug mode and
fix the instances.

* Source/WTF/wtf/glib/GRefPtr.h:
(WTF::GRefPtr::GRefPtr):
(WTF::GRefPtr::clear):
* Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/312176@main">https://commits.webkit.org/312176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f3e952eadcf631a137b3bbefeb7ff768041c8f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123178 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86487 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24491 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22899 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15561 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151010 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134177 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170282 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19793 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16024 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131372 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131484 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35583 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90071 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26172 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19187 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191242 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97546 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49156 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->