### PR TITLE
[AutoFill Debugging] Include transparent or offscreen inputs, as long as they are labeled by visible elements

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-hidden-radio-checkbox-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-hidden-radio-checkbox-expected.txt
@@ -1,0 +1,29 @@
+-- texttree
+
+root
+    form autocomplete=on name=verification
+        'Choose a verification method:'
+        input radio label='Text me a code' name=method value=sms
+        'Text me a code'
+        input radio checked label='Email me a code' name=method value=email
+        'Email me a code'
+        input checkbox label='Remember this device' name=remember value=yes
+        'Remember this device This label has a display:none input'
+        button 'Next'
+
+-- html
+
+<body>
+    <form autocomplete='on' name='verification'>
+        Choose a verification method:
+        <input type='radio' label='Text me a code' name='method' value='sms'>
+        Text me a code
+        <input type='radio' label='Email me a code' name='method' value='email'>
+        Email me a code
+        <input type='checkbox' label='Remember this device' name='remember' value='yes'>
+        Remember this device This label has a display:none input
+        <button>Next</button>
+    </form>
+</body>
+
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-hidden-radio-checkbox.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-hidden-radio-checkbox.html
@@ -1,0 +1,77 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+.text-representation {
+    white-space: pre-wrap;
+}
+
+.visually-hidden-input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    position: absolute;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<form name="verification" autocomplete="on">
+    <p>Choose a verification method:</p>
+    <label>
+        <input class="visually-hidden-input" type="radio" name="method" value="sms">
+        Text me a code
+    </label>
+    <label>
+        <input class="visually-hidden-input" type="radio" name="method" value="email" checked>
+        Email me a code
+    </label>
+    <label>
+        <input class="visually-hidden-input" type="checkbox" name="remember" value="yes">
+        Remember this device
+    </label>
+    <label>
+        <input style="display: none" type="radio" name="hidden" value="gone">
+        This label has a display:none input
+    </label>
+    <button type="submit">Next</button>
+</form>
+<input class="visually-hidden-input" type="radio" name="orphan" value="no-label">
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    const results = [];
+    for (let outputFormat of ["texttree", "html"]) {
+        const heading = document.createElement("h1");
+        heading.textContent = `-- ${outputFormat}`;
+
+        const container = document.createElement("pre");
+        container.classList.add("text-representation");
+        let textContent = await UIHelper.requestDebugText({
+            normalize: true,
+            includeRects: false,
+            includeURLs: false,
+            skipNearlyTransparentContent: true,
+            outputFormat,
+        });
+
+        container.textContent = textContent;
+        results.push(heading);
+        results.push(container);
+        results.push(document.createElement("br"));
+    }
+
+    document.body.replaceChildren(...results);
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -437,6 +437,35 @@ static inline String labelText(HTMLElement& element)
     return { };
 }
 
+static inline std::optional<FloatRect> visibleAssociatedLabelBounds(HTMLElement& element)
+{
+    auto labels = element.labels();
+    if (!labels)
+        return std::nullopt;
+
+    for (unsigned index = 0; index < labels->length(); ++index) {
+        RefPtr label = dynamicDowncast<Element>(labels->item(index));
+        if (!label)
+            continue;
+
+        CheckedPtr renderer = label->renderer();
+        if (!renderer)
+            continue;
+
+        if (renderer->style().usedVisibility() == Visibility::Hidden)
+            continue;
+
+        if (renderer->style().opacity() < minOpacityToConsiderVisible)
+            continue;
+
+        auto bounds = rootViewBounds(*label);
+        if (!bounds.isEmpty())
+            return bounds;
+    }
+
+    return std::nullopt;
+}
+
 template<typename T>
 RefPtr<T> shadowHostOrSelfInclusiveParent(Node& node)
 {
@@ -487,8 +516,10 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
     if (!renderer)
         return { SkipExtraction::SelfAndSubtree };
 
-    if (context.skipNearlyTransparentContent && renderer->style().opacity() < minOpacityToConsiderVisible)
-        return { SkipExtraction::SelfAndSubtree };
+    if (context.skipNearlyTransparentContent && renderer->style().opacity() < minOpacityToConsiderVisible) {
+        if (RefPtr input = dynamicDowncast<HTMLInputElement>(node); !input || !visibleAssociatedLabelBounds(*input))
+            return { SkipExtraction::SelfAndSubtree };
+    }
 
     if (renderer->style().usedVisibility() == Visibility::Hidden)
         return { SkipExtraction::Self };
@@ -639,6 +670,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
                 .autocomplete = control->autocomplete(),
                 .pattern = control->attributeWithoutSynchronization(HTMLNames::patternAttr),
                 .name = input ? stringOnlyIfHumanReadable(input->name()) : String { },
+                .value = input ? String { input->value() } : String { },
                 .minLength = input ? wholeNumberOrNull(input->minLength()) : std::optional<int> { },
                 .maxLength = input ? wholeNumberOrNull(input->maxLength()) : std::optional<int> { },
                 .isRequired = control->isRequired(),
@@ -961,6 +993,12 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
         },
         [&](ItemData&& result) {
             auto bounds = rootViewBounds(node);
+            if (bounds.isEmpty()) {
+                if (RefPtr input = dynamicDowncast<HTMLInputElement>(node)) {
+                    if (auto labelBounds = visibleAssociatedLabelBounds(*input))
+                        bounds = *labelBounds;
+                }
+            }
             if (!context.inAdditionalContainerToCollectCount && !context.shouldIncludeNodeWithRect(bounds)) {
                 if (context.hasOverflowItemsStack.isEmpty()) {
                     ASSERT_NOT_REACHED();

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -165,6 +165,7 @@ struct TextFormControlData {
     String autocomplete;
     String pattern;
     String name;
+    String value;
     std::optional<int> minLength;
     std::optional<int> maxLength;
     bool isRequired { false };

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -904,6 +904,23 @@ static String jsonTypeStringForItem(const TextExtraction::Item& item, const Text
     );
 }
 
+static bool shouldIncludeFormControlValue(const TextExtraction::TextFormControlData& controlData, const TextExtraction::Item& item)
+{
+    if (controlData.value.isEmpty())
+        return false;
+
+    if (equalLettersIgnoringASCIICase(controlData.value, "on"_s))
+        return false;
+
+    if (!equalLettersIgnoringASCIICase(controlData.controlType, "radio"_s) && !equalLettersIgnoringASCIICase(controlData.controlType, "checkbox"_s))
+        return false;
+
+    return !item.children.containsIf([](auto& child) {
+        auto text = child.template dataAs<TextExtraction::TextItemData>();
+        return text && !text->content.template containsOnly<isASCIIWhitespace>();
+    });
+}
+
 template<typename T> static Vector<String> sortedKeys(const HashMap<String, T>& dictionary)
 {
     auto keys = copyToVector(dictionary.keys());
@@ -1075,6 +1092,8 @@ static void populateJSONForItem(JSON::Object& jsonObject, const TextExtraction::
                 jsonObject.setString("pattern"_s, controlData.pattern);
             if (!controlData.name.isEmpty())
                 jsonObject.setString("name"_s, controlData.name);
+            if (shouldIncludeFormControlValue(controlData, item))
+                jsonObject.setString("value"_s, controlData.value);
             if (controlData.minLength)
                 jsonObject.setInteger("minLength"_s, *controlData.minLength);
             if (controlData.maxLength)
@@ -1400,6 +1419,9 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
                 if (!controlData.name.isEmpty())
                     attributes.append(makeString("name='"_s, escapeString(controlData.name), '\''));
 
+                if (shouldIncludeFormControlValue(controlData, item))
+                    attributes.append(makeString("value='"_s, escapeString(controlData.value), '\''));
+
                 if (auto minLength = controlData.minLength)
                     attributes.append(makeString("minlength="_s, *minLength));
 
@@ -1475,6 +1497,9 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
 
                 if (!controlData.name.isEmpty())
                     parts.append(makeString("name="_s, quoteValue(escapeString(controlData.name), streamlined)));
+
+                if (shouldIncludeFormControlValue(controlData, item))
+                    parts.append(makeString("value="_s, quoteValue(escapeString(controlData.value), streamlined)));
 
                 if (auto minLength = controlData.minLength)
                     parts.append(makeString("minlength="_s, *minLength));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6849,6 +6849,7 @@ header: <WebCore/TextExtractionTypes.h>
     String autocomplete;
     String pattern;
     String name;
+    String value;
     std::optional<int> minLength;
     std::optional<int> maxLength;
     bool isRequired;


### PR DESCRIPTION
#### 93299410c2e840be2f37ba7673ce11db3520a741
<pre>
[AutoFill Debugging] Include transparent or offscreen inputs, as long as they are labeled by visible elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=313146">https://bugs.webkit.org/show_bug.cgi?id=313146</a>
<a href="https://rdar.apple.com/175372296">rdar://175372296</a>

Reviewed by Aditya Keerthi.

All offscreen (i.e. does not intersect with the collection rect) or transparent DOM elements are
currently excluded by default. This change relaxes that policy in the case where an input or form
control is labeled by an element that is on-screen and non-transparent.

Test: fast/text-extraction/debug-text-extraction-hidden-radio-checkbox.html

* LayoutTests/fast/text-extraction/debug-text-extraction-hidden-radio-checkbox-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-hidden-radio-checkbox.html: Added.

Add a new layout test to exercise this scenario.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::visibleAssociatedLabelBounds):
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::extractRecursive):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::shouldIncludeFormControlValue):

Skip the `value` in the case where there is a rendered text child, to avoid redundancy.

(WebKit::populateJSONForItem):
(WebKit::addPartsForItem):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/311890@main">https://commits.webkit.org/311890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90d138cd26b7bd6bc08ffef7d24f8205e92b0b15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167127 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122599 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24868 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103268 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14900 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169618 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15225 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21594 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130783 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31381 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130897 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35441 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141764 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89236 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25601 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18570 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30872 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96637 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30392 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->