### PR TITLE
Crash/SIGILL/SIGSEGV when using wide-arithmetic instructions

### DIFF
--- a/JSTests/wasm/stress/wide-arithmetic-const-inputs.js
+++ b/JSTests/wasm/stress/wide-arithmetic-const-inputs.js
@@ -1,0 +1,208 @@
+//@ requireOptions("--useWasmWideArithmetic=1")
+import * as assert from '../assert.js';
+
+// Tests that wide arithmetic instructions work when operands come from i64.const
+// rather than local.get. This exercises the BBQ JIT's materializeToGPR path for
+// const values.
+//
+// Functions:
+//   f0: add128 all const          () -> (i64, i64)
+//   f1: sub128 all const          () -> (i64, i64)
+//   f2: mul_wide_u all const      () -> (i64, i64)
+//   f3: mul_wide_s all const      () -> (i64, i64)
+//   f4: add128 (p0, c0, p1, c0)  (i64, i64) -> (i64, i64)
+//   f5: sub128 (p0, c0, p1, c0)  (i64, i64) -> (i64, i64)
+//   f6: add128 (c1, p0, c0, p1)  (i64, i64) -> (i64, i64)
+//   f7: mul_wide_u (p0, c3)      (i64) -> (i64, i64)
+//   f8: mul_wide_s (c-1, p0)     (i64) -> (i64, i64)
+
+const bytes = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d,   // magic
+    0x01, 0x00, 0x00, 0x00,   // version
+
+    // type section (19 bytes)
+    0x01, 0x13,
+    0x03,                                      // 3 types
+    0x60, 0x00, 0x02, 0x7e, 0x7e,              // type 0: () -> (i64, i64)
+    0x60, 0x02, 0x7e, 0x7e, 0x02, 0x7e, 0x7e,  // type 1: (i64, i64) -> (i64, i64)
+    0x60, 0x01, 0x7e, 0x02, 0x7e, 0x7e,        // type 2: (i64) -> (i64, i64)
+
+    // function section (10 bytes)
+    0x03, 0x0a,
+    0x09,                                                // 9 functions
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x02, 0x02,
+
+    // export section (46 bytes)
+    0x07, 0x2e,
+    0x09,                                          // 9 exports
+    0x02, 0x66, 0x30, 0x00, 0x00,                  // "f0" -> func 0
+    0x02, 0x66, 0x31, 0x00, 0x01,                  // "f1" -> func 1
+    0x02, 0x66, 0x32, 0x00, 0x02,                  // "f2" -> func 2
+    0x02, 0x66, 0x33, 0x00, 0x03,                  // "f3" -> func 3
+    0x02, 0x66, 0x34, 0x00, 0x04,                  // "f4" -> func 4
+    0x02, 0x66, 0x35, 0x00, 0x05,                  // "f5" -> func 5
+    0x02, 0x66, 0x36, 0x00, 0x06,                  // "f6" -> func 6
+    0x02, 0x66, 0x37, 0x00, 0x07,                  // "f7" -> func 7
+    0x02, 0x66, 0x38, 0x00, 0x08,                  // "f8" -> func 8
+
+    // code section (102 bytes)
+    0x0a, 0x66,
+    0x09,                     // 9 functions
+
+    // func 0: add128 all const — (5, 0) + (3, 0) = (8, 0)
+    0x0c,                     // body length = 12
+    0x00,                     // no locals
+    0x42, 0x05,               // i64.const 5  (lhsLo)
+    0x42, 0x00,               // i64.const 0  (lhsHi)
+    0x42, 0x03,               // i64.const 3  (rhsLo)
+    0x42, 0x00,               // i64.const 0  (rhsHi)
+    0xfc, 0x13,               // i64.add128
+    0x0b,                     // end
+
+    // func 1: sub128 all const — (10, 1) - (3, 0) = (7, 1)
+    0x0c,                     // body length = 12
+    0x00,                     // no locals
+    0x42, 0x0a,               // i64.const 10 (lhsLo)
+    0x42, 0x01,               // i64.const 1  (lhsHi)
+    0x42, 0x03,               // i64.const 3  (rhsLo)
+    0x42, 0x00,               // i64.const 0  (rhsHi)
+    0xfc, 0x14,               // i64.sub128
+    0x0b,                     // end
+
+    // func 2: mul_wide_u all const — 5 * 3 = (15, 0)
+    0x08,                     // body length = 8
+    0x00,                     // no locals
+    0x42, 0x05,               // i64.const 5
+    0x42, 0x03,               // i64.const 3
+    0xfc, 0x16,               // i64.mul_wide_u
+    0x0b,                     // end
+
+    // func 3: mul_wide_s all const — (-2) * 3 = (-6, -1)
+    0x08,                     // body length = 8
+    0x00,                     // no locals
+    0x42, 0x7e,               // i64.const -2
+    0x42, 0x03,               // i64.const 3
+    0xfc, 0x15,               // i64.mul_wide_s
+    0x0b,                     // end
+
+    // func 4: add128 mixed — (param0, const 0, param1, const 0)
+    0x0c,                     // body length = 12
+    0x00,                     // no locals
+    0x20, 0x00,               // local.get 0  (lhsLo)
+    0x42, 0x00,               // i64.const 0  (lhsHi)
+    0x20, 0x01,               // local.get 1  (rhsLo)
+    0x42, 0x00,               // i64.const 0  (rhsHi)
+    0xfc, 0x13,               // i64.add128
+    0x0b,                     // end
+
+    // func 5: sub128 mixed — (param0, const 0, param1, const 0)
+    0x0c,                     // body length = 12
+    0x00,                     // no locals
+    0x20, 0x00,               // local.get 0  (lhsLo)
+    0x42, 0x00,               // i64.const 0  (lhsHi)
+    0x20, 0x01,               // local.get 1  (rhsLo)
+    0x42, 0x00,               // i64.const 0  (rhsHi)
+    0xfc, 0x14,               // i64.sub128
+    0x0b,                     // end
+
+    // func 6: add128 mixed — (const 1, param0, const 0, param1)
+    0x0c,                     // body length = 12
+    0x00,                     // no locals
+    0x42, 0x01,               // i64.const 1  (lhsLo)
+    0x20, 0x00,               // local.get 0  (lhsHi)
+    0x42, 0x00,               // i64.const 0  (rhsLo)
+    0x20, 0x01,               // local.get 1  (rhsHi)
+    0xfc, 0x13,               // i64.add128
+    0x0b,                     // end
+
+    // func 7: mul_wide_u mixed — (param0, const 3)
+    0x08,                     // body length = 8
+    0x00,                     // no locals
+    0x20, 0x00,               // local.get 0
+    0x42, 0x03,               // i64.const 3
+    0xfc, 0x16,               // i64.mul_wide_u
+    0x0b,                     // end
+
+    // func 8: mul_wide_s mixed — (const -1, param0)
+    0x08,                     // body length = 8
+    0x00,                     // no locals
+    0x42, 0x7f,               // i64.const -1
+    0x20, 0x00,               // local.get 0
+    0xfc, 0x15,               // i64.mul_wide_s
+    0x0b,                     // end
+]);
+
+function test() {
+    const module = new WebAssembly.Module(bytes);
+    const instance = new WebAssembly.Instance(module);
+    const { f0, f1, f2, f3, f4, f5, f6, f7, f8 } = instance.exports;
+
+    let r;
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        // All-const tests
+        r = f0();
+        assert.eq(r[0], 8n);
+        assert.eq(r[1], 0n);
+
+        r = f1();
+        assert.eq(r[0], 7n);
+        assert.eq(r[1], 1n);
+
+        r = f2();
+        assert.eq(r[0], 15n);
+        assert.eq(r[1], 0n);
+
+        r = f3();
+        assert.eq(r[0], -6n);
+        assert.eq(r[1], -1n);
+
+        // Mixed add128: (param0, 0) + (param1, 0)
+        r = f4(5n, 3n);
+        assert.eq(r[0], 8n);
+        assert.eq(r[1], 0n);
+
+        r = f4(-1n, 1n);
+        assert.eq(r[0], 0n);
+        assert.eq(r[1], 1n);
+
+        // Mixed sub128: (param0, 0) - (param1, 0)
+        r = f5(10n, 3n);
+        assert.eq(r[0], 7n);
+        assert.eq(r[1], 0n);
+
+        r = f5(1n, 3n);
+        assert.eq(r[0], -2n);
+        assert.eq(r[1], -1n);
+
+        // Mixed add128: (1, param0) + (0, param1)
+        r = f6(2n, 3n);
+        assert.eq(r[0], 1n);
+        assert.eq(r[1], 5n);
+
+        r = f6(0n, -1n);
+        assert.eq(r[0], 1n);
+        assert.eq(r[1], -1n);
+
+        // Mixed mul_wide_u: param0 * 3
+        r = f7(5n);
+        assert.eq(r[0], 15n);
+        assert.eq(r[1], 0n);
+
+        r = f7(-1n);
+        assert.eq(r[0], -3n);
+        assert.eq(r[1], 2n);
+
+        // Mixed mul_wide_s: (-1) * param0
+        r = f8(5n);
+        assert.eq(r[0], -5n);
+        assert.eq(r[1], -1n);
+
+        r = f8(-1n);
+        assert.eq(r[0], 1n);
+        assert.eq(r[1], 0n);
+    }
+}
+noInline(test);
+
+test();

--- a/JSTests/wasm/stress/wide-arithmetic-unreachable.js
+++ b/JSTests/wasm/stress/wide-arithmetic-unreachable.js
@@ -1,0 +1,101 @@
+//@ requireOptions("--useWasmWideArithmetic=1")
+import * as assert from '../assert.js';
+
+// Tests that wide arithmetic instructions in unreachable code (after return)
+// don't cause compilation failures. Before the fix, these would hit the default
+// case in parseUnreachableExpression() producing "invalid extended 0xfc op".
+//
+// Each function returns (42, 0) via return, then has a wide arithmetic op
+// in unreachable code that must be parsed but not executed.
+
+const bytes = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d,   // magic
+    0x01, 0x00, 0x00, 0x00,   // version
+
+    // type section (6 bytes)
+    0x01, 0x06,
+    0x01,                              // 1 type
+    0x60, 0x00, 0x02, 0x7e, 0x7e,      // type 0: () -> (i64, i64)
+
+    // function section (5 bytes)
+    0x03, 0x05,
+    0x04,                              // 4 functions
+    0x00, 0x00, 0x00, 0x00,            // all type 0
+
+    // export section (21 bytes)
+    0x07, 0x15,
+    0x04,                              // 4 exports
+    0x02, 0x66, 0x30, 0x00, 0x00,      // "f0" -> func 0
+    0x02, 0x66, 0x31, 0x00, 0x01,      // "f1" -> func 1
+    0x02, 0x66, 0x32, 0x00, 0x02,      // "f2" -> func 2
+    0x02, 0x66, 0x33, 0x00, 0x03,      // "f3" -> func 3
+
+    // code section (41 bytes)
+    0x0a, 0x29,
+    0x04,                     // 4 functions
+
+    // func 0: return then i64.add128
+    0x09,                     // body length = 9
+    0x00,                     // no locals
+    0x42, 0x2a,               // i64.const 42
+    0x42, 0x00,               // i64.const 0
+    0x0f,                     // return
+    0xfc, 0x13,               // i64.add128 (unreachable)
+    0x0b,                     // end
+
+    // func 1: return then i64.sub128
+    0x09,                     // body length = 9
+    0x00,                     // no locals
+    0x42, 0x2a,               // i64.const 42
+    0x42, 0x00,               // i64.const 0
+    0x0f,                     // return
+    0xfc, 0x14,               // i64.sub128 (unreachable)
+    0x0b,                     // end
+
+    // func 2: return then i64.mul_wide_s
+    0x09,                     // body length = 9
+    0x00,                     // no locals
+    0x42, 0x2a,               // i64.const 42
+    0x42, 0x00,               // i64.const 0
+    0x0f,                     // return
+    0xfc, 0x15,               // i64.mul_wide_s (unreachable)
+    0x0b,                     // end
+
+    // func 3: return then i64.mul_wide_u
+    0x09,                     // body length = 9
+    0x00,                     // no locals
+    0x42, 0x2a,               // i64.const 42
+    0x42, 0x00,               // i64.const 0
+    0x0f,                     // return
+    0xfc, 0x16,               // i64.mul_wide_u (unreachable)
+    0x0b,                     // end
+]);
+
+function test() {
+    const module = new WebAssembly.Module(bytes);
+    const instance = new WebAssembly.Instance(module);
+    const { f0, f1, f2, f3 } = instance.exports;
+
+    let r;
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        r = f0();
+        assert.eq(r[0], 42n);
+        assert.eq(r[1], 0n);
+
+        r = f1();
+        assert.eq(r[0], 42n);
+        assert.eq(r[1], 0n);
+
+        r = f2();
+        assert.eq(r[0], 42n);
+        assert.eq(r[1], 0n);
+
+        r = f3();
+        assert.eq(r[0], 42n);
+        assert.eq(r[1], 0n);
+    }
+}
+noInline(test);
+
+test();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -2465,10 +2465,11 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
 
 [[nodiscard]] PartialResult BBQJIT::addI64Add128(Value lhsLo, Value lhsHi, Value rhsLo, Value rhsHi, Value& resultLo, Value& resultHi)
 {
-    Location lhsLoLocation = loadIfNecessary(lhsLo);
-    Location lhsHiLocation = loadIfNecessary(lhsHi);
-    Location rhsLoLocation = loadIfNecessary(rhsLo);
-    Location rhsHiLocation = loadIfNecessary(rhsHi);
+    std::optional<ScratchScope<1, 0>> lhsLoScratch, lhsHiScratch, rhsLoScratch, rhsHiScratch;
+    Location lhsLoLocation = materializeToGPR(lhsLo, lhsLoScratch);
+    Location lhsHiLocation = materializeToGPR(lhsHi, lhsHiScratch);
+    Location rhsLoLocation = materializeToGPR(rhsLo, rhsLoScratch);
+    Location rhsHiLocation = materializeToGPR(rhsHi, rhsHiScratch);
     consume(lhsLo);
     consume(lhsHi);
     consume(rhsLo);
@@ -2512,10 +2513,11 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
 
 [[nodiscard]] PartialResult BBQJIT::addI64Sub128(Value lhsLo, Value lhsHi, Value rhsLo, Value rhsHi, Value& resultLo, Value& resultHi)
 {
-    Location lhsLoLocation = loadIfNecessary(lhsLo);
-    Location lhsHiLocation = loadIfNecessary(lhsHi);
-    Location rhsLoLocation = loadIfNecessary(rhsLo);
-    Location rhsHiLocation = loadIfNecessary(rhsHi);
+    std::optional<ScratchScope<1, 0>> lhsLoScratch, lhsHiScratch, rhsLoScratch, rhsHiScratch;
+    Location lhsLoLocation = materializeToGPR(lhsLo, lhsLoScratch);
+    Location lhsHiLocation = materializeToGPR(lhsHi, lhsHiScratch);
+    Location rhsLoLocation = materializeToGPR(rhsLo, rhsLoScratch);
+    Location rhsHiLocation = materializeToGPR(rhsHi, rhsHiScratch);
     consume(lhsLo);
     consume(lhsHi);
     consume(rhsLo);
@@ -2563,15 +2565,16 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
 
 [[nodiscard]] PartialResult BBQJIT::addI64MulWideU(Value lhs, Value rhs, Value& resultLo, Value& resultHi)
 {
-    Location lhsLocation = loadIfNecessary(lhs);
-    Location rhsLocation = loadIfNecessary(rhs);
-    consume(lhs);
-    consume(rhs);
-
 #if CPU(X86_64)
     for (JSC::Reg reg : clobbersForDivX86())
         clobber(reg);
 #endif
+
+    std::optional<ScratchScope<1, 0>> lhsScratch, rhsScratch;
+    Location lhsLocation = materializeToGPR(lhs, lhsScratch);
+    Location rhsLocation = materializeToGPR(rhs, rhsScratch);
+    consume(lhs);
+    consume(rhs);
 
     resultLo = topValue(TypeKind::I64);
     resultHi = topValue(TypeKind::I64, 1);
@@ -2582,6 +2585,8 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
 
 #if CPU(X86_64)
     // x86 mul: rax * src -> rdx:rax
+    if (rhsLocation.asGPR() == X86Registers::eax)
+        std::swap(lhsLocation, rhsLocation);
     m_jit.move(lhsLocation.asGPR(), X86Registers::eax);
     m_jit.x86UMulHigh64(rhsLocation.asGPR(), X86Registers::eax, X86Registers::edx);
     if (resultLoLocation.asGPR() != X86Registers::edx) {
@@ -2611,15 +2616,16 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
 
 [[nodiscard]] PartialResult BBQJIT::addI64MulWideS(Value lhs, Value rhs, Value& resultLo, Value& resultHi)
 {
-    Location lhsLocation = loadIfNecessary(lhs);
-    Location rhsLocation = loadIfNecessary(rhs);
-    consume(lhs);
-    consume(rhs);
-
 #if CPU(X86_64)
     for (JSC::Reg reg : clobbersForDivX86())
         clobber(reg);
 #endif
+
+    std::optional<ScratchScope<1, 0>> lhsScratch, rhsScratch;
+    Location lhsLocation = materializeToGPR(lhs, lhsScratch);
+    Location rhsLocation = materializeToGPR(rhs, rhsScratch);
+    consume(lhs);
+    consume(rhs);
 
     resultLo = topValue(TypeKind::I64);
     resultHi = topValue(TypeKind::I64, 1);
@@ -2630,6 +2636,8 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
 
 #if CPU(X86_64)
     // x86 imul: rax * src -> rdx:rax (signed)
+    if (rhsLocation.asGPR() == X86Registers::eax)
+        std::swap(lhsLocation, rhsLocation);
     m_jit.move(lhsLocation.asGPR(), X86Registers::eax);
     m_jit.x86MulHigh64(rhsLocation.asGPR(), X86Registers::eax, X86Registers::edx);
     if (resultLoLocation.asGPR() != X86Registers::edx) {

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -4259,6 +4259,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         }
 #define CREATE_EXT1_CASE(name, ...) case Ext1OpType::name:
         FOR_EACH_WASM_TRUNC_SATURATED_OP(CREATE_EXT1_CASE)
+        FOR_EACH_WASM_WIDE_ARITHMETIC_OP(CREATE_EXT1_CASE)
             return { };
 #undef CREATE_EXT1_CASE
         default:


### PR DESCRIPTION
#### c628c3c9d8ee39917b275755a3c671e2f05fc73f
<pre>
Crash/SIGILL/SIGSEGV when using wide-arithmetic instructions
<a href="https://rdar.apple.com/175356222">rdar://175356222</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313006">https://bugs.webkit.org/show_bug.cgi?id=313006</a>

Reviewed by Yusuke Suzuki.

BBQ JIT&apos;s wide arithmetic instructions (add128, sub128, mul_wide_s,
mul_wide_u) called loadIfNecessary() on their operands, which asserts
that the value is not a constant. When wasm code feeds i64.const values
into these instructions, the assertion fires and release builds emit
garbage code, causing traps or crashes.

Use materializeToGPR() instead, which handles both constant and
non-constant values by materializing constants into scratch registers.

Also add the wide arithmetic opcodes to parseUnreachableExpression()
so they are properly skipped in dead code after return/unreachable,
rather than hitting &quot;invalid extended 0xfc op&quot;.

Also, fix an issue when rhs conflicts with eax on X86 that would produce
incorrect results.

Tests: JSTests/wasm/stress/wide-arithmetic-const-inputs.js
       JSTests/wasm/stress/wide-arithmetic-unreachable.js

Canonical link: <a href="https://commits.webkit.org/311856@main">https://commits.webkit.org/311856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c784e84d8f6b4bb5c83f0d27005509196eb8703e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112239 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122482 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85978 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103151 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23809 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14757 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150207 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169474 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18991 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14828 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130663 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130778 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141634 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89073 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24051 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25489 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18440 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190285 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30729 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96262 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48839 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30250 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30480 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->