### PR TITLE
Fix CSP bypass in sandboxed srcdoc iframes

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-srcdoc-import-bypass-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-srcdoc-import-bypass-expected.txt
@@ -1,0 +1,14 @@
+CONSOLE MESSAGE: Refused to apply a stylesheet because its hash, its nonce, or 'unsafe-inline' appears in neither the style-src directive nor the default-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load https://localhost:8443/security/contentSecurityPolicy/resources/module-pass.py because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load https://localhost:8443/security/contentSecurityPolicy/resources/module-pass.py because it does not appear in the script-src directive of the Content Security Policy.
+This test checks if iframes without an initial srcdoc attribute incorrectly bypass CSP when srcdoc is set later.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframe1Loaded is false
+PASS iframe2Loaded is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-srcdoc-import-bypass.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/iframe-srcdoc-import-bypass.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval';">
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("This test checks if iframes without an initial srcdoc attribute incorrectly bypass CSP when srcdoc is set later.");
+
+window.jsTestIsAsync = true;
+
+let resultsReceived = 0;
+let iframe1Loaded;
+let iframe2Loaded;
+
+function reportResult(iframeId, loaded) {
+    if (iframeId === "iframe1")
+        iframe1Loaded = loaded;
+    else
+        iframe2Loaded = loaded;
+    resultsReceived++;
+
+    if (resultsReceived === 2)
+        finishTest();
+}
+
+function finishTest() {
+    shouldBeFalse("iframe1Loaded");
+    shouldBeFalse("iframe2Loaded");
+    finishJSTest();
+}
+
+window.addEventListener("message", (event) => {
+    if (event.data.type === "import-result")
+        reportResult(event.data.iframe, event.data.loaded);
+});
+
+document.addEventListener("DOMContentLoaded", function() {
+    const iframe1 = document.getElementById("iframe1");
+    const iframe2 = document.getElementById("iframe2");
+    const srcdocContent = `
+        <script>
+        (async function() {
+            try {
+                await import('https://localhost:8443/security/contentSecurityPolicy/resources/module-pass.py');
+                window.parent.postMessage({type: 'import-result', iframe: '${iframe1.id}', loaded: true}, '*');
+            } catch (e) {
+                window.parent.postMessage({type: 'import-result', iframe: '${iframe1.id}', loaded: false}, '*');
+            }
+        })();
+        <\/script>
+    `;
+
+    iframe1.srcdoc = srcdocContent;
+    iframe2.srcdoc = srcdocContent.replaceAll(iframe1.id, iframe2.id);
+});
+</script>
+<iframe id="iframe1" sandbox="allow-scripts"></iframe>
+<iframe id="iframe2" sandbox="allow-scripts" srcdoc=""></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/module-pass.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/module-pass.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    "Access-Control-Allow-Origin: *\r\n"
+    "Content-Type: application/javascript\r\n\r\n"
+)

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/inheritance-from-initiator.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/inheritance-from-initiator.sub-expected.txt
@@ -1,10 +1,10 @@
 
 
 PASS Setting src inherits from parent.
-FAIL Changing contentWindow.location inherits from who changed it. assert_equals: expected "a" but got "p"
+PASS Changing contentWindow.location inherits from who changed it.
 PASS Changing contentWindow.location indirectly inherits from who changed it directly.
-FAIL window.open() inherits from caller. assert_equals: expected "a" but got "p"
+PASS window.open() inherits from caller.
 PASS Click on anchor inherits from owner of the anchor.
-FAIL Form submission through submit() inherits from owner of form. assert_equals: expected "b" but got "p"
-FAIL Form submission through button click inherits from owner of form. assert_equals: expected "b" but got "p"
+PASS Form submission through submit() inherits from owner of form.
+PASS Form submission through button click inherits from owner of form.
 

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -228,7 +228,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
             return document->loader() && document->loader()->substituteData().isValid();
         };
 
-        if (currentHistoryItem && currentHistoryItem->policyContainer()) {
+        if (triggeringAction && triggeringAction->type() == NavigationType::BackForward && currentHistoryItem && currentHistoryItem->policyContainer()) {
             const auto& policyContainerFromHistory = currentHistoryItem->policyContainer();
             ASSERT(policyContainerFromHistory);
             document->inheritPolicyContainerFrom(*policyContainerFromHistory);


### PR DESCRIPTION
#### b4390e8352b7dc2ebbf53659e0ed9c3017b4efd2
<pre>
Fix CSP bypass in sandboxed srcdoc iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=304951">https://bugs.webkit.org/show_bug.cgi?id=304951</a>
<a href="https://rdar.apple.com/154201938">rdar://154201938</a>

Reviewed by Ryan Reno and Pascoe.

Only inherit the policy container from history item during back/forward navigations. Previously, iframes
without an initial srcdoc attribute could bypass CSP when srcdoc was set dynamically because they
incorrectly inherited from history instead of from the actual initiator.

Test: http/tests/security/contentSecurityPolicy/iframe-srcdoc-import-bypass.html
* LayoutTests/http/tests/security/contentSecurityPolicy/iframe-srcdoc-import-bypass-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/iframe-srcdoc-import-bypass.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/resources/module-pass.py: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/inheritance-from-initiator.sub-expected.txt:
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::begin):

Originally-landed-as: 305413.3@safari-7624-branch (ffc8c894635c). <a href="https://rdar.apple.com/173968774">rdar://173968774</a>
Canonical link: <a href="https://commits.webkit.org/312236@main">https://commits.webkit.org/312236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71400311210416f5946ed5923706ade2f4d64849

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112390 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122604 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86053 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103273 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23932 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22296 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14908 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169626 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15233 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130789 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31389 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26360 "Found 1 new test failure: inspector/worker/console-screenshot.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130903 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141776 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89244 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24246 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25607 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18582 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30880 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96645 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 32708 issues") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30400 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30554 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->