### PR TITLE
[JSC] Optimize returned promise from async function when it does not have await

### DIFF
--- a/JSTests/stress/async-function-empty-resolved-promise.js
+++ b/JSTests/stress/async-function-empty-resolved-promise.js
@@ -1,0 +1,83 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual} expected ${expected}`);
+}
+
+// Empty async function: must hit the `return @newResolvedPromise(undefined)` short-circuit.
+async function empty() {}
+async function emptyArrow() {}
+class C { async emptyMethod() {} }
+const obj = { async emptyShort() {} };
+
+// `await using` declaration is still classified as "without await" (no AwaitExpression),
+// but hasStatements() is true, so we must NOT take the empty short-circuit — the disposal
+// stack still has to run.
+let disposedSync = 0;
+let disposedAsync = 0;
+async function onlyUsing() {
+    using x = { [Symbol.dispose]() { disposedSync++; } };
+}
+async function onlyAwaitUsing() {
+    await using y = { [Symbol.asyncDispose]() { disposedAsync++; return Promise.resolve(); } };
+}
+
+// No-await body that returns a thenable: the resolved promise must pipe from the thenable,
+// not return it as-is (spec compliance — async function wrapper allocates its own promise).
+async function returnsThenable() {
+    return { then(r) { r(42); } };
+}
+
+// No-await body that throws: must return a rejected promise with the thrown value.
+async function throwsLiteral() { throw "boom"; }
+async function throwsError() { throw new Error("e"); }
+
+// No-await body with default arg that throws — crashes without the param-catch fix.
+function thrower() { throw new Error("default-arg"); }
+async function defaultThrower(arg = thrower()) {}
+async function defaultThrowerBody(arg = thrower()) { return arg; }
+
+async function run() {
+    shouldBe(await empty(), undefined);
+    shouldBe(await emptyArrow(), undefined);
+    shouldBe(await new C().emptyMethod(), undefined);
+    shouldBe(await obj.emptyShort(), undefined);
+
+    shouldBe(await onlyUsing(), undefined);
+    shouldBe(disposedSync, 1);
+
+    shouldBe(await onlyAwaitUsing(), undefined);
+    shouldBe(disposedAsync, 1);
+
+    // Thenable pipes through — final resolution is 42, not the thenable object.
+    shouldBe(await returnsThenable(), 42);
+
+    // The wrapper promise must be a brand-new promise, not === to any returned inner promise.
+    const inner = Promise.resolve(7);
+    async function returnsPromise() { return inner; }
+    const outer = returnsPromise();
+    if (outer === inner)
+        throw new Error("wrapper must not return the input promise");
+    shouldBe(await outer, 7);
+
+    // Rejections from throws and default-arg throws.
+    let caught;
+    try { await throwsLiteral(); } catch (e) { caught = e; }
+    shouldBe(caught, "boom");
+
+    try { await throwsError(); caught = null; } catch (e) { caught = e.message; }
+    shouldBe(caught, "e");
+
+    try { await defaultThrower(); caught = null; } catch (e) { caught = e.message; }
+    shouldBe(caught, "default-arg");
+
+    try { await defaultThrowerBody(); caught = null; } catch (e) { caught = e.message; }
+    shouldBe(caught, "default-arg");
+}
+
+// Drive enough iterations to tier up through DFG and FTL.
+(async () => {
+    for (let i = 0; i < 1000; i++)
+        await run();
+})().then(() => {}, e => { throw e; });

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -81,6 +81,8 @@ namespace JSC {
     macro(resolvePromiseWithFirstResolvingFunctionCallCheck) \
     macro(rejectPromiseWithFirstResolvingFunctionCallCheck) \
     macro(fulfillPromiseWithFirstResolvingFunctionCallCheck) \
+    macro(newResolvedPromise) \
+    macro(newRejectedPromise) \
     macro(resolveWithInternalMicrotaskForAsyncAwait) \
     macro(asyncGeneratorQueueEnqueue) \
     macro(asyncGeneratorQueueDequeueResolve) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -61,6 +61,8 @@ class JSGlobalObject;
     v(resolvePromiseWithFirstResolvingFunctionCallCheck, nullptr) \
     v(rejectPromiseWithFirstResolvingFunctionCallCheck, nullptr) \
     v(fulfillPromiseWithFirstResolvingFunctionCallCheck, nullptr) \
+    v(newResolvedPromise, nullptr) \
+    v(newRejectedPromise, nullptr) \
     v(resolveWithInternalMicrotaskForAsyncAwait, nullptr) \
     v(asyncGeneratorQueueEnqueue, nullptr) \
     v(asyncGeneratorQueueDequeueResolve, nullptr) \

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -306,16 +306,25 @@ ParserError BytecodeGenerator::generate(unsigned& size)
         AsyncFuncParametersTryCatchInfo& info = m_asyncFuncParametersTryCatchInfo.value();
         ASSERT(info.catchStartLabel && info.thrownValue);
         emitLabel(*info.catchStartLabel.get());
-        // @rejectPromiseWithFirstResolvingFunctionCallCheck(@promise, thrownValue);
-        // return @promise;
-        RefPtr<RegisterID> rejectPromise = moveLinkTimeConstant(nullptr, LinkTimeConstant::rejectPromiseWithFirstResolvingFunctionCallCheck);
-        CallArguments args(*this, nullptr, 2);
-        emitLoad(args.thisRegister(), jsUndefined());
-        move(args.argumentRegister(0), promiseRegister());
-        move(args.argumentRegister(1), info.thrownValue.get());
         JSTextPosition divot(m_scopeNode->firstLine(), m_scopeNode->startOffset(), m_scopeNode->lineStartOffset());
-        emitCallIgnoreResult(newTemporary(), rejectPromise.get(), NoExpectedFunction, args, divot, divot, divot, DebuggableCall::No);
-        emitReturn(promiseRegister());
+        if (promiseRegister()) {
+            RefPtr<RegisterID> rejectPromise = moveLinkTimeConstant(nullptr, LinkTimeConstant::rejectPromiseWithFirstResolvingFunctionCallCheck);
+            CallArguments args(*this, nullptr, 2);
+            emitLoad(args.thisRegister(), jsUndefined());
+            move(args.argumentRegister(0), promiseRegister());
+            move(args.argumentRegister(1), info.thrownValue.get());
+            emitCallIgnoreResult(newTemporary(), rejectPromise.get(), NoExpectedFunction, args, divot, divot, divot, DebuggableCall::No);
+            emitReturn(promiseRegister());
+        } else {
+            // If we are not creating a promise yet, we can just do `return @newRejectedPromise(thrownValue)`.
+            RefPtr<RegisterID> newRejectedPromise = moveLinkTimeConstant(nullptr, LinkTimeConstant::newRejectedPromise);
+            CallArguments args(*this, nullptr, 1);
+            emitLoad(args.thisRegister(), jsUndefined());
+            move(args.argumentRegister(0), info.thrownValue.get());
+            RefPtr<RegisterID> result = newTemporary();
+            emitCall(result.get(), newRejectedPromise.get(), NoExpectedFunction, args, divot, divot, divot, DebuggableCall::No);
+            emitReturn(result.get());
+        }
     }
 
     m_staticPropertyAnalyzer.kill();
@@ -822,9 +831,10 @@ IGNORE_GCC_WARNINGS_END
         bool isAsyncFunctionWithoutAwait = m_scopeNode->isAsyncFunctionWithoutAwait();
         // Check if this async function body doesn't use await.
         // If so, we can skip generator creation entirely.
-        if (!isAsyncFunctionWithoutAwait)
+        if (!isAsyncFunctionWithoutAwait) {
             m_generatorRegister = addVar();
-        m_promiseRegister = addVar();
+            m_promiseRegister = addVar();
+        }
 
         bool willEmitToThis = false;
         if (parseMode != SourceParseMode::AsyncArrowFunctionMode) {
@@ -838,9 +848,8 @@ IGNORE_GCC_WARNINGS_END
         if (willEmitToThis)
             emitToThis();
 
-        emitNewPromise(promiseRegister());
-
         if (!isAsyncFunctionWithoutAwait) {
+            emitNewPromise(promiseRegister());
             emitNewGenerator(m_generatorRegister);
             emitPutInternalField(generatorRegister(), static_cast<unsigned>(JSGenerator::Field::Context), promiseRegister());
         }

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -5516,12 +5516,38 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
             // - catch: Reject promise with the exception
             // - finally: Resolve promise with completion value and return promise
             //
-            // The finally block always resolves and returns the promise. Since promise
-            // resolution only takes effect on the first call, calling resolve after
-            // reject (from the catch block) is a no-op.
-
+            // try {
+            //     body
+            //     transfer completion-value with completion-type = normal / return
+            // } catch (error) {
+            //     transfer error with completion-type = throw
+            // } finally {
+            //     get value with completion-type
+            //     if (completion-type === throw)
+            //         return @newRejectedPromise(completion-value);
+            //     return @newResolvedPromise(completion-value);
+            // }
             if (generator.parseMode() == SourceParseMode::AsyncArrowFunctionMode && generator.isThisUsedInInnerArrowFunction())
                 generator.emitLoadThisFromArrowFunctionLexicalEnvironment();
+
+            // If async function is just used for a signaling, not having a body, then just convert it to @newResolvedPromise(undefined).
+            //
+            //     Turn this: async function empty() { }
+            //     Into this: function empty() { return @newResolvedPromise(undefined); }
+            //
+            if (isEmptyBody()) {
+                ASSERT(!usingDeclarationCount());
+                ASSERT(!hasAwaitUsingDeclaration());
+                RefPtr<RegisterID> newResolvedPromise = generator.moveLinkTimeConstant(nullptr, LinkTimeConstant::newResolvedPromise);
+                CallArguments resolveArgs(generator, nullptr, 1);
+                generator.emitLoad(resolveArgs.thisRegister(), jsUndefined());
+                generator.emitLoad(resolveArgs.argumentRegister(0), jsUndefined());
+                RefPtr<RegisterID> result = generator.newTemporary();
+                generator.emitCall(result.get(), newResolvedPromise.get(), NoExpectedFunction, resolveArgs, divot, divot, divot, DebuggableCall::No);
+                generator.emitWillLeaveCallFrameDebugHook();
+                generator.emitReturn(result.get());
+                break;
+            }
 
             // Set up finally context to capture return values from the body.
             // When a return statement is hit, it stores the value in completionValueRegister
@@ -5531,10 +5557,11 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
             generator.pushFinallyControlFlowScope(finallyContext);
             generator.emitLoad(finallyContext.completionValueRegister(), jsUndefined());
 
-            // Try block. Finally handler puts return value to completionValueRegister.
+            // Try block. FinallyContext routes `return V` to finally with completionType=Return
+            // and completionValue=V. Normal fallthrough keeps completionType=Normal (its initial value).
             Ref<Label> catchLabel = generator.newLabel();
             Ref<Label> tryStartLabel = generator.newEmittedLabel();
-            TryData* tryData = generator.pushTry(tryStartLabel.get(), catchLabel.get(), HandlerType::Catch);
+            TryData* tryData = generator.pushTry(tryStartLabel.get(), catchLabel.get(), HandlerType::Finally);
             generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
                 scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
                     emitStatementsBytecode(generator, generator.ignoredResult());
@@ -5544,43 +5571,43 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
             Ref<Label> tryEndLabel = generator.newEmittedLabel();
             generator.popTry(tryData, tryEndLabel.get());
 
-            // Catch block. Reject promise with the exception.
+            // Catch handler. Runtime populates completionValueRegister with the thrown value
+            // and completionTypeRegister with CompletionType::Throw.
             generator.emitLabel(catchLabel.get());
-            RefPtr<RegisterID> thrownValue = generator.newTemporary();
-            generator.emitOutOfLineCatchHandler(thrownValue.get(), finallyContext.completionTypeRegister(), tryData);
-
-            // Push try for catch block pointing to finally (for exceptions in catch).
-            TryData* catchTryData = generator.pushTry(catchLabel.get(), finallyLabel.get(), HandlerType::Finally);
-            {
-                RefPtr<RegisterID> rejectPromise = generator.moveLinkTimeConstant(nullptr, LinkTimeConstant::rejectPromiseWithFirstResolvingFunctionCallCheck);
-                CallArguments rejectArgs(generator, nullptr, 2);
-                generator.emitLoad(rejectArgs.thisRegister(), jsUndefined());
-                generator.move(rejectArgs.argumentRegister(0), generator.promiseRegister());
-                generator.move(rejectArgs.argumentRegister(1), thrownValue.get());
-                generator.emitCallIgnoreResult(generator.newTemporary(), rejectPromise.get(), NoExpectedFunction, rejectArgs, divot, divot, divot, DebuggableCall::No);
-            }
-
-            // Catch handled the exception, set completion type to Normal.
-            generator.emitLoad(finallyContext.completionTypeRegister(), CompletionType::Normal);
-            generator.popTry(catchTryData, finallyLabel.get());
+            generator.emitOutOfLineCatchHandler(finallyContext.completionValueRegister(), finallyContext.completionTypeRegister(), tryData);
 
             generator.popFinallyControlFlowScope();
 
-            // Emit out-of-line finally handler for exceptions thrown in catch block.
-            generator.emitOutOfLineFinallyHandler(finallyContext.completionValueRegister(), finallyContext.completionTypeRegister(), catchTryData);
-
-            // Finally block. Resolve promise with completion value and return promise.
+            // Dispatch on completionType: Throw -> rejected, else -> resolved.
             generator.emitLabel(finallyLabel.get());
             {
-                RefPtr<RegisterID> resolvePromise = generator.moveLinkTimeConstant(nullptr, LinkTimeConstant::resolvePromiseWithFirstResolvingFunctionCallCheck);
-                CallArguments resolveArgs(generator, nullptr, 2);
-                generator.emitLoad(resolveArgs.thisRegister(), jsUndefined());
-                generator.move(resolveArgs.argumentRegister(0), generator.promiseRegister());
-                generator.move(resolveArgs.argumentRegister(1), finallyContext.completionValueRegister());
-                generator.emitCallIgnoreResult(generator.newTemporary(), resolvePromise.get(), NoExpectedFunction, resolveArgs, divot, divot, divot, DebuggableCall::No);
+                Ref<Label> resolveCase = generator.newLabel();
+                RefPtr<RegisterID> throwType = generator.emitLoad(nullptr, jsNumber(static_cast<int32_t>(CompletionType::Throw)));
+                generator.emitJumpIfFalse(generator.emitEqualityOp<OpStricteq>(generator.newTemporary(), finallyContext.completionTypeRegister(), throwType.get()), resolveCase.get());
+
+                {
+                    RefPtr<RegisterID> newRejectedPromise = generator.moveLinkTimeConstant(nullptr, LinkTimeConstant::newRejectedPromise);
+                    CallArguments rejectArgs(generator, nullptr, 1);
+                    generator.emitLoad(rejectArgs.thisRegister(), jsUndefined());
+                    generator.move(rejectArgs.argumentRegister(0), finallyContext.completionValueRegister());
+                    RefPtr<RegisterID> result = generator.newTemporary();
+                    generator.emitCall(result.get(), newRejectedPromise.get(), NoExpectedFunction, rejectArgs, divot, divot, divot, DebuggableCall::No);
+                    generator.emitWillLeaveCallFrameDebugHook();
+                    generator.emitReturn(result.get());
+                }
+
+                generator.emitLabel(resolveCase.get());
+                {
+                    RefPtr<RegisterID> newResolvedPromise = generator.moveLinkTimeConstant(nullptr, LinkTimeConstant::newResolvedPromise);
+                    CallArguments resolveArgs(generator, nullptr, 1);
+                    generator.emitLoad(resolveArgs.thisRegister(), jsUndefined());
+                    generator.move(resolveArgs.argumentRegister(0), finallyContext.completionValueRegister());
+                    RefPtr<RegisterID> result = generator.newTemporary();
+                    generator.emitCall(result.get(), newResolvedPromise.get(), NoExpectedFunction, resolveArgs, divot, divot, divot, DebuggableCall::No);
+                    generator.emitWillLeaveCallFrameDebugHook();
+                    generator.emitReturn(result.get());
+                }
             }
-            generator.emitDebugHook(WillLeaveCallFrame, JSTextPosition(lastLine(), startOffset(), lineStartOffset()));
-            generator.emitReturn(generator.promiseRegister());
             break;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3973,6 +3973,13 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case NewResolvedPromise:
+    case NewRejectedPromise: {
+        clobberWorld();
+        setTypeForNode(node, SpecPromiseObject);
+        break;
+    }
+
     case CreateGenerator:
     case CreateAsyncGenerator: {
         auto tryToFold = [&] (const ClassInfo* classInfo) -> bool {

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -4699,6 +4699,26 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case NewResolvedPromiseIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* argument = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            setResult(addToGraph(NewResolvedPromise, Edge(argument)));
+            return CallOptimizationResult::Inlined;
+        }
+
+        case NewRejectedPromiseIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* argument = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            setResult(addToGraph(NewRejectedPromise, Edge(argument)));
+            return CallOptimizationResult::Inlined;
+        }
+
         case PromiseConstructorResolveIntrinsic: {
             if (argumentCountIncludingThis < 2)
                 return CallOptimizationResult::DidNothing;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2545,6 +2545,11 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         clobberTop();
         return;
 
+    case NewResolvedPromise:
+    case NewRejectedPromise:
+        clobberTop();
+        return;
+
     case PromiseResolve:
     case PromiseReject:
     case PromiseThen:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -488,6 +488,8 @@ bool doesGC(Graph& graph, Node* node)
     case ResolvePromiseFirstResolving:
     case RejectPromiseFirstResolving:
     case FulfillPromiseFirstResolving:
+    case NewResolvedPromise:
+    case NewRejectedPromise:
     case PromiseResolve:
     case PromiseReject:
     case PromiseThen:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3602,6 +3602,8 @@ private:
         case ResolvePromiseFirstResolving:
         case RejectPromiseFirstResolving:
         case FulfillPromiseFirstResolving:
+        case NewResolvedPromise:
+        case NewRejectedPromise:
         case PromiseResolve:
         case PromiseReject:
         case PromiseThen:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -646,6 +646,8 @@ namespace JSC { namespace DFG {
     macro(ResolvePromiseFirstResolving, NodeMustGenerate) \
     macro(RejectPromiseFirstResolving, NodeMustGenerate) \
     macro(FulfillPromiseFirstResolving, NodeMustGenerate) \
+    macro(NewResolvedPromise, NodeMustGenerate | NodeResultJS) \
+    macro(NewRejectedPromise, NodeMustGenerate | NodeResultJS) \
     macro(PromiseResolve, NodeMustGenerate | NodeResultJS) \
     macro(PromiseReject, NodeMustGenerate | NodeResultJS) \
     macro(PromiseThen, NodeMustGenerate | NodeResultJS) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -468,6 +468,26 @@ JSC_DEFINE_JIT_OPERATION(operationCreatePromise, JSCell*, (JSGlobalObject* globa
     OPERATION_RETURN(scope, JSPromise::create(vm, structure));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationNewResolvedPromise, JSCell*, (JSGlobalObject* globalObject, EncodedJSValue encodedValue))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+    promise->resolve(globalObject, vm, JSValue::decode(encodedValue));
+    OPERATION_RETURN(scope, promise);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationNewRejectedPromise, JSCell*, (JSGlobalObject* globalObject, EncodedJSValue encodedValue))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    OPERATION_RETURN(scope, JSPromise::rejectedPromise(globalObject, JSValue::decode(encodedValue)));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationCreateGenerator, JSCell*, (JSGlobalObject* globalObject, JSObject* constructor))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -78,6 +78,8 @@ JSC_DECLARE_JIT_OPERATION(operationReflectOwnKeys, JSArray*, (JSGlobalObject*, E
 JSC_DECLARE_JIT_OPERATION(operationReflectOwnKeysObject, JSArray*, (JSGlobalObject*, JSObject*));
 JSC_DECLARE_JIT_OPERATION(operationCreateThis, JSCell*, (JSGlobalObject*, JSObject* constructor, uint32_t inlineCapacity));
 JSC_DECLARE_JIT_OPERATION(operationCreatePromise, JSCell*, (JSGlobalObject*, JSObject* constructor));
+JSC_DECLARE_JIT_OPERATION(operationNewResolvedPromise, JSCell*, (JSGlobalObject*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationNewRejectedPromise, JSCell*, (JSGlobalObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationCreateGenerator, JSCell*, (JSGlobalObject*, JSObject* constructor));
 JSC_DECLARE_JIT_OPERATION(operationCreateAsyncGenerator, JSCell*, (JSGlobalObject*, JSObject* constructor));
 JSC_DECLARE_JIT_OPERATION(operationToThis, EncodedJSValue, (JSGlobalObject*, EncodedJSValue encodedOp1));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1349,6 +1349,11 @@ private:
             setPrediction(SpecPromiseObject);
             break;
 
+        case NewResolvedPromise:
+        case NewRejectedPromise:
+            setPrediction(SpecPromiseObject);
+            break;
+
         case CreateGenerator:
         case CreateAsyncGenerator:
             setPrediction(SpecObjectOther);

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -787,6 +787,8 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ResolvePromiseFirstResolving:
     case RejectPromiseFirstResolving:
     case FulfillPromiseFirstResolving:
+    case NewResolvedPromise:
+    case NewRejectedPromise:
     case PromiseResolve:
     case PromiseReject:
     case PromiseThen:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -18028,6 +18028,57 @@ void SpeculativeJIT::compileFulfillPromiseFirstResolving(Node* node)
     noResult(node);
 }
 
+void SpeculativeJIT::compileNewResolvedPromise(Node* node)
+{
+    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+    if (!(m_state.forNode(node->child1()).m_type & SpecObject)) {
+        JSValueOperand argument(this, node->child1());
+        JSValueRegs argumentRegs = argument.jsValueRegs();
+
+        GPRTemporary result(this);
+        GPRTemporary scratch1(this);
+        GPRTemporary scratch2(this);
+        GPRReg resultGPR = result.gpr();
+        GPRReg scratch1GPR = scratch1.gpr();
+        GPRReg scratch2GPR = scratch2.gpr();
+
+        JumpList slowCases;
+
+        auto structure = m_graph.registerStructure(globalObject->promiseStructure());
+        auto butterfly = TrustedImmPtr(nullptr);
+        emitAllocateJSObjectWithKnownSize<JSPromise>(resultGPR, TrustedImmPtr(structure), butterfly, scratch1GPR, scratch2GPR, slowCases, sizeof(JSPromise), SlowAllocationResult::UndefinedBehavior);
+        storeTrustedValue(jsNumber(static_cast<int32_t>(JSPromise::Status::Fulfilled)), Address(resultGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSPromise::Field::Flags))));
+        storeValue(argumentRegs, Address(resultGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSPromise::Field::ReactionsOrResult))));
+        mutatorFence(vm());
+
+        addSlowPathGenerator(slowPathCall(slowCases, this, operationNewResolvedPromise, resultGPR, LinkableConstant::globalObject(*this, node), argumentRegs));
+
+        cellResult(resultGPR, node);
+        return;
+    }
+
+    JSValueOperand argument(this, node->child1());
+    JSValueRegs argumentRegs = argument.jsValueRegs();
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationNewResolvedPromise, resultGPR, LinkableConstant::globalObject(*this, node), argumentRegs);
+    cellResult(resultGPR, node);
+}
+
+void SpeculativeJIT::compileNewRejectedPromise(Node* node)
+{
+    JSValueOperand argument(this, node->child1());
+    JSValueRegs argumentRegs = argument.jsValueRegs();
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationNewRejectedPromise, resultGPR, LinkableConstant::globalObject(*this, node), argumentRegs);
+    cellResult(resultGPR, node);
+}
+
 void SpeculativeJIT::compilePromiseResolve(Node* node)
 {
     SpeculateCellOperand constructor(this, node->child1());

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1805,6 +1805,8 @@ public:
     void compileResolvePromiseFirstResolving(Node*);
     void compileRejectPromiseFirstResolving(Node*);
     void compileFulfillPromiseFirstResolving(Node*);
+    void compileNewResolvedPromise(Node*);
+    void compileNewRejectedPromise(Node*);
     void compilePromiseResolve(Node*);
     void compilePromiseReject(Node*);
     void compilePromiseThen(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -4368,6 +4368,14 @@ void SpeculativeJIT::compile(Node* node)
         compileFulfillPromiseFirstResolving(node);
         break;
 
+    case NewResolvedPromise:
+        compileNewResolvedPromise(node);
+        break;
+
+    case NewRejectedPromise:
+        compileNewRejectedPromise(node);
+        break;
+
     case PromiseResolve:
         compilePromiseResolve(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -6504,6 +6504,14 @@ void SpeculativeJIT::compile(Node* node)
         compileFulfillPromiseFirstResolving(node);
         break;
 
+    case NewResolvedPromise:
+        compileNewResolvedPromise(node);
+        break;
+
+    case NewRejectedPromise:
+        compileNewRejectedPromise(node);
+        break;
+
     case PromiseResolve:
         compilePromiseResolve(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -501,6 +501,8 @@ inline CapabilityLevel canCompile(Node* node)
     case ResolvePromiseFirstResolving:
     case RejectPromiseFirstResolving:
     case FulfillPromiseFirstResolving:
+    case NewResolvedPromise:
+    case NewRejectedPromise:
     case PromiseResolve:
     case PromiseReject:
     case PromiseThen:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1923,6 +1923,14 @@ private:
             compileFulfillPromiseFirstResolving();
             break;
 
+        case NewResolvedPromise:
+            compileNewResolvedPromise();
+            break;
+
+        case NewRejectedPromise:
+            compileNewRejectedPromise();
+            break;
+
         case PromiseResolve:
             compilePromiseResolve();
             break;
@@ -20646,6 +20654,44 @@ IGNORE_CLANG_WARNINGS_END
         LValue promise = lowCell(m_node->child1());
         LValue argument = lowJSValue(m_node->child2());
         vmCall(Void, operationFulfillPromiseFirstResolving, weakPointer(globalObject), promise, argument);
+    }
+
+    void compileNewResolvedPromise()
+    {
+        auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+
+        if (!(abstractValue(m_node->child1()).m_type & SpecObject)) {
+            LValue argument = lowJSValue(m_node->child1());
+
+            LBasicBlock slowCase = m_out.newBlock();
+            LBasicBlock continuation = m_out.newBlock();
+
+            LValue structure = weakStructure(m_graph.registerStructure(globalObject->promiseStructure()));
+            LValue promise = allocateObject<JSPromise>(structure, m_out.intPtrZero, slowCase);
+            m_out.store64(m_out.constInt64(JSValue::encode(jsNumber(static_cast<int32_t>(JSPromise::Status::Fulfilled)))), promise, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSPromise::Field::Flags)]);
+            m_out.store64(argument, promise, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSPromise::Field::ReactionsOrResult)]);
+            mutatorFence();
+            ValueFromBlock fastResult = m_out.anchor(promise);
+            m_out.jump(continuation);
+
+            LBasicBlock lastNext = m_out.appendTo(slowCase, continuation);
+            ValueFromBlock slowResult = m_out.anchor(vmCall(pointerType(), operationNewResolvedPromise, weakPointer(globalObject), argument));
+            m_out.jump(continuation);
+
+            m_out.appendTo(continuation, lastNext);
+            setJSValue(m_out.phi(pointerType(), fastResult, slowResult));
+            return;
+        }
+
+        LValue argument = lowJSValue(m_node->child1());
+        setJSValue(vmCall(pointerType(), operationNewResolvedPromise, weakPointer(globalObject), argument));
+    }
+
+    void compileNewRejectedPromise()
+    {
+        auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LValue argument = lowJSValue(m_node->child1());
+        setJSValue(vmCall(pointerType(), operationNewRejectedPromise, weakPointer(globalObject), argument));
     }
 
     void compilePromiseResolve()

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -2002,6 +2002,8 @@ namespace JSC {
 
         StatementNode* singleStatement() const;
 
+        bool isEmptyBody() const { return !m_statements; }
+
         bool hasCompletionValue() const override;
         bool hasEarlyBreakOrContinue() const override;
 

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -210,6 +210,8 @@ namespace JSC {
     macro(ResolvePromiseWithFirstResolvingFunctionCallCheckIntrinsic) \
     macro(RejectPromiseWithFirstResolvingFunctionCallCheckIntrinsic) \
     macro(FulfillPromiseWithFirstResolvingFunctionCallCheckIntrinsic) \
+    macro(NewResolvedPromiseIntrinsic) \
+    macro(NewRejectedPromiseIntrinsic) \
     macro(PromiseConstructorResolveIntrinsic) \
     macro(PromiseResolveIntrinsic) \
     macro(PromiseConstructorRejectIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -362,6 +362,8 @@ static JSC_DECLARE_HOST_FUNCTION(fulfillPromise);
 static JSC_DECLARE_HOST_FUNCTION(resolvePromiseWithFirstResolvingFunctionCallCheck);
 static JSC_DECLARE_HOST_FUNCTION(rejectPromiseWithFirstResolvingFunctionCallCheck);
 static JSC_DECLARE_HOST_FUNCTION(fulfillPromiseWithFirstResolvingFunctionCallCheck);
+static JSC_DECLARE_HOST_FUNCTION(newResolvedPromise);
+static JSC_DECLARE_HOST_FUNCTION(newRejectedPromise);
 static JSC_DECLARE_HOST_FUNCTION(resolveWithInternalMicrotaskForAsyncAwait);
 static JSC_DECLARE_HOST_FUNCTION(driveAsyncFunction);
 static JSC_DECLARE_HOST_FUNCTION(newHandledRejectedPromise);
@@ -788,6 +790,21 @@ JSC_DEFINE_HOST_FUNCTION(fulfillPromiseWithFirstResolvingFunctionCallCheck, (JSG
     JSValue argument = callFrame->uncheckedArgument(1);
     promise->fulfill(globalObject->vm(), globalObject, argument);
     return encodedJSUndefined();
+}
+
+JSC_DEFINE_HOST_FUNCTION(newResolvedPromise, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    JSValue argument = callFrame->uncheckedArgument(0);
+    auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
+    promise->resolve(globalObject, vm, argument);
+    return JSValue::encode(promise);
+}
+
+JSC_DEFINE_HOST_FUNCTION(newRejectedPromise, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    JSValue argument = callFrame->uncheckedArgument(0);
+    return JSValue::encode(JSPromise::rejectedPromise(globalObject, argument));
 }
 
 JSC_DEFINE_HOST_FUNCTION(resolveWithInternalMicrotaskForAsyncAwait, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -1963,6 +1980,12 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::fulfillPromiseWithFirstResolvingFunctionCallCheck)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, init.owner, 2, "fulfillPromiseWithFirstResolvingFunctionCallCheck"_s, fulfillPromiseWithFirstResolvingFunctionCallCheck, ImplementationVisibility::Private, FulfillPromiseWithFirstResolvingFunctionCallCheckIntrinsic));
+        });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::newResolvedPromise)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, init.owner, 1, "newResolvedPromise"_s, newResolvedPromise, ImplementationVisibility::Private, NewResolvedPromiseIntrinsic));
+        });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::newRejectedPromise)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, init.owner, 1, "newRejectedPromise"_s, newRejectedPromise, ImplementationVisibility::Private, NewRejectedPromiseIntrinsic));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::resolveWithInternalMicrotaskForAsyncAwait)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, init.owner, 3, "resolveWithInternalMicrotaskForAsyncAwait"_s, resolveWithInternalMicrotaskForAsyncAwait, ImplementationVisibility::Private));


### PR DESCRIPTION
#### 19dc01a2c79d8df0739bd9b71db41b1d648f0ca3
<pre>
[JSC] Optimize returned promise from async function when it does not have await
<a href="https://bugs.webkit.org/show_bug.cgi?id=313029">https://bugs.webkit.org/show_bug.cgi?id=313029</a>
<a href="https://rdar.apple.com/175369313">rdar://175369313</a>

Reviewed by Yijia Huang.

Let&apos;s optimize returned promise from async function when we do not have
`await`. Currently, we are calling operationFulfillPromiseFirstResolving
for the created promise when resolving. But since we know that we do not
have `await`, we do not need to create a promise a-priori, and we can
just create and resolve a promise when returning. This is more efficient
since we can fold it into a fulfilled promise allocation when input is
proven as non-object.

Test: JSTests/stress/async-function-empty-resolved-promise.js

* JSTests/stress/async-function-empty-resolved-promise.js: Added.
(shouldBe):
(async empty):
(async emptyArrow):
(C.prototype.async emptyMethod):
(C):
(const.obj.async emptyShort):
(async onlyUsing):
(async onlyAwaitUsing):
(async returnsThenable):
(async throwsLiteral):
(async throwsError):
(thrower):
(async defaultThrower):
(async defaultThrowerBody):
(async run.async returnsPromise):
(async run):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::generate):
(JSC::BytecodeGenerator::BytecodeGenerator):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::FunctionNode::emitBytecode):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/parser/Nodes.h:
(JSC::ScopeNode::isEmptyBody const):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSGlobalObject::init):

Canonical link: <a href="https://commits.webkit.org/311883@main">https://commits.webkit.org/311883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/697b27962df9e52242eaeef588f6e6190be2f85f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158319 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167147 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/31813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31674 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161277 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/31813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/103303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/31813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14920 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150369 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/31813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169639 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19153 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/15247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/31435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/130931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/31343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141797 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24065 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/31343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190447 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30892 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/96658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48868 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/30412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->