### PR TITLE
[CMake] Fix iOS CMake build for WebKit

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -512,6 +512,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/NavigationActionData.serialization.in
     Shared/NetworkProcessConnectionParameters.serialization.in
     Shared/NodeHitTestResult.serialization.in
+    Shared/PDFDisplayMode.serialization.in
     Shared/Pasteboard.serialization.in
     Shared/PlatformPopupMenuData.serialization.in
     Shared/PolicyDecision.serialization.in
@@ -533,6 +534,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/SerializedNode.serialization.in
     Shared/ServiceWorkerTimingInfo.serialization.in
     Shared/SessionState.serialization.in
+    Shared/ShareableSpatialImage.serialization.in
     Shared/SyntheticEditingCommandType.serialization.in
     Shared/TextFlags.serialization.in
     Shared/TextManipulationParameters.serialization.in
@@ -786,7 +788,9 @@ if (USE_LIBWEBRTC)
     list(APPEND WebKit_SYSTEM_INCLUDE_DIRECTORIES "${THIRDPARTY_DIR}/libwebrtc/Source/"
         "${THIRDPARTY_DIR}/libwebrtc/Source/webrtc"
         "${THIRDPARTY_DIR}/libwebrtc/Source/third_party/abseil-cpp")
-    list(APPEND WebKit_LIBRARIES webrtc)
+    if (NOT APPLE)
+        list(APPEND WebKit_LIBRARIES webrtc)
+    endif ()
 endif ()
 
 if (USE_GSTREAMER_WEBRTC AND USE_LIBRICE)
@@ -1164,7 +1168,7 @@ if (APPLE)
     WEBKIT_ADD_TARGET_CXX_FLAGS(WebKit -fobjc-weak)
 endif ()
 
-if ("${PORT}" STREQUAL "Mac")
+if ("${PORT}" STREQUAL "Mac" OR "${PORT}" STREQUAL "IOS")
     WEBKIT_DEFINE_XPC_SERVICES()
 else ()
     if (NOT ANDROID)
@@ -1175,11 +1179,14 @@ else ()
     install(TARGETS WebKit WebProcess NetworkProcess
         LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
         RUNTIME DESTINATION "${LIBEXEC_INSTALL_DIR}"
+        FRAMEWORK DESTINATION "${LIB_INSTALL_DIR}"
+        BUNDLE DESTINATION "${LIBEXEC_INSTALL_DIR}"
     )
     if (ENABLE_GPU_PROCESS)
         install(TARGETS GPUProcess
             LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
             RUNTIME DESTINATION "${LIBEXEC_INSTALL_DIR}"
+            BUNDLE DESTINATION "${LIBEXEC_INSTALL_DIR}"
         )
     endif ()
 endif ()

--- a/Source/WebKit/Info.plist
+++ b/Source/WebKit/Info.plist
@@ -20,5 +20,18 @@
 	<string>${SHORT_VERSION_STRING}</string>
 	<key>CFBundleVersion</key>
 	<string>${BUNDLE_VERSION}</string>
+	<key>MinimumOSVersion</key>
+	<string>${IOS_DEPLOYMENT_TARGET}</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>${PLATFORM_NAME}</string>
+	</array>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>DTPlatformName</key>
+	<string>${PLATFORM_NAME}</string>
 </dict>
 </plist>

--- a/Source/WebKit/MoveDirectory.cmake
+++ b/Source/WebKit/MoveDirectory.cmake
@@ -1,0 +1,4 @@
+if (IS_DIRECTORY "${SRC}")
+    file(REMOVE_RECURSE "${DST}")
+    file(RENAME "${SRC}" "${DST}")
+endif ()

--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -1,0 +1,457 @@
+add_compile_options("$<$<COMPILE_LANGUAGE:CXX,OBJCXX>:-std=c++2b>" "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-D__STDC_WANT_LIB_EXT1__>")
+list(APPEND WebKit_COMPILE_OPTIONS
+    "$<$<COMPILE_LANGUAGE:CXX,OBJCXX>:-std=c++2b>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-D__STDC_WANT_LIB_EXT1__>"
+)
+
+find_library(NETWORK_LIBRARY Network)
+find_library(SECURITY_LIBRARY Security)
+find_library(UNIFORMTYPEIDENTIFIERS_LIBRARY UniformTypeIdentifiers)
+find_library(AVFOUNDATION_LIBRARY AVFoundation)
+find_library(DEVICEIDENTITY_LIBRARY DeviceIdentity HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+if (NOT DEVICEIDENTITY_LIBRARY)
+    set(DEVICEIDENTITY_LIBRARY "" CACHE FILEPATH "" FORCE)
+endif ()
+
+add_compile_options(
+    "$<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-DWK_XPC_SERVICE_SUFFIX=\".Development\">"
+    "$<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-DWEBKIT_BUNDLE_VERSION=\"${WEBKIT_MAC_VERSION}\">"
+)
+list(APPEND WebKit_COMPILE_OPTIONS
+    "$<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-DWK_XPC_SERVICE_SUFFIX=\".Development\">"
+    "$<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-DWEBKIT_BUNDLE_VERSION=\"${WEBKIT_MAC_VERSION}\">"
+)
+
+set(MACOSX_FRAMEWORK_IDENTIFIER com.apple.WebKit)
+
+include(Headers.cmake)
+
+list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
+    "SourcesCocoa.txt"
+
+    "Platform/SourcesCocoa.txt"
+)
+
+list(APPEND WebKit_SOURCES
+    GPUProcess/media/RemoteAudioDestinationManager.cpp
+
+    NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
+
+    NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+    NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+
+    NetworkProcess/webrtc/NetworkRTCProvider.cpp
+    NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+    NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+    NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
+
+    Platform/IPC/cocoa/SharedFileHandleCocoa.cpp
+
+    Shared/API/Cocoa/WKMain.mm
+
+    Shared/Cocoa/DefaultWebBrowserChecks.mm
+    Shared/Cocoa/XPCEndpoint.mm
+    Shared/Cocoa/XPCEndpointClient.mm
+
+    UIProcess/API/Cocoa/WKContentWorld.mm
+    UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.mm
+    UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm
+    UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.mm
+    UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.mm
+    UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm
+    UIProcess/API/Cocoa/_WKAuthenticatorSelectionCriteria.mm
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.mm
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialDescriptor.mm
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialEntity.mm
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialParameters.mm
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialRelyingPartyEntity.mm
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.mm
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialUserEntity.mm
+    UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstParty.mm
+    UIProcess/API/Cocoa/_WKResourceLoadStatisticsThirdParty.mm
+
+    UIProcess/Cocoa/PreferenceObserver.mm
+    UIProcess/Cocoa/WKShareSheet.mm
+    UIProcess/Cocoa/WKStorageAccessAlert.mm
+    UIProcess/Cocoa/WebInspectorPreferenceObserver.mm
+
+    UIProcess/PDF/WKPDFPageNumberIndicator.mm
+    ${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKTextExtraction.swift
+
+    WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
+
+    WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
+    WebProcess/cocoa/LaunchServicesDatabaseManager.mm
+)
+
+list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
+    "${CMAKE_BINARY_DIR}/libwebrtc/PrivateHeaders"
+    "${WEBKIT_DIR}/GPUProcess/graphics/Model"
+    "${WEBKIT_DIR}/GPUProcess/media/cocoa"
+    "${WEBKIT_DIR}/NetworkProcess/cocoa"
+    "${WEBKIT_DIR}/NetworkProcess/PrivateClickMeasurement/cocoa"
+    "${WEBKIT_DIR}/UIProcess/ios"
+    "${WEBKIT_DIR}/UIProcess/API/C/mac"
+    "${WEBKIT_DIR}/UIProcess/API/Cocoa"
+    "${WEBKIT_DIR}/UIProcess/Authentication/cocoa"
+    "${WEBKIT_DIR}/UIProcess/Cocoa"
+    "${WEBKIT_DIR}/UIProcess/Cocoa/SOAuthorization"
+    "${WEBKIT_DIR}/UIProcess/Cocoa/TextExtraction"
+    "${WEBKIT_DIR}/UIProcess/Extensions/Cocoa"
+    "${WEBKIT_DIR}/UIProcess/Inspector/Cocoa"
+    "${WEBKIT_DIR}/UIProcess/Launcher/mac"
+    "${WEBKIT_DIR}/UIProcess/Media/cocoa"
+    "${WEBKIT_DIR}/UIProcess/Notifications/cocoa"
+    "${WEBKIT_DIR}/UIProcess/PDF"
+    "${WEBKIT_DIR}/UIProcess/RemoteLayerTree"
+    "${WEBKIT_DIR}/UIProcess/RemoteLayerTree/cocoa"
+    "${WEBKIT_DIR}/UIProcess/WebAuthentication/Cocoa"
+    "${WEBKIT_DIR}/UIProcess/WebAuthentication/Virtual"
+    "${WEBKIT_DIR}/UIProcess/WebsiteData/Cocoa"
+    "${WEBKIT_DIR}/Platform/cg"
+    "${WEBKIT_DIR}/Platform/classifier"
+    "${WEBKIT_DIR}/Platform/classifier/cocoa"
+    "${WEBKIT_DIR}/Platform/cocoa"
+    "${WEBKIT_DIR}/Platform/ios"
+    "${WEBKIT_DIR}/Platform/mac"
+    "${WEBKIT_DIR}/Platform/unix"
+    "${WEBKIT_DIR}/WebKitSwift/MarketplaceKit"
+    "${WEBKIT_DIR}/WebKitSwift/WritingTools"
+    "${WEBKIT_DIR}/Platform/spi/Cocoa"
+    "${WEBKIT_DIR}/Platform/spi/ios"
+    "${WEBKIT_DIR}/Platform/spi/mac"
+    "${WEBKIT_DIR}/Platform/IPC/darwin"
+    "${WEBKIT_DIR}/Platform/IPC/mac"
+    "${WEBKIT_DIR}/Platform/IPC/cocoa"
+    "${WEBKIT_DIR}/Shared/API/Cocoa"
+    "${WEBKIT_DIR}/Shared/API/c/cf"
+    "${WEBKIT_DIR}/Shared/API/c/cg"
+    "${WEBKIT_DIR}/Shared/API/c/mac"
+    "${WEBKIT_DIR}/Shared/ApplePay/cocoa/"
+    "${WEBKIT_DIR}/Shared/Authentication/cocoa"
+    "${WEBKIT_DIR}/Shared/cf"
+    "${WEBKIT_DIR}/Shared/Cocoa"
+    "${WEBKIT_DIR}/Shared/Daemon"
+    "${WEBKIT_DIR}/Shared/EntryPointUtilities/Cocoa/Daemon"
+    "${WEBKIT_DIR}/Shared/EntryPointUtilities/Cocoa/XPCService"
+    "${WEBKIT_DIR}/Shared/Scrolling"
+    "${WEBKIT_DIR}/UIProcess/Cocoa/GroupActivities"
+    "${WEBKIT_DIR}/UIProcess/Media"
+    "${WEBKIT_DIR}/UIProcess/WebAuthentication/fido"
+    "${WEBKIT_DIR}/WebProcess/DigitalCredentials"
+    "${WEBKIT_DIR}/WebProcess/WebAuthentication"
+    "${WEBKIT_DIR}/WebProcess/cocoa"
+    "${WEBKIT_DIR}/WebProcess/cocoa/IdentityDocumentServices"
+    "${WEBKIT_DIR}/WebProcess/Extensions/Cocoa"
+    "${WEBKIT_DIR}/WebKitSwift/IdentityDocumentServices"
+    "${WEBKIT_DIR}/WebProcess/mac"
+    "${WEBKIT_DIR}/WebProcess/GPU/graphics/cocoa"
+    "${WEBKIT_DIR}/WebProcess/Inspector/mac"
+    "${WEBKIT_DIR}/WebProcess/InjectedBundle/API/Cocoa"
+    "${WEBKIT_DIR}/WebProcess/InjectedBundle/API/mac"
+    "${WEBKIT_DIR}/WebProcess/MediaSession"
+    "${WEBKIT_DIR}/WebProcess/Plugins/PDF"
+    "${WEBKIT_DIR}/WebProcess/Plugins/PDF/UnifiedPDF"
+    "${WEBKIT_DIR}/WebProcess/WebPage/Cocoa"
+    "${WEBKIT_DIR}/WebProcess/WebPage/RemoteLayerTree"
+    "${WEBKIT_DIR}/WebProcess/WebPage/mac"
+    "${WEBKIT_DIR}/WebProcess/WebCoreSupport/cocoa"
+    "${WEBKIT_DIR}/webpushd"
+    "${WEBKIT_DIR}/webpushd/webpushtool"
+    "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source"
+)
+
+# FIXME: These should not have Development in production builds.
+set(WebProcess_OUTPUT_NAME com.apple.WebKit.WebContent.Development)
+set(NetworkProcess_OUTPUT_NAME com.apple.WebKit.Networking.Development)
+set(GPUProcess_OUTPUT_NAME com.apple.WebKit.GPU.Development)
+
+set(WebKit_SWIFT_INCLUDE_DIRECTORIES
+    "${WEBKIT_DIR}/Platform/spi/Cocoa"
+    "${WEBKIT_DIR}/Platform/spi/Cocoa/Modules"
+    "${WEBKIT_DIR}/Platform/spi/ios"
+)
+
+
+file(WRITE "${CMAKE_BINARY_DIR}/WebKit/WebPushDaemonStubs.cpp"
+"#include \"config.h\"\n#if ENABLE(WEB_PUSH_NOTIFICATIONS)\nnamespace WebKit {\nint WebPushDaemonMain(int, char**) { return 1; }\nint WebPushToolMain(int, char**) { return 1; }\n}\n#endif\n")
+list(APPEND WebKit_SOURCES "${CMAKE_BINARY_DIR}/WebKit/WebPushDaemonStubs.cpp")
+
+set(WebKit_FORWARDING_HEADERS_FILES
+    Platform/cocoa/WKCrashReporter.h
+
+    Shared/API/c/WKDiagnosticLoggingResultType.h
+
+    UIProcess/API/C/WKPageDiagnosticLoggingClient.h
+    UIProcess/API/C/WKPageNavigationClient.h
+    UIProcess/API/C/WKPageRenderingProgressEvents.h
+)
+
+list(APPEND WebKit_MESSAGES_IN_FILES
+    GPUProcess/media/RemoteImageDecoderAVFProxy
+
+    GPUProcess/media/ios/RemoteMediaSessionHelperProxy
+
+    GPUProcess/webrtc/UserMediaCaptureManagerProxy
+
+    ModelProcess/cocoa/ModelProcessModelPlayerProxy
+
+    NetworkProcess/CustomProtocols/LegacyCustomProtocolManager
+
+    Shared/API/Cocoa/RemoteObjectRegistry
+
+    Shared/ApplePay/WebPaymentCoordinatorProxy
+
+    UIProcess/ViewGestureController
+
+    UIProcess/Cocoa/PlaybackSessionManagerProxy
+    UIProcess/Cocoa/VideoPresentationManagerProxy
+
+    UIProcess/Inspector/WebInspectorUIExtensionControllerProxy
+
+    UIProcess/Media/AudioSessionRoutingArbitratorProxy
+
+    UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy
+
+    UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy
+
+    UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy
+
+    UIProcess/ios/SmartMagnificationController
+    UIProcess/ios/WebDeviceOrientationUpdateProviderProxy
+
+    UIProcess/mac/SecItemShimProxy
+
+    WebProcess/ApplePay/WebPaymentCoordinator
+
+    WebProcess/GPU/media/RemoteImageDecoderAVFManager
+
+    WebProcess/GPU/media/ios/RemoteMediaSessionHelper
+
+    WebProcess/Inspector/WebInspectorUIExtensionController
+
+    WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider
+
+    WebProcess/WebPage/ViewGestureGeometryCollector
+    WebProcess/WebPage/ViewUpdateDispatcher
+
+    WebProcess/WebPage/Cocoa/TextCheckingControllerProxy
+
+    WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator
+
+    WebProcess/cocoa/PlaybackSessionManager
+    WebProcess/cocoa/RemoteCaptureSampleManager
+    WebProcess/cocoa/UserMediaCaptureManager
+    WebProcess/cocoa/VideoPresentationManager
+)
+
+
+
+set(_log_messages_inputs
+    ${WEBKIT_DIR}/Platform/LogMessages.in
+    ${WEBCORE_DIR}/platform/LogMessages.in
+)
+set(_log_messages_generated
+    ${WebKit_DERIVED_SOURCES_DIR}/LogStream.messages.in
+    ${WebKit_DERIVED_SOURCES_DIR}/LogMessagesDeclarations.h
+    ${WebKit_DERIVED_SOURCES_DIR}/LogMessagesImplementations.h
+    ${WebKit_DERIVED_SOURCES_DIR}/WebKitLogClientDeclarations.h
+    ${WebKit_DERIVED_SOURCES_DIR}/WebCoreLogClientDeclarations.h
+)
+
+
+list(APPEND WebKit_MESSAGES_IN_FILES LogStream)
+
+file(GLOB _webkit_cocoa_serialization_files RELATIVE "${WEBKIT_DIR}"
+    "${WEBKIT_DIR}/Platform/cocoa/*.serialization.in"
+    "${WEBKIT_DIR}/Shared/ApplePay/*.serialization.in"
+    "${WEBKIT_DIR}/Shared/Cocoa/*.serialization.in"
+    "${WEBKIT_DIR}/Shared/RemoteLayerTree/*.serialization.in"
+    "${WEBKIT_DIR}/Shared/cf/*.serialization.in"
+    "${WEBKIT_DIR}/Shared/mac/*.serialization.in"
+    "${WEBKIT_DIR}/WebProcess/WebPage/RemoteLayerTree/*.serialization.in"
+)
+list(APPEND WebKit_SERIALIZATION_IN_FILES ${_webkit_cocoa_serialization_files})
+unset(_webkit_cocoa_serialization_files)
+
+list(APPEND WebKit_SERIALIZATION_IN_FILES
+    Shared/AdditionalFonts.serialization.in
+    Shared/AlternativeTextClient.serialization.in
+    Shared/AppPrivacyReportTestingData.serialization.in
+    Shared/PushMessageForTesting.serialization.in
+    Shared/TextAnimationTypes.serialization.in
+    Shared/ViewWindowCoordinates.serialization.in
+)
+
+
+list(APPEND WebCore_SERIALIZATION_IN_FILES
+    PlaybackSessionModel.serialization.in
+)
+
+
+file(GLOB _webkit_additional_cocoa_sources RELATIVE "${WEBKIT_DIR}"
+    "${WEBKIT_DIR}/Shared/Cocoa/CoreIPC*.mm"
+    "${WEBKIT_DIR}/Shared/cf/CoreIPC*.mm"
+)
+list(APPEND WebKit_SOURCES ${_webkit_additional_cocoa_sources})
+unset(_webkit_additional_cocoa_sources)
+list(APPEND WebKit_SOURCES
+    NetworkProcess/cocoa/DeviceManagementSoftLink.mm
+    NetworkProcess/cocoa/NetworkSoftLink.mm
+
+    Platform/cocoa/_WKWebViewTextInputNotifications.mm
+
+    Shared/AdditionalFonts.mm
+
+    Shared/Cocoa/AnnotatedMachSendRight.mm
+    Shared/Cocoa/ArgumentCodersCocoa.mm
+    Shared/Cocoa/BackgroundFetchStateCocoa.mm
+    Shared/Cocoa/CoreTextHelpers.mm
+    Shared/Cocoa/DataDetectionResult.mm
+    Shared/Cocoa/LaunchLogHook.mm
+    Shared/Cocoa/WKKeyedCoder.mm
+    Shared/Cocoa/WKProcessExtension.mm
+    Shared/Cocoa/WebKit2InitializeCocoa.mm
+    Shared/Cocoa/WebPushMessageCocoa.mm
+
+    UIProcess/EndowmentStateTracker.mm
+
+    UIProcess/Cocoa/AboutSchemeHandlerCocoa.mm
+    UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+    UIProcess/Cocoa/CSPExtensionUtilities.mm
+    UIProcess/Cocoa/_WKWarningView.mm
+
+    UIProcess/Downloads/DownloadProxyCocoa.mm
+
+    UIProcess/Extensions/WebExtensionCommand.cpp
+    UIProcess/Extensions/WebExtensionMenuItem.cpp
+
+    UIProcess/Launcher/cocoa/ExtensionProcess.mm
+
+    UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.mm
+
+    UIProcess/WebAuthentication/AuthenticatorManager.cpp
+
+    UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.mm
+    UIProcess/WebAuthentication/Cocoa/HidConnection.mm
+    UIProcess/WebAuthentication/Cocoa/HidService.mm
+    UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+
+    UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.cpp
+    UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
+    UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp
+    UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.mm
+    UIProcess/WebAuthentication/Virtual/VirtualService.mm
+
+    UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+    UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
+    UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+
+    WebProcess/Inspector/ServiceWorkerDebuggableFrontendChannel.cpp
+    WebProcess/Inspector/ServiceWorkerDebuggableProxy.cpp
+
+    WebProcess/Network/WebMockContentFilterManager.cpp
+
+    WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+
+    WebProcess/cocoa/TextTrackRepresentationCocoa.mm
+
+    webpushd/ApplePushServiceConnection.mm
+    webpushd/MockPushServiceConnection.mm
+    webpushd/PushClientConnection.mm
+    webpushd/PushService.mm
+    webpushd/PushServiceConnection.mm
+    webpushd/WebClipCache.mm
+    webpushd/WebPushDaemon.mm
+    webpushd/_WKMockUserNotificationCenter.mm
+)
+
+find_library(CRYPTOTOKENKIT_LIBRARY CryptoTokenKit)
+find_library(USERNOTIFICATIONS_LIBRARY UserNotifications)
+find_library(WRITINGTOOLS_LIBRARY WritingTools HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+find_library(APPLEPUSHSERVICE_LIBRARY ApplePushService HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+list(APPEND WebKit_PRIVATE_LIBRARIES
+    ${CRYPTOTOKENKIT_LIBRARY}
+    ${USERNOTIFICATIONS_LIBRARY}
+    ${WRITINGTOOLS_LIBRARY}
+    ${APPLEPUSHSERVICE_LIBRARY}
+)
+
+set(WebKit_FORWARDING_HEADERS_DIRECTORIES
+    Platform
+    Shared
+
+    NetworkProcess/Downloads
+
+    Platform/IPC
+
+    Shared/API
+    Shared/Cocoa
+
+    Shared/API/Cocoa
+    Shared/API/c
+
+    Shared/API/c/cf
+    Shared/API/c/mac
+
+    UIProcess/Cocoa
+
+    UIProcess/API/C
+    UIProcess/API/Cocoa
+    UIProcess/API/cpp
+
+    UIProcess/API/C/Cocoa
+    UIProcess/API/C/mac
+
+    WebProcess/InjectedBundle/API/Cocoa
+    WebProcess/InjectedBundle/API/c
+    WebProcess/InjectedBundle/API/mac
+)
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -compatibility_version 1 -current_version ${WEBKIT_MAC_VERSION}")
+target_link_options(WebKit PRIVATE -framework AuthKit)
+
+
+target_link_options(WebKit PRIVATE
+    -Wl,-unexported_symbol,__ZTISt9bad_alloc
+    -Wl,-unexported_symbol,__ZTISt9exception
+    -Wl,-unexported_symbol,__ZTSSt9bad_alloc
+    -Wl,-unexported_symbol,__ZTSSt9exception
+    -Wl,-unexported_symbol,__ZdlPvS_
+    -Wl,-unexported_symbol,__ZnwmPv
+    -Wl,-unexported_symbol,__Znwm
+    -Wl,-unexported_symbol,__ZTVNSt3__117bad_function_callE
+    -Wl,-unexported_symbol,__ZTCNSt3__118basic_stringstreamIcNS_11char_traitsIcEENS_9allocatorIcEEEE0_NS_13basic_istreamIcS2_EE
+    -Wl,-unexported_symbol,__ZTCNSt3__118basic_stringstreamIcNS_11char_traitsIcEENS_9allocatorIcEEEE0_NS_14basic_iostreamIcS2_EE
+    -Wl,-unexported_symbol,__ZTCNSt3__118basic_stringstreamIcNS_11char_traitsIcEENS_9allocatorIcEEEE16_NS_13basic_ostreamIcS2_EE
+    -Wl,-unexported_symbol,__ZTTNSt3__118basic_stringstreamIcNS_11char_traitsIcEENS_9allocatorIcEEEE
+    -Wl,-unexported_symbol,__ZTVNSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEE
+    -Wl,-unexported_symbol,__ZTVNSt3__118basic_stringstreamIcNS_11char_traitsIcEENS_9allocatorIcEEEE
+    -Wl,-unexported_symbol,__ZTCNSt3__118basic_stringstreamIcNS_11char_traitsIcEENS_9allocatorIcEEEE8_NS_13basic_ostreamIcS2_EE
+    -Wl,-unexported_symbol,__ZTAXtlN7WebCore3CSS5RangeELdfff0000000000000ELd7ff0000000000000EEE
+    "-Wl,-unexported_symbol,_$s*3Cxx*"
+)
+
+set(WebKit_OUTPUT_NAME WebKit)
+if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    set_target_properties(WebKit PROPERTIES
+        INSTALL_NAME_DIR "${WebKit_INSTALL_NAME_DIR}"
+        VERSION "${WEBKIT_MAC_VERSION}"
+        SOVERSION 1
+    )
+endif ()
+
+set(WebKit_GENERATED_SERIALIZERS_SUFFIX mm)
+
+
+list(APPEND WebKit_DERIVED_SOURCES
+    ${WebKit_DERIVED_SOURCES_DIR}/GeneratedWebKitSecureCoding.h
+    ${WebKit_DERIVED_SOURCES_DIR}/GeneratedWebKitSecureCoding.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+)
+
+# Generated JSWebExtension*.mm IDL bindings need -fobjc-arc; route to WebKitARC.
+foreach (_file IN ITEMS ${WebKit_BINDINGS_IN_FILES})
+    get_filename_component(_name ${_file} NAME_WE)
+    list(APPEND WebKit_ARC_SOURCES ${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.mm)
+    set_source_files_properties(${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.mm PROPERTIES GENERATED TRUE)
+endforeach ()

--- a/Source/WebKit/PlatformIOS.cmake
+++ b/Source/WebKit/PlatformIOS.cmake
@@ -1,0 +1,1415 @@
+include(PlatformCocoa.cmake)
+
+find_library(CFNETWORK_LIBRARY CFNetwork)
+find_library(COREAUDIO_LIBRARY CoreAudio)
+find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+find_library(COREGRAPHICS_LIBRARY CoreGraphics)
+find_library(CORESERVICES_LIBRARY CoreServices)
+find_library(CORETEXT_LIBRARY CoreText)
+find_library(FOUNDATION_LIBRARY Foundation)
+find_library(GRAPHICSSERVICES_LIBRARY GraphicsServices HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+find_library(IMAGEIO_LIBRARY ImageIO)
+find_library(IOKIT_LIBRARY IOKit)
+find_library(IOSURFACE_LIBRARY IOSurface)
+find_library(METAL_LIBRARY Metal)
+find_library(MOBILECORESERVICES_LIBRARY MobileCoreServices)
+find_library(SPRINGBOARDSERVICES_LIBRARY SpringBoardServices HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+find_library(UIKITSERVICES_LIBRARY UIKitServices HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+find_library(UIKIT_LIBRARY UIKit)
+
+find_library(APPSTOREDAEMON_LIBRARY AppStoreDaemon HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+find_library(BACKBOARDSERVICES_LIBRARY BackBoardServices HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+find_library(CONTACTS_LIBRARY Contacts)
+find_library(CORETELEPHONY_LIBRARY CoreTelephony)
+find_library(FRONTBOARDSERVICES_LIBRARY FrontBoardServices HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+find_library(GAMECONTROLLERUI_LIBRARY GameControllerUI HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+find_library(INSTALLCOORDINATION_LIBRARY InstallCoordination HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+find_library(MOBILEKEYBAG_LIBRARY MobileKeyBag HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+find_library(NETWORKEXTENSION_LIBRARY NetworkExtension)
+find_library(PDFKIT_LIBRARY PDFKit)
+
+add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-DHAVE_CORE_PREDICTION=1>")
+
+set(BUNDLE_VERSION "${MACOSX_FRAMEWORK_BUNDLE_VERSION}")
+set(SHORT_VERSION_STRING "${WEBKIT_MAC_VERSION}")
+set(PRODUCT_NAME "WebKit")
+set(PRODUCT_BUNDLE_IDENTIFIER "com.apple.WebKit")
+configure_file(${WEBKIT_DIR}/Info.plist ${CMAKE_CURRENT_BINARY_DIR}/WebKit-Info.plist)
+execute_process(COMMAND plutil -convert binary1 ${CMAKE_CURRENT_BINARY_DIR}/WebKit-Info.plist)
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/WebKitLegacy.h
+    "#if defined(__has_include) && __has_include(<WebKitLegacy/WebKit.h>)\n"
+    "#import <WebKitLegacy/WebKit.h>\n"
+    "#endif\n"
+)
+set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/WebKitLegacy.h PROPERTIES
+    MACOSX_PACKAGE_LOCATION Headers
+    GENERATED TRUE
+)
+
+list(APPEND WebKit_PRIVATE_LIBRARIES
+    -lnetworkextension
+    -lsqlite3
+    Accessibility
+    ${CFNETWORK_LIBRARY}
+    ${CONTACTS_LIBRARY}
+    ${COREAUDIO_LIBRARY}
+    ${COREFOUNDATION_LIBRARY}
+    ${COREGRAPHICS_LIBRARY}
+    ${CORESERVICES_LIBRARY}
+    ${CORETEXT_LIBRARY}
+    ${FOUNDATION_LIBRARY}
+    ${IMAGEIO_LIBRARY}
+    ${IOKIT_LIBRARY}
+    ${IOSURFACE_LIBRARY}
+    ${METAL_LIBRARY}
+    ${NETWORK_LIBRARY}
+    ${NETWORKEXTENSION_LIBRARY}
+    ${PDFKIT_LIBRARY}
+    ${UNIFORMTYPEIDENTIFIERS_LIBRARY}
+    ${UIKIT_LIBRARY}
+)
+
+target_link_options(WebKit PRIVATE "-Wl,-delay_framework,CoreTelephony")
+
+foreach (_pfw
+    APPSTOREDAEMON_LIBRARY
+    BACKBOARDSERVICES_LIBRARY
+    CORETELEPHONY_LIBRARY
+    FRONTBOARDSERVICES_LIBRARY
+    GAMECONTROLLERUI_LIBRARY
+    GRAPHICSSERVICES_LIBRARY
+    INSTALLCOORDINATION_LIBRARY
+    MOBILECORESERVICES_LIBRARY
+    MOBILEKEYBAG_LIBRARY
+    SPRINGBOARDSERVICES_LIBRARY
+    UIKITSERVICES_LIBRARY
+)
+    if (${_pfw})
+        list(APPEND WebKit_PRIVATE_LIBRARIES ${${_pfw}})
+    endif ()
+endforeach ()
+unset(_pfw)
+
+if (DEVICEIDENTITY_LIBRARY)
+    list(APPEND WebKit_PRIVATE_LIBRARIES ${DEVICEIDENTITY_LIBRARY})
+endif ()
+
+list(APPEND WebKit_SOURCES
+    Shared/ios/WebAutocorrectionData.mm
+
+    UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+
+    UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
+    UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
+    UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm
+
+    UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.cpp
+)
+
+list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
+    "${WebKit_PRIVATE_FRAMEWORK_HEADERS_DIR}"
+    "${WEBKIT_DIR}/GPUProcess/mac"
+    "${WEBKIT_DIR}/GPUProcess/media/ios"
+    "${WEBKIT_DIR}/NetworkProcess/ios"
+    "${WEBKIT_DIR}/NetworkProcess/mac"
+    "${WEBKIT_DIR}/Shared/ios"
+    "${WEBKIT_DIR}/Shared/mac"
+    "${WEBKIT_DIR}/UIProcess/API/ios"
+    "${WEBKIT_DIR}/UIProcess/API/mac"
+    "${WEBKIT_DIR}/UIProcess/Inspector/ios"
+    "${WEBKIT_DIR}/UIProcess/Inspector/mac"
+    "${WEBKIT_DIR}/UIProcess/Launcher/cocoa"
+    "${WEBKIT_DIR}/UIProcess/RemoteLayerTree/ios"
+    "${WEBKIT_DIR}/UIProcess/RemoteLayerTree/mac"
+    "${WEBKIT_DIR}/UIProcess/XR/ios"
+    "${WEBKIT_DIR}/UIProcess/ios/forms"
+    "${WEBKIT_DIR}/UIProcess/ios/fullscreen"
+    "${WEBKIT_DIR}/UIProcess/mac"
+    "${WEBKIT_DIR}/WebKitSwift/Preview"
+    "${WEBKIT_DIR}/WebKitSwift/TextAnimation"
+    "${WEBKIT_DIR}/WebProcess/GPU/media/ios"
+    "${WEBKIT_DIR}/WebProcess/Model/mac"
+    "${WEBKIT_DIR}/WebProcess/WebCoreSupport/ios"
+    "${WEBKIT_DIR}/WebProcess/WebPage/ios"
+)
+
+set(XPCService_SOURCES
+    ${WEBKIT_DIR}/Shared/EntryPointUtilities/Cocoa/AuxiliaryProcessMain.cpp
+    ${WEBKIT_DIR}/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+    ${WEBKIT_DIR}/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+)
+
+list(APPEND WebKit_SOURCES
+    ${WEBKIT_DIR}/Shared/EntryPointUtilities/Cocoa/ExtensionEventHandler.mm
+    ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm
+)
+set(WebProcess_SOURCES
+    ${WEBKIT_DIR}/WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm
+    ${XPCService_SOURCES}
+)
+set(NetworkProcess_SOURCES
+    ${WEBKIT_DIR}/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
+    ${XPCService_SOURCES}
+)
+set(GPUProcess_SOURCES
+    ${WEBKIT_DIR}/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
+    ${XPCService_SOURCES}
+)
+
+set(WebKit_USE_PREFIX_HEADER ON)
+
+set(WebKit_CMAKE_MODULEMAP_DIR "${CMAKE_BINARY_DIR}/WebKit/SwiftModules")
+file(MAKE_DIRECTORY "${WebKit_CMAKE_MODULEMAP_DIR}")
+file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap"
+"module WebKit_Internal [system] {
+    module _WKTextExtractionInternal {
+        requires objc
+        header \"${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKTextExtractionInternal.h\"
+        export *
+    }
+    module WKMaterialHostingSupport {
+        requires objc
+        header \"${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.h\"
+        export *
+    }
+    module WKMouseDeviceObserver {
+        requires objc
+        header \"${WEBKIT_DIR}/UIProcess/ios/WKMouseDeviceObserver.h\"
+        export *
+    }
+    module WKScrollGeometry {
+        requires objc
+        header \"${WEBKIT_DIR}/UIProcess/API/Cocoa/WKScrollGeometry.h\"
+        export *
+    }
+    module WKSeparatedImageView {
+        requires objc
+        header \"${WEBKIT_DIR}/UIProcess/Cocoa/Separated/WKSeparatedImageView.h\"
+        export *
+    }
+    module WKStageModeOrbitSimulator {
+        requires objc
+        header \"${WEBKIT_DIR}/Shared/Model/WKStageModeOrbitSimulator.h\"
+        export *
+    }
+    module WKSurroundingsEffect {
+        requires objc
+        header \"${WEBKIT_DIR}/Platform/spi/visionos/WKSurroundingsEffect.h\"
+        export *
+    }
+    module WKTextEffectManager {
+        requires objc
+        header \"${WEBKIT_DIR}/UIProcess/Cocoa/WKTextEffectManager.h\"
+        export *
+    }
+    module WKUIDelegateInternal {
+        requires objc
+        header \"${WEBKIT_DIR}/UIProcess/API/Cocoa/WKUIDelegateInternal.h\"
+        export *
+    }
+    module WKProcessExtension {
+        requires objc
+        header \"${WEBKIT_DIR}/Shared/Cocoa/WKProcessExtension.h\"
+        export *
+    }
+    module WKUSDStageConverter {
+        requires objc
+        header \"${WEBKIT_DIR}/ModelProcess/cocoa/WKUSDStageConverter.h\"
+        export *
+    }
+}
+")
+set(_private_modulemap_input "${WEBKIT_DIR}/Modules/iOS_Private.modulemap")
+set(_private_modulemap_output "${CMAKE_BINARY_DIR}/WebKit/Modules/module.private.modulemap")
+
+set(_modulemap_arch "${CMAKE_OSX_ARCHITECTURES}")
+if (NOT _modulemap_arch)
+    if (_is_simulator)
+        set(_modulemap_arch "arm64")
+    else ()
+        set(_modulemap_arch "arm64e")
+    endif ()
+endif ()
+if (CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
+    set(_modulemap_triple "${_modulemap_arch}-apple-ios${CMAKE_OSX_DEPLOYMENT_TARGET}-simulator")
+else ()
+    set(_modulemap_triple "${_modulemap_arch}-apple-ios${CMAKE_OSX_DEPLOYMENT_TARGET}")
+endif ()
+
+add_custom_command(
+    OUTPUT "${_private_modulemap_output}"
+    DEPENDS "${_private_modulemap_input}"
+    COMMAND ${CMAKE_C_COMPILER} -E -P -w
+        -target ${_modulemap_triple}
+        -isysroot ${CMAKE_OSX_SYSROOT}
+        -x c "${_private_modulemap_input}"
+        -o "${_private_modulemap_output}"
+    COMMENT "Preprocessing iOS_Private.modulemap"
+    VERBATIM
+)
+add_custom_target(WebKit_PrivateModuleMap DEPENDS "${_private_modulemap_output}")
+add_dependencies(WebKit WebKit_PrivateModuleMap)
+
+file(WRITE "${CMAKE_BINARY_DIR}/swift-vfs-overlay.yaml"
+"{
+  \"version\": 0,
+  \"case-sensitive\": false,
+  \"roots\": [
+    {
+      \"name\": \"${CMAKE_OSX_SYSROOT}/System/Cryptexes/OS/System/Library/Frameworks/JavaScriptCore.framework/Modules/module.private.modulemap\",
+      \"type\": \"file\",
+      \"external-contents\": \"${CMAKE_BINARY_DIR}/JavaScriptCore/Modules/module.private.modulemap\"
+    },
+    {
+      \"name\": \"${CMAKE_OSX_SYSROOT}/System/Cryptexes/OS/System/Library/Frameworks/WebKit.framework/Modules/module.private.modulemap\",
+      \"type\": \"file\",
+      \"external-contents\": \"${CMAKE_BINARY_DIR}/WebKit/Modules/module.private.modulemap\"
+    },
+    {
+      \"name\": \"${CMAKE_OSX_SYSROOT}/System/Library/Frameworks/JavaScriptCore.framework/Modules/module.private.modulemap\",
+      \"type\": \"file\",
+      \"external-contents\": \"${CMAKE_BINARY_DIR}/JavaScriptCore/Modules/module.private.modulemap\"
+    },
+    {
+      \"name\": \"${CMAKE_OSX_SYSROOT}/System/Library/Frameworks/WebKit.framework/Modules/module.private.modulemap\",
+      \"type\": \"file\",
+      \"external-contents\": \"${CMAKE_BINARY_DIR}/WebKit/Modules/module.private.modulemap\"
+    }
+  ]
+}
+")
+
+
+set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WebKit_CMAKE_MODULEMAP_DIR}")
+
+target_compile_options(WebKit PRIVATE ${WEBKIT_PRIVATE_FRAMEWORKS_COMPILE_FLAG})
+target_compile_options(WebKit PRIVATE "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CMAKE_BINARY_DIR}>")
+
+set_target_properties(WebKit PROPERTIES
+    C_VISIBILITY_PRESET hidden
+    CXX_VISIBILITY_PRESET hidden
+    OBJC_VISIBILITY_PRESET hidden
+    OBJCXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+)
+target_compile_options(WebKit PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MATERIAL_HOSTING>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MOUSE_DEVICE_OBSERVATION>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DENABLE_WRITING_TOOLS>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_DIGITAL_CREDENTIALS_UI>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MARKETPLACE_KIT>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_CREDENTIAL_UPDATE_API>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-cxx-interoperability-mode=default>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -std=c++2b>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DHAVE_CONFIG_H=1>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DBUILDING_WITH_CMAKE=1>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${CMAKE_BINARY_DIR}>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-cross-import-overlays>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-name=WebKit>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_BINARY_DIR}/WebKit/Modules/module.private.modulemap>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -ivfsoverlay -Xcc ${CMAKE_BINARY_DIR}/swift-vfs-overlay.yaml>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"WK_IOS_TBA:iOS ${CMAKE_OSX_DEPLOYMENT_TARGET}\">"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"WK_MAC_TBA:macOS 9999\">"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"WK_XROS_TBA:visionOS 9999\">"
+    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa/Modules>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/ios>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${WTF_FRAMEWORK_HEADERS_DIR}>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${bmalloc_FRAMEWORK_HEADERS_DIR}>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${PAL_FRAMEWORK_HEADERS_DIR}>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -isystem${CMAKE_OSX_SYSROOT}/usr/local/include>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_OSX_SYSROOT}/usr/local/include/unicode_private.modulemap>"
+)
+
+target_compile_options(WebKit PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-swift-version 6>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-private-module-interface-path ${CMAKE_BINARY_DIR}/Source/WebKit/WebKit.private.swiftinterface>"
+)
+
+set(WebKit_SWIFT_EXTRA_OPTIONS
+    -DHAVE_MATERIAL_HOSTING
+    -Xcc -fmodule-name=WebKit
+)
+
+# FIXME: Fully compile once missing module dependencies are available. https://bugs.webkit.org/show_bug.cgi?id=314013
+set(WebKit_SWIFT_TYPECHECK_SOURCES
+    ${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKTextExtraction.swift
+)
+
+list(APPEND WebKit_SOURCES
+    ${WEBKIT_DIR}/ModelProcess/cocoa/WKUSDStageConverter.swift
+    ${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.swift
+    ${WEBKIT_DIR}/Platform/spi/visionos/WKSurroundingsEffect.swift
+    ${WEBKIT_DIR}/Platform/spi/visionos/WKSurroundingsEffectView.swift
+    ${WEBKIT_DIR}/Shared/Model/WKStageModeOrbitSimulator.swift
+    ${WEBKIT_DIR}/UIProcess/API/Cocoa/Logger+Extras.swift
+    ${WEBKIT_DIR}/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/Foundation+Extras.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/Separated/CALayer+CoreRE.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/Separated/WKSeparatedImageView.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/Separated/WKSeparatedImageView+Analysis.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/Separated/WKSeparatedImageView+Generation.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/Separated/WKSeparatedImageView+Rendering.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/Separated/WKSeparatedImageView+Surface.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/Separated/WKSeparatedImageViewConstants.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/WebPageWebView.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/WKScrollGeometryAdapter.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/WKTextEffectManager+VersionCheck.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift
+    ${WEBKIT_DIR}/UIProcess/WKMouseDeviceObserver.swift
+)
+
+set(_log_defines "${FEATURE_DEFINES_WITH_SPACE_SEPARATOR} ENABLE_STREAMING_IPC_IN_LOG_FORWARDING")
+add_custom_command(
+    OUTPUT ${_log_messages_generated}
+    DEPENDS
+        ${WEBKIT_DIR}/Scripts/generate-derived-log-sources.py
+        ${WEBCORE_DIR}/Scripts/generate-log-declarations.py
+        ${_log_messages_inputs}
+    COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${WEBCORE_DIR}/Scripts"
+        ${PYTHON_EXECUTABLE} ${WEBKIT_DIR}/Scripts/generate-derived-log-sources.py
+        ${_log_messages_inputs}
+        ${_log_messages_generated}
+        "${_log_defines}"
+    WORKING_DIRECTORY ${WebKit_DERIVED_SOURCES_DIR}
+    VERBATIM
+)
+
+file(GLOB _webkit_ios_serialization_files RELATIVE "${WEBKIT_DIR}"
+    "${WEBKIT_DIR}/Shared/ios/*.serialization.in"
+)
+list(APPEND WebKit_SERIALIZATION_IN_FILES ${_webkit_ios_serialization_files})
+unset(_webkit_ios_serialization_files)
+
+list(APPEND WebKit_SERIALIZATION_IN_FILES
+    Shared/KeyEventInterpretationContext.serialization.in
+    Shared/UserInterfaceIdiom.serialization.in
+)
+
+find_library(POWERLOG_LIBRARY PowerLog HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
+if (POWERLOG_LIBRARY)
+    list(APPEND WebKit_PRIVATE_LIBRARIES "-weak_framework PowerLog")
+endif ()
+
+list(APPEND WebKit_PRIVATE_FRAMEWORK_HEADERS ${WebKit_PUBLIC_FRAMEWORK_HEADERS})
+set(WebKit_PUBLIC_FRAMEWORK_HEADERS "")
+
+list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
+    Shared/API/Cocoa/WKDataDetectorTypes.h
+    Shared/API/Cocoa/WKFoundation.h
+    Shared/API/Cocoa/WebKit.apinotes
+    Shared/API/Cocoa/WebKit.h
+
+    UIProcess/API/Cocoa/NSAttributedString.h
+    UIProcess/API/Cocoa/WKBackForwardList.h
+    UIProcess/API/Cocoa/WKBackForwardListItem.h
+    UIProcess/API/Cocoa/WKContentRuleList.h
+    UIProcess/API/Cocoa/WKContentRuleListStore.h
+    UIProcess/API/Cocoa/WKContentWorld.h
+    UIProcess/API/Cocoa/WKContentWorldConfiguration.h
+    UIProcess/API/Cocoa/WKContextMenuElementInfo.h
+    UIProcess/API/Cocoa/WKDownload.h
+    UIProcess/API/Cocoa/WKDownloadDelegate.h
+    UIProcess/API/Cocoa/WKError.h
+    UIProcess/API/Cocoa/WKFindConfiguration.h
+    UIProcess/API/Cocoa/WKFindResult.h
+    UIProcess/API/Cocoa/WKFrameInfo.h
+    UIProcess/API/Cocoa/WKHTTPCookieStore.h
+    UIProcess/API/Cocoa/WKNavigation.h
+    UIProcess/API/Cocoa/WKNavigationAction.h
+    UIProcess/API/Cocoa/WKNavigationDelegate.h
+    UIProcess/API/Cocoa/WKNavigationResponse.h
+    UIProcess/API/Cocoa/WKOpenPanelParameters.h
+    UIProcess/API/Cocoa/WKPDFConfiguration.h
+    UIProcess/API/Cocoa/WKPreferences.h
+    UIProcess/API/Cocoa/WKPreviewActionItem.h
+    UIProcess/API/Cocoa/WKPreviewActionItemIdentifiers.h
+    UIProcess/API/Cocoa/WKPreviewElementInfo.h
+    UIProcess/API/Cocoa/WKProcessPool.h
+    UIProcess/API/Cocoa/WKScriptMessage.h
+    UIProcess/API/Cocoa/WKScriptMessageHandler.h
+    UIProcess/API/Cocoa/WKScriptMessageHandlerWithReply.h
+    UIProcess/API/Cocoa/WKSecurityOrigin.h
+    UIProcess/API/Cocoa/WKSnapshotConfiguration.h
+    UIProcess/API/Cocoa/WKUIDelegate.h
+    UIProcess/API/Cocoa/WKURLSchemeHandler.h
+    UIProcess/API/Cocoa/WKURLSchemeTask.h
+    UIProcess/API/Cocoa/WKUserContentController.h
+    UIProcess/API/Cocoa/WKUserScript.h
+    UIProcess/API/Cocoa/WKWebView.h
+    UIProcess/API/Cocoa/WKWebViewConfiguration.h
+    UIProcess/API/Cocoa/WKWebpagePreferences.h
+    UIProcess/API/Cocoa/WKWebsiteDataRecord.h
+    UIProcess/API/Cocoa/WKWebsiteDataStore.h
+    UIProcess/API/Cocoa/WKWindowFeatures.h
+
+    ${CMAKE_CURRENT_BINARY_DIR}/WebKitLegacy.h
+)
+
+list(APPEND WebKit_PRIVATE_FRAMEWORK_HEADERS
+    Platform/spi/ios/UIKitSPI.h
+
+    Shared/API/Cocoa/RemoteObjectInvocation.h
+    Shared/API/Cocoa/RemoteObjectRegistry.h
+    Shared/API/Cocoa/WKBrowsingContextHandle.h
+    Shared/API/Cocoa/WKDragDestinationAction.h
+    Shared/API/Cocoa/WKMain.h
+    Shared/API/Cocoa/WKRemoteObject.h
+    Shared/API/Cocoa/WKRemoteObjectCoder.h
+    Shared/API/Cocoa/WebKitPrivate.h
+    Shared/API/Cocoa/_WKFrameHandle.h
+    Shared/API/Cocoa/_WKHitTestResult.h
+    Shared/API/Cocoa/_WKNSFileManagerExtras.h
+    Shared/API/Cocoa/_WKNSWindowExtras.h
+    Shared/API/Cocoa/_WKRemoteObjectInterface.h
+    Shared/API/Cocoa/_WKRemoteObjectRegistry.h
+    Shared/API/Cocoa/_WKRenderingProgressEvents.h
+    Shared/API/Cocoa/_WKSameDocumentNavigationType.h
+
+    Shared/API/c/cf/WKErrorCF.h
+    Shared/API/c/cf/WKStringCF.h
+    Shared/API/c/cf/WKURLCF.h
+
+    Shared/API/c/cg/WKImageCG.h
+
+    Shared/API/c/mac/WKBaseMac.h
+    Shared/API/c/mac/WKCertificateInfoMac.h
+    Shared/API/c/mac/WKObjCTypeWrapperRef.h
+    Shared/API/c/mac/WKURLRequestNS.h
+    Shared/API/c/mac/WKURLResponseNS.h
+    Shared/API/c/mac/WKWebArchiveRef.h
+    Shared/API/c/mac/WKWebArchiveResource.h
+
+    Shared/mac/SecItemRequestData.h
+    Shared/mac/SecItemResponseData.h
+
+    UIProcess/API/C/mac/WKContextPrivateMac.h
+    UIProcess/API/C/mac/WKInspectorPrivateMac.h
+    UIProcess/API/C/mac/WKNotificationPrivateMac.h
+    UIProcess/API/C/mac/WKPagePrivateMac.h
+    UIProcess/API/C/mac/WKProtectionSpaceNS.h
+    UIProcess/API/C/mac/WKWebsiteDataStoreRefPrivateMac.h
+
+    UIProcess/API/Cocoa/NSAttributedStringPrivate.h
+    UIProcess/API/Cocoa/PageLoadStateObserver.h
+    UIProcess/API/Cocoa/WKBackForwardListItemPrivate.h
+    UIProcess/API/Cocoa/WKBackForwardListPrivate.h
+    UIProcess/API/Cocoa/WKBrowsingContextController.h
+    UIProcess/API/Cocoa/WKBrowsingContextControllerPrivate.h
+    UIProcess/API/Cocoa/WKBrowsingContextGroup.h
+    UIProcess/API/Cocoa/WKBrowsingContextGroupPrivate.h
+    UIProcess/API/Cocoa/WKBrowsingContextHistoryDelegate.h
+    UIProcess/API/Cocoa/WKBrowsingContextLoadDelegate.h
+    UIProcess/API/Cocoa/WKBrowsingContextLoadDelegatePrivate.h
+    UIProcess/API/Cocoa/WKBrowsingContextPolicyDelegate.h
+    UIProcess/API/Cocoa/WKContentRuleListPrivate.h
+    UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h
+    UIProcess/API/Cocoa/WKContentWorldPrivate.h
+    UIProcess/API/Cocoa/WKContextMenuElementInfoPrivate.h
+    UIProcess/API/Cocoa/WKErrorPrivate.h
+    UIProcess/API/Cocoa/WKFrameInfoPrivate.h
+    UIProcess/API/Cocoa/WKHTTPCookieStorePrivate.h
+    UIProcess/API/Cocoa/WKHistoryDelegatePrivate.h
+    UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
+    UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.h
+    UIProcess/API/Cocoa/WKNavigationActionPrivate.h
+    UIProcess/API/Cocoa/WKNavigationData.h
+    UIProcess/API/Cocoa/WKNavigationDelegatePrivate.h
+    UIProcess/API/Cocoa/WKNavigationPrivate.h
+    UIProcess/API/Cocoa/WKNavigationResponsePrivate.h
+    UIProcess/API/Cocoa/WKOpenPanelParametersPrivate.h
+    UIProcess/API/Cocoa/WKPreferencesPrivate.h
+    UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+    UIProcess/API/Cocoa/WKSecurityOriginPrivate.h
+    UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+    UIProcess/API/Cocoa/WKURLSchemeTaskPrivate.h
+    UIProcess/API/Cocoa/WKUserContentControllerPrivate.h
+    UIProcess/API/Cocoa/WKUserScriptPrivate.h
+    UIProcess/API/Cocoa/WKWebArchive.h
+    UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+    UIProcess/API/Cocoa/WKWebViewPrivate.h
+    UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+    UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+    UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
+    UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+    UIProcess/API/Cocoa/WKWindowFeaturesPrivate.h
+    UIProcess/API/Cocoa/_WKActivatedElementInfo.h
+    UIProcess/API/Cocoa/_WKAppHighlight.h
+    UIProcess/API/Cocoa/_WKAppHighlightDelegate.h
+    UIProcess/API/Cocoa/_WKApplicationManifest.h
+    UIProcess/API/Cocoa/_WKAttachment.h
+    UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h
+    UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.h
+    UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.h
+    UIProcess/API/Cocoa/_WKAuthenticatorAttachment.h
+    UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.h
+    UIProcess/API/Cocoa/_WKAuthenticatorResponse.h
+    UIProcess/API/Cocoa/_WKAuthenticatorSelectionCriteria.h
+    UIProcess/API/Cocoa/_WKAutomationDelegate.h
+    UIProcess/API/Cocoa/_WKAutomationSession.h
+    UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.h
+    UIProcess/API/Cocoa/_WKAutomationSessionDelegate.h
+    UIProcess/API/Cocoa/_WKContentRuleListAction.h
+    UIProcess/API/Cocoa/_WKContextMenuElementInfo.h
+    UIProcess/API/Cocoa/_WKCustomHeaderFields.h
+    UIProcess/API/Cocoa/_WKDiagnosticLoggingDelegate.h
+    UIProcess/API/Cocoa/_WKDownload.h
+    UIProcess/API/Cocoa/_WKDownloadDelegate.h
+    UIProcess/API/Cocoa/_WKElementAction.h
+    UIProcess/API/Cocoa/_WKErrorRecoveryAttempting.h
+    UIProcess/API/Cocoa/_WKExperimentalFeature.h
+    UIProcess/API/Cocoa/_WKFindDelegate.h
+    UIProcess/API/Cocoa/_WKFindOptions.h
+    UIProcess/API/Cocoa/_WKFocusedElementInfo.h
+    UIProcess/API/Cocoa/_WKFormInputSession.h
+    UIProcess/API/Cocoa/_WKFrameTreeNode.h
+    UIProcess/API/Cocoa/_WKFullscreenDelegate.h
+    UIProcess/API/Cocoa/_WKGeolocationCoreLocationProvider.h
+    UIProcess/API/Cocoa/_WKGeolocationPosition.h
+    UIProcess/API/Cocoa/_WKIconLoadingDelegate.h
+    UIProcess/API/Cocoa/_WKInputDelegate.h
+    UIProcess/API/Cocoa/_WKInspector.h
+    UIProcess/API/Cocoa/_WKInspectorConfiguration.h
+    UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.h
+    UIProcess/API/Cocoa/_WKInspectorDelegate.h
+    UIProcess/API/Cocoa/_WKInspectorExtension.h
+    UIProcess/API/Cocoa/_WKInspectorExtensionDelegate.h
+    UIProcess/API/Cocoa/_WKInspectorExtensionHost.h
+    UIProcess/API/Cocoa/_WKInspectorIBActions.h
+    UIProcess/API/Cocoa/_WKInspectorPrivate.h
+    UIProcess/API/Cocoa/_WKInspectorPrivateForTesting.h
+    UIProcess/API/Cocoa/_WKInspectorWindow.h
+    UIProcess/API/Cocoa/_WKInternalDebugFeature.h
+    UIProcess/API/Cocoa/_WKLayoutMode.h
+    UIProcess/API/Cocoa/_WKLinkIconParameters.h
+    UIProcess/API/Cocoa/_WKOverlayScrollbarStyle.h
+    UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.h
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialDescriptor.h
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialEntity.h
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialParameters.h
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialRelyingPartyEntity.h
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.h
+    UIProcess/API/Cocoa/_WKPublicKeyCredentialUserEntity.h
+    UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.h
+    UIProcess/API/Cocoa/_WKRemoteWebInspectorViewControllerPrivate.h
+    UIProcess/API/Cocoa/_WKResourceLoadDelegate.h
+    UIProcess/API/Cocoa/_WKResourceLoadInfo.h
+    UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstParty.h
+    UIProcess/API/Cocoa/_WKResourceLoadStatisticsThirdParty.h
+    UIProcess/API/Cocoa/_WKSessionState.h
+    UIProcess/API/Cocoa/_WKSystemPreferences.h
+    UIProcess/API/Cocoa/_WKTapHandlingResult.h
+    UIProcess/API/Cocoa/_WKTextInputContext.h
+    UIProcess/API/Cocoa/_WKTextManipulationConfiguration.h
+    UIProcess/API/Cocoa/_WKTextManipulationDelegate.h
+    UIProcess/API/Cocoa/_WKTextManipulationExclusionRule.h
+    UIProcess/API/Cocoa/_WKTextManipulationItem.h
+    UIProcess/API/Cocoa/_WKTextManipulationToken.h
+    UIProcess/API/Cocoa/_WKThumbnailView.h
+    UIProcess/API/Cocoa/_WKUserContentWorld.h
+    UIProcess/API/Cocoa/_WKUserInitiatedAction.h
+    UIProcess/API/Cocoa/_WKUserStyleSheet.h
+    UIProcess/API/Cocoa/_WKUserVerificationRequirement.h
+    UIProcess/API/Cocoa/_WKVisitedLinkStore.h
+    UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.h
+    UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
+    UIProcess/API/Cocoa/_WKWebAuthenticationPanelForTesting.h
+    UIProcess/API/Cocoa/_WKWebsiteDataSize.h
+    UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+    UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
+
+    UIProcess/Cocoa/WKContactPicker.h
+    UIProcess/Cocoa/WKShareSheet.h
+    UIProcess/Cocoa/_WKCaptionStyleMenuController.h
+
+    UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
+    UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h
+
+    WebKitSwift/Preview/WKPreviewWindowController.h
+
+    WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.h
+    WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h
+
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessBundleParameters.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInEditingDelegate.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFormDelegatePrivate.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFramePrivate.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInLoadDelegate.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandlePrivate.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInPageGroup.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.h
+    WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.h
+
+    WebProcess/InjectedBundle/API/mac/WKDOMDocument.h
+    WebProcess/InjectedBundle/API/mac/WKDOMElement.h
+    WebProcess/InjectedBundle/API/mac/WKDOMInternals.h
+    WebProcess/InjectedBundle/API/mac/WKDOMNode.h
+    WebProcess/InjectedBundle/API/mac/WKDOMNodePrivate.h
+    WebProcess/InjectedBundle/API/mac/WKDOMRange.h
+    WebProcess/InjectedBundle/API/mac/WKDOMRangePrivate.h
+    WebProcess/InjectedBundle/API/mac/WKDOMText.h
+    WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.h
+    WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.h
+    WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.h
+    WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextControllerPrivate.h
+    WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInPrivate.h
+)
+
+file(GLOB _webkit_api_headers RELATIVE "${WEBKIT_DIR}"
+    "${WEBKIT_DIR}/GPUProcess/graphics/Model/*.h"
+    "${WEBKIT_DIR}/Shared/API/Cocoa/*.h"
+    "${WEBKIT_DIR}/UIProcess/API/Cocoa/*.h"
+    "${WEBKIT_DIR}/UIProcess/API/ios/*.h"
+    "${WEBKIT_DIR}/UIProcess/DigitalCredentials/*.h"
+    "${WEBKIT_DIR}/UIProcess/ios/fullscreen/*.h"
+    "${WEBKIT_DIR}/WebKitSwift/IdentityDocumentServices/*.h"
+)
+list(APPEND WebKit_PRIVATE_FRAMEWORK_HEADERS ${_webkit_api_headers})
+unset(_webkit_api_headers)
+
+list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
+    UIProcess/API/Cocoa/WKFormInfo.h
+    UIProcess/API/Cocoa/WKImmersiveEnvironment.h
+    UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h
+    UIProcess/API/Cocoa/WKJSHandle.h
+    UIProcess/API/Cocoa/WKJSScriptingBuffer.h
+    UIProcess/API/Cocoa/WKJSSerializedNode.h
+    UIProcess/API/Cocoa/WKWebExtension.h
+    UIProcess/API/Cocoa/WKWebExtensionAction.h
+    UIProcess/API/Cocoa/WKWebExtensionCommand.h
+    UIProcess/API/Cocoa/WKWebExtensionContext.h
+    UIProcess/API/Cocoa/WKWebExtensionController.h
+    UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.h
+    UIProcess/API/Cocoa/WKWebExtensionControllerDelegate.h
+    UIProcess/API/Cocoa/WKWebExtensionDataRecord.h
+    UIProcess/API/Cocoa/WKWebExtensionDataType.h
+    UIProcess/API/Cocoa/WKWebExtensionMatchPattern.h
+    UIProcess/API/Cocoa/WKWebExtensionMessagePort.h
+    UIProcess/API/Cocoa/WKWebExtensionPermission.h
+    UIProcess/API/Cocoa/WKWebExtensionTab.h
+    UIProcess/API/Cocoa/WKWebExtensionTabConfiguration.h
+    UIProcess/API/Cocoa/WKWebExtensionWindow.h
+    UIProcess/API/Cocoa/WKWebExtensionWindowConfiguration.h
+)
+
+set(_internal_headers ${WebKit_PUBLIC_FRAMEWORK_HEADERS})
+list(FILTER _internal_headers INCLUDE REGEX "Internal\\.h$")
+list(APPEND WebKit_PRIVATE_FRAMEWORK_HEADERS ${_internal_headers})
+list(FILTER WebKit_PUBLIC_FRAMEWORK_HEADERS EXCLUDE REGEX "Internal\\.h$")
+unset(_internal_headers)
+
+file(GLOB _webkit_ios_impl_headers RELATIVE "${WEBKIT_DIR}"
+    "${WEBKIT_DIR}/UIProcess/ios/*.h"
+    "${WEBKIT_DIR}/UIProcess/ios/forms/*.h"
+)
+list(APPEND WebKit_PRIVATE_FRAMEWORK_HEADERS ${_webkit_ios_impl_headers})
+unset(_webkit_ios_impl_headers)
+
+list(REMOVE_DUPLICATES WebKit_PUBLIC_FRAMEWORK_HEADERS)
+list(REMOVE_DUPLICATES WebKit_PRIVATE_FRAMEWORK_HEADERS)
+
+
+list(APPEND WebKit_PRIVATE_FRAMEWORK_HEADERS
+    ${CMAKE_SOURCE_DIR}/Source/WebKitLegacy/ios/WebCoreSupport/WebSelectionRect.h
+    ${CMAKE_SOURCE_DIR}/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.h
+    ${CMAKE_SOURCE_DIR}/Source/WebKitLegacy/mac/WebView/WebFeature.h
+)
+
+# FIXME: Re-export all WebKitLegacy headers. https://bugs.webkit.org/show_bug.cgi?id=312083
+
+configure_file(${WEBKIT_DIR}/Modules/iOS.modulemap ${CMAKE_BINARY_DIR}/WebKit/Modules/module.modulemap COPYONLY)
+
+# FIXME: Generate module.private.modulemap. https://bugs.webkit.org/show_bug.cgi?id=312083
+
+make_directory("${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework")
+
+set(_webkit_swiftmodule_dir "${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftmodule")
+make_directory(${_webkit_swiftmodule_dir})
+set(_webkit_swift_output "${CMAKE_BINARY_DIR}/Source/WebKit")
+set(_webkit_swift_arch "${CMAKE_OSX_ARCHITECTURES}")
+if (NOT _webkit_swift_arch)
+    if (_is_simulator)
+        set(_webkit_swift_arch "arm64")
+    else ()
+        set(_webkit_swift_arch "arm64e")
+    endif ()
+endif ()
+if (CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
+    set(_webkit_swift_triple "${_webkit_swift_arch}-apple-ios-simulator")
+else ()
+    set(_webkit_swift_triple "${_webkit_swift_arch}-apple-ios")
+endif ()
+set(WebKit_POST_BUILD_COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+        "${_webkit_swift_output}/WebKit.swiftmodule"
+        "${_webkit_swiftmodule_dir}/${_webkit_swift_triple}.swiftmodule"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${_webkit_swift_output}/WebKit.swiftdoc"
+        "${_webkit_swiftmodule_dir}/${_webkit_swift_triple}.swiftdoc"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${_webkit_swift_output}/WebKit.abi.json"
+        "${_webkit_swiftmodule_dir}/${_webkit_swift_triple}.abi.json"
+    COMMAND sh -c "[ -f '${_webkit_swift_output}/WebKit.swiftinterface' ] && ${CMAKE_COMMAND} -E copy_if_different '${_webkit_swift_output}/WebKit.swiftinterface' '${_webkit_swiftmodule_dir}/${_webkit_swift_triple}.swiftinterface' || true"
+    COMMAND sh -c "[ -f '${_webkit_swift_output}/WebKit.private.swiftinterface' ] && ${CMAKE_COMMAND} -E copy_if_different '${_webkit_swift_output}/WebKit.private.swiftinterface' '${_webkit_swiftmodule_dir}/${_webkit_swift_triple}.private.swiftinterface' || true"
+)
+
+make_directory("${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftcrossimport")
+file(WRITE "${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftcrossimport/SwiftUI.swiftoverlay"
+"---\nversion: 1\nmodules:\n- name: _WebKit_SwiftUI\n")
+
+target_link_options(WebKit PRIVATE
+    "SHELL:-weak_framework BrowserEngineKit"
+    "SHELL:-weak_framework CoreML"
+    "SHELL:-weak_framework CorePrediction"
+    "SHELL:-weak_framework NaturalLanguage"
+    -Wl,-sectcreate,__TEXT,__info_plist,${CMAKE_CURRENT_BINARY_DIR}/WebKit-Info.plist
+)
+
+if (CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
+    target_link_options(WebKit PRIVATE "SHELL:-L${CMAKE_OSX_SYSROOT}/usr/local/lib/dyld" "SHELL:-Wl,-hidden-lsandbox-static")
+else ()
+    target_link_options(WebKit PRIVATE -lsandbox)
+endif ()
+
+add_dependencies(WebKit WebKitLegacy)
+target_link_options(WebKit PRIVATE
+    "-Wl,-reexport_library,$<TARGET_LINKER_FILE:WebKitLegacy>"
+)
+
+set(_wk_framework_dir ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework)
+
+set(_wk_assets_staging "${CMAKE_CURRENT_BINARY_DIR}/WebKit-Assets")
+set(_wk_xcassets
+    ${WEBKIT_DIR}/Resources/SafeBrowsing.xcassets
+    ${WEBKIT_DIR}/HTTPSBrowsingWarning.xcassets
+    ${WEBKIT_DIR}/Resources/ios/iOS.xcassets
+)
+if (CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
+    set(_actool_platform "iphonesimulator")
+else ()
+    set(_actool_platform "iphoneos")
+endif ()
+add_custom_command(
+    OUTPUT ${_wk_assets_staging}/Assets.car
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${_wk_assets_staging}
+    COMMAND xcrun actool --compile ${_wk_assets_staging}
+        --platform ${_actool_platform} --minimum-deployment-target ${CMAKE_OSX_DEPLOYMENT_TARGET}
+        ${_wk_xcassets}
+    DEPENDS ${_wk_xcassets}
+    COMMENT "Compiling WebKit asset catalogs"
+    VERBATIM)
+add_custom_target(WebKit_Assets DEPENDS ${_wk_assets_staging}/Assets.car)
+add_dependencies(WebKit WebKit_Assets)
+
+function(WEBKIT_EMBED_EXTENSION _host_target _ext_name _host_bundle_id)
+    set(options CHANGE_EXTENSION_POINT ADD_ATS)
+    cmake_parse_arguments(ARG "${options}" "" "" ${ARGN})
+
+    set(_dst_plist "$<TARGET_FILE_DIR:${_host_target}>/Extensions/${_ext_name}.appex/Info.plist")
+
+    add_custom_command(TARGET ${_host_target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+            "$<TARGET_FILE_DIR:${_host_target}>/Extensions"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf
+            "$<TARGET_FILE_DIR:${_host_target}>/Extensions/${_ext_name}.appex"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${_ext_name}.appex"
+            "$<TARGET_FILE_DIR:${_host_target}>/Extensions/${_ext_name}.appex"
+        COMMAND /usr/libexec/PlistBuddy -c
+            "Set :CFBundleIdentifier ${_host_bundle_id}.${_ext_name}"
+            "${_dst_plist}"
+        COMMENT "Embedding ${_ext_name} in ${_host_target}")
+
+    if (ARG_CHANGE_EXTENSION_POINT)
+        add_custom_command(TARGET ${_host_target} POST_BUILD
+            COMMAND /usr/libexec/PlistBuddy -c
+                "Set :EXAppExtensionAttributes:EXExtensionPointIdentifier com.apple.web-browser-engine.content"
+                "${_dst_plist}")
+    endif ()
+
+    if (ARG_ADD_ATS)
+        add_custom_command(TARGET ${_host_target} POST_BUILD
+            COMMAND /usr/libexec/PlistBuddy -c
+                "Add :NSAppTransportSecurity dict"
+                "${_dst_plist}"
+            COMMAND /usr/libexec/PlistBuddy -c
+                "Add :NSAppTransportSecurity:NSAllowsArbitraryLoads bool true"
+                "${_dst_plist}")
+    endif ()
+
+    add_custom_command(TARGET ${_host_target} POST_BUILD
+        COMMAND codesign --force --sign -
+            "$<TARGET_FILE_DIR:${_host_target}>/Extensions/${_ext_name}.appex")
+endfunction()
+
+function(WEBKIT_DEFINE_XPC_SERVICES)
+    set(WebKit_XPC_SERVICE_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+
+    if (CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
+        set(_is_simulator TRUE)
+    else ()
+        set(_is_simulator FALSE)
+    endif ()
+
+    set(_default_sim_entitlements "${WEBKIT_DIR}/Resources/ios/XPCService-embedded-simulator.entitlements")
+
+    set(_wka_entitlements_dir "")
+    if (WEBKIT_ADDITIONS_INCLUDE_PATH AND EXISTS "${WEBKIT_ADDITIONS_INCLUDE_PATH}/WebKitAdditions/Entitlements")
+        set(_wka_entitlements_dir "${WEBKIT_ADDITIONS_INCLUDE_PATH}/WebKitAdditions/Entitlements")
+    endif ()
+
+    function(WEBKIT_RESOLVE_ENTITLEMENTS _result _filename)
+        if (_wka_entitlements_dir AND EXISTS "${_wka_entitlements_dir}/${_filename}")
+            set(${_result} "${_wka_entitlements_dir}/${_filename}" PARENT_SCOPE)
+        else ()
+            set(${_result} "${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/${_filename}" PARENT_SCOPE)
+        endif ()
+    endfunction()
+
+    set(_der_script "${CMAKE_CURRENT_BINARY_DIR}/generate_der_entitlements.py")
+    file(WRITE ${_der_script} "
+import plistlib, sys
+with open(sys.argv[1], 'rb') as f:
+    ents = plistlib.load(f)
+def dl(n):
+    return bytes([n]) if n < 128 else (bytes([0x81, n]) if n < 256 else bytes([0x82, (n>>8)&0xff, n&0xff]))
+entries = b''
+for k, v in sorted(ents.items()):
+    e = bytes([0x0c]) + dl(len(k)) + k.encode() + bytes([0x01, 0x01, 0xff if v else 0x00])
+    entries += bytes([0x30]) + dl(len(e)) + e
+ctx = bytes([0xb0]) + dl(len(entries)) + entries
+inner = bytes([0x02, 0x01, 0x01]) + ctx
+with open(sys.argv[2], 'wb') as f:
+    f.write(bytes([0x70]) + dl(len(inner)) + inner)
+")
+    function(WEBKIT_GENERATE_DER_ENTITLEMENTS _xml_path _der_output)
+        execute_process(
+            COMMAND ${PYTHON_EXECUTABLE} ${_der_script} "${_xml_path}" "${_der_output}")
+    endfunction()
+
+    set(_sim_get_task_allow "${CMAKE_CURRENT_BINARY_DIR}/XPCService-get-task-allow.entitlements")
+    file(WRITE ${_sim_get_task_allow}
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+        "<plist version=\"1.0\">\n"
+        "<dict>\n"
+        "\t<key>com.apple.security.get-task-allow</key>\n"
+        "\t<true/>\n"
+        "</dict>\n"
+        "</plist>\n"
+    )
+
+    string(REPLACE "." ";" _sdk_ver_parts "${CMAKE_OSX_DEPLOYMENT_TARGET}")
+    list(GET _sdk_ver_parts 0 _sdk_major)
+    list(GET _sdk_ver_parts 1 _sdk_minor)
+    math(EXPR _sdk_version_actual "${_sdk_major} * 10000 + ${_sdk_minor} * 100")
+    execute_process(COMMAND sw_vers -productVersion
+        OUTPUT_VARIABLE _host_os_ver OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+    string(REGEX MATCH "^([0-9]+)" _host_major "${_host_os_ver}")
+    math(EXPR _target_macos_major "${_host_major} * 10000")
+
+    function(WEBKIT_IOS_XPC_SERVICE _target _bundle_identifier _info_plist _executable_name _xpc_entitlements)
+        set(_service_dir ${WebKit_XPC_SERVICE_DIR}/${_bundle_identifier}.xpc)
+        make_directory(${_service_dir})
+
+        set(BUNDLE_VERSION ${MACOSX_FRAMEWORK_BUNDLE_VERSION})
+        set(SHORT_VERSION_STRING ${WEBKIT_MAC_VERSION})
+        set(EXECUTABLE_NAME ${_executable_name})
+        set(PRODUCT_BUNDLE_IDENTIFIER ${_bundle_identifier}.Service)
+        set(PRODUCT_NAME ${_bundle_identifier})
+        configure_file(${_info_plist} ${_service_dir}/Info.plist)
+
+        execute_process(COMMAND plutil -insert CFBundleSupportedPlatforms -json "[\"${WEBKIT_PLATFORM_NAME}\"]" ${_service_dir}/Info.plist)
+        execute_process(COMMAND plutil -insert UIDeviceFamily -json "[1]" ${_service_dir}/Info.plist)
+        execute_process(COMMAND plutil -insert MinimumOSVersion -string "${CMAKE_OSX_DEPLOYMENT_TARGET}" ${_service_dir}/Info.plist)
+        execute_process(COMMAND plutil -insert DTPlatformName -string "${WEBKIT_PLATFORM_NAME}" ${_service_dir}/Info.plist)
+
+        target_link_options(${_target} PRIVATE
+            -Wl,-rpath,@executable_path/..
+            -Wl,-dyld_env,DYLD_FRAMEWORK_PATH=@executable_path/..
+            -Wl,-dyld_env,DYLD_LIBRARY_PATH=@executable_path/..
+        )
+
+        if (_is_simulator)
+            set(_xpc_der "${CMAKE_CURRENT_BINARY_DIR}/${_bundle_identifier}.entitlements.der")
+            WEBKIT_GENERATE_DER_ENTITLEMENTS(${_default_sim_entitlements} ${_xpc_der})
+            target_link_options(${_target} PRIVATE
+                -Wl,-sectcreate,__TEXT,__entitlements,${_default_sim_entitlements}
+                -Wl,-sectcreate,__TEXT,__ents_der,${_xpc_der})
+        endif ()
+
+        target_link_libraries(${_target} PRIVATE
+            "-framework Foundation"
+            "-framework CoreFoundation"
+        )
+
+        add_custom_command(TARGET ${_target} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E rm -f
+                "${_service_dir}/${_executable_name}"
+            COMMAND ${CMAKE_COMMAND} -E copy
+                "$<TARGET_FILE:${_target}>"
+                "${_service_dir}/${_executable_name}"
+            COMMENT "Copying ${_executable_name} into ${_bundle_identifier}.xpc")
+
+        if (_is_simulator)
+            add_custom_command(TARGET ${_target} POST_BUILD
+                COMMAND codesign --force --sign -
+                    --timestamp=none --generate-entitlement-der
+                    --entitlements ${_sim_get_task_allow}
+                    "${_service_dir}"
+                COMMENT "Codesigning ${_bundle_identifier}.xpc (simulator)")
+        else ()
+            add_custom_command(TARGET ${_target} POST_BUILD
+                COMMAND codesign --force --sign -
+                    --timestamp=none --generate-entitlement-der
+                    --entitlements ${_xpc_entitlements}
+                    "${_service_dir}"
+                COMMENT "Codesigning ${_bundle_identifier}.xpc (device)")
+        endif ()
+    endfunction()
+
+    WEBKIT_RESOLVE_ENTITLEMENTS(_webcontent_xpc_ents "WebContentXPCService.entitlements")
+    WEBKIT_IOS_XPC_SERVICE(WebProcess
+        "com.apple.WebKit.WebContent"
+        ${WEBKIT_DIR}/WebProcess/EntryPoint/Cocoa/XPCService/WebContentService/Info-iOS.plist
+        ${WebProcess_OUTPUT_NAME}
+        ${_webcontent_xpc_ents})
+
+    WEBKIT_RESOLVE_ENTITLEMENTS(_networking_xpc_ents "NetworkingXPCService.entitlements")
+    WEBKIT_IOS_XPC_SERVICE(NetworkProcess
+        "com.apple.WebKit.Networking"
+        ${WEBKIT_DIR}/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkService/Info-iOS.plist
+        ${NetworkProcess_OUTPUT_NAME}
+        ${_networking_xpc_ents})
+
+    if (ENABLE_GPU_PROCESS)
+        WEBKIT_RESOLVE_ENTITLEMENTS(_gpu_xpc_ents "GPUXPCService.entitlements")
+        WEBKIT_IOS_XPC_SERVICE(GPUProcess
+            "com.apple.WebKit.GPU"
+            ${WEBKIT_DIR}/GPUProcess/EntryPoint/Cocoa/XPCService/GPUService/Info-iOS.plist
+            ${GPUProcess_OUTPUT_NAME}
+            ${_gpu_xpc_ents})
+    endif ()
+
+    function(WEBKIT_IOS_WEBCONTENT_VARIANT _variant)
+        set(_target WebProcess${_variant})
+        set(_exec_name com.apple.WebKit.WebContent.${_variant}.Development)
+        add_executable(${_target} ${WebProcess_SOURCES})
+        target_link_libraries(${_target} PRIVATE WebKit)
+        target_include_directories(${_target} PRIVATE
+            ${CMAKE_BINARY_DIR}
+            $<TARGET_PROPERTY:WebKit,INCLUDE_DIRECTORIES>)
+        target_compile_options(${_target} PRIVATE -Wno-unused-parameter)
+        set_target_properties(${_target} PROPERTIES OUTPUT_NAME ${_exec_name})
+        WEBKIT_IOS_XPC_SERVICE(${_target}
+            "com.apple.WebKit.WebContent.${_variant}"
+            ${WEBKIT_DIR}/WebProcess/EntryPoint/Cocoa/XPCService/WebContentService/Info-iOS.plist
+            ${_exec_name}
+            ${_webcontent_xpc_ents})
+    endfunction()
+    WEBKIT_IOS_WEBCONTENT_VARIANT(EnhancedSecurity)
+    WEBKIT_IOS_WEBCONTENT_VARIANT(CaptivePortal)
+
+    add_custom_command(TARGET WebKit POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${WebKit_FRAMEWORK_HEADERS_DIR}/WebKit
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Headers
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${WebKit_PRIVATE_FRAMEWORK_HEADERS_DIR}/WebKit
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/PrivateHeaders
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_BINARY_DIR}/WebKit/Modules
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Modules
+        COMMENT "Populating WebKit.framework Headers/, PrivateHeaders/, and Modules/")
+
+    add_custom_command(TARGET WebKit POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E rm -f
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/WebKit.emit-module.d
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/WebKit.swiftdeps
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_CURRENT_BINARY_DIR}/WebKit-Info.plist
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Info.plist
+        COMMENT "Cleaning WebKit.framework build artifacts")
+
+    add_custom_command(TARGET WebKit POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/en.lproj
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${WEBKIT_DIR}/en.lproj/InfoPlist.strings
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/en.lproj/InfoPlist.strings
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${WEBKIT_DIR}/Resources/ResourceLoadStatistics/corePrediction_model
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/corePrediction_model
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${_wk_assets_staging}/Assets.car
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Assets.car
+        COMMAND ${CMAKE_COMMAND} -E rm -rf
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Resources
+        COMMAND ${CMAKE_COMMAND} -E rm -rf
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Versions
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/XPCServices
+        COMMAND ${CMAKE_COMMAND} -E create_symlink ../../com.apple.WebKit.Networking.xpc
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/XPCServices/com.apple.WebKit.Networking.xpc
+        COMMAND ${CMAKE_COMMAND} -E create_symlink ../../com.apple.WebKit.WebContent.xpc
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/XPCServices/com.apple.WebKit.WebContent.xpc
+        COMMAND ${CMAKE_COMMAND} -E create_symlink ../../com.apple.WebKit.WebContent.CaptivePortal.xpc
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/XPCServices/com.apple.WebKit.WebContent.CaptivePortal.xpc
+        COMMAND ${CMAKE_COMMAND} -E create_symlink ../../com.apple.WebKit.WebContent.EnhancedSecurity.xpc
+            ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/XPCServices/com.apple.WebKit.WebContent.EnhancedSecurity.xpc
+        COMMAND codesign --force --sign - ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework
+        COMMENT "Installing WebKit.framework resources and codesigning")
+
+    if (ENABLE_GPU_PROCESS)
+        add_custom_command(TARGET WebKit POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E create_symlink ../../com.apple.WebKit.GPU.xpc
+                ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/XPCServices/com.apple.WebKit.GPU.xpc)
+    endif ()
+
+    function(WEBKIT_IOS_EXTENSION _name _bundle_id _info_plist _swift_source _entitlements)
+        set(_appex_dir ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${_name}.appex)
+        set(_executable_name ${_bundle_id})
+        make_directory(${_appex_dir})
+
+        set(BUNDLE_VERSION ${MACOSX_FRAMEWORK_BUNDLE_VERSION})
+        set(EXECUTABLE_NAME ${_executable_name})
+        set(PRODUCT_BUNDLE_IDENTIFIER ${_bundle_id})
+        set(PRODUCT_BUNDLE_NAME ${_name})
+        configure_file(${_info_plist} ${_appex_dir}/Info.plist)
+
+        # Add platform keys required by runningboardd/ExtensionKit validation.
+        execute_process(COMMAND plutil -insert CFBundleSupportedPlatforms -json "[\"${WEBKIT_PLATFORM_NAME}\"]" ${_appex_dir}/Info.plist)
+        execute_process(COMMAND plutil -insert UIDeviceFamily -json "[1,2]" ${_appex_dir}/Info.plist)
+        execute_process(COMMAND plutil -insert MinimumOSVersion -string "${CMAKE_OSX_DEPLOYMENT_TARGET}" ${_appex_dir}/Info.plist)
+        execute_process(COMMAND plutil -insert DTPlatformName -string "${WEBKIT_PLATFORM_NAME}" ${_appex_dir}/Info.plist)
+
+        add_executable(${_name} ${_swift_source})
+        add_dependencies(${_name} WebKit)
+
+        set_target_properties(${_name} PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${_appex_dir}"
+            OUTPUT_NAME "${_executable_name}"
+            Swift_MODULE_NAME "${_name}"
+            MACOSX_BUNDLE FALSE
+        )
+
+        target_compile_options(${_name} PRIVATE
+            "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-import-objc-header ${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/CMakeExtensionBridge.h>"
+            "$<$<COMPILE_LANGUAGE:Swift>:-parse-as-library>"
+            "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-swift-version 6>"
+            "$<$<COMPILE_LANGUAGE:Swift>:-application-extension>"
+        )
+
+        target_link_libraries(${_name} PRIVATE
+            "-F${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+            "-framework WebKit"
+            "-framework BrowserEngineKit"
+            "-framework ExtensionFoundation"
+            "-framework Foundation"
+        )
+
+        target_link_options(${_name} PRIVATE
+            -Wl,-rpath,@loader_path/../../Frameworks
+            -Wl,-rpath,@loader_path/../..
+            -Wl,-e,_NSExtensionMain
+        )
+
+        # Simulator: embed only. Device: embed and pass to codesign.
+        set(_ext_der "${CMAKE_CURRENT_BINARY_DIR}/${_name}.entitlements.der")
+        WEBKIT_GENERATE_DER_ENTITLEMENTS(${_entitlements} ${_ext_der})
+        target_link_options(${_name} PRIVATE
+            -Wl,-sectcreate,__TEXT,__entitlements,${_entitlements}
+            -Wl,-sectcreate,__TEXT,__ents_der,${_ext_der})
+
+        if (_is_simulator)
+            add_custom_command(TARGET ${_name} POST_BUILD
+                COMMAND codesign --force --sign -
+                    --timestamp=none --generate-entitlement-der
+                    "${_appex_dir}"
+                COMMENT "Codesigning ${_name}.appex (simulator)")
+        else ()
+            add_custom_command(TARGET ${_name} POST_BUILD
+                COMMAND codesign --force --sign -
+                    --timestamp=none --generate-entitlement-der
+                    --entitlements ${_entitlements}
+                    "${_appex_dir}"
+                COMMENT "Codesigning ${_name}.appex (device)")
+        endif ()
+    endfunction()
+
+    WEBKIT_RESOLVE_ENTITLEMENTS(_webcontent_ext_ents "WebContentProcessExtension.entitlements")
+    WEBKIT_IOS_EXTENSION(WebContentExtension
+        "com.apple.WebKit.WebContent"
+        ${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist
+        ${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift
+        ${_webcontent_ext_ents})
+
+    WEBKIT_IOS_EXTENSION(WebContentEnhancedSecurityExtension
+        "com.apple.WebKit.WebContent.EnhancedSecurity"
+        ${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/WebContentExtension-EnhancedSecurity-Info.plist
+        ${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift
+        ${_webcontent_ext_ents})
+
+    WEBKIT_IOS_EXTENSION(WebContentCaptivePortalExtension
+        "com.apple.WebKit.WebContent.CaptivePortal"
+        ${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist
+        ${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift
+        ${_webcontent_ext_ents})
+
+    WEBKIT_RESOLVE_ENTITLEMENTS(_networking_ext_ents "NetworkingProcessExtension.entitlements")
+    WEBKIT_IOS_EXTENSION(NetworkingExtension
+        "com.apple.WebKit.Networking"
+        ${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist
+        ${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift
+        ${_networking_ext_ents})
+
+    if (ENABLE_GPU_PROCESS)
+        WEBKIT_RESOLVE_ENTITLEMENTS(_gpu_ext_ents "GPUProcessExtension.entitlements")
+        WEBKIT_IOS_EXTENSION(GPUExtension
+            "com.apple.WebKit.GPU"
+            ${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist
+            ${WEBKIT_DIR}/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift
+            ${_gpu_ext_ents})
+    endif ()
+
+    set(_sb_profiles_dir "${WEBKIT_DIR}/Resources/SandboxProfiles/ios")
+    set(_sb_output_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Resources")
+    make_directory(${_sb_output_dir})
+
+    set(_sb_include_flags
+        -I ${WEBKIT_DIR}
+        -I ${WTF_FRAMEWORK_HEADERS_DIR}
+        -I ${bmalloc_FRAMEWORK_HEADERS_DIR}
+    )
+    if (WEBKIT_ADDITIONS_INCLUDE_PATH)
+        list(APPEND _sb_include_flags -I ${WEBKIT_ADDITIONS_INCLUDE_PATH})
+    endif ()
+    if (WEBKIT_ADDITIONS_COMPILE_PATH)
+        list(APPEND _sb_include_flags -I ${WEBKIT_ADDITIONS_COMPILE_PATH})
+    endif ()
+    if (EXISTS "${CMAKE_BINARY_DIR}/generated-stubs")
+        list(APPEND _sb_include_flags -I ${CMAKE_BINARY_DIR}/generated-stubs)
+    endif ()
+
+    set(WebKit_SB_FILES "")
+    foreach (_sb_profile
+        com.apple.WebKit.WebContent.Development
+        com.apple.WebKit.Networking.Development
+        com.apple.WebKit.GPU.Development)
+        add_custom_command(
+            OUTPUT ${_sb_output_dir}/${_sb_profile}.sb
+            COMMAND grep -o "^[^;]*" ${_sb_profiles_dir}/${_sb_profile}.sb.in |
+                    xcrun clang -E -P -w -include wtf/Platform.h ${_sb_include_flags} - >
+                    ${_sb_output_dir}/${_sb_profile}.sb
+            DEPENDS ${_sb_profiles_dir}/${_sb_profile}.sb.in
+            COMMENT "Compiling sandbox profile ${_sb_profile}.sb"
+            VERBATIM)
+        list(APPEND WebKit_SB_FILES ${_sb_output_dir}/${_sb_profile}.sb)
+    endforeach ()
+    add_custom_target(WebKitIOSSandboxProfiles ALL DEPENDS ${WebKit_SB_FILES})
+    add_dependencies(WebKit WebKitIOSSandboxProfiles)
+
+    add_custom_target(WebKitPostBuild ALL
+        COMMAND ${CMAKE_COMMAND}
+            -DSRC=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/WebKit.dSYM
+            -DDST=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework.dSYM
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/MoveDirectory.cmake
+        COMMENT "Moving WebKit.framework dSYM to adjacent directory")
+    add_dependencies(WebKitPostBuild WebKit WebProcess NetworkProcess
+        WebProcessEnhancedSecurity WebProcessCaptivePortal)
+endfunction()
+
+# libWebKitSwift
+
+set(_wks_dir "${WEBKIT_DIR}/WebKitSwift")
+
+add_library(WebKitSwift SHARED
+    ${_wks_dir}/WebKitSwift.swift
+    ${_wks_dir}/AVKit/WKSExperienceController.swift
+    ${_wks_dir}/CredentialUpdaterShim.swift
+    ${_wks_dir}/GroupActivities/WKGroupSession.swift
+    ${_wks_dir}/IdentityDocumentServices/ISO18013MobileDocumentRequest+Extras.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentRawRequest.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentRequest.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentResponse.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.swift
+    ${_wks_dir}/LinearMediaKit/LinearMediaPlayer.swift
+    ${_wks_dir}/LinearMediaKit/LinearMediaTypes.swift
+    ${_wks_dir}/MarketplaceKit/WKMarketplaceKit.swift
+    ${_wks_dir}/Preview/WKPreviewWindowController.swift
+    ${_wks_dir}/RealityKit/WKRKEntity.swift
+    ${_wks_dir}/StageMode/WKStageMode.swift
+    ${_wks_dir}/TextAnimation/WKTextAnimationManagerIOS.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentError.mm
+)
+
+set_target_properties(WebKitSwift PROPERTIES
+    OUTPUT_NAME WebKitSwift
+    PREFIX "lib"
+    SUFFIX ".dylib"
+    Swift_MODULE_NAME WebKitSwift
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Frameworks"
+)
+
+target_include_directories(WebKitSwift PRIVATE
+    ${_wks_dir}
+    ${_wks_dir}/AVKit
+    ${_wks_dir}/GroupActivities
+    ${_wks_dir}/IdentityDocumentServices
+    ${_wks_dir}/LinearMediaKit
+    ${_wks_dir}/MarketplaceKit
+    ${_wks_dir}/Preview
+    ${_wks_dir}/RealityKit
+    ${_wks_dir}/StageMode
+    ${_wks_dir}/TextAnimation
+    ${_wks_dir}/WritingTools
+    ${WEBKIT_DIR}
+    ${WEBKIT_DIR}/Shared/Model
+    ${WEBKIT_DIR}/GPUProcess/graphics/Model
+    ${CMAKE_BINARY_DIR}
+    ${WTF_FRAMEWORK_HEADERS_DIR}
+    ${bmalloc_FRAMEWORK_HEADERS_DIR}
+)
+
+target_compile_options(WebKitSwift PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:-parse-as-library>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-swift-version 6>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MATERIAL_HOSTING>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MOUSE_DEVICE_OBSERVATION>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DENABLE_WRITING_TOOLS>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_DIGITAL_CREDENTIALS_UI>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MARKETPLACE_KIT>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_CREDENTIAL_UPDATE_API>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-cross-import-overlays>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"WK_IOS_TBA:iOS ${CMAKE_OSX_DEPLOYMENT_TARGET}\">"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"WK_MAC_TBA:macOS 9999\">"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"WK_XROS_TBA:visionOS 9999\">"
+    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa/Modules>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/ios>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DHAVE_CONFIG_H=1>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DBUILDING_WITH_CMAKE=1>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${CMAKE_BINARY_DIR}>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${WTF_FRAMEWORK_HEADERS_DIR}>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${bmalloc_FRAMEWORK_HEADERS_DIR}>"
+)
+
+target_compile_options(WebKitSwift PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX,OBJCXX>:-std=c++2b>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-DHAVE_CONFIG_H=1>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-DBUILDING_WITH_CMAKE=1>"
+)
+
+target_compile_options(WebKitSwift PRIVATE
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CMAKE_BINARY_DIR}>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-I${WebKit_FRAMEWORK_HEADERS_DIR}>"
+    ${WEBKIT_PRIVATE_FRAMEWORKS_COMPILE_FLAG}
+)
+
+target_link_libraries(WebKitSwift PRIVATE WebKit)
+add_dependencies(WebKitSwift WebKit)
+
+unset(_wks_dir)
+
+# _WebKit_SwiftUI
+
+set(_swiftui_dir "${WEBKIT_DIR}/_WebKit_SwiftUI")
+
+add_library(_WebKit_SwiftUI SHARED
+    ${_swiftui_dir}/CrossImportOverlay.swift
+    ${_swiftui_dir}/Empty.swift
+    ${_swiftui_dir}/API/View+WebViewModifiers.swift
+    ${_swiftui_dir}/API/WebPage+SwiftUI.swift
+    ${_swiftui_dir}/API/WebPageNavigationAction+SwiftUI.swift
+    ${_swiftui_dir}/API/WebView.swift
+    ${_swiftui_dir}/Implementation/CocoaWebViewAdapter.swift
+    ${_swiftui_dir}/Implementation/EnvironmentValues+Extras.swift
+    ${_swiftui_dir}/Implementation/Foundation+Extras.swift
+    ${_swiftui_dir}/Implementation/PlatformTextSearching.swift
+    ${_swiftui_dir}/Implementation/SwiftUI+Extras.swift
+    ${_swiftui_dir}/Implementation/ViewModifierContexts.swift
+    ${_swiftui_dir}/Implementation/WebViewRepresentable.swift
+)
+
+if (ENABLE_MODEL_ELEMENT_IMMERSIVE)
+    target_sources(_WebKit_SwiftUI PRIVATE
+        ${_swiftui_dir}/API/WebViewImmersiveEnvironmentView.swift
+    )
+endif ()
+
+set_target_properties(_WebKit_SwiftUI PROPERTIES
+    OUTPUT_NAME _WebKit_SwiftUI
+    FRAMEWORK TRUE
+    MACOSX_FRAMEWORK_IDENTIFIER com.apple.WebKit._webkit_swiftui
+    Swift_MODULE_NAME _WebKit_SwiftUI
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+)
+
+target_compile_options(_WebKit_SwiftUI PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:-parse-as-library>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-swift-version 5>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-DENABLE_SWIFTUI>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"WK_IOS_TBA:iOS ${CMAKE_OSX_DEPLOYMENT_TARGET}\">"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"WK_MAC_TBA:macOS 9999\">"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"WK_XROS_TBA:visionOS 9999\">"
+    "$<$<COMPILE_LANGUAGE:Swift>:-F${CMAKE_OSX_SYSROOT}/System/Cryptexes/OS/System/Library/Frameworks>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa/Modules>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/ios>"
+    ${WEBKIT_PRIVATE_FRAMEWORKS_COMPILE_FLAG}
+)
+
+target_link_libraries(_WebKit_SwiftUI PRIVATE
+    "-framework SwiftUI"
+    "-framework Foundation"
+)
+
+target_link_options(_WebKit_SwiftUI PRIVATE
+    "-F${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+    "-framework" "WebKit"
+)
+
+add_dependencies(_WebKit_SwiftUI WebKit)
+
+set(_swiftui_module_output "${CMAKE_BINARY_DIR}/Source/WebKit")
+set(_swiftui_arch "${CMAKE_OSX_ARCHITECTURES}")
+if (NOT _swiftui_arch)
+    if (_is_simulator)
+        set(_swiftui_arch "arm64")
+    else ()
+        set(_swiftui_arch "arm64e")
+    endif ()
+endif ()
+if (CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
+    set(_swiftui_triple "${_swiftui_arch}-apple-ios-simulator")
+else ()
+    set(_swiftui_triple "${_swiftui_arch}-apple-ios")
+endif ()
+set(_swiftui_module_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/_WebKit_SwiftUI.framework/Modules/_WebKit_SwiftUI.swiftmodule")
+add_custom_command(TARGET _WebKit_SwiftUI POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${_swiftui_module_dir}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${_swiftui_module_output}/_WebKit_SwiftUI.swiftmodule"
+        "${_swiftui_module_dir}/${_swiftui_triple}.swiftmodule"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${_swiftui_module_output}/_WebKit_SwiftUI.swiftdoc"
+        "${_swiftui_module_dir}/${_swiftui_triple}.swiftdoc"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${_swiftui_module_output}/_WebKit_SwiftUI.abi.json"
+        "${_swiftui_module_dir}/${_swiftui_triple}.abi.json"
+    COMMAND codesign --force --sign - "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/_WebKit_SwiftUI.framework"
+)
+
+unset(_swiftui_dir)

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -1,34 +1,24 @@
-# -ObjC++ only for .mm unified sources. Applying it to .cpp files causes ambiguity
-# errors (WebCore::Pattern vs QuickDraw::Pattern, WebCore::IOSurface vs IOSurface ObjC class)
-# when `using namespace WebCore;` pulls WebCore names into the global scope alongside SDK ObjC types.
-add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-std=c++2b>" "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-D__STDC_WANT_LIB_EXT1__>")
+include(PlatformCocoa.cmake)
+
 find_library(APPLICATIONSERVICES_LIBRARY ApplicationServices)
 find_library(CARBON_LIBRARY Carbon)
 find_library(CORESERVICES_LIBRARY CoreServices)
-find_library(NETWORK_LIBRARY Network)
-find_library(SECURITY_LIBRARY Security)
 find_library(SECURITYINTERFACE_LIBRARY SecurityInterface)
 find_library(QUARTZ_LIBRARY Quartz)
-find_library(UNIFORMTYPEIDENTIFIERS_LIBRARY UniformTypeIdentifiers)
-find_library(AVFOUNDATION_LIBRARY AVFoundation)
 find_library(AVFAUDIO_LIBRARY AVFAudio HINTS ${AVFOUNDATION_LIBRARY}/Versions/*/Frameworks)
-find_library(DEVICEIDENTITY_LIBRARY DeviceIdentity HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
 add_compile_options(
     "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${QUARTZ_LIBRARY}/Frameworks>"
     "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CARBON_LIBRARY}/Frameworks>"
     "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${APPLICATIONSERVICES_LIBRARY}/Versions/Current/Frameworks>"
 )
-add_definitions(-DWK_XPC_SERVICE_SUFFIX=".Development")
-
-# Match Xcode's BaseTarget.xcconfig WEBKIT_BUNDLE_VERSION. XPC child processes compare this
-# at launch; empty string crashes (crashDueWebKitFrameworkVersionMismatch).
-add_definitions(-DWEBKIT_BUNDLE_VERSION="${WEBKIT_MAC_VERSION}")
-
-set(MACOSX_FRAMEWORK_IDENTIFIER com.apple.WebKit)
+list(APPEND WebKit_COMPILE_OPTIONS
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${QUARTZ_LIBRARY}/Frameworks>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CARBON_LIBRARY}/Frameworks>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${APPLICATIONSERVICES_LIBRARY}/Versions/Current/Frameworks>"
+)
 
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CORESERVICES_LIBRARY}/Versions/Current/Frameworks>")
-
-include(Headers.cmake)
+list(APPEND WebKit_COMPILE_OPTIONS "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CORESERVICES_LIBRARY}/Versions/Current/Frameworks>")
 
 list(APPEND WebKit_PRIVATE_LIBRARIES
     Accessibility
@@ -44,163 +34,30 @@ if (NOT AVFAUDIO_LIBRARY-NOTFOUND)
     list(APPEND WebKit_LIBRARIES ${AVFAUDIO_LIBRARY})
 endif ()
 
-list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
-    "SourcesCocoa.txt"
-
-    "Platform/SourcesCocoa.txt"
-)
+list(APPEND WebKit_PRIVATE_LIBRARIES "-weak_framework PowerLog")
 
 list(APPEND WebKit_SOURCES
-    GPUProcess/media/RemoteAudioDestinationManager.cpp
-
-    NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
-    NetworkProcess/cocoa/WebSocketTaskCocoa.mm
-
     NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm
-
-    NetworkProcess/webrtc/NetworkRTCProvider.cpp
-    NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
-    NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
-    NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
-
-    NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
-
-    Platform/IPC/cocoa/SharedFileHandleCocoa.cpp
-
-    Shared/API/Cocoa/WKMain.mm
-
-    Shared/Cocoa/DefaultWebBrowserChecks.mm
-    Shared/Cocoa/XPCEndpoint.mm
-    Shared/Cocoa/XPCEndpointClient.mm
-
-    UIProcess/API/Cocoa/WKContentWorld.mm
-    UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.mm
-    UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm
-    UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.mm
-    UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.mm
-    UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm
-    UIProcess/API/Cocoa/_WKAuthenticatorSelectionCriteria.mm
-    UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.mm
-    UIProcess/API/Cocoa/_WKPublicKeyCredentialDescriptor.mm
-    UIProcess/API/Cocoa/_WKPublicKeyCredentialEntity.mm
-    UIProcess/API/Cocoa/_WKPublicKeyCredentialParameters.mm
-    UIProcess/API/Cocoa/_WKPublicKeyCredentialRelyingPartyEntity.mm
-    UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.mm
-    UIProcess/API/Cocoa/_WKPublicKeyCredentialUserEntity.mm
-    UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstParty.mm
-    UIProcess/API/Cocoa/_WKResourceLoadStatisticsThirdParty.mm
-
-    UIProcess/Cocoa/PreferenceObserver.mm
-    UIProcess/Cocoa/WKShareSheet.mm
-    UIProcess/Cocoa/WKStorageAccessAlert.mm
-    UIProcess/Cocoa/WebInspectorPreferenceObserver.mm
 
     UIProcess/PDF/WKPDFHUDView.mm
     ${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.swift
-    UIProcess/PDF/WKPDFPageNumberIndicator.mm
-
     ${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.swift
 
-    ${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKTextExtraction.swift
-
     WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm
-
-    WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
-
-    WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
-    WebProcess/cocoa/LaunchServicesDatabaseManager.mm
 )
 
 list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
-    "${CMAKE_BINARY_DIR}/libwebrtc/PrivateHeaders"
     "${ICU_INCLUDE_DIRS}"
-    "${WEBKIT_DIR}/GPUProcess/graphics/Model"
     "${WEBKIT_DIR}/GPUProcess/mac"
-    "${WEBKIT_DIR}/GPUProcess/media/cocoa"
-    "${WEBKIT_DIR}/NetworkProcess/cocoa"
     "${WEBKIT_DIR}/NetworkProcess/mac"
-    "${WEBKIT_DIR}/NetworkProcess/PrivateClickMeasurement/cocoa"
     "${WEBKIT_DIR}/UIProcess/mac"
-    "${WEBKIT_DIR}/UIProcess/API/C/mac"
-    "${WEBKIT_DIR}/UIProcess/API/Cocoa"
     "${WEBKIT_DIR}/UIProcess/API/mac"
-    "${WEBKIT_DIR}/UIProcess/Authentication/cocoa"
-    "${WEBKIT_DIR}/UIProcess/Cocoa"
-    "${WEBKIT_DIR}/UIProcess/Cocoa/SOAuthorization"
-    "${WEBKIT_DIR}/UIProcess/Cocoa/TextExtraction"
-    "${WEBKIT_DIR}/UIProcess/Extensions/Cocoa"
-    "${WEBKIT_DIR}/UIProcess/Inspector/Cocoa"
     "${WEBKIT_DIR}/UIProcess/Inspector/mac"
-    "${WEBKIT_DIR}/UIProcess/Launcher/mac"
-    "${WEBKIT_DIR}/UIProcess/Media/cocoa"
-    "${WEBKIT_DIR}/UIProcess/Notifications/cocoa"
-    "${WEBKIT_DIR}/UIProcess/PDF"
-    "${WEBKIT_DIR}/UIProcess/RemoteLayerTree"
-    "${WEBKIT_DIR}/UIProcess/RemoteLayerTree/cocoa"
     "${WEBKIT_DIR}/UIProcess/RemoteLayerTree/mac"
-    "${WEBKIT_DIR}/UIProcess/ios"
-    "${WEBKIT_DIR}/UIProcess/WebAuthentication/Cocoa"
-    "${WEBKIT_DIR}/UIProcess/WebAuthentication/Virtual"
-    "${WEBKIT_DIR}/UIProcess/WebsiteData/Cocoa"
-    "${WEBKIT_DIR}/Platform/cg"
-    "${WEBKIT_DIR}/Platform/classifier"
-    "${WEBKIT_DIR}/Platform/classifier/cocoa"
-    "${WEBKIT_DIR}/Platform/cocoa"
-    "${WEBKIT_DIR}/Platform/ios"
-    "${WEBKIT_DIR}/Platform/mac"
-    "${WEBKIT_DIR}/Platform/unix"
-    # WebKitSwift headers imported by Cocoa .mm files (WKMarketplaceKit.h, WKIntelligence*.h,
-    # WKIdentityDocument*.h). These are the ObjC-side interface headers to the Swift modules --
-    # they self-guard with feature checks, safe to include-path them.
-    "${WEBKIT_DIR}/WebKitSwift/MarketplaceKit"
-    "${WEBKIT_DIR}/WebKitSwift/WritingTools"
-    "${WEBKIT_DIR}/Platform/spi/Cocoa"
-    "${WEBKIT_DIR}/Platform/spi/mac"
-    "${WEBKIT_DIR}/Platform/IPC/darwin"
-    "${WEBKIT_DIR}/Platform/IPC/mac"
-    "${WEBKIT_DIR}/Platform/IPC/cocoa"
-    "${WEBKIT_DIR}/Platform/spi/ios"
-    "${WEBKIT_DIR}/Shared/API/Cocoa"
-    "${WEBKIT_DIR}/Shared/API/c/cf"
-    "${WEBKIT_DIR}/Shared/API/c/cg"
-    "${WEBKIT_DIR}/Shared/API/c/mac"
-    "${WEBKIT_DIR}/Shared/ApplePay/cocoa/"
-    "${WEBKIT_DIR}/Shared/Authentication/cocoa"
-    "${WEBKIT_DIR}/Shared/cf"
-    "${WEBKIT_DIR}/Shared/Cocoa"
-    "${WEBKIT_DIR}/Shared/Daemon"
-    "${WEBKIT_DIR}/Shared/EntryPointUtilities/Cocoa/Daemon"
-    "${WEBKIT_DIR}/Shared/EntryPointUtilities/Cocoa/XPCService"
+    # WebKitSwift ObjC interface headers — self-guard with feature checks.
     "${WEBKIT_DIR}/Shared/mac"
-    "${WEBKIT_DIR}/Shared/Scrolling"
-    "${WEBKIT_DIR}/UIProcess/Cocoa/GroupActivities"
-    "${WEBKIT_DIR}/UIProcess/Media"
-    "${WEBKIT_DIR}/UIProcess/WebAuthentication/fido"
-    "${WEBKIT_DIR}/WebProcess/DigitalCredentials"
-    "${WEBKIT_DIR}/WebProcess/WebAuthentication"
-    "${WEBKIT_DIR}/WebProcess/cocoa"
-    "${WEBKIT_DIR}/WebProcess/cocoa/IdentityDocumentServices"
-    "${WEBKIT_DIR}/WebProcess/Extensions/Cocoa"
-    "${WEBKIT_DIR}/WebKitSwift/IdentityDocumentServices"
-    "${WEBKIT_DIR}/WebProcess/mac"
-    "${WEBKIT_DIR}/WebProcess/GPU/graphics/cocoa"
-    "${WEBKIT_DIR}/WebProcess/Inspector/mac"
-    "${WEBKIT_DIR}/WebProcess/InjectedBundle/API/Cocoa"
-    "${WEBKIT_DIR}/WebProcess/InjectedBundle/API/mac"
-    "${WEBKIT_DIR}/WebProcess/MediaSession"
-    "${WEBKIT_DIR}/WebProcess/Model/mac"
-    "${WEBKIT_DIR}/WebProcess/Plugins/PDF"
-    "${WEBKIT_DIR}/WebProcess/Plugins/PDF/UnifiedPDF"
-    "${WEBKIT_DIR}/WebProcess/WebPage/Cocoa"
-    "${WEBKIT_DIR}/WebProcess/WebPage/RemoteLayerTree"
-    "${WEBKIT_DIR}/WebProcess/WebPage/mac"
-    "${WEBKIT_DIR}/WebProcess/WebCoreSupport/cocoa"
     "${WEBKIT_DIR}/WebProcess/WebCoreSupport/mac"
-    "${WEBKIT_DIR}/webpushd"
-    "${WEBKIT_DIR}/webpushd/webpushtool"
-    # <webrtc/webkit_sdk/WebKit/CMBaseObjectSPI.h> -- Apple SPI headers in libwebrtc's overlay.
-    # Referenced with the full webrtc/ prefix even when USE(LIBWEBRTC) is off.
-    "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source"
+    "${WEBKIT_DIR}/WebProcess/Model/mac"
     "${WEBKITLEGACY_DIR}"
     "${WebKitLegacy_FRAMEWORK_HEADERS_DIR}"
 )
@@ -227,23 +84,10 @@ set(GPUProcess_SOURCES
     ${XPCService_SOURCES}
 )
 
-# FIXME: These should not have Development in production builds.
-set(WebProcess_OUTPUT_NAME com.apple.WebKit.WebContent.Development)
-set(NetworkProcess_OUTPUT_NAME com.apple.WebKit.Networking.Development)
-set(GPUProcess_OUTPUT_NAME com.apple.WebKit.GPU.Development)
-
 set(WebProcess_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR})
 set(NetworkProcess_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR})
 
-# Generate a simplified module map for Swift interop.
-# The source-tree module.modulemap includes many C++ submodules with deep header
-# dependencies (WEBCORE_EXPORT, API::Object, etc.) that fail in CMake's explicit
-# module build context. We generate a stripped-down map that only includes the
-# submodules needed by the Swift files compiled in this CMake build.
-#
-# Public API headers (WKWebView.h, _WKTextExtraction*.h) use WK_API_AVAILABLE
-# macros from WKFoundation.h. These resolve via -Xcc -I${WebKit_FRAMEWORK_HEADERS_DIR}
-# which points to the copied framework headers where WKFoundation.h is colocated.
+# Stripped-down module map for Swift — full map's C++ submodules fail in CMake's explicit module context.
 set(WebKit_CMAKE_MODULEMAP_DIR "${CMAKE_BINARY_DIR}/WebKit/SwiftModules")
 file(MAKE_DIRECTORY "${WebKit_CMAKE_MODULEMAP_DIR}")
 file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap"
@@ -275,18 +119,10 @@ file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap"
 ")
 set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WebKit_CMAKE_MODULEMAP_DIR}")
 
-# SPI .swiftinterface modules (SwiftUI_SPI, AVKit_SPI, etc.) live under
-# Platform/spi/. These paths mirror Xcode's SWIFT_INCLUDE_PATHS setting.
-set(WebKit_SWIFT_INCLUDE_DIRECTORIES
-    "${WEBKIT_DIR}/Platform/spi/Cocoa"
-    "${WEBKIT_DIR}/Platform/spi/Cocoa/Modules"
-    "${WEBKIT_DIR}/Platform/spi/ios"
-)
-
-# HAVE_MATERIAL_HOSTING is a PlatformHave.h preprocessor flag (macOS 16+),
-# not a CMake define. SWIFT_EXTRA_OPTIONS and SWIFT_INCLUDE_DIRECTORIES only
-# affect the typecheck custom command. Mirror everything to target_compile_options
-# so the actual Swift compilation sees the same flags.
+# Mirror flags to target_compile_options so native Swift compilation matches typecheck.
+# Xcode does not set SWIFT_TREAT_WARNINGS_AS_ERRORS; override CMake's -warnings-as-errors.
+# Must go in WebKit_COMPILE_OPTIONS (applied after -warnings-as-errors in _WEBKIT_TARGET_SETUP).
+list(APPEND WebKit_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:Swift>:-no-warnings-as-errors>")
 target_compile_options(WebKit PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MATERIAL_HOSTING>"
     "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa>"
@@ -308,94 +144,6 @@ set(WebKit_SWIFT_EXTRA_OPTIONS
     -Xcc -I${ICU_INCLUDE_DIRS}
 )
 
-# webpushd entry points are standalone daemon executables, not part of the
-# framework. WKMain.mm references them, so provide stubs that return error.
-file(WRITE "${CMAKE_BINARY_DIR}/WebKit/WebPushDaemonStubs.cpp"
-"#include \"config.h\"\n#if ENABLE(WEB_PUSH_NOTIFICATIONS)\nnamespace WebKit {\nint WebPushDaemonMain(int, char**) { return 1; }\nint WebPushToolMain(int, char**) { return 1; }\n}\n#endif\n")
-list(APPEND WebKit_SOURCES "${CMAKE_BINARY_DIR}/WebKit/WebPushDaemonStubs.cpp")
-
-set(WebKit_FORWARDING_HEADERS_FILES
-    Platform/cocoa/WKCrashReporter.h
-
-    Shared/API/c/WKDiagnosticLoggingResultType.h
-
-    UIProcess/API/C/WKPageDiagnosticLoggingClient.h
-    UIProcess/API/C/WKPageNavigationClient.h
-    UIProcess/API/C/WKPageRenderingProgressEvents.h
-)
-
-list(APPEND WebKit_MESSAGES_IN_FILES
-    GPUProcess/media/RemoteImageDecoderAVFProxy
-
-    ModelProcess/cocoa/ModelProcessModelPlayerProxy
-
-    GPUProcess/media/ios/RemoteMediaSessionHelperProxy
-
-    GPUProcess/webrtc/UserMediaCaptureManagerProxy
-
-    NetworkProcess/CustomProtocols/LegacyCustomProtocolManager
-
-    Shared/API/Cocoa/RemoteObjectRegistry
-
-    Shared/ApplePay/WebPaymentCoordinatorProxy
-
-    UIProcess/ViewGestureController
-
-    UIProcess/Cocoa/PlaybackSessionManagerProxy
-    UIProcess/Cocoa/VideoPresentationManagerProxy
-
-    UIProcess/Inspector/WebInspectorUIExtensionControllerProxy
-
-    UIProcess/Media/AudioSessionRoutingArbitratorProxy
-
-    UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy
-
-    UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy
-
-    UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy
-
-    UIProcess/ios/SmartMagnificationController
-    UIProcess/ios/WebDeviceOrientationUpdateProviderProxy
-
-    UIProcess/mac/SecItemShimProxy
-
-    WebProcess/ApplePay/WebPaymentCoordinator
-
-    WebProcess/GPU/media/RemoteImageDecoderAVFManager
-
-    WebProcess/GPU/media/ios/RemoteMediaSessionHelper
-
-    WebProcess/Inspector/WebInspectorUIExtensionController
-
-    WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider
-
-    WebProcess/WebPage/ViewGestureGeometryCollector
-    WebProcess/WebPage/ViewUpdateDispatcher
-
-    WebProcess/WebPage/Cocoa/TextCheckingControllerProxy
-
-    WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator
-
-    WebProcess/cocoa/PlaybackSessionManager
-    WebProcess/cocoa/RemoteCaptureSampleManager
-    WebProcess/cocoa/UserMediaCaptureManager
-    WebProcess/cocoa/VideoPresentationManager
-)
-
-# LogStream uses two-stage generation: LogMessages.in -> LogStream.messages.in -> LogStreamMessageReceiver.cpp.
-# Stage 1 runs generate-derived-log-sources.py (Xcode's DerivedSources.make equivalent).
-
-set(_log_messages_inputs
-    ${WEBKIT_DIR}/Platform/LogMessages.in
-    ${WEBCORE_DIR}/platform/LogMessages.in
-)
-set(_log_messages_generated
-    ${WebKit_DERIVED_SOURCES_DIR}/LogStream.messages.in
-    ${WebKit_DERIVED_SOURCES_DIR}/LogMessagesDeclarations.h
-    ${WebKit_DERIVED_SOURCES_DIR}/LogMessagesImplementations.h
-    ${WebKit_DERIVED_SOURCES_DIR}/WebKitLogClientDeclarations.h
-    ${WebKit_DERIVED_SOURCES_DIR}/WebCoreLogClientDeclarations.h
-)
 add_custom_command(
     OUTPUT ${_log_messages_generated}
     DEPENDS
@@ -411,134 +159,12 @@ add_custom_command(
     VERBATIM
 )
 
-# Stage 2: GENERATE_MESSAGE_SOURCES handles LogStream via the derived .messages.in path
-# fallback in CMakeLists.txt, so LogStream appears in the MessageNames enum.
-list(APPEND WebKit_MESSAGES_IN_FILES LogStream)
-
-# 49 serialization.in files in Shared/Cocoa + 10 in Shared/cf; the original list had 6. Each
-# unregistered file leaves its type forward-declared-only -> 'incomplete type' errors in
-# WebKitPlatformGeneratedSerializers.mm. Glob keeps this in sync as WebKit adds types.
-file(GLOB _webkit_cocoa_serialization_files RELATIVE "${WEBKIT_DIR}"
-    "${WEBKIT_DIR}/Shared/Cocoa/*.serialization.in"
-    "${WEBKIT_DIR}/Shared/cf/*.serialization.in"
-    "${WEBKIT_DIR}/Shared/mac/*.serialization.in"
-    "${WEBKIT_DIR}/Shared/RemoteLayerTree/*.serialization.in"
-    "${WEBKIT_DIR}/Shared/ApplePay/*.serialization.in"
-    "${WEBKIT_DIR}/WebProcess/WebPage/RemoteLayerTree/*.serialization.in"
-    "${WEBKIT_DIR}/Platform/cocoa/*.serialization.in"
-)
-list(APPEND WebKit_SERIALIZATION_IN_FILES ${_webkit_cocoa_serialization_files})
-unset(_webkit_cocoa_serialization_files)
-
-# Cocoa-only types in Shared/ not in the cross-platform base list. Can't glob
-# Shared/*.serialization.in -- it would duplicate base entries and double-register types.
-list(APPEND WebKit_SERIALIZATION_IN_FILES
-    Shared/AdditionalFonts.serialization.in
-    Shared/AlternativeTextClient.serialization.in
-    Shared/AppPrivacyReportTestingData.serialization.in
-    Shared/PushMessageForTesting.serialization.in
-    Shared/TextAnimationTypes.serialization.in
-    Shared/ViewWindowCoordinates.serialization.in
-)
-
-# PlaybackSessionModel.serialization.in is Cocoa-only; the cross-platform CMakeLists.txt omits it.
-list(APPEND WebCore_SERIALIZATION_IN_FILES
-    PlaybackSessionModel.serialization.in
-)
-
-# CoreIPC* and other .mm files compiled by .pbxproj directly, not via SourcesCocoa.txt.
-file(GLOB _webkit_missing_cocoa_sources RELATIVE "${WEBKIT_DIR}"
-    "${WEBKIT_DIR}/Shared/Cocoa/CoreIPC*.mm"
-    "${WEBKIT_DIR}/Shared/cf/CoreIPC*.mm"
-    # Shared/mac/CoreIPCDDSecureActionContext.mm already in SourcesCocoa.txt
-)
-list(APPEND WebKit_SOURCES ${_webkit_missing_cocoa_sources})
-unset(_webkit_missing_cocoa_sources)
 list(APPEND WebKit_SOURCES
-    NetworkProcess/cocoa/NetworkSoftLink.mm
-
-    Platform/cocoa/_WKWebViewTextInputNotifications.mm
-
-    Shared/AdditionalFonts.mm
-
-    Shared/Cocoa/AnnotatedMachSendRight.mm
-    Shared/Cocoa/ArgumentCodersCocoa.mm
-    Shared/Cocoa/BackgroundFetchStateCocoa.mm
-    Shared/Cocoa/CoreTextHelpers.mm
-    Shared/Cocoa/DataDetectionResult.mm
-    Shared/Cocoa/LaunchLogHook.mm
-    Shared/Cocoa/WKKeyedCoder.mm
-    Shared/Cocoa/WKProcessExtension.mm
-    Shared/Cocoa/WebKit2InitializeCocoa.mm
-    Shared/Cocoa/WebPushMessageCocoa.mm
-
-    UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
-    UIProcess/Cocoa/CSPExtensionUtilities.mm
-    UIProcess/Cocoa/_WKWarningView.mm
-
-    UIProcess/Downloads/DownloadProxyCocoa.mm
-
-    UIProcess/Extensions/WebExtensionCommand.cpp
-    UIProcess/Extensions/WebExtensionMenuItem.cpp
-
-    UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.mm
-
-    UIProcess/WebAuthentication/AuthenticatorManager.cpp
-
-    UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.mm
-    UIProcess/WebAuthentication/Cocoa/HidConnection.mm
-    UIProcess/WebAuthentication/Cocoa/HidService.mm
-    UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
-
-    UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.cpp
-    UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
-    UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp
-    UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.mm
-    UIProcess/WebAuthentication/Virtual/VirtualService.mm
-
-    UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
-    UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
-    UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
-
     UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm
     UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm
-
-    WebProcess/Inspector/ServiceWorkerDebuggableFrontendChannel.cpp
-    WebProcess/Inspector/ServiceWorkerDebuggableProxy.cpp
-
-    WebProcess/Network/WebMockContentFilterManager.cpp
-
-    WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
-
-    WebProcess/cocoa/TextTrackRepresentationCocoa.mm
-
-    webpushd/ApplePushServiceConnection.mm
-    webpushd/MockPushServiceConnection.mm
-    webpushd/PushClientConnection.mm
-    webpushd/PushService.mm
-    webpushd/PushServiceConnection.mm
-    webpushd/WebClipCache.mm
-    webpushd/WebPushDaemon.mm
-    webpushd/_WKMockUserNotificationCenter.mm
 )
 
-# Generated JSWebExtension*.mm IDL bindings need -fobjc-arc; route to WebKitARC.
-foreach (_file IN LISTS WebKit_BINDINGS_IN_FILES)
-    get_filename_component(_name ${_file} NAME_WE)
-    list(APPEND WebKit_ARC_SOURCES ${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.mm)
-    set_source_files_properties(${WebKit_DERIVED_SOURCES_DIR}/JS${_name}.mm PROPERTIES GENERATED TRUE)
-endforeach ()
-unset(_name)
-
-find_library(CRYPTOTOKENKIT_LIBRARY CryptoTokenKit)
-find_library(USERNOTIFICATIONS_LIBRARY UserNotifications)
-find_library(WRITINGTOOLS_LIBRARY WritingTools HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
-find_library(APPLEPUSHSERVICE_LIBRARY ApplePushService HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
 list(APPEND WebKit_PRIVATE_LIBRARIES
-    ${CRYPTOTOKENKIT_LIBRARY}
-    ${USERNOTIFICATIONS_LIBRARY}
-    ${WRITINGTOOLS_LIBRARY}
-    ${APPLEPUSHSERVICE_LIBRARY}
     "-weak_framework PowerLog"
 )
 # FIXME: Replace with targeted -U flags or explicit stubs.
@@ -552,14 +178,6 @@ list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
     Shared/API/Cocoa/RemoteObjectRegistry.h
     Shared/API/Cocoa/WKBrowsingContextHandle.h
     Shared/API/Cocoa/WKDataDetectorTypes.h
-
-    UIProcess/Cocoa/_WKCaptionStyleMenuController.h
-
-    UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
-    UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h
-
-    WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.h
-    WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h
     Shared/API/Cocoa/WKDragDestinationAction.h
     Shared/API/Cocoa/WKFoundation.h
     Shared/API/Cocoa/WKMain.h
@@ -774,6 +392,13 @@ list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
     UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
 
     UIProcess/Cocoa/WKShareSheet.h
+    UIProcess/Cocoa/_WKCaptionStyleMenuController.h
+
+    UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
+    UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.h
+
+    WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.h
+    WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h
 
     WebProcess/InjectedBundle/API/Cocoa/WKWebProcessBundleParameters.h
     WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.h
@@ -803,7 +428,6 @@ list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
     WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextControllerPrivate.h
     WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInPrivate.h
 )
-# WEBKIT_COPY_FILES symlinks on APPLE, so glob is safe (same inode avoids duplicate @interface).
 file(GLOB _webkit_api_headers RELATIVE "${WEBKIT_DIR}"
     "${WEBKIT_DIR}/UIProcess/API/Cocoa/*.h"
     "${WEBKIT_DIR}/Shared/API/Cocoa/*.h"
@@ -816,37 +440,6 @@ file(GLOB _webkit_api_headers RELATIVE "${WEBKIT_DIR}"
 list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS ${_webkit_api_headers})
 list(REMOVE_DUPLICATES WebKit_PUBLIC_FRAMEWORK_HEADERS)
 unset(_webkit_api_headers)
-
-set(WebKit_FORWARDING_HEADERS_DIRECTORIES
-    Platform
-    Shared
-
-    NetworkProcess/Downloads
-
-    Platform/IPC
-
-    Shared/API
-    Shared/Cocoa
-
-    Shared/API/Cocoa
-    Shared/API/c
-
-    Shared/API/c/cf
-    Shared/API/c/mac
-
-    UIProcess/Cocoa
-
-    UIProcess/API/C
-    UIProcess/API/Cocoa
-    UIProcess/API/cpp
-
-    UIProcess/API/C/Cocoa
-    UIProcess/API/C/mac
-
-    WebProcess/InjectedBundle/API/Cocoa
-    WebProcess/InjectedBundle/API/c
-    WebProcess/InjectedBundle/API/mac
-)
 
 # FIXME: Forwarding headers should be complete copies of the header.
 set(WebKitLegacyForwardingHeaders
@@ -861,9 +454,9 @@ set(WebKitLegacyForwardingHeaders
     WebCoreStatistics.h
     WebDOMOperations.h
     WebDOMOperationsPrivate.h
-    WebDatabaseManagerPrivate.h
     WebDataSource.h
     WebDataSourcePrivate.h
+    WebDatabaseManagerPrivate.h
     WebDefaultPolicyDelegate.h
     WebDeviceOrientation.h
     WebDeviceOrientationProviderMock.h
@@ -1070,6 +663,8 @@ target_link_options(WebKit PRIVATE
 
 set(WebKit_OUTPUT_NAME WebKit)
 
+target_link_options(WebKit PRIVATE -lsandbox)
+
 # XPC Services
 
 function(WEBKIT_DEFINE_XPC_SERVICES)
@@ -1077,8 +672,7 @@ function(WEBKIT_DEFINE_XPC_SERVICES)
     # or the XPC event handler never fires and WebContent hangs.
     set(RUNLOOP_TYPE NSRunLoop)
     set(WebKit_XPC_SERVICE_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Versions/A/XPCServices)
-    # Relative symlink (matches Xcode's framework layout). Absolute symlinks work for launchd
-    # but break if the build dir is moved/copied. Parent dir must exist for CREATE_LINK.
+    # Relative symlink (matches Xcode layout; absolute breaks if build dir is moved).
     make_directory("${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework")
     file(CREATE_LINK "Versions/Current/XPCServices"
                      "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/XPCServices" SYMBOLIC)
@@ -1118,9 +712,7 @@ function(WEBKIT_DEFINE_XPC_SERVICES)
             ${GPUProcess_OUTPUT_NAME})
     endif ()
 
-    # EnhancedSecurity and CaptivePortal WebContent variants -- without these XPC bundles,
-    # process swaps for enhanced security tracking or Lockdown Mode fail with
-    # "Invalid connection identifier" and navigation hangs.
+    # Without these XPC bundles, process swaps fail with "Invalid connection identifier".
     function(WEBKIT_WEBCONTENT_VARIANT _variant)
         set(_target WebProcess${_variant})
         set(_exec_name com.apple.WebKit.WebContent.${_variant}.Development)
@@ -1140,8 +732,6 @@ function(WEBKIT_DEFINE_XPC_SERVICES)
     WEBKIT_WEBCONTENT_VARIANT(CaptivePortal)
 
     set(WebKit_RESOURCES_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Versions/A/Resources)
-    # Sandbox profile preprocessing uses raw clang -E, which doesn't get cmake's
-    # add_compile_options. Build the same -isystem flags that OptionsMac.cmake sets.
     set(_sb_extra_includes "")
     file(GLOB _sb_additions "${CMAKE_SOURCE_DIR}/WebKitLibraries/SDKs/macosx*-additions.sdk/usr/local/include")
     list(SORT _sb_additions)
@@ -1155,12 +745,7 @@ function(WEBKIT_DEFINE_XPC_SERVICES)
     if (EXISTS "${CMAKE_BINARY_DIR}/generated-stubs/AppleFeatures/AppleFeatures.h")
         list(APPEND _sb_extra_includes "-isystem" "${CMAKE_BINARY_DIR}/generated-stubs")
     endif ()
-    # Sandbox profiles gate ASan-required syscalls (SYS_sigaltstack, ...) on
-    # #if ASAN_ENABLED, which wtf/Compiler.h derives from
-    # __has_feature(address_sanitizer). Pass -fsanitize so the preprocessor sees
-    # the same feature set the compiled code does -- mirrors $(SANITIZE_FLAGS) in
-    # DerivedSources.make. Without this the WebContent sandbox blocks
-    # sigaltstack() and ASan CHECK-fails inside __asan_handle_no_return.
+    # Pass -fsanitize so sandbox preprocessor sees __has_feature(address_sanitizer).
     if (ENABLE_SANITIZERS)
         foreach (_san IN LISTS ENABLE_SANITIZERS)
             list(APPEND _sb_extra_includes "-fsanitize=${_san}")
@@ -1198,11 +783,3 @@ function(WEBKIT_DEFINE_XPC_SERVICES)
     add_custom_target(WebContentProcessNib ALL DEPENDS ${WebKit_XPC_SERVICE_DIR}/com.apple.WebKit.WebContent.xpc/Contents/Resources/WebContentProcess.nib)
     add_dependencies(WebKit WebContentProcessNib)
 endfunction()
-
-set(WebKit_GENERATED_SERIALIZERS_SUFFIX mm)
-
-# SecureCoding codegen is Cocoa-only (includes ArgumentCodersCocoa.h).
-list(APPEND WebKit_DERIVED_SOURCES
-    ${WebKit_DERIVED_SOURCES_DIR}/GeneratedWebKitSecureCoding.h
-    ${WebKit_DERIVED_SOURCES_DIR}/GeneratedWebKitSecureCoding.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
-)

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/CMakeExtensionBridge.h
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/CMakeExtensionBridge.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#import <Foundation/Foundation.h>
+#import <xpc/xpc.h>
+
+@interface WKProcessExtension : NSObject
+- (void)setSharedInstance:(WKProcessExtension *)instance;
+- (void)lockdownSandbox:(NSString *)version;
+- (void)applyRestrictedSandbox:(NSUInteger)revision;
+@end
+
+extern void ExtensionEventHandler(xpc_connection_t);
+
+static inline void handleNewConnection(xpc_connection_t connection)
+{
+    ExtensionEventHandler(connection);
+}

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist
@@ -2,26 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_BUNDLE_NAME}</string>
+	<key>CFBundleVersion</key>
+	<string>${BUNDLE_VERSION}</string>
+	<key>CanInheritApplicationStateFromOtherProcesses</key>
+	<true/>
 	<key>EXAppExtensionAttributes</key>
 	<dict>
 		<key>EXExtensionPointIdentifier</key>
 		<string>com.apple.web-browser-engine.rendering</string>
 	</dict>
-	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleVersion</key>
-	<string>${BUNDLE_VERSION}</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_BUNDLE_NAME}</string>
+	<key>MDESupportsUniversalURLPlayback</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
 	</array>
-	<key>CanInheritApplicationStateFromOtherProcesses</key>
-	<true/>
-	<key>MDESupportsUniversalURLPlayback</key>
-	<true/>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.entitlements
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.entitlements
@@ -2,13 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.runningboard.assertions.webkit</key>
-	<true/>
-	<key>com.apple.private.webkit.use-xpc-endpoint</key>
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
 	<true/>
 	<key>com.apple.developer.web-browser-engine.rendering</key>
-	<true/>
-	<key>com.apple.private.extensionkit.host-requirement-exemption</key>
 	<true/>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUXPCService.entitlements
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUXPCService.entitlements
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.web-browser-engine.networking</key>
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
 	<true/>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist
@@ -2,20 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleFollowParentLocalization</key>
+	<true/>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_BUNDLE_NAME}</string>
+	<key>CFBundleVersion</key>
+	<string>${BUNDLE_VERSION}</string>
 	<key>EXAppExtensionAttributes</key>
 	<dict>
 		<key>EXExtensionPointIdentifier</key>
 		<string>com.apple.web-browser-engine.networking</string>
 	</dict>
-	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleVersion</key>
-	<string>${BUNDLE_VERSION}</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_BUNDLE_NAME}</string>
-	<key>CFBundleFollowParentLocalization</key>
-	<true/>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingXPCService.entitlements
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingXPCService.entitlements
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.web-browser-engine.networking</key>
-	<true/>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist
@@ -2,18 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_BUNDLE_NAME}</string>
+	<key>CFBundleVersion</key>
+	<string>${BUNDLE_VERSION}</string>
 	<key>EXAppExtensionAttributes</key>
 	<dict>
 		<key>EXExtensionPointIdentifier</key>
 		<string>com.apple.web-browser-engine.webcontent</string>
 	</dict>
-	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleVersion</key>
-	<string>${BUNDLE_VERSION}</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_BUNDLE_NAME}</string>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-EnhancedSecurity-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-EnhancedSecurity-Info.plist
@@ -2,18 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_BUNDLE_NAME}</string>
+	<key>CFBundleVersion</key>
+	<string>${BUNDLE_VERSION}</string>
 	<key>EXAppExtensionAttributes</key>
 	<dict>
 		<key>EXExtensionPointIdentifier</key>
 		<string>com.apple.web-browser-engine.webcontent</string>
 	</dict>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_BUNDLE_NAME}</string>
-	<key>CFBundleVersion</key>
-	<string>${BUNDLE_VERSION}</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist
@@ -2,20 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleFollowParentLocalization</key>
+	<true/>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_BUNDLE_NAME}</string>
+	<key>CFBundleVersion</key>
+	<string>${BUNDLE_VERSION}</string>
 	<key>EXAppExtensionAttributes</key>
 	<dict>
 		<key>EXExtensionPointIdentifier</key>
 		<string>com.apple.web-browser-engine.webcontent</string>
 	</dict>
-	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleVersion</key>
-	<string>${BUNDLE_VERSION}</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_BUNDLE_NAME}</string>
-	<key>CFBundleFollowParentLocalization</key>
-	<true/>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements
@@ -2,15 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.runningboard.assertions.webkit</key>
+	<key>com.apple.developer.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.private.webkit.use-xpc-endpoint</key>
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
 	<true/>
 	<key>com.apple.developer.web-browser-engine.webcontent</key>
-	<true/>
-	<key>com.apple.developer.web-browser-engine.restrict.notifyd</key>
-	<true/>
-	<key>com.apple.private.extensionkit.host-requirement-exemption</key>
 	<true/>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentXPCService.entitlements
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentXPCService.entitlements
@@ -2,7 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.web-browser-engine.networking</key>
+	<key>com.apple.developer.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
 	<true/>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -230,6 +230,10 @@ void XPCServiceEventHandler(xpc_connection_t peer)
             }
 
             RetainPtr webKitBundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.WebKit"));
+            if (!webKitBundle) {
+                RetainPtr webKitFrameworkURL = adoptCF(CFURLCreateWithFileSystemPath(nullptr, CFSTR("/System/Library/Frameworks/WebKit.framework"), kCFURLPOSIXPathStyle, true));
+                webKitBundle = adoptCF(CFBundleCreate(nullptr, webKitFrameworkURL.get()));
+            }
             typedef void (*InitializerFunction)(xpc_connection_t, xpc_object_t);
             InitializerFunction initializerFunctionPtr = reinterpret_cast<InitializerFunction>(CFBundleGetFunctionPointerForName(webKitBundle.get(), entryPointFunctionName));
             if (!initializerFunctionPtr) {

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -938,6 +938,7 @@ LibWebRTCCodecsMessageReceiver.cpp
 LibWebRTCCodecsProxyMessageReceiver.cpp
 LibWebRTCNetworkMessageReceiver.cpp
 LogStreamMessageReceiver.cpp
+Shared/LogStream.mm @no-unify
 ModelConnectionToWebProcessMessageReceiver.cpp
 MediaPlayerPrivateRemoteMessageReceiver.cpp
 MediaSourcePrivateRemoteMessageReceiverMessageReceiver.cpp

--- a/Source/WebKit/SwiftPrefix.h
+++ b/Source/WebKit/SwiftPrefix.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Prefix header for Swift's embedded Clang — provides platform macros and
+// export macro definitions without triggering SDK framework module builds.
+#if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H && defined(BUILDING_WITH_CMAKE)
+#include "cmakeconfig.h"
+#endif
+
+#include <wtf/Platform.h>
+
+#if PLATFORM(COCOA)
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreGraphics/CoreGraphics.h>
+#ifdef __OBJC__
+#if !USE(APPLE_INTERNAL_SDK)
+#define _SECURITY_SECTASK_H_
+#endif
+#import <Foundation/Foundation.h>
+#endif // __OBJC__
+#endif // PLATFORM(COCOA)
+
+#ifdef __cplusplus
+#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
+#endif
+
+// Export macros defined directly to avoid triggering SDK framework module builds
+// (importing <JavaScriptCore/JSExportMacros.h> would build JSC_Private module
+// which has stale PrivateHeaders incompatible with our WTF).
+#include <wtf/ExportMacros.h>
+
+#ifndef JS_EXPORT_PRIVATE
+#define JS_EXPORT_PRIVATE WTF_EXPORT_DECLARATION
+#endif
+
+#ifndef WEBCORE_EXPORT
+#define WEBCORE_EXPORT WTF_EXPORT_DECLARATION
+#endif
+
+#ifndef PAL_EXPORT
+#define PAL_EXPORT WTF_EXPORT_DECLARATION
+#endif

--- a/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
@@ -159,7 +159,7 @@ static NSString *browsingWarningText(BrowsingWarning::Data data)
 
 static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBServiceLookupResult *result)
 {
-    BROWSING_WARNING_DETAILS_TEXT_ADDITIONS
+    BROWSING_WARNING_DETAILS_TEXT_ADDITIONS;
 
     if (result.isPhishing) {
         RetainPtr phishingDescription = WEB_UI_NSSTRING(@"Warnings are shown for websites that have been reported as deceptive. Deceptive websites try to trick you into believing they are legitimate websites you trust.", "Phishing warning description");

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
@@ -30,6 +30,7 @@
 #include "SOAuthorizationSession.h"
 #include "WebViewDidMoveToWindowObserver.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -31,10 +31,10 @@
 #include "WebExtensionEventListenerType.h"
 #include "WebExtensionTabIdentifier.h"
 #include "WebPageProxyIdentifier.h"
-#include <wtf/Forward.h>
 #include <wtf/Identified.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 #if PLATFORM(COCOA)
 #include "CocoaImage.h"
 #include <wtf/WeakObjCPtr.h>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -30,10 +30,10 @@
 #include "WebExtensionError.h"
 #include "WebExtensionWindowIdentifier.h"
 #include "WebPageProxyIdentifier.h"
-#include <wtf/Forward.h>
 #include <wtf/Identified.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 #if PLATFORM(COCOA)
 #include <wtf/WeakObjCPtr.h>
 #endif


### PR DESCRIPTION
#### d401799f3c75c566ec385f373e9953b59539b057
<pre>
[CMake] Fix iOS CMake build for WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=312916">https://bugs.webkit.org/show_bug.cgi?id=312916</a>
&lt;<a href="https://rdar.apple.com/problem/175263847">rdar://problem/175263847</a>&gt;

Reviewed by BJ Burg.

Create PlatformIOS.cmake to configure WebKit for iOS builds with XPC services,
app extensions, entitlements, codesigning, and framework resource installation.
The configuration mirrors PlatformMac.cmake but includes iOS-specific paths and
libraries while excluding Mac-only frameworks. Enable iOS to use
WEBKIT_DEFINE_XPC_SERVICES() for network and GPU process XPC connections.

Update CMakeLists.txt to install WebKit framework and process bundles to
appropriate destinations for iOS. Add missing Swift module declarations and
sandbox profiles for XPC services. Include 13 missing SourcesCocoa entries for
iOS authentication APIs, geometry utilities, and device orientation handling.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/PlatformCocoa.cmake: Added.
* Source/WebKit/PlatformIOS.cmake: Added.
* Source/WebKit/PlatformMac.cmake:
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::browsingDetailsText):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h:

Canonical link: <a href="https://commits.webkit.org/312577@main">https://commits.webkit.org/312577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23e33a25dbbffff23ef1b6caae51822b34169384

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169338 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33908 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163393 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104995 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17057 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171816 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/18199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23510 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33582 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132672 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143665 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24410 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27271 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33076 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/99864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32576 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->