### PR TITLE
Remove `unsafe` from use of Data in WebKit model source

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -302,22 +302,12 @@ extension WKBridgeUpdateMesh {
 }
 
 #if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 19)
-func decodeValues<T>(from data: Data) -> [T] {
+func decodeValues<T>(from data: Data) -> [T] where T: BitwiseCopyable {
     let stride = MemoryLayout<T>.stride
-
-    guard data.count > 0, data.count % stride == 0 else {
-        return []
-    }
-
-    return unsafe data.withUnsafeBytes { rawBufferPointer in
-        guard let baseAddress = rawBufferPointer.baseAddress else {
-            return []
-        }
-
-        let count = rawBufferPointer.count / stride
-        let pointer = unsafe baseAddress.assumingMemoryBound(to: T.self)
-        return (0..<count).map { unsafe pointer[$0] }
-    }
+    guard !data.isEmpty, data.count % stride == 0 else { return [] }
+    // rdar://164559261 - this is needed because there is no way to represnt an NSArray of
+    // primitive types in Objective-C
+    return unsafe data.withUnsafeBytes { unsafe Array(unsafe $0.bindMemory(to: T.self)) }
 }
 
 extension WKBridgeBlendShapeData {
@@ -632,10 +622,9 @@ extension WKBridgeMaterialGraph {
 #if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 19)
 
 func toData<T>(_ input: [T]) -> Data {
-    // FIXME: (rdar://164559261) understand/document/remove unsafety
-    unsafe input.withUnsafeBytes { bufferPointer in
-        unsafe Data(bufferPointer)
-    }
+    // rdar://164559261 - this is needed because there is no way to represnt an NSArray of
+    // primitive types in Objective-C
+    unsafe input.withUnsafeBytes { unsafe Data($0) }
 }
 
 private func toDataArray<T>(_ input: [[T]]) -> [Data] {
@@ -692,117 +681,10 @@ extension WKBridgeMeshDescriptor {
     }
 }
 extension WKBridgeSkinningData {
-    var jointTransforms: [simd_float4x4] {
-        guard let data = jointTransformsData else {
-            return []
-        }
-
-        let jointTransformsCount = data.count / MemoryLayout<simd_float4x4>.size
-        guard jointTransformsCount > 0 else {
-            return []
-        }
-
-        let matrixSize = MemoryLayout<simd_float4x4>.stride
-        let expectedSize = matrixSize * jointTransformsCount
-
-        guard data.count >= expectedSize else {
-            assertionFailure("instanceTransforms data size (\(data.count)) is less than expected (\(expectedSize))")
-            return []
-        }
-
-        return unsafe data.withUnsafeBytes { rawBufferPointer in
-            guard let baseAddress = rawBufferPointer.baseAddress else {
-                return []
-            }
-
-            let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
-            return (0..<jointTransformsCount).map { unsafe matrices[$0] }
-        }
-    }
-
-    var inverseBindPoses: [simd_float4x4] {
-        guard let data = inverseBindPosesData else {
-            return []
-        }
-
-        let inverseBindPosesCount = data.count / MemoryLayout<simd_float4x4>.size
-        guard inverseBindPosesCount > 0 else {
-            return []
-        }
-
-        let matrixSize = MemoryLayout<simd_float4x4>.stride
-        let expectedSize = matrixSize * inverseBindPosesCount
-
-        guard data.count >= expectedSize else {
-            assertionFailure("instanceTransforms data size (\(data.count)) is less than expected (\(expectedSize))")
-            return []
-        }
-
-        return unsafe data.withUnsafeBytes { rawBufferPointer in
-            guard let baseAddress = rawBufferPointer.baseAddress else {
-                return []
-            }
-
-            let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
-            return (0..<inverseBindPosesCount).map { unsafe matrices[$0] }
-        }
-    }
-
-    var influenceJointIndices: [UInt32] {
-        guard let data = influenceJointIndicesData else {
-            return []
-        }
-
-        let influenceJointIndicesCount = data.count / MemoryLayout<UInt32>.size
-        guard influenceJointIndicesCount > 0 else {
-            return []
-        }
-
-        let matrixSize = MemoryLayout<UInt32>.stride
-        let expectedSize = matrixSize * influenceJointIndicesCount
-
-        guard data.count >= expectedSize else {
-            assertionFailure("instanceTransforms data size (\(data.count)) is less than expected (\(expectedSize))")
-            return []
-        }
-
-        return unsafe data.withUnsafeBytes { rawBufferPointer in
-            guard let baseAddress = rawBufferPointer.baseAddress else {
-                return []
-            }
-
-            let matrices = unsafe baseAddress.assumingMemoryBound(to: UInt32.self)
-            return (0..<influenceJointIndicesCount).map { unsafe matrices[$0] }
-        }
-    }
-
-    var influenceWeights: [Float] {
-        guard let data = influenceWeightsData else {
-            return []
-        }
-
-        let influenceWeightsCount = data.count / MemoryLayout<Float>.size
-        guard influenceWeightsCount > 0 else {
-            return []
-        }
-
-        let matrixSize = MemoryLayout<Float>.stride
-        let expectedSize = matrixSize * influenceWeightsCount
-
-        guard data.count >= expectedSize else {
-            assertionFailure("instanceTransforms data size (\(data.count)) is less than expected (\(expectedSize))")
-            return []
-        }
-
-        return unsafe data.withUnsafeBytes { rawBufferPointer in
-            guard let baseAddress = rawBufferPointer.baseAddress else {
-                return []
-            }
-
-            let matrices = unsafe baseAddress.assumingMemoryBound(to: Float.self)
-            return (0..<influenceWeightsCount).map { unsafe matrices[$0] }
-        }
-    }
+    var jointTransforms: [simd_float4x4] { jointTransformsData.map { decodeValues(from: $0) } ?? [] }
+    var inverseBindPoses: [simd_float4x4] { inverseBindPosesData.map { decodeValues(from: $0) } ?? [] }
+    var influenceJointIndices: [UInt32] { influenceJointIndicesData.map { decodeValues(from: $0) } ?? [] }
+    var influenceWeights: [Float] { influenceWeightsData.map { decodeValues(from: $0) } ?? [] }
 
     @nonobjc
     convenience init?(_ request: _Proto_DeformationData_v1.SkinningData?) {

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -108,31 +108,22 @@ extension _Proto_LowLevelMeshResource_v1.Descriptor {
     }
 }
 
+@_lifetime(buffer: copy buffer)
+private func copyDataIntoBuffer(_ buffer: inout MutableRawSpan, from data: Data) {
+    // unsafe used here as that is the method for populating a MTLBuffer
+    unsafe buffer.withUnsafeMutableBytes { unsafe $0.copyBytes(from: data) }
+}
+
 extension _Proto_LowLevelMeshResource_v1 {
     func replaceVertexData(_ vertexData: [Data]) {
         for (vertexBufferIndex, vertexData) in vertexData.enumerated() {
-            let bufferSizeInByte = vertexData.bytes.byteCount
-            self.replaceVertices(at: vertexBufferIndex) { vertexBytes in
-                // FIXME: (rdar://164559261) understand/document/remove unsafety
-                unsafe vertexBytes.withUnsafeMutableBytes { ptr in
-                    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-                    // swift-format-ignore: NeverForceUnwrap
-                    unsafe vertexData.copyBytes(to: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: bufferSizeInByte)
-                }
-            }
+            self.replaceVertices(at: vertexBufferIndex) { copyDataIntoBuffer(&$0, from: vertexData) }
         }
     }
 
     func replaceIndexData(_ indexData: Data?) {
         if let indexData = indexData {
-            self.replaceIndices { indicesBytes in
-                // FIXME: (rdar://164559261) understand/document/remove unsafety
-                unsafe indicesBytes.withUnsafeMutableBytes { ptr in
-                    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-                    // swift-format-ignore: NeverForceUnwrap
-                    unsafe indexData.copyBytes(to: ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), count: ptr.count)
-                }
-            }
+            self.replaceIndices { copyDataIntoBuffer(&$0, from: indexData) }
         }
     }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -548,7 +548,8 @@ extension WKBridgeReceiver {
         self.fallbackTexture = makeFallBackTextureResource(
             renderContext,
             commandQueue: configuration.commandQueue,
-            device: configuration.device
+            device: configuration.device,
+            memoryOwner: configuration.appRenderer.memoryOwner
         )
     }
 
@@ -1580,9 +1581,7 @@ private func makeConstantSGNode(from constant: WKBridgeConstantContainer) throws
         let comps =
             (0..<n).map { CGFloat(values[$0].number.floatValue) }
             + (n == 3 ? [CGFloat(1.0)] : [])
-        let cs = CGColorSpace(name: CGColorSpace.extendedLinearSRGB)
-        return cs.flatMap { unsafe CGColor(colorSpace: $0, components: comps) }
-            ?? CGColor(red: comps[0], green: comps[1], blue: comps[2], alpha: comps.count > 3 ? comps[3] : 1)
+        return CGColor(red: comps[0], green: comps[1], blue: comps[2], alpha: comps.count > 3 ? comps[3] : 1)
     }
 
     switch constant.constant {
@@ -1899,11 +1898,6 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             CGFloat(values[2].number.floatValue),
             1.0,
         ]
-        if let cs = CGColorSpace(name: CGColorSpace.extendedLinearSRGB),
-            let color = unsafe CGColor(colorSpace: cs, components: components3)
-        {
-            return .cgColor3(color)
-        }
         return .cgColor3(CGColor(red: components3[0], green: components3[1], blue: components3[2], alpha: 1.0))
     case .cgColor4:
         guard values.count >= 4 else {
@@ -1917,11 +1911,6 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             CGFloat(values[2].number.floatValue),
             CGFloat(values[3].number.floatValue),
         ]
-        if let cs = CGColorSpace(name: CGColorSpace.extendedLinearSRGB),
-            let color = unsafe CGColor(colorSpace: cs, components: components4)
-        {
-            return .cgColor4(color)
-        }
         return .cgColor4(CGColor(red: components4[0], green: components4[1], blue: components4[2], alpha: components4[3]))
     case .color4f:
         // USD/MaterialX color4f or color4h — encoded as 4 raw floats without CGColor clamping.
@@ -1935,11 +1924,6 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             CGFloat(values[2].number.floatValue),
             CGFloat(values[3].number.floatValue),
         ]
-        if let cs = CGColorSpace(name: CGColorSpace.extendedLinearSRGB),
-            let color = unsafe CGColor(colorSpace: cs, components: components4f)
-        {
-            return .cgColor4(color)
-        }
         return .cgColor4(CGColor(red: components4f[0], green: components4f[1], blue: components4f[2], alpha: components4f[3]))
     case .color3f:
         // USD/MaterialX color3f or color3h — encoded as 3 raw floats without CGColor clamping.
@@ -1953,11 +1937,6 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             CGFloat(values[2].number.floatValue),
             1.0,
         ]
-        if let cs = CGColorSpace(name: CGColorSpace.extendedLinearSRGB),
-            let color = unsafe CGColor(colorSpace: cs, components: components3f)
-        {
-            return .cgColor3(color)
-        }
         return .cgColor3(CGColor(red: components3f[0], green: components3f[1], blue: components3f[2], alpha: 1.0))
     @unknown default:
         fatalError("fromWKBridgeConstant: unhandled constant type \(constant.constant) for '\(constant.name)'")
@@ -2257,7 +2236,8 @@ extension WKBridgeModelLoader {
 private func makeFallBackTextureResource(
     _ renderContext: any _Proto_LowLevelRenderContext_v1,
     commandQueue: any MTLCommandQueue,
-    device: any MTLDevice
+    device: any MTLDevice,
+    memoryOwner: task_id_token_t
 ) -> _Proto_LowLevelTextureResource_v1 {
     // Create 1x1 white fallback texture
     let fallbackDescriptor = _Proto_LowLevelTextureResource_v1.Descriptor(
@@ -2274,11 +2254,7 @@ private func makeFallBackTextureResource(
     // White color: RGBA = (255, 255, 255, 255)
     let whitePixel: [UInt8] = [255, 255, 255, 255]
 
-    // Create staging buffer for white pixel data
-    let stagingBuffer = unsafe whitePixel.withUnsafeBytes { bytes in
-        // swift-format-ignore: NeverForceUnwrap
-        unsafe device.makeBuffer(bytes: bytes.baseAddress!, length: bytes.count, options: .storageModeShared)!
-    }
+    let stagingBuffer = device.makeBuffer(fromSpan: whitePixel.span, length: whitePixel.count, memoryOwner: memoryOwner)
 
     // Create command buffer to upload white pixel data
     // swift-format-ignore: NeverForceUnwrap


### PR DESCRIPTION
#### 3d1cee5c55dcac580b3979588de6baddd9d088f4
<pre>
Remove `unsafe` from use of Data in WebKit model source
<a href="https://bugs.webkit.org/show_bug.cgi?id=313009">https://bugs.webkit.org/show_bug.cgi?id=313009</a>
<a href="https://rdar.apple.com/173226084">rdar://173226084</a>

Reviewed by Adrian Taylor.

Based on Adrian&apos;s patches:  <a href="https://github.com/WebKit/WebKit/compare/main...adetaylor">https://github.com/WebKit/WebKit/compare/main...adetaylor</a>:WebKit:zap-data-stuff
remove / coalesce unsafe usages.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
(WKBridgeSkinningData.jointTransforms):
(WKBridgeSkinningData.inverseBindPoses):
(WKBridgeSkinningData.influenceJointIndices):
(WKBridgeSkinningData.influenceWeights):
* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
(copyDataIntoBuffer(_:from:)):
(_Proto_LowLevelMeshResource_v1.replaceVertexData(_:)):
(_Proto_LowLevelMeshResource_v1.replaceIndexData(_:)):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(makeConstantSGNode(from:)):
(fromWKBridgeConstant(_:)):

Canonical link: <a href="https://commits.webkit.org/311970@main">https://commits.webkit.org/311970@main</a>
</pre>
