### PR TITLE
Don't wait for SafeBrowsing

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9410,14 +9410,7 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
         }
 #endif
         completionHandlerWrapper(policyAction);
-    }, expectSafeBrowsing , ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No);
-    if (expectSafeBrowsing == ShouldExpectSafeBrowsingResult::Yes && navigation) {
-        Seconds timeout = (MonotonicTime::now() - requestStart) * 1.5 + 0.25_s;
-        RunLoop::mainSingleton().dispatchAfter(timeout, [listener, navigation] mutable {
-            listener->didReceiveSafeBrowsingResults({ });
-            navigation->setSafeBrowsingCheckTimedOut();
-        });
-    }
+    }, ShouldExpectSafeBrowsingResult::No, ShouldExpectAppBoundDomainResult::No, ShouldWaitForInitialLinkDecorationFilteringData::No, ShouldWaitForSiteHasStorageCheck::No, ShouldWaitForEnhancedSecurityLinkCheck::No);
 
     if (m_policyClient)
         m_policyClient->decidePolicyForResponse(*this, *frame, response, request, canShowMIMEType, WTF::move(listener));


### PR DESCRIPTION
#### 371f6d546e4b88848530f45114e645b4f6d7649b
<pre>
Don&apos;t wait for SafeBrowsing
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForResponseShared):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/371f6d546e4b88848530f45114e645b4f6d7649b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158096 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31433 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24626 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166925 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112179 "Failed to compile WebKit") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31570 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31435 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/166925 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/112179 "Failed to compile WebKit") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161054 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/31570 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/24626 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/166925 "Hash 371f6d54 for PR 63365 does not build (failure)") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/31570 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/31435 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14697 "Hash 371f6d54 for PR 63365 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/31570 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/24626 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169414 "Hash 371f6d54 for PR 63365 does not build (failure)") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14768 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/24626 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/169414 "Hash 371f6d54 for PR 63365 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31179 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/31435 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/169414 "Hash 371f6d54 for PR 63365 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31117 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/24626 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89013 "Hash 371f6d54 for PR 63365 does not build (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/31117 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/24626 "Hash 371f6d54 for PR 63365 does not build (failure)") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30669 "Hash 371f6d54 for PR 63365 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96202 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30190 "Hash 371f6d54 for PR 63365 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30420 "Hash 371f6d54 for PR 63365 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30317 "Hash 371f6d54 for PR 63365 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->