### PR TITLE
[Site Isolation] gamepad/gamepad-timestamp.html fails

### DIFF
--- a/LayoutTests/gamepad/gamepad-timestamp.html
+++ b/LayoutTests/gamepad/gamepad-timestamp.html
@@ -33,11 +33,13 @@ function rafCallback()
     if (gamepad2Timestamp != gamepad2.timestamp) {
         log("Timestamp of gamepad 2 should never change throughout this test, but it did!");
         finishTest();
+        return;
     }
 
     if (gamepad.timestamp < timestamp) {
         log("Timestamp on gamepad is " + gamepad.timestamp + " which is less than " + timestamp);
         finishTest();
+        return;
     }
 
     if (gamepad.timestamp > timestamp)
@@ -46,12 +48,14 @@ function rafCallback()
     if (increasingTimestampsSeen == 10) {
         log("Increasing timestamp values seen for 10 RAF cycles");
         finishTest();
+        return;
     }
 
     if (++rafCount == 120) {
         log("Went 120 RAF cycles without seeing 10 increasing timestamp values... yikes!");
         log("Number of actual timestamp increases seen: " + increasingTimestampsSeen);
         finishTest();
+        return;
     }
 
     timestamp = gamepad.timestamp;


### PR DESCRIPTION
#### e6b1093808aa052d5dab93a5a4740ac231af15bb
<pre>
[Site Isolation] gamepad/gamepad-timestamp.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313110">https://bugs.webkit.org/show_bug.cgi?id=313110</a>

Reviewed by Megan Gardner.

The test failure was caused by finishTest, which calls testRunner.notifyDone,
does not synchronously finishing the test when site isolation is enabled so that
another round of requestAnimationFrame fired. Fixed the test by adding an early
return after calling finishTest to avoid scheduling an extra requestAnimationFrame.

* LayoutTests/gamepad/gamepad-timestamp.html:

Canonical link: <a href="https://commits.webkit.org/311877@main">https://commits.webkit.org/311877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50727a11cbe62b060da7ad8c9a7be15c7904d030

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167045 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112299 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122528 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86008 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103197 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23854 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14817 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169534 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130710 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31299 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26280 "Failed to checkout and rebase branch from PR 63405") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130825 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89133 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24061 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25533 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18496 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30789 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30310 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30540 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->