### PR TITLE
[JSC] Uniformly track source columns while lazily parsing functions

### DIFF
--- a/JSTests/stress/lazily-parsed-function-column-tracking.js
+++ b/JSTests/stress/lazily-parsed-function-column-tracking.js
@@ -1,0 +1,68 @@
+// Test that source positions are tracked correctly in the lazy parsing of functions.
+// Lazy parsing begins in the middle of a line, at the opening parenthesis of the
+// parameter list. Despite that, source positions should reflect positions in the full text.
+
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message);
+}
+
+function getFirstFrameLocation(e) {
+    var frame = e.stack.split('\n')[0];
+    var match = frame.match(/:(\d+):(\d+)$/);
+    assert(match, "Could not parse location from stack frame: " + frame);
+    return { line: parseInt(match[1]), column: parseInt(match[2]) };
+}
+
+function checkLocation(e, expectedLine, expectedColumn, label) {
+    var loc = getFirstFrameLocation(e);
+    assert(loc.line === expectedLine && loc.column === expectedColumn,
+        label + ": expected " + expectedLine + ":" + expectedColumn + ", got " + loc.line + ":" + loc.column);
+}
+
+// Case 1: throw on the same line as the function start.
+var f1 = function() { throw new Error(); };
+try { f1(); } catch(e) {
+    checkLocation(e, 24, 38, "Case 1");
+}
+
+// Case 2: throw on its own line.
+var f2 = function() {
+    throw new Error();
+};
+try { f2(); } catch(e) {
+    checkLocation(e, 31, 20, "Case 2");
+}
+
+// Case 3: nested functions, everything on the same line.
+var f3 = function() { var g = function() { throw new Error(); }; return g; };
+try { f3()(); } catch(e) {
+    checkLocation(e, 38, 59, "Case 3");
+}
+
+// Case 4: nested functions, inner throw on a different line.
+var f4 = function() {
+    var g = function() { throw new Error(); };
+    return g;
+};
+try { f4()(); } catch(e) {
+    checkLocation(e, 45, 41, "Case 4");
+}
+
+// Case 5: three-level nesting, all on the same line.
+var f5 = function() { var g = function() { var h = function() { throw new Error(); }; return h; }; return g; };
+try { f5()()(); } catch(e) {
+    checkLocation(e, 53, 80, "Case 5");
+}
+
+// Case 6: three-level nesting, each on its own line.
+var f6 = function() {
+    var g = function() {
+        var h = function() { throw new Error(); };
+        return h;
+    };
+    return g;
+};
+try { f6()()(); } catch(e) {
+    checkLocation(e, 61, 45, "Case 6");
+}

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2170,7 +2170,7 @@ LineColumn CodeBlock::lineColumnForBytecodeIndex(BytecodeIndex bytecodeIndex) co
 {
     RELEASE_ASSERT(bytecodeIndex.offset() < instructions().size());
     auto lineColumn = m_unlinkedCode->lineColumnForBytecodeIndex(bytecodeIndex);
-    lineColumn.column += lineColumn.line ? 1 : firstLineColumnOffset();
+    lineColumn.column += 1;
     lineColumn.line += ownerExecutable()->firstLine();
     return lineColumn;
 }
@@ -2179,7 +2179,7 @@ ExpressionInfo::Entry CodeBlock::expressionInfoForBytecodeIndex(BytecodeIndex by
 {
     auto entry = m_unlinkedCode->expressionInfoForBytecodeIndex(bytecodeIndex);
     entry.divot += sourceOffset();
-    entry.lineColumn.column += entry.lineColumn.line ? 1 : firstLineColumnOffset();
+    entry.lineColumn.column += 1;
     entry.lineColumn.line += ownerExecutable()->firstLine();
     return entry;
 }

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -412,7 +412,6 @@ public:
 
     const SourceCode& source() const LIFETIME_BOUND { return m_ownerExecutable->source(); }
     unsigned sourceOffset() const { return m_ownerExecutable->source().startOffset(); }
-    unsigned firstLineColumnOffset() const { return m_ownerExecutable->startColumn(); }
 
     size_t numberOfJumpTargets() const { return m_unlinkedCode->numberOfJumpTargets(); }
     unsigned jumpTarget(int index) const { return m_unlinkedCode->jumpTarget(index); }

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -95,7 +95,7 @@ UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* struct
     , m_isBuiltinFunction(kind == UnlinkedBuiltinFunction)
     , m_unlinkedBodyStartColumn(node->startColumn())
     , m_isBuiltinDefaultClassConstructor(isBuiltinDefaultClassConstructor)
-    , m_unlinkedBodyEndColumn(m_lineCount ? node->endColumn() : node->endColumn() - node->startColumn())
+    , m_unlinkedBodyEndColumn(node->endColumn())
     , m_constructAbility(static_cast<unsigned>(constructAbility))
     , m_startOffset(node->source().startOffset() - parentSource.startOffset())
     , m_scriptMode(static_cast<unsigned>(scriptMode))
@@ -185,7 +185,7 @@ DEFINE_VISIT_CHILDREN(UnlinkedFunctionExecutable);
 SourceCode UnlinkedFunctionExecutable::linkedSourceCode(const SourceCode& passedParentSource) const
 {
     const SourceCode& parentSource = !m_isBuiltinDefaultClassConstructor ? passedParentSource : BuiltinExecutables::defaultConstructorSourceCode(constructorKind());
-    unsigned startColumn = linkedStartColumn(parentSource.startColumn().oneBasedInt());
+    unsigned startColumn = linkedStartColumn();
     unsigned startOffset = parentSource.startOffset() + m_startOffset;
     unsigned firstLine = parentSource.firstLine().oneBasedInt() + m_firstLineOffset;
     return SourceCode(parentSource.provider(), startOffset, startOffset + m_sourceLength, firstLine, startColumn);

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -106,8 +106,8 @@ public:
     SuperBinding superBinding() const { return static_cast<SuperBinding>(m_superBinding); }
 
     unsigned lineCount() const { return m_lineCount; }
-    unsigned linkedStartColumn(unsigned parentStartColumn) const { return m_unlinkedBodyStartColumn + (!m_firstLineOffset ? parentStartColumn : 1); }
-    unsigned linkedEndColumn(unsigned startColumn) const { return m_unlinkedBodyEndColumn + (!m_lineCount ? startColumn : 1); }
+    unsigned linkedStartColumn() const { return m_unlinkedBodyStartColumn + 1; }
+    unsigned linkedEndColumn() const { return m_unlinkedBodyEndColumn + 1; }
 
     unsigned unlinkedFunctionStart() const { return m_unlinkedFunctionStart; }
     unsigned unlinkedFunctionEnd() const { return m_unlinkedFunctionEnd; }

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -635,16 +635,7 @@ namespace JSC {
             ASSERT(line >= firstLine);
             line -= firstLine;
 
-            unsigned lineStart = divot.lineStartOffset;
-            if (lineStart > sourceOffset)
-                lineStart -= sourceOffset;
-            else
-                lineStart = 0;
-
-            if (divotOffset < lineStart)
-                return;
-
-            unsigned column = divotOffset - lineStart;
+            unsigned column = divot.column();
 
             unsigned instructionOffset = instructions().size();
             m_codeBlock->addExpressionInfo(instructionOffset, divotOffset, startOffset, endOffset, { line, column });

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -570,7 +570,7 @@ void Lexer<T>::setCode(const SourceCode& source, ParserArena* arena)
     m_codeEnd = m_codeStart + source.endOffset();
     m_error = false;
     m_atLineStart = true;
-    m_lineStart = m_code;
+    m_lineStart = m_codeStartPlusOffset - source.startColumn().zeroBasedInt();
     m_lexErrorMessage = String();
     m_sourceURLDirective = String();
     m_sourceMappingURLDirective = String();

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -145,7 +145,7 @@ Parser<LexerType>::Parser(VM& vm, const SourceCode& source, ImplementationVisibi
     m_lexer->setCode(source, &m_parserArena);
     m_token.m_startPosition.line = source.firstLine().oneBasedInt();
     m_token.m_startPosition.offset = source.startOffset();
-    m_token.m_startPosition.lineStartOffset = source.startOffset();
+    m_token.m_startPosition.lineStartOffset = source.startOffset() - source.startColumn().zeroBasedInt();
     m_token.m_endPosition.offset = source.startOffset();
     m_functionCache = vm.addSourceProviderCache(source.provider());
 

--- a/Source/JavaScriptCore/runtime/CodeCache.cpp
+++ b/Source/JavaScriptCore/runtime/CodeCache.cpp
@@ -88,10 +88,8 @@ UnlinkedCodeBlockType* generateUnlinkedCodeBlockImpl(VM& vm, const SourceCode& s
         return nullptr;
 
     unsigned lineCount = rootNode->lastLine() - rootNode->firstLine();
-    unsigned startColumn = rootNode->startColumn() + 1;
-    bool endColumnIsOnStartLine = !lineCount;
     unsigned unlinkedEndColumn = rootNode->endColumn();
-    unsigned endColumn = unlinkedEndColumn + (endColumnIsOnStartLine ? startColumn : 1);
+    unsigned endColumn = unlinkedEndColumn + 1;
     if (executable)
         executable->recordParse(rootNode->features(), rootNode->lexicallyScopedFeatures(), rootNode->hasCapturedVariables(), rootNode->lastLine(), endColumn);
 
@@ -167,9 +165,7 @@ UnlinkedCodeBlockType* CodeCache::getUnlinkedGlobalCodeBlock(VM& vm, ExecutableT
     UnlinkedCodeBlockType* unlinkedCodeBlock = m_sourceCode.findCacheAndUpdateAge<UnlinkedCodeBlockType>(vm, key);
     if (unlinkedCodeBlock && Options::useCodeCache()) {
         unsigned lineCount = unlinkedCodeBlock->lineCount();
-        unsigned startColumn = unlinkedCodeBlock->startColumn() + source.startColumn().oneBasedInt();
-        bool endColumnIsOnStartLine = !lineCount;
-        unsigned endColumn = unlinkedCodeBlock->endColumn() + (endColumnIsOnStartLine ? startColumn : 1);
+        unsigned endColumn = unlinkedCodeBlock->endColumn() + 1;
         executable->recordParse(unlinkedCodeBlock->codeFeatures(), unlinkedCodeBlock->lexicallyScopedFeatures(), unlinkedCodeBlock->hasCapturedVariables(), source.firstLine().oneBasedInt() + lineCount, endColumn);
         if (unlinkedCodeBlock->sourceURLDirective())
             source.provider()->setSourceURLDirective(unlinkedCodeBlock->sourceURLDirective());

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.h
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.h
@@ -192,7 +192,7 @@ public:
     {
         if (m_rareData) [[unlikely]]
             return m_rareData->m_endColumn;
-        return m_unlinkedExecutable->linkedEndColumn(m_source.startColumn().oneBasedInt());
+        return m_unlinkedExecutable->linkedEndColumn();
     }
 
     int firstLine() const


### PR DESCRIPTION
#### b232e209c299365ad4df5a8d65d5a25f593348ae
<pre>
[JSC] Uniformly track source columns while lazily parsing functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=313052">https://bugs.webkit.org/show_bug.cgi?id=313052</a>
<a href="https://rdar.apple.com/175371902">rdar://175371902</a>

Reviewed by NOBODY (OOPS!).

Currently, when we re-parse a function that was previously syntax-checked, the parsed
range begins at the opening parenthesis of the function parameter list. Lexer::m_lineStart
is set to the start of that range. This leads to an inconsistency in the tracking of
column positions. On the first line of a lazily parsed function columns are relative
(counted from the opening parenthesis) and not absolute (counted from the actual line
start in the full text). Downstream code in BytecodeGenerator, UnlinkedFunctionExecutable,
and CodeBlock includes conditional logic to translate columns on the first line to
absolute values.

Besides the extra complexity in itself, this complicates the eager parsing of IIFEs
(immediately invoked function expressions). In eager parsing columns are always absolute,
so currently on the first line they need to be adjusted to relative values to match what&apos;s
expected by the downstream code.

This patch changes Lexer and Parser so that columns are always counted from the actual
start of the line, and changes the downstream code so it expects them to already be
absolute.

- Lexer::setCode — m_lineStart now points to actual line start.
- Parser constructor — lineStartOffset matches the Lexer.
- BytecodeGenerator, CodeBlock, UnlinkedFunctionExecutable, CodeCache — special
  cases removed.

Test: added JSTests/stress/lazily-parsed-function-column-tracking.js,
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b232e209c299365ad4df5a8d65d5a25f593348ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112171 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31427 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122437 "Failure limit exceed. At least found 500 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85942 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161046 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24714 "Found 1 new test failure: js/dom/script-start-end-locations.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141991 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103106 "Found 53 new API test failures: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, WPE/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode, TestWebKit:WebKit.GeolocationTransitionToLowAccuracy, WPE/TestBackForwardList:/webkit/WebKitWebView/session-state-with-form-data, WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/console-api, WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, WPE/TestUIClient:/webkit/WebKitWebView/javascript-dialogs, WPE/TestUIClient:/webkit/WebKitWebView/create-ready-close, TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback ... (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23770 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22085 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14689 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150139 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169406 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18923 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14760 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21406 "Found 2 new test failures: js/dom/line-column-numbers.html js/dom/script-start-end-locations.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130626 "Failure limit exceed. At least found 498 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31171 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26150 "Found 61 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html accessibility/custom-elements/autocomplete.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130741 "Found 68 new API test failures: WebKitGTK/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode, TestWebKit:WebKit.GeolocationTransitionToLowAccuracy, WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print, WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/enable-html5-database, WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/handle-corrupted-local-storage, WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editable/editable, TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89005 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25447 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18383 "Found 2 new test failures: js/dom/line-column-numbers.html js/dom/script-start-end-locations.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190217 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30661 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96194 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48831 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30182 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30412 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30309 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->