### PR TITLE
NodeIterator::updateForNodeRemoval: remove unreachable dead code with wrong traversal direction

### DIFF
--- a/Source/WebCore/dom/NodeIterator.cpp
+++ b/Source/WebCore/dom/NodeIterator.cpp
@@ -201,28 +201,19 @@ void NodeIterator::updateForNodeRemoval(Node& removedNode, NodePointer& referenc
             }
         }
     } else {
+        // NodeTraversal::previous() without a stayWithin boundary only returns null when
+        // the node has no parent. Since removedNode.isDescendantOf(root) was verified above,
+        // removedNode is in the tree and always has a parent.
         RefPtr node = NodeTraversal::previous(removedNode);
-        if (node) {
-            // Move out from under the node being removed if the reference node is
-            // a descendant of the node being removed.
-            if (willRemoveReferenceNodeAncestor) {
-                while (node && node->isDescendantOf(removedNode))
-                    node = NodeTraversal::previous(*node);
-            }
-            if (node)
-                referenceNode.node = node;
-        } else {
-            // FIXME: This branch doesn't appear to have any LayoutTests.
-            node = NodeTraversal::next(removedNode, &root);
-            // Move out from under the node being removed if the reference node is
-            // a descendant of the node being removed.
-            if (willRemoveReferenceNodeAncestor) {
-                while (node && node->isDescendantOf(removedNode))
-                    node = NodeTraversal::previous(*node);
-            }
-            if (node)
-                referenceNode.node = WTF::move(node);
+        ASSERT(node);
+        // Move out from under the node being removed if the reference node is
+        // a descendant of the node being removed.
+        if (willRemoveReferenceNodeAncestor) {
+            while (node && node->isDescendantOf(removedNode))
+                node = NodeTraversal::previous(*node);
         }
+        if (node)
+            referenceNode.node = node;
     }
 }
 


### PR DESCRIPTION
#### c4d770d2e1c849df705d79021304ef37002cf62b
<pre>
NodeIterator::updateForNodeRemoval: remove unreachable dead code with wrong traversal direction
<a href="https://bugs.webkit.org/show_bug.cgi?id=313119">https://bugs.webkit.org/show_bug.cgi?id=313119</a>

Reviewed by Anne van Kesteren.

Remove a dead else branch in updateForNodeRemoval that contained a bug
(NodeTraversal::previous used where NodeTraversal::next was needed). The
branch was unreachable because NodeTraversal::previous() without a
stayWithin boundary only returns null when the node has no parent, and
removedNode is guaranteed to be in the tree at this point
(isDescendantOf(root) was already verified). Replace with an ASSERT.

* Source/WebCore/dom/NodeIterator.cpp:
(WebCore::NodeIterator::updateForNodeRemoval const):

Canonical link: <a href="https://commits.webkit.org/311903@main">https://commits.webkit.org/311903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dc197f9abc76eb2afe1fe400fd71e9063352e12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112315 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122541 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86013 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103210 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23869 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22233 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14833 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169550 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14904 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130724 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130839 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35449 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141707 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89149 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25546 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18513 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190361 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30805 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96338 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/190361 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30326 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30556 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30453 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->