### PR TITLE
iFrames (remote or otherwise) without any focusable elements cause focus advancment to fail.

### DIFF
--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -578,7 +578,12 @@ FocusableElementSearchResult FocusController::findFocusableElementContinuingFrom
     if (!ownerElement)
         return { nullptr };
 
-    auto findResult = findFocusableElementAcrossFocusScope(direction, FocusNavigationScope::scopeOf(*ownerElement), ownerElement.get(), focusEventData, shouldFocusElement);
+    return findFocusableElementContinuingFromOwnerElement(direction, *ownerElement, focusEventData, shouldFocusElement);
+}
+
+FocusableElementSearchResult FocusController::findFocusableElementContinuingFromOwnerElement(FocusDirection direction, Element& ownerElement, const FocusEventData& focusEventData, ShouldFocusElement shouldFocusElement)
+{
+    auto findResult = findFocusableElementAcrossFocusScope(direction, FocusNavigationScope::scopeOf(ownerElement), &ownerElement, focusEventData, shouldFocusElement);
 
     if (findResult.continuedSearchInRemoteFrame == ContinuedSearchInRemoteFrame::Yes)
         return findResult;
@@ -604,6 +609,12 @@ FocusableElementSearchResult FocusController::findFocusableElementContinuingFrom
             return findResult;
     }
 
+    if (shouldFocusElement == ShouldFocusElement::Yes) {
+        RefPtr element = findResult.element;
+        setFocusedFrame(element->document().frame());
+        element->focus({ { }, { }, SelectionRestorationMode::SelectAll, direction, { }, { }, FocusVisibility::Visible });
+    }
+
     return findResult;
 }
 
@@ -616,8 +627,24 @@ FocusableElementSearchResult FocusController::findFocusableElementDescendingInto
     RefPtr element = startingElement;
     while (RefPtr owner = dynamicDowncast<HTMLFrameOwnerElement>(element)) {
         if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(owner->contentFrame())) {
-            remoteFrame->client().findFocusableElementDescendingIntoRemoteFrame(direction, focusEventData, shouldFocusElement, [](FoundElementInRemoteFrame) {
-                // FIXME: Implement sibling frame search by continuing here.
+            remoteFrame->client().findFocusableElementDescendingIntoRemoteFrame(direction, focusEventData, shouldFocusElement, [weakPage = WeakPtr { m_page.get() }, weakOwner = WeakPtr { *owner }, shouldFocusElement](FoundElementInRemoteFrame found) {
+                if (found == FoundElementInRemoteFrame::Yes)
+                    return;
+
+                RefPtr page = weakPage.get();
+                if (!page)
+                    return;
+
+                RefPtr ownerElement = weakOwner.get();
+                if (!ownerElement)
+                    return;
+
+                // The remote frame has no focusable elements. Focus the frame itself,
+                // matching the behavior of local empty iframes (see findFocusableElementInDocumentOrderStartingWithFrame).
+                if (shouldFocusElement == ShouldFocusElement::Yes) {
+                    ownerElement->document().setFocusedElement(nullptr);
+                    page->focusController().setFocusedFrame(ownerElement->contentFrame());
+                }
             });
 
             return { nullptr, ContinuedSearchInRemoteFrame::Yes };
@@ -865,14 +892,16 @@ FocusableElementSearchResult FocusController::findFocusableElementAcrossFocusSco
             [&](const RefPtr<Frame>& frame) -> FocusableElementSearchResult {
                 switch (frame->frameType()) {
                 case Frame::FrameType::Remote: {
-                    if (!currentNode)
-                        return { };
-                    RefPtr currentFrame = currentNode->document().frame();
+                    RefPtr<LocalFrame> currentFrame;
+                    if (currentNode)
+                        currentFrame = currentNode->document().frame();
+                    else if (RefPtr firstNode = scope.firstNodeInScope())
+                        currentFrame = protect(firstNode->document())->frame();
                     if (!currentFrame)
                         return { };
                     if (shouldFocusElement == ShouldFocusElement::Yes) {
                         clearSelectionIfNeeded(currentFrame.get(), nullptr, nullptr);
-                        currentNode->document().setFocusedElement(nullptr);
+                        currentFrame->document()->setFocusedElement(nullptr);
                     }
                     downcast<RemoteFrame>(*frame).client().findFocusableElementContinuingFromFrame(direction, currentFrame->frameID(), focusEventData, shouldFocusElement);
                     return { nullptr, ContinuedSearchInRemoteFrame::Yes };

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -111,6 +111,8 @@ private:
 
     FocusableElementSearchResult findFocusableElementDescendingIntoSubframes(FocusDirection, Element*, const FocusEventData&, ShouldFocusElement);
 
+    FocusableElementSearchResult findFocusableElementContinuingFromOwnerElement(FocusDirection, Element&, const FocusEventData&, ShouldFocusElement);
+
     // Searches through the given tree scope, starting from start node, for the next/previous selectable element that comes after/before start node.
     // The order followed is as specified in section 17.11.1 of the HTML4 spec, which is elements with tab indexes
     // first (from lowest to highest), and then elements without tab indexes (in document order).

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm
@@ -290,6 +290,55 @@ TEST(FocusWebView, FocusNavigationIntoFrameWithNestedRemoteFrameSiteIsolation)
     runFocusNavigationIntoFrameWithNestedRemoteFrameTest(true);
 }
 
+TEST(FocusWebView, MultipleFramesSomeUnfocusable)
+{
+    auto exampleHTML = "<body>"
+        "<input id='input'>"
+        "<iframe src='https://webkit.org/webkitframe'></iframe>"
+        "<iframe src='https://apple.com/appleframe'></iframe>"
+        "</body>"_s;
+
+    auto focusableIframeHTML = "<script>"
+        "onload = () => {"
+        "    document.getElementById('iframeInput').addEventListener('focusin', (e) => {"
+        "        alert(window.origin + ' focused');"
+        "    });"
+        "};"
+        "</script>"
+        "<input id='iframeInput' type='text' value='Iframe Input'>"
+        "</body>"_s;
+
+    auto unfocusableIframeHTML = "<script>"
+        "</body>"_s;
+
+    HTTPServer server({
+        { "/example"_s, { exampleHTML } },
+        { "/webkitframe"_s, { unfocusableIframeHTML } },
+        { "/appleframe"_s, { focusableIframeHTML } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+
+    auto [webView, navigationDelegate, uiDelegate] = makeWebViewAndDelegates(WTF::move(configuration));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView evaluateJavaScript:@""
+        "let i = document.getElementById('input');"
+        "i.addEventListener('focusin', (e) => {"
+        "    alert('main frame focused');"
+        "});"
+        "i.focus()" completionHandler:nil];
+
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "main frame focused");
+    // First tab enters the empty webkit.org iframe (no focusable elements, but
+    // the frame itself is a valid focus target). Second tab advances past it.
+    [webView typeCharacter:'\t'];
+    [webView typeCharacter:'\t'];
+
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "https://apple.com focused");
+}
+
 TEST(FocusWebView, DoNotFocusWebViewWhenUnparented)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];


### PR DESCRIPTION
#### 94d5b98165664247be64bbed481802defda28dd3
<pre>
iFrames (remote or otherwise) without any focusable elements cause focus advancment to fail.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313065">https://bugs.webkit.org/show_bug.cgi?id=313065</a>
<a href="https://rdar.apple.com/175375806">rdar://175375806</a>

Reviewed by Ryosuke Niwa.

It was always known that we did not continue searching in sibling
subframes if we ended up in a subframe without any focusable elements.

I created a test to highlight this issue, and updated the callback to
continue searching in sibling frames. It also seems that this didn&apos;t even
work without site-isolation on, so I also updated the code to cover that
case as well.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementContinuingFromFrame):
(WebCore::FocusController::findFocusableElementContinuingFromOwnerElement):
(WebCore::FocusController::findFocusableElementDescendingIntoSubframes):
(WebCore::FocusController::findFocusableElementAcrossFocusScope):
* Source/WebCore/page/FocusController.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm:
(TestWebKitAPI::MultipleFramesSomeUnfocusable)):

Canonical link: <a href="https://commits.webkit.org/311922@main">https://commits.webkit.org/311922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fafe8782bee3399be5bc20a638faab339a00ac87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167285 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31868 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161413 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/24977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103392 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15056 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169775 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/15476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21741 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31571 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131025 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35460 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141910 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25717 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31028 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96887 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30548 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30821 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->