### PR TITLE
Web Inspector: Network: Filtering by resource type does not work after clearing a filter without matches

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ScopeBar.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeBar.js
@@ -100,9 +100,18 @@ WI.ScopeBar = class ScopeBar extends WI.NavigationItem
         if (selectedItems.length === 1 && selectedItems[0] === this._defaultItem)
             return;
 
+        this._ignoreItemSelectedEvent = true;
+
         for (let item of this._items)
             item.selected = false;
-        this._defaultItem.selected = true;
+
+        if (this._multipleItem && !this._defaultItem.exclusive)
+            this._multipleItem.selectedScopeBarItem = this._defaultItem;
+        else
+            this._defaultItem.selected = true;
+
+        this._ignoreItemSelectedEvent = false;
+        this._element.classList.toggle("default-item-selected", this._defaultItem.selected);
 
         this.dispatchEventToListeners(WI.ScopeBar.Event.SelectionChanged);
     }


### PR DESCRIPTION
#### 210c5c04a4a3c18e995dfeed81649a2e24696971
<pre>
Web Inspector: Network: Filtering by resource type does not work after clearing a filter without matches
<a href="https://bugs.webkit.org/show_bug.cgi?id=313002">https://bugs.webkit.org/show_bug.cgi?id=313002</a>
<a href="https://rdar.apple.com/161570940">rdar://161570940</a>

Reviewed by Qianlang Chen and Devin Rousso.

There is a re-entrancy issue with handling `ScopeBarItem.Event.SelectionChanged` events
in response to clearing filters in a `WI.ScopeBar` which contains a `WI.MultipleScopeBarItem`.

`WI.ScopeBar.prototype.resetToDefault()` sets `item.selected = false` on individual items,
which triggers `MultipleScopeBarItem.set selectedScopeBarItem(null)`. That setter
ignores the next selection change event with `_ignoreItemSelectedEvent = true`.

While still inside that setter, the `WI.ScopeBar._itemSelectionDidChange` handler sets
`_defaultItem.selected = true` which fires another `ScopeBarItem.Event.SelectionChanged`
for the default item. `WI.MultipleScopeBarItem._itemSelectionDidChange` handler for
that event returns early because `_ignoreItemSelectedEvent` is still `true`.

The `WI.MultipleScopeBarItem` never updates its internal state to reflect the default selection,
leaving `_selectedScopeBarItem` as `null` and the `&quot;selected&quot;` CSS class removed. This
causes the `&lt;select&gt;` dropdown within `WI.MultipleScopeBarItem` to become `display: none`
and stop responding to input.

To fix this, when `WI.ScopeBar._multipleItem` exists, use its `selectedScopeBarItem` setter
directly to switch to the default item. This atomically deselects the old item,
selects the new one, and keeps the `WI.MultipleScopeBarItem`&apos;s internal state consistent.
`WI.ScopeBar`&apos;s own `_ignoreItemSelectedEvent` flag suppresses the redundant `_itemSelectionDidChange`
handler during the operation.

* Source/WebInspectorUI/UserInterface/Views/ScopeBar.js:
(WI.ScopeBar.prototype.resetToDefault):

Canonical link: <a href="https://commits.webkit.org/311947@main">https://commits.webkit.org/311947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ca6f3e280637ac37c2b94a19d98392b44031f0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167342 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31925 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103445 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15113 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169832 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15577 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21798 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130962 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31628 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131076 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35472 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141967 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89453 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25770 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18773 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31085 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97099 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30605 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30878 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30759 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->