### PR TITLE
Expand :is()/:where() optimization beyond tag selectors

### DIFF
--- a/PerformanceTests/CSS/WhereIsClassRuleIndexing.html
+++ b/PerformanceTests/CSS/WhereIsClassRuleIndexing.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Performance test for :where()/:is() class rule indexing</title>
+</head>
+<body>
+<div id="container" style="height: 1px; overflow: hidden;"></div>
+<script src="../resources/runner.js"></script>
+<script>
+
+var ruleClasses = ['heading-1', 'heading-2', 'heading-3', 'heading-4', 'heading-5', 'heading-6',
+    'paragraph', 'link', 'quote', 'bold', 'italic', 'mono', 'pre', 'list-ord', 'list-unord',
+    'list-item', 'tbl', 'image', 'rule', 'def-list'];
+var style = document.createElement('style');
+var css = '';
+for (var i = 0; i < ruleClasses.length; i++)
+    css += '.prose :where(.' + ruleClasses[i] + '):not(:where([class~="not-prose"], [class~="not-prose"] *)) { margin: ' + (i + 1) + 'px; }\n';
+style.textContent = css;
+document.head.appendChild(style);
+
+var container = document.getElementById('container');
+for (var i = 0; i < 25000; i++) {
+    var el = document.createElement('div');
+    el.textContent = 'x';
+    if (i % 500 === 0)
+        el.className = 'not-prose';
+    container.appendChild(el);
+}
+
+PerfTestRunner.measureRunsPerSecond({
+    description: "Style recalculation with :where(.class) rules on a large DOM. Tests that single-argument :where()/:is() rules are indexed by class.",
+    run: function() {
+        container.classList.add('prose');
+        container.offsetHeight;
+
+        container.classList.remove('prose');
+        container.offsetHeight;
+    }
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -175,6 +175,11 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     if (featureCollectionContext)
         m_features.collectFeatures(*featureCollectionContext, ruleData, scopeRules);
 
+    addRuleToBucket(ruleData);
+}
+
+void RuleSet::addRuleToBucket(RuleData& ruleData)
+{
     unsigned classBucketSize = 0;
     const CSSSelector* idSelector = nullptr;
     const CSSSelector* tagSelector = nullptr;
@@ -195,130 +200,134 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
 #if ENABLE(VIDEO)
     const CSSSelector* cuePseudoElementSelector = nullptr;
 #endif
+    Vector<const CSSSelector*, 4> nestedSelectors;
     const CSSSelector* selector = &ruleData.selector();
     do {
-        switch (selector->match()) {
-        case CSSSelector::Match::Id:
-            idSelector = selector;
-            break;
-        case CSSSelector::Match::Class: {
-            auto& className = selector->value();
-            if (!classSelector) {
-                classSelector = selector;
-                classBucketSize = rulesCountForName(m_classRules, className);
-            } else if (classBucketSize) {
-                unsigned newClassBucketSize = rulesCountForName(m_classRules, className);
-                if (newClassBucketSize < classBucketSize) {
-                    classSelector = selector;
-                    classBucketSize = newClassBucketSize;
-                }
-            }
-            break;
-        }
-        case CSSSelector::Match::Exact:
-        case CSSSelector::Match::Set:
-        case CSSSelector::Match::List:
-        case CSSSelector::Match::Hyphen:
-        case CSSSelector::Match::Contain:
-        case CSSSelector::Match::Begin:
-        case CSSSelector::Match::End:
-            if (shouldHaveBucketForAttributeName(*selector))
-                attributeSelector = selector;
-            break;
-        case CSSSelector::Match::Tag:
-            if (selector->tagQName().localName() != starAtom())
-                tagSelector = selector;
-            break;
-        case CSSSelector::Match::PseudoElement:
-            switch (selector->pseudoElement()) {
-            case CSSSelector::PseudoElement::Picker:
-                pickerPseudoElementSelector = selector;
+        nestedSelectors.append(selector);
+        while (!nestedSelectors.isEmpty()) {
+            const CSSSelector* current = nestedSelectors.takeLast();
+            switch (current->match()) {
+            case CSSSelector::Match::Id:
+                idSelector = current;
                 break;
-            case CSSSelector::PseudoElement::UserAgentPart:
-            case CSSSelector::PseudoElement::UserAgentPartLegacyAlias:
-                customPseudoElementSelector = selector;
-                break;
-            case CSSSelector::PseudoElement::Slotted:
-                slottedPseudoElementSelector = selector;
-                break;
-            case CSSSelector::PseudoElement::Part:
-                partPseudoElementSelector = selector;
-                break;
-#if ENABLE(VIDEO)
-            case CSSSelector::PseudoElement::Cue:
-                cuePseudoElementSelector = selector;
-                break;
-#endif
-            case CSSSelector::PseudoElement::ViewTransitionGroup:
-            case CSSSelector::PseudoElement::ViewTransitionImagePair:
-            case CSSSelector::PseudoElement::ViewTransitionOld:
-            case CSSSelector::PseudoElement::ViewTransitionNew:
-                if (selector->stringList()->first() != starAtom())
-                    namedPseudoElementSelector = selector;
-                break;
-            default:
-                otherPseudoElementSelector = selector;
-                break;
-            }
-            break;
-        case CSSSelector::Match::PseudoClass:
-            switch (selector->pseudoClass()) {
-            case CSSSelector::PseudoClass::Link:
-            case CSSSelector::PseudoClass::Visited:
-            case CSSSelector::PseudoClass::AnyLink:
-                linkSelector = selector;
-                break;
-            case CSSSelector::PseudoClass::Focus:
-                focusSelector = selector;
-                break;
-            case CSSSelector::PseudoClass::FocusVisible:
-                focusVisibleSelector = selector;
-                break;
-            case CSSSelector::PseudoClass::Host:
-                hostPseudoClassSelector = selector;
-                break;
-            case CSSSelector::PseudoClass::Root:
-                rootElementSelector = selector;
-                break;
-#if ENABLE(FULLSCREEN_API)
-            case CSSSelector::PseudoClass::Fullscreen:
-            case CSSSelector::PseudoClass::InternalInWindowFullscreen:
-            case CSSSelector::PseudoClass::InternalFullscreenDocument:
-            case CSSSelector::PseudoClass::InternalAnimatingFullscreenTransition:
-                fullscreenPseudoClassSelector = selector;
-                break;
-#endif
-            case CSSSelector::PseudoClass::Scope:
-                m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;
-                break;
-            case CSSSelector::PseudoClass::Is:
-            case CSSSelector::PseudoClass::Where: {
-                auto* selectorList = selector->selectorList();
-                if (selectorList && selectorList->size() == 1) {
-                    for (auto* inner = &selectorList->first(); inner; inner = inner->precedingInComplexSelector()) {
-                        if (inner->match() == CSSSelector::Match::Tag && inner->tagQName().localName() != starAtom() && !tagSelector)
-                            tagSelector = inner;
-                        if (inner->relation() != CSSSelector::Relation::Subselector)
-                            break;
+            case CSSSelector::Match::Class: {
+                auto& className = current->value();
+                if (!classSelector) {
+                    classSelector = current;
+                    classBucketSize = rulesCountForName(m_classRules, className);
+                } else if (classBucketSize) {
+                    unsigned newClassBucketSize = rulesCountForName(m_classRules, className);
+                    if (newClassBucketSize < classBucketSize) {
+                        classSelector = current;
+                        classBucketSize = newClassBucketSize;
                     }
                 }
-                if (hasHostOrScopePseudoClassSubjectInSelectorList(selector->selectorList()))
-                    m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;
                 break;
             }
-            default:
-                if (hasHostOrScopePseudoClassSubjectInSelectorList(selector->selectorList()))
+            case CSSSelector::Match::Exact:
+            case CSSSelector::Match::Set:
+            case CSSSelector::Match::List:
+            case CSSSelector::Match::Hyphen:
+            case CSSSelector::Match::Contain:
+            case CSSSelector::Match::Begin:
+            case CSSSelector::Match::End:
+                if (shouldHaveBucketForAttributeName(*current))
+                    attributeSelector = current;
+                break;
+            case CSSSelector::Match::Tag:
+                if (current->tagQName().localName() != starAtom())
+                    tagSelector = current;
+                break;
+            case CSSSelector::Match::PseudoElement:
+                switch (current->pseudoElement()) {
+                case CSSSelector::PseudoElement::Picker:
+                    pickerPseudoElementSelector = current;
+                    break;
+                case CSSSelector::PseudoElement::UserAgentPart:
+                case CSSSelector::PseudoElement::UserAgentPartLegacyAlias:
+                    customPseudoElementSelector = current;
+                    break;
+                case CSSSelector::PseudoElement::Slotted:
+                    slottedPseudoElementSelector = current;
+                    break;
+                case CSSSelector::PseudoElement::Part:
+                    partPseudoElementSelector = current;
+                    break;
+#if ENABLE(VIDEO)
+                case CSSSelector::PseudoElement::Cue:
+                    cuePseudoElementSelector = current;
+                    break;
+#endif
+                case CSSSelector::PseudoElement::ViewTransitionGroup:
+                case CSSSelector::PseudoElement::ViewTransitionImagePair:
+                case CSSSelector::PseudoElement::ViewTransitionOld:
+                case CSSSelector::PseudoElement::ViewTransitionNew:
+                    if (current->stringList()->first() != starAtom())
+                        namedPseudoElementSelector = current;
+                    break;
+                default:
+                    otherPseudoElementSelector = current;
+                    break;
+                }
+                break;
+            case CSSSelector::Match::PseudoClass:
+                switch (current->pseudoClass()) {
+                case CSSSelector::PseudoClass::Link:
+                case CSSSelector::PseudoClass::Visited:
+                case CSSSelector::PseudoClass::AnyLink:
+                    linkSelector = current;
+                    break;
+                case CSSSelector::PseudoClass::Focus:
+                    focusSelector = current;
+                    break;
+                case CSSSelector::PseudoClass::FocusVisible:
+                    focusVisibleSelector = current;
+                    break;
+                case CSSSelector::PseudoClass::Host:
+                    hostPseudoClassSelector = current;
+                    break;
+                case CSSSelector::PseudoClass::Root:
+                    rootElementSelector = current;
+                    break;
+#if ENABLE(FULLSCREEN_API)
+                case CSSSelector::PseudoClass::Fullscreen:
+                case CSSSelector::PseudoClass::InternalInWindowFullscreen:
+                case CSSSelector::PseudoClass::InternalFullscreenDocument:
+                case CSSSelector::PseudoClass::InternalAnimatingFullscreenTransition:
+                    fullscreenPseudoClassSelector = current;
+                    break;
+#endif
+                case CSSSelector::PseudoClass::Scope:
                     m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;
+                    break;
+                case CSSSelector::PseudoClass::Is:
+                case CSSSelector::PseudoClass::Where: {
+                    auto* selectorList = current->selectorList();
+                    if (selectorList && selectorList->size() == 1) {
+                        for (auto* inner = &selectorList->first(); inner; inner = inner->precedingInComplexSelector()) {
+                            nestedSelectors.append(inner);
+                            if (inner->relation() != CSSSelector::Relation::Subselector)
+                                break;
+                        }
+                    }
+                    if (hasHostOrScopePseudoClassSubjectInSelectorList(selectorList))
+                        m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;
+                    break;
+                }
+                default:
+                    if (hasHostOrScopePseudoClassSubjectInSelectorList(current->selectorList()))
+                        m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;
+                    break;
+                }
+                break;
+            case CSSSelector::Match::Unknown:
+            case CSSSelector::Match::ForgivingUnknown:
+            case CSSSelector::Match::ForgivingUnknownNestContaining:
+            case CSSSelector::Match::HasScope:
+            case CSSSelector::Match::NestingParent:
+            case CSSSelector::Match::PagePseudoClass:
                 break;
             }
-            break;
-        case CSSSelector::Match::Unknown:
-        case CSSSelector::Match::ForgivingUnknown:
-        case CSSSelector::Match::ForgivingUnknownNestContaining:
-        case CSSSelector::Match::HasScope:
-        case CSSSelector::Match::NestingParent:
-        case CSSSelector::Match::PagePseudoClass:
-            break;
         }
         // We only process the subject (rightmost compound selector).
         if (selector->relation() != CSSSelector::Relation::Subselector)

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -157,6 +157,7 @@ private:
     using ScopeRuleIdentifier = unsigned;
 
     void addRule(RuleData&&, CascadeLayerIdentifier, ContainerQueryIdentifier, ScopeRuleIdentifier, RuleFeatureSet::CollectionContext*);
+    void addRuleToBucket(RuleData&);
 
     struct ResolverMutatingRule {
         Ref<StyleRuleBase> rule;


### PR DESCRIPTION
#### 38b6ce2aafaa50e1f214cc20c89cfab7c709406c
<pre>
Expand :is()/:where() optimization beyond tag selectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=313030">https://bugs.webkit.org/show_bug.cgi?id=313030</a>
<a href="https://rdar.apple.com/175369601">rdar://175369601</a>

Reviewed by Antti Koivisto.

This change is a follow-up to 311212@main, which extracted tag selectors
from single-argument :is()/:where(). We wrap the switch in RuleSet::addRule
in a recursive lambda so the inner walk applies the full logic: :is(.foo)
now goes to the class bucket, :is(#id) to the id bucket, :is([attr]) to
the attribute bucket, and :where(:focus) to the focus pseudo-class bucket.

The included performance test progresses from ~70 runs/s to ~1050 run/s
with this change.

* PerformanceTests/CSS/WhereIsClassRuleIndexing.html: Added.
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
(WebCore::Style::RuleSet::addRuleToBucket):
* Source/WebCore/style/RuleSet.h:

Canonical link: <a href="https://commits.webkit.org/312134@main">https://commits.webkit.org/312134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f4502cab8ea1f3a8fa63bbf3d957358376fa8b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167805 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123177 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86500 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103845 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24505 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22911 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170298 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16040 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131366 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131478 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35561 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90087 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19201 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31548 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97562 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->