### PR TITLE
[cocoa] Explicitly handle cookies with NSHTTPCookieSameSiteNone

### DIFF
--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -80,9 +80,11 @@ static std::optional<double> cookieExpiry(NSHTTPCookie *cookie)
     return [expiryDate timeIntervalSince1970] * 1000.0;
 }
 
+// FIXME: This should be API.
+#define NSHTTPCookieSameSiteNone @"none"
 static Cookie::SameSitePolicy coreSameSitePolicy(NSHTTPCookieStringPolicy _Nullable policy)
 {
-    if (!policy)
+    if (!policy || [policy isEqualToString:NSHTTPCookieSameSiteNone])
         return Cookie::SameSitePolicy::None;
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     if ([policy isEqualToString:NSHTTPCookieSameSiteLax])
@@ -98,7 +100,7 @@ static NSHTTPCookieStringPolicy _Nullable NODELETE nsSameSitePolicy(Cookie::Same
 {
     switch (policy) {
     case Cookie::SameSitePolicy::None:
-        return nil;
+        return NSHTTPCookieSameSiteNone;
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     case Cookie::SameSitePolicy::Lax:
         return NSHTTPCookieSameSiteLax;
@@ -107,6 +109,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
 ALLOW_NEW_API_WITHOUT_GUARDS_END
     }
 }
+#undef NSHTTPCookieSameSiteNone
 
 Cookie::Cookie(NSHTTPCookie *cookie)
     : name { cookie.name }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
@@ -1115,6 +1115,7 @@ TEST(WKHTTPCookieStore, SetCookies)
         NSHTTPCookieName: @"SessionCookieName",
         NSHTTPCookieValue: @"CookieValue",
         NSHTTPCookieDomain: @"127.0.0.1",
+        NSHTTPCookieSameSitePolicy: @"none",
     }];
 
     RetainPtr<NSHTTPCookie> persistentCookie = [NSHTTPCookie cookieWithProperties:@{
@@ -1143,6 +1144,8 @@ TEST(WKHTTPCookieStore, SetCookies)
         auto sortedCookies = [cookies sortedArrayUsingComparator:sortFunction];
         EXPECT_WK_STREQ(@"PersistentCookieName", [[sortedCookies objectAtIndex:0] name]);
         EXPECT_WK_STREQ(@"SessionCookieName", [[sortedCookies objectAtIndex:1] name]);
+        if ([[sortedCookies objectAtIndex:1] sameSitePolicy])
+            EXPECT_WK_STREQ(@"none", [[sortedCookies objectAtIndex:1] sameSitePolicy]);
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);


### PR DESCRIPTION
#### 205ddc426aa9415813bde2740d059d7574048238
<pre>
[cocoa] Explicitly handle cookies with NSHTTPCookieSameSiteNone
<a href="https://bugs.webkit.org/show_bug.cgi?id=313010">https://bugs.webkit.org/show_bug.cgi?id=313010</a>
<a href="https://rdar.apple.com/175354204">rdar://175354204</a>

Reviewed by Charlie Wolfe.

A recent change in CFNetwork results in WebKit potentially receiving a @&quot;none&quot;
value for the cookie&apos;s SameSite property. This wasn&apos;t previously possible
because unspecified and None were handled identically. Since the CFNetwork
change, a debug assertion within WebKit is now being triggered on some sites.
This change adds explicit support for the @&quot;none&quot; SameSite value.

* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::coreSameSitePolicy):
(WebCore::nsSameSitePolicy):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm:
(TEST(WKHTTPCookieStore, SetCookies)):

Canonical link: <a href="https://commits.webkit.org/312270@main">https://commits.webkit.org/312270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dd6d4c4ab4bd42d5caf3aa608e6a4ca4e08572b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168163 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113711 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123448 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86652 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143118 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104115 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/379e0e9f-1f69-4b67-8284-72723e7d8b5a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24760 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23202 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15936 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170657 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16691 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131655 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131767 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35652 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142691 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90519 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26452 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19500 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31905 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98357 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31425 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31698 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31580 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->