### PR TITLE
[JSC] RegExpSearch DFG constant folding mishandles lastIndex for global/sticky regular expressions

### DIFF
--- a/JSTests/stress/regexp-search-lastIndex.js
+++ b/JSTests/stress/regexp-search-lastIndex.js
@@ -1,0 +1,37 @@
+function test1() {
+    const re = /x/g;
+    re.lastIndex = 3;
+    return "axbx".search(re);
+}
+
+function test2() {
+    const re = /x/g;
+    re.lastIndex = 42;
+    "axbx".search(re);
+    return re.lastIndex;
+}
+
+function test3() {
+    const re = /x/y;
+    re.lastIndex = 3;
+    return "axbx".search(re);
+}
+
+const u1 = test1(), u2 = test2(), u3 = test3();
+
+for (let i = 0; i < 300000; i++) {
+    test1();
+    test2();
+    test3();
+}
+
+const o1 = test1(), o2 = test2(), o3 = test3();
+
+if (o1 !== u1)
+    throw o1 + " !== " + u1;
+
+if (o2 !== u2)
+    throw o2 + " !== " + u2;
+
+if (o3 !== u3)
+    throw o3 + " !== " + u3;

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -870,7 +870,7 @@ private:
                 }
             }
 
-            if (!regExp->globalOrSticky())
+            if (!regExp->globalOrSticky() || m_node->op() == RegExpSearch)
                 lastIndex = 0;
 
             auto foldToConstant = [&] {
@@ -950,6 +950,7 @@ private:
 
                 m_changed = true;
 
+                bool wasSearch = m_node->op() == RegExpSearch;
                 NodeOrigin origin = m_node->origin;
 
                 m_insertionSet.insertNode(m_nodeIndex, SpecNone, Check, origin, m_node->children.justChecks());
@@ -1059,7 +1060,7 @@ private:
                 // Because SetRegExpObjectLastIndex may exit and it clobbers exit state, we do that
                 // first.
 
-                if (regExp->globalOrSticky()) {
+                if (regExp->globalOrSticky() && !wasSearch) {
                     ASSERT(regExpObjectNode);
                     m_insertionSet.insertNode(
                         m_nodeIndex, SpecNone, SetRegExpObjectLastIndex, origin,


### PR DESCRIPTION
#### 4a2761ccd07210ab20b88b7f6242b0f32ead3e29
<pre>
[JSC] RegExpSearch DFG constant folding mishandles lastIndex for global/sticky regular expressions
<a href="https://bugs.webkit.org/show_bug.cgi?id=313139">https://bugs.webkit.org/show_bug.cgi?id=313139</a>
<a href="https://rdar.apple.com/175066379">rdar://175066379</a>

Reviewed by Yijia Huang.

This patch ensures RegExpSearch will always match from position 0 without changing
lastIndex in DFG constant folding, regardless of whether the regex is global or sticky.

Test: JSTests/stress/regexp-search-lastIndex.js

* JSTests/stress/regexp-search-lastIndex.js: Added.
(test1):
(test2):
(test3):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):

Canonical link: <a href="https://commits.webkit.org/313029@main">https://commits.webkit.org/313029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e740e334ba05dcfc9b0a39701ad10f97d4940a9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158269 "Failed to checkout and rebase branch from PR 63433") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167098 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112353 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122576 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86030 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103245 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23903 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22266 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14871 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150320 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169589 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19104 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15196 "Failed to checkout and rebase branch from PR 63433") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130758 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130872 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36160 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141742 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89205 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25581 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18548 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190398 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30843 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96607 "Failed to checkout and rebase branch from PR 63433") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30363 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30594 "Failed to checkout and rebase branch from PR 63433") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30490 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->