### PR TITLE
Update state of WPEToplevelQtQuick when window state changes

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
@@ -145,6 +145,10 @@ void WPEQtView::createWebView()
     else if (!d->m_html.isEmpty())
         webkit_web_view_load_html(d->m_webView.get(), d->m_html.toUtf8().constData(), d->m_baseUrl.toString().toUtf8().constData());
 
+    updateWpeToplevelState();
+    connect(window(), &QQuickWindow::activeChanged, this, &WPEQtView::updateWpeToplevelState);
+    connect(window(), &QQuickWindow::windowStateChanged, this, &WPEQtView::updateWpeToplevelState);
+
     Q_EMIT webViewCreated();
 }
 
@@ -621,6 +625,25 @@ void WPEQtView::invalidateSceneGraph()
 
     auto* wpeView = webkit_web_view_get_wpe_view(d->m_webView.get());
     wpe_view_qtquick_invalidate_rendering(WPE_VIEW_QTQUICK(wpeView));
+}
+
+void WPEQtView::updateWpeToplevelState()
+{
+    Q_D(WPEQtView);
+    auto* wpeView = webkit_web_view_get_wpe_view(d->m_webView.get());
+    if (auto* wpeToplevel = wpe_view_get_toplevel(wpeView)) {
+        auto active = window()->isActive();
+        auto states = window()->windowStates();
+        uint32_t toplevelState = WPE_TOPLEVEL_STATE_NONE;
+        if (states & Qt::WindowMaximized)
+            toplevelState |= WPE_TOPLEVEL_STATE_MAXIMIZED;
+        if (states & Qt::WindowFullScreen)
+            toplevelState |= WPE_TOPLEVEL_STATE_FULLSCREEN;
+        if (active)
+            toplevelState |= WPE_TOPLEVEL_STATE_ACTIVE;
+
+        wpe_toplevel_state_changed(wpeToplevel, static_cast<WPEToplevelState>(toplevelState));
+    }
 }
 
 WebKitWebView* WPEQtView::webView() const

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
@@ -113,6 +113,7 @@ private Q_SLOTS:
     void createWebView();
     void didUpdateScene();
     void invalidateSceneGraph();
+    void updateWpeToplevelState();
 
 private:
     QSGNode* updatePaintNode(QSGNode*, UpdatePaintNodeData*) final;


### PR DESCRIPTION
#### 71b64438bcf203926f468e53d58e483b2ce31744
<pre>
Update state of WPEToplevelQtQuick when window state changes

<a href="https://bugs.webkit.org/show_bug.cgi?id=312624">https://bugs.webkit.org/show_bug.cgi?id=312624</a>

Reviewed by Adrian Perez de Castro.

The focus style is only displayed when the window is active. This
commit updates the WPEToplevelState whenever the relevant states of
the QQuickWindow changes.

Open the qt-wpe-mini-browser and Tab within the page. Check that the
focused item has focus styles.

* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp:
(WPEQtView::createWebView): Initialize WPEToplevelState and listen to
signals that should make updates to it.
(WPEQtView::updateWpeToplevelState): Convert QQuickWindow&apos;s relevant
properties into WPEToplevelState
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h:

Canonical link: <a href="https://commits.webkit.org/312021@main">https://commits.webkit.org/312021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1e985dcdbc22d2aa6192212eb7ae87f6b6a3c62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112796 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122953 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86285 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103622 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24270 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22671 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15313 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133956 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170033 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15776 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21984 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131139 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31828 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131253 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142152 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89720 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24127 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18961 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97298 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30804 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31077 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->