### PR TITLE
[Site Isolation] fast/loader/main-document-url-for-non-http-loads.html fails

### DIFF
--- a/LayoutTests/fast/loader/main-document-url-for-non-http-loads-expected.txt
+++ b/LayoutTests/fast/loader/main-document-url-for-non-http-loads-expected.txt
@@ -1,6 +1,7 @@
 resources/subframe-notify-done.html - willSendRequest <NSURLRequest URL resources/subframe-notify-done.html, main document URL main-document-url-for-non-http-loads.html, http method GET> redirectResponse (null)
 main-document-url-for-non-http-loads.html - didFinishLoading
 resources/subframe-notify-done.html - didReceiveResponse <NSURLResponse resources/subframe-notify-done.html, http status code 0>
+resources/subframe-notify-done.html - didFinishLoading
 Radar 6616664 - Non-HTTP/HTTPS loads need to have their main document URL set.
 When run in DumpRenderTree, this test will dump the resource load callback for the following subframe to make sure it had its main document URL set in its NSURLRequest.
 

--- a/LayoutTests/fast/loader/resources/subframe-notify-done.html
+++ b/LayoutTests/fast/loader/resources/subframe-notify-done.html
@@ -2,9 +2,8 @@
 <head>
 <script>
 function loaded() {
-    if (window.testRunner) {
-        testRunner.notifyDone();
-    }
+    if (window.testRunner)
+        setTimeout(() => testRunner.notifyDone(), 0);
 }
 </script>
 </head>

--- a/LayoutTests/platform/wk2/fast/loader/main-document-url-for-non-http-loads-expected.txt
+++ b/LayoutTests/platform/wk2/fast/loader/main-document-url-for-non-http-loads-expected.txt
@@ -1,6 +1,7 @@
 main-document-url-for-non-http-loads.html - didFinishLoading
 resources/subframe-notify-done.html - willSendRequest <NSURLRequest URL resources/subframe-notify-done.html, main document URL main-document-url-for-non-http-loads.html, http method GET> redirectResponse (null)
 resources/subframe-notify-done.html - didReceiveResponse <NSURLResponse resources/subframe-notify-done.html, http status code 0>
+resources/subframe-notify-done.html - didFinishLoading
 Radar 6616664 - Non-HTTP/HTTPS loads need to have their main document URL set.
 When run in DumpRenderTree, this test will dump the resource load callback for the following subframe to make sure it had its main document URL set in its NSURLRequest.
 


### PR DESCRIPTION
#### e8e624bc5f23a162e003aab73328f40b200f40db
<pre>
[Site Isolation] fast/loader/main-document-url-for-non-http-loads.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313087">https://bugs.webkit.org/show_bug.cgi?id=313087</a>

Reviewed by Megan Gardner.

The test failure was caused by the race condition between notifyDone is called and &quot;didFinishLoading&quot;
logging happens for the subframe. Fixed the failure by always delaying notifyDone with 0s timer.

* LayoutTests/fast/loader/main-document-url-for-non-http-loads-expected.txt:
* LayoutTests/fast/loader/resources/subframe-notify-done.html:
* LayoutTests/platform/wk2/fast/loader/main-document-url-for-non-http-loads-expected.txt:

Canonical link: <a href="https://commits.webkit.org/311826@main">https://commits.webkit.org/311826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2285b43498b1b1e8bd15589467cd65f58e3c7dbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166970 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122468 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24737 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103137 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14742 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169459 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130649 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31224 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130764 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141621 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89058 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24033 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25477 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18427 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30714 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30235 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30465 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30362 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->