### PR TITLE
Support eventSender dispatching click events to popup windows

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-from-click-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-from-click-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT pageswap on navigation from user click Test timed out
+PASS pageswap on navigation from user click
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/navigate-top-to-aboutblank.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/navigate-top-to-aboutblank.https-expected.txt
@@ -6,7 +6,7 @@ Opener opens a new window, to a network document with the same origin and COOP v
 Opener's iframe navigates its parent frame (opener) to about:blank.
 Verify the openee still has access to its opener.
 
-FAIL Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin), iframe origin: https://web-platform.test:9443 assert_equals: expected "about:blank loaded" but got "about:blank NOT loaded"
-FAIL Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin), iframe origin: https://www1.web-platform.test:9443 assert_equals: expected "about:blank loaded" but got "about:blank NOT loaded"
-FAIL Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin-allow-popups), iframe origin: https://www1.web-platform.test:9443 assert_equals: expected "about:blank loaded" but got "about:blank NOT loaded"
+PASS Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin), iframe origin: https://web-platform.test:9443
+PASS Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin), iframe origin: https://www1.web-platform.test:9443
+FAIL Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin-allow-popups), iframe origin: https://www1.web-platform.test:9443 assert_equals: expected "false" but got "true"
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/navigate-top-to-aboutblank.https-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/navigate-top-to-aboutblank.https-expected.txt
@@ -1,0 +1,12 @@
+Non-initial empty documents (about:blank) should inherit their cross-origin-opener-policy from the navigation's initiator top level document, if the initiator and its top level document are same-origin, or default (to unsafe-none) otherwise.
+
+Create the opener popup with a given COOP openerCOOP.
+Add iframe to the opener popup that is either same-origin or cross-origin.
+Opener opens a new window, to a network document with the same origin and COOP value as opener.
+Opener's iframe navigates its parent frame (opener) to about:blank.
+Verify the openee still has access to its opener.
+
+FAIL Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin), iframe origin: https://web-platform.test:9443 assert_equals: expected "about:blank loaded" but got "about:blank NOT loaded"
+FAIL Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin), iframe origin: https://www1.web-platform.test:9443 assert_equals: expected "about:blank loaded" but got "about:blank NOT loaded"
+FAIL Navigate top to about:blank from iframe with opener COOP: |header(Cross-Origin-Opener-Policy,same-origin-allow-popups), iframe origin: https://www1.web-platform.test:9443 assert_equals: expected "about:blank loaded" but got "about:blank NOT loaded"
+

--- a/LayoutTests/resources/testdriver-vendor.js
+++ b/LayoutTests/resources/testdriver-vendor.js
@@ -386,9 +386,14 @@ window.test_driver_internal.click = async function (element, coords)
         return;
     }
 
-    await eventSender.asyncMouseMoveTo(coords.x, coords.y);
-    await eventSender.asyncMouseDown();
-    await eventSender.asyncMouseUp();
+    // Use the eventSender from the element's window so that events are
+    // dispatched to the correct view (e.g. a popup opened via window.open).
+    const targetWindow = element.ownerDocument.defaultView || window;
+    const targetEventSender = targetWindow.eventSender || eventSender;
+
+    await targetEventSender.asyncMouseMoveTo(coords.x, coords.y);
+    await targetEventSender.asyncMouseDown();
+    await targetEventSender.asyncMouseUp();
 }
 
 /**

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -589,6 +589,24 @@ void TestController::closeOtherPage(WKPageRef page, PlatformWebView* view)
         m_auxiliaryWebViews.removeAt(index);
 }
 
+PlatformWebView* TestController::viewForPage(WKPageRef page)
+{
+    if (mainWebView() && mainWebView()->page() == page)
+        return mainWebView();
+    for (auto& auxiliaryWebView : m_auxiliaryWebViews) {
+        if (auxiliaryWebView->page() == page)
+            return auxiliaryWebView.ptr();
+    }
+    return mainWebView();
+}
+
+void TestController::setTargetViewFromMessage(WKScriptMessageRef message)
+{
+    auto* frameInfo = WKScriptMessageGetFrameInfo(message);
+    auto* sourcePage = frameInfo ? WKFrameInfoGetPage(frameInfo) : nullptr;
+    setTargetView(sourcePage ? viewForPage(sourcePage) : mainWebView());
+}
+
 WKPageRef TestController::createOtherPage(WKPageRef, WKPageConfigurationRef configuration, WKNavigationActionRef navigationAction, WKWindowFeaturesRef windowFeatures, const void *clientInfo)
 {
     PlatformWebView* parentView = static_cast<PlatformWebView*>(const_cast<void*>(clientInfo));
@@ -2755,13 +2773,19 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         const auto y = doubleValue(argument2);
         const auto pointerType = stringValue(argument3);
 
+        // Route event to the view that sent this message (e.g. a popup window).
+        setTargetViewFromMessage(message);
+
         auto array = adoptWK(WKMutableArrayCreate());
         WKArrayAppendItem(array.get(), argument);
         WKArrayAppendItem(array.get(), argument2);
-        WKPagePostMessageToInjectedBundle(mainWebView()->page(), toWK("SetMousePosition").get(), array.get());
+        WKPagePostMessageToInjectedBundle(targetView()->page(), toWK("SetMousePosition").get(), array.get());
 
         m_eventSenderProxy->mouseMoveTo(x, y, pointerType,
-            [completionHandler = WTF::move(completionHandler)] mutable { completionHandler(nullptr); });
+            [this, completionHandler = WTF::move(completionHandler)] mutable {
+                setTargetView(nullptr);
+                completionHandler(nullptr);
+            });
         return;
     }
 
@@ -2769,8 +2793,14 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         const auto button = static_cast<uint64_t>(doubleValue(argument));
         const auto array = arrayValue(argument2);
         const auto pointerType = stringValue(argument3);
+
+        setTargetViewFromMessage(message);
+
         m_eventSenderProxy->mouseDown(button, parseModifierArray(array), pointerType,
-            [completionHandler = WTF::move(completionHandler)] mutable { completionHandler(nullptr); });
+            [this, completionHandler = WTF::move(completionHandler)] mutable {
+                setTargetView(nullptr);
+                completionHandler(nullptr);
+            });
         return;
     }
 
@@ -2778,8 +2808,14 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         const auto button = static_cast<uint64_t>(doubleValue(argument));
         const auto array = arrayValue(argument2);
         const auto pointerType = stringValue(argument3);
+
+        setTargetViewFromMessage(message);
+
         m_eventSenderProxy->mouseUp(button, parseModifierArray(array), pointerType,
-            [completionHandler = WTF::move(completionHandler)] mutable { completionHandler(nullptr); });
+            [this, completionHandler = WTF::move(completionHandler)] mutable {
+                setTargetView(nullptr);
+                completionHandler(nullptr);
+            });
         return;
     }
 
@@ -5773,7 +5809,7 @@ void TestController::handleAXPerformAction(WKDictionaryRef messageBody)
 void TestController::doAfterProcessingAllPendingMouseEvents(CompletionHandler<void()>&& handler)
 {
     auto* completionHandler = new CompletionHandler<void()>(WTF::move(handler));
-    WKPageDoAfterProcessingAllPendingMouseEvents(mainWebView()->page(), completionHandler, [](void* userData) {
+    WKPageDoAfterProcessingAllPendingMouseEvents(targetView()->page(), completionHandler, [](void* userData) {
         auto* completionHandler = static_cast<CompletionHandler<void()>*>(userData);
         (*completionHandler)();
         delete completionHandler;

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -113,6 +113,10 @@ public:
     WKStringRef testPluginDirectory() const { return m_testPluginDirectory.get(); }
 
     PlatformWebView* mainWebView() { return m_mainWebView.get(); }
+    PlatformWebView* viewForPage(WKPageRef);
+    PlatformWebView* targetView() { return m_targetView ? m_targetView : m_mainWebView.get(); }
+    void setTargetView(PlatformWebView* view) { m_targetView = view; }
+    void setTargetViewFromMessage(WKScriptMessageRef);
     WKContextRef context() { return m_context.get(); }
     WKUserContentControllerRef userContentController() { return m_userContentController.get(); }
 
@@ -738,6 +742,7 @@ private:
 
     std::unique_ptr<PlatformWebView> m_mainWebView;
     Vector<UniqueRef<PlatformWebView>> m_auxiliaryWebViews;
+    PlatformWebView* m_targetView { nullptr };
     WKRetainPtr<WKContextRef> m_context;
     WKRetainPtr<WKPreferencesRef> m_preferences;
     WKRetainPtr<WKUserContentControllerRef> m_userContentController;

--- a/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
@@ -292,7 +292,7 @@ void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, 
     updateClickCountForButton(button);
     m_mouseButtonsCurrentlyDown |= modifier;
 
-    webkitWebViewBaseSynthesizeMouseEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()),
+    webkitWebViewBaseSynthesizeMouseEvent(toWebKitGLibAPI(m_testController->targetView()->platformView()),
         MouseEventType::Press, gdkButton, m_mouseButtonsCurrentlyDown, m_position.x, m_position.y, webkitModifiersToGDKModifiers(wkModifiers), m_clickCount, toWTFString(pointerType));
     if (completionHandler)
         m_testController->doAfterProcessingAllPendingMouseEvents(WTF::move(completionHandler));
@@ -303,7 +303,7 @@ void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WK
     unsigned gdkButton = eventSenderButtonToGDKButton(button);
     auto modifier = stateModifierForGdkButton(gdkButton);
     m_mouseButtonsCurrentlyDown &= ~modifier;
-    webkitWebViewBaseSynthesizeMouseEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()),
+    webkitWebViewBaseSynthesizeMouseEvent(toWebKitGLibAPI(m_testController->targetView()->platformView()),
         MouseEventType::Release, gdkButton, m_mouseButtonsCurrentlyDown, m_position.x, m_position.y, webkitModifiersToGDKModifiers(wkModifiers), 0, toWTFString(pointerType));
 
     m_clickPosition = m_position;
@@ -317,7 +317,7 @@ void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, 
     m_position.x = x;
     m_position.y = y;
 
-    webkitWebViewBaseSynthesizeMouseEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()),
+    webkitWebViewBaseSynthesizeMouseEvent(toWebKitGLibAPI(m_testController->targetView()->platformView()),
         MouseEventType::Motion, 0, m_mouseButtonsCurrentlyDown, m_position.x, m_position.y, 0, 0, toWTFString(pointerType));
     if (completionHandler)
         m_testController->doAfterProcessingAllPendingMouseEvents(WTF::move(completionHandler));

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.cpp
@@ -66,7 +66,7 @@ EventSenderProxyClientLibWPE::~EventSenderProxyClientLibWPE() = default;
 
 struct wpe_view_backend* viewBackend(TestController& controller)
 {
-    return static_cast<PlatformWebViewClientLibWPE*>(controller.mainWebView()->platformWindow())->backend()->backend();
+    return static_cast<PlatformWebViewClientLibWPE*>(controller.targetView()->platformWindow())->backend()->backend();
 }
 
 static uint32_t secToMsTimestamp(double currentEventTime)

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -361,13 +361,13 @@ void EventSenderProxy::mouseDown(unsigned buttonNumber, WKEventModifiers modifie
         location:NSMakePoint(m_position.x, m_position.y)
         modifierFlags:buildModifierFlags(modifiers)
         timestamp:absoluteTimeForEventTime(currentEventTime())
-        windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
+        windowNumber:[m_testController->targetView()->platformWindow() windowNumber]
         context:[NSGraphicsContext currentContext]
         eventNumber:++m_eventNumber
         clickCount:m_clickCount
         pressure:WebCore::ForceAtClick];
 
-    RetainPtr targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]];
+    RetainPtr targetView = [m_testController->targetView()->platformView() hitTest:[event locationInWindow]];
     if (!targetView) {
         if (completionHandler)
             completionHandler();
@@ -390,7 +390,7 @@ void EventSenderProxy::mouseDown(unsigned buttonNumber, WKEventModifiers modifie
         return;
     }
 
-    RetainPtr webView = m_testController->mainWebView()->platformView();
+    RetainPtr webView = m_testController->targetView()->platformView();
     dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([dispatchMouseDown = WTF::move(dispatchMouseDown), webView, completionHandler = WTF::move(completionHandler)] mutable {
         dispatchMouseDown();
         [webView _doAfterProcessingAllPendingMouseEvents:makeBlockPtr([completionHandler = WTF::move(completionHandler)] mutable {
@@ -410,7 +410,7 @@ void EventSenderProxy::mouseUp(unsigned buttonNumber, WKEventModifiers modifiers
         location:NSMakePoint(m_position.x, m_position.y)
         modifierFlags:buildModifierFlags(modifiers)
         timestamp:absoluteTimeForEventTime(currentEventTime())
-        windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
+        windowNumber:[m_testController->targetView()->platformWindow() windowNumber]
         context:[NSGraphicsContext currentContext]
         eventNumber:++m_eventNumber
         clickCount:m_clickCount
@@ -419,9 +419,9 @@ void EventSenderProxy::mouseUp(unsigned buttonNumber, WKEventModifiers modifiers
     // FIXME: Silly hack to teach WKTR to respect capturing mouse events outside the WKView.
     // The right solution is just to use NSApplication's built-in event sending methods,
     // instead of rolling our own algorithm for selecting an event target.
-    RetainPtr targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]];
+    RetainPtr targetView = [m_testController->targetView()->platformView() hitTest:[event locationInWindow]];
     if (!targetView)
-        targetView = m_testController->mainWebView()->platformView();
+        targetView = m_testController->targetView()->platformView();
 
     if (button == WebCore::MouseButton::Left)
         m_leftMouseButtonDown = false;
@@ -441,7 +441,7 @@ void EventSenderProxy::mouseUp(unsigned buttonNumber, WKEventModifiers modifiers
         return;
     }
 
-    RetainPtr webView = m_testController->mainWebView()->platformView();
+    RetainPtr webView = m_testController->targetView()->platformView();
     dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([dispatchMouseUp = WTF::move(dispatchMouseUp), webView, completionHandler = WTF::move(completionHandler)] mutable {
         dispatchMouseUp();
         [webView _doAfterProcessingAllPendingMouseEvents:makeBlockPtr([completionHandler = WTF::move(completionHandler)] mutable {
@@ -652,7 +652,7 @@ void EventSenderProxy::mouseForceChanged(float force)
 
 void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
-    auto *view = m_testController->mainWebView()->platformView();
+    auto *view = m_testController->targetView()->platformView();
     auto newMousePosition = [view convertPoint:NSMakePoint(x, y) toView:nil];
     auto isDrag = m_leftMouseButtonDown;
     RetainPtr event = [NSEvent mouseEventWithType:(isDrag ? NSEventTypeLeftMouseDragged : NSEventTypeMouseMoved)
@@ -672,9 +672,9 @@ void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, 
     m_position.x = newMousePosition.x;
     m_position.y = newMousePosition.y;
 
-    m_testController->mainWebView()->setCursorOverlayPosition(x, y);
+    m_testController->targetView()->setCursorOverlayPosition(x, y);
 
-    RetainPtr webView = m_testController->mainWebView()->platformView();
+    RetainPtr webView = m_testController->targetView()->platformView();
 
     // Always target drags at the WKWebView to allow for drag-scrolling outside the view.
     // For non-drag moves, _simulateMouseMove: must be called on the WKWebView directly

--- a/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
+++ b/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
@@ -39,7 +39,7 @@ namespace WTR {
 LRESULT EventSenderProxy::dispatchMessage(UINT message, WPARAM wParam, LPARAM lParam)
 {
     MSG msg { };
-    msg.hwnd = WKViewGetWindow(m_testController->mainWebView()->platformView());
+    msg.hwnd = WKViewGetWindow(m_testController->targetView()->platformView());
     msg.message = message;
     msg.wParam = wParam;
     msg.lParam = lParam;

--- a/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp
@@ -139,7 +139,7 @@ void EventSenderProxyClientWPE::mouseDown(unsigned button, double time, WKEventM
     mouseButtonsCurrentlyDown |= modifierForButton(wpeButton);
     auto modifiers = static_cast<WPEModifiers>(wkEventModifiersToWPE(wkModifiers) | mouseButtonsCurrentlyDown);
     auto timestamp = secToMsTimestamp(time);
-    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
+    auto* view = WKViewGetView(m_testController.targetView()->platformView());
     auto* event = wpe_event_pointer_button_new(WPE_EVENT_POINTER_DOWN, view, WPE_INPUT_SOURCE_MOUSE, timestamp, modifiers, wpeButton, x, y, clickCount);
     wpe_view_event(view, event);
     wpe_event_unref(event);
@@ -150,7 +150,7 @@ void EventSenderProxyClientWPE::mouseUp(unsigned button, double time, WKEventMod
     auto wpeButton = eventSenderButtonToWPEButton(button);
     mouseButtonsCurrentlyDown &= ~modifierForButton(wpeButton);
     auto modifiers = static_cast<WPEModifiers>(wkEventModifiersToWPE(wkModifiers) | mouseButtonsCurrentlyDown);
-    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
+    auto* view = WKViewGetView(m_testController.targetView()->platformView());
     auto* event = wpe_event_pointer_button_new(WPE_EVENT_POINTER_UP, view, WPE_INPUT_SOURCE_MOUSE, secToMsTimestamp(time), modifiers, wpeButton, x, y, 0);
     wpe_view_event(view, event);
     wpe_event_unref(event);
@@ -158,7 +158,7 @@ void EventSenderProxyClientWPE::mouseUp(unsigned button, double time, WKEventMod
 
 void EventSenderProxyClientWPE::mouseMoveTo(double x, double y, double time, WKEventMouseButton, unsigned mouseButtonsCurrentlyDown)
 {
-    auto* view = WKViewGetView(m_testController.mainWebView()->platformView());
+    auto* view = WKViewGetView(m_testController.targetView()->platformView());
     auto* event = wpe_event_pointer_move_new(WPE_EVENT_POINTER_MOVE, view, WPE_INPUT_SOURCE_MOUSE, secToMsTimestamp(time),
         static_cast<WPEModifiers>(mouseButtonsCurrentlyDown), x, y, 0, 0);
     wpe_view_event(view, event);


### PR DESCRIPTION
#### 75e2fd9ca577e7e2d8ed354418c8817d3beeec1d
<pre>
Support eventSender dispatching click events to popup windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=312719">https://bugs.webkit.org/show_bug.cgi?id=312719</a>

Reviewed by Carlos Alberto Lopez Perez.

eventSender always dispatched click events to mainWebView(), making it
impossible to click elements in popup windows opened via window.open().
This caused WPT tests using cross-window test_driver.click() to timeout.

The fix introduces a targetView that is set based on the source page of
the script message, so click events are routed to the correct view.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-from-click-expected.txt:
* LayoutTests/resources/testdriver-vendor.js:
(window.test_driver_internal.click):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::viewForPage):
(WTR::TestController::didReceiveScriptMessage):
(WTR::TestController::doAfterProcessingAllPendingMouseEvents):
* Tools/WebKitTestRunner/TestController.h:
(WTR::TestController::targetView):
(WTR::TestController::setTargetView):
* Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp:
(WTR::EventSenderProxy::mouseDown):
(WTR::EventSenderProxy::mouseUp):
(WTR::EventSenderProxy::mouseMoveTo):
* Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.cpp:
(WTR::viewBackend):
* Tools/WebKitTestRunner/mac/EventSenderProxy.mm:
(WTR::EventSenderProxy::mouseDown):
(WTR::EventSenderProxy::mouseUp):
(WTR::EventSenderProxy::mouseMoveTo):
* Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp:
(WTR::EventSenderProxy::dispatchMessage):
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp:
(WTR::EventSenderProxyClientWPE::mouseDown):
(WTR::EventSenderProxyClientWPE::mouseUp):
(WTR::EventSenderProxyClientWPE::mouseMoveTo):

Canonical link: <a href="https://commits.webkit.org/312424@main">https://commits.webkit.org/312424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f8cd1a4a72b431a0574d798cf770403f5270180

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114231 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123872 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104502 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25183 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23656 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171203 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132135 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132175 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35770 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143141 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/91079 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26790 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19955 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32490 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31987 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->