### PR TITLE
[iOS] chatgpt.com: text selection in chat entry field sometimes flickers or disappears

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -971,8 +971,10 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     // Updating the selection requires a full editor state. If the editor state is missing post layout
     // data then it means there is a layout pending and we're going to be called again after the layout
     // so we delay the selection update.
-    if (page->editorState().hasPostLayoutAndVisualData())
+    if (page->editorState().hasPostLayoutAndVisualData()) {
+        _cachedSelectionContainerView = nil;
         [self _updateChangedSelection];
+    }
 }
 
 - (void)_layerTreeCommitComplete

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -9564,8 +9564,16 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
             _shouldRestoreSelection = NO;
         }
     } else {
-        if (_lastSiblingBeforeSelectionHighlight != [self _siblingBeforeSelectionHighlight])
-            [_textInteractionWrapper prepareToMoveSelectionContainer:self._selectionContainerViewInternal];
+        RetainPtr container = [self _selectionContainerViewInternal];
+        RetainPtr selectionHighlightContainer = [[_textInteractionWrapper selectionHighlightView] superview];
+        BOOL siblingChanged = _lastSiblingBeforeSelectionHighlight != [self _siblingBeforeSelectionHighlight];
+        BOOL parentChanged = editorState.isEditableOrRanged() && selectionHighlightContainer != container;
+        if (!siblingChanged && parentChanged)
+            RELEASE_LOG(TextInteraction, "Selection highlight view was reparented");
+
+        if (siblingChanged || parentChanged)
+            [_textInteractionWrapper prepareToMoveSelectionContainer:container.get()];
+
         [self _updateSelectionViewsIfNeeded];
     }
 
@@ -14454,7 +14462,7 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
 
 - (UIView *)_selectionContainerViewInternal
 {
-    if (_cachedSelectionContainerView)
+    if ([protect(_cachedSelectionContainerView) window])
         return _cachedSelectionContainerView;
 
     _cachedSelectionContainerView = [&] -> UIView * {
@@ -14466,7 +14474,7 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
             return self;
 
         RetainPtr enclosingView = [self _viewForLayerID:page->editorState().visualData->enclosingLayerID];
-        if (!enclosingView)
+        if (![enclosingView window])
             return self;
 
         for (UIView *selectedView in self.allViewsIntersectingSelectionRange) {


### PR DESCRIPTION
#### eb95cba0c2421219846b4ef9f9a0fb440eca488d
<pre>
[iOS] chatgpt.com: text selection in chat entry field sometimes flickers or disappears
<a href="https://bugs.webkit.org/show_bug.cgi?id=313014">https://bugs.webkit.org/show_bug.cgi?id=313014</a>
<a href="https://rdar.apple.com/174689058">rdar://174689058</a>

Reviewed by Abrar Rahman Protyasha.

Implement a speculative fix for this bug, which I have not been able to reproduce in either debug or
release builds. While attached to a build of Safari in state, I was able to determine that:

1.  Initially, we correctly install the text selection interaction views in the bottom fixed-
    position container containing the chat box.

2.  `-_updateChangedSelection:` is invoked as layer tree commits arrive, but this doesn&apos;t call into
    `-prepareToMoveSelectionContainer:` again because the editor state&apos;s comparison result is
    `EquivalentIncludingEnclosingLayer`.

3.  At some point, the compositing view corresponding to that enclosing layer is unparented, taking
    the selection views out of the window along with it (this is what causes it to disappear). In
    this state, `-_selectionContainerViewInternal` returns `WKContentView`, indicating that the
    enclosing layer can no longer be found.

This seems to hint at some underlying issue where the computed `EditorState`&apos;s enclosing layer ID
isn&apos;t being correctly recomputed, but it&apos;s unclear how this is happening. To mitigate this for now,
harden the UI-side logic to detect when the selection interaction views end up in the wrong parent
view (or are unparented altogether), and fix it up in `-prepareToMoveSelectionContainer:` (similar
to the case where the last sibling view changes).

* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _didCommitLayerTree:mainFrameData:pageData:transactionID:]):

Additionally, invalidate the `_cachedSelectionContainerView` when the layer tree commits. A stale
`_cachedSelectionContainerView` that points to an unparented view might also explain the selection
being missing from the view hierarchy, though I was also not able to reproduce this locally.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateChangedSelection:]):
(-[WKContentView _selectionContainerViewInternal]):

Canonical link: <a href="https://commits.webkit.org/311869@main">https://commits.webkit.org/311869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0661fe93b07f5e57bd505156bb9c0665178dc1db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158268 "Failed to checkout and rebase branch from PR 63350") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167097 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122575 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24844 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103244 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14870 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169588 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15195 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130757 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31351 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130871 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35437 "Built successfully and passed tests") | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31289 "Failed to checkout and rebase branch from PR 63350") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141743 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89202 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/31289 "Failed to checkout and rebase branch from PR 63350") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18549 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30842 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96606 "Failed to checkout and rebase branch from PR 63350") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30362 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30489 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->