### PR TITLE
ANGLE: Metal: Make StateCache descriptors hash consistent

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
@@ -57,29 +57,29 @@ constexpr uint32_t kMaxTriFanLineLoopBuffersPerFrame = 0;
 constexpr uint32_t kMaxTriFanLineLoopBuffersPerFrame = 10;
 #endif
 
-#define ANGLE_MTL_XFB_DRAW(DRAW_PROC)                                                            \
-    if (!mState.isTransformFeedbackActiveUnpaused())                                             \
-    {                                                                                            \
-        /* Normal draw call */                                                                   \
-        DRAW_PROC(false);                                                                        \
-    }                                                                                            \
-    else                                                                                         \
-    {                                                                                            \
-        /* First pass: write to XFB buffers in vertex shader, fragment shader inactive */        \
-        bool rasterizationNotDisabled =                                                          \
-            mRenderPipelineDesc.rasterizationType != mtl::RenderPipelineRasterization::Disabled; \
-        if (rasterizationNotDisabled)                                                            \
-        {                                                                                        \
-            invalidateRenderPipeline();                                                          \
-        }                                                                                        \
-        DRAW_PROC(true);                                                                         \
-        if (rasterizationNotDisabled)                                                            \
-        {                                                                                        \
-            /* Second pass: full rasterization: vertex shader + fragment shader are active.      \
-               Vertex shader writes to stage output but won't write to XFB buffers */            \
-            invalidateRenderPipeline();                                                          \
-            DRAW_PROC(false);                                                                    \
-        }                                                                                        \
+#define ANGLE_MTL_XFB_DRAW(DRAW_PROC)                                                       \
+    if (!mState.isTransformFeedbackActiveUnpaused())                                        \
+    {                                                                                       \
+        /* Normal draw call */                                                              \
+        DRAW_PROC(false);                                                                   \
+    }                                                                                       \
+    else                                                                                    \
+    {                                                                                       \
+        /* First pass: write to XFB buffers in vertex shader, fragment shader inactive */   \
+        bool rasterizationEnabled = mRenderPipelineDesc.getRasterizationType() !=           \
+                                    mtl::RenderPipelineRasterization::Disabled;             \
+        if (rasterizationEnabled)                                                           \
+        {                                                                                   \
+            invalidateRenderPipeline();                                                     \
+        }                                                                                   \
+        DRAW_PROC(true);                                                                    \
+        if (rasterizationEnabled)                                                           \
+        {                                                                                   \
+            /* Second pass: full rasterization: vertex shader + fragment shader are active. \
+               Vertex shader writes to stage output but won't write to XFB buffers */       \
+            invalidateRenderPipeline();                                                     \
+            DRAW_PROC(false);                                                               \
+        }                                                                                   \
     }
 
 angle::Result AllocateTriangleFanBufferFromPool(ContextMtl *context,
@@ -211,12 +211,12 @@ angle::Result ContextMtl::initialize(const angle::ImageLoadContext &imageLoadCon
 {
     for (mtl::BlendDesc &blendDesc : mBlendDescArray)
     {
-        blendDesc.reset();
+        blendDesc = {};
     }
 
     mWriteMaskArray.fill(MTLColorWriteMaskAll);
 
-    mDepthStencilDesc.reset();
+    mDepthStencilDesc = {};
 
     mTriFanIndexBuffer.initialize(this, 0, mtl::kIndexBufferOffsetAlignment,
                                   kMaxTriFanLineLoopBuffersPerFrame);
@@ -1164,12 +1164,12 @@ angle::Result ContextMtl::syncState(const gl::Context *context,
                 for (; i < blendStateExt.getDrawBufferCount(); i++)
                 {
                     mBlendDescArray[i].updateWriteMask(blendStateExt.getColorMaskIndexed(i));
-                    mWriteMaskArray[i] = mBlendDescArray[i].writeMask;
+                    mWriteMaskArray[i] = static_cast<uint8_t>(mBlendDescArray[i].getWriteMask());
                 }
                 for (; i < mBlendDescArray.size(); i++)
                 {
                     mBlendDescArray[i].updateWriteMask(0);
-                    mWriteMaskArray[i] = mBlendDescArray[i].writeMask;
+                    mWriteMaskArray[i] = static_cast<uint8_t>(mBlendDescArray[i].getWriteMask());
                 }
                 invalidateRenderPipeline();
                 break;
@@ -2128,25 +2128,17 @@ void ContextMtl::updateBlendDescArray(const gl::BlendStateExt &blendStateExt)
         mtl::BlendDesc &blendDesc = mBlendDescArray[i];
         if (blendStateExt.getEnabledMask().test(i))
         {
-            blendDesc.blendingEnabled = true;
-
-            blendDesc.sourceRGBBlendFactor =
-                mtl::GetBlendFactor(blendStateExt.getSrcColorIndexed(i));
-            blendDesc.sourceAlphaBlendFactor =
-                mtl::GetBlendFactor(blendStateExt.getSrcAlphaIndexed(i));
-            blendDesc.destinationRGBBlendFactor =
-                mtl::GetBlendFactor(blendStateExt.getDstColorIndexed(i));
-            blendDesc.destinationAlphaBlendFactor =
-                mtl::GetBlendFactor(blendStateExt.getDstAlphaIndexed(i));
-
-            blendDesc.rgbBlendOperation = mtl::GetBlendOp(blendStateExt.getEquationColorIndexed(i));
-            blendDesc.alphaBlendOperation =
-                mtl::GetBlendOp(blendStateExt.getEquationAlphaIndexed(i));
+            blendDesc.setBlendingEnabled(mtl::GetBlendFactor(blendStateExt.getSrcColorIndexed(i)),
+                                         mtl::GetBlendFactor(blendStateExt.getSrcAlphaIndexed(i)),
+                                         mtl::GetBlendFactor(blendStateExt.getDstColorIndexed(i)),
+                                         mtl::GetBlendFactor(blendStateExt.getDstAlphaIndexed(i)),
+                                         mtl::GetBlendOp(blendStateExt.getEquationColorIndexed(i)),
+                                         mtl::GetBlendOp(blendStateExt.getEquationAlphaIndexed(i)));
         }
         else
         {
             // Enforce default state when blending is disabled,
-            blendDesc.reset(blendDesc.writeMask);
+            blendDesc.reset(blendDesc.getWriteMask());
         }
     }
     invalidateRenderPipeline();
@@ -2453,7 +2445,7 @@ static bool isDrawNoOp(const mtl::RenderPipelineDesc &descriptor,
     for (NSUInteger i = 0; i < maxColorRenderTargets; ++i)
     {
         const auto &colorAttachment = descriptor.outputDescriptor.colorAttachments[i];
-        if (colorAttachment.pixelFormat != MTLPixelFormatInvalid)
+        if (colorAttachment.getPixelFormat() != MTLPixelFormatInvalid)
         {
             hasValidRenderTarget = true;
             break;
@@ -2461,13 +2453,13 @@ static bool isDrawNoOp(const mtl::RenderPipelineDesc &descriptor,
     }
 
     if (!hasValidRenderTarget &&
-        descriptor.outputDescriptor.depthAttachmentPixelFormat != MTLPixelFormatInvalid)
+        descriptor.outputDescriptor.getDepthAttachmentPixelFormat() != MTLPixelFormatInvalid)
     {
         hasValidRenderTarget = true;
     }
 
     if (!hasValidRenderTarget &&
-        descriptor.outputDescriptor.stencilAttachmentPixelFormat != MTLPixelFormatInvalid)
+        descriptor.outputDescriptor.getStencilAttachmentPixelFormat() != MTLPixelFormatInvalid)
     {
         hasValidRenderTarget = true;
     }
@@ -2915,14 +2907,13 @@ angle::Result ContextMtl::handleDirtyDepthStencilState(const gl::Context *contex
 
     if (!renderPassDesc.depthAttachment.texture)
     {
-        dsDesc.depthWriteEnabled    = false;
-        dsDesc.depthCompareFunction = MTLCompareFunctionAlways;
+        dsDesc.setDepthWriteDisabled();
     }
 
     if (!renderPassDesc.stencilAttachment.texture)
     {
-        dsDesc.frontFaceStencil.reset();
-        dsDesc.backFaceStencil.reset();
+        dsDesc.frontFaceStencil = {};
+        dsDesc.backFaceStencil  = {};
     }
 
     // Apply depth stencil state
@@ -2956,7 +2947,7 @@ angle::Result ContextMtl::checkIfPipelineChanged(const gl::Context *context,
     ASSERT(mRenderEncoder.valid());
     bool rppChange =
         mDirtyBits.test(DIRTY_BIT_RENDER_PIPELINE) ||
-        MTLPrimitiveTopologyClassUnspecified != mRenderPipelineDesc.inputPrimitiveTopology;
+        MTLPrimitiveTopologyClassUnspecified != mRenderPipelineDesc.getInputPrimitiveTopology();
 
     // Obtain RenderPipelineDesc's vertex array descriptor.
     ANGLE_TRY(mVertexArray->setupDraw(context, &mRenderEncoder, &rppChange,
@@ -2972,25 +2963,25 @@ angle::Result ContextMtl::checkIfPipelineChanged(const gl::Context *context,
         if (xfbPass)
         {
             // In XFB pass, we disable fragment shader.
-            mRenderPipelineDesc.rasterizationType = mtl::RenderPipelineRasterization::Disabled;
+            mRenderPipelineDesc.setRasterizationType(mtl::RenderPipelineRasterization::Disabled);
         }
         else if (mState.isRasterizerDiscardEnabled())
         {
             // If XFB is not active and rasterizer discard is enabled, we need to emulate the
             // discard. Because in this case, vertex shader might write to stage output values and
             // Metal doesn't allow rasterization to be disabled.
-            mRenderPipelineDesc.rasterizationType =
-                mtl::RenderPipelineRasterization::EmulatedDiscard;
+            mRenderPipelineDesc.setRasterizationType(
+                mtl::RenderPipelineRasterization::EmulatedDiscard);
         }
         else
         {
-            mRenderPipelineDesc.rasterizationType = mtl::RenderPipelineRasterization::Enabled;
+            mRenderPipelineDesc.setRasterizationType(mtl::RenderPipelineRasterization::Enabled);
         }
-        mRenderPipelineDesc.inputPrimitiveTopology = MTLPrimitiveTopologyClassUnspecified;
-        mRenderPipelineDesc.alphaToCoverageEnabled =
+        mRenderPipelineDesc.setInputPrimitiveTopology(MTLPrimitiveTopologyClassUnspecified);
+        mRenderPipelineDesc.setAlphaToCoverageEnabled(
             mState.isSampleAlphaToCoverageEnabled() &&
-            mRenderPipelineDesc.outputDescriptor.rasterSampleCount > 1 &&
-            !getDisplay()->getFeatures().emulateAlphaToCoverage.enabled;
+            mRenderPipelineDesc.outputDescriptor.getRasterSampleCount() > 1 &&
+            !getDisplay()->getFeatures().emulateAlphaToCoverage.enabled);
 
         mRenderPipelineDesc.outputDescriptor.updateEnabledDrawBuffers(
             mDrawFramebuffer->getState().getEnabledDrawBuffers());

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm
@@ -1026,7 +1026,7 @@ angle::Result FramebufferMtl::updateColorRenderTarget(const gl::Context *context
 {
     ASSERT(colorIndexGL < mColorRenderTargets.size());
     // Reset load store action
-    mRenderPassDesc.colorAttachments[colorIndexGL].reset();
+    mRenderPassDesc.colorAttachments[colorIndexGL] = {};
     ANGLE_TRY(updateCachedRenderTarget(context, mState.getColorAttachment(colorIndexGL),
                                        &mColorRenderTargets[colorIndexGL]));
 #if ANGLE_WEBKIT_EXPLICIT_RESOLVE_TARGET_ENABLED
@@ -1042,7 +1042,7 @@ angle::Result FramebufferMtl::updateColorRenderTarget(const gl::Context *context
 angle::Result FramebufferMtl::updateDepthRenderTarget(const gl::Context *context)
 {
     // Reset load store action
-    mRenderPassDesc.depthAttachment.reset();
+    mRenderPassDesc.depthAttachment = {};
     ANGLE_TRY(updateCachedRenderTarget(context, mState.getDepthAttachment(), &mDepthRenderTarget));
 #if ANGLE_WEBKIT_EXPLICIT_RESOLVE_TARGET_ENABLED
     if (mState.getDepthResolveAttachment())
@@ -1057,7 +1057,7 @@ angle::Result FramebufferMtl::updateDepthRenderTarget(const gl::Context *context
 angle::Result FramebufferMtl::updateStencilRenderTarget(const gl::Context *context)
 {
     // Reset load store action
-    mRenderPassDesc.stencilAttachment.reset();
+    mRenderPassDesc.stencilAttachment = {};
     ANGLE_TRY(
         updateCachedRenderTarget(context, mState.getStencilAttachment(), &mStencilRenderTarget));
 #if ANGLE_WEBKIT_EXPLICIT_RESOLVE_TARGET_ENABLED
@@ -1147,7 +1147,7 @@ angle::Result FramebufferMtl::prepareRenderPass(const gl::Context *context,
         }
         else
         {
-            colorAttachment.reset();
+            colorAttachment = {};
         }
     }
 
@@ -1165,7 +1165,7 @@ angle::Result FramebufferMtl::prepareRenderPass(const gl::Context *context,
     }
     else
     {
-        desc.depthAttachment.reset();
+        desc.depthAttachment = {};
     }
 
     if (mStencilRenderTarget)
@@ -1182,7 +1182,7 @@ angle::Result FramebufferMtl::prepareRenderPass(const gl::Context *context,
     }
     else
     {
-        desc.stencilAttachment.reset();
+        desc.stencilAttachment = {};
     }
 
     if (desc.numColorAttachments == 0 && mDepthRenderTarget == nullptr &&

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm
@@ -901,11 +901,11 @@ angle::Result ProgramExecutableMtl::setupDraw(const gl::Context *glContext,
 
         // Cache current shader variant references for easier querying.
         mCurrentShaderVariants[gl::ShaderType::Vertex] =
-            &mVertexShaderVariants[pipelineDesc.rasterizationType];
+            &mVertexShaderVariants[pipelineDesc.getRasterizationType()];
 
-        const bool multisampledRendering = pipelineDesc.outputDescriptor.rasterSampleCount > 1;
+        const bool multisampledRendering = pipelineDesc.outputDescriptor.getRasterSampleCount() > 1;
         const bool allowFragDepthWrite =
-            pipelineDesc.outputDescriptor.depthAttachmentPixelFormat != 0;
+            pipelineDesc.outputDescriptor.getDepthAttachmentPixelFormat() != MTLPixelFormatInvalid;
         mCurrentShaderVariants[gl::ShaderType::Fragment] =
             pipelineDesc.rasterizationEnabled()
                 ? &mFragmentShaderVariants[PipelineParametersToFragmentShaderVariantIndex(
@@ -945,7 +945,7 @@ angle::Result ProgramExecutableMtl::getSpecializedShader(
     {
         // For vertex shader, we need to create 3 variants, one with emulated rasterization
         // discard, one with true rasterization discard and one without.
-        shaderVariant = &mVertexShaderVariants[renderPipelineDesc.rasterizationType];
+        shaderVariant = &mVertexShaderVariants[renderPipelineDesc.getRasterizationType()];
         if (shaderVariant->metalShader)
         {
             // Already created.
@@ -953,7 +953,7 @@ angle::Result ProgramExecutableMtl::getSpecializedShader(
             return angle::Result::Continue;
         }
 
-        if (renderPipelineDesc.rasterizationType == mtl::RenderPipelineRasterization::Disabled)
+        if (renderPipelineDesc.getRasterizationType() == mtl::RenderPipelineRasterization::Disabled)
         {
             // Special case: XFB output only vertex shader.
             ASSERT(!mExecutable->getLinkedTransformFeedbackVaryings().empty());
@@ -970,7 +970,7 @@ angle::Result ProgramExecutableMtl::getSpecializedShader(
 
         ANGLE_MTL_OBJC_SCOPE
         {
-            BOOL emulateDiscard = renderPipelineDesc.rasterizationType ==
+            BOOL emulateDiscard = renderPipelineDesc.getRasterizationType() ==
                                   mtl::RenderPipelineRasterization::EmulatedDiscard;
 
             NSString *discardEnabledStr =
@@ -987,9 +987,10 @@ angle::Result ProgramExecutableMtl::getSpecializedShader(
         // For fragment shader, we need to create 4 variants,
         // combining multisampled rendering and depth write enabled states.
         const bool multisampledRendering =
-            renderPipelineDesc.outputDescriptor.rasterSampleCount > 1;
+            renderPipelineDesc.outputDescriptor.getRasterSampleCount() > 1;
         const bool allowFragDepthWrite =
-            renderPipelineDesc.outputDescriptor.depthAttachmentPixelFormat != 0;
+            renderPipelineDesc.outputDescriptor.getDepthAttachmentPixelFormat() !=
+            MTLPixelFormatInvalid;
         shaderVariant = &mFragmentShaderVariants[PipelineParametersToFragmentShaderVariantIndex(
             multisampledRendering, allowFragDepthWrite)];
         if (shaderVariant->metalShader)

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm
@@ -1108,14 +1108,14 @@ angle::Result TextureMtl::ensureSamplerStateCreated(const gl::Context *context)
     {
         // On devices not supporting filtering for depth textures, we need to convert to nearest
         // here.
-        samplerDesc.minFilter = MTLSamplerMinMagFilterNearest;
-        samplerDesc.magFilter = MTLSamplerMinMagFilterNearest;
-        if (samplerDesc.mipFilter != MTLSamplerMipFilterNotMipmapped)
+        samplerDesc.setMinFilter(MTLSamplerMinMagFilterNearest);
+        samplerDesc.setMagFilter(MTLSamplerMinMagFilterNearest);
+        if (samplerDesc.getMipFilter() != MTLSamplerMipFilterNotMipmapped)
         {
-            samplerDesc.mipFilter = MTLSamplerMipFilterNearest;
+            samplerDesc.setMipFilter(MTLSamplerMipFilterNearest);
         }
 
-        samplerDesc.maxAnisotropy = 1;
+        samplerDesc.setMaxAnisotropy(1);
     }
 
     // OpenGL ES 3.x: The rules for texel selection are modified
@@ -1124,9 +1124,9 @@ angle::Result TextureMtl::ensureSamplerStateCreated(const gl::Context *context)
          mState.getType() == gl::TextureType::CubeMapArray) &&
         context->getState().getClientVersion() >= gl::ES_3_0)
     {
-        samplerDesc.rAddressMode = MTLSamplerAddressModeClampToEdge;
-        samplerDesc.sAddressMode = MTLSamplerAddressModeClampToEdge;
-        samplerDesc.tAddressMode = MTLSamplerAddressModeClampToEdge;
+        samplerDesc.setRAddressMode(MTLSamplerAddressModeClampToEdge);
+        samplerDesc.setSAddressMode(MTLSamplerAddressModeClampToEdge);
+        samplerDesc.setTAddressMode(MTLSamplerAddressModeClampToEdge);
     }
     mMetalSamplerState = contextMtl->getDisplay()->getStateCache().getSamplerState(
         contextMtl->getMetalDevice(), samplerDesc);

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
@@ -181,13 +181,6 @@ inline size_t GetIndexCount(BufferMtl *srcBuffer, size_t offset, gl::DrawElement
     return (srcBuffer->size() - offset) / elementSize;
 }
 
-inline void SetDefaultVertexBufferLayout(mtl::VertexBufferLayoutDesc *layout)
-{
-    layout->stepFunction = mtl::kVertexStepFunctionInvalid;
-    layout->stepRate     = 0;
-    layout->stride       = 0;
-}
-
 inline MTLVertexFormat GetCurrentAttribFormat(GLenum type)
 {
     switch (type)
@@ -372,9 +365,9 @@ angle::Result VertexArrayMtl::setupDraw(const gl::Context *glContext,
         desc.numBufferLayouts = mtl::kMaxVertexAttribs;
 
         // Initialize the buffer layouts with constant step rate
-        for (uint32_t b = 0; b < mtl::kMaxVertexAttribs; ++b)
+        for (mtl::VertexBufferLayoutDesc &layout : desc.layouts)
         {
-            SetDefaultVertexBufferLayout(&desc.layouts[b]);
+            layout = {0, 0, mtl::kVertexStepFunctionInvalid};
         }
 
         // Cache vertex shader input types
@@ -396,9 +389,7 @@ angle::Result VertexArrayMtl::setupDraw(const gl::Context *glContext,
         {
             if (!programActiveAttribsMask.test(v))
             {
-                desc.attributes[v].format      = MTLVertexFormatInvalid;
-                desc.attributes[v].bufferIndex = 0;
-                desc.attributes[v].offset      = 0;
+                desc.attributes[v] = {MTLVertexFormatInvalid, 0, 0};
                 continue;
             }
 
@@ -427,31 +418,24 @@ angle::Result VertexArrayMtl::setupDraw(const gl::Context *glContext,
             if (!attribEnabled)
             {
                 // Use default attribute
-                desc.attributes[v].bufferIndex = mtl::kDefaultAttribsBindingIndex;
-                desc.attributes[v].offset      = v * mtl::kDefaultAttributeSize;
-                desc.attributes[v].format      = currentAttribFormat;
+                desc.attributes[v] = {currentAttribFormat,
+                                      /*offset*/ v * mtl::kDefaultAttributeSize,
+                                      /*bufferIndex*/ mtl::kDefaultAttribsBindingIndex};
             }
             else
             {
                 uint32_t bufferIdx    = mtl::kVboBindingIndexStart + v;
-                uint32_t bufferOffset = static_cast<uint32_t>(mCurrentArrayBufferOffsets[v]);
-
-                desc.attributes[v].format = mCurrentArrayBufferFormats[v]->metalFormat;
-
-                desc.attributes[v].bufferIndex = bufferIdx;
-                desc.attributes[v].offset      = 0;
-                ASSERT((bufferOffset % mtl::kVertexAttribBufferStrideAlignment) == 0);
-
                 ASSERT(bufferIdx < mtl::kMaxVertexAttribs);
-                if (binding.getDivisor() == 0)
+                uint32_t bufferOffset = static_cast<uint32_t>(mCurrentArrayBufferOffsets[v]);
+                ASSERT((bufferOffset % mtl::kVertexAttribBufferStrideAlignment) == 0);
+                desc.attributes[v]                 = {mCurrentArrayBufferFormats[v]->metalFormat,
+                                                      /*offset*/ 0, bufferIdx};
+                MTLVertexStepFunction stepFunction = MTLVertexStepFunctionPerVertex;
+                uint32_t stepRate                  = 1;
+                if (binding.getDivisor() != 0)
                 {
-                    desc.layouts[bufferIdx].stepFunction = MTLVertexStepFunctionPerVertex;
-                    desc.layouts[bufferIdx].stepRate     = 1;
-                }
-                else
-                {
-                    desc.layouts[bufferIdx].stepFunction = MTLVertexStepFunctionPerInstance;
-                    desc.layouts[bufferIdx].stepRate     = binding.getDivisor();
+                    stepFunction = MTLVertexStepFunctionPerInstance;
+                    stepRate     = binding.getDivisor();
                 }
 
                 // Metal does not allow the sum of the buffer binding
@@ -471,7 +455,7 @@ angle::Result VertexArrayMtl::setupDraw(const gl::Context *glContext,
                         ASSERT(stride % mtl::kVertexAttribBufferStrideAlignment == 0);
                     }
                 }
-                desc.layouts[bufferIdx].stride = stride;
+                desc.layouts[bufferIdx] = {stepRate, stride, stepFunction};
             }
         }  // for (v)
     }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_pipeline_cache.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_pipeline_cache.mm
@@ -28,7 +28,7 @@ bool HasDefaultAttribs(const RenderPipelineDesc &rpdesc)
     const VertexDesc &desc = rpdesc.vertexDescriptor;
     for (uint8_t i = 0; i < desc.numAttribs; ++i)
     {
-        if (desc.attributes[i].bufferIndex == kDefaultAttribsBindingIndex)
+        if (desc.attributes[i].getBufferIndex() == kDefaultAttribsBindingIndex)
         {
             return true;
         }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
@@ -527,8 +527,8 @@ RenderPipelineDesc GetComputingVertexShaderOnlyRenderPipelineDesc(RenderCommandE
     const RenderPassDesc &renderPassDesc = cmdEncoder->renderPassDesc();
 
     renderPassDesc.populateRenderPipelineOutputDesc(&pipelineDesc.outputDescriptor);
-    pipelineDesc.rasterizationType      = RenderPipelineRasterization::Disabled;
-    pipelineDesc.inputPrimitiveTopology = MTLPrimitiveTopologyClassPoint;
+    pipelineDesc.setRasterizationType(RenderPipelineRasterization::Disabled);
+    pipelineDesc.setInputPrimitiveTopology(MTLPrimitiveTopologyClassPoint);
 
     return pipelineDesc;
 }
@@ -1056,25 +1056,13 @@ id<MTLDepthStencilState> ClearUtils::getClearDepthStencilState(const gl::Context
             contextMtl->getMetalDevice());
     }
 
-    DepthStencilDesc desc;
-    desc.reset();
-
-    if (params.clearDepth.valid())
-    {
-        // Clear depth state
-        desc.depthWriteEnabled = true;
-    }
-    else
-    {
-        desc.depthWriteEnabled = false;
-    }
-
+    DepthStencilDesc desc(MTLCompareFunctionAlways, params.clearDepth.valid());
     if (params.clearStencil.valid())
     {
         // Clear stencil state
-        desc.frontFaceStencil.depthStencilPassOperation = MTLStencilOperationReplace;
+        desc.frontFaceStencil.setDepthStencilPassOperation(MTLStencilOperationReplace);
         desc.frontFaceStencil.writeMask                 = contextMtl->getStencilMask();
-        desc.backFaceStencil.depthStencilPassOperation  = MTLStencilOperationReplace;
+        desc.backFaceStencil.setDepthStencilPassOperation(MTLStencilOperationReplace);
         desc.backFaceStencil.writeMask                  = contextMtl->getStencilMask();
     }
 
@@ -1111,7 +1099,7 @@ angle::Result ClearUtils::getClearRenderPipelineState(
     renderPassDesc.populateRenderPipelineOutputDesc(clearWriteMaskArray,
                                                     &pipelineDesc.outputDescriptor);
 
-    pipelineDesc.inputPrimitiveTopology = MTLPrimitiveTopologyClassTriangle;
+    pipelineDesc.setInputPrimitiveTopology(MTLPrimitiveTopologyClassTriangle);
 
     ANGLE_TRY(ensureShadersInitialized(contextMtl, renderPassDesc.numColorAttachments));
 
@@ -1282,7 +1270,7 @@ angle::Result ColorBlitUtils::getColorBlitRenderPipelineState(
     // Disable blit for some outputs that are not enabled
     pipelineDesc.outputDescriptor.updateEnabledDrawBuffers(params.enabledBuffers);
 
-    pipelineDesc.inputPrimitiveTopology = MTLPrimitiveTopologyClassTriangle;
+    pipelineDesc.setInputPrimitiveTopology(MTLPrimitiveTopologyClassTriangle);
 
     ShaderKey key(GetShaderTextureType(params.src), renderPassDesc.numColorAttachments,
                   params.unpackUnmultiplyAlpha, params.unpackPremultiplyAlpha,
@@ -1317,8 +1305,8 @@ angle::Result ColorBlitUtils::setupColorBlitWithDraw(const gl::Context *context,
 
     // Set sampler state
     SamplerDesc samplerDesc;
-    samplerDesc.reset();
-    samplerDesc.minFilter = samplerDesc.magFilter = GetFilter(params.filter);
+    samplerDesc.setMinFilter(GetFilter(params.filter));
+    samplerDesc.setMagFilter(GetFilter(params.filter));
 
     cmdEncoder->setFragmentSamplerState(contextMtl->getDisplay()->getStateCache().getSamplerState(
                                             contextMtl->getMetalDevice(), samplerDesc),
@@ -1458,7 +1446,7 @@ angle::Result DepthStencilBlitUtils::getDepthStencilBlitRenderPipelineState(
     // Disable all color outputs
     pipelineDesc.outputDescriptor.updateEnabledDrawBuffers(gl::DrawBufferMask());
 
-    pipelineDesc.inputPrimitiveTopology = MTLPrimitiveTopologyClassTriangle;
+    pipelineDesc.setInputPrimitiveTopology(MTLPrimitiveTopologyClassTriangle);
 
     angle::ObjCPtr<id<MTLFunction>> *fragmentShader = nullptr;
     int depthTextureType                            = GetShaderTextureType(params.src);
@@ -1505,20 +1493,8 @@ angle::Result DepthStencilBlitUtils::setupDepthStencilBlitWithDraw(
     cmdEncoder->setRenderPipelineState(renderPipelineState);
 
     // Depth stencil state
-    mtl::DepthStencilDesc dsStateDesc;
-    dsStateDesc.reset();
-    dsStateDesc.depthCompareFunction = MTLCompareFunctionAlways;
-
-    if (params.src)
-    {
-        // Enable depth write
-        dsStateDesc.depthWriteEnabled = true;
-    }
-    else
-    {
-        // Disable depth write
-        dsStateDesc.depthWriteEnabled = false;
-    }
+    mtl::DepthStencilDesc dsStateDesc(MTLCompareFunctionAlways,
+                                      /*depthWriteEnabled*/ params.src != nullptr);
 
     if (params.srcStencil)
     {
@@ -1530,11 +1506,11 @@ angle::Result DepthStencilBlitUtils::setupDepthStencilBlitWithDraw(
             UNREACHABLE();
         }
         // Enable stencil write to framebuffer
-        dsStateDesc.frontFaceStencil.stencilCompareFunction = MTLCompareFunctionAlways;
-        dsStateDesc.backFaceStencil.stencilCompareFunction  = MTLCompareFunctionAlways;
+        dsStateDesc.frontFaceStencil.setStencilCompareFunction(MTLCompareFunctionAlways);
+        dsStateDesc.backFaceStencil.setStencilCompareFunction(MTLCompareFunctionAlways);
 
-        dsStateDesc.frontFaceStencil.depthStencilPassOperation = MTLStencilOperationReplace;
-        dsStateDesc.backFaceStencil.depthStencilPassOperation  = MTLStencilOperationReplace;
+        dsStateDesc.frontFaceStencil.setDepthStencilPassOperation(MTLStencilOperationReplace);
+        dsStateDesc.backFaceStencil.setDepthStencilPassOperation(MTLStencilOperationReplace);
 
         dsStateDesc.frontFaceStencil.writeMask = kStencilMaskAll;
         dsStateDesc.backFaceStencil.writeMask  = kStencilMaskAll;
@@ -2476,7 +2452,7 @@ angle::Result CopyPixelsUtils::getB2TRenderPipeline(
     const RenderPassDesc &renderPassDesc = cmdEncoder->renderPassDesc();
     renderPassDesc.populateRenderPipelineOutputDesc(&pipelineDesc.outputDescriptor);
 
-    pipelineDesc.inputPrimitiveTopology = MTLPrimitiveTopologyClassTriangle;
+    pipelineDesc.setInputPrimitiveTopology(MTLPrimitiveTopologyClassTriangle);
 
     return contextMtl->getPipelineCache().getRenderPipeline(
         contextMtl, mB2TVertexShader, fragmentShader, pipelineDesc, outRenderPipeline);

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_state_cache.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_state_cache.h
@@ -19,6 +19,7 @@
 
 #include <unordered_map>
 
+#include "common/hash_utils.h"
 #include "libANGLE/State.h"
 #include "libANGLE/angletypes.h"
 #include "libANGLE/renderer/metal/mtl_common.h"
@@ -40,39 +41,83 @@ namespace mtl
 {
 
 ANGLE_ENABLE_STRUCT_PADDING_WARNINGS
-struct alignas(4) StencilDesc
+class StencilDesc
 {
-    bool operator==(const StencilDesc &rhs) const;
+  public:
+    constexpr StencilDesc()
+        : readMask(mtl::kStencilMaskAll),
+          writeMask(mtl::kStencilMaskAll),
+          mStencilFailureOperation(MTLStencilOperationKeep),
+          mDepthFailureOperation(MTLStencilOperationKeep),
+          mDepthStencilPassOperation(MTLStencilOperationKeep),
+          mStencilCompareFunction(MTLCompareFunctionAlways)
+    {}
 
-    // Set default values
-    void reset();
+    constexpr bool operator==(const StencilDesc &rhs) const = default;
+    size_t hash() const;
 
-    // Use bitfield instead of MTLStencilOperation to compact space
-    uint16_t stencilFailureOperation : 4;
-    uint16_t depthFailureOperation : 4;
-    uint16_t depthStencilPassOperation : 4;
+    void setStencilFailureOperation(MTLStencilOperation op)
+    {
+        mStencilFailureOperation = static_cast<uint32_t>(op);
+    }
+    MTLStencilOperation getStencilFailureOperation() const
+    {
+        return static_cast<MTLStencilOperation>(mStencilFailureOperation);
+    }
+    void setDepthFailureOperation(MTLStencilOperation op)
+    {
+        mDepthFailureOperation = static_cast<uint32_t>(op);
+    }
+    MTLStencilOperation getDepthFailureOperation() const
+    {
+        return static_cast<MTLStencilOperation>(mDepthFailureOperation);
+    }
+    void setDepthStencilPassOperation(MTLStencilOperation op)
+    {
+        mDepthStencilPassOperation = static_cast<uint32_t>(op);
+    }
+    MTLStencilOperation getDepthStencilPassOperation() const
+    {
+        return static_cast<MTLStencilOperation>(mDepthStencilPassOperation);
+    }
+    void setStencilCompareFunction(MTLCompareFunction func)
+    {
+        mStencilCompareFunction = static_cast<uint32_t>(func);
+    }
+    MTLCompareFunction getStencilCompareFunction() const
+    {
+        return static_cast<MTLCompareFunction>(mStencilCompareFunction);
+    }
 
-    // Use bitfield instead of MTLCompareFunction to compact space
-    uint16_t stencilCompareFunction : 4;
-
-    uint16_t readMask : 8;
-    uint16_t writeMask : 8;
+    // All bitfields in same access section to avoid padding between access specifiers.
+    uint32_t readMask : 8;                    // uint8_t.
+    uint32_t writeMask : 8;                   // uint8_t.
+    uint32_t mStencilFailureOperation : 3;    // MTLStencilOperation.
+    uint32_t mDepthFailureOperation : 3;      // MTLStencilOperation.
+    uint32_t mDepthStencilPassOperation : 3;  // MTLStencilOperation.
+    uint32_t mStencilCompareFunction : 7;     // MTLCompareFunction 3 bits + 4 bits padding.
 };
+static_assert(alignof(StencilDesc) == 4);
+static_assert(sizeof(StencilDesc) == 4);
+ANGLE_DISABLE_STRUCT_PADDING_WARNINGS
 
-struct alignas(4) DepthStencilDesc
+inline size_t StencilDesc::hash() const
 {
-    DepthStencilDesc();
-    DepthStencilDesc(const DepthStencilDesc &src);
-    DepthStencilDesc(DepthStencilDesc &&src);
+    return angle::HashMultiple<uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t>(
+        readMask, writeMask, mStencilFailureOperation, mDepthFailureOperation,
+        mDepthStencilPassOperation, mStencilCompareFunction);
+}
 
-    DepthStencilDesc &operator=(const DepthStencilDesc &src);
+ANGLE_ENABLE_STRUCT_PADDING_WARNINGS
+class DepthStencilDesc
+{
+  public:
+    constexpr DepthStencilDesc() : DepthStencilDesc(MTLCompareFunctionAlways, true) {}
+    constexpr DepthStencilDesc(MTLCompareFunction func, bool depthWriteEnabled)
+        : mDepthCompareFunction(static_cast<uint32_t>(func)), mDepthWriteEnabled(depthWriteEnabled)
+    {}
 
-    bool operator==(const DepthStencilDesc &rhs) const;
-
-    // Set default values.
-    // Default is depth/stencil test disabled. Depth/stencil write enabled.
-    void reset();
-
+    constexpr bool operator==(const DepthStencilDesc &rhs) const = default;
     size_t hash() const;
 
     void updateDepthTestEnabled(const gl::DepthStencilState &dsState);
@@ -86,146 +131,434 @@ struct alignas(4) DepthStencilDesc
     void updateStencilFrontWriteMask(const gl::DepthStencilState &dsState);
     void updateStencilBackWriteMask(const gl::DepthStencilState &dsState);
 
+    MTLCompareFunction getDepthCompareFunction() const
+    {
+        return static_cast<MTLCompareFunction>(mDepthCompareFunction);
+    }
+    void setDepthWriteDisabled()
+    {
+        mDepthCompareFunction = MTLCompareFunctionAlways;
+        mDepthWriteEnabled    = false;
+    }
+    bool isDepthWriteEnabled() const { return mDepthWriteEnabled; }
+
     StencilDesc backFaceStencil;
     StencilDesc frontFaceStencil;
 
-    // Use bitfield instead of MTLCompareFunction to compact space
-    uint16_t depthCompareFunction;
-    uint16_t depthWriteEnabled;
+    // All bitfields in same access section to avoid padding between access specifiers.
+    uint32_t mDepthCompareFunction : 3;  // MTLCompareFunction.
+    uint32_t mDepthWriteEnabled : 29;    // bool + 28 bit padding.
 };
+static_assert(alignof(DepthStencilDesc) == 4);
+static_assert(sizeof(DepthStencilDesc) == 12);
+ANGLE_DISABLE_STRUCT_PADDING_WARNINGS
 
-struct alignas(4) SamplerDesc
+inline size_t DepthStencilDesc::hash() const
 {
-    SamplerDesc();
-    SamplerDesc(const SamplerDesc &src);
-    SamplerDesc(SamplerDesc &&src);
+    return angle::HashMultiple<StencilDesc, StencilDesc, uint8_t, bool>(
+        backFaceStencil, frontFaceStencil, mDepthCompareFunction, mDepthWriteEnabled);
+}
 
+ANGLE_ENABLE_STRUCT_PADDING_WARNINGS
+class SamplerDesc
+{
+  public:
+    constexpr SamplerDesc()
+        : mRAddressMode(MTLSamplerAddressModeClampToEdge),
+          mSAddressMode(MTLSamplerAddressModeClampToEdge),
+          mTAddressMode(MTLSamplerAddressModeClampToEdge),
+          mMinFilter(MTLSamplerMinMagFilterNearest),
+          mMagFilter(MTLSamplerMinMagFilterNearest),
+          mMipFilter(MTLSamplerMipFilterNearest),
+          mMaxAnisotropy(1),
+          mCompareFunction(MTLCompareFunctionNever)
+    {}
     explicit SamplerDesc(const gl::SamplerState &glState);
 
-    SamplerDesc &operator=(const SamplerDesc &src);
-
-    // Set default values. All filters are nearest, and addresModes are clamp to edge.
-    void reset();
-
-    bool operator==(const SamplerDesc &rhs) const;
-
+    constexpr bool operator==(const SamplerDesc &rhs) const = default;
     size_t hash() const;
 
-    // Use bitfield instead of MTLSamplerAddressMode to compact space
-    uint16_t rAddressMode : 3;
-    uint16_t sAddressMode : 3;
-    uint16_t tAddressMode : 3;
-
-    uint16_t maxAnisotropy : 5;
-
-    // Use bitfield instead of MTLSamplerMinMagFilter to compact space
-    uint16_t minFilter : 1;
-    uint16_t magFilter : 1;
-    uint16_t mipFilter : 2;
-
-    // Use bitfield instead of MTLCompareFunction to compact space
-    uint16_t compareFunction : 14;
-};
-
-struct VertexAttributeDesc
-{
-    inline bool operator==(const VertexAttributeDesc &rhs) const
+    void setRAddressMode(MTLSamplerAddressMode mode)
     {
-        return format == rhs.format && offset == rhs.offset && bufferIndex == rhs.bufferIndex;
+        mRAddressMode = static_cast<uint32_t>(mode);
     }
-    inline bool operator!=(const VertexAttributeDesc &rhs) const { return !(*this == rhs); }
+    MTLSamplerAddressMode getRAddressMode() const
+    {
+        return static_cast<MTLSamplerAddressMode>(mRAddressMode);
+    }
+    void setSAddressMode(MTLSamplerAddressMode mode)
+    {
+        mSAddressMode = static_cast<uint32_t>(mode);
+    }
+    MTLSamplerAddressMode getSAddressMode() const
+    {
+        return static_cast<MTLSamplerAddressMode>(mSAddressMode);
+    }
+    void setTAddressMode(MTLSamplerAddressMode mode)
+    {
+        mTAddressMode = static_cast<uint32_t>(mode);
+    }
+    MTLSamplerAddressMode getTAddressMode() const
+    {
+        return static_cast<MTLSamplerAddressMode>(mTAddressMode);
+    }
+    void setMinFilter(MTLSamplerMinMagFilter filter) { mMinFilter = static_cast<uint32_t>(filter); }
+    MTLSamplerMinMagFilter getMinFilter() const
+    {
+        return static_cast<MTLSamplerMinMagFilter>(mMinFilter);
+    }
+    void setMagFilter(MTLSamplerMinMagFilter filter) { mMagFilter = static_cast<uint32_t>(filter); }
+    MTLSamplerMinMagFilter getMagFilter() const
+    {
+        return static_cast<MTLSamplerMinMagFilter>(mMagFilter);
+    }
+    void setMipFilter(MTLSamplerMipFilter filter) { mMipFilter = static_cast<uint32_t>(filter); }
+    MTLSamplerMipFilter getMipFilter() const
+    {
+        return static_cast<MTLSamplerMipFilter>(mMipFilter);
+    }
+    void setMaxAnisotropy(NSUInteger value) { mMaxAnisotropy = static_cast<uint32_t>(value); }
+    NSUInteger getMaxAnisotropy() const { return static_cast<NSUInteger>(mMaxAnisotropy); }
+    void setCompareFunction(MTLCompareFunction func)
+    {
+        mCompareFunction = static_cast<uint32_t>(func);
+    }
+    MTLCompareFunction getCompareFunction() const
+    {
+        return static_cast<MTLCompareFunction>(mCompareFunction);
+    }
 
-    // Use uint16_t instead of MTLVertexFormat to compact space
-    uint16_t format;
+  private:
+    uint32_t mRAddressMode : 3;      // MTLSamplerAddressMode.
+    uint32_t mSAddressMode : 3;      // MTLSamplerAddressMode.
+    uint32_t mTAddressMode : 3;      // MTLSamplerAddressMode.
+    uint32_t mMinFilter : 1;         // MTLSamplerMinMagFilter.
+    uint32_t mMagFilter : 1;         // MTLSamplerMinMagFilter
+    uint32_t mMipFilter : 2;         // MTLSamplerMipFilter.
+    uint32_t mMaxAnisotropy : 5;     // NSUInteger.
+    uint32_t mCompareFunction : 14;  // MTLCompareFunction 3 bits + 11 bits padding.
+};
+static_assert(alignof(SamplerDesc) == 4);
+static_assert(sizeof(SamplerDesc) == 4);
+ANGLE_DISABLE_STRUCT_PADDING_WARNINGS
+
+inline size_t SamplerDesc::hash() const
+{
+    return angle::HashMultiple<uint8_t, uint8_t, uint8_t, bool, bool, uint8_t, uint8_t, uint8_t>(
+        mRAddressMode, mSAddressMode, mTAddressMode, mMinFilter, mMagFilter, mMipFilter,
+        mMaxAnisotropy, mCompareFunction);
+}
+
+ANGLE_ENABLE_STRUCT_PADDING_WARNINGS
+class VertexAttributeDesc
+{
+  public:
+    constexpr VertexAttributeDesc() : mFormat(0), mOffset(0), mBufferIndex(0) {}
+    constexpr VertexAttributeDesc(MTLVertexFormat format, NSUInteger offset, NSUInteger bufferIndex)
+        : mFormat(static_cast<uint32_t>(format)),
+          mOffset(static_cast<uint32_t>(offset)),
+          mBufferIndex(static_cast<uint32_t>(bufferIndex))
+    {}
+
+    constexpr bool operator==(const VertexAttributeDesc &rhs) const = default;
+    size_t hash() const;
+
+    MTLVertexFormat getFormat() const { return static_cast<MTLVertexFormat>(mFormat); }
+    NSUInteger getOffset() const { return static_cast<NSUInteger>(mOffset); }
+    NSUInteger getBufferIndex() const { return static_cast<NSUInteger>(mBufferIndex); }
+
+  private:
+    uint32_t mFormat : 8;  // MTLVertexFormat.
     // Offset is only used for default attributes buffer. So 8 bits are enough.
-    uint16_t offset : 8;
-    uint16_t bufferIndex : 8;
+    uint32_t mOffset : 8;        // NSUInteger.
+    uint32_t mBufferIndex : 16;  // NSUInteger 8 bits + 8 bits padding.
 };
+static_assert(alignof(VertexAttributeDesc) == 4);
+static_assert(sizeof(VertexAttributeDesc) == 4);
+ANGLE_DISABLE_STRUCT_PADDING_WARNINGS
 
-struct VertexBufferLayoutDesc
+inline size_t VertexAttributeDesc::hash() const
 {
-    inline bool operator==(const VertexBufferLayoutDesc &rhs) const
+    return angle::HashMultiple<uint8_t, uint8_t, uint8_t>(mFormat, mOffset, mBufferIndex);
+}
+
+ANGLE_ENABLE_STRUCT_PADDING_WARNINGS
+class VertexBufferLayoutDesc
+{
+  public:
+    constexpr VertexBufferLayoutDesc() = default;
+    constexpr VertexBufferLayoutDesc(uint32_t stepRate, uint32_t stride, MTLVertexStepFunction func)
+        : stepRate(stepRate), stride(stride), mStepFunction(static_cast<uint32_t>(func))
+    {}
+    constexpr bool operator==(const VertexBufferLayoutDesc &rhs) const = default;
+    size_t hash() const;
+
+    uint32_t stepRate = 0;
+    uint32_t stride   = 0;
+
+    MTLVertexStepFunction getStepFunction() const
     {
-        return stepFunction == rhs.stepFunction && stepRate == rhs.stepRate && stride == rhs.stride;
+        return static_cast<MTLVertexStepFunction>(mStepFunction);
     }
-    inline bool operator!=(const VertexBufferLayoutDesc &rhs) const { return !(*this == rhs); }
 
-    uint32_t stepRate;
-    uint32_t stride;
-
-    uint32_t stepFunction;
+  private:
+    uint32_t mStepFunction = MTLVertexStepFunctionConstant;  // MTLVertexStepFunction.
 };
+static_assert(alignof(VertexBufferLayoutDesc) == 4);
+static_assert(sizeof(VertexBufferLayoutDesc) == 12);
+ANGLE_DISABLE_STRUCT_PADDING_WARNINGS
 
+inline size_t VertexBufferLayoutDesc::hash() const
+{
+    return angle::HashMultiple<uint32_t, uint32_t, uint8_t>(stepRate, stride, mStepFunction);
+}
+
+ANGLE_ENABLE_STRUCT_PADDING_WARNINGS
 struct VertexDesc
 {
+    constexpr VertexDesc() : numAttribs(0), numBufferLayouts(0) {}
+    constexpr bool operator==(const VertexDesc &rhs) const;
+    size_t hash() const;
+
     VertexAttributeDesc attributes[kMaxVertexAttribs];
     VertexBufferLayoutDesc layouts[kMaxVertexAttribs];
 
-    uint16_t numAttribs;
-    uint16_t numBufferLayouts;
+    uint16_t numAttribs       = 0;
+    uint16_t numBufferLayouts = 0;
 };
+static_assert(alignof(VertexDesc) == 4);
+static_assert(sizeof(VertexDesc) == 260);
+ANGLE_DISABLE_STRUCT_PADDING_WARNINGS
 
-struct alignas(2) BlendDesc
+constexpr inline bool VertexDesc::operator==(const VertexDesc &rhs) const
 {
-    bool operator==(const BlendDesc &rhs) const;
-    BlendDesc &operator=(const BlendDesc &src) = default;
+    if (numAttribs != rhs.numAttribs || numBufferLayouts != rhs.numBufferLayouts)
+    {
+        return false;
+    }
+    for (uint8_t i = 0; i < numAttribs; ++i)
+    {
+        if (attributes[i] != rhs.attributes[i])
+        {
+            return false;
+        }
+    }
+    for (uint8_t i = 0; i < numBufferLayouts; ++i)
+    {
+        if (layouts[i] != rhs.layouts[i])
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+inline size_t VertexDesc::hash() const
+{
+    size_t hash = 0;
+    angle::HashCombine(hash, numAttribs);
+    angle::HashCombine(hash, numBufferLayouts);
+    for (uint8_t i = 0; i < numAttribs; ++i)
+    {
+        angle::HashCombine(hash, attributes[i]);
+    }
+    for (uint8_t i = 0; i < numBufferLayouts; ++i)
+    {
+        angle::HashCombine(hash, layouts[i]);
+    }
+    return hash;
+}
+
+ANGLE_ENABLE_STRUCT_PADDING_WARNINGS
+class BlendDesc
+{
+  public:
+    constexpr BlendDesc()
+        : mWriteMask(MTLColorWriteMaskAll),
+          mSourceRgbBlendFactor(MTLBlendFactorOne),
+          mSourceAlphaBlendFactor(MTLBlendFactorOne),
+          mDestinationRgbBlendFactor(MTLBlendFactorZero),
+          mDestinationAlphaBlendFactor(MTLBlendFactorZero),
+          mRgbBlendOperation(MTLBlendOperationAdd),
+          mAlphaBlendOperation(MTLBlendOperationAdd),
+          mBlendingEnabled(false)
+    {}
+    constexpr bool operator==(const BlendDesc &rhs) const = default;
+    size_t hash() const;
 
     // Set default values
-    void reset();
-    void reset(MTLColorWriteMask writeMask);
+    void reset(MTLColorWriteMask mask)
+    {
+        *this      = {};
+        mWriteMask = static_cast<uint32_t>(mask);
+    }
+    void updateWriteMask(uint8_t angleMask);
+    void setBlendingEnabled(MTLBlendFactor sourceRgb,
+                            MTLBlendFactor sourceAlpha,
+                            MTLBlendFactor destRgb,
+                            MTLBlendFactor destAlpha,
+                            MTLBlendOperation opRgb,
+                            MTLBlendOperation opAlpha)
+    {
+        mSourceRgbBlendFactor        = static_cast<uint32_t>(sourceRgb);
+        mSourceAlphaBlendFactor      = static_cast<uint32_t>(sourceAlpha);
+        mDestinationRgbBlendFactor   = static_cast<uint32_t>(destRgb);
+        mDestinationAlphaBlendFactor = static_cast<uint32_t>(destAlpha);
+        mRgbBlendOperation           = static_cast<uint32_t>(opRgb);
+        mAlphaBlendOperation         = static_cast<uint32_t>(opAlpha);
+        mBlendingEnabled             = true;
+    }
+    void setBlendingDisabled()
+    {
+        mSourceRgbBlendFactor        = MTLBlendFactorOne;
+        mSourceAlphaBlendFactor      = MTLBlendFactorOne;
+        mDestinationRgbBlendFactor   = MTLBlendFactorZero;
+        mDestinationAlphaBlendFactor = MTLBlendFactorZero;
+        mRgbBlendOperation           = MTLBlendOperationAdd;
+        mAlphaBlendOperation         = MTLBlendOperationAdd;
+        mBlendingEnabled             = false;
+    }
+    void setWriteMask(MTLColorWriteMask mask) { mWriteMask = static_cast<uint32_t>(mask); }
+    MTLColorWriteMask getWriteMask() const { return static_cast<uint8_t>(mWriteMask); }
+    MTLBlendFactor getSourceRgbBlendFactor() const
+    {
+        return static_cast<MTLBlendFactor>(mSourceRgbBlendFactor);
+    }
+    MTLBlendFactor getSourceAlphaBlendFactor() const
+    {
+        return static_cast<MTLBlendFactor>(mSourceAlphaBlendFactor);
+    }
+    MTLBlendFactor getDestinationRgbBlendFactor() const
+    {
+        return static_cast<MTLBlendFactor>(mDestinationRgbBlendFactor);
+    }
+    MTLBlendFactor getDestinationAlphaBlendFactor() const
+    {
+        return static_cast<MTLBlendFactor>(mDestinationAlphaBlendFactor);
+    }
+    MTLBlendOperation getRgbBlendOperation() const
+    {
+        return static_cast<MTLBlendOperation>(mRgbBlendOperation);
+    }
+    MTLBlendOperation getAlphaBlendOperation() const
+    {
+        return static_cast<MTLBlendOperation>(mAlphaBlendOperation);
+    }
+    bool isBlendingEnabled() const { return mBlendingEnabled; }
 
-    void updateWriteMask(const uint8_t angleMask);
-
-    // Use bitfield instead of MTLColorWriteMask to compact space
-    uint16_t writeMask : 4;
-
-    uint16_t blendingEnabled : 1;
-
-    // Use bitfield instead of MTLBlendOperation to compact space
-    uint16_t alphaBlendOperation : 3;
-    uint16_t rgbBlendOperation : 3;
-
-    // Use bitfield instead of MTLBlendFactor to compact space
-    uint16_t destinationAlphaBlendFactor : 5;
-    uint16_t destinationRGBBlendFactor : 5;
-    uint16_t sourceAlphaBlendFactor : 5;
-    uint16_t sourceRGBBlendFactor : 6;
+  protected:
+    uint32_t mWriteMask : 4;                    // MTLColorWriteMask.
+    uint32_t mSourceRgbBlendFactor : 5;         // MTLBlendFactor.
+    uint32_t mSourceAlphaBlendFactor : 5;       // MTLBlendFactor
+    uint32_t mDestinationRgbBlendFactor : 5;    // MTLBlendFactor
+    uint32_t mDestinationAlphaBlendFactor : 5;  // MTLBlendFactor
+    uint32_t mRgbBlendOperation : 3;            // MTLBlendOperation.
+    uint32_t mAlphaBlendOperation : 3;          // MTLBlendOperation.
+    uint32_t mBlendingEnabled : 2;              // bool + 1 bit padding.
 };
+static_assert(alignof(BlendDesc) == 4);
+static_assert(sizeof(BlendDesc) == 4);
+ANGLE_DISABLE_STRUCT_PADDING_WARNINGS
+
+inline size_t BlendDesc::hash() const
+{
+    return angle::HashMultiple<uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, bool>(
+        mWriteMask, mSourceRgbBlendFactor, mSourceAlphaBlendFactor, mDestinationRgbBlendFactor,
+        mDestinationAlphaBlendFactor, mRgbBlendOperation, mAlphaBlendOperation, mBlendingEnabled);
+}
 
 using BlendDescArray = std::array<BlendDesc, kMaxRenderTargets>;
 using WriteMaskArray = std::array<uint8_t, kMaxRenderTargets>;
 
-struct alignas(2) RenderPipelineColorAttachmentDesc : public BlendDesc
+ANGLE_ENABLE_STRUCT_PADDING_WARNINGS
+class RenderPipelineColorAttachmentDesc : public BlendDesc
 {
-    bool operator==(const RenderPipelineColorAttachmentDesc &rhs) const;
-    inline bool operator!=(const RenderPipelineColorAttachmentDesc &rhs) const
-    {
-        return !(*this == rhs);
-    }
+  public:
+    constexpr bool operator==(const RenderPipelineColorAttachmentDesc &rhs) const = default;
+    size_t hash() const;
 
     // Set default values
-    void reset();
-    void reset(MTLPixelFormat format);
+    void reset(MTLPixelFormat format)
+    {
+        *this        = {};
+        mPixelFormat = static_cast<uint32_t>(format);
+    }
     void reset(MTLPixelFormat format, MTLColorWriteMask writeMask);
     void reset(MTLPixelFormat format, const BlendDesc &blendDesc);
 
-    // Use uint16_t instead of MTLPixelFormat to compact space
-    uint16_t pixelFormat;
-};
+    void setPixelFormat(MTLPixelFormat format) { mPixelFormat = static_cast<uint32_t>(format); }
+    MTLPixelFormat getPixelFormat() const { return static_cast<MTLPixelFormat>(mPixelFormat); }
 
-struct alignas(2) RenderPipelineOutputDesc
+  private:
+    uint32_t mPixelFormat = MTLPixelFormatInvalid;  // MTLPixelFormat + 16 bits padding.
+};
+static_assert(alignof(RenderPipelineColorAttachmentDesc) == 4);
+static_assert(sizeof(RenderPipelineColorAttachmentDesc) == 8);
+ANGLE_DISABLE_STRUCT_PADDING_WARNINGS
+
+inline size_t RenderPipelineColorAttachmentDesc::hash() const
 {
+    size_t hash = BlendDesc::hash();
+    angle::HashCombine(hash, static_cast<uint16_t>(mPixelFormat));
+    return hash;
+}
+
+ANGLE_ENABLE_STRUCT_PADDING_WARNINGS
+class RenderPipelineOutputDesc
+{
+  public:
+    constexpr RenderPipelineOutputDesc()
+        : mDepthAttachmentPixelFormat(0),
+          mStencilAttachmentPixelFormat(0),
+          mNumColorAttachments(0),
+          mRasterSampleCount(1)
+    {}
+    bool operator==(const RenderPipelineOutputDesc &rhs) const;
+    size_t hash() const;
+
     void updateEnabledDrawBuffers(gl::DrawBufferMask enabledBuffers);
 
     std::array<RenderPipelineColorAttachmentDesc, kMaxRenderTargets> colorAttachments;
 
-    // Use uint16_t instead of MTLPixelFormat to compact space
-    uint16_t depthAttachmentPixelFormat;
-    uint16_t stencilAttachmentPixelFormat;
+    void setDepthAttachmentPixelFormat(MTLPixelFormat value)
+    {
+        mDepthAttachmentPixelFormat = static_cast<uint32_t>(value);
+    }
+    MTLPixelFormat getDepthAttachmentPixelFormat() const
+    {
+        return static_cast<MTLPixelFormat>(mDepthAttachmentPixelFormat);
+    }
+    void setStencilAttachmentPixelFormat(MTLPixelFormat value)
+    {
+        mStencilAttachmentPixelFormat = static_cast<uint32_t>(value);
+    }
+    MTLPixelFormat getStencilAttachmentPixelFormat() const
+    {
+        return static_cast<MTLPixelFormat>(mStencilAttachmentPixelFormat);
+    }
+    void setNumColorAttachments(NSUInteger value)
+    {
+        mNumColorAttachments = static_cast<uint32_t>(value);
+    }
+    NSUInteger getNumColorAttachments() const
+    {
+        return static_cast<NSUInteger>(mNumColorAttachments);
+    }
+    void setRasterSampleCount(NSUInteger value)
+    {
+        mRasterSampleCount = static_cast<uint32_t>(value);
+    }
+    NSUInteger getRasterSampleCount() const { return static_cast<NSUInteger>(mRasterSampleCount); }
 
-    uint16_t numColorAttachments : 8;
-    uint16_t rasterSampleCount : 8;
+  private:
+    uint32_t mDepthAttachmentPixelFormat : 16;    // MTLPixelFormat.
+    uint32_t mStencilAttachmentPixelFormat : 16;  // MTLPixelFormat.
+    uint32_t mNumColorAttachments : 16;           // NSUInteger.
+    uint32_t mRasterSampleCount : 16;             // NSUInteger.
 };
+static_assert(alignof(RenderPipelineOutputDesc) == 4);
+static_assert(sizeof(RenderPipelineOutputDesc) == 72);
+ANGLE_DISABLE_STRUCT_PADDING_WARNINGS
 
 enum class RenderPipelineRasterization : uint32_t
 {
@@ -249,15 +582,16 @@ enum class RenderPipelineRasterization : uint32_t
 template <typename T>
 using RenderPipelineRasterStateMap = angle::PackedEnumMap<RenderPipelineRasterization, T>;
 
-struct alignas(4) RenderPipelineDesc
+ANGLE_ENABLE_STRUCT_PADDING_WARNINGS
+class RenderPipelineDesc
 {
-    RenderPipelineDesc();
-    RenderPipelineDesc(const RenderPipelineDesc &src);
-    RenderPipelineDesc(RenderPipelineDesc &&src);
-
-    RenderPipelineDesc &operator=(const RenderPipelineDesc &src);
-
-    bool operator==(const RenderPipelineDesc &rhs) const;
+  public:
+    constexpr RenderPipelineDesc()
+        : mInputPrimitiveTopology(MTLPrimitiveTopologyClassUnspecified),
+          mAlphaToCoverageEnabled(false),
+          mRasterizationType(static_cast<uint32_t>(RenderPipelineRasterization::Enabled))
+    {}
+    constexpr bool operator==(const RenderPipelineDesc &rhs) const = default;
     size_t hash() const;
     bool rasterizationEnabled() const;
 
@@ -266,29 +600,52 @@ struct alignas(4) RenderPipelineDesc
         id<MTLFunction> fragmentShader) const;
 
     VertexDesc vertexDescriptor;
-
     RenderPipelineOutputDesc outputDescriptor;
 
-    // Use bitfield instead of MTLPrimitiveTopologyClass to compact space.
-    uint16_t inputPrimitiveTopology : 8;
+    void setInputPrimitiveTopology(MTLPrimitiveTopologyClass value)
+    {
+        mInputPrimitiveTopology = static_cast<uint32_t>(value);
+    }
+    MTLPrimitiveTopologyClass getInputPrimitiveTopology() const
+    {
+        return static_cast<MTLPrimitiveTopologyClass>(mInputPrimitiveTopology);
+    }
+    void setAlphaToCoverageEnabled(bool value)
+    {
+        mAlphaToCoverageEnabled = static_cast<uint32_t>(value);
+    }
+    bool getAlphaToCoverageEnabled() const { return mAlphaToCoverageEnabled; }
+    void setRasterizationType(RenderPipelineRasterization value)
+    {
+        mRasterizationType = static_cast<uint32_t>(value);
+    }
+    RenderPipelineRasterization getRasterizationType() const
+    {
+        return static_cast<RenderPipelineRasterization>(mRasterizationType);
+    }
 
-    uint16_t alphaToCoverageEnabled : 8;
+  private:
+    uint32_t mInputPrimitiveTopology : 8;  // MTLPrimitiveTopologyClass.
+    uint32_t mAlphaToCoverageEnabled : 8;  // bool.
 
     // These flags are for emulation and do not correspond to any flags in
     // MTLRenderPipelineDescriptor descriptor. These flags should be used by
     // RenderPipelineCacheSpecializeShaderFactory.
-    RenderPipelineRasterization rasterizationType;
+    uint32_t mRasterizationType : 16;  // RenderPipelineRasterization + padding.
 };
-
-
+static_assert(alignof(RenderPipelineDesc) == 4);
+static_assert(sizeof(RenderPipelineDesc) == 336);
 ANGLE_DISABLE_STRUCT_PADDING_WARNINGS
+
+inline size_t RenderPipelineDesc::hash() const
+{
+    return angle::HashMultiple(
+        vertexDescriptor, outputDescriptor, static_cast<uint8_t>(mInputPrimitiveTopology),
+        static_cast<bool>(mAlphaToCoverageEnabled), static_cast<uint8_t>(mRasterizationType));
+}
 
 struct RenderPassAttachmentDesc
 {
-    RenderPassAttachmentDesc();
-    // Set default values
-    void reset();
-
     bool equalIgnoreLoadStoreOptions(const RenderPassAttachmentDesc &other) const;
     bool operator==(const RenderPassAttachmentDesc &other) const;
 
@@ -301,56 +658,34 @@ struct RenderPassAttachmentDesc
     // Implicit multisample texture that will be rendered into and discarded at the end of
     // a render pass. Its result will be resolved into normal texture above.
     TextureRef resolveTexture;
-    MipmapNativeLevel level;
-    uint32_t sliceOrDepth;
-
-    MipmapNativeLevel resolveLevel;
-    uint32_t resolveSliceOrDepth;
+    MipmapNativeLevel level        = mtl::kZeroNativeMipLevel;
+    uint32_t sliceOrDepth          = 0;
+    MipmapNativeLevel resolveLevel = mtl::kZeroNativeMipLevel;
+    uint32_t resolveSliceOrDepth   = 0;
 
     // This attachment is blendable or not.
-    bool blendable;
-    MTLLoadAction loadAction;
-    MTLStoreAction storeAction;
-    MTLStoreActionOptions storeActionOptions;
+    bool blendable                           = false;
+    MTLLoadAction loadAction                 = MTLLoadActionLoad;
+    MTLStoreAction storeAction               = MTLStoreActionStore;
+    MTLStoreActionOptions storeActionOptions = MTLStoreActionOptionNone;
 };
 
 struct RenderPassColorAttachmentDesc : public RenderPassAttachmentDesc
 {
-    inline bool operator==(const RenderPassColorAttachmentDesc &other) const
-    {
-        return RenderPassAttachmentDesc::operator==(other) && clearColor == other.clearColor;
-    }
-    inline bool operator!=(const RenderPassColorAttachmentDesc &other) const
-    {
-        return !(*this == other);
-    }
+    bool operator==(const RenderPassColorAttachmentDesc &other) const = default;
     MTLClearColor clearColor = {0, 0, 0, 0};
 };
 
 struct RenderPassDepthAttachmentDesc : public RenderPassAttachmentDesc
 {
-    inline bool operator==(const RenderPassDepthAttachmentDesc &other) const
-    {
-        return RenderPassAttachmentDesc::operator==(other) && clearDepth == other.clearDepth;
-    }
-    inline bool operator!=(const RenderPassDepthAttachmentDesc &other) const
-    {
-        return !(*this == other);
-    }
+    bool operator==(const RenderPassDepthAttachmentDesc &other) const = default;
 
     double clearDepth = 1.0;
 };
 
 struct RenderPassStencilAttachmentDesc : public RenderPassAttachmentDesc
 {
-    inline bool operator==(const RenderPassStencilAttachmentDesc &other) const
-    {
-        return RenderPassAttachmentDesc::operator==(other) && clearStencil == other.clearStencil;
-    }
-    inline bool operator!=(const RenderPassStencilAttachmentDesc &other) const
-    {
-        return !(*this == other);
-    }
+    bool operator==(const RenderPassStencilAttachmentDesc &other) const = default;
     uint32_t clearStencil = 0;
 };
 
@@ -396,6 +731,12 @@ namespace std
 {
 
 template <>
+struct hash<rx::mtl::StencilDesc>
+{
+    size_t operator()(const rx::mtl::StencilDesc &key) const { return key.hash(); }
+};
+
+template <>
 struct hash<rx::mtl::DepthStencilDesc>
 {
     size_t operator()(const rx::mtl::DepthStencilDesc &key) const { return key.hash(); }
@@ -405,6 +746,45 @@ template <>
 struct hash<rx::mtl::SamplerDesc>
 {
     size_t operator()(const rx::mtl::SamplerDesc &key) const { return key.hash(); }
+};
+
+template <>
+struct hash<rx::mtl::VertexAttributeDesc>
+{
+    size_t operator()(const rx::mtl::VertexAttributeDesc &key) const { return key.hash(); }
+};
+
+template <>
+struct hash<rx::mtl::VertexBufferLayoutDesc>
+{
+    size_t operator()(const rx::mtl::VertexBufferLayoutDesc &key) const { return key.hash(); }
+};
+
+template <>
+struct hash<rx::mtl::VertexDesc>
+{
+    size_t operator()(const rx::mtl::VertexDesc &key) const { return key.hash(); }
+};
+
+template <>
+struct hash<rx::mtl::BlendDesc>
+{
+    size_t operator()(const rx::mtl::BlendDesc &key) const { return key.hash(); }
+};
+
+template <>
+struct hash<rx::mtl::RenderPipelineColorAttachmentDesc>
+{
+    size_t operator()(const rx::mtl::RenderPipelineColorAttachmentDesc &key) const
+    {
+        return key.hash();
+    }
+};
+
+template <>
+struct hash<rx::mtl::RenderPipelineOutputDesc>
+{
+    size_t operator()(const rx::mtl::RenderPipelineOutputDesc &key) const { return key.hash(); }
 };
 
 template <>
@@ -448,29 +828,6 @@ class StateCache final : angle::NonCopyable
 
 }  // namespace mtl
 }  // namespace rx
-
-static inline bool operator==(const rx::mtl::VertexDesc &lhs, const rx::mtl::VertexDesc &rhs)
-{
-    if (lhs.numAttribs != rhs.numAttribs || lhs.numBufferLayouts != rhs.numBufferLayouts)
-    {
-        return false;
-    }
-    for (uint8_t i = 0; i < lhs.numAttribs; ++i)
-    {
-        if (lhs.attributes[i] != rhs.attributes[i])
-        {
-            return false;
-        }
-    }
-    for (uint8_t i = 0; i < lhs.numBufferLayouts; ++i)
-    {
-        if (lhs.layouts[i] != rhs.layouts[i])
-        {
-            return false;
-        }
-    }
-    return true;
-}
 
 static inline bool operator==(const MTLClearColor &lhs, const MTLClearColor &rhs)
 {

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_state_cache.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_state_cache.mm
@@ -17,17 +17,11 @@
 #include <sstream>
 
 #include "common/debug.h"
-#include "common/hash_utils.h"
 #include "common/span.h"
 #include "libANGLE/renderer/metal/ContextMtl.h"
 #include "libANGLE/renderer/metal/mtl_resources.h"
 #include "libANGLE/renderer/metal/mtl_utils.h"
 #include "platform/autogen/FeaturesMtl_autogen.h"
-
-#define ANGLE_OBJC_CP_PROPERTY(DST, SRC, PROPERTY) \
-    (DST).PROPERTY = static_cast<__typeof__((DST).PROPERTY)>(ToObjC((SRC).PROPERTY))
-
-#define ANGLE_PROP_EQ(LHS, RHS, PROP) ((LHS).PROP == (RHS).PROP)
 
 namespace rx
 {
@@ -37,64 +31,58 @@ namespace mtl
 namespace
 {
 
-template <class T>
-inline T ToObjC(const T p)
-{
-    return p;
-}
-
 inline angle::ObjCPtr<MTLStencilDescriptor> ToObjC(const StencilDesc &desc)
 {
     auto objCDesc = angle::adoptObjCPtr([[MTLStencilDescriptor alloc] init]);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, stencilFailureOperation);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, depthFailureOperation);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, depthStencilPassOperation);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, stencilCompareFunction);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, readMask);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, writeMask);
+    objCDesc.get().stencilFailureOperation = desc.getStencilFailureOperation();
+    objCDesc.get().depthFailureOperation   = desc.getDepthFailureOperation();
+    objCDesc.get().depthStencilPassOperation = desc.getDepthStencilPassOperation();
+    objCDesc.get().stencilCompareFunction    = desc.getStencilCompareFunction();
+    objCDesc.get().readMask                  = desc.readMask;
+    objCDesc.get().writeMask                 = desc.writeMask;
     return objCDesc;
 }
 
 inline angle::ObjCPtr<MTLDepthStencilDescriptor> ToObjC(const DepthStencilDesc &desc)
 {
     auto objCDesc = angle::adoptObjCPtr([[MTLDepthStencilDescriptor alloc] init]);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, backFaceStencil);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, frontFaceStencil);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, depthCompareFunction);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, depthWriteEnabled);
+    objCDesc.get().backFaceStencil  = ToObjC(desc.backFaceStencil);
+    objCDesc.get().frontFaceStencil = ToObjC(desc.frontFaceStencil);
+    objCDesc.get().depthCompareFunction = desc.getDepthCompareFunction();
+    objCDesc.get().depthWriteEnabled    = desc.isDepthWriteEnabled();
     return objCDesc;
 }
 
 inline angle::ObjCPtr<MTLSamplerDescriptor> ToObjC(const SamplerDesc &desc)
 {
     auto objCDesc = angle::adoptObjCPtr([[MTLSamplerDescriptor alloc] init]);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, rAddressMode);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, sAddressMode);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, tAddressMode);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, minFilter);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, magFilter);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, mipFilter);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, maxAnisotropy);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, compareFunction);
+    objCDesc.get().rAddressMode    = desc.getRAddressMode();
+    objCDesc.get().sAddressMode    = desc.getSAddressMode();
+    objCDesc.get().tAddressMode    = desc.getTAddressMode();
+    objCDesc.get().minFilter       = desc.getMinFilter();
+    objCDesc.get().magFilter       = desc.getMagFilter();
+    objCDesc.get().mipFilter       = desc.getMipFilter();
+    objCDesc.get().maxAnisotropy   = desc.getMaxAnisotropy();
+    objCDesc.get().compareFunction = desc.getCompareFunction();
     return objCDesc;
 }
 
 inline angle::ObjCPtr<MTLVertexAttributeDescriptor> ToObjC(const VertexAttributeDesc &desc)
 {
     auto objCDesc = angle::adoptObjCPtr([[MTLVertexAttributeDescriptor alloc] init]);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, format);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, offset);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, bufferIndex);
-    ASSERT(desc.bufferIndex >= kVboBindingIndexStart);
+    objCDesc.get().format      = desc.getFormat();
+    objCDesc.get().offset      = desc.getOffset();
+    objCDesc.get().bufferIndex = desc.getBufferIndex();
+    ASSERT(desc.getBufferIndex() >= kVboBindingIndexStart);
     return objCDesc;
 }
 
 inline angle::ObjCPtr<MTLVertexBufferLayoutDescriptor> ToObjC(const VertexBufferLayoutDesc &desc)
 {
     auto objCDesc = angle::adoptObjCPtr([[MTLVertexBufferLayoutDescriptor alloc] init]);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, stepFunction);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, stepRate);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, stride);
+    objCDesc.get().stepFunction = desc.getStepFunction();
+    objCDesc.get().stepRate     = desc.stepRate;
+    objCDesc.get().stride       = desc.stride;
     return objCDesc;
 }
 
@@ -112,7 +100,7 @@ inline angle::ObjCPtr<MTLVertexDescriptor> ToObjC(const VertexDesc &desc)
     {
         // Ignore if stepFunction is kVertexStepFunctionInvalid.
         // If we don't set this slot, it will apparently be disabled by metal runtime.
-        if (desc.layouts[i].stepFunction != kVertexStepFunctionInvalid)
+        if (desc.layouts[i].getStepFunction() != kVertexStepFunctionInvalid)
         {
             [objCDesc.get().layouts setObject:ToObjC(desc.layouts[i]) atIndexedSubscript:i];
         }
@@ -125,15 +113,15 @@ inline angle::ObjCPtr<MTLRenderPipelineColorAttachmentDescriptor> ToObjC(
     const RenderPipelineColorAttachmentDesc &desc)
 {
     auto objCDesc = angle::adoptObjCPtr([[MTLRenderPipelineColorAttachmentDescriptor alloc] init]);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, pixelFormat);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, writeMask);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, alphaBlendOperation);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, rgbBlendOperation);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, destinationAlphaBlendFactor);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, destinationRGBBlendFactor);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, sourceAlphaBlendFactor);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, sourceRGBBlendFactor);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), desc, blendingEnabled);
+    objCDesc.get().pixelFormat                 = desc.getPixelFormat();
+    objCDesc.get().writeMask                   = desc.getWriteMask();
+    objCDesc.get().sourceRGBBlendFactor        = desc.getSourceRgbBlendFactor();
+    objCDesc.get().sourceAlphaBlendFactor      = desc.getSourceAlphaBlendFactor();
+    objCDesc.get().destinationRGBBlendFactor   = desc.getDestinationRgbBlendFactor();
+    objCDesc.get().destinationAlphaBlendFactor = desc.getDestinationAlphaBlendFactor();
+    objCDesc.get().rgbBlendOperation           = desc.getRgbBlendOperation();
+    objCDesc.get().alphaBlendOperation         = desc.getAlphaBlendOperation();
+    objCDesc.get().blendingEnabled             = desc.isBlendingEnabled();
     return objCDesc;
 }
 
@@ -172,33 +160,30 @@ void BaseRenderPassAttachmentDescToObjC(const RenderPassAttachmentDesc &src,
         dst.resolveDepthPlane = 0;
     }
 
-    ANGLE_OBJC_CP_PROPERTY(dst, src, loadAction);
-    ANGLE_OBJC_CP_PROPERTY(dst, src, storeAction);
-    ANGLE_OBJC_CP_PROPERTY(dst, src, storeActionOptions);
+    dst.loadAction         = src.loadAction;
+    dst.storeAction        = src.storeAction;
+    dst.storeActionOptions = src.storeActionOptions;
 }
 
 void ToObjC(const RenderPassColorAttachmentDesc &desc,
             MTLRenderPassColorAttachmentDescriptor *objCDesc)
 {
     BaseRenderPassAttachmentDescToObjC(desc, objCDesc);
-
-    ANGLE_OBJC_CP_PROPERTY(objCDesc, desc, clearColor);
+    objCDesc.clearColor = desc.clearColor;
 }
 
 void ToObjC(const RenderPassDepthAttachmentDesc &desc,
             MTLRenderPassDepthAttachmentDescriptor *objCDesc)
 {
     BaseRenderPassAttachmentDescToObjC(desc, objCDesc);
-
-    ANGLE_OBJC_CP_PROPERTY(objCDesc, desc, clearDepth);
+    objCDesc.clearDepth = desc.clearDepth;
 }
 
 void ToObjC(const RenderPassStencilAttachmentDesc &desc,
             MTLRenderPassStencilAttachmentDescriptor *objCDesc)
 {
     BaseRenderPassAttachmentDescToObjC(desc, objCDesc);
-
-    ANGLE_OBJC_CP_PROPERTY(objCDesc, desc, clearStencil);
+    objCDesc.clearStencil = desc.clearStencil;
 }
 
 MTLColorWriteMask AdjustColorWriteMaskForSharedExponent(MTLColorWriteMask mask)
@@ -213,72 +198,11 @@ MTLColorWriteMask AdjustColorWriteMaskForSharedExponent(MTLColorWriteMask mask)
 
 }  // namespace
 
-// StencilDesc implementation
-bool StencilDesc::operator==(const StencilDesc &rhs) const
-{
-    return ANGLE_PROP_EQ(*this, rhs, stencilFailureOperation) &&
-           ANGLE_PROP_EQ(*this, rhs, depthFailureOperation) &&
-           ANGLE_PROP_EQ(*this, rhs, depthStencilPassOperation) &&
-
-           ANGLE_PROP_EQ(*this, rhs, stencilCompareFunction) &&
-
-           ANGLE_PROP_EQ(*this, rhs, readMask) && ANGLE_PROP_EQ(*this, rhs, writeMask);
-}
-
-void StencilDesc::reset()
-{
-    stencilFailureOperation = depthFailureOperation = depthStencilPassOperation =
-        MTLStencilOperationKeep;
-
-    stencilCompareFunction = MTLCompareFunctionAlways;
-    readMask = writeMask = std::numeric_limits<uint32_t>::max() & mtl::kStencilMaskAll;
-}
-
-// DepthStencilDesc implementation
-DepthStencilDesc::DepthStencilDesc()
-{
-    memset(this, 0, sizeof(*this));
-}
-DepthStencilDesc::DepthStencilDesc(const DepthStencilDesc &src)
-{
-    memcpy(this, &src, sizeof(*this));
-}
-DepthStencilDesc::DepthStencilDesc(DepthStencilDesc &&src)
-{
-    memcpy(this, &src, sizeof(*this));
-}
-
-DepthStencilDesc &DepthStencilDesc::operator=(const DepthStencilDesc &src)
-{
-    memcpy(this, &src, sizeof(*this));
-    return *this;
-}
-
-bool DepthStencilDesc::operator==(const DepthStencilDesc &rhs) const
-{
-    return ANGLE_PROP_EQ(*this, rhs, backFaceStencil) &&
-           ANGLE_PROP_EQ(*this, rhs, frontFaceStencil) &&
-
-           ANGLE_PROP_EQ(*this, rhs, depthCompareFunction) &&
-
-           ANGLE_PROP_EQ(*this, rhs, depthWriteEnabled);
-}
-
-void DepthStencilDesc::reset()
-{
-    frontFaceStencil.reset();
-    backFaceStencil.reset();
-
-    depthCompareFunction = MTLCompareFunctionAlways;
-    depthWriteEnabled    = true;
-}
-
 void DepthStencilDesc::updateDepthTestEnabled(const gl::DepthStencilState &dsState)
 {
     if (!dsState.depthTest)
     {
-        depthCompareFunction = MTLCompareFunctionAlways;
-        depthWriteEnabled    = false;
+        setDepthWriteDisabled();
     }
     else
     {
@@ -289,7 +213,7 @@ void DepthStencilDesc::updateDepthTestEnabled(const gl::DepthStencilState &dsSta
 
 void DepthStencilDesc::updateDepthWriteEnabled(const gl::DepthStencilState &dsState)
 {
-    depthWriteEnabled = dsState.depthTest && dsState.depthMask;
+    mDepthWriteEnabled = dsState.depthTest && dsState.depthMask;
 }
 
 void DepthStencilDesc::updateDepthCompareFunc(const gl::DepthStencilState &dsState)
@@ -298,21 +222,21 @@ void DepthStencilDesc::updateDepthCompareFunc(const gl::DepthStencilState &dsSta
     {
         return;
     }
-    depthCompareFunction = GetCompareFunc(dsState.depthFunc);
+    mDepthCompareFunction = static_cast<uint32_t>(GetCompareFunc(dsState.depthFunc));
 }
 
 void DepthStencilDesc::updateStencilTestEnabled(const gl::DepthStencilState &dsState)
 {
     if (!dsState.stencilTest)
     {
-        frontFaceStencil.stencilCompareFunction    = MTLCompareFunctionAlways;
-        frontFaceStencil.depthFailureOperation     = MTLStencilOperationKeep;
-        frontFaceStencil.depthStencilPassOperation = MTLStencilOperationKeep;
-        frontFaceStencil.writeMask                 = 0;
+        frontFaceStencil.setStencilCompareFunction(MTLCompareFunctionAlways);
+        frontFaceStencil.setDepthFailureOperation(MTLStencilOperationKeep);
+        frontFaceStencil.setDepthStencilPassOperation(MTLStencilOperationKeep);
+        frontFaceStencil.writeMask = 0;
 
-        backFaceStencil.stencilCompareFunction    = MTLCompareFunctionAlways;
-        backFaceStencil.depthFailureOperation     = MTLStencilOperationKeep;
-        backFaceStencil.depthStencilPassOperation = MTLStencilOperationKeep;
+        backFaceStencil.setStencilCompareFunction(MTLCompareFunctionAlways);
+        backFaceStencil.setDepthFailureOperation(MTLStencilOperationKeep);
+        backFaceStencil.setDepthStencilPassOperation(MTLStencilOperationKeep);
         backFaceStencil.writeMask                 = 0;
     }
     else
@@ -332,9 +256,9 @@ void DepthStencilDesc::updateStencilFrontOps(const gl::DepthStencilState &dsStat
     {
         return;
     }
-    frontFaceStencil.stencilFailureOperation   = GetStencilOp(dsState.stencilFail);
-    frontFaceStencil.depthFailureOperation     = GetStencilOp(dsState.stencilPassDepthFail);
-    frontFaceStencil.depthStencilPassOperation = GetStencilOp(dsState.stencilPassDepthPass);
+    frontFaceStencil.setStencilFailureOperation(GetStencilOp(dsState.stencilFail));
+    frontFaceStencil.setDepthFailureOperation(GetStencilOp(dsState.stencilPassDepthFail));
+    frontFaceStencil.setDepthStencilPassOperation(GetStencilOp(dsState.stencilPassDepthPass));
 }
 
 void DepthStencilDesc::updateStencilBackOps(const gl::DepthStencilState &dsState)
@@ -343,9 +267,9 @@ void DepthStencilDesc::updateStencilBackOps(const gl::DepthStencilState &dsState
     {
         return;
     }
-    backFaceStencil.stencilFailureOperation   = GetStencilOp(dsState.stencilBackFail);
-    backFaceStencil.depthFailureOperation     = GetStencilOp(dsState.stencilBackPassDepthFail);
-    backFaceStencil.depthStencilPassOperation = GetStencilOp(dsState.stencilBackPassDepthPass);
+    backFaceStencil.setStencilFailureOperation(GetStencilOp(dsState.stencilBackFail));
+    backFaceStencil.setDepthFailureOperation(GetStencilOp(dsState.stencilBackPassDepthFail));
+    backFaceStencil.setDepthStencilPassOperation(GetStencilOp(dsState.stencilBackPassDepthPass));
 }
 
 void DepthStencilDesc::updateStencilFrontFuncs(const gl::DepthStencilState &dsState)
@@ -354,8 +278,8 @@ void DepthStencilDesc::updateStencilFrontFuncs(const gl::DepthStencilState &dsSt
     {
         return;
     }
-    frontFaceStencil.stencilCompareFunction = GetCompareFunc(dsState.stencilFunc);
-    frontFaceStencil.readMask               = dsState.stencilMask & mtl::kStencilMaskAll;
+    frontFaceStencil.setStencilCompareFunction(GetCompareFunc(dsState.stencilFunc));
+    frontFaceStencil.readMask = dsState.stencilMask & mtl::kStencilMaskAll;
 }
 
 void DepthStencilDesc::updateStencilBackFuncs(const gl::DepthStencilState &dsState)
@@ -364,8 +288,8 @@ void DepthStencilDesc::updateStencilBackFuncs(const gl::DepthStencilState &dsSta
     {
         return;
     }
-    backFaceStencil.stencilCompareFunction = GetCompareFunc(dsState.stencilBackFunc);
-    backFaceStencil.readMask               = dsState.stencilBackMask & mtl::kStencilMaskAll;
+    backFaceStencil.setStencilCompareFunction(GetCompareFunc(dsState.stencilBackFunc));
+    backFaceStencil.readMask = dsState.stencilBackMask & mtl::kStencilMaskAll;
 }
 
 void DepthStencilDesc::updateStencilFrontWriteMask(const gl::DepthStencilState &dsState)
@@ -386,119 +310,26 @@ void DepthStencilDesc::updateStencilBackWriteMask(const gl::DepthStencilState &d
     backFaceStencil.writeMask = dsState.stencilBackWritemask & mtl::kStencilMaskAll;
 }
 
-size_t DepthStencilDesc::hash() const
+SamplerDesc::SamplerDesc(const gl::SamplerState &glState)
+    : mRAddressMode(static_cast<uint32_t>(GetSamplerAddressMode(glState.getWrapR()))),
+      mSAddressMode(static_cast<uint32_t>(GetSamplerAddressMode(glState.getWrapS()))),
+      mTAddressMode(static_cast<uint32_t>(GetSamplerAddressMode(glState.getWrapT()))),
+      mMinFilter(static_cast<uint32_t>(GetFilter(glState.getMinFilter()))),
+      mMagFilter(static_cast<uint32_t>(GetFilter(glState.getMagFilter()))),
+      mMipFilter(static_cast<uint32_t>(GetMipmapFilter(glState.getMinFilter()))),
+      mMaxAnisotropy(static_cast<uint32_t>(glState.getMaxAnisotropy())),
+      mCompareFunction(static_cast<uint32_t>(GetCompareFunc(glState.getCompareFunc())))
 {
-    return angle::ComputeGenericHash(angle::byte_span_from_ref(*this));
 }
 
-// SamplerDesc implementation
-SamplerDesc::SamplerDesc()
-{
-    memset(this, 0, sizeof(*this));
-}
-SamplerDesc::SamplerDesc(const SamplerDesc &src)
-{
-    memcpy(this, &src, sizeof(*this));
-}
-SamplerDesc::SamplerDesc(SamplerDesc &&src)
-{
-    memcpy(this, &src, sizeof(*this));
-}
-
-SamplerDesc::SamplerDesc(const gl::SamplerState &glState) : SamplerDesc()
-{
-    rAddressMode = GetSamplerAddressMode(glState.getWrapR());
-    sAddressMode = GetSamplerAddressMode(glState.getWrapS());
-    tAddressMode = GetSamplerAddressMode(glState.getWrapT());
-
-    minFilter = GetFilter(glState.getMinFilter());
-    magFilter = GetFilter(glState.getMagFilter());
-    mipFilter = GetMipmapFilter(glState.getMinFilter());
-
-    maxAnisotropy = static_cast<uint32_t>(glState.getMaxAnisotropy());
-
-    compareFunction = GetCompareFunc(glState.getCompareFunc());
-}
-
-SamplerDesc &SamplerDesc::operator=(const SamplerDesc &src)
-{
-    memcpy(this, &src, sizeof(*this));
-    return *this;
-}
-
-void SamplerDesc::reset()
-{
-    rAddressMode = MTLSamplerAddressModeClampToEdge;
-    sAddressMode = MTLSamplerAddressModeClampToEdge;
-    tAddressMode = MTLSamplerAddressModeClampToEdge;
-
-    minFilter = MTLSamplerMinMagFilterNearest;
-    magFilter = MTLSamplerMinMagFilterNearest;
-    mipFilter = MTLSamplerMipFilterNearest;
-
-    maxAnisotropy = 1;
-
-    compareFunction = MTLCompareFunctionNever;
-}
-
-bool SamplerDesc::operator==(const SamplerDesc &rhs) const
-{
-    return ANGLE_PROP_EQ(*this, rhs, rAddressMode) && ANGLE_PROP_EQ(*this, rhs, sAddressMode) &&
-           ANGLE_PROP_EQ(*this, rhs, tAddressMode) &&
-
-           ANGLE_PROP_EQ(*this, rhs, minFilter) && ANGLE_PROP_EQ(*this, rhs, magFilter) &&
-           ANGLE_PROP_EQ(*this, rhs, mipFilter) &&
-
-           ANGLE_PROP_EQ(*this, rhs, maxAnisotropy) &&
-
-           ANGLE_PROP_EQ(*this, rhs, compareFunction);
-}
-
-size_t SamplerDesc::hash() const
-{
-    return angle::ComputeGenericHash(angle::byte_span_from_ref(*this));
-}
-
-// BlendDesc implementation
-bool BlendDesc::operator==(const BlendDesc &rhs) const
-{
-    return ANGLE_PROP_EQ(*this, rhs, writeMask) &&
-
-           ANGLE_PROP_EQ(*this, rhs, alphaBlendOperation) &&
-           ANGLE_PROP_EQ(*this, rhs, rgbBlendOperation) &&
-
-           ANGLE_PROP_EQ(*this, rhs, destinationAlphaBlendFactor) &&
-           ANGLE_PROP_EQ(*this, rhs, destinationRGBBlendFactor) &&
-           ANGLE_PROP_EQ(*this, rhs, sourceAlphaBlendFactor) &&
-           ANGLE_PROP_EQ(*this, rhs, sourceRGBBlendFactor) &&
-
-           ANGLE_PROP_EQ(*this, rhs, blendingEnabled);
-}
-
-void BlendDesc::reset()
-{
-    reset(MTLColorWriteMaskAll);
-}
-
-void BlendDesc::reset(MTLColorWriteMask _writeMask)
-{
-    writeMask = _writeMask;
-
-    blendingEnabled     = false;
-    alphaBlendOperation = rgbBlendOperation = MTLBlendOperationAdd;
-
-    destinationAlphaBlendFactor = destinationRGBBlendFactor = MTLBlendFactorZero;
-    sourceAlphaBlendFactor = sourceRGBBlendFactor = MTLBlendFactorOne;
-}
-
-void BlendDesc::updateWriteMask(const uint8_t angleMask)
+void BlendDesc::updateWriteMask(uint8_t angleMask)
 {
     ASSERT(angleMask == (angleMask & 0xF));
 
 // ANGLE's packed color mask is abgr (matches Vulkan & D3D11), while Metal expects rgba.
 #if defined(__aarch64__)
     // ARM64 can reverse bits in a single instruction
-    writeMask = __builtin_bitreverse8(angleMask) >> 4;
+    mWriteMask = __builtin_bitreverse8(angleMask) >> 4;
 #else
     /* On other architectures, Clang generates a polyfill that uses more
        instructions than the following expression optimized for a 4-bit value.
@@ -516,107 +347,81 @@ void BlendDesc::updateWriteMask(const uint8_t angleMask)
         b.r.bargbarg.a.g.
               ^^^^
     */
-    writeMask = ((((angleMask * 0x41) & 0x14A) * 0x111) >> 7) & 0xF;
+    mWriteMask = ((((angleMask * 0x41) & 0x14A) * 0x111) >> 7) & 0xF;
 #endif
 }
 
-// RenderPipelineColorAttachmentDesc implementation
-bool RenderPipelineColorAttachmentDesc::operator==(
-    const RenderPipelineColorAttachmentDesc &rhs) const
+void RenderPipelineColorAttachmentDesc::reset(MTLPixelFormat format, MTLColorWriteMask writeMask)
 {
-    if (!BlendDesc::operator==(rhs))
-    {
-        return false;
-    }
-    return ANGLE_PROP_EQ(*this, rhs, pixelFormat);
-}
-
-void RenderPipelineColorAttachmentDesc::reset()
-{
-    reset(MTLPixelFormatInvalid);
-}
-
-void RenderPipelineColorAttachmentDesc::reset(MTLPixelFormat format)
-{
-    reset(format, MTLColorWriteMaskAll);
-}
-
-void RenderPipelineColorAttachmentDesc::reset(MTLPixelFormat format, MTLColorWriteMask _writeMask)
-{
-    this->pixelFormat = format;
-
     if (format == MTLPixelFormatRGB9E5Float)
     {
-        _writeMask = AdjustColorWriteMaskForSharedExponent(_writeMask);
+        writeMask = static_cast<uint32_t>(AdjustColorWriteMaskForSharedExponent(writeMask));
     }
-
-    BlendDesc::reset(_writeMask);
+    // Reset the entire BlendDesc to defaults (blendingEnabled=false, default factors/operations),
+    // then set the specific values.
+    BlendDesc::operator=({});
+    mWriteMask   = static_cast<uint32_t>(writeMask);
+    mPixelFormat = static_cast<uint32_t>(format);
 }
 
 void RenderPipelineColorAttachmentDesc::reset(MTLPixelFormat format, const BlendDesc &blendDesc)
 {
-    this->pixelFormat = format;
-
     BlendDesc::operator=(blendDesc);
-
     if (format == MTLPixelFormatRGB9E5Float)
     {
-        writeMask = AdjustColorWriteMaskForSharedExponent(writeMask);
+        mWriteMask = static_cast<uint32_t>(AdjustColorWriteMaskForSharedExponent(mWriteMask));
     }
+    mPixelFormat = static_cast<uint32_t>(format);
 }
 
-// RenderPipelineOutputDesc implementation
+bool RenderPipelineOutputDesc::operator==(const RenderPipelineOutputDesc &rhs) const
+{
+    if (mNumColorAttachments != rhs.mNumColorAttachments)
+    {
+        return false;
+    }
+
+    for (uint8_t i = 0; i < mNumColorAttachments; ++i)
+    {
+        if (colorAttachments[i] != rhs.colorAttachments[i])
+        {
+            return false;
+        }
+    }
+
+    return mDepthAttachmentPixelFormat == rhs.mDepthAttachmentPixelFormat &&
+           mStencilAttachmentPixelFormat == rhs.mStencilAttachmentPixelFormat &&
+           mRasterSampleCount == rhs.mRasterSampleCount;
+}
+
+size_t RenderPipelineOutputDesc::hash() const
+{
+    size_t hash = 0;
+    angle::HashCombine(hash, mNumColorAttachments);
+    for (uint8_t i = 0; i < mNumColorAttachments; ++i)
+    {
+        angle::HashCombine(hash, colorAttachments[i]);
+    }
+    angle::HashCombine(hash, mDepthAttachmentPixelFormat);
+    angle::HashCombine(hash, mStencilAttachmentPixelFormat);
+    angle::HashCombine(hash, mRasterSampleCount);
+    return hash;
+}
+
 void RenderPipelineOutputDesc::updateEnabledDrawBuffers(gl::DrawBufferMask enabledBuffers)
 {
-    for (uint32_t colorIndex = 0; colorIndex < this->numColorAttachments; ++colorIndex)
+    for (uint32_t colorIndex = 0; colorIndex < mNumColorAttachments; ++colorIndex)
     {
         if (!enabledBuffers.test(colorIndex))
         {
-            this->colorAttachments[colorIndex].writeMask = MTLColorWriteMaskNone;
+            colorAttachments[colorIndex].setWriteMask(MTLColorWriteMaskNone);
         }
     }
 }
 
-// RenderPipelineDesc implementation
-RenderPipelineDesc::RenderPipelineDesc()
-{
-    memset(this, 0, sizeof(*this));
-    outputDescriptor.rasterSampleCount = 1;
-    rasterizationType                  = RenderPipelineRasterization::Enabled;
-}
-
-RenderPipelineDesc::RenderPipelineDesc(const RenderPipelineDesc &src)
-{
-    memcpy(this, &src, sizeof(*this));
-}
-
-RenderPipelineDesc::RenderPipelineDesc(RenderPipelineDesc &&src)
-{
-    memcpy(this, &src, sizeof(*this));
-}
-
-RenderPipelineDesc &RenderPipelineDesc::operator=(const RenderPipelineDesc &src)
-{
-    memcpy(this, &src, sizeof(*this));
-    return *this;
-}
-
-bool RenderPipelineDesc::operator==(const RenderPipelineDesc &rhs) const
-{
-    // NOTE(hqle): Use a faster way to compare, i.e take into account
-    // the number of active vertex attributes & render targets.
-    // If that way is used, hash() method must be changed also.
-    return memcmp(this, &rhs, sizeof(*this)) == 0;
-}
-
-size_t RenderPipelineDesc::hash() const
-{
-    return angle::ComputeGenericHash(angle::byte_span_from_ref(*this));
-}
-
 bool RenderPipelineDesc::rasterizationEnabled() const
 {
-    return rasterizationType != RenderPipelineRasterization::Disabled;
+    return mRasterizationType != static_cast<uint32_t>(RenderPipelineRasterization::Disabled);
 }
 
 angle::ObjCPtr<MTLRenderPipelineDescriptor> RenderPipelineDesc::createMetalDesc(
@@ -626,19 +431,19 @@ angle::ObjCPtr<MTLRenderPipelineDescriptor> RenderPipelineDesc::createMetalDesc(
     auto objCDesc = angle::adoptObjCPtr([[MTLRenderPipelineDescriptor alloc] init]);
     [objCDesc reset];
 
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), *this, vertexDescriptor);
+    objCDesc.get().vertexDescriptor = ToObjC(vertexDescriptor);
 
-    for (uint8_t i = 0; i < outputDescriptor.numColorAttachments; ++i)
+    for (uint8_t i = 0; i < outputDescriptor.getNumColorAttachments(); ++i)
     {
         [objCDesc.get().colorAttachments setObject:ToObjC(outputDescriptor.colorAttachments[i])
                                 atIndexedSubscript:i];
     }
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), outputDescriptor, depthAttachmentPixelFormat);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), outputDescriptor, stencilAttachmentPixelFormat);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), outputDescriptor, rasterSampleCount);
-
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), *this, inputPrimitiveTopology);
-    ANGLE_OBJC_CP_PROPERTY(objCDesc.get(), *this, alphaToCoverageEnabled);
+    objCDesc.get().depthAttachmentPixelFormat = outputDescriptor.getDepthAttachmentPixelFormat();
+    objCDesc.get().stencilAttachmentPixelFormat =
+        outputDescriptor.getStencilAttachmentPixelFormat();
+    objCDesc.get().rasterSampleCount      = outputDescriptor.getRasterSampleCount();
+    objCDesc.get().inputPrimitiveTopology = getInputPrimitiveTopology();
+    objCDesc.get().alphaToCoverageEnabled = getAlphaToCoverageEnabled();
 
     // rasterizationEnabled will be true for both EmulatedDiscard & Enabled.
     objCDesc.get().rasterizationEnabled = rasterizationEnabled();
@@ -647,26 +452,6 @@ angle::ObjCPtr<MTLRenderPipelineDescriptor> RenderPipelineDesc::createMetalDesc(
     objCDesc.get().fragmentFunction = objCDesc.get().rasterizationEnabled ? fragmentShader : nil;
 
     return objCDesc;
-}
-
-// RenderPassDesc implementation
-RenderPassAttachmentDesc::RenderPassAttachmentDesc()
-{
-    reset();
-}
-
-void RenderPassAttachmentDesc::reset()
-{
-    texture.reset();
-    resolveTexture.reset();
-    level               = mtl::kZeroNativeMipLevel;
-    sliceOrDepth        = 0;
-    resolveLevel        = mtl::kZeroNativeMipLevel;
-    resolveSliceOrDepth = 0;
-    blendable           = false;
-    loadAction          = MTLLoadActionLoad;
-    storeAction         = MTLStoreActionStore;
-    storeActionOptions  = MTLStoreActionOptionNone;
 }
 
 bool RenderPassAttachmentDesc::equalIgnoreLoadStoreOptions(
@@ -710,22 +495,20 @@ void RenderPassDesc::populateRenderPipelineOutputDesc(const WriteMaskArray &writ
 void RenderPassDesc::populateRenderPipelineOutputDesc(const BlendDescArray &blendDescArray,
                                                       RenderPipelineOutputDesc *outDesc) const
 {
-    RenderPipelineOutputDesc &outputDescriptor = *outDesc;
-    outputDescriptor.numColorAttachments       = this->numColorAttachments;
-    outputDescriptor.rasterSampleCount         = this->rasterSampleCount;
+    outDesc->setNumColorAttachments(numColorAttachments);
+    outDesc->setRasterSampleCount(rasterSampleCount);
     for (uint32_t i = 0; i < this->numColorAttachments; ++i)
     {
-        auto &renderPassColorAttachment = this->colorAttachments[i];
+        auto &renderPassColorAttachment = colorAttachments[i];
         auto texture                    = renderPassColorAttachment.texture;
-
+        auto &outColorAttachment        = outDesc->colorAttachments[i];
         if (texture)
         {
             if (renderPassColorAttachment.blendable &&
-                blendDescArray[i].writeMask != MTLColorWriteMaskNone)
+                blendDescArray[i].getWriteMask() != MTLColorWriteMaskNone)
             {
                 // Copy parameters from blend state
-                outputDescriptor.colorAttachments[i].reset(texture->pixelFormat(),
-                                                           blendDescArray[i]);
+                outColorAttachment.reset(texture->pixelFormat(), blendDescArray[i]);
             }
             else
             {
@@ -742,36 +525,36 @@ void RenderPassDesc::populateRenderPipelineOutputDesc(const BlendDescArray &blen
                 //
                 // Besides disabling blending, use default values for factors and
                 // operations to reduce the number of unique pipeline states.
-                outputDescriptor.colorAttachments[i].reset(texture->pixelFormat(),
-                                                           blendDescArray[i].writeMask);
+                outColorAttachment.reset(texture->pixelFormat(), blendDescArray[i].getWriteMask());
             }
 
             // Combine the masks. This is useful when the texture is not supposed to have alpha
             // channel such as GL_RGB8, however, Metal doesn't natively support 24 bit RGB, so
             // we need to use RGBA texture, and then disable alpha write to this texture
-            outputDescriptor.colorAttachments[i].writeMask &= texture->getColorWritableMask();
+            outColorAttachment.setWriteMask(outColorAttachment.getWriteMask() &
+                                            texture->getColorWritableMask());
         }
         else
         {
 
-            outputDescriptor.colorAttachments[i].blendingEnabled = false;
-            outputDescriptor.colorAttachments[i].pixelFormat     = MTLPixelFormatInvalid;
+            outColorAttachment.setBlendingDisabled();
+            outColorAttachment.setPixelFormat(MTLPixelFormatInvalid);
         }
     }
 
     // Reset the unused output slots to ensure consistent hash value
-    for (uint32_t i = this->numColorAttachments; i < outputDescriptor.colorAttachments.size(); ++i)
+    for (uint32_t i = this->numColorAttachments; i < outDesc->colorAttachments.size(); ++i)
     {
-        outputDescriptor.colorAttachments[i].reset();
+        outDesc->colorAttachments[i] = {};
     }
 
-    auto depthTexture = this->depthAttachment.texture;
-    outputDescriptor.depthAttachmentPixelFormat =
-        depthTexture ? depthTexture->pixelFormat() : MTLPixelFormatInvalid;
+    auto depthTexture = depthAttachment.texture;
+    outDesc->setDepthAttachmentPixelFormat(depthTexture ? depthTexture->pixelFormat()
+                                                        : MTLPixelFormatInvalid);
 
-    auto stencilTexture = this->stencilAttachment.texture;
-    outputDescriptor.stencilAttachmentPixelFormat =
-        stencilTexture ? stencilTexture->pixelFormat() : MTLPixelFormatInvalid;
+    auto stencilTexture = stencilAttachment.texture;
+    outDesc->setStencilAttachmentPixelFormat(stencilTexture ? stencilTexture->pixelFormat()
+                                                            : MTLPixelFormatInvalid);
 }
 
 bool RenderPassDesc::equalIgnoreLoadStoreOptions(const RenderPassDesc &other) const
@@ -814,20 +597,14 @@ bool RenderPassDesc::operator==(const RenderPassDesc &other) const
 
     for (uint32_t i = 0; i < numColorAttachments; ++i)
     {
-        auto &renderPassColorAttachment = colorAttachments[i];
-        auto &otherRPAttachment         = other.colorAttachments[i];
-        if (renderPassColorAttachment != (otherRPAttachment))
+        if (colorAttachments[i] != other.colorAttachments[i])
         {
             return false;
         }
     }
-
-    if (defaultWidth != other.defaultWidth || defaultHeight != other.defaultHeight)
-    {
-        return false;
-    }
-
-    return depthAttachment == other.depthAttachment && stencilAttachment == other.stencilAttachment;
+    return depthAttachment == other.depthAttachment &&
+           stencilAttachment == other.stencilAttachment && defaultWidth == other.defaultWidth &&
+           defaultHeight == other.defaultHeight && rasterSampleCount == other.rasterSampleCount;
 }
 
 // Convert to Metal object
@@ -872,10 +649,8 @@ angle::ObjCPtr<id<MTLDepthStencilState>> StateCache::getNullDepthStencilState(
 {
     if (!mNullDepthStencilState)
     {
-        DepthStencilDesc desc;
-        desc.reset();
-        ASSERT(desc.frontFaceStencil.stencilCompareFunction == MTLCompareFunctionAlways);
-        desc.depthWriteEnabled = false;
+        DepthStencilDesc desc(MTLCompareFunctionAlways, false);
+        ASSERT(desc.frontFaceStencil.getStencilCompareFunction() == MTLCompareFunctionAlways);
         mNullDepthStencilState = getDepthStencilState(device, desc);
     }
     return mNullDepthStencilState;
@@ -933,8 +708,6 @@ angle::ObjCPtr<id<MTLSamplerState>> StateCache::getNullSamplerState(
     const mtl::ContextDevice &device)
 {
     SamplerDesc desc;
-    desc.reset();
-
     return getSamplerState(device, desc);
 }
 


### PR DESCRIPTION
#### 820f19705059247dd1e5420f695bfadff64b30e7
<pre>
ANGLE: Metal: Make StateCache descriptors hash consistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=313116">https://bugs.webkit.org/show_bug.cgi?id=313116</a>
<a href="https://rdar.apple.com/175408135">rdar://175408135</a>

Reviewed by NOBODY (OOPS!).

Various descriptors would compare equality and do hashing based on the
underlying storage. The storage contains alignment padding and
bitfields. The contents of these are not defined, even when the
constructors tried to memset and memcpy.

The various hash and compare functions also seemed to be missing some
elements, like rasterSampleCount.

Missing == on fields and hashing unused memory may lead to inconsistency
where a==b is true but hash(a) != hash(b).

Fix by:
Remove the memset/memcpy and write out the operator== and
hash() consistently.

Initialize the members to their default values.

Use uint32_t : 1 instead of bool if the struct tries to optimize for
size, since mixing types stops the packing.

Use uint32_t to get the alignment to uint32_t, which is mostly what
is expected.

Use uint32 someVar : N where N is payload bits + padding bits for
the last member. This way the assignment clears the padding bits.
The goal is to get the operator== to compare the padding bits, which
lets the compiler elide the memberwise compares and use word-wise
compares where it makes sense.

This is an attempt to fix rare crashes related to map inserts
and lookups. std::unordered_map will crash if operator== is not
consistent with hash.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm:
(rx::ContextMtl::initialize):
(rx::ContextMtl::syncState):
(rx::ContextMtl::updateBlendDescArray):
(rx::isDrawNoOp):
(rx::ContextMtl::handleDirtyDepthStencilState):
(rx::ContextMtl::checkIfPipelineChanged):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/FrameBufferMtl.mm:
(rx::FramebufferMtl::updateColorRenderTarget):
(rx::FramebufferMtl::updateDepthRenderTarget):
(rx::FramebufferMtl::updateStencilRenderTarget):
(rx::FramebufferMtl::prepareRenderPass):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm:
(rx::ProgramExecutableMtl::setupDraw):
(rx::ProgramExecutableMtl::getSpecializedShader):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm:
(rx::TextureMtl::ensureSamplerStateCreated):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm:
(rx::VertexArrayMtl::setupDraw):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_pipeline_cache.mm:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm:
(rx::mtl::ClearUtils::getClearDepthStencilState):
(rx::mtl::ClearUtils::getClearRenderPipelineState):
(rx::mtl::ColorBlitUtils::getColorBlitRenderPipelineState):
(rx::mtl::ColorBlitUtils::setupColorBlitWithDraw):
(rx::mtl::DepthStencilBlitUtils::getDepthStencilBlitRenderPipelineState):
(rx::mtl::DepthStencilBlitUtils::setupDepthStencilBlitWithDraw):
(rx::mtl::CopyPixelsUtils::getB2TRenderPipeline):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_state_cache.h:
(rx::mtl::StencilDesc::StencilDesc):
(rx::mtl::StencilDesc::setStencilFailureOperation):
(rx::mtl::StencilDesc::getStencilFailureOperation const):
(rx::mtl::StencilDesc::setDepthFailureOperation):
(rx::mtl::StencilDesc::getDepthFailureOperation const):
(rx::mtl::StencilDesc::setDepthStencilPassOperation):
(rx::mtl::StencilDesc::getDepthStencilPassOperation const):
(rx::mtl::StencilDesc::setStencilCompareFunction):
(rx::mtl::StencilDesc::getStencilCompareFunction const):
(rx::mtl::StencilDesc::operator== const):
(rx::mtl::StencilDesc::hash const):
(rx::mtl::DepthStencilDesc::DepthStencilDesc):
(rx::mtl::DepthStencilDesc::getDepthCompareFunction const):
(rx::mtl::DepthStencilDesc::setDepthWriteDisabled):
(rx::mtl::DepthStencilDesc::isDepthWriteEnabled const):
(rx::mtl::DepthStencilDesc::operator== const):
(rx::mtl::DepthStencilDesc::hash const):
(rx::mtl::SamplerDesc::SamplerDesc):
(rx::mtl::SamplerDesc::setRAddressMode):
(rx::mtl::SamplerDesc::getRAddressMode const):
(rx::mtl::SamplerDesc::setSAddressMode):
(rx::mtl::SamplerDesc::getSAddressMode const):
(rx::mtl::SamplerDesc::setTAddressMode):
(rx::mtl::SamplerDesc::getTAddressMode const):
(rx::mtl::SamplerDesc::setMinFilter):
(rx::mtl::SamplerDesc::getMinFilter const):
(rx::mtl::SamplerDesc::setMagFilter):
(rx::mtl::SamplerDesc::getMagFilter const):
(rx::mtl::SamplerDesc::setMipFilter):
(rx::mtl::SamplerDesc::getMipFilter const):
(rx::mtl::SamplerDesc::setMaxAnisotropy):
(rx::mtl::SamplerDesc::getMaxAnisotropy const):
(rx::mtl::SamplerDesc::setCompareFunction):
(rx::mtl::SamplerDesc::getCompareFunction const):
(rx::mtl::SamplerDesc::operator== const):
(rx::mtl::SamplerDesc::hash const):
(rx::mtl::VertexAttributeDesc::VertexAttributeDesc):
(rx::mtl::VertexAttributeDesc::operator!= const):
(rx::mtl::VertexAttributeDesc::getFormat const):
(rx::mtl::VertexAttributeDesc::getOffset const):
(rx::mtl::VertexAttributeDesc::getBufferIndex const):
(rx::mtl::VertexAttributeDesc::operator== const):
(rx::mtl::VertexAttributeDesc::hash const):
(rx::mtl::VertexBufferLayoutDesc::VertexBufferLayoutDesc):
(rx::mtl::VertexBufferLayoutDesc::operator!= const):
(rx::mtl::VertexBufferLayoutDesc::getStepFunction const):
(rx::mtl::VertexBufferLayoutDesc::operator== const):
(rx::mtl::VertexBufferLayoutDesc::hash const):
(rx::mtl::VertexDesc::VertexDesc):
(rx::mtl::VertexDesc::operator== const):
(rx::mtl::VertexDesc::hash const):
(rx::mtl::BlendDesc::BlendDesc):
(rx::mtl::BlendDesc::reset):
(rx::mtl::BlendDesc::setBlendingEnabled):
(rx::mtl::BlendDesc::setBlendingDisabled):
(rx::mtl::BlendDesc::setWriteMask):
(rx::mtl::BlendDesc::getWriteMask const):
(rx::mtl::BlendDesc::getSourceRgbBlendFactor const):
(rx::mtl::BlendDesc::getSourceAlphaBlendFactor const):
(rx::mtl::BlendDesc::getDestinationRgbBlendFactor const):
(rx::mtl::BlendDesc::getDestinationAlphaBlendFactor const):
(rx::mtl::BlendDesc::getRgbBlendOperation const):
(rx::mtl::BlendDesc::getAlphaBlendOperation const):
(rx::mtl::BlendDesc::isBlendingEnabled const):
(rx::mtl::BlendDesc::operator== const):
(rx::mtl::BlendDesc::hash const):
(rx::mtl::RenderPipelineColorAttachmentDesc::operator!= const):
(rx::mtl::RenderPipelineColorAttachmentDesc::reset):
(rx::mtl::RenderPipelineColorAttachmentDesc::setPixelFormat):
(rx::mtl::RenderPipelineColorAttachmentDesc::getPixelFormat const):
(rx::mtl::RenderPipelineColorAttachmentDesc::operator== const):
(rx::mtl::RenderPipelineColorAttachmentDesc::hash const):
(rx::mtl::RenderPipelineOutputDesc::RenderPipelineOutputDesc):
(rx::mtl::RenderPipelineOutputDesc::setDepthAttachmentPixelFormat):
(rx::mtl::RenderPipelineOutputDesc::getDepthAttachmentPixelFormat const):
(rx::mtl::RenderPipelineOutputDesc::setStencilAttachmentPixelFormat):
(rx::mtl::RenderPipelineOutputDesc::getStencilAttachmentPixelFormat const):
(rx::mtl::RenderPipelineOutputDesc::setNumColorAttachments):
(rx::mtl::RenderPipelineOutputDesc::getNumColorAttachments const):
(rx::mtl::RenderPipelineOutputDesc::setRasterSampleCount):
(rx::mtl::RenderPipelineOutputDesc::getRasterSampleCount const):
(rx::mtl::RenderPipelineDesc::RenderPipelineDesc):
(rx::mtl::RenderPipelineDesc::setInputPrimitiveTopology):
(rx::mtl::RenderPipelineDesc::getInputPrimitiveTopology const):
(rx::mtl::RenderPipelineDesc::setAlphaToCoverageEnabled):
(rx::mtl::RenderPipelineDesc::getAlphaToCoverageEnabled const):
(rx::mtl::RenderPipelineDesc::setRasterizationType):
(rx::mtl::RenderPipelineDesc::getRasterizationType const):
(rx::mtl::RenderPipelineDesc::operator== const):
(rx::mtl::RenderPipelineDesc::hash const):
(std::hash&lt;rx::mtl::StencilDesc&gt;::operator() const):
(std::hash&lt;rx::mtl::VertexAttributeDesc&gt;::operator() const):
(std::hash&lt;rx::mtl::VertexBufferLayoutDesc&gt;::operator() const):
(std::hash&lt;rx::mtl::VertexDesc&gt;::operator() const):
(std::hash&lt;rx::mtl::BlendDesc&gt;::operator() const):
(std::hash&lt;rx::mtl::RenderPipelineColorAttachmentDesc&gt;::operator() const):
(std::hash&lt;rx::mtl::RenderPipelineOutputDesc&gt;::operator() const):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_state_cache.mm:
(rx::mtl::DepthStencilDesc::updateDepthTestEnabled):
(rx::mtl::DepthStencilDesc::updateDepthWriteEnabled):
(rx::mtl::DepthStencilDesc::updateDepthCompareFunc):
(rx::mtl::DepthStencilDesc::updateStencilTestEnabled):
(rx::mtl::DepthStencilDesc::updateStencilFrontOps):
(rx::mtl::DepthStencilDesc::updateStencilBackOps):
(rx::mtl::DepthStencilDesc::updateStencilFrontFuncs):
(rx::mtl::DepthStencilDesc::updateStencilBackFuncs):
(rx::mtl::SamplerDesc::SamplerDesc):
(rx::mtl::BlendDesc::updateWriteMask):
(rx::mtl::RenderPipelineColorAttachmentDesc::reset):
(rx::mtl::RenderPipelineOutputDesc::operator== const):
(rx::mtl::RenderPipelineOutputDesc::hash const):
(rx::mtl::RenderPipelineOutputDesc::updateEnabledDrawBuffers):
(rx::mtl::RenderPipelineDesc::rasterizationEnabled const):
(rx::mtl::RenderPipelineDesc::createMetalDesc const):
(rx::mtl::RenderPassDesc::populateRenderPipelineOutputDesc const):
(rx::mtl::RenderPassDesc::operator== const):
(rx::mtl::StateCache::getNullDepthStencilState):
(rx::mtl::StateCache::getNullSamplerState):
(rx::mtl::StencilDesc::operator== const): Deleted.
(rx::mtl::StencilDesc::reset): Deleted.
(rx::mtl::DepthStencilDesc::DepthStencilDesc): Deleted.
(rx::mtl::DepthStencilDesc::operator=): Deleted.
(rx::mtl::DepthStencilDesc::operator== const): Deleted.
(rx::mtl::DepthStencilDesc::reset): Deleted.
(rx::mtl::DepthStencilDesc::hash const): Deleted.
(rx::mtl::SamplerDesc::operator=): Deleted.
(rx::mtl::SamplerDesc::reset): Deleted.
(rx::mtl::SamplerDesc::operator== const): Deleted.
(rx::mtl::SamplerDesc::hash const): Deleted.
(rx::mtl::BlendDesc::operator== const): Deleted.
(rx::mtl::BlendDesc::reset): Deleted.
(rx::mtl::RenderPipelineColorAttachmentDesc::operator== const): Deleted.
(rx::mtl::RenderPipelineDesc::RenderPipelineDesc): Deleted.
(rx::mtl::RenderPipelineDesc::operator=): Deleted.
(rx::mtl::RenderPipelineDesc::operator== const): Deleted.
(rx::mtl::RenderPipelineDesc::hash const): Deleted.
(rx::mtl::RenderPassAttachmentDesc::RenderPassAttachmentDesc): Deleted.
(rx::mtl::RenderPassAttachmentDesc::reset): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/820f19705059247dd1e5420f695bfadff64b30e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112313 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122538 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86015 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142118 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103207 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23866 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22229 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14831 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169548 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130718 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130833 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141701 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89147 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25547 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18507 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30803 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30324 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30554 "Hash 820f1970 for PR 63411 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30451 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->