### PR TITLE
[Site Isolation] http/tests/cache/willsendrequest-returns-null-for-memory-cache-load.html fails

### DIFF
--- a/LayoutTests/http/tests/cache/willsendrequest-returns-null-for-memory-cache-load-expected.txt
+++ b/LayoutTests/http/tests/cache/willsendrequest-returns-null-for-memory-cache-load-expected.txt
@@ -1,9 +1,10 @@
-http://127.0.0.1:8000/misc/resources/compass.jpg - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/misc/resources/compass.jpg, main document URL (null), http method GET> redirectResponse (null)
+http://127.0.0.1:8000/misc/resources/compass.jpg - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/misc/resources/compass.jpg, main document URL http://127.0.0.1:8000/cache/willsendrequest-returns-null-for-memory-cache-load.html, http method GET> redirectResponse (null)
+http://127.0.0.1:8000/cache/willsendrequest-returns-null-for-memory-cache-load.html - didFinishLoading
 http://127.0.0.1:8000/misc/resources/compass.jpg - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/misc/resources/compass.jpg, http status code 200>
 http://127.0.0.1:8000/misc/resources/compass.jpg - didFinishLoading
-http://127.0.0.1:8000/cache/willsendrequest-returns-null-for-memory-cache-load.html - didFinishLoading
 http://127.0.0.1:8000/cache/resources/cached-image.html - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/cache/resources/cached-image.html, main document URL http://127.0.0.1:8000/cache/willsendrequest-returns-null-for-memory-cache-load.html, http method GET> redirectResponse (null)
 http://127.0.0.1:8000/cache/resources/cached-image.html - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/cache/resources/cached-image.html, http status code 200>
 http://127.0.0.1:8000/misc/resources/compass.jpg - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/misc/resources/compass.jpg, main document URL (null), http method GET> redirectResponse (null)
 http://127.0.0.1:8000/misc/resources/compass.jpg - didFailLoadingWithError: <NSError domain NSURLErrorDomain, code -999, failing URL "http://127.0.0.1:8000/misc/resources/compass.jpg">
+http://127.0.0.1:8000/cache/resources/cached-image.html - didFinishLoading
 

--- a/LayoutTests/http/tests/cache/willsendrequest-returns-null-for-memory-cache-load.html
+++ b/LayoutTests/http/tests/cache/willsendrequest-returns-null-for-memory-cache-load.html
@@ -3,6 +3,7 @@
 <head>
     <script>
         if (window.testRunner) {
+            testRunner.clearMemoryCache();
             testRunner.dumpAsText();
             testRunner.waitUntilDone();
             testRunner.dumpResourceLoadCallbacks();
@@ -14,7 +15,7 @@
             document.body.appendChild(iframe);
             iframe.onload = function() {
                 if (window.testRunner)
-                    testRunner.notifyDone();
+                    setTimeout(() => testRunner.notifyDone(), 0);
             }
             iframe.src = "resources/cached-image.html";
         }

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -573,8 +573,6 @@ fast/dom/rtl-scroll-to-leftmost-and-resize.html [ Failure ]
 
 webkit.org/b/131477 fast/repaint/obscured-background-no-repaint.html [ Pass Failure ]
 
-webkit.org/b/116259 http/tests/cache/willsendrequest-returns-null-for-memory-cache-load.html [ Pass Failure ]
-
 # --- Start media tests ---
 ## --- Start media wontfix tests ---
 # This test requires ogg codecs


### PR DESCRIPTION
#### 6ab66278347f7271f63a749a62ebcf846fa9f7a3
<pre>
[Site Isolation] http/tests/cache/willsendrequest-returns-null-for-memory-cache-load.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313111">https://bugs.webkit.org/show_bug.cgi?id=313111</a>

Reviewed by Sihui Liu.

The test failure was caused by didFinishLoading for the subframe getting logged when site isolation
is enabled as testRunner.notifyDone does not synchronously end the test under site isolation.

Made the test output identical with or without site isolation by adding 0s delay before calling
testRunner.notifyDone so that didFinishLoading gets logged consistently.

Also made the test more reliable by clearing the memory cache at the beginning of the test and
rebaselined the test results with the latest macOS results and removed the flaky test expectation.

* LayoutTests/http/tests/cache/willsendrequest-returns-null-for-memory-cache-load-expected.txt:
* LayoutTests/http/tests/cache/willsendrequest-returns-null-for-memory-cache-load.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/311876@main">https://commits.webkit.org/311876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afcb15fa41a057293a49f27835cf4e33c98fa394

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167049 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112303 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122532 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86016 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103201 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23858 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14821 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169538 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130714 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130829 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141693 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89137 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24060 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25537 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18499 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30793 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30314 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30544 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30441 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->