### PR TITLE
[Site Isolation] Make WebPage::scheduleFullEditorStateUpdate() work for cross-site iframes

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -287,7 +287,6 @@ using WebKit::PageData::TransactionCallbackID = IPC::AsyncReplyID;
     bool isInStableState;
     WebCore::InteractiveWidget viewportMetaTagInteractiveWidget;
 
-    std::optional<WebKit::EditorState> editorState;
 #if PLATFORM(IOS_FAMILY)
     std::optional<uint64_t> dynamicViewportSizeUpdateID;
 #endif
@@ -299,6 +298,8 @@ struct WebKit::RemoteLayerTreeCommitBundle {
     Vector<WebKit::RemoteLayerTreeCommitBundle::RootFrameData> transactions;
     WebKit::PageData pageData;
     std::optional<WebKit::MainFrameData> mainFrameData;
+
+    std::optional<WebKit::EditorState> editorState;
     
     WebKit::TransactionID transactionID;
     MonotonicTime startTime;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
@@ -89,7 +89,6 @@ struct MainFrameData {
     bool isInStableState { false };
     WebCore::InteractiveWidget viewportMetaTagInteractiveWidget { WebCore::InteractiveWidget::ResizesVisual };
 
-    std::optional<EditorState> editorState;
 #if PLATFORM(IOS_FAMILY)
     std::optional<DynamicViewportSizeUpdateID> dynamicViewportSizeUpdateID;
 #endif
@@ -105,6 +104,8 @@ struct RemoteLayerTreeCommitBundle {
     Vector<RootFrameData> transactions;
     PageData pageData;
     std::optional<MainFrameData> mainFrameData;
+
+    std::optional<EditorState> editorState;
 
     TransactionID transactionID;
     MonotonicTime startTime;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.mm
@@ -78,12 +78,6 @@ String MainFrameData::description() const
     ts.dumpProperty("avoidsUnsafeArea"_s, avoidsUnsafeArea);
     ts.dumpProperty("isInStableState"_s, isInStableState);
 
-    if (editorState) {
-        TextStream::GroupScope scope(ts);
-        ts << "EditorState"_s;
-        ts << *editorState;
-    }
-
     ts.endGroup();
 
     return ts.release();
@@ -98,6 +92,12 @@ String RemoteLayerTreeCommitBundle::description() const
 
     ts.dumpProperty("transactionID"_s, transactionID);
     ts.dumpProperty("startTime"_s, startTime.secondsSinceEpoch().milliseconds());
+
+    if (editorState) {
+        TextStream::GroupScope scope(ts);
+        ts << "EditorState"_s;
+        ts << *editorState;
+    }
 
     ts.endGroup();
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -379,12 +379,13 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
     if (!page)
         return;
 
+    if (bundle.editorState) {
+        if (page->updateEditorState(EditorState { *bundle.editorState }, WebPageProxy::ShouldMergeVisualEditorState::Yes))
+            page->dispatchDidUpdateEditorState();
+    }
+
     if (bundle.mainFrameData) {
         m_activityStateChangeID = bundle.mainFrameData->activityStateChangeID;
-
-        // FIXME(site-isolation): Editor state should be updated for subframes.
-        if (bundle.mainFrameData->editorState && page->updateEditorState(EditorState { *bundle.mainFrameData->editorState }, WebPageProxy::ShouldMergeVisualEditorState::Yes))
-            page->dispatchDidUpdateEditorState();
 
         // Process any callbacks for unhiding content early, so that we
         // set the root node during the same CA transaction.

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2333,12 +2333,20 @@ void WebPage::willCommitMainFrameData(MainFrameData& data, const TransactionID& 
         m_internals->lastTransactionIDWithScaleChange = transactionID;
     }
 #endif
+}
+
+std::optional<EditorState> WebPage::editorStateIfUpdateNeeded()
+{
+    std::optional<EditorState> editorState;
 
     if (hasPendingEditorStateUpdate() || m_needsEditorStateVisualDataUpdate) {
-        data.editorState = editorState();
+        editorState = this->editorState();
+
         m_pendingEditorStateUpdateStatus = PendingEditorStateUpdateStatus::NotScheduled;
         m_needsEditorStateVisualDataUpdate = false;
     }
+
+    return editorState;
 }
 
 void WebPage::didFlushLayerTreeAtTime(MonotonicTime timestamp, bool flushSucceeded)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -395,7 +395,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     for (auto& transaction : transactions)
         backingStoreCollection->willCommitLayerTree(CheckedRef { transaction.first });
 
-    RemoteLayerTreeCommitBundle bundle { WTF::move(transactions), { WTF::move(m_pendingCallbackIDs), protect(webPage->corePage())->renderTreeSize() }, std::nullopt, transactionID };
+    RemoteLayerTreeCommitBundle bundle { WTF::move(transactions), { WTF::move(m_pendingCallbackIDs), protect(webPage->corePage())->renderTreeSize() }, std::nullopt, std::nullopt, transactionID };
 
     if (webPage->localMainFrame()) {
         bundle.mainFrameData = MainFrameData { };
@@ -406,6 +406,9 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         webPage->willCommitMainFrameData(mainFrameData, transactionID);
         willCommitMainFrameData(mainFrameData);
     }
+
+    bundle.editorState = webPage->editorStateIfUpdateNeeded();
+
     bundle.startTime = *std::exchange(m_updateStartTime, std::nullopt);
 
     auto commitEncoder = makeUniqueRef<IPC::Encoder>(Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree::name(), m_identifier.toUInt64());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -683,6 +683,7 @@ public:
     void willCommitLayerTree(RemoteLayerTreeTransaction&, WebCore::FrameIdentifier);
     void willCommitMainFrameData(MainFrameData&, const TransactionID&);
     void didFlushLayerTreeAtTime(MonotonicTime, bool flushSucceeded);
+    std::optional<EditorState> editorStateIfUpdateNeeded();
 #endif
 
     void layoutIfNeeded();


### PR DESCRIPTION
#### 6939be86d6d771a3c94810704a94ebbead81b551
<pre>
[Site Isolation] Make WebPage::scheduleFullEditorStateUpdate() work for cross-site iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=313084">https://bugs.webkit.org/show_bug.cgi?id=313084</a>
<a href="https://rdar.apple.com/175382453">rdar://175382453</a>

Reviewed by Wenson Hsieh, Ryosuke Niwa, and Aditya Keerthi.

Many user actions can result in the editing state of the webview being changed.
When this happens, the web process must send the UI process a new EditorState to
reflect these changes.

The web process does this by calling WebPage::scheduleFullEditorStateUpdate().
This sets m_needsEditorStateVisualDataUpdate to true and schedules a rendering
update. Then, when RemoteLayerTreeDrawingArea::updateRendering() is called,
it will compute the new EditorState and send it to the UIProcess as part of the
RemoteLayerTreeDrawingAreaProxy::CommitLayerTree IPC message.

With site isolation on, when such actions happen in a cross-site iframe, (such
as tapping on an input element which changes the selection), no EditorState is
sent from the iframe&apos;s web process. The web process does indeed schedule the
editor state update, but it never arrives in the UI process.

The issue is that RemoteLayerTreeDrawingArea::updateRendering() only computes
and sends the new EditorState if this web process is that of the main frame:

if (webPage-&gt;localMainFrame()) {
    ...
    webPage-&gt;willCommitMainFrameData(mainFrameData, transactionID);
    ...
}

Here, willCommitMainFrameData() computes the EditorState and stores it in
mainFrameData. This is part of the the data that is sent to the UI Process by the
RemoteLayerTreeDrawingAreaProxy::CommitLayerTree IPC message.

This was fine before site isolation since the main frame and cross-site iframe
were in the same web process. So if the iframe scheduled an editor state update,
this code would still compute and send the new EditorState. But with site
isolation, the iframe is in its own process, and so webPage-&gt;localMainFrame() is
false.

To fix this, we amend the code to send the EditorState any time this web process
has noted that the editor state needs to be updated (not just when it&apos;s the main
frame&apos;s process).

Note that WebPageProxy stores only a single EditorState. This is fine with site
isolation off because there is only web process per WebPageProxy. But with site
isolation on, there are multiple web processes per WebPageProxy, and since there
is one EditorState per web process, making this change will mean WebPageProxy
will now receive EditorStates from multiple web process.

WebPageProxy hasn&apos;t yet been modified to handle this. But for now, it will mostly
ignore EditorStates that come from non-main frame web processes since the
EditorStates they send will likely have an identifier less than that of the
EditorStates sent by the main frame&apos;s web process (assuming more changes are
happening in the main frame&apos;s web process).

So this will cause no behavior change for now. This is the first step in making
EditorState work with site isolation. A follow up patch will make WebPageProxy
deal with multiple web processes sending it EditorStates.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h:

Move editorState out of mainFrameData and into RemoteLayerTreeCommitBundle since
its no longer tied to the main frame.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.mm:
(WebKit::MainFrameData::description const):
(WebKit::RemoteLayerTreeCommitBundle::description const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):

If the web process sent an EditorState, send it to WebPageProxy.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willCommitMainFrameData):
(WebKit::WebPage::editorStateIfUpdateNeeded):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):

Compute and store the editorState if this web process says the editor state
needs updating. The IPC will send it to the UI process.

* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/311887@main">https://commits.webkit.org/311887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/635ea420c5c0875ce6c30d1def6ea45f67802288

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166981 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112235 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122477 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85975 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103146 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23808 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22156 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14753 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133492 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169470 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14824 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21460 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130658 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130773 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141631 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89069 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24068 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18437 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96258 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30246 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30373 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->