### PR TITLE
[Site Isolation] [Gardening] CSP embed-redirect-allowed tests are passing but expected to fail

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -225,8 +225,6 @@ http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-ne
 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-nested-cross-in-same-url-block.html [ Failure ]
 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-self-block.html [ Failure ]
 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-url-block.html [ Failure ]
-http/tests/security/contentSecurityPolicy/embed-redirect-allowed.html [ Failure ]
-http/tests/security/contentSecurityPolicy/embed-redirect-allowed2.html [ Failure ]
 http/tests/security/cross-origin-local-storage.html [ Failure ]
 http/tests/security/video-poster-cross-origin-crash2.html [ Failure ]
 http/tests/security/window-events-clear-domain.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -242,8 +242,6 @@ http/tests/security/XFrameOptions/x-frame-options-ancestors-same-origin-deny.htm
 http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-multiple-headers-sameorigin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-parent-same-origin-deny.html [ Failure ]
-http/tests/security/contentSecurityPolicy/embed-redirect-allowed.html [ Failure ]
-http/tests/security/contentSecurityPolicy/embed-redirect-allowed2.html [ Failure ]
 http/tests/security/cross-origin-local-storage.html [ Failure ]
 http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Pass ]


### PR DESCRIPTION
#### 5fcf086f3c6772cec41aa03338e2eedb96d3631b
<pre>
[Site Isolation] [Gardening] CSP embed-redirect-allowed tests are passing but expected to fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=313066">https://bugs.webkit.org/show_bug.cgi?id=313066</a>
<a href="https://rdar.apple.com/175376455">rdar://175376455</a>

Reviewed by Sihui Liu.

The following two CSP tests are marked as expected to fail with Site Isolation enabled, however they are passing.

http/tests/security/contentSecurityPolicy/embed-redirect-allowed.html
http/tests/security/contentSecurityPolicy/embed-redirect-allowed2.html

This progression came from Roberto&apos;s work with <a href="https://commits.webkit.org/310557@main">https://commits.webkit.org/310557@main</a>

See <a href="https://results.webkit.org/?suite=layout-tests&amp">https://results.webkit.org/?suite=layout-tests&amp</a>;suite=layout-tests&amp;test=http%2Ftests%2Fsecurity%2FcontentSecurityPolicy%2Fembed-redirect-allowed.html&amp;test=http%2Ftests%2Fsecurity%2FcontentSecurityPolicy%2Fembed-redirect-allowed2.html&amp;flavor=site-isolation

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/311888@main">https://commits.webkit.org/311888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dc349f36a1816a4d5c53942c97a311b3e6771cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112189 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122438 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85951 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103107 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23774 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22101 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14707 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169424 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130616 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130731 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31127 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141579 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89023 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24069 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18385 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30679 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30200 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30430 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30327 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->