### PR TITLE
AX: [iOS] Migrate to the BEKit versions of details, keyshortcuts, and orientation in the wrapper

### DIFF
--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -73,6 +73,10 @@
 #import "ModelPlayerAccessibilityChildren.h"
 #endif
 
+#if USE(BROWSERENGINEKIT)
+#import <BrowserEngineKit/BrowserEngineKit.h>
+#endif
+
 #if ENABLE(SPATIAL_IMAGE_CONTROLS)
 #import "HTMLImageElement.h"
 #import "SpatialImageControls.h"
@@ -2093,7 +2097,7 @@ static NSArray *accessibleElementsForObjects(const AXCoreObject::AccessibilityCh
     return makeNSArray(accessibleElements);
 }
 
-- (NSArray *)accessibilityDetailsElements
+- (NSArray<NSObject *> *)browserAccessibilityDetailsElements
 {
     if (![self _prepareAccessibilityCall])
         return nil;
@@ -3372,30 +3376,32 @@ static RenderObject* rendererForView(WAKView* view)
     return [NSString stringWithFormat:@"%@: %@", [self class], [self accessibilityLabel]];
 }
 
-- (AccessibilityOrientation)accessibilityOrientation
+#if USE(BROWSERENGINEKIT)
+- (BEAccessibilityOrientation)browserAccessibilityOrientation
 {
     if (![self _prepareAccessibilityCall])
-        return AccessibilityOrientation::Undefined;
+        return BEAccessibilityOrientationUnknown;
 
     std::optional defaultOrientation = self.axBackingObject->defaultOrientation();
-    // If we don't have a default orientation (unknown or otherwise), don't expose anything.
     if (!defaultOrientation)
-        return AccessibilityOrientation::Undefined;
+        return BEAccessibilityOrientationUnknown;
 
-    // If the orientation is the default, we don't need to share that with ATs.
     std::optional orientation = self.axBackingObject->orientation();
-    return orientation && *orientation == *defaultOrientation ? AccessibilityOrientation::Undefined : *orientation;
+    if (orientation && *orientation != *defaultOrientation) {
+        switch (*orientation) {
+        case AccessibilityOrientation::Vertical:
+            return BEAccessibilityOrientationVertical;
+        case AccessibilityOrientation::Horizontal:
+            return BEAccessibilityOrientationHorizontal;
+        case AccessibilityOrientation::Undefined:
+            break;
+        }
+    }
+    return BEAccessibilityOrientationUnknown;
 }
+#endif
 
-- (BOOL)accessibilitySupportsKeyboardShortcuts
-{
-    if (![self _prepareAccessibilityCall])
-        return NO;
-
-    return self.axBackingObject->supportsKeyShortcuts();
-}
-
-- (NSString *)accessibilityKeyboardShortcuts
+- (NSString *)browserAccessibilityKeyboardShortcuts
 {
     if (![self _prepareAccessibilityCall])
         return nil;


### PR DESCRIPTION
#### 1764fd43311250ae497ec7fd3359749b9b33b9d7
<pre>
AX: [iOS] Migrate to the BEKit versions of details, keyshortcuts, and orientation in the wrapper
<a href="https://bugs.webkit.org/show_bug.cgi?id=313133">https://bugs.webkit.org/show_bug.cgi?id=313133</a>
<a href="https://rdar.apple.com/169708854">rdar://169708854</a>

Reviewed by NOBODY (OOPS!).

Adopt these BrowserEngineKitAPIs in the iOS wrapper.

* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper browserAccessibilityDetailsElements]):
(-[WebAccessibilityObjectWrapper browserAccessibilityOrientation]):
(-[WebAccessibilityObjectWrapper browserAccessibilityKeyboardShortcuts]):
(-[WebAccessibilityObjectWrapper accessibilityDetailsElements]): Deleted.
(-[WebAccessibilityObjectWrapper accessibilityOrientation]): Deleted.
(-[WebAccessibilityObjectWrapper accessibilitySupportsKeyboardShortcuts]): Deleted.
(-[WebAccessibilityObjectWrapper accessibilityKeyboardShortcuts]): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1764fd43311250ae497ec7fd3359749b9b33b9d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158258 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31595 "Hash 1764fd43 for PR 63427 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167087 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160129 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31732 "Hash 1764fd43 for PR 63427 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31613 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161216 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/31732 "Hash 1764fd43 for PR 63427 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103234 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/31732 "Hash 1764fd43 for PR 63427 does not build (failure)") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14859 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/31732 "Hash 1764fd43 for PR 63427 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/19937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169576 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15124 "Failed to build and analyze WebKit") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31341 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130861 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31279 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/141731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89190 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/25576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30831 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96548 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30352 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30582 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->