### PR TITLE
Cherry-pick 311544@main (fc2dea65e706). https://bugs.webkit.org/show_bug.cgi?id=312725

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
@@ -148,7 +148,7 @@ bool AccessibilityObjectAtspi::focus() const
     if (!m_coreObject)
         return false;
 
-    RefPtr<AXCoreObject> coreObject = m_coreObject;
+    Ref coreObject = *m_coreObject;
     coreObject->setFocused(true);
     coreObject->updateBackingStore();
     return coreObject->isFocused();

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
@@ -148,9 +148,10 @@ bool AccessibilityObjectAtspi::focus() const
     if (!m_coreObject)
         return false;
 
-    m_coreObject->setFocused(true);
-    m_coreObject->updateBackingStore();
-    return m_coreObject->isFocused();
+    RefPtr<AXCoreObject> coreObject = m_coreObject;
+    coreObject->setFocused(true);
+    coreObject->updateBackingStore();
+    return coreObject->isFocused();
 }
 
 float AccessibilityObjectAtspi::opacity() const


### PR DESCRIPTION
#### 20a1eb73acf56ebbfe53c7a4ceabd542da1f546b
<pre>
Cherry-pick 311544@main (fc2dea65e706). <a href="https://bugs.webkit.org/show_bug.cgi?id=312725">https://bugs.webkit.org/show_bug.cgi?id=312725</a>

    AX: Clean up ref handling in AccessibilityObjectAtspi::focus()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312725">https://bugs.webkit.org/show_bug.cgi?id=312725</a>

    Reviewed by Claudio Saavedra.

    There is already a check that m_coreObject is not nullptr, so this can
    be a Ref.

    * Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp:
    (WebCore::AccessibilityObjectAtspi::focus const):

    Canonical link: <a href="https://commits.webkit.org/311544@main">https://commits.webkit.org/311544@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.452@webkitglib/2.52">https://commits.webkit.org/305877.452@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c00042e805933e1b40466c97f9401ded026e1ee6
<pre>
Cherry-pick 311534@main (d7f440a382f0). <a href="https://bugs.webkit.org/show_bug.cgi?id=286444">https://bugs.webkit.org/show_bug.cgi?id=286444</a>

    AX: Check for object going away when handling GrabFocus
    <a href="https://bugs.webkit.org/show_bug.cgi?id=286444">https://bugs.webkit.org/show_bug.cgi?id=286444</a>

    Reviewed by Claudio Saavedra.

    Calling setFocused or updateBackingStore could delete the reference to the
    object.

    * Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp:
    (WebCore::AccessibilityObjectAtspi::focus const):

    Canonical link: <a href="https://commits.webkit.org/311534@main">https://commits.webkit.org/311534@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.451@webkitglib/2.52">https://commits.webkit.org/305877.451@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea3bf92fc469872332acc2c73c8c59ea7b15a415

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158239 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31576 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24771 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167068 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112323 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160110 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31713 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31594 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122548 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112323 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161197 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/31713 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/24771 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103217 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/31713 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/31594 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14840 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/31713 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/24771 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169557 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15194 "Failed to checkout and rebase branch from PR 63419") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/24771 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/169557 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31322 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/31594 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/169557 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31260 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/24771 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89158 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24066 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/31260 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/24771 "Unable to build WebKit without PR, please check manually (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30812 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96604 "Failed to checkout and rebase branch from PR 63419") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30333 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30563 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30460 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->