### PR TITLE
marketwatch.com: Tapping the “share” button causes the media controls to shift to the top of the video.

### DIFF
--- a/LayoutTests/fast/shadow-dom/slot-display-contents-composed-tree-after-display-toggle-expected.txt
+++ b/LayoutTests/fast/shadow-dom/slot-display-contents-composed-tree-after-display-toggle-expected.txt
@@ -1,0 +1,11 @@
+Composed tree from #mutate:
+      div
+        #text
+      #text
+      div
+        #text
+      #text
+    #text
+A
+B
+

--- a/LayoutTests/fast/shadow-dom/slot-display-contents-composed-tree-after-display-toggle.html
+++ b/LayoutTests/fast/shadow-dom/slot-display-contents-composed-tree-after-display-toggle.html
@@ -1,0 +1,35 @@
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<body>
+<pre id="console"></pre>
+<my-el id="host">
+  <div style="display:contents">
+    <div id="mutate">A</div>
+    <div>B</div>
+  </div>
+</my-el>
+<script>
+customElements.define('my-el', class extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' }).innerHTML = '<slot></slot>';
+  }
+});
+
+document.body.offsetHeight;
+
+var host = document.getElementById('host');
+var mutate = document.getElementById('mutate');
+var output = document.getElementById('console');
+
+mutate.style.display = 'none';
+document.body.offsetHeight;
+mutate.style.display = '';
+document.body.offsetHeight;
+
+output.innerText = "Composed tree from #mutate:\n";
+output.innerText += internals.composedTreeAsTextFromNode(host, mutate);
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/slot-display-contents-display-toggle-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/slot-display-contents-display-toggle-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="height:20px;background:green">A</div>
+<div style="height:20px;background:blue">B</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/slot-display-contents-display-toggle-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/slot-display-contents-display-toggle-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="height:20px;background:green">A</div>
+<div style="height:20px;background:blue">B</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/slot-display-contents-display-toggle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/slot-display-contents-display-toggle.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-display/#valdef-display-contents">
+<link rel="match" href="slot-display-contents-display-toggle-ref.html">
+<body>
+<my-el>
+  <div style="display:contents">
+    <div id="a" style="height:20px;background:green">A</div>
+    <div style="height:20px;background:blue">B</div>
+  </div>
+</my-el>
+<script>
+customElements.define('my-el', class extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' }).innerHTML = '<slot></slot>';
+  }
+});
+document.body.offsetHeight;
+document.getElementById('a').style.display = 'none';
+document.body.offsetHeight;
+document.getElementById('a').style.display = '';
+document.body.offsetHeight;
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/ComposedTreeIterator.cpp
+++ b/Source/WebCore/dom/ComposedTreeIterator.cpp
@@ -55,4 +55,24 @@ String composedTreeAsText(ContainerNode& root, ComposedTreeAsTextMode mode)
     return stream.release();
 }
 
+String composedTreeAsTextFromNode(ContainerNode& root, Node& startNode)
+{
+    TextStream stream;
+    auto descendants = composedTreeDescendants(root);
+    for (auto it = descendants.at(startNode), end = descendants.end(); it != end; ++it) {
+        writeIndent(stream, it.depth());
+
+        if (is<Text>(*it)) {
+            stream << "#text\n";
+            continue;
+        }
+        Ref element = downcast<Element>(*it);
+        stream << element->localName();
+        if (element->shadowRoot())
+            stream << " (shadow root)";
+        stream << "\n";
+    }
+    return stream.release();
+}
+
 }

--- a/Source/WebCore/dom/ComposedTreeIterator.h
+++ b/Source/WebCore/dom/ComposedTreeIterator.h
@@ -72,7 +72,7 @@ private:
         Context(ContainerNode& root, Node& node);
 
         enum SlottedTag { Slotted };
-        Context(ContainerNode& root, Node& node, SlottedTag);
+        Context(ContainerNode& root, Node& current, Node& slottedNode, SlottedTag);
         ElementAndTextDescendantIterator iterator;
         ElementAndTextDescendantIterator end;
         size_t slotNodeIndex { notFound };
@@ -210,6 +210,7 @@ inline ComposedTreeChildAdapter<ContextInlineCapacity> composedTreeChildren(Cont
 
 enum class ComposedTreeAsTextMode { Normal, WithPointers };
 WEBCORE_EXPORT String composedTreeAsText(ContainerNode& root, ComposedTreeAsTextMode = ComposedTreeAsTextMode::Normal);
+WEBCORE_EXPORT String composedTreeAsTextFromNode(ContainerNode& root, Node& startNode);
 
 
 // Helper functions for walking the composed tree.
@@ -292,9 +293,9 @@ inline ComposedTreeIterator<ContextInlineCapacity>::Context::Context(ContainerNo
 }
 
 template <size_t ContextInlineCapacity>
-inline ComposedTreeIterator<ContextInlineCapacity>::Context::Context(ContainerNode& root, Node& node, SlottedTag)
-    : iterator(root, &node)
-    , end(iterator)
+inline ComposedTreeIterator<ContextInlineCapacity>::Context::Context(ContainerNode& root, Node& current, Node& slottedNode, SlottedTag)
+    : iterator(root, &current)
+    , end(root, &slottedNode)
 {
     end.traverseNextSkippingChildren();
 }
@@ -358,7 +359,7 @@ inline void ComposedTreeIterator<ContextInlineCapacity>::initializeContextStack(
             continue;
         }
         if (RefPtr shadowRoot = parent->shadowRoot()) {
-            m_contextStack.append(Context(*parent, *contextCurrent, Context::Slotted));
+            m_contextStack.append(Context(*parent, *contextCurrent, *node, Context::Slotted));
             m_contextStack.last().slotNodeIndex = currentSlotNodeIndex;
 
             RefPtr assignedSlot = shadowRoot->findAssignedSlot(*node);
@@ -416,7 +417,7 @@ inline void ComposedTreeIterator<ContextInlineCapacity>::traverseNextInShadowTre
             RefPtr assignedNode = assignedNodes->at(0).get();
             ASSERT(assignedNode);
             ASSERT(is<Element>(assignedNode->parentNode()));
-            m_contextStack.append(Context(*dynamicDowncast<Element>(assignedNode->parentNode()), *assignedNode, Context::Slotted));
+            m_contextStack.append(Context(*dynamicDowncast<Element>(assignedNode->parentNode()), *assignedNode, *assignedNode, Context::Slotted));
             return;
         }
     }
@@ -454,7 +455,7 @@ inline bool ComposedTreeIterator<ContextInlineCapacity>::advanceInSlot(int direc
     RefPtr slotNode = assignedNodes.at(context().slotNodeIndex).get();
     ASSERT(slotNode);
     ASSERT(is<Element>(slotNode->parentNode()));
-    m_contextStack.append(Context(*dynamicDowncast<Element>(slotNode->parentNode()), *slotNode, Context::Slotted));
+    m_contextStack.append(Context(*dynamicDowncast<Element>(slotNode->parentNode()), *slotNode, *slotNode, Context::Slotted));
     return true;
 }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6272,6 +6272,13 @@ String Internals::composedTreeAsText(Node& node)
     return WebCore::composedTreeAsText(downcast<ContainerNode>(node));
 }
 
+String Internals::composedTreeAsTextFromNode(Node& root, Node& startNode)
+{
+    if (!is<ContainerNode>(root))
+        return emptyString();
+    return WebCore::composedTreeAsTextFromNode(downcast<ContainerNode>(root), startNode);
+}
+
 bool Internals::isProcessingUserGesture()
 {
     return UserGestureIndicator::processingUserGesture();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1009,6 +1009,7 @@ public:
     JSC::JSValue cloneArrayBuffer(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue, JSC::JSValue);
 
     String composedTreeAsText(Node&);
+    String composedTreeAsTextFromNode(Node& root, Node& startNode);
 
     bool isProcessingUserGesture();
     double NODELETE lastHandledUserGestureTimestamp();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1179,6 +1179,7 @@ enum ContentsFormat {
     undefined setCanShowModalDialogOverride(boolean allow);
 
     DOMString composedTreeAsText(Node parent);
+    DOMString composedTreeAsTextFromNode(Node root, Node startNode);
 
     boolean isProcessingUserGesture();
     double lastHandledUserGestureTimestamp();


### PR DESCRIPTION
#### 93f39b4a340fd08d92f9b267c774229ebabefeaf
<pre>
marketwatch.com: Tapping the “share” button causes the media controls to shift to the top of the video.
<a href="https://rdar.apple.com/157607616">rdar://157607616</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313028">https://bugs.webkit.org/show_bug.cgi?id=313028</a>

Reviewed by Antti Koivisto.

When an element goes from display: none to some other display we need to
find a spot in the render tree to insert it. This is done by taking said
element and its rendering parent and finding its next sibling in the
render tree. One of the things that happens is we create an iterator to
go over the composed tree in order to find this spot.

However, one problem that can arise, which seems to be the source of the
bug on MarketWatch, is when the element we are creating a renderer for is
part of some slotted content that is a descendant of elements with
display: contents.

When we try to initialize the context stack, we walk up from the target
node to the root. Initially currentContext is set to the targeted node
and gets updated as we cross different boundaries. However, one thing to
note is that if we hit a parent/ancestor that has display: contents we
do not update contextCurrent. Then by the time we hit a boundary
and need to create a Context for the slotted content we use the targeted
node to compute the iterator&apos;s start and end.

For the case of the MarketWatch bug the iterator points to the targeted
node and the end iterator points to its sibling which is the source of
the bug. When we try to traverse the iterator we reach the end (the
sibling) and that gives us an incorrect insertion point. What should
instead happen is that the end should point to the end of the slotted
content, which is the end of the display: contents subtree.

To fix this we can:
1.) Detect this case if the node and the current context is not the
same *and* the node has display: contents.
2.) Create a dedicated constructor that will take in a separate node to
compute the iterator&apos;s end from alongside the current context and root.
This can replace the existing one and we can just pass in the same node
which is what we were doing before.

* LayoutTests/fast/shadow-dom/slot-display-contents-composed-tree-after-display-toggle-expected.txt: Added.
* LayoutTests/fast/shadow-dom/slot-display-contents-composed-tree-after-display-toggle.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/slot-display-contents-display-toggle-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/slot-display-contents-display-toggle-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/slot-display-contents-display-toggle.html: Added.
&lt;my-el&gt;                         &lt;!-- parent: has a shadow root --&gt;
    &lt;div style=&quot;display:contents&quot;&gt;   &lt;!-- node: the slotted element --&gt;
      &lt;div id=&quot;a&quot;&gt;A&lt;/div&gt;            &lt;!-- contextCurrent: the target --&gt;
      &lt;div&gt;B&lt;/div&gt;
    &lt;/div&gt;
&lt;/my-el&gt;

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::composedTreeAsTextFromNode):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
A new internal function so that we can trigger the stack initialization
logic along with a unit test for it.

Canonical link: <a href="https://commits.webkit.org/312003@main">https://commits.webkit.org/312003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67523a19aa2d94d67d4d8063ae75cf5c2f4ea3da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112640 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60dd0e38-744f-4f31-8b01-5fec4b461992) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122810 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86184 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53c156f5-80c5-4ab0-813c-391635f4fbee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103480 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cfec4883-4c96-45ac-a30a-f478da9d8f08) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24128 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22522 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15156 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169875 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15620 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21831 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130998 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26587 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131112 "Found 1 new API test failure: TestWebKit:WebKit.GeolocationTransitionToLowAccuracy (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35505 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89523 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18807 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31128 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97142 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30648 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30921 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30802 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->