### PR TITLE
REGRESSION (307593@main): fixed-positioned box that uses position-area does not fallback properly when body is scrollable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-016-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-016-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Initially, anchored is at top left position
+PASS Scroll to end of page, anchored should be at bottom left position
+PASS Scroll back to top of page, anchored should be at top left position
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-016.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-016.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+
+<title>Fixed element using position-area should fallback when it is outside the viewport</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#scroll">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#fallback-apply">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/test-common.js"></script>
+
+<style>
+body {
+  margin: 0;
+  border: solid black;
+  width: 200vw;
+  height: 200vh;
+  scrollbar-width: none;
+}
+
+#anchor {
+  anchor-name: --a;
+  width: 40vw;
+  height: 40vh;
+  margin-inline-start: 80vw;
+  margin-block-start: 80vh;
+  background: orange;
+}
+
+#anchored {
+  position: fixed;
+  width: 40vw;
+  height: 40vh;
+
+  position-anchor: --a;
+  position-area: start;
+  position-try: end start, start end, end end;
+  background: teal;
+  z-index: -1;
+}
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>
+
+<script>
+  promise_test(async () => {
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+
+    assert_fallback_position(anchored, anchor, 'top');
+    assert_fallback_position(anchored, anchor, 'left');
+  }, "Initially, anchored is at top left position");
+
+  promise_test(async () => {
+    window.scroll(0, document.body.scrollHeight);
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+
+    assert_fallback_position(anchored, anchor, 'bottom');
+    assert_fallback_position(anchored, anchor, 'left');
+  }, "Scroll to end of page, anchored should be at bottom left position");
+
+  promise_test(async () => {
+    window.scroll(0, 0);
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+
+    assert_fallback_position(anchored, anchor, 'top');
+    assert_fallback_position(anchored, anchor, 'left');
+  }, "Scroll back to top of page, anchored should be at top left position");
+</script>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4149,8 +4149,6 @@ LayoutRange RenderBox::containingBlockRangeForPositioned(const RenderBoxModelObj
 
     if (isFixedPositioned()) {
         if (auto* renderView = dynamicDowncast<RenderView>(container)) {
-            if (!style().positionArea().isNone() && renderView->hasRenderOverflow())
-                return getScrollableContainingBlockRange(*renderView, physicalAxis);
             return isContainerInlineAxis
                 ? LayoutRange(startEdge, renderView->clientLogicalWidthForFixedPosition())
                 : LayoutRange(startEdge, renderView->clientLogicalHeightForFixedPosition());


### PR DESCRIPTION
#### aac4aed489d110e69808bf5b2a885f23e9a35fe4
<pre>
REGRESSION (307593@main): fixed-positioned box that uses position-area does not fallback properly when body is scrollable
<a href="https://rdar.apple.com/175203020">rdar://175203020</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312831">https://bugs.webkit.org/show_bug.cgi?id=312831</a>

Reviewed by Elika Etemad.

Fixed-positioned elements that use position-area should still use the viewport
as its containing block, not its scrollable containing block.

Test: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-016.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-016-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-016.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::containingBlockRangeForPositioned const):

Canonical link: <a href="https://commits.webkit.org/311981@main">https://commits.webkit.org/311981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5f1a6ad65c3a6f7c1743a7bb188811d6cce518b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167390 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122814 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103484 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15161 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169880 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15625 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21836 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31676 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131114 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35494 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142004 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89528 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25810 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18812 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31133 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97147 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30653 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30926 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->