### PR TITLE
[iOS] Remove use of deprecated `UIColorPickerViewController` API

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
@@ -68,9 +68,7 @@
 - (void)selectColor:(UIColor *)color
 {
     [_colorPickerViewController setSelectedColor:color];
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [self colorPickerViewControllerDidSelectColor:_colorPickerViewController.get()];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    [self colorPickerViewController:_colorPickerViewController.get() didSelectColor:color continuously:NO];
 }
 
 - (NSArray<UIColor *> *)focusedElementSuggestedColors
@@ -145,12 +143,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #pragma mark UIColorPickerViewControllerDelegate
 
-ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
-- (void)colorPickerViewControllerDidSelectColor:(UIColorPickerViewController *)viewController
+- (void)colorPickerViewController:(UIColorPickerViewController *)viewController didSelectColor:(UIColor *)color continuously:(BOOL)continuously
 {
-    [protect(_view) updateFocusedElementValueAsColor:viewController.selectedColor];
+    [protect(_view) updateFocusedElementValueAsColor:color];
 }
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)colorPickerViewControllerDidFinish:(UIColorPickerViewController *)viewController
 {


### PR DESCRIPTION
#### ee36694e6d009ce0f0abf97061df50cddfbc6638
<pre>
[iOS] Remove use of deprecated `UIColorPickerViewController` API
<a href="https://bugs.webkit.org/show_bug.cgi?id=313097">https://bugs.webkit.org/show_bug.cgi?id=313097</a>
<a href="https://rdar.apple.com/175394843">rdar://175394843</a>

Reviewed by Richard Robinson.

`colorPickerViewControllerDidSelectColor:` was deprecated in iOS 15. Adopt the
replacement.

* Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm:
(-[WKColorPicker selectColor:]):
(-[WKColorPicker colorPickerViewController:didSelectColor:continuously:]):
(-[WKColorPicker colorPickerViewControllerDidSelectColor:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/311866@main">https://commits.webkit.org/311866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f59aef21565dc5b86839ce827a4b4f3c2a899fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167006 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112260 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122496 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85985 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103165 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23822 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14778 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133506 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169495 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14849 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130678 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130793 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141654 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89094 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24055 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25502 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18460 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30750 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96283 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30271 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30501 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->