### PR TITLE
Transform camera instead of model

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -29,12 +29,6 @@ import USDKit
 @_spi(RealityCoreRendererAPI) @_spi(Private) import RealityKit
 import simd
 
-internal struct CameraTransform {
-    var rotation: simd_quatf
-    var translation: simd_float3
-    var scale: simd_float3
-}
-
 class Renderer {
     let device: any MTLDevice
     let commandQueue: any MTLCommandQueue
@@ -127,19 +121,29 @@ class Renderer {
         commandBuffer.commit()
     }
 
-    internal func setFOV(_ fovYRadians: Float) {
+    func setFOV(_ fovYRadians: Float) {
         fovY = fovYRadians
     }
 
-    internal func setBackgroundColor(_ color: simd_float3) {
+    func setBackgroundColor(_ color: simd_float3) {
         clearColor = MTLClearColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
     }
 
-    internal func setCameraTransform(_ transform: CameraTransform) {
-        pose = .init(
-            translation: transform.translation,
-            rotation: transform.rotation,
-        )
+    func setCameraTransformForModelTransform(_ modelTransform: simd_float4x4) {
+        // To keep the model stationary while achieving the same visual result as applying
+        // modelTransform to the model, derive the equivalent camera pose by composing the
+        // inverse model transform with the default camera matrix.
+        var defaultCameraMatrix = matrix_identity_float4x4
+        defaultCameraMatrix.columns.3 = [0, 0, Self.cameraDistance, 1]
+        let cameraMatrix = simd_inverse(modelTransform) * defaultCameraMatrix
+
+        let col0 = simd_float3(cameraMatrix.columns.0.x, cameraMatrix.columns.0.y, cameraMatrix.columns.0.z)
+        let col1 = simd_float3(cameraMatrix.columns.1.x, cameraMatrix.columns.1.y, cameraMatrix.columns.1.z)
+        let col2 = simd_float3(cameraMatrix.columns.2.x, cameraMatrix.columns.2.y, cameraMatrix.columns.2.z)
+        let scale = simd_float3(simd_length(col0), simd_length(col1), simd_length(col2))
+        let rotation = simd_quatf(simd_float3x3(col0 / scale.x, col1 / scale.y, col2 / scale.z))
+        let translation = simd_float3(cameraMatrix.columns.3.x, cameraMatrix.columns.3.y, cameraMatrix.columns.3.z)
+        pose = .init(translation: translation, rotation: rotation)
     }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -444,8 +444,6 @@ extension WKBridgeReceiver {
     @nonobjc
     fileprivate var meshToMeshInstances: [WKBridgeTypedResourceId: [_Proto_LowLevelMeshInstance_v1]] = [:]
     @nonobjc
-    fileprivate var meshTransforms: [WKBridgeTypedResourceId: [simd_float4x4]] = [:]
-    @nonobjc
     fileprivate var rotationAngle: Float = 0
 
     @nonobjc
@@ -467,9 +465,6 @@ extension WKBridgeReceiver {
     fileprivate var textureHashesAndResources: [WKBridgeTypedResourceId: (String, _Proto_LowLevelTextureResource_v1)] = [:]
 
     @nonobjc
-    fileprivate var modelTransform: simd_float4x4
-
-    @nonobjc
     fileprivate var dontCaptureAgain: Bool = false
 
     @nonobjc
@@ -484,11 +479,23 @@ extension WKBridgeReceiver {
         enum UpdateType {
             // First time mesh update, should add mesh instances to the scene
             case newMesh
+            // Transform update on existing mesh, should only update the transform on relevant mesh instances
+            case transformUpdate([simd_float4x4])
         }
 
         let identifier: WKBridgeTypedResourceId
         let type: UpdateType
         var updatedInstances: [_Proto_LowLevelMeshInstance_v1]
+
+        init(identifier: WKBridgeTypedResourceId, type: UpdateType, updatedInstances: [_Proto_LowLevelMeshInstance_v1]) {
+            self.identifier = identifier
+            self.type = type
+            self.updatedInstances = updatedInstances
+
+            if case .transformUpdate(let newTransforms) = type {
+                assert(newTransforms.count == updatedInstances.count)
+            }
+        }
     }
 
     init(
@@ -503,7 +510,6 @@ extension WKBridgeReceiver {
         self.textureProcessingContext = _Proto_LowLevelTextureProcessingContext_v1(device: configuration.device)
         self.commandQueue = configuration.commandQueue
         self.deformationSystem = try _Proto_LowLevelDeformationSystem_v1.make(configuration.device, configuration.commandQueue).get()
-        modelTransform = matrix_identity_float4x4
         let meshInstances = try configuration.renderContext.makeMeshInstanceArray(renderTargets: [configuration.renderTarget], count: 16)
         self.meshInstancePool = MeshInstancePool(renderContext: configuration.renderContext, meshInstances: meshInstances)
         let lightingFunction = configuration.renderContext.makePhysicallyBasedLightingFunction()
@@ -561,19 +567,6 @@ extension WKBridgeReceiver {
 
     @objc(renderWithTexture:commandBuffer:)
     func render(with texture: any MTLTexture, commandBuffer: any MTLCommandBuffer) {
-        for (identifier, meshes) in meshToMeshInstances {
-            let originalTransforms = meshTransforms[identifier]
-            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-            // swift-format-ignore: NeverForceUnwrap
-
-            for (index, meshInstance) in meshes.enumerated() {
-                // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-                // swift-format-ignore: NeverForceUnwrap
-                let computedTransform = modelTransform * originalTransforms![index]
-                meshInstance.setTransform(.single(computedTransform))
-            }
-        }
-
         // animate
         if !meshResourceToDeformationContext.isEmpty {
             let commandBuffer = self.commandQueue.makeCommandBuffer()!
@@ -790,7 +783,6 @@ extension WKBridgeReceiver {
                 if meshData.instanceTransformsCount > 0 {
                     if meshToMeshInstances[identifier] == nil {
                         meshToMeshInstances[identifier] = []
-                        meshTransforms[identifier] = []
 
                         var deferredMeshUpdate = DeferredMeshUpdate(identifier: identifier, type: .newMesh, updatedInstances: [])
 
@@ -839,9 +831,6 @@ extension WKBridgeReceiver {
                                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                                 // swift-format-ignore: NeverForceUnwrap
                                 meshToMeshInstances[identifier]!.append(meshInstance)
-                                // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-                                // swift-format-ignore: NeverForceUnwrap
-                                meshTransforms[identifier]!.append(instanceTransform)
                                 deferredMeshUpdate.updatedInstances.append(meshInstance)
                             }
                         }
@@ -851,14 +840,26 @@ extension WKBridgeReceiver {
                         // Update transforms otherwise
                         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                         // swift-format-ignore: NeverForceUnwrap
+                        var newTransforms: [simd_float4x4] = []
+                        var updatedInstances: [_Proto_LowLevelMeshInstance_v1] = []
+
                         let partCount = meshToMeshInstances[identifier]!.count / meshData.instanceTransforms.count
                         for (instanceIndex, instanceTransform) in meshData.instanceTransforms.enumerated() {
                             for partIndex in 0..<partCount {
                                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                                 // swift-format-ignore: NeverForceUnwrap
-                                meshTransforms[identifier]![instanceIndex * partCount + partIndex] = instanceTransform
+                                let meshInstance = meshToMeshInstances[identifier]![instanceIndex * meshData.parts.count + partIndex]
+                                updatedInstances.append(meshInstance)
+                                newTransforms.append(instanceTransform)
                             }
                         }
+
+                        let deferredMeshUpdate = DeferredMeshUpdate(
+                            identifier: identifier,
+                            type: .transformUpdate(newTransforms),
+                            updatedInstances: updatedInstances
+                        )
+                        deferredMeshUpdates.append(deferredMeshUpdate)
                     }
                 }
 
@@ -874,6 +875,10 @@ extension WKBridgeReceiver {
                     for newMeshInstance in deferredUpdate.updatedInstances {
                         try meshInstancePool.add(newMeshInstance)
                     }
+                case .transformUpdate(let newTransforms):
+                    for (instanceIndex, meshInstance) in deferredUpdate.updatedInstances.enumerated() {
+                        meshInstance.setTransform(.single(newTransforms[instanceIndex]))
+                    }
                 }
             }
         } catch {
@@ -883,7 +888,7 @@ extension WKBridgeReceiver {
 
     @objc(setTransform:)
     func setTransform(_ transform: simd_float4x4) {
-        modelTransform = transform
+        appRenderer.setCameraTransformForModelTransform(transform)
     }
 
     func setFOV(_ fovY: Float) {


### PR DESCRIPTION
#### 43f24006d708eb6b9e0952d3cc4c58602cd08f7d
<pre>
Transform camera instead of model
<a href="https://bugs.webkit.org/show_bug.cgi?id=313026">https://bugs.webkit.org/show_bug.cgi?id=313026</a>
<a href="https://rdar.apple.com/175367866">rdar://175367866</a>

Reviewed by Etienne Segonzac.

Instead of rotating all parts of the mesh by the desired transform,
we can leave the mesh as-is and apply an inverse transform to the
camera which is mathematically identical post-vertex transform.

It is both simpler and computationally less expensive than performing
the compounded rotation every render call.

* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
(Renderer.setCameraTransformForModelTransform(_:)):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(render(with:commandBuffer:)):
(updateMesh(_:)):
(setTransform(_:)):
(Material.modelTransform): Deleted.

Canonical link: <a href="https://commits.webkit.org/312334@main">https://commits.webkit.org/312334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fd2c81b991fd3b4a05262517eed1ca864680a2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168424 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123639 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104291 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16188 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170911 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16945 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131868 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131956 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35714 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142895 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90790 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26600 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19709 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98613 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31714 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31961 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31865 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->