### PR TITLE
Update -[WKUIScrollEdgeEffect setStyle:] with a more robust check

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm
+++ b/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm
@@ -119,7 +119,7 @@ enum class HiddenScrollEdgeEffectSource : uint8_t {
 - (void)setStyle:(UIScrollEdgeEffectStyle *)style
 {
     BOOL wasUsingHardStyle = _usesHardStyle;
-    _usesHardStyle = [style isEqual:UIScrollEdgeEffectStyle.hardStyle];
+    _usesHardStyle = ![style isEqual:UIScrollEdgeEffectStyle.softStyle] && ![style isEqual:UIScrollEdgeEffectStyle.automaticStyle];
 
     [protect(_effect) setStyle:style];
 


### PR DESCRIPTION
#### 4c25f907479089681343bd4b77037a46b4b98144
<pre>
Update -[WKUIScrollEdgeEffect setStyle:] with a more robust check
<a href="https://bugs.webkit.org/show_bug.cgi?id=313081">https://bugs.webkit.org/show_bug.cgi?id=313081</a>
<a href="https://rdar.apple.com/175379727">rdar://175379727</a>

Reviewed by Wenson Hsieh.

Update -[WKUIScrollEdgeEffect setStyle:] with a more robust check, by checking for styles other than .softStyle and .automaticStyle.

* Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm:
(-[WKUIScrollEdgeEffect setStyle:]):
Same as above.

Canonical link: <a href="https://commits.webkit.org/311857@main">https://commits.webkit.org/311857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d25fba183a018bda9a0d7517715744dd371e8896

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112223 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122466 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85970 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23806 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14741 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133490 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169458 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14812 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130648 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130763 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35424 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141620 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89057 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18426 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30713 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96246 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30234 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30464 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30361 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->