### PR TITLE
Add test to show that we properly begin at the top of the document tree when looping the progression tabbed element focus.

### DIFF
--- a/LayoutTests/http/tests/site-isolation/focus-wrap-across-remote-frames-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/focus-wrap-across-remote-frames-expected.txt
@@ -1,0 +1,16 @@
+Tests Tab focus navigation into a cross-origin iframe, and that focus relinquishes to chrome after the last element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.activeElement.tagName is 'BODY'
+PASS document.activeElement.id is 'outerInput'
+PASS Outer input focused
+PASS document.activeElement.tagName is 'IFRAME'
+PASS Tab moved focus into iframe
+PASS document.activeElement.tagName is 'BODY'
+PASS Tab relinquished focus to chrome
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/focus-wrap-across-remote-frames.html
+++ b/LayoutTests/http/tests/site-isolation/focus-wrap-across-remote-frames.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Tests Tab focus navigation into a cross-origin iframe, and that focus relinquishes to chrome after the last element.");
+jsTestIsAsync = true;
+
+function waitForActiveElementTagName(expected) {
+    return new Promise((resolve, reject) => {
+        let attempts = 0;
+        function check() {
+            if (document.activeElement && document.activeElement.tagName === expected) {
+                resolve();
+                return;
+            }
+            if (++attempts > 100) {
+                reject(new Error(`Timed out waiting for activeElement.tagName to be '${expected}', was '${document.activeElement ? document.activeElement.tagName : "null"}'`));
+                return;
+            }
+            setTimeout(check, 50);
+        }
+        check();
+    });
+}
+</script>
+
+<body>
+<input type="text" id="outerInput" placeholder="Outer frame input">
+<iframe id="testIframe" src="http://localhost:8000/site-isolation/resources/focus-wrap-iframe.html"></iframe>
+
+<script>
+async function runTest() {
+    testRunner?.dumpAsText();
+    await UIHelper.setHardwareKeyboardAttached(true);
+
+    shouldBe("document.activeElement.tagName", "'BODY'");
+
+    // Focus the outer input.
+    document.getElementById('outerInput').focus();
+    shouldBe("document.activeElement.id", "'outerInput'");
+    testPassed("Outer input focused");
+
+    // Tab into the cross-origin iframe.
+    await UIHelper.keyDown("\t");
+    await waitForActiveElementTagName('IFRAME');
+    shouldBe("document.activeElement.tagName", "'IFRAME'");
+    testPassed("Tab moved focus into iframe");
+
+    // Tab again — focus should relinquish to chrome (leave the web view).
+    await UIHelper.keyDown("\t");
+    await waitForActiveElementTagName('BODY');
+    shouldBe("document.activeElement.tagName", "'BODY'");
+    testPassed("Tab relinquished focus to chrome");
+
+    finishJSTest();
+}
+
+window.addEventListener('load', runTest);
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -598,7 +598,6 @@ FocusableElementSearchResult FocusController::findFocusableElementContinuingFrom
         }
 
         // Chrome doesn't want focus, so we should wrap focus.
-        // FIXME: We probably want to travel up the document tree
         RefPtr localTopDocument = m_page->localTopDocument();
         if (!localTopDocument)
             return findResult;


### PR DESCRIPTION
#### ce921a9c9a6cddcb6107924f31d03fef1218ea7d
<pre>
Add test to show that we properly begin at the top of the document tree when looping the progression tabbed element focus.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313096">https://bugs.webkit.org/show_bug.cgi?id=313096</a>
<a href="https://rdar.apple.com/175393903">rdar://175393903</a>

Reviewed by Ryosuke Niwa.

When investigating FIXMEs that I left in the focus controller, I found
that this FIXME was actually unneeded. Adding a test to prove that this
code functions properly.

Test: http/tests/site-isolation/focus-wrap-across-remote-frames.html

* LayoutTests/http/tests/site-isolation/focus-wrap-across-remote-frames-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/focus-wrap-across-remote-frames.html: Added.
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementContinuingFromOwnerElement):

Canonical link: <a href="https://commits.webkit.org/312015@main">https://commits.webkit.org/312015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/deb523f359ab717a738b766d1a71525eb5f09822

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32032 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25139 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112691 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36a32ff1-a5b5-43d0-a061-a6a5cb8c9ff8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122859 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86214 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac0538a8-6b5a-4e58-a15e-6e2d06dedff3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103528 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75f017e9-238f-478f-ad7f-e3426d8830be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24170 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22571 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15208 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169927 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15671 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131045 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131159 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35515 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142049 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89574 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25849 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18857 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97193 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30699 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30972 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->