### PR TITLE
[CMake] Fix iOS CMake build for Tools

### DIFF
--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -12,7 +12,7 @@ if (ENABLE_LAYOUT_TESTS)
         add_subdirectory(ImageDiff)
     endif ()
 
-    if (ENABLE_WEBKIT_LEGACY)
+    if (ENABLE_WEBKIT_LEGACY AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
         add_subdirectory(DumpRenderTree)
     endif ()
 

--- a/Tools/ImageDiff/PlatformIOS.cmake
+++ b/Tools/ImageDiff/PlatformIOS.cmake
@@ -1,0 +1,15 @@
+find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+find_library(COREGRAPHICS_LIBRARY CoreGraphics)
+find_library(CORETEXT_LIBRARY CoreText)
+find_library(IMAGEIO_LIBRARY ImageIO)
+
+list(APPEND ImageDiff_SOURCES
+    cg/PlatformImageCG.cpp
+)
+
+list(APPEND ImageDiff_LIBRARIES
+    ${COREFOUNDATION_LIBRARY}
+    ${COREGRAPHICS_LIBRARY}
+    ${CORETEXT_LIBRARY}
+    ${IMAGEIO_LIBRARY}
+)

--- a/Tools/ImageDiff/cg/PlatformImageCG.cpp
+++ b/Tools/ImageDiff/cg/PlatformImageCG.cpp
@@ -42,9 +42,7 @@
 #if __APPLE__
 #include <TargetConditionals.h>
 
-#if TARGET_OS_IPHONE
-#include <MobileCoreServices/UTCoreTypes.h>
-#else
+#if !TARGET_OS_IPHONE
 #include <CoreServices/CoreServices.h>
 #endif
 
@@ -65,7 +63,7 @@ typedef float CGFloat;
 #define FORMAT_SIZE_T "zu"
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) || (defined(__APPLE__) && TARGET_OS_IPHONE)
 static const CFStringRef kUTTypePNG = CFSTR("public.png");
 #endif
 

--- a/Tools/TestRunnerShared/CMakeLists.txt
+++ b/Tools/TestRunnerShared/CMakeLists.txt
@@ -56,3 +56,6 @@ set(TestRunnerShared_INTERFACE_INCLUDE_DIRECTORIES
 WEBKIT_LIBRARY_DECLARE(TestRunnerShared)
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 WEBKIT_LIBRARY(TestRunnerShared)
+if (APPLE)
+    set_target_properties(TestRunnerShared PROPERTIES LINKER_LANGUAGE CXX)
+endif ()

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -434,10 +434,13 @@ if (ENABLE_WEBKIT)
             Tests/WebKit/WKPage/DOMWindowExtensionBasic_Bundle.cpp
 
             Helpers/cocoa/UtilitiesCocoa.mm
-
             InjectedBundle/mac/InjectedBundleControllerMac.mm
-            Helpers/mac/PlatformUtilitiesMac.mm
         )
+        if (NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+            list(APPEND TestWebKitAPIInjectedBundle_SOURCES
+                Helpers/mac/PlatformUtilitiesMac.mm
+            )
+        endif ()
     endif ()
     # macOS: MODULE + BUNDLE TRUE (PlatformMac) emits a CFBundle matching Xcode's MH_BUNDLE.
     # Other ports: SHARED dylib/so.

--- a/Tools/TestWebKitAPI/PlatformIOS.cmake
+++ b/Tools/TestWebKitAPI/PlatformIOS.cmake
@@ -1,0 +1,117 @@
+set(TESTWEBKITAPI_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+
+set(_test_main_SOURCES generic/main.cpp)
+
+# TestWTF
+list(APPEND TestWTF_SOURCES
+    ${_test_main_SOURCES}
+    Helpers/cocoa/UtilitiesCocoa.mm
+)
+list(APPEND TestWTF_PRIVATE_COMPILE_OPTIONS -Wno-error)
+
+# TestJavaScriptCore
+list(APPEND TestJavaScriptCore_SOURCES
+    ${_test_main_SOURCES}
+)
+
+# TestWebCore
+list(APPEND TestWebCore_SOURCES
+    ${_test_main_SOURCES}
+    Helpers/cocoa/UtilitiesCocoa.mm
+)
+
+# TestWebKitLegacy
+list(APPEND TestWebKitLegacy_SOURCES
+    ${_test_main_SOURCES}
+)
+
+# TestWebKit
+list(APPEND TestWebKit_SOURCES
+    ${_test_main_SOURCES}
+    Helpers/cocoa/UtilitiesCocoa.mm
+)
+
+list(APPEND TestWebKit_PRIVATE_LIBRARIES
+    "-Wl,-undefined,dynamic_lookup"
+)
+
+list(APPEND TestWebKit_LIBRARIES
+    "-framework QuartzCore"
+    "-framework UniformTypeIdentifiers"
+    JavaScriptCore
+    WebCoreTestSupport
+    WebKitLegacy
+)
+
+# TestIPC
+list(APPEND TestIPC_SOURCES
+    ${_test_main_SOURCES}
+    Helpers/cocoa/UtilitiesCocoa.mm
+)
+
+list(APPEND TestIPC_PRIVATE_INCLUDE_DIRECTORIES
+    ${WTF_FRAMEWORK_HEADERS_DIR}
+    ${bmalloc_FRAMEWORK_HEADERS_DIR}
+    ${WEBKIT_DIR}/Platform/cocoa
+    ${WEBKIT_DIR}/Platform/IPC/darwin
+    ${WEBKIT_DIR}/Platform/IPC/cocoa
+    ${WEBKIT_DIR}/Shared/Cocoa
+    ${WEBKIT_DIR}/Shared/cf
+)
+
+list(APPEND TestIPC_LIBRARIES
+    "-framework CoreVideo"
+    "-framework Foundation"
+    "-framework IOSurface"
+    "-framework UniformTypeIdentifiers"
+    JavaScriptCore
+)
+
+WEBKIT_ADD_TARGET_CXX_FLAGS(TestIPC -Wno-deprecated-declarations)
+target_link_options(TestIPC PRIVATE -Wl,-undefined,dynamic_lookup -Wl,-not_for_dyld_shared_cache)
+
+# InjectedBundle configuration.
+set_target_properties(TestWebKitAPIInjectedBundle PROPERTIES
+    BUNDLE TRUE
+    BUNDLE_EXTENSION bundle
+    OUTPUT_NAME InjectedBundleTestWebKitAPI
+)
+target_include_directories(TestWebKitAPIInjectedBundle PRIVATE
+    ${WebKit_PRIVATE_FRAMEWORK_HEADERS_DIR}
+    ${TESTWEBKITAPI_DIR}/InjectedBundle
+)
+target_link_options(TestWebKitAPIInjectedBundle PRIVATE "LINKER:-undefined,dynamic_lookup" "LINKER:-not_for_dyld_shared_cache")
+target_link_libraries(TestWebKitAPIInjectedBundle PRIVATE
+    JavaScriptCore
+    WebCoreTestSupport
+    WebKit
+    "-framework Foundation"
+)
+
+# Bundle ID required for extension scoping.
+set_target_properties(TestWebKit PROPERTIES
+    MACOSX_BUNDLE TRUE
+    MACOSX_BUNDLE_GUI_IDENTIFIER "org.webkit.TestWebKitAPI"
+    MACOSX_BUNDLE_BUNDLE_NAME "TestWebKitAPI"
+)
+
+set(_twkapi_bundle_id "org.webkit.TestWebKitAPI")
+
+add_dependencies(TestWebKit WebContentExtension NetworkingExtension)
+if (ENABLE_GPU_PROCESS)
+    add_dependencies(TestWebKit GPUExtension)
+endif ()
+
+WEBKIT_EMBED_EXTENSION(TestWebKit WebContentExtension ${_twkapi_bundle_id}
+    CHANGE_EXTENSION_POINT ADD_ATS)
+WEBKIT_EMBED_EXTENSION(TestWebKit NetworkingExtension ${_twkapi_bundle_id}
+    ADD_ATS)
+if (ENABLE_GPU_PROCESS)
+    WEBKIT_EMBED_EXTENSION(TestWebKit GPUExtension ${_twkapi_bundle_id})
+endif ()
+
+set_target_properties(TestWebKit PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(TestWTF PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(TestWebCore PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(TestWebKitLegacy PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(TestWebKitAPIInjectedBundle PROPERTIES LINKER_LANGUAGE CXX)

--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -145,13 +145,44 @@ WEBKIT_ADD_TARGET_CXX_FLAGS(TestWebKit -Wno-deprecated-declarations)
 set_target_properties(TestWebKit PROPERTIES OUTPUT_NAME TestWebKitAPI)
 
 # TestIPC
+file(GLOB _ipc_core_sources
+    "${WEBKIT_DIR}/Platform/IPC/ArgumentCoders.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/Connection.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/Decoder.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/Encoder.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/IPCUtilities.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/MessageLog.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/MessageReceiveQueueMap.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/MessageReceiverMap.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/MessageSender.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/SharedBufferReference.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/SharedFileHandle.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/StreamClientConnection.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/StreamConnectionBuffer.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/StreamConnectionWorkQueue.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/StreamServerConnection.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/TransferString.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/cocoa/ConnectionCocoa.mm"
+    "${WEBKIT_DIR}/Platform/IPC/cocoa/MachMessage.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/cocoa/SharedFileHandleCocoa.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/cocoa/TransferStringCocoa.mm"
+    "${WEBKIT_DIR}/Platform/IPC/darwin/IPCEventDarwin.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp"
+    "${WEBKIT_DIR}/Platform/IPC/darwin/MachPort.mm"
+)
 list(APPEND TestIPC_SOURCES
     ${_test_main_SOURCES}
     Helpers/cocoa/UtilitiesCocoa.mm
 
     Tests/IPC/IPCSerialization.mm
     Tests/IPC/TransferStringObjCTests.mm
+
+    ${_ipc_core_sources}
+    ${WEBKIT_DIR}/Platform/Logging.cpp
+    ${WEBKIT_DIR}/Platform/mac/MachUtilities.cpp
+    ${WebKit_DERIVED_SOURCES_DIR}/MessageNames.cpp
 )
+unset(_ipc_core_sources)
 
 list(APPEND TestIPC_PRIVATE_INCLUDE_DIRECTORIES
     ${ICU_INCLUDE_DIRS}
@@ -162,6 +193,13 @@ list(APPEND TestIPC_PRIVATE_INCLUDE_DIRECTORIES
     ${WEBKIT_DIR}/Platform/IPC/cocoa
     ${WEBKIT_DIR}/Shared/Cocoa
     ${WEBKIT_DIR}/Shared/cf
+    ${WEBKIT_DIR}
+    ${WEBKIT_DIR}/Platform
+    ${WEBKIT_DIR}/Platform/IPC
+    ${WEBKIT_DIR}/Platform/mac
+    ${WEBKIT_DIR}/Shared
+    ${WebKit_DERIVED_SOURCES_DIR}
+    ${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}
 )
 
 list(APPEND TestIPC_LIBRARIES

--- a/Tools/TestWebKitAPI/Tests/WTF/DataMutex.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/DataMutex.cpp
@@ -61,7 +61,7 @@ TEST(WTF_DataMutex, TakingTheMutex)
 }
 
 // FIXME: Tests using ASSERT_DEATH currently panic on playstation
-#if !PLATFORM(PLAYSTATION)
+#if !PLATFORM(PLAYSTATION) && GTEST_HAS_DEATH_TEST
 TEST(WTF_DataMutex, RunUnlockedIllegalAccessDeathTest)
 {
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";

--- a/Tools/WebKitTestRunner/PlatformIOS.cmake
+++ b/Tools/WebKitTestRunner/PlatformIOS.cmake
@@ -1,0 +1,155 @@
+set(WebKitTestRunner_SHARED_DIR ${TOOLS_DIR}/TestRunnerShared)
+
+find_library(FOUNDATION_LIBRARY Foundation)
+find_library(UIKIT_LIBRARY UIKit)
+
+set(_wktr_ios_compile_options
+    -include "${WebKitTestRunner_DIR}/WebKitTestRunnerPrefix.h"
+    -Wno-deprecated
+    -Wno-deprecated-declarations
+    -Wno-objc-method-access
+)
+list(APPEND WebKitTestRunner_COMPILE_OPTIONS ${_wktr_ios_compile_options})
+list(APPEND TestRunnerInjectedBundle_COMPILE_OPTIONS ${_wktr_ios_compile_options})
+
+set(EXECUTABLE_NAME WebKitTestRunnerInjectedBundle)
+set(PRODUCT_BUNDLE_IDENTIFIER com.apple.WebKitTestRunner.InjectedBundle)
+configure_file("${WebKitTestRunner_DIR}/InjectedBundle-Info.plist"
+               "${CMAKE_CURRENT_BINARY_DIR}/InjectedBundle-Info.plist")
+set_target_properties(TestRunnerInjectedBundle PROPERTIES
+    BUNDLE TRUE
+    BUNDLE_EXTENSION bundle
+    OUTPUT_NAME WebKitTestRunnerInjectedBundle
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/InjectedBundle-Info.plist"
+)
+
+# Fonts for layout tests.
+file(GLOB _wktr_fonts
+    "${WebKitTestRunner_DIR}/fonts/*.ttf"
+    "${WebKitTestRunner_DIR}/fonts/*.TTF"
+    "${WebKitTestRunner_DIR}/fonts/*.otf"
+    "${WebKitTestRunner_DIR}/FakeHelvetica-ArmenianCharacter.ttf"
+    "${WebKitTestRunner_DIR}/FontWithFeatures.ttf"
+    "${WebKitTestRunner_DIR}/FontWithFeatures.otf"
+)
+set_property(TARGET TestRunnerInjectedBundle APPEND PROPERTY RESOURCE "${_wktr_fonts}")
+target_sources(TestRunnerInjectedBundle PRIVATE ${_wktr_fonts})
+
+list(APPEND WebKitTestRunner_INCLUDE_DIRECTORIES
+    ${WebKit_FRAMEWORK_HEADERS_DIR}
+    ${WebKit_PRIVATE_FRAMEWORK_HEADERS_DIR}
+    ${WebKitLegacy_FRAMEWORK_HEADERS_DIR}
+    ${WEBKIT_DIR}/UIProcess/API/C/mac
+    ${WEBKIT_DIR}/UIProcess/API/Cocoa
+    ${WEBKIT_DIR}/UIProcess/Cocoa
+    ${WEBKIT_DIR}/Shared
+)
+
+list(APPEND WebKitTestRunner_LIBRARIES
+    JavaScriptCore
+)
+
+set(_wktr_ios_include_dirs
+    ${CMAKE_BINARY_DIR}
+    ${CMAKE_SOURCE_DIR}/WebKitLibraries
+    ${WEBCORE_DIR}/testing/cocoa
+    ${PAL_FRAMEWORK_HEADERS_DIR}
+    ${WEBKIT_DIR}/Platform/spi/ios
+    ${WEBKIT_DIR}/Platform/spi/watchos
+    ${WEBKIT_DIR}/UIProcess/ios
+    ${WebKitTestRunner_DIR}/cf
+    ${WebKitTestRunner_DIR}/cg
+    ${WebKitTestRunner_DIR}/cocoa
+    ${WebKitTestRunner_DIR}/ios
+    ${WebKitTestRunner_DIR}/InjectedBundle/cocoa
+    ${WebKitTestRunner_DIR}/InjectedBundle/ios
+    ${WebKitTestRunner_SHARED_DIR}/cocoa
+    ${WebKitTestRunner_SHARED_DIR}/spi
+)
+list(APPEND WebKitTestRunner_INCLUDE_DIRECTORIES ${_wktr_ios_include_dirs})
+list(APPEND TestRunnerInjectedBundle_INCLUDE_DIRECTORIES ${_wktr_ios_include_dirs})
+
+list(APPEND TestRunnerInjectedBundle_PRIVATE_LIBRARIES "-Wl,-undefined,dynamic_lookup" "-Wl,-not_for_dyld_shared_cache")
+
+list(APPEND TestRunnerInjectedBundle_SOURCES
+    ${WebKitTestRunner_DIR}/cocoa/CrashReporterInfo.mm
+
+    ${WebKitTestRunner_DIR}/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+    ${WebKitTestRunner_DIR}/InjectedBundle/cocoa/AccessibilityTextMarkerRangeCocoa.mm
+    ${WebKitTestRunner_DIR}/InjectedBundle/cocoa/ActivateFontsCocoa.mm
+    ${WebKitTestRunner_DIR}/InjectedBundle/cocoa/InjectedBundlePageCocoa.mm
+
+    ${WebKitTestRunner_DIR}/InjectedBundle/ios/AccessibilityControllerIOS.mm
+    ${WebKitTestRunner_DIR}/InjectedBundle/ios/AccessibilityTextMarkerIOS.mm
+    ${WebKitTestRunner_DIR}/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+    ${WebKitTestRunner_DIR}/InjectedBundle/ios/EventSenderProxyIOS.mm
+    ${WebKitTestRunner_DIR}/InjectedBundle/ios/InjectedBundleIOS.mm
+)
+
+list(APPEND TestRunnerInjectedBundle_LIBRARIES
+    ${FOUNDATION_LIBRARY}
+    JavaScriptCore
+    WebCoreTestSupport
+    WebKit
+)
+
+list(APPEND WebKitTestRunner_SOURCES
+    ${WebKitTestRunner_DIR}/cocoa/CrashReporterInfo.mm
+    ${WebKitTestRunner_DIR}/cocoa/EventSenderProxyCocoa.mm
+    ${WebKitTestRunner_DIR}/cocoa/TestControllerCocoa.mm
+    ${WebKitTestRunner_DIR}/cocoa/TestInvocationCocoa.mm
+    ${WebKitTestRunner_DIR}/cocoa/TestRunnerWKWebView.mm
+    ${WebKitTestRunner_DIR}/cocoa/TestWebsiteDataStoreDelegate.mm
+    ${WebKitTestRunner_DIR}/cocoa/UIScriptControllerCocoa.mm
+    ${WebKitTestRunner_DIR}/cocoa/WebNotificationProviderCocoa.mm
+    ${WebKitTestRunner_DIR}/cocoa/WKTextExtractionTestingHelpers.mm
+
+    ${WebKitTestRunner_DIR}/InjectedBundle/ios/EventSenderProxyIOS.mm
+
+    ${WebKitTestRunner_DIR}/ios/GeneratedTouchesDebugWindow.mm
+    ${WebKitTestRunner_DIR}/ios/HIDEventGenerator.mm
+    ${WebKitTestRunner_DIR}/ios/PlatformWebViewIOS.mm
+    ${WebKitTestRunner_DIR}/ios/TestControllerIOS.mm
+    ${WebKitTestRunner_DIR}/ios/UIPasteboardConsistencyEnforcer.mm
+    ${WebKitTestRunner_DIR}/ios/UIScriptControllerIOS.mm
+    ${WebKitTestRunner_DIR}/ios/mainIOS.mm
+
+    ${WebKitTestRunner_SHARED_DIR}/cocoa/ClassMethodSwizzler.mm
+    ${WebKitTestRunner_SHARED_DIR}/cocoa/InstanceMethodSwizzler.mm
+    ${WebKitTestRunner_SHARED_DIR}/cocoa/LayoutTestSpellChecker.mm
+    ${WebKitTestRunner_SHARED_DIR}/cocoa/ModifierKeys.mm
+    ${WebKitTestRunner_SHARED_DIR}/cocoa/PlatformViewHelpers.mm
+    ${WebKitTestRunner_SHARED_DIR}/cocoa/PoseAsClass.mm
+    ${WebKitTestRunner_SHARED_DIR}/IOSLayoutTestCommunication.cpp
+)
+
+target_link_libraries(WebKitTestRunner PRIVATE
+    ${FOUNDATION_LIBRARY}
+    ${UIKIT_LIBRARY}
+)
+
+set_target_properties(WebKitTestRunner PROPERTIES
+    MACOSX_BUNDLE TRUE
+    MACOSX_BUNDLE_GUI_IDENTIFIER "org.webkit.WebKitTestRunner"
+    MACOSX_BUNDLE_BUNDLE_NAME "WebKitTestRunner"
+)
+
+set(_wktr_bundle_id "org.webkit.WebKitTestRunner")
+
+add_dependencies(WebKitTestRunner WebContentExtension WebContentCaptivePortalExtension NetworkingExtension)
+if (ENABLE_GPU_PROCESS)
+    add_dependencies(WebKitTestRunner GPUExtension)
+endif ()
+
+WEBKIT_EMBED_EXTENSION(WebKitTestRunner WebContentExtension ${_wktr_bundle_id}
+    CHANGE_EXTENSION_POINT ADD_ATS)
+WEBKIT_EMBED_EXTENSION(WebKitTestRunner WebContentCaptivePortalExtension ${_wktr_bundle_id}
+    CHANGE_EXTENSION_POINT ADD_ATS)
+WEBKIT_EMBED_EXTENSION(WebKitTestRunner NetworkingExtension ${_wktr_bundle_id}
+    ADD_ATS)
+if (ENABLE_GPU_PROCESS)
+    WEBKIT_EMBED_EXTENSION(WebKitTestRunner GPUExtension ${_wktr_bundle_id})
+endif ()
+
+set_target_properties(WebKitTestRunner PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(TestRunnerInjectedBundle PROPERTIES LINKER_LANGUAGE CXX)


### PR DESCRIPTION
#### 9073a949412a4fd7e0c6d894d8945b2aff50f201
<pre>
[CMake] Fix iOS CMake build for Tools
<a href="https://bugs.webkit.org/show_bug.cgi?id=312918">https://bugs.webkit.org/show_bug.cgi?id=312918</a>
&lt;<a href="https://rdar.apple.com/problem/175263773">rdar://problem/175263773</a>&gt;

Reviewed by BJ Burg.

Add CMake build support for iOS Tools by creating platform-specific
configuration files for DumpRenderTree, ImageDiff, TestWebKitAPI, and
WebKitTestRunner. These files configure framework dependencies, source
files, and compile options needed for iOS.

Skip building DumpRenderTree on iOS since WebKitTestRunner is used for
testing instead, and DumpRenderTree has unresolved test infrastructure
symbols not compiled for the iOS WebCore target. Fix TestWebKitAPI to
exclude Mac-specific sources on iOS, and explicitly link Foundation
symbols needed by UtilitiesCocoa.mm. Add a fetch script for comparing
CMake iOS build output with Xcode artifacts. Fix a DataMutex test to
check for GTest death test support in addition to non-PlayStation
platforms.

* Tools/CMakeLists.txt:
* Tools/ImageDiff/PlatformIOS.cmake: Added.
* Tools/ImageDiff/cg/PlatformImageCG.cpp:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/PlatformIOS.cmake: Added.
* Tools/TestWebKitAPI/Tests/WTF/DataMutex.cpp:
* Tools/WebKitTestRunner/PlatformIOS.cmake: Added.

Canonical link: <a href="https://commits.webkit.org/312574@main">https://commits.webkit.org/312574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85a03c10c27799d70f9f7b8b2c2830dc90018e64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169332 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/115495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74ada665-97c0-45c9-97a0-094c60868ef4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33902 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/124388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/115495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bcab5144-32ba-4da2-ac7f-e2724ae885aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163387 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/26630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/144091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104987 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/24186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17051 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/135376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171810 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23494 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/132647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33576 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/28280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132668 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143649 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/95342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24408 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27266 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/20463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33070 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32570 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32814 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32718 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->