### PR TITLE
Remove unused CheckedPtr scopeRoot in CachedMatchFinder TextRun

### DIFF
--- a/Source/WebCore/editing/CachedMatchFinder.cpp
+++ b/Source/WebCore/editing/CachedMatchFinder.cpp
@@ -361,7 +361,7 @@ auto CachedMatchFinder::textForScope(ContainerNode& scope, FindOptions options) 
     Vector<TextRun> runs;
     for (; !it.atEnd(); it.advance()) {
         auto textRunRange = it.range();
-        runs.append(TextRun { static_cast<unsigned>(builder.length()), textRunRange, &textRunRange.start.container->treeScope().rootNode() });
+        runs.append(TextRun { static_cast<unsigned>(builder.length()), textRunRange });
         auto text = it.text();
         if (text.is8Bit()) {
             for (auto character : text.span8())

--- a/Source/WebCore/editing/CachedMatchFinder.h
+++ b/Source/WebCore/editing/CachedMatchFinder.h
@@ -27,7 +27,6 @@
 
 #include "FindOptions.h"
 #include "SimpleRange.h"
-#include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -52,7 +51,6 @@ private:
     struct TextRun {
         unsigned offset;
         SimpleRange range;
-        CheckedPtr<ContainerNode> scopeRoot;
     };
 
     struct TextRunCache {


### PR DESCRIPTION
#### 49274a6aa8fcbc351b9d867a5f6573f8fb0b427a
<pre>
Remove unused CheckedPtr scopeRoot in CachedMatchFinder TextRun
<a href="https://bugs.webkit.org/show_bug.cgi?id=313149">https://bugs.webkit.org/show_bug.cgi?id=313149</a>
<a href="https://rdar.apple.com/175162582">rdar://175162582</a>

Reviewed by Darin Adler and Ryosuke Niwa.

There is an unused field named scopeRoot in CachedMatchFinder::TextRun.
It is a CheckedPtr that can cause a crash in its destructor.

This field is unused, so I removed it.

* Source/WebCore/editing/CachedMatchFinder.cpp:
(WebCore::CachedMatchFinder::textForScope):
* Source/WebCore/editing/CachedMatchFinder.h:

Canonical link: <a href="https://commits.webkit.org/311921@main">https://commits.webkit.org/311921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a08c012b6516e62187a99edc957b7ebaa351005e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112378 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160165 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122593 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86050 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103262 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23916 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22286 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14896 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169614 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15221 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130779 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130893 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35458 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141760 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89232 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25600 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18566 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96633 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30388 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30619 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30515 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->