### PR TITLE
[:has()] Sibling invalidation failures because NodeStyleFlag bitfield overflows

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-sibling-insertion-removal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-sibling-insertion-removal-expected.txt
@@ -1,8 +1,8 @@
 
 PASS subject1: initial color should be rgb(128, 128, 128)
-FAIL subject1: color after #sibling1_1 inserted should be rgb(255, 0, 0) assert_equals: expected "rgb(255, 0, 0)" but got "rgb(128, 128, 128)"
+PASS subject1: color after #sibling1_1 inserted should be rgb(255, 0, 0)
 PASS subject2: initial color should be rgb(128, 128, 128)
-FAIL subject2: color after #sibling2_1 removed should be rgb(0, 128, 0) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS subject2: color after #sibling2_1 removed should be rgb(0, 128, 0)
 PASS subject3: initial color should be rgb(128, 128, 128)
 FAIL subject3: color after #sibling3_1 inserted should be rgb(0, 0, 255) assert_equals: expected "rgb(0, 0, 255)" but got "rgb(128, 128, 128)"
 PASS subject4: initial color should be rgb(128, 128, 128)
@@ -10,13 +10,13 @@ FAIL subject4: color after #sibling4_1 removed should be rgb(255, 255, 0) assert
 PASS subject5: initial color should be rgb(255, 0, 0)
 PASS subject5: color after #sibling5_1 removed should be rgb(128, 128, 128)
 PASS subject6: initial color should be rgb(0, 128, 0)
-FAIL subject6: color after #sibling6_1 inserted should be rgb(128, 128, 128) assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 128, 0)"
+PASS subject6: color after #sibling6_1 inserted should be rgb(128, 128, 128)
 PASS subject7: initial color should be rgb(0, 0, 255)
 FAIL subject7: color after #sibling7_1 removed should be rgb(128, 128, 128) assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 0, 255)"
 PASS subject8: initial color should be rgb(255, 255, 0)
 FAIL subject8: color after #sibling8_1 inserted should be rgb(128, 128, 128) assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 255, 0)"
 PASS subject9: initial color should be rgb(128, 128, 128)
-FAIL subject9: color after #sibling9_1 inserted should be rgb(255, 0, 0) assert_equals: expected "rgb(255, 0, 0)" but got "rgb(128, 128, 128)"
+PASS subject9: color after #sibling9_1 inserted should be rgb(255, 0, 0)
 PASS subject10: initial color should be rgb(128, 128, 128)
 PASS subject10: color after #sibling10_1 removed should be rgb(0, 128, 0)
 PASS subject11: initial color should be rgb(128, 128, 128)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-side-effect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-side-effect-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Initial colors
-FAIL Matches after #blocks_match removed assert_equals: expected "rgb(255, 0, 0)" but got "rgb(128, 128, 128)"
+PASS Matches after #blocks_match removed
 PASS Does not match after #blocks_match added
 

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -47,8 +47,8 @@ public:
     bool hasChildNodes() const { return m_firstChild; }
     bool hasOneChild() const { return m_firstChild && m_firstChild == m_lastChild; }
 
-    bool directChildNeedsStyleRecalc() const { return hasStyleFlag(NodeStyleFlag::DirectChildNeedsStyleResolution); }
-    void setDirectChildNeedsStyleRecalc() { setStyleFlag(NodeStyleFlag::DirectChildNeedsStyleResolution); }
+    bool directChildNeedsStyleRecalc() const { return hasStateFlag(StateFlag::DirectChildNeedsStyleResolution); }
+    void setDirectChildNeedsStyleRecalc() { setStateFlag(StateFlag::DirectChildNeedsStyleResolution); }
 
     WEBCORE_EXPORT unsigned NODELETE countChildNodes() const;
     WEBCORE_EXPORT Node* NODELETE traverseToChildAt(unsigned) const;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -363,7 +363,7 @@ public:
     Style::Validity styleValidity() const { return styleBitfields().styleValidity(); }
     bool hasInvalidRenderer() const { return hasStateFlag(StateFlag::HasInvalidRenderer); }
     bool styleResolutionShouldRecompositeLayer() const { return hasStateFlag(StateFlag::StyleResolutionShouldRecompositeLayer); }
-    bool childNeedsStyleRecalc() const { return hasStyleFlag(NodeStyleFlag::DescendantNeedsStyleResolution); }
+    bool childNeedsStyleRecalc() const { return hasStateFlag(StateFlag::DescendantNeedsStyleResolution); }
     bool isEditingText() const { return isTextNode() && hasTypeFlag(TypeFlag::IsPseudoElementOrSpecialInternalNode); }
 
     bool isDocumentFragmentForInnerOuterHTML() const { return isDocumentFragment() && hasTypeFlag(TypeFlag::IsPseudoElementOrSpecialInternalNode); }
@@ -381,7 +381,7 @@ public:
     void setWasParsedWithFastPath() { setStateFlag(StateFlag::WasParsedWithFastPath); }
     void clearWasParsedWithFastPath() { clearStateFlag(StateFlag::WasParsedWithFastPath); }
 
-    void setChildNeedsStyleRecalc() { setStyleFlag(NodeStyleFlag::DescendantNeedsStyleResolution); }
+    void setChildNeedsStyleRecalc() { setStateFlag(StateFlag::DescendantNeedsStyleResolution); }
     inline void clearChildNeedsStyleRecalc();
 
     inline void setHasValidStyle();
@@ -664,7 +664,9 @@ protected:
         DidMutateSubtreeAfterSetInnerHTML = 1 << 21,
         WasParsedWithFastPath = 1 << 22,
         ShouldNotifyTextManipulationControllerIfDisplayed = 1 << 23,
-        // 8 bits free.
+        DescendantNeedsStyleResolution = 1 << 24,
+        DirectChildNeedsStyleResolution = 1 << 25,
+        // 6 bits free.
     };
 
     enum class TabIndexState : uint8_t {
@@ -712,23 +714,20 @@ protected:
     static constexpr uint32_t s_refCountMask = ~static_cast<uint32_t>(1);
 
     enum class NodeStyleFlag : uint16_t {
-        DescendantNeedsStyleResolution                          = 1 << 0,
-        DirectChildNeedsStyleResolution                         = 1 << 1,
-
-        AffectedByHasWithSiblingRelationship                    = 1 << 2,
-        ChildrenAffectedByFirstChildRules                       = 1 << 3,
-        ChildrenAffectedByLastChildRules                        = 1 << 4,
-        AffectsNextSiblingElementStyle                          = 1 << 5,
-        StyleIsAffectedByPreviousSibling                        = 1 << 6,
-        DescendantsAffectedByPreviousSibling                    = 1 << 7,
-        StyleAffectedByEmpty                                    = 1 << 8,
+        AffectedByHasWithSiblingRelationship                    = 1 << 0,
+        ChildrenAffectedByFirstChildRules                       = 1 << 1,
+        ChildrenAffectedByLastChildRules                        = 1 << 2,
+        AffectsNextSiblingElementStyle                          = 1 << 3,
+        StyleIsAffectedByPreviousSibling                        = 1 << 4,
+        DescendantsAffectedByPreviousSibling                    = 1 << 5,
+        StyleAffectedByEmpty                                    = 1 << 6,
         // We optimize for :first-child and :last-child. The other positional child selectors like nth-child or
         // *-child-of-type, we will just give up and re-evaluate whenever children change at all.
-        ChildrenAffectedByForwardPositionalRules                = 1 << 9,
-        DescendantsAffectedByForwardPositionalRules             = 1 << 10,
-        ChildrenAffectedByBackwardPositionalRules               = 1 << 11,
-        DescendantsAffectedByBackwardPositionalRules            = 1 << 12,
-        AffectedByHasWithAdjacentSiblingRelationship            = 1 << 13,
+        ChildrenAffectedByForwardPositionalRules                = 1 << 7,
+        DescendantsAffectedByForwardPositionalRules             = 1 << 8,
+        ChildrenAffectedByBackwardPositionalRules               = 1 << 9,
+        DescendantsAffectedByBackwardPositionalRules            = 1 << 10,
+        AffectedByHasWithAdjacentSiblingRelationship            = 1 << 11,
     };
 
     struct StyleBitfields {
@@ -743,11 +742,11 @@ protected:
         void setFlag(NodeStyleFlag flag) { m_flags = (flags() | flag).toRaw(); }
         void clearFlag(NodeStyleFlag flag) { m_flags = (flags() - flag).toRaw(); }
         void clearFlags(OptionSet<NodeStyleFlag> flagsToClear) { m_flags = (flags() - flagsToClear).toRaw(); }
-        void clearDescendantsNeedStyleResolution() { m_flags = (flags() - NodeStyleFlag::DescendantNeedsStyleResolution - NodeStyleFlag::DirectChildNeedsStyleResolution).toRaw(); }
 
     private:
         uint16_t m_styleValidity : 3 { 0 };
-        uint16_t m_flags : 13 { 0 };
+        uint16_t m_flags : 12 { 0 };
+        // 1 bit free.
     };
 
     StyleBitfields styleBitfields() const { return m_styleBitfields; }

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -202,9 +202,8 @@ ALWAYS_INLINE void Node::clearStyleFlags(OptionSet<NodeStyleFlag> flags)
 
 inline void Node::clearChildNeedsStyleRecalc()
 {
-    auto bitfields = styleBitfields();
-    bitfields.clearDescendantsNeedStyleResolution();
-    setStyleBitfields(bitfields);
+    clearStateFlag(StateFlag::DescendantNeedsStyleResolution);
+    clearStateFlag(StateFlag::DirectChildNeedsStyleResolution);
 }
 
 inline void Node::setHasValidStyle()


### PR DESCRIPTION
#### bfee0acbeffd57ba6f6c09cd9cb81e3c09487858
<pre>
[:has()] Sibling invalidation failures because NodeStyleFlag bitfield overflows
<a href="https://bugs.webkit.org/show_bug.cgi?id=313138">https://bugs.webkit.org/show_bug.cgi?id=313138</a>
<a href="https://rdar.apple.com/175433733">rdar://175433733</a>

Reviewed by Alan Baradlay.

StyleBitfields::m_flags had 13 bits but NodeStyleFlag enum had 14 values.
This caused AffectedByHasWithAdjacentSiblingRelationship relation bit get lost.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-sibling-insertion-removal-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-side-effect-expected.txt:
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::directChildNeedsStyleRecalc const):
(WebCore::ContainerNode::setDirectChildNeedsStyleRecalc):
* Source/WebCore/dom/Node.h:
(WebCore::Node::childNeedsStyleRecalc const):
(WebCore::Node::setChildNeedsStyleRecalc):
(WebCore::Node::StyleBitfields::clearDescendantsNeedStyleResolution):

Fix by moving DescendantNeedsStyleResolution and DirectChildNeedsStyleResolution bits to NodeFlags enum shrinking NodeStyleFlag.

* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::clearChildNeedsStyleRecalc):

Canonical link: <a href="https://commits.webkit.org/311870@main">https://commits.webkit.org/311870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67972bd827efc040e35a1087d5d919bc72a5d268

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167101 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31627 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24855 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103257 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14874 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169592 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15199 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21582 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31355 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35435 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141752 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89210 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25590 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30846 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96611 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30366 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30597 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30493 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->