### PR TITLE
[GTK][WPE] Skia Compositor: add SkiaBackingStore

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -15,6 +15,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/GraphicsContextSkia.h
     platform/graphics/skia/ImageBufferSkiaBackend.h
     platform/graphics/skia/PathSkia.h
+    platform/graphics/skia/SkiaBackingStore.h
     platform/graphics/skia/SkiaCompositingLayer.h
     platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h
     platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -58,6 +58,7 @@ platform/graphics/skia/PathSkia.cpp
 platform/graphics/skia/PatternSkia.cpp
 platform/graphics/skia/PlatformDisplaySkia.cpp @no-unify
 platform/graphics/skia/ShareableBitmapSkia.cpp
+platform/graphics/skia/SkiaBackingStore.cpp
 platform/graphics/skia/SkiaCompositingLayer.cpp
 platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp
 platform/graphics/skia/SkiaCompositingLayerOverlapRegions.cpp

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaBackingStore.h"
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "BitmapTexturePool.h"
+#include "CoordinatedTileBuffer.h"
+#include "PlatformDisplay.h"
+#include "SkiaPaintingEngine.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/SystemTracing.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaBackingStore);
+
+void SkiaBackingStore::update(const FloatSize& size, float scale, CoordinatedBackingStoreProxy::Update&& update)
+{
+    m_size = size;
+    m_scale = scale;
+
+    for (auto tileID : update.tilesToCreate())
+        m_tiles.add(tileID, Tile(m_scale));
+
+    for (auto tileID : update.tilesToRemove()) {
+        ASSERT(m_tiles.contains(tileID));
+        m_tiles.remove(tileID);
+    }
+
+    for (const auto& tileUpdate : update.tilesToUpdate()) {
+        auto it = m_tiles.find(tileUpdate.tileID);
+        ASSERT(it != m_tiles.end());
+        it->value.update(tileUpdate.dirtyRect, tileUpdate.tileRect, tileUpdate.buffer);
+    }
+}
+
+static inline bool allTileEdgesExposed(const FloatRect& totalRect, const FloatRect& tileRect)
+{
+    return !tileRect.x() && !tileRect.y() && tileRect.width() + tileRect.x() >= totalRect.width() && tileRect.height() + tileRect.y() >= totalRect.height();
+}
+
+void SkiaBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint)
+{
+    if (m_tiles.isEmpty())
+        return;
+
+    FloatRect layerRect = { { }, m_size };
+
+    auto tilePaint = paint;
+    for (auto& tile : m_tiles.values()) {
+        if (canvas.quickReject(tile.rect()))
+            continue;
+
+        const auto& image = tile.image();
+        if (!image)
+            continue;
+
+        tilePaint.setAntiAlias(allTileEdgesExposed(layerRect, tile.rect()));
+        canvas.drawImageRect(image, SkRect::MakeWH(image->width(), image->height()), tile.rect(), SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), &tilePaint, SkCanvas::kFast_SrcRectConstraint);
+    }
+}
+
+void SkiaBackingStore::drawDebugBorders(SkCanvas& canvas, const SkPaint& paint)
+{
+    for (const auto& tile : m_tiles.values())
+        canvas.drawRect(SkRect(tile.rect()), paint);
+}
+
+bool SkiaBackingStore::Tile::tryEnsureSurface(const IntSize& size, CoordinatedTileBuffer& buffer)
+{
+    if (m_surface)
+        return true;
+
+    OptionSet<BitmapTexture::Flags> flags;
+    if (buffer.supportsAlpha())
+        flags.add(BitmapTexture::Flags::SupportsAlpha);
+
+#if USE(GBM)
+    if (SkiaPaintingEngine::shouldUseLinearTileTextures()) {
+        flags.add(BitmapTexture::Flags::BackedByDMABuf);
+        flags.add(BitmapTexture::Flags::ForceLinearBuffer);
+    } else if (SkiaPaintingEngine::shouldUseVivanteSuperTiledTileTextures()) {
+        flags.add(BitmapTexture::Flags::BackedByDMABuf);
+        flags.add(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer);
+    }
+#endif
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    auto texture = BitmapTexturePool::singleton().acquireTexture(size, flags);
+    GrBackendTexture backendTexture = texture->createSkiaBackendTexture();
+    auto surface = SkSurfaces::WrapBackendTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr, +[](void* userData) {
+        static_cast<BitmapTexture*>(userData)->deref();
+    }, &texture.leakRef());
+    if (!surface)
+        return false;
+
+    auto* canvas = surface->getCanvas();
+    if (!canvas)
+        return false;
+
+    canvas->clear(SK_ColorTRANSPARENT);
+    m_surface = WTF::move(surface);
+    return true;
+}
+
+void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& tileRect, CoordinatedTileBuffer& buffer)
+{
+    WTFBeginSignpost(this, CoordinatedSwapBuffer, "rect %ix%i+%i+%i", tileRect.x(), tileRect.y(), tileRect.width(), tileRect.height());
+
+    FloatRect unscaledTileRect(tileRect);
+    unscaledTileRect.scale(1. / m_scale);
+
+    if (unscaledTileRect != m_rect) {
+        m_rect = unscaledTileRect;
+        m_surface = nullptr;
+    }
+
+    WTFBeginSignpost(this, CoordinatedUpdateTileTexture, "%s", buffer.isBackedByOpenGL() ? "GPUToGPU" : "CPUToGPU");
+
+    if (buffer.isBackedByOpenGL()) {
+        auto& acceleratedBuffer = static_cast<CoordinatedAcceleratedTileBuffer&>(buffer);
+        acceleratedBuffer.serverWait();
+
+        Ref texture = acceleratedBuffer.texture();
+        GrBackendTexture backendTexture = texture->createSkiaBackendTexture();
+        if (dirtyRect.size() == tileRect.size()) {
+            // Fast path: whole tile content changed -- take ownership of the incoming texture, replacing the existing tile buffer (avoiding texture copies).
+            if (m_surface) {
+                m_surface->replaceBackendTexture(backendTexture, kTopLeft_GrSurfaceOrigin, SkSurface::kDiscard_ContentChangeMode, +[](void* userData) {
+                    static_cast<BitmapTexture*>(userData)->deref();
+                }, &texture.leakRef());
+                m_surface->notifyContentWillChange(SkSurface::kDiscard_ContentChangeMode);
+            } else {
+                auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+                m_surface = SkSurfaces::WrapBackendTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr, +[](void* userData) {
+                    static_cast<BitmapTexture*>(userData)->deref();
+                }, &texture.leakRef());
+            }
+        } else if (tryEnsureSurface(tileRect.size(), buffer)) {
+            auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+            auto image = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+            m_surface->getCanvas()->drawImageRect(image, SkRect::MakeWH(dirtyRect.width(), dirtyRect.height()), SkRect::Make(SkIRect(dirtyRect)), SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), nullptr, SkCanvas::kFast_SrcRectConstraint);
+        }
+    } else if (tryEnsureSurface(tileRect.size(), buffer)) {
+        auto& unacceleratedBuffer = static_cast<CoordinatedUnacceleratedTileBuffer&>(buffer);
+        auto imageInfo = SkImageInfo::Make(dirtyRect.width(), dirtyRect.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+        SkPixmap pixmap(imageInfo, unacceleratedBuffer.data(), unacceleratedBuffer.stride());
+        m_surface->writePixels(pixmap, dirtyRect.x(), dirtyRect.y());
+    }
+
+    WTFEndSignpost(this, CoordinatedUpdateTileTexture);
+    WTFEndSignpost(this, CoordinatedSwapBuffer);
+}
+
+sk_sp<SkImage> SkiaBackingStore::Tile::image()
+{
+    return m_surface ? m_surface->makeImageSnapshot() : nullptr;
+}
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "CoordinatedBackingStoreProxy.h"
+#include "FloatRect.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkSurface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/HashMap.h>
+
+namespace WebCore {
+class CoordinatedTileBuffer;
+
+class SkiaBackingStore {
+    WTF_MAKE_TZONE_ALLOCATED(SkiaBackingStore);
+public:
+    SkiaBackingStore() = default;
+    ~SkiaBackingStore() = default;
+
+    float scale() const { return m_scale; }
+
+    void update(const FloatSize&, float scale, CoordinatedBackingStoreProxy::Update&&);
+    void paintToCanvas(SkCanvas&, const SkPaint&);
+    void drawDebugBorders(SkCanvas&, const SkPaint&);
+
+private:
+    class Tile {
+    public:
+        Tile() = default;
+        explicit Tile(float scale)
+            : m_scale(scale)
+        {
+        }
+
+        ~Tile() = default;
+
+        void update(const IntRect& dirtyRect, const IntRect& tileRect, CoordinatedTileBuffer&);
+        const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
+        sk_sp<SkImage> image();
+
+    private:
+        bool tryEnsureSurface(const IntSize&, CoordinatedTileBuffer&);
+
+        float m_scale { 1. };
+        FloatRect m_rect;
+        sk_sp<SkSurface> m_surface;
+    };
+
+    HashMap<uint32_t, Tile> m_tiles;
+    FloatSize m_size;
+    float m_scale { 1. };
+};
+
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -29,7 +29,6 @@
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
 #include "ColorMatrix.h"
 #include "CoordinatedAnimatedBackingStoreClient.h"
-#include "CoordinatedBackingStore.h"
 #include "CoordinatedImageBackingStore.h"
 #include "CoordinatedPlatformLayerBuffer.h"
 #include "CoordinatedTileBuffer.h"
@@ -37,6 +36,7 @@
 #include "FontCache.h"
 #include "PlatformDisplay.h"
 #include "Region.h"
+#include "SkiaBackingStore.h"
 #include "SkiaCompositingLayer3DRenderingContext.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -148,25 +148,17 @@ void SkiaCompositingLayer::setUseBackingStore(bool useBackingStore, CoordinatedA
     }
 
     if (!m_backingStore)
-        m_backingStore = CoordinatedBackingStore::create();
+        m_backingStore = makeUnique<SkiaBackingStore>();
     m_animatedBackingStoreClient = animatedBackingStoreClient;
 }
 
 void SkiaCompositingLayer::updateBackingStore(CoordinatedBackingStoreProxy::Update&& update, float scale)
 {
-    ASSERT(m_backingStore);
-    m_backingStore->resize(m_size, scale);
-    for (auto tileID : update.tilesToCreate())
-        m_backingStore->createTile(tileID);
-    for (auto tileID : update.tilesToRemove())
-        m_backingStore->removeTile(tileID);
-    for (const auto& tileUpdate : update.tilesToUpdate())
-        m_backingStore->updateTile(tileUpdate.tileID, tileUpdate.dirtyRect, tileUpdate.tileRect, tileUpdate.buffer.copyRef(), { });
-
     if (m_maskImage && !update.isEmpty())
         m_maskImage = nullptr;
 
-    m_backingStore->processPendingUpdates();
+    ASSERT(m_backingStore);
+    m_backingStore->update(m_size, scale, WTF::move(update));
 }
 
 void SkiaCompositingLayer::setImageBackingStore(CoordinatedImageBackingStore* imageBackingStore)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -50,10 +50,10 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 class CoordinatedAnimatedBackingStoreClient;
-class CoordinatedBackingStore;
 class CoordinatedImageBackingStore;
 class CoordinatedPlatformLayerBuffer;
 class FilterOperations;
+class SkiaBackingStore;
 
 class SkiaCompositingLayer final : public RefCountedAndCanMakeWeakPtr<SkiaCompositingLayer> {
     WTF_MAKE_TZONE_ALLOCATED(SkiaCompositingLayer);
@@ -218,7 +218,7 @@ private:
     RefPtr<SkiaCompositingLayer> m_mask;
     RefPtr<SkiaCompositingLayer> m_replica;
     WeakPtr<SkiaCompositingLayer> m_replicatedLayer;
-    RefPtr<CoordinatedBackingStore> m_backingStore;
+    std::unique_ptr<SkiaBackingStore> m_backingStore;
     RefPtr<CoordinatedAnimatedBackingStoreClient> m_animatedBackingStoreClient;
     RefPtr<CoordinatedImageBackingStore> m_imageBackingStore;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_contentsBuffer;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -22,18 +22,11 @@
 
 #if USE(COORDINATED_GRAPHICS)
 #include "BitmapTexture.h"
-#include "ColorMatrix.h"
 #include "CoordinatedTileBuffer.h"
 #include "GraphicsLayer.h"
 #include "TextureMapper.h"
 #include "TextureMapperFlags.h"
 #include <wtf/SystemTracing.h>
-
-#if USE(SKIA)
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkColorFilter.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-#endif
 
 namespace WebCore {
 
@@ -123,47 +116,6 @@ void CoordinatedBackingStore::drawRepaintCounter(TextureMapper& textureMapper, i
     for (const auto& tile : m_tiles.values())
         textureMapper.drawNumber(repaintCount, borderColor, tile.rect().location(), adjustedTransform);
 }
-
-#if USE(SKIA)
-void CoordinatedBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint)
-{
-    if (m_tiles.isEmpty())
-        return;
-
-    FloatRect layerRect = { { }, m_size };
-
-    sk_sp<SkColorFilter> bgraFilter;
-    auto tilePaint = paint;
-    for (auto& tile : m_tiles.values()) {
-        if (canvas.quickReject(tile.rect()))
-            continue;
-
-        const auto& image = tile.ensureSkImage();
-        if (!image)
-            continue;
-
-        tilePaint.setAntiAlias(allTileEdgesExposed(layerRect, tile.rect()));
-
-        if (tile.texture().colorConvertFlags().contains(TextureMapperFlags::ShouldConvertTextureBGRAToRGBA)) {
-            if (!bgraFilter) {
-                const auto matrix = swapRedBlueMatrix();
-                bgraFilter = SkColorFilters::Matrix(matrix.data().data());
-            }
-            if (auto* colorFilter = paint.getColorFilter())
-                tilePaint.setColorFilter(colorFilter->makeComposed(bgraFilter));
-            else
-                tilePaint.setColorFilter(bgraFilter);
-        }
-        canvas.drawImageRect(image, SkRect::MakeWH(image->width(), image->height()), tile.rect(), SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &tilePaint, SkCanvas::kFast_SrcRectConstraint);
-    }
-}
-
-void CoordinatedBackingStore::drawDebugBorders(SkCanvas& canvas, const SkPaint& paint)
-{
-    for (const auto& tile : m_tiles.values())
-        canvas.drawRect(SkRect(tile.rect()), paint);
-}
-#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -25,12 +25,6 @@
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 
-#if USE(SKIA)
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkCanvas.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-#endif
-
 namespace WebCore {
 class CoordinatedTileBuffer;
 class TextureMapper;
@@ -55,11 +49,6 @@ public:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float) override;
     void drawBorder(TextureMapper&, const Color&, float borderWidth, const FloatRect&, const TransformationMatrix&) override;
     void drawRepaintCounter(TextureMapper&, int repaintCount, const Color&, const FloatRect&, const TransformationMatrix&) override;
-
-#if USE(SKIA)
-    void paintToCanvas(SkCanvas&, const SkPaint&);
-    void drawDebugBorders(SkCanvas&, const SkPaint&);
-#endif
 
 private:
     CoordinatedBackingStore() = default;


### PR DESCRIPTION
#### f3ed054dc660698adec3a734f0c1f1287af39617
<pre>
[GTK][WPE] Skia Compositor: add SkiaBackingStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=313100">https://bugs.webkit.org/show_bug.cgi?id=313100</a>

Reviewed by Nikolas Zimmermann.

And use it instead of CoordinatedBackingStore and
CoordinatedBackingStoreTile. It&apos;s a simplified version of those by using
skia API.

* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp: Added.
(WebCore::SkiaBackingStore::update):
(WebCore::allTileEdgesExposed):
(WebCore::SkiaBackingStore::paintToCanvas):
(WebCore::SkiaBackingStore::drawDebugBorders):
(WebCore::SkiaBackingStore::Tile::tryEnsureSurface):
(WebCore::SkiaBackingStore::Tile::update):
(WebCore::SkiaBackingStore::Tile::image):
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h: Added.
(WebCore::SkiaBackingStore::scale const):
(WebCore::SkiaBackingStore::Tile::Tile):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::setUseBackingStore):
(WebCore::SkiaCompositingLayer::updateBackingStore):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStore::paintToCanvas): Deleted.
(WebCore::CoordinatedBackingStore::drawDebugBorders): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h:

Canonical link: <a href="https://commits.webkit.org/311835@main">https://commits.webkit.org/311835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d3ad546d765b2e3cbfe5897e7c145328e588977

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167025 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122509 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24778 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103178 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14797 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169514 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14868 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21500 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130692 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31279 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130807 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141671 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89113 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24039 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25514 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30769 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96302 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30520 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->