### PR TITLE
http/tests/frame-throttling/raf-throttle-in-cross-origin-subframe.html is flaky

### DIFF
--- a/LayoutTests/http/tests/frame-throttling/raf-throttle-in-cross-origin-subframe-expected.txt
+++ b/LayoutTests/http/tests/frame-throttling/raf-throttle-in-cross-origin-subframe-expected.txt
@@ -6,9 +6,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 Received message: frameload
 Received message: frameload
 Checking that requestAnimationFrame is throttled in cross origin frame
-Received message: throttled[cross]: NonInteractiveCrossOriginFrame
+Received message: throttled[cross]: NonInteractedCrossOriginFrame
 Received message: throttled[same]: [Unthrottled]
-PASS throttledState['cross'] is "NonInteractiveCrossOriginFrame"
+PASS throttledState['cross'] is "NonInteractedCrossOriginFrame"
 PASS throttledState['same'] is "[Unthrottled]"
 Interacted with cross-origin frame
 Interacted with same-origin frame

--- a/LayoutTests/http/tests/frame-throttling/raf-throttle-in-cross-origin-subframe.html
+++ b/LayoutTests/http/tests/frame-throttling/raf-throttle-in-cross-origin-subframe.html
@@ -22,70 +22,58 @@
         'same' : undefined,
     }
 
-    var messageHandler;
-    var messagesReceived = 0;
+    var frameLoadCount = 0;
 
-    function interactWithSubframes()
+    function queryThrottleState(frame, id)
     {
-        UIHelper.activateAt(crossOriginFrame.offsetLeft + 20, crossOriginFrame.offsetTop + 20).then(function() {
-            debug("Interacted with cross-origin frame");
-            UIHelper.activateAt(sameOriginFrame.offsetLeft + 20, sameOriginFrame.offsetTop + 20).then(function() {
-                debug("Interacted with same-origin frame");
-                messageHandler = checkUnthrottledAfterInteraction;
-                messagesReceived = 0;
-                crossOriginFrame.contentWindow.postMessage("report-throttle-cross", "*");
-                sameOriginFrame.contentWindow.postMessage("report-throttle-same", "*");
-            });
+        return new Promise(function(resolve) {
+            function handler(message) {
+                var re = /throttled\[(\w+)\]: ((\w+)(\|\w+)*|\[Unthrottled\])/;
+                var match = re.exec(message.data);
+                if (match && match[1] === id) {
+                    window.removeEventListener("message", handler);
+                    debug("Received message: " + message.data);
+                    throttledState[id] = match[2];
+                    resolve();
+                }
+            }
+            window.addEventListener("message", handler);
+            frame.contentWindow.postMessage("report-throttle-" + id, "*");
         });
     }
 
-    function runTest()
+    async function runTest()
     {
         crossOriginFrame = document.getElementById("cross-origin-frame");
         sameOriginFrame = document.getElementById("same-origin-frame");
 
         debug("Checking that requestAnimationFrame is throttled in cross origin frame");
-        
-        messageHandler = checkInitiallyThrottled;
-        messagesReceived = 0;
-        crossOriginFrame.contentWindow.postMessage("report-throttle-cross", "*");
-        sameOriginFrame.contentWindow.postMessage("report-throttle-same", "*");
-    }
 
-    function checkInitiallyThrottled()
-    {
-        shouldBeEqualToString("throttledState['cross']", "NonInteractiveCrossOriginFrame");
+        await queryThrottleState(crossOriginFrame, "cross");
+        await queryThrottleState(sameOriginFrame, "same");
+        shouldBeEqualToString("throttledState['cross']", "NonInteractedCrossOriginFrame");
         shouldBeEqualToString("throttledState['same']", "[Unthrottled]");
-        interactWithSubframes();
-    }
 
-    function checkUnthrottledAfterInteraction()
-    {
+        await UIHelper.activateAt(crossOriginFrame.offsetLeft + 20, crossOriginFrame.offsetTop + 20);
+        debug("Interacted with cross-origin frame");
+        await UIHelper.activateAt(sameOriginFrame.offsetLeft + 20, sameOriginFrame.offsetTop + 20);
+        debug("Interacted with same-origin frame");
+
+        await queryThrottleState(crossOriginFrame, "cross");
+        await queryThrottleState(sameOriginFrame, "same");
         shouldBeEqualToString("throttledState['cross']", "[Unthrottled]");
         shouldBeEqualToString("throttledState['same']", "[Unthrottled]");
+
         finishJSTest();
     }
 
     window.onmessage = function(message)
     {
-        debug("Received message: " + message.data);
         if (message.data === "frameload") {
-            if (++messagesReceived == 2)
+            debug("Received message: " + message.data);
+            if (++frameLoadCount == 2)
                 runTest();
-            return;
         }
-
-        var re = /throttled\[(\w+)\]: ((\w+)(\|\w+)*|\[Unthrottled\])/;
-        var match = re.exec(message.data);
-        if (match) {
-            frameID = match[1];
-            throttledState[frameID] = match[2];
-            if (++messagesReceived == 2)
-                messageHandler();
-            return;
-        }
-        
-        debug("Failed to handle message " + message.data);
     }
     </script>
 </head>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1500,8 +1500,6 @@ webkit.org/b/210517 storage/indexeddb/result-request-cycle.html [ Pass Failure ]
 
 webkit.org/b/211856 media/video-poster-set-after-playback.html [ Pass Failure ]
 
-http/tests/frame-throttling/raf-throttle-in-cross-origin-subframe.html [ Pass Failure ]
-
 webkit.org/b/212215 media/video-isplayingtoautomotiveheadunit.html [ Pass Failure ]
 
 webkit.org/b/212219 media/track/track-cue-missing.html [ Pass Failure ]


### PR DESCRIPTION
#### db63ddf0702c0d89f925e983ad07d7b90a69f7a7
<pre>
http/tests/frame-throttling/raf-throttle-in-cross-origin-subframe.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=313132">https://bugs.webkit.org/show_bug.cgi?id=313132</a>
<a href="https://rdar.apple.com/168818015">rdar://168818015</a>

Reviewed by Simon Fraser.

The test was consistently failing now because of the stale enum name: NonInteractiveCrossOriginFrame.
Fixed it by updating it to use NonInteractedCrossOriginFrame instead to match the source in AnimationFrameRate.h.

The flakiness was caused by non-deterministic ordering between script executions in two iframes.
Replaced the fire-both-and-wait-for-two pattern with a sequential queryThrottleState helper that uses a per-query
addEventListener, posts to one frame at a time, and awaits the response before proceeding to the next.

The window.onmessage handler now only handles frameload messages. This guarantees cross-origin is always queried
and logged before same-origin.

* LayoutTests/http/tests/frame-throttling/raf-throttle-in-cross-origin-subframe-expected.txt:
* LayoutTests/http/tests/frame-throttling/raf-throttle-in-cross-origin-subframe.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/311875@main">https://commits.webkit.org/311875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dae71193ef0a6c2852675c5deda563cecf6fe7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167092 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160134 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122571 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103240 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14864 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169581 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15160 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130754 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31346 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130867 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89196 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25577 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18542 "Failed to checkout and rebase branch from PR 63426") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190392 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30836 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/190392 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30357 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30587 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30484 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->