### PR TITLE
GC correctness for TreeWalker.currentNode

### DIFF
--- a/LayoutTests/fast/dom/tree-walker-disconnected-currentNode-expected.txt
+++ b/LayoutTests/fast/dom/tree-walker-disconnected-currentNode-expected.txt
@@ -1,0 +1,10 @@
+This tests holding onto a node via TreeWalker. WebKit should keep the root node alive.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS treeWalker.currentNode.getRootNode().localName is "b"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/tree-walker-disconnected-currentNode.html
+++ b/LayoutTests/fast/dom/tree-walker-disconnected-currentNode.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests holding onto a node via TreeWalker. WebKit should keep the root node alive.');
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+let treeWalker = (function setup() {
+    let div = document.createElement('div');
+    let span = document.createElement('span');
+    span.innerHTML = '<b><i></i></b>';
+    div.appendChild(span);
+    return document.createTreeWalker(span);
+})();
+
+treeWalker.nextNode();
+treeWalker.nextNode();
+treeWalker.root.replaceChildren();
+
+if (window.GCController) {
+    GCController.collect();
+    internals.releaseMemoryNow();
+} else
+    testFailed('This tests requires GCController');
+
+shouldBeEqualToString('treeWalker.currentNode.getRootNode().localName', 'b');
+
+</script></body>

--- a/Source/WebCore/bindings/js/JSTreeWalkerCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTreeWalkerCustom.cpp
@@ -32,6 +32,7 @@ void JSTreeWalker::visitAdditionalChildrenInGCThread(Visitor& visitor)
     if (auto filter = wrapped().filter())
         addWebCoreOpaqueRoot(visitor, *filter);
     addWebCoreOpaqueRoot(visitor, wrapped().root());
+    addWebCoreOpaqueRoot(visitor, wrapped().opaqueRootForCurrentNodeInGCThread());
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSTreeWalker);

--- a/Source/WebCore/dom/TreeWalker.cpp
+++ b/Source/WebCore/dom/TreeWalker.cpp
@@ -40,8 +40,16 @@ TreeWalker::TreeWalker(Node& rootNode, unsigned long whatToShow, RefPtr<NodeFilt
 {
 }
 
+WebCoreOpaqueRoot TreeWalker::opaqueRootForCurrentNodeInGCThread() const
+{
+    Locker locker { m_currentLock };
+    // Cannot ref in a GC thread.
+    SUPPRESS_UNCOUNTED_LOCAL return m_current->opaqueRoot();
+}
+
 void TreeWalker::setCurrentNode(Node& node)
 {
+    Locker locker { m_currentLock };
     m_current = node;
 }
 
@@ -78,8 +86,7 @@ ExceptionOr<Node*> TreeWalker::firstChild()
 
         switch (filterResult.returnValue()) {
             case NodeFilter::FILTER_ACCEPT:
-                m_current = node.releaseNonNull();
-                return m_current.ptr();
+                return setCurrent(node.releaseNonNull());
             case NodeFilter::FILTER_SKIP:
                 if (node->firstChild()) {
                     node = node->firstChild();
@@ -112,8 +119,7 @@ ExceptionOr<Node*> TreeWalker::lastChild()
 
         switch (filterResult.returnValue()) {
             case NodeFilter::FILTER_ACCEPT:
-                m_current = node.releaseNonNull();
-                return m_current.ptr();
+                return setCurrent(node.releaseNonNull());
             case NodeFilter::FILTER_SKIP:
                 if (node->lastChild()) {
                     node = node->lastChild();
@@ -150,10 +156,8 @@ template<TreeWalker::SiblingTraversalType type> ExceptionOr<Node*> TreeWalker::t
             if (filterResult.hasException())
                 return filterResult.releaseException();
 
-            if (filterResult.returnValue() == NodeFilter::FILTER_ACCEPT) {
-                m_current = sibling.releaseNonNull();
-                return m_current.ptr();
-            }
+            if (filterResult.returnValue() == NodeFilter::FILTER_ACCEPT)
+                return setCurrent(sibling.releaseNonNull());
             node = sibling;
             sibling = isNext ? sibling->firstChild() : sibling->lastChild();
             if (filterResult.returnValue() == NodeFilter::FILTER_REJECT || !sibling)
@@ -218,10 +222,8 @@ ExceptionOr<Node*> TreeWalker::previousNode()
                 if (acceptNodeResult == NodeFilter::FILTER_REJECT)
                     break;
             }
-            if (acceptNodeResult == NodeFilter::FILTER_ACCEPT) {
-                m_current = node.releaseNonNull();
-                return m_current.ptr();
-            }
+            if (acceptNodeResult == NodeFilter::FILTER_ACCEPT)
+                return setCurrent(node.releaseNonNull());
         }
         if (node == &root())
             return nullptr;

--- a/Source/WebCore/dom/TreeWalker.h
+++ b/Source/WebCore/dom/TreeWalker.h
@@ -27,11 +27,13 @@
 #include <WebCore/NodeFilter.h>
 #include <WebCore/ScriptWrappable.h>
 #include <WebCore/Traversal.h>
+#include <wtf/Lock.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
+class WebCoreOpaqueRoot;
 template<typename> class ExceptionOr;
 
 class TreeWalker final : public ScriptWrappable, public RefCounted<TreeWalker>, public NodeIteratorBase {
@@ -44,6 +46,8 @@ public:
 
     Node& currentNode() { return m_current.get(); }
     const Node& currentNode() const { return m_current.get(); }
+
+    WebCoreOpaqueRoot opaqueRootForCurrentNodeInGCThread() const;
 
     WEBCORE_EXPORT void setCurrentNode(Node&);
 
@@ -60,9 +64,10 @@ private:
 
     enum class SiblingTraversalType { Previous, Next };
     template<SiblingTraversalType> ExceptionOr<Node*> traverseSiblings();
-    
+
     Node* setCurrent(Ref<Node>&&);
 
+    mutable Lock m_currentLock;
     Ref<Node> m_current;
 };
 


### PR DESCRIPTION
#### 7e8fd0583ea42ebe4f12659daec84a3513b731e7
<pre>
GC correctness for TreeWalker.currentNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=313107">https://bugs.webkit.org/show_bug.cgi?id=313107</a>

Reviewed by Anne van Kesteren.

Keep JS wrappers for ancestors of TreeWalker.currentNode alive.

Test: fast/dom/tree-walker-disconnected-currentNode.html

* LayoutTests/fast/dom/tree-walker-disconnected-currentNode-expected.txt: Added.
* LayoutTests/fast/dom/tree-walker-disconnected-currentNode.html: Added.
* Source/WebCore/bindings/js/JSTreeWalkerCustom.cpp:
(WebCore::JSTreeWalker::visitAdditionalChildrenInGCThread):
* Source/WebCore/dom/TreeWalker.cpp:
(WebCore::TreeWalker::opaqueRootForCurrentNodeInGCThread const):
(WebCore::TreeWalker::setCurrentNode):
* Source/WebCore/dom/TreeWalker.h:

Canonical link: <a href="https://commits.webkit.org/311873@main">https://commits.webkit.org/311873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df7bac5b1e6a5d6751bd043cd3814aea15e62603

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167094 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122573 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103242 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14866 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169583 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15174 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130755 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31348 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130869 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89198 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24058 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25580 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18545 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30838 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96596 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30359 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30589 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30486 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->