### PR TITLE
[iOS] CheckedPtr crash under [WebThermalMitigationObserver thermalStateDidChange]

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -444,7 +444,10 @@ Page::Page(PageConfiguration&& pageConfiguration)
     , m_isUtilityPage(isUtilityPageChromeClient(chrome().client()))
     , m_performanceMonitor(isUtilityPage() ? nullptr : makeUniqueWithoutRefCountedCheck<PerformanceMonitor>(*this))
     , m_lowPowerModeNotifier(makeUniqueRef<LowPowerModeNotifier>([this](bool isLowPowerModeEnabled) { handleLowPowerModeChange(isLowPowerModeEnabled); }))
-    , m_thermalMitigationNotifier(makeUniqueRef<ThermalMitigationNotifier>([this](bool thermalMitigationEnabled) { handleThermalMitigationChange(thermalMitigationEnabled); }))
+    , m_thermalMitigationNotifier(ThermalMitigationNotifier::create([weakThis = WeakPtr { *this }](bool thermalMitigationEnabled) {
+        if (RefPtr protectedThis = weakThis)
+            protectedThis->handleThermalMitigationChange(thermalMitigationEnabled);
+    }))
     , m_performanceLogging(makeUniqueRef<PerformanceLogging>(*this))
 #if PLATFORM(MAC) && (ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION))
     , m_servicesOverlayController(makeUniqueRefWithoutRefCountedCheck<ServicesOverlayController>(*this))

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1699,7 +1699,7 @@ private:
 
     const std::unique_ptr<PerformanceMonitor> m_performanceMonitor;
     const UniqueRef<LowPowerModeNotifier> m_lowPowerModeNotifier;
-    const UniqueRef<ThermalMitigationNotifier> m_thermalMitigationNotifier;
+    const Ref<ThermalMitigationNotifier> m_thermalMitigationNotifier;
     OptionSet<ThrottlingReason> m_throttlingReasons;
     OptionSet<ThrottlingReason> m_throttlingReasonsOverridenForTesting;
 

--- a/Source/WebCore/platform/ThermalMitigationNotifier.cpp
+++ b/Source/WebCore/platform/ThermalMitigationNotifier.cpp
@@ -29,6 +29,11 @@
 
 namespace WebCore {
 
+Ref<ThermalMitigationNotifier> ThermalMitigationNotifier::create(ThermalMitigationChangeCallback&& callback)
+{
+    return adoptRef(*new ThermalMitigationNotifier(WTF::move(callback)));
+}
+
 #if !HAVE(APPLE_THERMAL_MITIGATION_SUPPORT)
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ThermalMitigationNotifier);

--- a/Source/WebCore/platform/ThermalMitigationNotifier.h
+++ b/Source/WebCore/platform/ThermalMitigationNotifier.h
@@ -25,10 +25,9 @@
 
 #pragma once
 
-#include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakPtr.h>
 
 #if HAVE(APPLE_THERMAL_MITIGATION_SUPPORT)
 #include <wtf/RetainPtr.h>
@@ -37,18 +36,19 @@ OBJC_CLASS WebThermalMitigationObserver;
 
 namespace WebCore {
 
-class ThermalMitigationNotifier final : public CanMakeWeakPtr<ThermalMitigationNotifier>, public CanMakeCheckedPtr<ThermalMitigationNotifier> {
+class ThermalMitigationNotifier final : public RefCountedAndCanMakeWeakPtr<ThermalMitigationNotifier> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ThermalMitigationNotifier, WEBCORE_EXPORT);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ThermalMitigationNotifier);
 public:
     using ThermalMitigationChangeCallback = Function<void(bool thermalMitigationEnabled)>;
-    WEBCORE_EXPORT explicit ThermalMitigationNotifier(ThermalMitigationChangeCallback&&);
+    WEBCORE_EXPORT static Ref<ThermalMitigationNotifier> create(ThermalMitigationChangeCallback&&);
     WEBCORE_EXPORT ~ThermalMitigationNotifier();
 
     WEBCORE_EXPORT bool thermalMitigationEnabled() const;
     WEBCORE_EXPORT static bool isThermalMitigationEnabled();
 
 private:
+    explicit ThermalMitigationNotifier(ThermalMitigationChangeCallback&&);
+
 #if HAVE(APPLE_THERMAL_MITIGATION_SUPPORT)
     void notifyThermalMitigationChanged(bool);
     friend void notifyThermalMitigationChanged(ThermalMitigationNotifier&, bool);

--- a/Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm
+++ b/Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm
@@ -67,7 +67,7 @@ static bool isThermalMitigationEnabled()
 - (void)thermalStateDidChange
 {
     callOnMainThread([self, protectedSelf = RetainPtr<WebThermalMitigationObserver>(self)] {
-        if (CheckedPtr notifier = _notifier.get())
+        if (RefPtr notifier = _notifier)
             notifyThermalMitigationChanged(*notifier, self.thermalMitigationEnabled);
     });
 }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -123,9 +123,9 @@ Cache::Cache(NetworkProcess& networkProcess, const String& storageDirectory, Ref
             if (RefPtr protectedThis = weakThis.get())
                 updateSpeculativeLoadManagerEnabledState();
         });
-        m_thermalMitigationNotifier = makeUnique<WebCore::ThermalMitigationNotifier>([this, weakThis = WeakPtr { *this }](bool) {
-            if (RefPtr protectedThis = weakThis.get())
-                updateSpeculativeLoadManagerEnabledState();
+        m_thermalMitigationNotifier = WebCore::ThermalMitigationNotifier::create([weakThis = WeakPtr { *this }](bool) {
+            if (RefPtr protectedThis = weakThis)
+                protectedThis->updateSpeculativeLoadManagerEnabledState();
         });
         if (shouldUseSpeculativeLoadManager())
             m_speculativeLoadManager = makeUnique<SpeculativeLoadManager>(*this, protect(m_storage));

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -255,7 +255,7 @@ private:
     void updateSpeculativeLoadManagerEnabledState();
 
     std::unique_ptr<WebCore::LowPowerModeNotifier> m_lowPowerModeNotifier;
-    std::unique_ptr<WebCore::ThermalMitigationNotifier> m_thermalMitigationNotifier;
+    RefPtr<WebCore::ThermalMitigationNotifier> m_thermalMitigationNotifier;
     std::unique_ptr<SpeculativeLoadManager> m_speculativeLoadManager;
 
     HashMap<Key, Ref<AsyncRevalidation>> m_pendingAsyncRevalidations;


### PR DESCRIPTION
#### 421f42aa5ebaae6ab363c800237a0ed8464da6f7
<pre>
[iOS] CheckedPtr crash under [WebThermalMitigationObserver thermalStateDidChange]
<a href="https://bugs.webkit.org/show_bug.cgi?id=313091">https://bugs.webkit.org/show_bug.cgi?id=313091</a>
<a href="https://rdar.apple.com/170616981">rdar://170616981</a>

Reviewed by Ryosuke Niwa.

Make ThermalMitigationNotifier ref-counted instead of CanMakeCheckedPtr
and protect this in `[WebThermalMitigationObserver thermalStateDidChange]`
before calling notifyThermalMitigationChanged() on it.

* Source/WebCore/page/Page.cpp:
(WebCore::m_thermalMitigationNotifier):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/ThermalMitigationNotifier.cpp:
(WebCore::ThermalMitigationNotifier::create):
* Source/WebCore/platform/ThermalMitigationNotifier.h:
* Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm:
(-[WebThermalMitigationObserver thermalStateDidChange]):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::Cache):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:

Canonical link: <a href="https://commits.webkit.org/311843@main">https://commits.webkit.org/311843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43774df0c765acb7759721e75522e934c2b517e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158229 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167058 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122537 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24814 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103206 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14830 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169547 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14901 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130721 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31312 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130836 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35414 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141705 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89146 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25549 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30802 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96335 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30323 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30553 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30450 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->