### PR TITLE
ANGLE: VertexAttributeShiftInstancedArrayDataWithOffsetTest.ShiftInstancedArrayDataWithOffsetSlowPath fails validation

### DIFF
--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/VertexAttributeTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/VertexAttributeTest.cpp
@@ -5974,8 +5974,8 @@ TEST_P(VertexAttributeShiftInstancedArrayDataWithOffsetTest,
 attribute vec4 instance;
 varying vec4 color;
 void main() {
-    gl_Position = position + instance * 0.001;
-    color = vec4(1, 0, 0, 1);
+    gl_Position = position;
+    color = vec4(instance.x, 1.0, 0, 1.0);
 })";
     constexpr char kFS[] = R"(varying lowp vec4 color;
 void main() {
@@ -5987,28 +5987,46 @@ void main() {
     GLint posLoc  = glGetAttribLocation(program, "position");
     GLint instLoc = glGetAttribLocation(program, "instance");
 
-    auto quadVertices = GetQuadVertices();
+    const int first       = 100;
+    const int vertexCount = 6;
+    auto quadVertices     = GetQuadVertices();
+    std::vector<Vector3> posData(first + quadVertices.size());
+    // Place quad vertices at the 'first' offset so they are read during the draw.
+    std::copy(quadVertices.begin(), quadVertices.end(), posData.begin() + first);
     GLBuffer posBuf;
     glBindBuffer(GL_ARRAY_BUFFER, posBuf);
-    glBufferData(GL_ARRAY_BUFFER, quadVertices.size() * sizeof(Vector3), quadVertices.data(),
+    glBufferData(GL_ARRAY_BUFFER, posData.size() * sizeof(Vector3), posData.data(),
                  GL_STATIC_DRAW);
     glEnableVertexAttribArray(posLoc);
     glVertexAttribPointer(posLoc, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
 
-    const int instanceCount = 1024;
-    const int srcStride     = 20;  // 20 bytes stride for vec4 (16 bytes) forces slow path
-    std::vector<uint8_t> instData(instanceCount * srcStride, 0);
+    constexpr int instanceCount = 1024;
+    struct Inst {
+        float v0 = 1.0;
+        float v1 = 0.0;
+        float v2 = 0.0;
+        float v3 = 0.0;
+        float v4 = 0.0;
+    };
+    constexpr int srcStride = sizeof(Inst);  // 20 bytes stride for vec4 (16 bytes) forces slow path
+    static_assert(srcStride == 20);
+    std::array<Inst, instanceCount> instData;
     GLBuffer instBuf;
     glBindBuffer(GL_ARRAY_BUFFER, instBuf);
-    glBufferData(GL_ARRAY_BUFFER, instData.size(), instData.data(), GL_STATIC_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, instData.size() * sizeof(Inst), instData.data(), GL_STATIC_DRAW);
     glEnableVertexAttribArray(instLoc);
     glVertexAttribPointer(instLoc, 4, GL_FLOAT, GL_FALSE, srcStride, nullptr);
     glVertexAttribDivisorANGLE(instLoc, 1);
 
-    const int first = 100;
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_ONE, GL_ONE);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
     // This will trigger the workaround and the overflow if the fix is not present.
-    glDrawArraysInstancedANGLE(GL_TRIANGLES, first, 6, instanceCount);
+    glDrawArraysInstancedANGLE(GL_TRIANGLES, first, vertexCount, instanceCount);
     EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_RECT_EQ(0, 0, getWindowWidth(), getWindowHeight(), GLColor::yellow);
 }
 
 class VertexAttributeUint8Test : public VertexAttributeTestES3


### PR DESCRIPTION
#### d58f5b9e11ca024fcbdf8bd4539e6602e84409e7
<pre>
ANGLE: VertexAttributeShiftInstancedArrayDataWithOffsetTest.ShiftInstancedArrayDataWithOffsetSlowPath fails validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=313125">https://bugs.webkit.org/show_bug.cgi?id=313125</a>
<a href="https://rdar.apple.com/175417671">rdar://175417671</a>

Reviewed by Dan Glastonbury.

The test set up 6 vertices but was accessing vertices 100...106.
Fix by adding the needed vertices and verifying that the test actually
draws and actually draws with with instancing.

* Source/ThirdParty/ANGLE/src/tests/gl_tests/VertexAttributeTest.cpp:

Canonical link: <a href="https://commits.webkit.org/311935@main">https://commits.webkit.org/311935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67f13d584609c20955028c2e2a4e7b1abf5b2186

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167070 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112325 "Failed to checkout and rebase branch from PR 63420") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122549 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/112325 "Failed to checkout and rebase branch from PR 63420") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103218 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23877 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22238 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14842 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133562 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169559 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130730 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26302 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130845 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35468 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141713 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89162 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25555 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18519 "Found 1 new test failure: http/tests/webgpu/webgpu/web_platform/copyToTexture/image_file.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30814 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30335 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30565 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30462 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->