### PR TITLE
AX: The scroll position applied during convertFrameToSpace needs to include content insets

### DIFF
--- a/LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame-after-scroll-expected.txt
+++ b/LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame-after-scroll-expected.txt
@@ -1,0 +1,8 @@
+This test verifies that the scroll area position remains correct after scrolling when a content inset is active.
+
+PASS: scrollArea.y === scrollAreaYBeforeScroll
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame-after-scroll.html
+++ b/LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame-after-scroll.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>body { height: 10000px; }</style>
+</head>
+<body>
+<script>
+window.jsTestIsAsync = true;
+
+var output = "This test verifies that the scroll area position remains correct after scrolling when a content inset is active.\n\n";
+
+var scrollArea, webArea, scrollAreaYBeforeScroll, initialWebAreaY;
+if (window.accessibilityController) {
+    setTimeout(async () => {
+        await waitForFrameGeometryReady();
+
+        scrollArea = accessibilityController.rootElement;
+        webArea = scrollArea.childAtIndex(0);
+
+        // Set the content inset and wait for the geometry update to propagate.
+        initialWebAreaY = webArea.y;
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
+        await waitFor(() => webArea.y !== initialWebAreaY);
+
+        scrollAreaYBeforeScroll = scrollArea.y;
+        let webAreaYBeforeScroll = webArea.y;
+
+        // Scroll and verify the scroll area position stays fixed.
+        window.scrollTo(0, 500);
+        await waitFor(() => webArea.y !== webAreaYBeforeScroll);
+
+        output += expect("scrollArea.y", "scrollAreaYBeforeScroll");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1194,10 +1194,10 @@ void AXObjectCache::setFrameGeometry(LocalFrame& frame, const AXFrameGeometry& g
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID)) {
-        IntPoint scrollPosition;
+        IntPoint viewOriginScrollPosition;
         if (CheckedPtr view = frame.view())
-            scrollPosition = view->scrollPosition();
-        tree->setFrameGeometry(AXFrameGeometry { geometry }, scrollPosition);
+            viewOriginScrollPosition = IntPoint(view->documentScrollPositionRelativeToViewOrigin());
+        tree->setFrameGeometry(AXFrameGeometry { geometry }, viewOriginScrollPosition);
     }
 #endif
 }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -589,12 +589,13 @@ FloatRect AccessibilityObject::convertFrameToSpace(const FloatRect& frameRect, A
         auto scaledRect = geometry.screenTransform.mapRect(FloatRect(snappedFrameRect));
 
         auto screenPosition = geometry.screenPosition;
-        // The root scroll view represents the viewport, which doesn't account for it scroll.
-        // Undo the scroll component to get the viewport's fixed screen position.
+        // screenPosition tracks the document origin, which moves with scroll.
+        // The viewport is fixed on screen, so subtract the scroll and content
+        // inset offsets that contentsToView baked into screenPosition.
         if (this == rootScrollView.get()) {
             if (RefPtr scrollView = rootScrollView->scrollView()) {
-                auto scrollOffset = geometry.screenTransform.mapPoint(FloatPoint(scrollView->scrollPosition()));
-                screenPosition.move(-roundToInt(scrollOffset.x()), -roundToInt(scrollOffset.y()));
+                auto viewOriginScrollPosition = geometry.screenTransform.mapPoint(FloatPoint(scrollView->documentScrollPositionRelativeToViewOrigin()));
+                screenPosition.move(-roundToInt(viewOriginScrollPosition.x()), -roundToInt(viewOriginScrollPosition.y()));
             }
         }
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1638,11 +1638,12 @@ FloatRect AXIsolatedObject::convertFrameToSpace(const FloatRect& rect, Accessibi
         auto screenTransform = frameScreenTransform();
         auto scaledRect = screenTransform.mapRect(rect);
 
-        // The root scroll view represents the viewport, which doesn't account for it scroll.
-        // Undo the scroll component to get the viewport's fixed screen position.
+        // screenPosition tracks the document origin, which moves with scroll.
+        // The viewport is fixed on screen, so subtract the scroll and content
+        // inset offsets that contentsToView baked into screenPosition.
         if (isScrollArea() && !parent()) {
-            auto scrollOffset = screenTransform.mapPoint(FloatPoint(tree().frameScrollPosition()));
-            screenPosition.move(-roundToInt(scrollOffset.x()), -roundToInt(scrollOffset.y()));
+            auto viewOriginScrollPosition = screenTransform.mapPoint(FloatPoint(tree().frameViewOriginScrollPosition()));
+            screenPosition.move(-roundToInt(viewOriginScrollPosition.x()), -roundToInt(viewOriginScrollPosition.y()));
         }
 
         // Screen coordinates use bottom-left origin (on macOS).

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1261,20 +1261,20 @@ void AXIsolatedTree::setSelectedTextMarkerRange(AXTextMarkerRange&& range)
 }
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-void AXIsolatedTree::setFrameGeometry(AXFrameGeometry&& geometry, IntPoint scrollPosition)
+void AXIsolatedTree::setFrameGeometry(AXFrameGeometry&& geometry, IntPoint viewOriginScrollPosition)
 {
     Locker locker { m_changeLogLock };
     m_pendingFrameGeometry = WTF::move(geometry);
-    m_pendingFrameScrollPosition = scrollPosition;
+    m_pendingFrameViewOriginScrollPosition = viewOriginScrollPosition;
 }
 
 void AXIsolatedTree::updateFrameGeometryAndScrollPositionIfNeeded(AXObjectCache& cache)
 {
     if (std::optional geometry = cache.getAndUpdateFrameGeometry()) {
-        IntPoint scrollPosition;
+        IntPoint viewOriginScrollPosition;
         if (CheckedPtr view = cache.document()->view())
-            scrollPosition = view->scrollPosition();
-        setFrameGeometry(AXFrameGeometry { *geometry }, scrollPosition);
+            viewOriginScrollPosition = IntPoint(view->documentScrollPositionRelativeToViewOrigin());
+        setFrameGeometry(AXFrameGeometry { *geometry }, viewOriginScrollPosition);
     }
 }
 #endif
@@ -1678,8 +1678,8 @@ void AXIsolatedTree::applyPendingChangesLocked()
         m_frameGeometry = std::exchange(m_pendingFrameGeometry, std::nullopt).value();
         m_hasReceivedFrameGeometry = true;
     }
-    if (m_pendingFrameScrollPosition)
-        m_frameScrollPosition = std::exchange(m_pendingFrameScrollPosition, std::nullopt).value();
+    if (m_pendingFrameViewOriginScrollPosition)
+        m_frameViewOriginScrollPosition = std::exchange(m_pendingFrameViewOriginScrollPosition, std::nullopt).value();
 #endif
 
     // Do this at the end because it requires looking up the root node by ID, so doing it at the end

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -446,9 +446,9 @@ public:
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     AXFrameGeometry frameGeometry() const { return m_frameGeometry; }
-    IntPoint frameScrollPosition() const { return m_frameScrollPosition; }
+    IntPoint frameViewOriginScrollPosition() const { return m_frameViewOriginScrollPosition; }
     bool isFrameGeometryInitialized() const { return m_hasReceivedFrameGeometry; }
-    void setFrameGeometry(AXFrameGeometry&&, IntPoint scrollPosition);
+    void setFrameGeometry(AXFrameGeometry&&, IntPoint viewOriginScrollPosition);
     void updateFrameGeometryAndScrollPositionIfNeeded(AXObjectCache&);
 #endif
 
@@ -688,7 +688,7 @@ private:
     std::optional<AXTextMarkerRange> m_pendingSelectedTextMarkerRange WTF_GUARDED_BY_LOCK(m_changeLogLock);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     std::optional<AXFrameGeometry> m_pendingFrameGeometry WTF_GUARDED_BY_LOCK(m_changeLogLock);
-    std::optional<IntPoint> m_pendingFrameScrollPosition WTF_GUARDED_BY_LOCK(m_changeLogLock);
+    std::optional<IntPoint> m_pendingFrameViewOriginScrollPosition WTF_GUARDED_BY_LOCK(m_changeLogLock);
 #endif
     Markable<AXID> m_focusedNodeID;
     std::atomic<double> m_loadingProgress { 0 };
@@ -701,7 +701,7 @@ private:
     HashMap<AXID, AXRelations> m_relations;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     AXFrameGeometry m_frameGeometry;
-    IntPoint m_frameScrollPosition;
+    IntPoint m_frameViewOriginScrollPosition;
     bool m_hasReceivedFrameGeometry { false };
 #endif
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1131,8 +1131,12 @@ void LocalFrameView::obscuredContentInsetsDidChange(const FloatBoxExtent& newObs
             tiledBacking->setObscuredContentInsets(newObscuredContentInsets);
     }
 
-    if (RefPtr page = m_frame->page())
+    if (RefPtr page = m_frame->page()) {
         page->chrome().client().setNeedsFixedContainerEdgesUpdate();
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+        page->chrome().client().scheduleAccessibilityFrameGeometryUpdate();
+#endif
+    }
 }
 
 void LocalFrameView::topContentDirectionDidChange()


### PR DESCRIPTION
#### 023b7cdd7312232a6c26168c008d5cc60c6d0be7
<pre>
AX: The scroll position applied during convertFrameToSpace needs to include content insets
<a href="https://bugs.webkit.org/show_bug.cgi?id=313130">https://bugs.webkit.org/show_bug.cgi?id=313130</a>
<a href="https://rdar.apple.com/175426173">rdar://175426173</a>

Reviewed by Tyler Wilcock.

When we compute the screen position for AXFrameGeometry, that calculation has the scroll
position baked in using documentScrollPositionRelativeToViewOrigin, not the regular scroll
offset. We need to make sure convertFrameToSpace matches that, so that when we &quot;undo&quot;
the scroll offset to compute the bounds of the scroll view, we get an accurate position.

This PR also adds a hook to trigger a frame geometry update whenever the content insets
change. Before, this worked by chance, so now we make that update explicit.

A new test was added to verify that we verify that the scroll view&apos;s screen position stays
consistent after scrolling with a content inset.

Test: platform/mac-wk2/accessibility/content-inset-scrollview-frame-after-scroll.html

* LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame-after-scroll-expected.txt: Added.
* LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame-after-scroll.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::setFrameGeometry):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::convertFrameToSpace const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::convertFrameToSpace const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::setFrameGeometry):
(WebCore::AXIsolatedTree::updateFrameGeometryAndScrollPositionIfNeeded):
(WebCore::AXIsolatedTree::applyPendingChangesLocked):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::frameViewOriginScrollPosition const):
(WebCore::AXIsolatedTree::frameScrollPosition const): Deleted.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::obscuredContentInsetsDidChange):

Canonical link: <a href="https://commits.webkit.org/311997@main">https://commits.webkit.org/311997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b25fb2182fca1a4351ea59b63c8e3f9ff32ce98c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167384 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112639 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6a03678-353f-41eb-abd4-66f114f108ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122809 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86183 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f81c7572-8dc7-4b68-9f41-7277fd352fc6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103479 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce1f9eb0-807a-4c1b-8919-114ea7155c18) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24125 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22521 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15155 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169874 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15619 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130996 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131110 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35499 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142000 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89522 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18808 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97141 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30647 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30920 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30801 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->