### PR TITLE
Implement node moving for moveBefore()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5992,6 +5992,9 @@ webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBef
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/select-option-optgroup.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/css-transition-trigger.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/relevant-mutations.html [ Skip ]
+webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/selection-preserve.html [ Skip ]
+webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/hover-style-update.html [ Skip ]
+webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/pointer-events.html [ Skip ]
 
 # uncategorized dialog element failures
 webkit.org/b/286022 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-close-via-attribute.tentative.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/Node-moveBefore-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/Node-moveBefore-expected.txt
@@ -15,18 +15,17 @@ PASS moveBefore() on disconnected parent throws a HierarchyRequestError
 PASS moveBefore() with disconnected target node throws a HierarchyRequestError
 PASS moveBefore() on a cross-document target node throws a HierarchyRequestError
 PASS moveBefore() into a Document throws a HierarchyRequestError
-FAIL moveBefore() CharacterData into a Document assert_equals: expected Document node with 1 child but got Element node <body><!--comment--></body>
+PASS moveBefore() CharacterData into a Document
 PASS moveBefore() with node being an inclusive ancestor of parent throws a HierarchyRequestError
 PASS moveBefore() with a non-{Element, CharacterData} throws a HierarchyRequestError
-FAIL moveBefore with an Element or CharacterData succeeds assert_equals: expected Text node "child text" but got Text node "
-"
-FAIL moveBefore on a paragraph's Text node child assert_equals: expected Text node "Some content" but got Element node <iframe></iframe>
+PASS moveBefore with an Element or CharacterData succeeds
+PASS moveBefore on a paragraph's Text node child
 PASS moveBefore with reference child whose parent is NOT the destination parent (context node) throws a NotFoundError.
 FAIL moveBefore() returns undefined assert_array_equals: expected property 0 to be Element node <div></div> but got Element node <div></div> (expected array [Element node <div></div>, Element node <div></div>] got object "[object NodeList]")
 PASS Moving a node before itself should not move the node
 PASS Moving a node from a disconnected container to a disconnected new parent without a shared ancestor throws a HIERARCHY_REQUEST_ERR
-FAIL Moving a node from a disconnected container to a disconnected new parent in the same tree succeeds assert_equals: <p> Was successfully moved expected Element node <p></p> but got null
-FAIL Moving a node from a disconnected container to a disconnected new parent in the same tree succeeds,also across shadow-roots assert_equals: <p> Was successfully moved expected Element node <p></p> but got null
+PASS Moving a node from a disconnected container to a disconnected new parent in the same tree succeeds
+PASS Moving a node from a disconnected container to a disconnected new parent in the same tree succeeds,also across shadow-roots
 PASS Moving a node from disconnected->connected throws a HIERARCHY_REQUEST_ERR
 PASS Moving a node from connected->disconnected throws a HIERARCHY_REQUEST_ERR
 PASS No custom element callbacks are run during disconnected moveBefore()

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/child-style-preserve-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/child-style-preserve-expected.txt
@@ -1,6 +1,6 @@
-Test1
-
 Test2
+
+Test1
 
 
 PASS child-style-preserve

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-left-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-left-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Node.moveBefore should preserve CSS animation state (left)
+FAIL Node.moveBefore should preserve CSS animation state (left) assert_not_equals: got disallowed value "0px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-transform-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Node.moveBefore should preserve CSS animation state (transform)
+FAIL Node.moveBefore should preserve CSS animation state (transform) assert_not_equals: got disallowed value "none"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/fieldset-child-blur-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/fieldset-child-blur-event-expected.txt
@@ -1,5 +1,4 @@
 
 
-
 PASS The 'blur' event is not fired on children of HTMLFieldSetElement during moveBefore()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/fire-focusin-focusout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/fire-focusin-focusout-expected.txt
@@ -3,6 +3,6 @@ Button
 PASS Don't fire focusin/out when reparenting focused element directly
 PASS Don't fire focusin/out when reparenting an element that has focus within
 PASS Don't fire focusin/out when moving to the same parent
-FAIL Don't fire focusin and then correct when moving to an inert subtree assert_array_equals: lengths differ, expected array ["button.onfocusin", "button.onfocusout"] length 2, got ["button.onfocusin"] length 1
+PASS Don't fire focusin and then correct when moving to an inert subtree
 FAIL Don't fire focusin and then correct when moving to a tree that is made inert using style assert_array_equals: lengths differ, expected array ["button.onfocusin", "button.onfocusout"] length 2, got ["button.onfocusin"] length 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-within-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-within-expected.txt
@@ -1,8 +1,8 @@
 Button
 
-FAIL focus-within should be updated when reparenting focused element directly assert_array_equals: expected property 2 to be "new_parent" but got "old_parent" (expected array ["HTML", "BODY", "new_parent", "button"] got ["HTML", "BODY", "old_parent", "button"])
-FAIL focus-within should be updated when reparenting an element that has focus within assert_array_equals: lengths differ, expected array ["HTML", "BODY", "new_parent", "old_parent", "button"] length 5, got ["HTML", "BODY", "old_parent", "button"] length 4
+PASS focus-within should be updated when reparenting focused element directly
+PASS focus-within should be updated when reparenting an element that has focus within
 PASS focus-within should remain the same when moving to the same parent
-FAIL :focus-within should be eventually up to date when moving to an inert subtree assert_array_equals: expected property 2 to be "inert_parent" but got "old_parent" (expected array ["HTML", "BODY", "inert_parent", "button"] got ["HTML", "BODY", "old_parent", "button"])
-FAIL :focus-within should be eventually up to date when moving to a subtree that would become inert via style assert_array_equals: expected property 2 to be "inert_when_not_empty_parent" but got "old_parent" (expected array ["HTML", "BODY", "inert_when_not_empty_parent", "button"] got ["HTML", "BODY", "old_parent", "button"])
+PASS :focus-within should be eventually up to date when moving to an inert subtree
+FAIL :focus-within should be eventually up to date when moving to a subtree that would become inert via style assert_array_equals: lengths differ, expected array [] length 0, got ["HTML", "BODY", "inert_when_not_empty_parent", "button"] length 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/iframe-document-preserve.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/iframe-document-preserve.window-expected.txt
@@ -5,8 +5,5 @@ PASS moveBefore(): cross-origin iframe is preserved: remove new parent
 PASS moveBefore(): cross-origin iframe is preserved: remove self
 PASS moveBefore(): cross-origin iframe is preserved: remove self via replaceChildren()
 PASS moveBefore(): cross-origin iframe is preserved: remove self via innerHTML
-FAIL window.frames ordering does not change due to moveBefore() assert_equals: iframe1 comes first in DOM expected "iframe1" but got ""
-
-
-
+FAIL window.frames ordering does not change due to moveBefore() assert_equals: iframe3 comes first in DOM after moveBefore expected "iframe3" but got "iframe1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/listed-form-element-reset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/listed-form-element-reset-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Listed form element form owner is reset when a new form is moved closer before the listed element assert_equals: button.form is correctly reset to form2 expected Element node <form id="form1"></form> but got Element node <form id="form1"></form>
+PASS Listed form element form owner is reset when a new form is moved closer before the listed element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/live-range-updates-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/live-range-updates-expected.txt
@@ -1,12 +1,13 @@
 RangeStartTarget
-RangeEndTarget
 Middle
+RangeEndTarget
 
 FAIL moveBefore still results in range startContainer snapping up to parent when startContainer is moved assert_equals: startContainer updates during move expected Element node <div id="old_parent">
-      <span id="start">RangeStartTa... but got Element node <span id="start">RangeStartTarget</span>
+
+      <span id="middle">Midd... but got Element node <span id="start">RangeStartTarget</span>
 FAIL moveBefore still causes range startContainer to snap up to parent, when startContainer ancestor is moved assert_equals: startContainer still updates during move, to snap to parent expected Element node <div id="old_parent">
-      <div id="movable_div">
-      ... but got Element node <span id="start">RangeStartTarget</span>
+
+      <span id="end">RangeEn... but got Element node <span id="start">RangeStartTarget</span>
 FAIL moveBefore still causes range endContainer to snap up to parent, when endContainer ancestor is moved assert_equals: endContainer still snaps up to parent after move expected Element node <div id="old_parent">
       <span id="start">RangeStartTa... but got Element node <span id="end">RangeEndTarget</span>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map-expected.txt
@@ -1,3 +1,6 @@
 
-FAIL moveBefore() correctly updates id map assert_equals: expected Element node <span id="target" data-span=""></span> but got Element node <div id="target" data-target=""></div>
+PASS moveBefore() correctly updates id map when moving into shadow root
+PASS moveBefore() correctly updates window map when moving id-mapped element into shadow root
+PASS moveBefore() correctly updates id map when moving between shadow roots
+PASS moveBefore() correctly updates id map when swapping elements with duplicate ids
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map.html
@@ -7,6 +7,17 @@
   <div id="container"></div>
   <div id="target" data-target></div>
   <span id="target" data-span></span>
+
+  <div id="container2"></div>
+  <div id="target2"></div>
+
+  <div id="host1"></div>
+  <div id="host2"></div>
+
+  <div id="swap-parent">
+    <div id="duplicate" data-a></div>
+    <div id="duplicate" data-b></div>
+  </div>
 </body>
 
 <script>
@@ -23,5 +34,58 @@
 
       assert_equals(document.getElementById("target"), document.querySelector('[data-span]'));
       assert_equals(shadowRoot.getElementById("target"), target);
-  }, 'moveBefore() correctly updates id map');
+  }, 'moveBefore() correctly updates id map when moving into shadow root');
+
+  test(() => {
+      let shadowRoot = container2.attachShadow({mode: "open"});
+      let div = document.createElement("div");
+      shadowRoot.appendChild(div);
+      let localTarget = document.getElementById("target2");
+
+      assert_equals(window.target2, localTarget);
+
+      div.moveBefore(localTarget, null);
+
+      assert_equals(window.target2, undefined);
+  }, 'moveBefore() correctly updates window map when moving id-mapped element into shadow root');
+
+  test(() => {
+      let shadowRoot1 = host1.attachShadow({mode: "open"});
+      let shadowRoot2 = host2.attachShadow({mode: "open"});
+
+      let container1 = document.createElement("div");
+      let container2 = document.createElement("div");
+      shadowRoot1.appendChild(container1);
+      shadowRoot2.appendChild(container2);
+
+      let div = document.createElement("div");
+      div.id = "a";
+      container1.appendChild(div);
+
+      assert_equals(shadowRoot1.getElementById("a"), div);
+      assert_equals(shadowRoot2.getElementById("a"), null);
+
+      container2.moveBefore(div, null);
+
+      assert_equals(shadowRoot1.getElementById("a"), null);
+      assert_equals(shadowRoot2.getElementById("a"), div);
+  }, 'moveBefore() correctly updates id map when moving between shadow roots');
+
+  test(() => {
+      let parent = document.getElementById("swap-parent");
+      let a = parent.querySelector('[data-a]');
+      let b = parent.querySelector('[data-b]');
+
+      assert_equals(document.getElementById("duplicate"), a);
+
+      parent.moveBefore(b, a);
+
+      assert_equals(parent.firstElementChild, b);
+      assert_equals(document.getElementById("duplicate"), b);
+
+      parent.moveBefore(a, b);
+
+      assert_equals(parent.firstElementChild, a);
+      assert_equals(document.getElementById("duplicate"), a);
+  }, 'moveBefore() correctly updates id map when swapping elements with duplicate ids');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map-expected.txt
@@ -1,4 +1,6 @@
 
 
-FAIL moveBefore() correctly updates name map assert_equals: expected (undefined) undefined but got (object) Element node <img name="target" data-target=""></img>
+FAIL moveBefore() correctly updates name map when moving into shadow root assert_equals: expected 0 but got 1
+PASS moveBefore() correctly updates window map
+FAIL moveBefore() correctly updates name map ordering in document assert_equals: expected Element node <img name="duplicate"></img> but got Element node <img name="duplicate"></img>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map.html
@@ -5,7 +5,12 @@
 
 <body>
   <div id="container"></div>
+  <div id="window-container"></div>
   <img name="target" data-target>
+  <img name="target2" data-target2>
+
+  <div id="host1"></div>
+  <div id="host2"></div>
 </body>
 
 <script>
@@ -16,15 +21,60 @@
 
       let target = document.querySelector('[data-target]');
 
-      assert_equals(window.target, target);
       let nameMap = document.getElementsByName("target");
       assert_equals(nameMap.length, 1);
       assert_equals(nameMap[0], target);
 
       div.moveBefore(target, null);
 
-      assert_equals(window.target, undefined);
-      nameMap = document.getElementsByName("target");
       assert_equals(nameMap.length, 0);
-  }, 'moveBefore() correctly updates name map');
+  }, 'moveBefore() correctly updates name map when moving into shadow root');
+
+  test(() => {
+      let shadowRoot = document.getElementById("window-container").attachShadow({mode: "open"});
+      let div = document.createElement("div");
+      shadowRoot.appendChild(div);
+
+      let target = document.querySelector('[data-target2]');
+
+      assert_equals(window.target2, target);
+
+      div.moveBefore(target, null);
+
+      assert_equals(window.target2, undefined);
+  }, 'moveBefore() correctly updates window map');
+
+  test(() => {
+      let host = document.createElement("div");
+      document.body.appendChild(host);
+
+      let shadowRoot = host.attachShadow({mode: "open"});
+      let parent = document.createElement("div");
+      shadowRoot.appendChild(parent);
+
+      let a = document.createElement("img");
+      let b = document.createElement("img");
+
+      a.name = "duplicate";
+      b.name = "duplicate";
+
+      parent.appendChild(a);
+      parent.appendChild(b);
+
+      let nameMap = document.getElementsByName("duplicate");
+
+      assert_equals(nameMap.length, 0);
+
+      document.body.appendChild(a);
+      document.body.appendChild(b);
+
+      nameMap = document.getElementsByName("duplicate");
+      assert_equals(nameMap.length, 2);
+      assert_equals(nameMap[0], a);
+
+      document.body.moveBefore(b, a);
+
+      assert_equals(nameMap.length, 2);
+      assert_equals(nameMap[0], b);
+  }, 'moveBefore() correctly updates name map ordering in document');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-shadow-inside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-shadow-inside-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL moveBefore-shadow-inside assert_equals: expected 300 but got 200
+PASS moveBefore-shadow-inside
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-shadow-root-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-shadow-root-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL moveBefore() is allowed in ShadowRoots (i.e., connected DocumentFragments) assert_equals: Original lastChild is now firstChild expected Element node <p>Child2</p> but got Element node <p>Child1</p>
+PASS moveBefore() is allowed in ShadowRoots (i.e., connected DocumentFragments)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt
@@ -1,4 +1,3 @@
- window.__ranHTMLInsideMoveBefore = true; window.__ranSVGInsideMoveBefore = true;
 
 PASS Synchronous script execution in HTMLScriptElement during moveBefore should be blocked
 PASS Synchronous script execution in SVGScriptElement during moveBefore should be blocked

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-preserve-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-preserve-expected.txt
@@ -3,5 +3,5 @@ Button
 PASS when reparenting an element, don't automatically reset the document focus
 PASS when reparenting a focused element into an inert parent, reset the document focus
 PASS when reparenting a focused element into a hidden parent, reset the document focus
-PASS when reparenting an ancestor of an focused element into a hidden parent, reset the document focus
+FAIL when reparenting an ancestor of an focused element into a hidden parent, reset the document focus promise_test: Unhandled rejection with value: undefined
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -51,6 +51,7 @@
 #include "LabelsNodeList.h"
 #include "LocalFrameView.h"
 #include "MutationEvent.h"
+#include "Node.h"
 #include "NodeRareData.h"
 #include "NodeRenderStyle.h"
 #include "RadioNodeList.h"
@@ -1461,12 +1462,63 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
         }
     }
 
-    if (isConnected()) {
-        for (RefPtr inclusiveDescendant = &node; inclusiveDescendant; inclusiveDescendant = NodeTraversal::next(*inclusiveDescendant, &node)) {
+    RefPtr oldParent = node.parentNode();
+    ASSERT(oldParent);
+
+    RefPtr oldPreviousSibling = node.previousSibling();
+    RefPtr oldNextSibling = node.nextSibling();
+
+    // FIXME(281223): Run NodeIterator and live range pre-remove steps.
+
+    {
+        WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
+        ScriptDisallowedScope::InMainThread scriptDisallowedScope;
+
+        if (oldNextSibling) {
+            oldNextSibling->setPreviousSibling(oldPreviousSibling.get());
+            node.setNextSibling(nullptr);
+        } else {
+            ASSERT(oldParent->lastChild() == &node);
+            oldParent->setLastChild(oldPreviousSibling.get());
+        }
+
+        if (oldPreviousSibling) {
+            oldPreviousSibling->setNextSibling(oldNextSibling.get());
+            node.setPreviousSibling(nullptr);
+        } else {
+            ASSERT(oldParent->firstChild() == &node);
+            oldParent->setFirstChild(oldNextSibling.get());
+        }
+
+        node.updateAncestorConnectedSubframeCountForRemoval();
+        node.setParentNode(nullptr);
+
+        // FIXME(281223): Handle slot assignments and live ranges.
+
+        if (refChild)
+            insertBeforeCommon(*refChild, node);
+        else
+            appendChildCommon(node);
+
+        node.setTreeScopeRecursively(treeScope());
+        node.updateAncestorConnectedSubframeCountForInsertion();
+    }
+
+    auto newParentIsConnected = isConnected();
+
+    // FIXME(281223): Need to recurse into shadow trees.
+    for (RefPtr inclusiveDescendant = &node; inclusiveDescendant; inclusiveDescendant = NodeTraversal::next(*inclusiveDescendant, &node)) {
+        bool isSubtreeRoot = inclusiveDescendant.get() == &node;
+
+        inclusiveDescendant->movingSteps(isSubtreeRoot, *oldParent);
+
+        if (newParentIsConnected) {
             if (RefPtr element = dynamicDowncast<Element>(*inclusiveDescendant); element && element->isDefinedCustomElement())
                 CustomElementReactionQueue::enqueueConnectedMoveCallbackIfNeeded(*element);
         }
     }
+
+    // FIXME(281223): Queue tree mutation records.
 
     return { };
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3280,6 +3280,49 @@ void Element::removingSteps(RemovalType removalType, ContainerNode& oldParentOfR
     }
 }
 
+void Element::movingSteps(bool isSubtreeRoot, ContainerNode& oldParent)
+{
+    ContainerNode::movingSteps(isSubtreeRoot, oldParent);
+
+    Ref oldTreeScope = oldParent.treeScope();
+    Ref newTreeScope = treeScope();
+    RefPtr<HTMLDocument> oldHTMLDocument = oldTreeScope->rootNode().isDocumentNode()
+        ? dynamicDowncast<HTMLDocument>(oldTreeScope->documentScope()) : nullptr;
+    RefPtr<HTMLDocument> newHTMLDocument = newTreeScope->rootNode().isDocumentNode()
+        ? dynamicDowncast<HTMLDocument>(newTreeScope->documentScope()) : nullptr;
+
+    if (auto& idValue = getIdAttribute(); !idValue.isEmpty()) {
+        oldTreeScope->removeElementById(idValue, *this);
+        newTreeScope->addElementById(idValue, *this);
+        if (oldHTMLDocument)
+            updateIdForDocument(*oldHTMLDocument, idValue, nullAtom(), HTMLDocumentNamedItemMapsUpdatingCondition::Always);
+        if (newHTMLDocument)
+            updateIdForDocument(*newHTMLDocument, nullAtom(), idValue, HTMLDocumentNamedItemMapsUpdatingCondition::Always);
+    }
+
+    if (auto& nameValue = getNameAttribute(); !nameValue.isEmpty()) {
+        oldTreeScope->removeElementByName(nameValue, *this);
+        newTreeScope->addElementByName(nameValue, *this);
+        if (oldHTMLDocument)
+            updateNameForDocument(*oldHTMLDocument, nameValue, nullAtom());
+        if (newHTMLDocument)
+            updateNameForDocument(*newHTMLDocument, nullAtom(), nameValue);
+    }
+
+    if (!isSubtreeRoot || !hasFocusWithin())
+        return;
+
+    if (RefPtr oldParentElement = dynamicDowncast<Element>(oldParent))
+        oldParentElement->setHasFocusWithin(false);
+    for (Ref oldAncestor : composedTreeAncestors(oldParent))
+        oldAncestor->setHasFocusWithin(false);
+
+    for (Ref newAncestor : composedTreeAncestors(*this))
+        newAncestor->setHasFocusWithin(true);
+
+    // FIXME(314066): Audit removingSteps and insertionSteps and handle all internal state that needs updating here.
+}
+
 PopoverData* Element::popoverData() const
 {
     return hasRareData() ? elementRareData()->popoverData() : nullptr;

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -929,6 +929,7 @@ protected:
 
     NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
     void removingSteps(RemovalType, ContainerNode&) override;
+    void movingSteps(bool, ContainerNode&) override;
     void childrenChanged(const ChildChange&) override;
     void removeAllEventListeners() override;
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -508,6 +508,9 @@ public:
     // https://dom.spec.whatwg.org/#concept-node-remove-ext
     virtual void removingSteps(RemovalType, ContainerNode& oldParentOfRemovedTree);
 
+    // https://dom.spec.whatwg.org/#concept-node-move-ext
+    virtual void movingSteps(bool, ContainerNode&) { };
+
     virtual String description() const;
     virtual String debugDescription() const;
 


### PR DESCRIPTION
#### 00d65752a4af199afcc8ad3a90bfef88f6384aaa
<pre>
Implement node moving for moveBefore()
<a href="https://bugs.webkit.org/show_bug.cgi?id=313148">https://bugs.webkit.org/show_bug.cgi?id=313148</a>

Reviewed by Ryosuke Niwa.

This implements the actual moving part of moveBefore(),
minimal moving steps are implemented to prevent crashes related to the id
and name maps.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/Node-moveBefore-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/child-style-preserve-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-left-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/continue-css-animation-transform-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/fieldset-child-blur-event-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/fire-focusin-focusout-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-preserve-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-within-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/iframe-document-preserve.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/listed-form-element-reset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/live-range-updates-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-id-map.html:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map.html:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-shadow-inside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-shadow-root-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-preserve-expected.txt: Added.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::moveBefore):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::movingSteps):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Node.h:
(WebCore::Node::movingSteps):

Canonical link: <a href="https://commits.webkit.org/313302@main">https://commits.webkit.org/313302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f83abd73ea93894ce0581483af2ba8cecb392f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118988 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126149 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106727 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27542 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26069 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19181 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137246 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173985 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21298 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134459 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35693 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30323 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134457 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36315 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145564 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97996 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22398 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35187 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102938 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34688 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->