### PR TITLE
[Xcode] Skip dead-code stripping in Debug for WebKit and WebKitLegacy/mac

### DIFF
--- a/Source/WebKit/Configurations/Base.xcconfig
+++ b/Source/WebKit/Configurations/Base.xcconfig
@@ -89,10 +89,8 @@ WARNING_CFLAGS = $(inherited) $(WK_FIXME_WARNING_CFLAGS) -Wcast-qual -Wchar-subs
 WK_FIXME_WARNING_CFLAGS = -Wno-unused-parameter;
 
 COPY_PHASE_STRIP = NO;
-// Dead code stripping needs to be on in the debug variant to avoid link errors.  This is due to unconditionally
-// building the MiG bindings for WebKitPluginClient even when the functions that the bindings wrap are not built.
-// FIXME: This explanation isn't correct any more, because plug-ins are gone. But is there any reason to change this setting?
 DEAD_CODE_STRIPPING = YES;
+DEAD_CODE_STRIPPING[config=Debug] = NO;
 
 DEBUG_DEFINES = NDEBUG;
 DEBUG_DEFINES[config=Debug] = $(WK_ENABLE_CONJECTURE_ASSERT_YES);

--- a/Source/WebKitLegacy/mac/Configurations/Base.xcconfig
+++ b/Source/WebKitLegacy/mac/Configurations/Base.xcconfig
@@ -88,9 +88,8 @@ WARNING_CFLAGS = $(inherited) $(WK_FIXME_WARNING_CFLAGS) -Wcast-qual -Wchar-subs
 // Remove WK_FIXME_WARNING_CFLAGS once all warnings are fixed.
 WK_FIXME_WARNING_CFLAGS = -Wno-unused-parameter;
 
-// Dead code stripping needs to be on in the debug variant to avoid link errors.  This is due to unconditionally
-// building the MiG bindings for WebKitPluginClient even when the functions that the bindings wrap are not built.
 DEAD_CODE_STRIPPING = YES;
+DEAD_CODE_STRIPPING[config=Debug] = NO;
 
 DEBUG_DEFINES = NDEBUG;
 DEBUG_DEFINES[config=Debug] = $(WK_ENABLE_CONJECTURE_ASSERT_YES);


### PR DESCRIPTION
#### 1d1a53c700eabad70ea5a297e3743fd2ba197305
<pre>
[Xcode] Skip dead-code stripping in Debug for WebKit and WebKitLegacy/mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=313021">https://bugs.webkit.org/show_bug.cgi?id=313021</a>
<a href="https://rdar.apple.com/175364616">rdar://175364616</a>

Reviewed by NOBODY (OOPS!).

Source/WebKit/Configurations/Base.xcconfig and
Source/WebKitLegacy/mac/Configurations/Base.xcconfig were the only
xcconfig files in the tree that set DEAD_CODE_STRIPPING = YES
unconditionally, including for Debug. The original justification
(link errors from unconditionally built MiG bindings for
WebKitPluginClient) is no longer applicable because plug-ins have
been removed, as the existing FIXME in WebKit/Base.xcconfig already
acknowledged.

Match the convention used by WTF, WebCore, JavaScriptCore, PAL,
WebInspectorUI, WebGPU, and bmalloc, which set
DEAD_CODE_STRIPPING[config=Debug] = NO. This preserves useful
symbols while debugging and speeds up Debug link times, and it
aligns Xcode with the CMake behavior added in 312609
(Source/cmake/OptionsMac.cmake).

Drop the obsolete MiG plug-in comments while we&apos;re here.

* Source/WebKit/Configurations/Base.xcconfig:
* Source/WebKitLegacy/mac/Configurations/Base.xcconfig:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d1a53c700eabad70ea5a297e3743fd2ba197305

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166953 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112207 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31598 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31479 "Hash 1d1a53c7 for PR 63379 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122454 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85963 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103123 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23802 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/31479 "Hash 1d1a53c7 for PR 63379 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14725 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169442 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14796 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130636 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31207 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/31479 "Hash 1d1a53c7 for PR 63379 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130751 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141601 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89041 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25467 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18407 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30697 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96230 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30218 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30448 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30345 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->