### PR TITLE
[GTK][WPE] Always route GPU-sampling dma-buf exports through gbm_bo_get_fd_for_plane()

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp
@@ -33,8 +33,6 @@
 #include "MemoryMappedGPUBuffer.h"
 #include <atomic>
 #include <drm_fourcc.h>
-#include <fcntl.h>
-#include <xf86drm.h>
 
 #if USE(LIBEPOXY)
 #include <epoxy/egl.h>
@@ -93,7 +91,7 @@ std::optional<DMABufBufferAttributes> DMABufBufferAttributes::fromGBMBufferObjec
     attributes.modifier = enableModifiers == EnableModifiers::Yes ? gbm_bo_get_modifier(bo) : DRM_FORMAT_MOD_INVALID;
 
     for (int i = 0; i < planeCount; ++i) {
-        int fd = MemoryMappedGPUBuffer::exportFDForPlane(bo, i);
+        int fd = MemoryMappedGPUBuffer::exportFDForPlane(bo, i, MemoryMappedGPUBuffer::FDExportPurpose::GPUSampling);
         if (fd < 0) {
             LOG_ERROR("DMABufBufferAttributes::fromGBMBufferObject(), failed to export dma-buf for plane %d", i);
             return std::nullopt;

--- a/Source/WebCore/platform/graphics/gbm/GBMVersioning.h
+++ b/Source/WebCore/platform/graphics/gbm/GBMVersioning.h
@@ -27,20 +27,12 @@
 
 #if USE(GBM)
 
-#include "GBMUtilities.h"
 #include <gbm.h>
 
 #if !HAVE(GBM_BO_CREATE_WITH_MODIFIERS2)
 static inline struct gbm_bo* gbm_bo_create_with_modifiers2(struct gbm_device* gbm, uint32_t width, uint32_t height, uint32_t format, const uint64_t* modifiers, const unsigned count, uint32_t)
 {
     return gbm_bo_create_with_modifiers(gbm, width, height, format, modifiers, count);
-}
-#endif
-
-#if !HAVE(GBM_BO_GET_FD_FOR_PLANE)
-static inline int gbm_bo_get_fd_for_plane(struct gbm_bo* bo, int plane)
-{
-    return gbmExportPlaneFDWithExplicitReadWriteMapping(bo, plane);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
@@ -144,30 +144,24 @@ static DMABufExportCapabilities runCapabilityProbe()
         return { true, probeReadWriteMappability(fd.value(), gbm_bo_get_stride_for_plane(bo, 0) * probeSize) };
     };
 
-    ProbeResult gbmCall;
-#if HAVE(GBM_BO_GET_FD_FOR_PLANE)
-    // Without HAVE(GBM_BO_GET_FD_FOR_PLANE) the GBMVersioning.h shim forwards to the
-    // DRMSystemCall path, so there's no point in probing GBMCall separately.
-    gbmCall = runProbe([](struct gbm_bo* bo) {
+    DMABufExportCapabilities caps;
+    ProbeResult gbmCall = runProbe([](struct gbm_bo* bo) {
         return gbm_bo_get_fd_for_plane(bo, 0);
     });
-#endif
 
-    ProbeResult drmSystemCall = runProbe([](struct gbm_bo* bo) {
-        return gbmExportPlaneFDWithExplicitReadWriteMapping(bo, 0);
-    });
-
-    // Pick the first mmap-capable path. Otherwise keep any path that at
-    // least exports, so non-mmap callers (e.g. EGLImage wrapping) still work.
-    DMABufExportCapabilities caps;
     if (gbmCall.mappable)
         caps = { DMABufExportStrategy::GBMCall, SupportsReadWriteMemoryMapping::Yes };
-    else if (drmSystemCall.mappable)
-        caps = { DMABufExportStrategy::DRMSystemCall, SupportsReadWriteMemoryMapping::Yes };
-    else if (gbmCall.exported)
-        caps = { DMABufExportStrategy::GBMCall, SupportsReadWriteMemoryMapping::No };
-    else if (drmSystemCall.exported)
-        caps = { DMABufExportStrategy::DRMSystemCall, SupportsReadWriteMemoryMapping::No };
+    else {
+        ProbeResult drmSystemCall = runProbe([](struct gbm_bo* bo) {
+            return gbmExportPlaneFDWithExplicitReadWriteMapping(bo, 0);
+        });
+        if (drmSystemCall.mappable)
+            caps = { DMABufExportStrategy::DRMSystemCall, SupportsReadWriteMemoryMapping::Yes };
+        else if (gbmCall.exported)
+            caps = { DMABufExportStrategy::GBMCall, SupportsReadWriteMemoryMapping::No };
+        else if (drmSystemCall.exported)
+            caps = { DMABufExportStrategy::DRMSystemCall, SupportsReadWriteMemoryMapping::No };
+    }
 
     RELEASE_LOG(GraphicsBuffer, "MemoryMappedGPUBuffer capability probe: strategy=%s mmap-capable=%s",
         strategyName(caps.strategy).characters(),
@@ -187,15 +181,21 @@ bool MemoryMappedGPUBuffer::isSupported()
     return cachedExportCapabilities().memoryMappable == SupportsReadWriteMemoryMapping::Yes;
 }
 
-int MemoryMappedGPUBuffer::exportFDForPlane(struct gbm_bo* bo, int plane)
+int MemoryMappedGPUBuffer::exportFDForPlane(struct gbm_bo* bo, int plane, FDExportPurpose purpose)
 {
-    switch (cachedExportCapabilities().strategy) {
-    case DMABufExportStrategy::GBMCall:
+    switch (purpose) {
+    case FDExportPurpose::GPUSampling:
         return gbm_bo_get_fd_for_plane(bo, plane);
-    case DMABufExportStrategy::DRMSystemCall:
-        return gbmExportPlaneFDWithExplicitReadWriteMapping(bo, plane);
-    case DMABufExportStrategy::Unsupported:
-        return -1;
+    case FDExportPurpose::CPUMapping:
+        switch (cachedExportCapabilities().strategy) {
+        case DMABufExportStrategy::GBMCall:
+            return gbm_bo_get_fd_for_plane(bo, plane);
+        case DMABufExportStrategy::DRMSystemCall:
+            return gbmExportPlaneFDWithExplicitReadWriteMapping(bo, plane);
+        case DMABufExportStrategy::Unsupported:
+            return -1;
+        }
+        break;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
@@ -280,6 +280,14 @@ std::unique_ptr<MemoryMappedGPUBuffer> MemoryMappedGPUBuffer::create(const IntSi
         return nullptr;
     }
 
+    // Must happen before gbm_bo_destroy() below.
+    buffer->m_exportedFDForMapping = UnixFileDescriptor { exportFDForPlane(bo, 0, FDExportPurpose::CPUMapping), UnixFileDescriptor::Adopt };
+    if (!buffer->m_exportedFDForMapping) {
+        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer::create(), failed to export dma-buf FD for mapping: %s", safeStrerror(errno).data());
+        gbm_bo_destroy(bo);
+        return nullptr;
+    }
+
     gbm_bo_destroy(bo);
     return buffer;
 }
@@ -337,19 +345,6 @@ bool MemoryMappedGPUBuffer::createDMABufFromGBMBufferObject(struct gbm_bo* bo)
     return true;
 }
 
-int MemoryMappedGPUBuffer::primaryPlaneDmaBufFD() const
-{
-    ASSERT(m_dmaBuf);
-
-    auto& fds = m_dmaBuf->attributes().fds;
-    ASSERT(!fds.isEmpty());
-
-    auto fd = fds[0].value();
-    ASSERT(fd >= 0);
-
-    return fd;
-}
-
 uint32_t MemoryMappedGPUBuffer::primaryPlaneDmaBufStride() const
 {
     ASSERT(m_dmaBuf);
@@ -368,8 +363,9 @@ bool MemoryMappedGPUBuffer::mapIfNeeded()
         return true;
 
     ASSERT(isLinear() || isVivanteSuperTiled());
+    ASSERT(m_exportedFDForMapping);
     m_mappedLength = primaryPlaneDmaBufStride() * m_allocatedSize.height();
-    m_mappedData = mmap(nullptr, m_mappedLength, PROT_READ | PROT_WRITE, MAP_SHARED, primaryPlaneDmaBufFD(), 0);
+    m_mappedData = mmap(nullptr, m_mappedLength, PROT_READ | PROT_WRITE, MAP_SHARED, m_exportedFDForMapping.value(), 0);
     if (m_mappedData == MAP_FAILED) {
         m_mappedLength = 0;
         m_mappedData = nullptr;
@@ -500,7 +496,8 @@ bool MemoryMappedGPUBuffer::performDMABufSyncSystemCall(OptionSet<DMABufSyncFlag
     mapFlag(DMABufSyncFlag::Read, DMA_BUF_SYNC_READ);
     mapFlag(DMABufSyncFlag::Write, DMA_BUF_SYNC_WRITE);
 
-    auto fd = primaryPlaneDmaBufFD();
+    ASSERT(m_exportedFDForMapping);
+    auto fd = m_exportedFDForMapping.value();
 
     unsigned counter = 0;
     int result;

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
@@ -54,14 +54,25 @@ public:
         UseBGRALayout = 1 << 2
     };
 
-    // On some non-Mesa stacks gbm_bo allocation and dma-buf export succeed but mmap still
-    // fails; the probe verifies all three once per session before committing to this path.
-    // Gates only MemoryMappedGPUBuffer::create() -- exportFDForPlane() remains usable for
-    // non-mmap callers (e.g. EGLImage wrapping) when export works but the FD isn't RDWR.
+    // On some non-Mesa stacks gbm_bo allocation and dma-buf export succeed but mmap
+    // still fails; the probe verifies all three once per session before committing
+    // to this path. Gates only MemoryMappedGPUBuffer::create() -- callers that only
+    // need a GPUSampling FD do not depend on this flag.
     static bool isSupported();
 
-    // The returned FD may not be RDWR-mappable; callers that mmap must gate on isSupported().
-    static int exportFDForPlane(struct gbm_bo*, int plane);
+    enum class FDExportPurpose : uint8_t {
+        // FD will be imported as an EGLImage and sampled/rendered by GL. Always uses
+        // gbm_bo_get_fd_for_plane() so Mesa observes the export and attaches its
+        // implicit-sync fence; bypassing gbm here leads to EINVAL in gallium's fence
+        // wait when the dma-buf is re-imported as EGLImage (Mesa >= 25).
+        GPUSampling,
+        // FD will be mmap'd with PROT_READ | PROT_WRITE. Uses the probe-selected
+        // strategy that produced a writable mapping on this system. Not suitable
+        // for EGLImage imports -- the RDWR fallback bypasses gbm.
+        CPUMapping,
+    };
+
+    static int exportFDForPlane(struct gbm_bo*, int plane, FDExportPurpose);
 
     static ASCIILiteral exportStrategyDescription();
 
@@ -135,7 +146,6 @@ private:
     void updateContentsInLinearFormat(const void* srcData, const IntRect& targetRect, unsigned bytesPerLine);
     void updateContentsInVivanteSuperTiledFormat(const void* srcData, const IntRect& targetRect, unsigned bytesPerLine);
 
-    int primaryPlaneDmaBufFD() const;
     uint32_t primaryPlaneDmaBufStride() const;
 
     IntSize m_size;
@@ -143,6 +153,12 @@ private:
     OptionSet<BufferFlag> m_flags;
     uint64_t m_modifier { 0 };
     RefPtr<DMABufBuffer> m_dmaBuf;
+
+    // Distinct from the GPU-sampling FDs in m_dmaBuf: those must come from
+    // gbm_bo_get_fd_for_plane() to stay in gbm's bookkeeping. m_exportedFDForMapping
+    // is exported via the probe-selected strategy so it is guaranteed RDWR-mmappable
+    // on this system.
+    UnixFileDescriptor m_exportedFDForMapping;
 
     void* m_mappedData { nullptr };
     size_t m_mappedLength { 0 };

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -314,7 +314,6 @@ if (USE_GBM)
 
     set(CMAKE_REQUIRED_LIBRARIES GBM::GBM)
     WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_CREATE_WITH_MODIFIERS2 gbm_bo_create_with_modifiers2 gbm.h)
-    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_GET_FD_FOR_PLANE gbm_bo_get_fd_for_plane gbm.h)
     unset(CMAKE_REQUIRED_LIBRARIES)
 endif ()
 

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -440,7 +440,6 @@ if (USE_GBM)
 
     set(CMAKE_REQUIRED_LIBRARIES GBM::GBM)
     WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_CREATE_WITH_MODIFIERS2 gbm_bo_create_with_modifiers2 gbm.h)
-    WEBKIT_CHECK_HAVE_FUNCTION(HAVE_GBM_BO_GET_FD_FOR_PLANE gbm_bo_get_fd_for_plane gbm.h)
     unset(CMAKE_REQUIRED_LIBRARIES)
 endif ()
 


### PR DESCRIPTION
#### d5d69806a3887a44747c4b00854f932a140d583f
<pre>
[GTK][WPE] Always route GPU-sampling dma-buf exports through gbm_bo_get_fd_for_plane()
<a href="https://bugs.webkit.org/show_bug.cgi?id=313068">https://bugs.webkit.org/show_bug.cgi?id=313068</a>

The capability-probe PR (311802@main) routed every dma-buf FD export through
MemoryMappedGPUBuffer::exportFDForPlane(), which on systems where the probe
selects DRMSystemCall calls drmPrimeHandleToFD(DRM_RDWR) directly. Bypassing
GBM there means Mesa never observes the export and never attaches its
implicit-sync dma_resv fence to the buffer. When the same dma-buf is later
sampled by the GPU (for us, via EGLImage re-import), gallium&apos;s pre-draw
fence wait returns EINVAL (&quot;wait failed: -22&quot;) and aborts at flush time.

Split the FD export by purpose via a new FDExportPurpose enum parameter on
exportFDForPlane(). GPUSampling always goes through gbm_bo_get_fd_for_plane()
so Mesa keeps tracking the export; DMABufBuffer::fromGBMBufferObject() -- the
consumer that wraps the FD for GPU-side sampling -- passes this purpose.
CPUMapping keeps the two-strategy probe dispatch, since the whole reason it
exists is to find a path that yields an RDWR-mappable FD on Mesa versions
where gbm_bo_get_fd_for_plane() doesn&apos;t. That FD is stored in a new
m_exportedFDForMapping member of MemoryMappedGPUBuffer, distinct from the
GPU-sampling FDs held by m_dmaBuf; mapIfNeeded() mmaps it lazily and
DMA_BUF_IOCTL_SYNC reuses it.

Also short-circuit the capability probe: if gbm_bo_get_fd_for_plane()
already yields an mmap-capable FD we skip the DRMSystemCall probe entirely,
saving one gbm_bo alloc/export/mmap cycle at session startup.

Drop the gbm_bo_get_fd_for_plane() compatibility shim and its cmake check;
we no longer support Mesa &lt; 21 nor Debian 11, where this was standard.

* Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp:
(WebCore::DMABufBufferAttributes::fromGBMBufferObject):
* Source/WebCore/platform/graphics/gbm/GBMVersioning.h:
(gbm_bo_get_fd_for_plane): Deleted.
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp:
(WebCore::runCapabilityProbe):
(WebCore::MemoryMappedGPUBuffer::exportFDForPlane):
(WebCore::MemoryMappedGPUBuffer::create):
(WebCore::MemoryMappedGPUBuffer::primaryPlaneDmaBufFD): Deleted.
(WebCore::MemoryMappedGPUBuffer::mapIfNeeded):
(WebCore::MemoryMappedGPUBuffer::performDMABufSyncSystemCall):
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h:
* Source/cmake/OptionsGTK.cmake:
* Source/cmake/OptionsWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/311834@main">https://commits.webkit.org/311834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/796bd145e31cf51dbd6716f403f6c6fc6aad38c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166938 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112192 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122440 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85953 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103109 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23789 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14710 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150160 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169427 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/18944 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14781 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130621 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130736 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141587 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89026 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24038 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25458 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18393 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190238 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96215 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48834 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30203 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30433 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->