### PR TITLE
[GTK][WPE] Skia Compositor: Deduplicate overlap region consolidation threshold

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -860,7 +860,6 @@ Vector<IntRect, 1> SkiaCompositingLayer::computeConsolidatedOverlapRegionRects(c
     computeOverlapRegions(data, context.accumulatedReplicaTransform, IncludesReplica::No);
 
     auto rects = data.overlapRegion.rects();
-    static constexpr size_t cOverlapRegionConsolidationThreshold = 4;
     if (rects.size() > cOverlapRegionConsolidationThreshold) {
         rects.clear();
         rects.append(data.overlapRegion.bounds());
@@ -972,7 +971,6 @@ void SkiaCompositingLayer::paintUsingOverlapRegions(SkCanvas& canvas, PaintConte
     }
 
     auto overlapRects = data.overlapRegion.rects();
-    static constexpr size_t cOverlapRegionConsolidationThreshold = 4;
     if (data.nonOverlapRegion.isEmpty() && overlapRects.size() > cOverlapRegionConsolidationThreshold) {
         overlapRects.clear();
         overlapRects.append(data.overlapRegion.bounds());

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h
@@ -34,6 +34,8 @@ namespace WebCore {
 class FloatRect;
 class TransformationMatrix;
 
+static constexpr size_t cOverlapRegionConsolidationThreshold = 4;
+
 enum class ComputeOverlapRegionMode : uint8_t {
     Intersection,
     Union,


### PR DESCRIPTION
#### a77b2e65596fadacec0aec218cf1ec6b44d86f99
<pre>
[GTK][WPE] Skia Compositor: Deduplicate overlap region consolidation threshold
<a href="https://bugs.webkit.org/show_bug.cgi?id=313154">https://bugs.webkit.org/show_bug.cgi?id=313154</a>

Reviewed by Carlos Garcia Campos.

The overlap region consolidation threshold was declared as a
function-local constant in two places in SkiaCompositingLayer.cpp.
Move it to SkiaCompositingLayerOverlapRegions.h so there is a single
place to tune the value.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::computeConsolidatedOverlapRegionRects):
(WebCore::SkiaCompositingLayer::paintUsingOverlapRegions):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h:

Canonical link: <a href="https://commits.webkit.org/311920@main">https://commits.webkit.org/311920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b840dedf4e2c36c96f5063d723267b421270fa82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167145 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112400 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122615 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86059 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103284 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23938 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14918 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169637 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15271 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130799 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31430 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130913 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31387 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141778 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89254 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24084 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25625 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18584 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30890 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96700 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30410 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30683 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->