### PR TITLE
[GLIB] Assorted IPC testing fixes

### DIFF
--- a/LayoutTests/ipc/serialized-type-info.html
+++ b/LayoutTests/ipc/serialized-type-info.html
@@ -142,6 +142,7 @@
             "uint16_t",
             "int64_t",
             "pid_t",
+            "size_t",
             "String",
             "WTF::String",
             "uint32_t",

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3568,6 +3568,7 @@ http/tests/ipc/gpu-load-error-empty-user-info-crssh.html [ Skip ]
 
 # ATTACHMENT_ELEMENT is disabled in glib ports.
 ipc/restrictedendpoints/allow-access-attachmentElement.html [ Skip ]
+ipc/restrictedendpoints/deny-access-attachmentElement.html [ Skip ]
 
 # libwebrtc-specific.
 ipc/videoEncode.html [ Skip ]
@@ -3593,7 +3594,6 @@ ipc/stream-sync-reply-shared-memory.html [ Failure ]
 ipc/decode-feConvolveMatrix-kernelSize-overflow.html [ Failure ]
 ipc/invalid-addSourceBuffer-to-GPU-process-crash.html [ Failure ]
 ipc/restore-empty-stack-crash.html [ Failure ]
-ipc/restrictedendpoints/deny-access-attachmentElement.html [ Failure ]
 ipc/serialized-type-info.html [ Failure ]
 
 ipc/restrictedendpoints/deny-access-testOnlyIPC.html [ Crash ]

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7941,6 +7941,7 @@ header: <WebCore/WebCodecsEncodedAudioChunk.h>
 
 #if USE(LIBRICE)
 header: <WebCore/RiceGatherResult.h>
+using WebCore::RiceSocket = std::pair<String, WebCore::RTCIceProtocol>;
 [CustomHeader] struct WebCore::RiceGatherResult {
     HashMap<WebCore::RiceSocket, String> addresses;
     Vector<WebCore::RiceSocket> turnAddresses;


### PR DESCRIPTION
#### b7c5e6a19552b5dabd0427ff351a73afe1a63639
<pre>
[GLIB] Assorted IPC testing fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=313126">https://bugs.webkit.org/show_bug.cgi?id=313126</a>

Reviewed by Fujii Hironori.

* LayoutTests/ipc/serialized-type-info.html: Add missing size_t fundamental type.
* LayoutTests/platform/glib/TestExpectations: Skip test for feature disabled in GLib ports.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in: Add definition of WebCore::RiceSocket.

Canonical link: <a href="https://commits.webkit.org/311917@main">https://commits.webkit.org/311917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e30d9b48f9c518bb5a8867a0a0709fe24eecf204

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167071 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112326 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122550 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86019 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23878 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22240 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14843 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169560 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14972 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21544 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130731 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130846 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89165 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24082 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18521 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30815 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96402 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30336 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30566 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->