### PR TITLE
[GTK][WPE] Skia Compositor: implement blend modes

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -182,82 +182,6 @@ void GraphicsContextSkia::drawRect(const FloatRect& rect, float borderThickness)
     m_canvas.drawRegion(region, strokePaint);
 }
 
-static SkBlendMode toSkiaBlendMode(CompositeOperator operation, BlendMode blendMode)
-{
-    switch (blendMode) {
-    case BlendMode::Normal:
-        switch (operation) {
-        case CompositeOperator::Clear:
-            return SkBlendMode::kClear;
-        case CompositeOperator::Copy:
-            return SkBlendMode::kSrc;
-        case CompositeOperator::SourceOver:
-            return SkBlendMode::kSrcOver;
-        case CompositeOperator::SourceIn:
-            return SkBlendMode::kSrcIn;
-        case CompositeOperator::SourceOut:
-            return SkBlendMode::kSrcOut;
-        case CompositeOperator::SourceAtop:
-            return SkBlendMode::kSrcATop;
-        case CompositeOperator::DestinationOver:
-            return SkBlendMode::kDstOver;
-        case CompositeOperator::DestinationIn:
-            return SkBlendMode::kDstIn;
-        case CompositeOperator::DestinationOut:
-            return SkBlendMode::kDstOut;
-        case CompositeOperator::DestinationAtop:
-            return SkBlendMode::kDstATop;
-        case CompositeOperator::XOR:
-            return SkBlendMode::kXor;
-        case CompositeOperator::PlusLighter:
-            return SkBlendMode::kPlus;
-        case CompositeOperator::PlusDarker:
-            notImplemented();
-            return SkBlendMode::kSrcOver;
-        case CompositeOperator::Difference:
-            return SkBlendMode::kDifference;
-        }
-        break;
-    case BlendMode::Multiply:
-        return SkBlendMode::kMultiply;
-    case BlendMode::Screen:
-        return SkBlendMode::kScreen;
-    case BlendMode::Overlay:
-        return SkBlendMode::kOverlay;
-    case BlendMode::Darken:
-        return SkBlendMode::kDarken;
-    case BlendMode::Lighten:
-        return SkBlendMode::kLighten;
-    case BlendMode::ColorDodge:
-        return SkBlendMode::kColorDodge;
-    case BlendMode::ColorBurn:
-        return SkBlendMode::kColorBurn;
-    case BlendMode::HardLight:
-        return SkBlendMode::kHardLight;
-    case BlendMode::SoftLight:
-        return SkBlendMode::kSoftLight;
-    case BlendMode::Difference:
-        return SkBlendMode::kDifference;
-    case BlendMode::Exclusion:
-        return SkBlendMode::kExclusion;
-    case BlendMode::Hue:
-        return SkBlendMode::kHue;
-    case BlendMode::Saturation:
-        return SkBlendMode::kSaturation;
-    case BlendMode::Color:
-        return SkBlendMode::kColor;
-    case BlendMode::Luminosity:
-        return SkBlendMode::kLuminosity;
-    case BlendMode::PlusLighter:
-        return SkBlendMode::kPlus;
-    case BlendMode::PlusDarker:
-        notImplemented();
-        break;
-    }
-
-    return SkBlendMode::kSrcOver;
-}
-
 static SkSamplingOptions toSkSamplingOptions(InterpolationQuality quality)
 {
     switch (quality) {
@@ -319,7 +243,7 @@ void GraphicsContextSkia::drawNativeImage(const NativeImage& nativeImage, const 
 
     SkPaint paint = createFillPaint();
     paint.setAlphaf(alpha());
-    paint.setBlendMode(toSkiaBlendMode(options.compositeOperator(), options.blendMode()));
+    paint.setBlendMode(SkiaUtilities::toSkiaBlendMode(options.blendMode(), options.compositeOperator()));
     bool inExtraTransparencyLayer = false;
     auto clampingConstraint = options.strictImageClamping() == StrictImageClamping::Yes ? SkCanvas::kStrict_SrcRectConstraint : SkCanvas::kFast_SrcRectConstraint;
 
@@ -631,7 +555,7 @@ SkPaint GraphicsContextSkia::createFillPaint() const
     SkPaint paint;
     paint.setAntiAlias(shouldAntialias());
     paint.setStyle(SkPaint::kFill_Style);
-    paint.setBlendMode(toSkiaBlendMode(compositeMode().operation, blendMode()));
+    paint.setBlendMode(SkiaUtilities::toSkiaBlendMode(blendMode(), compositeMode().operation));
     return paint;
 }
 
@@ -652,7 +576,7 @@ SkPaint GraphicsContextSkia::createStrokePaint() const
     SkPaint paint;
     paint.setAntiAlias(shouldAntialias());
     paint.setStyle(SkPaint::kStroke_Style);
-    paint.setBlendMode(toSkiaBlendMode(compositeMode().operation, blendMode()));
+    paint.setBlendMode(SkiaUtilities::toSkiaBlendMode(blendMode(), compositeMode().operation));
     paint.setStrokeCap(m_skiaState.stroke.cap);
     paint.setStrokeJoin(m_skiaState.stroke.join);
     paint.setStrokeMiter(m_skiaState.stroke.miter);
@@ -922,7 +846,7 @@ void GraphicsContextSkia::saveLayer(float opacity, CompositeMode compositeMode)
 
     SkPaint paint;
     paint.setAlphaf(opacity);
-    paint.setBlendMode(toSkiaBlendMode(compositeMode.operation, compositeMode.blendMode));
+    paint.setBlendMode(SkiaUtilities::toSkiaBlendMode(compositeMode.blendMode, compositeMode.operation));
     if (m_enableStateReplayTracking) [[unlikely]]
         currentState.layerPaint = paint;
 
@@ -1180,7 +1104,7 @@ void GraphicsContextSkia::drawPattern(const NativeImage& nativeImage, const Floa
     auto samplingOptions = toSkSamplingOptions(m_state.imageInterpolationQuality());
 
     SkPaint paint = createFillPaint();
-    paint.setBlendMode(toSkiaBlendMode(options.compositeOperator(), options.blendMode()));
+    paint.setBlendMode(SkiaUtilities::toSkiaBlendMode(options.blendMode(), options.compositeOperator()));
 
     auto size = nativeImage.size();
     if (spacing.isZero() && tileRect.size() == size) {

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -39,6 +39,7 @@
 #include "SkiaCompositingLayer3DRenderingContext.h"
 #include "SkiaCompositingLayerFilters.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
+#include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkFont.h>
 #include <skia/core/SkPathBuilder.h>
@@ -103,6 +104,16 @@ void SkiaCompositingLayer::setOpacity(float opacity)
         damageWholeLayer();
 #endif
     m_opacity = opacity;
+}
+
+void SkiaCompositingLayer::setBlendMode(BlendMode blendMode)
+{
+    if (blendMode == BlendMode::Normal) {
+        m_blendMode = std::nullopt;
+        return;
+    }
+
+    m_blendMode = SkiaUtilities::toSkiaBlendMode(blendMode);
 }
 
 void SkiaCompositingLayer::setChildren(Vector<Ref<SkiaCompositingLayer>>&& newChildren)
@@ -447,6 +458,8 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
     paint.setStyle(SkPaint::kFill_Style);
     paint.setAntiAlias(true);
     paint.setAlphaf(context.opacity);
+    if (context.blendMode)
+        paint.setBlendMode(*context.blendMode);
     if (context.colorFilter)
         paint.setColorFilter(context.colorFilter);
 
@@ -594,9 +607,12 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
         SkPaint paint;
         paint.setImageFilter(m_backdrop.filter);
         paint.setAlphaf(context.opacity);
+        if (context.blendMode)
+            paint.setBlendMode(*context.blendMode);
         paintWithIntermediateSurface(canvas, context, enclosingIntRect(clipTransform.mapRect(m_backdrop.clipRect.rect())), &paint, [&](SkCanvas& canvas, PaintContext& context) {
             SetForScope scopedPaintBackdropForLayer(context.paintingBackdropForLayer, this);
             SetForScope scopedOpacity(context.opacity, 1.f);
+            SetForScope scopedBlendMode(context.blendMode, std::nullopt);
             SetForScope scopedReplicaTransform(context.accumulatedReplicaTransform, TransformationMatrix());
             backdropRoot()->paintSelfAndChildren(canvas, context);
         });
@@ -824,13 +840,14 @@ void SkiaCompositingLayer::recursivePaint(SkCanvas& canvas, PaintContext& contex
         return;
 
     SetForScope scopedOpacity(context.opacity, context.opacity * opacity());
+    SetForScope scopedBlendMode(context.blendMode, context.blendMode ? context.blendMode : m_blendMode);
 
     if (m_preserves3D) {
         paintUsing3DRenderingContext(canvas, context);
         return;
     }
 
-    if (opacity() < 1)
+    if (opacity() < 1 || m_blendMode)
         paintUsingOverlapRegions(canvas, context);
     else
         paintSelfAndChildrenWithReplicaFilterAndMask(canvas, context);
@@ -917,10 +934,13 @@ void SkiaCompositingLayer::paintUsingOverlapRegions(SkCanvas& canvas, PaintConte
 
     SkPaint layerPaint;
     layerPaint.setAlphaf(context.opacity);
+    if (context.blendMode)
+        layerPaint.setBlendMode(*context.blendMode);
     for (const auto& rect : overlapRects) {
         SkAutoCanvasRestore autoRestore(&canvas, true);
         paintWithIntermediateSurface(canvas, context, rect, &layerPaint, [&](SkCanvas& canvas, PaintContext& context) {
             SetForScope scopedOpacity(context.opacity, 1);
+            SetForScope scopedBlendMode(context.blendMode, std::nullopt);
             paintSelfAndChildrenWithReplicaFilterAndMask(canvas, context);
         });
     }

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -76,6 +76,7 @@ public:
     void setContentsClippingRect(const FloatRoundedRect& rect) { m_contentsClippingRect = rect; }
     void setContentsRectClipsDescendants(bool clips) { m_contentsRectClipsDescendants = clips; }
     void setOpacity(float);
+    void setBlendMode(BlendMode);
     void setContentsRect(const FloatRect& rect) { m_contentsRect = rect; }
     void setAnimations(const TextureMapperAnimations& animations) { m_animations = animations; }
     void setContentsTiling(const FloatSize& size, const FloatSize& phase) { m_contentsTiling = { size, phase }; }
@@ -126,6 +127,7 @@ private:
         }
 
         float opacity { 1 };
+        std::optional<SkBlendMode> blendMode;
         IntSize offset;
         sk_sp<SkColorFilter> colorFilter;
         TransformationMatrix accumulatedReplicaTransform;
@@ -213,6 +215,7 @@ private:
     bool m_contentsRectClipsDescendants { false };
     FloatRoundedRect m_contentsClippingRect;
     float m_opacity { 1 };
+    std::optional<SkBlendMode> m_blendMode;
     SkPath m_clipPath;
     sk_sp<SkImage> m_maskImage;
     RefPtr<SkiaCompositingLayer> m_mask;

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
@@ -31,6 +31,8 @@
 #include "BitmapTexture.h"
 #include "ColorSpaceSkia.h"
 #include "GLFence.h"
+#include "GraphicsTypes.h"
+#include "NotImplemented.h"
 #include "PlatformDisplay.h"
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -124,6 +126,82 @@ std::unique_ptr<GLFence> flushAndSubmitWithFence(GrDirectContext* grContext)
 {
     grContext->flush();
     return createFenceAfterFlush(grContext);
+}
+
+SkBlendMode toSkiaBlendMode(BlendMode blendMode, std::optional<CompositeOperator> operation)
+{
+    switch (blendMode) {
+    case BlendMode::Normal:
+        switch (operation.value_or(CompositeOperator::SourceOver)) {
+        case CompositeOperator::Clear:
+            return SkBlendMode::kClear;
+        case CompositeOperator::Copy:
+            return SkBlendMode::kSrc;
+        case CompositeOperator::SourceOver:
+            return SkBlendMode::kSrcOver;
+        case CompositeOperator::SourceIn:
+            return SkBlendMode::kSrcIn;
+        case CompositeOperator::SourceOut:
+            return SkBlendMode::kSrcOut;
+        case CompositeOperator::SourceAtop:
+            return SkBlendMode::kSrcATop;
+        case CompositeOperator::DestinationOver:
+            return SkBlendMode::kDstOver;
+        case CompositeOperator::DestinationIn:
+            return SkBlendMode::kDstIn;
+        case CompositeOperator::DestinationOut:
+            return SkBlendMode::kDstOut;
+        case CompositeOperator::DestinationAtop:
+            return SkBlendMode::kDstATop;
+        case CompositeOperator::XOR:
+            return SkBlendMode::kXor;
+        case CompositeOperator::PlusLighter:
+            return SkBlendMode::kPlus;
+        case CompositeOperator::PlusDarker:
+            notImplemented();
+            return SkBlendMode::kSrcOver;
+        case CompositeOperator::Difference:
+            return SkBlendMode::kDifference;
+        }
+        break;
+    case BlendMode::Multiply:
+        return SkBlendMode::kMultiply;
+    case BlendMode::Screen:
+        return SkBlendMode::kScreen;
+    case BlendMode::Overlay:
+        return SkBlendMode::kOverlay;
+    case BlendMode::Darken:
+        return SkBlendMode::kDarken;
+    case BlendMode::Lighten:
+        return SkBlendMode::kLighten;
+    case BlendMode::ColorDodge:
+        return SkBlendMode::kColorDodge;
+    case BlendMode::ColorBurn:
+        return SkBlendMode::kColorBurn;
+    case BlendMode::HardLight:
+        return SkBlendMode::kHardLight;
+    case BlendMode::SoftLight:
+        return SkBlendMode::kSoftLight;
+    case BlendMode::Difference:
+        return SkBlendMode::kDifference;
+    case BlendMode::Exclusion:
+        return SkBlendMode::kExclusion;
+    case BlendMode::Hue:
+        return SkBlendMode::kHue;
+    case BlendMode::Saturation:
+        return SkBlendMode::kSaturation;
+    case BlendMode::Color:
+        return SkBlendMode::kColor;
+    case BlendMode::Luminosity:
+        return SkBlendMode::kLuminosity;
+    case BlendMode::PlusLighter:
+        return SkBlendMode::kPlus;
+    case BlendMode::PlusDarker:
+        notImplemented();
+        break;
+    }
+
+    return SkBlendMode::kSrcOver;
 }
 
 } // namespace SkiaUtilities

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
@@ -31,6 +31,7 @@
 #include <optional>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkBlendMode.h>
 #include <skia/core/SkRefCnt.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
 #include <skia/gpu/ganesh/GrDirectContext.h>
@@ -45,6 +46,8 @@ namespace WebCore {
 
 class BitmapTexture;
 class GLFence;
+enum class BlendMode : uint8_t;
+enum class CompositeOperator : uint8_t;
 
 namespace SkiaUtilities {
 
@@ -81,6 +84,8 @@ std::unique_ptr<GLFence> flushAndSubmitImageWithFence(GrDirectContext*, const sk
 // synchronization. Falls back to synchronous submit if fences are not
 // supported or creation fails, and returns nullptr.
 std::unique_ptr<GLFence> flushAndSubmitWithFence(GrDirectContext*);
+
+SkBlendMode toSkiaBlendMode(BlendMode, std::optional<CompositeOperator> = std::nullopt);
 
 } // namespace SkiaUtilities
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -424,6 +424,17 @@ void CoordinatedPlatformLayer::setOpacity(float opacity)
     notifyCompositionRequired();
 }
 
+void CoordinatedPlatformLayer::setBlendMode(BlendMode blendMode)
+{
+    ASSERT(m_lock.isHeld());
+    if (m_blendMode == blendMode)
+        return;
+
+    m_blendMode = blendMode;
+    m_pendingChanges.add(Change::BlendMode);
+    notifyCompositionRequired();
+}
+
 void CoordinatedPlatformLayer::setContentsVisible(bool contentsVisible)
 {
     ASSERT(m_lock.isHeld());
@@ -1242,6 +1253,11 @@ void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet
         if (m_pendingChanges.contains(Change::Opacity)) {
             layer.setOpacity(m_opacity);
             m_pendingChanges.remove(Change::Opacity);
+        }
+
+        if (m_pendingChanges.contains(Change::BlendMode)) {
+            layer.setBlendMode(m_blendMode);
+            m_pendingChanges.remove(Change::BlendMode);
         }
 
         if (m_pendingChanges.contains(Change::BackingStore)) {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -142,6 +142,7 @@ public:
     void setPreserves3D(bool);
     void setBackfaceVisibility(bool);
     void setOpacity(float);
+    void setBlendMode(BlendMode);
 
     void setContentsVisible(bool);
     bool contentsVisible() const;
@@ -234,31 +235,32 @@ private:
         Preserves3D                  = 1LLU << 8,
         BackfaceVisibility           = 1LLU << 9,
         Opacity                      = 1LLU << 10,
-        Children                     = 1LLU << 11,
-        BackingStore                 = 1LLU << 12,
-        ContentsVisible              = 1LLU << 13,
-        ContentsOpaque               = 1LLU << 14,
-        ContentsRect                 = 1LLU << 15,
-        ContentsRectClipsDescendants = 1LLU << 16,
-        ContentsClippingRect         = 1LLU << 17,
-        ContentsTiling               = 1LLU << 18,
-        ContentsBuffer               = 1LLU << 19,
-        ContentsImage                = 1LLU << 20,
-        ContentsColor                = 1LLU << 21,
-        ClipPath                     = 1LLU << 22,
-        Filters                      = 1LLU << 23,
-        Mask                         = 1LLU << 24,
-        Replica                      = 1LLU << 25,
-        Backdrop                     = 1LLU << 26,
-        BackdropRect                 = 1LLU << 27,
-        BackdropRoot                 = 1LLU << 28,
-        Animations                   = 1LLU << 29,
-        DebugIndicators              = 1LLU << 30,
+        BlendMode                    = 1LLU << 11,
+        Children                     = 1LLU << 12,
+        BackingStore                 = 1LLU << 13,
+        ContentsVisible              = 1LLU << 14,
+        ContentsOpaque               = 1LLU << 15,
+        ContentsRect                 = 1LLU << 16,
+        ContentsRectClipsDescendants = 1LLU << 17,
+        ContentsClippingRect         = 1LLU << 18,
+        ContentsTiling               = 1LLU << 19,
+        ContentsBuffer               = 1LLU << 20,
+        ContentsImage                = 1LLU << 21,
+        ContentsColor                = 1LLU << 22,
+        ClipPath                     = 1LLU << 23,
+        Filters                      = 1LLU << 24,
+        Mask                         = 1LLU << 25,
+        Replica                      = 1LLU << 26,
+        Backdrop                     = 1LLU << 27,
+        BackdropRect                 = 1LLU << 28,
+        BackdropRoot                 = 1LLU << 29,
+        Animations                   = 1LLU << 30,
+        DebugIndicators              = 1LLU << 31,
 #if ENABLE(DAMAGE_TRACKING)
-        Damage                       = 1LLU << 31,
+        Damage                       = 1LLU << 32,
 #endif
 #if ENABLE(SCROLLING_THREAD)
-        ScrollingNode                = 1LLU << 32
+        ScrollingNode                = 1LLU << 33
 #endif
     };
 
@@ -296,6 +298,7 @@ private:
     bool m_preserves3D WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_backfaceVisibility WTF_GUARDED_BY_LOCK(m_lock) { true };
     float m_opacity WTF_GUARDED_BY_LOCK(m_lock) { 1. };
+    BlendMode m_blendMode WTF_GUARDED_BY_LOCK(m_lock) { BlendMode::Normal };
     bool m_contentsVisible WTF_GUARDED_BY_LOCK(m_lock) { true };
     bool m_contentsOpaque WTF_GUARDED_BY_LOCK(m_lock) { false };
     FloatRect m_contentsRect WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -282,6 +282,15 @@ void GraphicsLayerCoordinated::setOpacity(float opacity)
     noteLayerPropertyChanged(Change::Opacity, ScheduleFlush::Yes);
 }
 
+void GraphicsLayerCoordinated::setBlendMode(BlendMode blendMode)
+{
+    if (m_blendMode == blendMode)
+        return;
+
+    GraphicsLayer::setBlendMode(blendMode);
+    noteLayerPropertyChanged(Change::BlendMode, ScheduleFlush::Yes);
+}
+
 void GraphicsLayerCoordinated::setContentsVisible(bool contentsVisible)
 {
     if (m_contentsVisible == contentsVisible)
@@ -1084,6 +1093,9 @@ void GraphicsLayerCoordinated::commitLayerChanges(CommitState& commitState, floa
 
     if (m_pendingChanges.contains(Change::Opacity))
         m_platformLayer->setOpacity(m_opacity);
+
+    if (m_pendingChanges.contains(Change::BlendMode))
+        m_platformLayer->setBlendMode(m_blendMode);
 
     if (m_pendingChanges.contains(Change::ContentsVisible)) {
         m_platformLayer->setContentsVisible(m_contentsVisible);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -71,6 +71,7 @@ private:
     void setPreserves3D(bool) override;
     void setBackfaceVisibility(bool) override;
     void setOpacity(float) override;
+    void setBlendMode(BlendMode) override;
     void setContentsVisible(bool) override;
     void setContentsOpaque(bool) override;
     void setContentsRect(const FloatRect&) override;
@@ -142,32 +143,33 @@ private:
         Preserves3D                  = 1LLU << 5,
         BackfaceVisibility           = 1LLU << 6,
         Opacity                      = 1LLU << 7,
-        Children                     = 1LLU << 8,
-        ContentsVisible              = 1LLU << 9,
-        ContentsOpaque               = 1LLU << 10,
-        ContentsRect                 = 1LLU << 11,
-        ContentsRectClipsDescendants = 1LLU << 12,
-        ContentsClippingRect         = 1LLU << 13,
-        ContentsScale                = 1LLU << 14,
-        ContentsTiling               = 1LLU << 15,
-        ContentsBuffer               = 1LLU << 16,
-        ContentsBufferNeedsDisplay   = 1LLU << 17,
-        ContentsImage                = 1LLU << 18,
-        ContentsColor                = 1LLU << 19,
-        DirtyRegion                  = 1LLU << 20,
-        EventRegion                  = 1LLU << 21,
-        Shape                        = 1LLU << 22,
-        Filters                      = 1LLU << 23,
-        Mask                         = 1LLU << 24,
-        Replica                      = 1LLU << 25,
-        Backdrop                     = 1LLU << 26,
-        BackdropRect                 = 1LLU << 27,
-        BackdropRoot                 = 1LLU << 28,
-        Animations                   = 1LLU << 29,
-        TileCoverage                 = 1LLU << 30,
-        DebugIndicators              = 1LLU << 31,
+        BlendMode                    = 1LLU << 8,
+        Children                     = 1LLU << 9,
+        ContentsVisible              = 1LLU << 10,
+        ContentsOpaque               = 1LLU << 11,
+        ContentsRect                 = 1LLU << 12,
+        ContentsRectClipsDescendants = 1LLU << 13,
+        ContentsClippingRect         = 1LLU << 14,
+        ContentsScale                = 1LLU << 15,
+        ContentsTiling               = 1LLU << 16,
+        ContentsBuffer               = 1LLU << 17,
+        ContentsBufferNeedsDisplay   = 1LLU << 18,
+        ContentsImage                = 1LLU << 19,
+        ContentsColor                = 1LLU << 20,
+        DirtyRegion                  = 1LLU << 21,
+        EventRegion                  = 1LLU << 22,
+        Shape                        = 1LLU << 23,
+        Filters                      = 1LLU << 24,
+        Mask                         = 1LLU << 25,
+        Replica                      = 1LLU << 26,
+        Backdrop                     = 1LLU << 27,
+        BackdropRect                 = 1LLU << 28,
+        BackdropRoot                 = 1LLU << 29,
+        Animations                   = 1LLU << 30,
+        TileCoverage                 = 1LLU << 31,
+        DebugIndicators              = 1LLU << 32,
 #if ENABLE(SCROLLING_THREAD)
-        ScrollingNode                = 1LLU << 32
+        ScrollingNode                = 1LLU << 33
 #endif
     };
 


### PR DESCRIPTION
#### 4e375d40055b1f45d5af2017eee981f4b0f3b139
<pre>
[GTK][WPE] Skia Compositor: implement blend modes
<a href="https://bugs.webkit.org/show_bug.cgi?id=313124">https://bugs.webkit.org/show_bug.cgi?id=313124</a>

Reviewed by Nikolas Zimmermann.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::drawNativeImage):
(WebCore::GraphicsContextSkia::createFillPaint const):
(WebCore::GraphicsContextSkia::createStrokePaint const):
(WebCore::GraphicsContextSkia::saveLayer):
(WebCore::GraphicsContextSkia::drawPattern):
(WebCore::toSkiaBlendMode): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::setBlendMode):
(WebCore::SkiaCompositingLayer::paintSelf):
(WebCore::SkiaCompositingLayer::paintSelfAndChildren):
(WebCore::SkiaCompositingLayer::recursivePaint):
(WebCore::SkiaCompositingLayer::paintUsingOverlapRegions):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp:
(WebCore::SkiaUtilities::toSkiaBlendMode):
* Source/WebCore/platform/graphics/skia/SkiaUtilities.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setBlendMode):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
(WebCore::CoordinatedPlatformLayer::WTF_GUARDED_BY_LOCK):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::setBlendMode):
(WebCore::GraphicsLayerCoordinated::commitLayerChanges):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:

Canonical link: <a href="https://commits.webkit.org/311943@main">https://commits.webkit.org/311943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de9dd627e96df6a9afb8a0ed4b830a554496ed17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167327 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122760 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103430 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15098 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169817 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15562 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130949 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31613 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131063 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141949 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89435 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24098 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25754 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18755 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31070 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97084 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30590 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30744 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->