### PR TITLE
[HDR] Introduce GainMap and ShareableGainMap

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -95,6 +95,13 @@ symbols = [
     "MACaptionAppearanceCopyPreviewText",
 ]
 
+[[temporary-usage]]
+request = "rdar://175714562"
+cleanup = "rdar://175714562"
+symbols = [
+    "CGImageApplyHDRGainMap",
+]
+
 [[not-web-essential]]
 request = "rdar://168411469"
 symbols = [

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2493,6 +2493,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/FontSizeAdjust.h
     platform/graphics/FontTaggedSettings.h
     platform/graphics/FourCC.h
+    platform/graphics/GainMap.h
     platform/graphics/GCGLExtension.h
     platform/graphics/GCGLSpan.h
     platform/graphics/GeneratedImage.h

--- a/Source/WebCore/PAL/pal/spi/cg/ImageIOSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/ImageIOSPI.h
@@ -27,19 +27,28 @@
 
 DECLARE_SYSTEM_HEADER
 
+#include <ImageIO/CGImageMetadata.h>
 #include <ImageIO/CGImageSource.h>
 #include <ImageIO/ImageIOBase.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 
+#include <ImageIO/CGImageHDRFunctionsPrivate.h>
+#include <ImageIO/CGImageMetadataPrivate.h>
+#include <ImageIO/CGImagePropertiesPriv.h>
 #include <ImageIO/CGImageSourcePrivate.h>
 
 #else
 
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
+
+IMAGEIO_EXTERN const CFStringRef kCGImageAuxiliaryDataInfoColorSpace;
+IMAGEIO_EXTERN const CFStringRef kCGImageAuxiliaryDataInfoMetadata;
+IMAGEIO_EXTERN const CFStringRef kCGImageAuxiliaryDataTypeISOGainMap;
+IMAGEIO_EXTERN const CFStringRef kCGImageSourceShouldCacheImmediately;
 IMAGEIO_EXTERN const CFStringRef kCGImageSourceShouldPreferRGB32;
 IMAGEIO_EXTERN const CFStringRef kCGImageSourceSkipMetadata;
 IMAGEIO_EXTERN const CFStringRef kCGImageSourceSubsampleFactor;
-IMAGEIO_EXTERN const CFStringRef kCGImageSourceShouldCacheImmediately;
 IMAGEIO_EXTERN const CFStringRef kCGImageSourceUseHardwareAcceleration;
 
 WTF_EXTERN_C_BEGIN
@@ -50,6 +59,8 @@ IMAGEIO_EXTERN OSStatus CGImageSourceDisableHardwareDecoding();
 IMAGEIO_EXTERN OSStatus CGImageSourceEnableRestrictedDecoding();
 
 IMAGEIO_EXTERN uint16_t CGImageGetContentAverageLightLevelNits(CGImageRef);
+
+IMAGEIO_EXTERN OSStatus CGImageApplyHDRGainMap(CVPixelBufferRef inputImage, CVPixelBufferRef inputGainmap, CVPixelBufferRef outputImage, CFDictionaryRef options);
 
 WTF_EXTERN_C_END
 

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -475,6 +475,7 @@ platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
 platform/graphics/cocoa/PlatformTimeRangesCocoa.mm @nonARC @no-unify
 platform/graphics/cocoa/ShareableCVPixelBuffer.cpp
 platform/graphics/cocoa/ShareableCVPixelFormat.cpp
+platform/graphics/cocoa/ShareableGainMap.cpp
 platform/graphics/cocoa/SourceBufferParser.cpp
 platform/graphics/cocoa/SourceBufferParserWebM.cpp
 platform/graphics/cocoa/SystemFontDatabaseCocoa.mm @nonARC

--- a/Source/WebCore/platform/graphics/GainMap.h
+++ b/Source/WebCore/platform/graphics/GainMap.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+#include <ImageIO/CGImageMetadata.h>
+#include <WebCore/DestinationColorSpace.h>
+#include <wtf/RetainPtr.h>
+
+typedef struct CF_BRIDGED_TYPE(id) __CVBuffer *CVPixelBufferRef;
+#endif
+
+namespace WebCore {
+
+struct GainMap {
+#if PLATFORM(COCOA)
+    RetainPtr<CGImageMetadataRef> metadata;
+    RetainPtr<CVPixelBufferRef> gainMapPixelBuffer;
+    DestinationColorSpace colorSpace;
+#endif
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,24 +37,33 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NativeImage);
 
 #if !USE(CG) && !USE(SKIA)
-RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& platformImage)
+RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& platformImage, std::optional<GainMap>&& gainMap)
 {
     if (!platformImage)
         return nullptr;
-    return adoptRef(*new NativeImage(WTF::move(platformImage)));
+    return adoptRef(*new NativeImage(WTF::move(platformImage), WTF::move(gainMap)));
 }
 
-RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image)
+RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& platformImage)
 {
-    return create(WTF::move(image));
+    return create(WTF::move(platformImage), std::nullopt);
+}
+
+RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& platformImage)
+{
+    return create(WTF::move(platformImage));
 }
 #endif
 
+NativeImage::NativeImage() = default;
+
 #if !USE(SKIA)
-NativeImage::NativeImage(PlatformImagePtr&& platformImage)
+NativeImage::NativeImage(PlatformImagePtr&& platformImage, std::optional<GainMap>&& gainMap)
     : m_platformImage(WTF::move(platformImage))
+    , m_gainMap(WTF::move(gainMap))
 {
     computeHeadroom();
+    ASSERT_IMPLIES(m_gainMap, m_headroom == Headroom::None);
 }
 #endif
 
@@ -69,6 +78,11 @@ const PlatformImagePtr& NativeImage::platformImage() const
     return m_platformImage;
 }
 
+const std::optional<GainMap>& NativeImage::gainMap() const
+{
+    return m_gainMap;
+}
+
 bool NativeImage::hasHDRContent() const
 {
     return colorSpace().usesITUR_2100TF();
@@ -79,6 +93,7 @@ void NativeImage::replacePlatformImage(PlatformImagePtr&& platformImage) const
     ASSERT(platformImage);
     m_platformImage = WTF::move(platformImage);
     computeHeadroom();
+    ASSERT_IMPLIES(m_gainMap, m_headroom == Headroom::None);
 }
 
 #if !USE(CG)

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007-2008 Torch Mobile, Inc.
  * Copyright (C) 2012 Company 100 Inc.
  *
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <WebCore/GainMap.h>
 #include <WebCore/ImageTypes.h>
 #include <WebCore/PlatformExportMacros.h>
 #include <WebCore/PlatformImage.h>
@@ -54,10 +55,12 @@ class NativeImage : public ThreadSafeRefCounted<NativeImage>, public CanMakeThre
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NativeImage);
 public:
 #if USE(SKIA)
+    static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&, std::optional<GainMap>&&, GrDirectContext* = nullptr);
     static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&, GrDirectContext* = nullptr);
     // Creates a NativeImage that is intended to be drawn once or only few times. Signals the platform to avoid generating any caches for the image.
     static WEBCORE_EXPORT RefPtr<NativeImage> createTransient(PlatformImagePtr&&, GrDirectContext* = nullptr);
 #else
+    static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&, std::optional<GainMap>&&);
     static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&);
     // Creates a NativeImage that is intended to be drawn once or only few times. Signals the platform to avoid generating any caches for the image.
     static WEBCORE_EXPORT RefPtr<NativeImage> createTransient(PlatformImagePtr&&);
@@ -66,6 +69,7 @@ public:
     WEBCORE_EXPORT virtual ~NativeImage();
 
     WEBCORE_EXPORT virtual const PlatformImagePtr& platformImage() const;
+    WEBCORE_EXPORT const std::optional<GainMap>& gainMap() const;
     WEBCORE_EXPORT virtual IntSize size() const;
     WEBCORE_EXPORT virtual bool hasAlpha() const;
     std::optional<Color> singlePixelSolidColor() const;
@@ -96,15 +100,17 @@ public:
     }
 
 protected:
+    WEBCORE_EXPORT NativeImage();
 #if USE(SKIA)
-    WEBCORE_EXPORT NativeImage(PlatformImagePtr&&, GrDirectContext* = nullptr);
+    WEBCORE_EXPORT NativeImage(PlatformImagePtr&&, std::optional<GainMap>&&, GrDirectContext*);
 #else
-    WEBCORE_EXPORT NativeImage(PlatformImagePtr&&);
+    WEBCORE_EXPORT NativeImage(PlatformImagePtr&&, std::optional<GainMap>&&);
 #endif
 
     void computeHeadroom() const;
 
     mutable PlatformImagePtr m_platformImage;
+    mutable std::optional<GainMap> m_gainMap;
     mutable Headroom m_headroom { Headroom::None };
     mutable WeakHashSet<RenderingResourceObserver> m_observers;
     RenderingResourceIdentifier m_renderingResourceIdentifier { RenderingResourceIdentifier::generate() };

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,6 +58,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
 ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, Headroom headroom, bool isOpaque, unsigned bitsPerComponent, unsigned bytesPerPixel, unsigned bytesPerRow
 #if USE(CG)
     , CGBitmapInfo bitmapInfo
+    , std::optional<ShareableGainMap>&& shareableGainMap
 #endif
 )
     : m_size(size)
@@ -69,6 +70,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     , m_bytesPerRow(bytesPerRow)
 #if USE(CG)
     , m_bitmapInfo(bitmapInfo)
+    , m_shareableGainMap(WTF::move(shareableGainMap))
 #endif
 #if USE(SKIA)
     , m_imageInfo(SkImageInfo::MakeN32Premul(size.width(), size.height(), this->colorSpace().platformColorSpace()))
@@ -170,7 +172,7 @@ auto ShareableBitmap::createReadOnlyHandle() const -> std::optional<Handle>
     return createHandle(SharedMemory::Protection::ReadOnly);
 }
 
-ShareableBitmap::ShareableBitmap(ShareableBitmapConfiguration configuration, Ref<SharedMemory>&& sharedMemory)
+ShareableBitmap::ShareableBitmap(const ShareableBitmapConfiguration& configuration, Ref<SharedMemory>&& sharedMemory)
     : m_configuration(configuration)
     , m_sharedMemory(WTF::move(sharedMemory))
 {

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,10 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
+#if USE(CG)
+#include <WebCore/ShareableGainMap.h>
+#endif
+
 namespace WebCore {
 
 class GraphicsContext;
@@ -55,16 +59,21 @@ inline constexpr auto defaultCopyOnWrite = SharedMemory::CopyOnWrite::No;
 class ShareableBitmapConfiguration {
 public:
     ShareableBitmapConfiguration() = default;
+    explicit ShareableBitmapConfiguration(const ShareableBitmapConfiguration&) = default;
+    ShareableBitmapConfiguration(ShareableBitmapConfiguration&&) = default;
 
     WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace> = std::nullopt, Headroom = Headroom::None, bool isOpaque = false);
     WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace>, Headroom, bool isOpaque, unsigned bitsPerComponent, unsigned bytesPerPixel, unsigned bytesPerRow
 #if USE(CG)
         , CGBitmapInfo
+        , std::optional<ShareableGainMap>&&
 #endif
     );
 #if USE(CG)
     ShareableBitmapConfiguration(const NativeImage&);
 #endif
+
+    ShareableBitmapConfiguration& operator=(ShareableBitmapConfiguration&&) = default;
 
     IntSize size() const { return m_size; }
     const DestinationColorSpace& colorSpace() const { return m_colorSpace ? *m_colorSpace : DestinationColorSpace::SRGB(); }
@@ -77,6 +86,7 @@ public:
     unsigned bytesPerRow() const { ASSERT(!m_bytesPerRow.hasOverflowed()); return m_bytesPerRow; }
 #if USE(CG)
     CGBitmapInfo bitmapInfo() const { return m_bitmapInfo; }
+    std::optional<ShareableGainMap> shareableGainMap() const { return m_shareableGainMap; }
 #endif
 #if USE(SKIA)
     const SkImageInfo& imageInfo() const LIFETIME_BOUND { return m_imageInfo; }
@@ -107,6 +117,7 @@ private:
     CheckedUint32 m_bytesPerRow;
 #if USE(CG)
     CGBitmapInfo m_bitmapInfo { 0 };
+    std::optional<ShareableGainMap> m_shareableGainMap;
 #endif
 #if USE(SKIA)
     SkImageInfo m_imageInfo;
@@ -187,6 +198,8 @@ public:
     // This is only safe to use when we know that the contents of the shareable bitmap won't change.
     WEBCORE_EXPORT RefPtr<Image> createImage();
 
+    WEBCORE_EXPORT PlatformImagePtr createBasePlatformImage(BackingStoreCopy = CopyBackingStore, ShouldInterpolate = ShouldInterpolate::No);
+
     WEBCORE_EXPORT PlatformImagePtr createPlatformImage(BackingStoreCopy = CopyBackingStore, ShouldInterpolate = ShouldInterpolate::No);
 
 #if USE(CAIRO)
@@ -201,7 +214,7 @@ public:
 #endif
 
 private:
-    ShareableBitmap(ShareableBitmapConfiguration, Ref<SharedMemory>&&);
+    ShareableBitmap(const ShareableBitmapConfiguration&, Ref<SharedMemory>&&);
 
 #if USE(CG)
     static void releaseBitmapContextData(void* typelessBitmap, void* typelessData);

--- a/Source/WebCore/platform/graphics/cairo/ShareableBitmapCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ShareableBitmapCairo.cpp
@@ -86,11 +86,16 @@ void ShareableBitmap::paint(GraphicsContext& context, float scaleFactor, const I
     Cairo::drawSurface(*context.platformContext(), surface.get(), destRect, srcRect, state.imageInterpolationQuality(), state.alpha(), Cairo::ShadowState(state));
 }
 
-PlatformImagePtr ShareableBitmap::createPlatformImage(BackingStoreCopy, ShouldInterpolate)
+PlatformImagePtr ShareableBitmap::createBasePlatformImage(BackingStoreCopy, ShouldInterpolate)
 {
     // FIXME: Implement and remove createPersistentCairoSurface(), createCairoSurface().
     ASSERT_NOT_REACHED();
     return nullptr;
+}
+
+PlatformImagePtr ShareableBitmap::createPlatformImage(BackingStoreCopy copyBehavior, ShouldInterpolate shouldInterpolate)
+{
+    return createBasePlatformImage(copyBehavior, shouldInterpolate);
 }
 
 RefPtr<cairo_surface_t> ShareableBitmap::createPersistentCairoSurface()

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,13 +38,18 @@
 namespace WebCore {
 
 
-RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& image)
+RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& image, std::optional<GainMap>&& gainMap)
 {
     if (!image)
         return nullptr;
     if (CGImageGetWidth(image.get()) > std::numeric_limits<int>::max() || CGImageGetHeight(image.get()) > std::numeric_limits<int>::max())
         return nullptr;
-    return adoptRef(*new NativeImage(WTF::move(image)));
+    return adoptRef(*new NativeImage(WTF::move(image), WTF::move(gainMap)));
+}
+
+RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& image)
+{
+    return create(WTF::move(image), std::nullopt);
 }
 
 RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image)

--- a/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
+++ b/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const NativeImage& im
     , m_bytesPerPixel(CGImageGetBitsPerPixel(image.platformImage().get()) / 8)
     , m_bytesPerRow(CGImageGetBytesPerRow(image.platformImage().get()))
     , m_bitmapInfo(CGImageGetBitmapInfo(image.platformImage().get()))
+    , m_shareableGainMap(ShareableGainMap::create(image.gainMap()))
 {
 }
 
@@ -210,7 +211,7 @@ void ShareableBitmap::paint(GraphicsContext& context, float scaleFactor, const I
     CGContextRestoreGState(cgContext.get());
 }
 
-PlatformImagePtr ShareableBitmap::createPlatformImage(BackingStoreCopy copyBehavior, ShouldInterpolate shouldInterpolate)
+PlatformImagePtr ShareableBitmap::createBasePlatformImage(BackingStoreCopy copyBehavior, ShouldInterpolate shouldInterpolate)
 {
     verifyImageBufferIsBigEnough(span());
 
@@ -241,6 +242,28 @@ PlatformImagePtr ShareableBitmap::createPlatformImage(BackingStoreCopy copyBehav
 #endif
     return adoptCF(CGImageCreate(size().width(), size().height(), bitsPerComponent, bitsPerPixel, bytesPerRow, protect(m_configuration.platformColorSpace()).get(), m_configuration.bitmapInfo(), dataProvider.get(), 0, shouldInterpolate == ShouldInterpolate::Yes, kCGRenderingIntentDefault));
 
+}
+
+PlatformImagePtr ShareableBitmap::createPlatformImage(BackingStoreCopy copyBehavior, ShouldInterpolate shouldInterpolate)
+{
+    auto basePlatformImage = createBasePlatformImage(copyBehavior, shouldInterpolate);
+    if (!basePlatformImage)
+        return basePlatformImage;
+
+    auto shareableGainMap = m_configuration.shareableGainMap();
+    if (!shareableGainMap)
+        return basePlatformImage;
+
+    auto outputPlatformImage = shareableGainMap->applyGainMapToBaseImage(basePlatformImage);
+    if (!outputPlatformImage)
+        return basePlatformImage;
+
+#if ENABLE(DUMP_GAIN_MAP_IMAGES)
+    CGImageDumpToFile(basePlatformImage.get(), "*/base-image.br2");
+    CGImageDumpToFile(outputPlatformImage.get(), "*/output-image.br2");
+#endif
+
+    return outputPlatformImage;
 }
 
 void ShareableBitmap::releaseBitmapContextData(void* typelessBitmap, void* typelessData)

--- a/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.cpp
@@ -60,18 +60,51 @@ RetainPtr<CVPixelBufferRef> createScratchMetalCompatibleCVPixelBuffer(unsigned w
 {
     RetainPtr attributes = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     RetainPtr surfaceProperties = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-    CFDictionarySetValue(attributes.get(), kCVPixelBufferIOSurfacePropertiesKey, surfaceProperties.get());
-    CFDictionarySetValue(attributes.get(), kCVPixelBufferMetalCompatibilityKey, kCFBooleanTrue);
-
+    CFDictionarySetValue(attributes, kCVPixelBufferIOSurfacePropertiesKey, surfaceProperties);
+    CFDictionarySetValue(attributes, kCVPixelBufferMetalCompatibilityKey, kCFBooleanTrue);
     return createScratchCVPixelBuffer(width, height, pixelFormat, attributes, colorSpace);
+}
+
+RetainPtr<CVPixelBufferRef> createScratchMetalCompatibleCVPixelBuffer(CVPixelBufferRef pixelBuffer, CGColorSpaceRef colorSpace)
+{
+    unsigned width = CVPixelBufferGetWidth(pixelBuffer);
+    unsigned height = CVPixelBufferGetHeight(pixelBuffer);
+    OSType pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer);
+    return createScratchMetalCompatibleCVPixelBuffer(width, height, pixelFormat, colorSpace);
 }
 
 RetainPtr<CVPixelBufferRef> createScratchMetalCompatibleCVPixelBuffer(const ShareableCVPixelBuffer& pixelBuffer, CGColorSpaceRef colorSpace)
 {
     unsigned width = pixelBuffer.configuration().width();
     unsigned height = pixelBuffer.configuration().height();
-    ShareableCVPixelFormat pixelFormat = pixelBuffer.configuration().pixelFormat();
-    return createScratchMetalCompatibleCVPixelBuffer(width, height, toCVPixelFormat(pixelFormat), colorSpace);
+    OSType pixelFormat = toCVPixelFormat(pixelBuffer.configuration().pixelFormat());
+    return createScratchMetalCompatibleCVPixelBuffer(width, height, pixelFormat, colorSpace);
+}
+
+RetainPtr<CVPixelBufferRef> createMetalCompatibleCVPixelBufferFromImage(PlatformImagePtr platformImage)
+{
+    unsigned width = CGImageGetWidth(platformImage);
+    unsigned height = CGImageGetHeight(platformImage);
+    RetainPtr colorSpace = CGImageGetColorSpace(platformImage);
+
+    RetainPtr pixelBuffer = createScratchMetalCompatibleCVPixelBuffer(width, height, kCVPixelFormatType_32BGRA);
+    if (!pixelBuffer)
+        return nullptr;
+
+    CVPixelBufferLockBaseAddress(pixelBuffer, 0);
+    {
+        unsigned destinationBytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
+        auto* destinationBaseAddress = static_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer));
+
+        // kCGBitmapByteOrder32Little | kCGImageAlphaPremultipliedFirst => BGRA layout
+        auto bitmapInfo = static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedFirst);
+
+        RetainPtr context = adoptCF(CGBitmapContextCreate(destinationBaseAddress, width, height, 8, destinationBytesPerRow, colorSpace, bitmapInfo));
+        CGContextDrawImage(context, CGRectMake(0, 0, static_cast<CGFloat>(width), static_cast<CGFloat>(height)), platformImage);
+    }
+    CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+
+    return WTF::move(pixelBuffer);
 }
 
 #if ENABLE(DUMP_GAIN_MAP_IMAGES)

--- a/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.h
@@ -39,7 +39,11 @@ RetainPtr<CVPixelBufferRef> createScratchCVPixelBuffer(unsigned width, unsigned 
 
 RetainPtr<CVPixelBufferRef> createScratchMetalCompatibleCVPixelBuffer(unsigned width, unsigned height, OSType pixelFormat, CGColorSpaceRef = nullptr);
 
+RetainPtr<CVPixelBufferRef> createScratchMetalCompatibleCVPixelBuffer(CVPixelBufferRef, CGColorSpaceRef = nullptr);
+
 RetainPtr<CVPixelBufferRef> createScratchMetalCompatibleCVPixelBuffer(const ShareableCVPixelBuffer&, CGColorSpaceRef = nullptr);
+
+RetainPtr<CVPixelBufferRef> createMetalCompatibleCVPixelBufferFromImage(PlatformImagePtr);
 
 #if ENABLE(DUMP_GAIN_MAP_IMAGES)
 void CVPixelBufferDumpToFile(CVPixelBufferRef, const String& name);

--- a/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ShareableGainMap.h"
+
+#if PLATFORM(COCOA)
+
+#include "Logging.h"
+#include <pal/spi/cg/ImageIOSPI.h>
+
+#include "CoreVideoSoftLink.h"
+#include "VideoToolboxSoftLink.h"
+
+namespace WebCore {
+
+std::optional<ShareableGainMap> ShareableGainMap::create(const std::optional<GainMap>& gainMap)
+{
+    if (!gainMap || !gainMap->gainMapPixelBuffer)
+        return std::nullopt;
+
+    RetainPtr metadata = adoptCF(CGImageMetadataCreateXMPData(gainMap->metadata, nullptr));
+    if (!metadata)
+        return std::nullopt;
+
+    RefPtr gainMapShareablePixelBuffer = ShareableCVPixelBuffer::create(gainMap->gainMapPixelBuffer);
+    if (!gainMapShareablePixelBuffer)
+        return std::nullopt;
+
+    return ShareableGainMap { WTF::move(metadata), gainMapShareablePixelBuffer.releaseNonNull(), gainMap->colorSpace };
+}
+
+std::optional<ShareableGainMap> ShareableGainMap::create(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, const DestinationColorSpace& colorSpace)
+{
+    if (!metadata)
+        return std::nullopt;
+
+    return ShareableGainMap { WTF::move(metadata), WTF::move(gainMapShareablePixelBuffer), colorSpace };
+}
+
+ShareableGainMap::ShareableGainMap(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, const DestinationColorSpace& colorSpace)
+    : m_metadata(WTF::move(metadata))
+    , m_gainMapShareablePixelBuffer(WTF::move(gainMapShareablePixelBuffer))
+    , m_colorSpace(colorSpace)
+{
+}
+
+PlatformImagePtr ShareableGainMap::applyGainMapToBaseImage(PlatformImagePtr basePlatformImage) const
+{
+    if (!basePlatformImage)
+        return nullptr;
+
+    if (!canLoad_VideoToolbox_VTCreateCGImageFromCVPixelBuffer())
+        return nullptr;
+
+    RetainPtr baseImagePixelBuffer = createMetalCompatibleCVPixelBufferFromImage(basePlatformImage);
+    if (!baseImagePixelBuffer) {
+        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: Failed to create baseImagePixelBuffer", __FUNCTION__);
+        return nullptr;
+    }
+
+    RetainPtr gainMapPixelBuffer = protect(m_gainMapShareablePixelBuffer)->createMetalCompatibleCVPixelBuffer();
+    if (!gainMapPixelBuffer) {
+        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: Failed to create gainMapPixelBuffer", __FUNCTION__);
+        return nullptr;
+    }
+
+    RetainPtr outputColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3_PQ));
+    RetainPtr outputImagePixelBuffer = createScratchMetalCompatibleCVPixelBuffer(baseImagePixelBuffer, outputColorSpace);
+    if (!outputImagePixelBuffer) {
+        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: Failed to create outputImagePixelBuffer", __FUNCTION__);
+        return nullptr;
+    }
+
+    RetainPtr metadata = adoptCF(CGImageMetadataCreateFromXMPData(m_metadata));
+
+    RetainPtr options = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    CFDictionarySetValue(options, kCGImageAuxiliaryDataInfoMetadata, metadata);
+    CFDictionarySetValue(options, kCGImageAuxiliaryDataInfoColorSpace, m_colorSpace.platformColorSpace());
+
+    auto status = CGImageApplyHDRGainMap(baseImagePixelBuffer, gainMapPixelBuffer, outputImagePixelBuffer, options);
+    if (status != kCVReturnSuccess) {
+        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: CGImageApplyHDRGainMap() failed with status=%d", __FUNCTION__, static_cast<int>(status));
+        return nullptr;
+    }
+
+#if ENABLE(DUMP_GAIN_MAP_IMAGES)
+    CVPixelBufferDumpToFile(baseImagePixelBuffer, "*/base-image.cvpb"_s);
+    CVPixelBufferDumpToFile(gainMapPixelBuffer, "*/gainmap-image.cvpb"_s);
+    CVPixelBufferDumpToFile(outputImagePixelBuffer, "*/output-image.cvpb"_s);
+#endif
+
+    CGImageRef outputPlatformImage = nullptr;
+    status = VTCreateCGImageFromCVPixelBuffer(outputImagePixelBuffer, nullptr, &outputPlatformImage);
+    if (status != kCVReturnSuccess) {
+        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: VTCreateCGImageFromCVPixelBuffer() failed with status=%d", __FUNCTION__, static_cast<int>(status));
+        return nullptr;
+    }
+
+    return adoptCF(outputPlatformImage);
+}
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.h
+++ b/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+#include <WebCore/GainMap.h>
+#include <WebCore/PlatformImage.h>
+#include <WebCore/ShareableCVPixelBuffer.h>
+
+namespace WebCore {
+
+class ShareableGainMap {
+public:
+    WEBCORE_EXPORT static std::optional<ShareableGainMap> create(const std::optional<GainMap>&);
+    WEBCORE_EXPORT static std::optional<ShareableGainMap> create(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, const DestinationColorSpace&);
+
+    WEBCORE_EXPORT PlatformImagePtr applyGainMapToBaseImage(PlatformImagePtr) const;
+
+private:
+    friend struct IPC::ArgumentCoder<ShareableGainMap>;
+
+    ShareableGainMap(RetainPtr<CFDataRef>&& metadata, Ref<ShareableCVPixelBuffer>&& gainMapShareablePixelBuffer, const DestinationColorSpace&);
+
+    RetainPtr<CFDataRef> m_metadata;
+    Ref<ShareableCVPixelBuffer> m_gainMapShareablePixelBuffer;
+    DestinationColorSpace m_colorSpace;
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -36,20 +36,26 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
-RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& platformImage, GrDirectContext* grContext)
+RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& platformImage, std::optional<GainMap>&& gainMap, GrDirectContext* grContext)
 {
     if (!platformImage)
         return nullptr;
-    return adoptRef(*new NativeImage(WTF::move(platformImage), grContext));
+    return adoptRef(*new NativeImage(WTF::move(platformImage), WTF::move(gainMap), grContext));
 }
 
-RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image, GrDirectContext* grContext)
+RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& platformImage, GrDirectContext* grContext)
 {
-    return create(WTF::move(image), grContext);
+    return create(WTF::move(platformImage), std::nullopt, grContext);
 }
 
-NativeImage::NativeImage(PlatformImagePtr&& platformImage, GrDirectContext* grContext)
+RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& platformImage, GrDirectContext* grContext)
+{
+    return create(WTF::move(platformImage), grContext);
+}
+
+NativeImage::NativeImage(PlatformImagePtr&& platformImage, std::optional<GainMap>&& gainMap, GrDirectContext* grContext)
     : m_platformImage(WTF::move(platformImage))
+    , m_gainMap(WTF::move(gainMap))
     , m_grContext(grContext)
 {
     ASSERT(!m_platformImage->isTextureBacked() || m_grContext);

--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -103,7 +103,7 @@ RefPtr<Image> ShareableBitmap::createImage()
     return BitmapImage::create(createPlatformImage(BackingStoreCopy::DontCopyBackingStore));
 }
 
-PlatformImagePtr ShareableBitmap::createPlatformImage(BackingStoreCopy backingStoreCopy, ShouldInterpolate)
+PlatformImagePtr ShareableBitmap::createBasePlatformImage(BackingStoreCopy backingStoreCopy, ShouldInterpolate)
 {
     sk_sp<SkData> pixelData;
     if (backingStoreCopy == BackingStoreCopy::CopyBackingStore)
@@ -115,6 +115,11 @@ PlatformImagePtr ShareableBitmap::createPlatformImage(BackingStoreCopy backingSt
         }, this);
     }
     return SkImages::RasterFromData(m_configuration.imageInfo(), pixelData, bytesPerRow());
+}
+
+PlatformImagePtr ShareableBitmap::createPlatformImage(BackingStoreCopy copyBehavior, ShouldInterpolate shouldInterpolate)
+{
+    return createBasePlatformImage(copyBehavior, shouldInterpolate);
 }
 
 void ShareableBitmap::setOwnershipOfMemory(const ProcessIdentity&)

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -374,6 +374,7 @@
 }
 
 [UnsafeWrapper] RetainPtr<CFDataRef> {
+    [Legacy] StructureParam WebCore::ShareableGainMap.m_metadata
     [Legacy] StructureParam WebCore::MultiRepresentationHEICAttachmentData.data
     [Legacy] StructureParam WebCore::TextAttachmentFileWrapper.data
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8570,11 +8570,18 @@ header: <WebCore/ShareableCVPixelBuffer.h>
 [CustomHeader, RefCounted] class WebCore::ShareableCVPixelBufferWithPlanarBytes {
     WebCore::ShareableCVPixelBufferConfiguration m_configuration;
     Vector<Ref<WebCore::ShareableCVPixelBufferBytes>> m_planes;
-};
+}
 
 [CustomHeader, RefCounted] class WebCore::ShareableCVPixelBuffer subclasses {
     WebCore::ShareableCVPixelBufferWithBytes
     WebCore::ShareableCVPixelBufferWithPlanarBytes
+}
+
+header: <WebCore/ShareableGainMap.h>
+[CreateUsing=create] class WebCore::ShareableGainMap {
+    RetainPtr<CFDataRef> m_metadata;
+    Ref<WebCore::ShareableCVPixelBuffer> m_gainMapShareablePixelBuffer;
+    WebCore::DestinationColorSpace m_colorSpace;
 }
 
 #endif
@@ -8590,6 +8597,7 @@ header: <WebCore/ShareableBitmap.h>
     [Validator='[&]() { std::remove_cvref_t<decltype(*bytesPerRow)> bytesForWidth; return WTF::safeMultiply(m_size->width(), *bytesPerPixel, bytesForWidth) && *bytesPerRow >= bytesForWidth; }()'] unsigned bytesPerRow();
 #if USE(CG)
     CGBitmapInfo m_bitmapInfo;
+    std::optional<WebCore::ShareableGainMap> m_shareableGainMap;
 #endif
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp
@@ -60,8 +60,7 @@ Ref<RemoteNativeImageProxy> RemoteNativeImageProxy::create(const IntSize& size, 
 }
 
 RemoteNativeImageProxy::RemoteNativeImageProxy(const IntSize& size, PlatformColorSpace&& colorSpace, bool hasAlpha, WeakRef<RemoteResourceCacheProxy>&& resourceCache)
-    : NativeImage(nullptr)
-    , m_resourceCache(WTF::move(resourceCache))
+    : m_resourceCache(WTF::move(resourceCache))
     , m_size(size)
     , m_colorSpace(WTF::move(colorSpace))
     , m_hasAlpha(hasAlpha)


### PR DESCRIPTION
#### ff6f5a8f40079145a1b55600de630a342712db2b
<pre>
[HDR] Introduce GainMap and ShareableGainMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=312933">https://bugs.webkit.org/show_bug.cgi?id=312933</a>
<a href="https://rdar.apple.com/175284361">rdar://175284361</a>

Reviewed by Cameron McCormack.

`GainMap` is where the HDR gain-map data will be stored. It will be serialized
to GPU process through `ShareableGainMap`. The members of `GainMap` are:
a `CVPixelBuffer` for the gain-map image, image-metadata and colorSpace.
`ShareableGainMap` will be responsible for generating the HDR image from the
base image and the `GainMap`.

`NativeImage` will hold `std::optional&lt;GainMap&gt;`. In this PR, it is never set.
In future patches, `ImageDecoder` will be asked to retrieve the frame&apos;s `GainMap`.

`ShareableBitmap` will store a `GainMap` as `std::optional&lt;ShareableGainMap&gt;` in
its `ShareableBitmapConfiguration`. IPC decoder will serialize `ShareableGainMap`
as a member of `ShareableBitmapConfiguration` through serializing `ShareableBitmap`.

`ShareableBitmap::createPlatformImage()` will be renamed `createBasePlatformImage()`.
A new method called `ShareableBitmap::createPlatformImage()` will be added which
will `createBasePlatformImage` from its `SharedMemory` then (2) decides  whether
to apply the `GainMap` to generate an HDR image. Or just return basePlatformImage.
All the existing callers to `createPlatformImage()` will not change their calls.

* Source/WebCore/Configurations/AllowedSPI.toml:
* Source/WebCore/Headers.cmake:
* Source/WebCore/PAL/pal/spi/cg/ImageIOSPI.h:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/GainMap.h: Added.
* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::NativeImage::create):
(WebCore::NativeImage::createTransient):
(WebCore::NativeImage::NativeImage):
(WebCore::NativeImage::gainMap const):
(WebCore::NativeImage::replacePlatformImage const):
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
(WebCore::ShareableBitmap::ShareableBitmap):
* Source/WebCore/platform/graphics/ShareableBitmap.h:
(WebCore::ShareableBitmapConfiguration::shareableGainMap const):
* Source/WebCore/platform/graphics/cairo/ShareableBitmapCairo.cpp:
(WebCore::ShareableBitmap::createBasePlatformImage):
(WebCore::ShareableBitmap::createPlatformImage):
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::create):
* Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm:
(WebCore::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
(WebCore::ShareableBitmap::createBasePlatformImage):
(WebCore::ShareableBitmap::createPlatformImage):
* Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.cpp:
(WebCore::createScratchMetalCompatibleCVPixelBuffer):
(WebCore::createMetalCompatibleCVPixelBufferFromImage):
* Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.h:
* Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp: Added.
(WebCore::ShareableGainMap::create):
(WebCore::ShareableGainMap::ShareableGainMap):
(WebCore::ShareableGainMap::applyGainMapToBaseImage const):
* Source/WebCore/platform/graphics/cocoa/ShareableGainMap.h: Added.
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::NativeImage::create):
(WebCore::NativeImage::createTransient):
(WebCore::NativeImage::NativeImage):
* Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp:
(WebCore::ShareableBitmap::createBasePlatformImage):
(WebCore::ShareableBitmap::createPlatformImage):
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp:
(WebKit::RemoteNativeImageProxy::RemoteNativeImageProxy):

Canonical link: <a href="https://commits.webkit.org/312341@main">https://commits.webkit.org/312341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cbaba76441f4e779386b16d3fa3d81541dc8dc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168496 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/114026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123690 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/114026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25959 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104341 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/158965 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16260 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170987 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/17013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22797 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32791 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132014 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35717 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90858 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/26639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19770 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32285 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/98681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/32029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->