### PR TITLE
webkit_uri_for_display fails on s390x

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -305,7 +305,11 @@ RefPtr<StringImpl> StringImpl::create(std::span<const char8_t> codeUnits)
     std::span<char16_t> data;
     auto string = createUninitializedInternalNonEmpty(utf16Length, data);
 
+#if CPU(BIG_ENDIAN)
+    size_t written = simdutf::convert_valid_utf8_to_utf16be(input, inputLength, data.data());
+#else
     size_t written = simdutf::convert_valid_utf8_to_utf16le(input, inputLength, data.data());
+#endif
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(written == utf16Length);
 
     return string;


### PR DESCRIPTION
#### 585ad22df82d53282d1ff38da4517088bda825df
<pre>
webkit_uri_for_display fails on s390x
<a href="https://bugs.webkit.org/show_bug.cgi?id=312973">https://bugs.webkit.org/show_bug.cgi?id=312973</a>

Reviewed by Claudio Saavedra and Adrian Perez de Castro.

Use the correct byte ordering when converting utf8 to utf16 on
big-endian platforms.

* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::create):

Canonical link: <a href="https://commits.webkit.org/305877.448@webkitglib/2.52">https://commits.webkit.org/305877.448@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db848c2aad5c2fb1a61cc1b6c7af992f7f1d9024

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158235 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31572 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/24767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167064 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112319 "The change is no longer eligible for processing.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31709 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31590 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112319 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161193 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/31709 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/24767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103213 "run-api-tests (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/31709 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/31590 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14836 "Unable to build WebKit without PR, please check manually (failure)") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/150286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/31709 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/24767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169553 "Unable to build WebKit without PR, please check manually (failure)") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/19070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/14920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/24767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/169553 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/31318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/31590 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/169553 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/31256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/24767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89152 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24046 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/31256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/24767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190364 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/30808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96354 "Failed to checkout and rebase branch from PR 63416") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/48853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30329 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30456 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->