### PR TITLE
[:has()] Fix failures in css/selectors/invalidation/has-sibling-insertion-removal.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-sibling-insertion-removal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-sibling-insertion-removal-expected.txt
@@ -4,27 +4,27 @@ PASS subject1: color after #sibling1_1 inserted should be rgb(255, 0, 0)
 PASS subject2: initial color should be rgb(128, 128, 128)
 PASS subject2: color after #sibling2_1 removed should be rgb(0, 128, 0)
 PASS subject3: initial color should be rgb(128, 128, 128)
-FAIL subject3: color after #sibling3_1 inserted should be rgb(0, 0, 255) assert_equals: expected "rgb(0, 0, 255)" but got "rgb(128, 128, 128)"
+PASS subject3: color after #sibling3_1 inserted should be rgb(0, 0, 255)
 PASS subject4: initial color should be rgb(128, 128, 128)
-FAIL subject4: color after #sibling4_1 removed should be rgb(255, 255, 0) assert_equals: expected "rgb(255, 255, 0)" but got "rgb(128, 128, 128)"
+PASS subject4: color after #sibling4_1 removed should be rgb(255, 255, 0)
 PASS subject5: initial color should be rgb(255, 0, 0)
 PASS subject5: color after #sibling5_1 removed should be rgb(128, 128, 128)
 PASS subject6: initial color should be rgb(0, 128, 0)
 PASS subject6: color after #sibling6_1 inserted should be rgb(128, 128, 128)
 PASS subject7: initial color should be rgb(0, 0, 255)
-FAIL subject7: color after #sibling7_1 removed should be rgb(128, 128, 128) assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 0, 255)"
+PASS subject7: color after #sibling7_1 removed should be rgb(128, 128, 128)
 PASS subject8: initial color should be rgb(255, 255, 0)
-FAIL subject8: color after #sibling8_1 inserted should be rgb(128, 128, 128) assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 255, 0)"
+PASS subject8: color after #sibling8_1 inserted should be rgb(128, 128, 128)
 PASS subject9: initial color should be rgb(128, 128, 128)
 PASS subject9: color after #sibling9_1 inserted should be rgb(255, 0, 0)
 PASS subject10: initial color should be rgb(128, 128, 128)
 PASS subject10: color after #sibling10_1 removed should be rgb(0, 128, 0)
 PASS subject11: initial color should be rgb(128, 128, 128)
-FAIL subject11: color after #sibling11_1 inserted should be rgb(0, 0, 255) assert_equals: expected "rgb(0, 0, 255)" but got "rgb(128, 128, 128)"
+PASS subject11: color after #sibling11_1 inserted should be rgb(0, 0, 255)
 PASS subject12: initial color should be rgb(128, 128, 128)
-FAIL subject12: color after #sibling12_1 removed should be rgb(255, 255, 0) assert_equals: expected "rgb(255, 255, 0)" but got "rgb(128, 128, 128)"
+PASS subject12: color after #sibling12_1 removed should be rgb(255, 255, 0)
 PASS subject13: initial color should be rgb(128, 128, 128)
-FAIL subject13: color after #sibling12_1 removed should be rgb(0, 128, 0) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS subject13: color after #sibling12_1 removed should be rgb(0, 128, 0)
 PASS subject14: initial color should be rgb(0, 128, 0)
 PASS subject14: color after #sibling14_2 removed should be rgb(128, 128, 128)
 

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -54,6 +54,25 @@ static bool rightmostCompoundContainsEmpty(const CSSSelector& selector)
     return false;
 }
 
+static bool isSiblingHasRelation(const MatchElement& matchElement)
+{
+    if (!matchElement.hasRelation)
+        return false;
+    switch (*matchElement.hasRelation) {
+    case MatchElement::HasRelation::DirectSibling:
+    case MatchElement::HasRelation::IndirectSibling:
+    case MatchElement::HasRelation::SiblingChild:
+    case MatchElement::HasRelation::SiblingDescendant:
+        return true;
+    case MatchElement::HasRelation::Child:
+    case MatchElement::HasRelation::Descendant:
+    case MatchElement::HasRelation::ScopeBreaking:
+        return false;
+    }
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElement, MatchingHasSelectors& matchingHasSelectors, ChangedElementRelation changedElementRelation, EmptyInvalidation emptyInvalidation)
 {
     auto& ruleSets = parentElement().styleResolver().ruleSets();
@@ -79,7 +98,20 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
         }
     };
 
-    bool isFirst = isChild && m_childChange.previousSiblingElement == changedElement.previousElementSibling() && changedElementRelation == ChangedElementRelation::SelfOrDescendant;
+    auto hasAlreadyMatchedAndMutationIsIrrelevant = [&](const InvalidationRuleSet& invalidationRuleSet) {
+        // For the first changed element at the mutation point, check if a neighbor already matches the
+        // :has() argument. If so, adding/removing one more matching element doesn't change the :has() result.
+        // This doesn't apply inside :not() (inverted logic) or for sibling :has() arguments (direction matters).
+        if (!isChild || changedElementRelation != ChangedElementRelation::SelfOrDescendant)
+            return false;
+        if (m_childChange.previousSiblingElement != changedElement.previousElementSibling())
+            return false;
+        if (invalidationRuleSet.isNegation == IsNegation::Yes)
+            return false;
+        if (isSiblingHasRelation(invalidationRuleSet.matchElement))
+            return false;
+        return true;
+    };
 
     auto hasMatchingInvalidationSelector = [&](auto& invalidationRuleSet) {
         SelectorChecker selectorChecker(changedElement.document());
@@ -91,8 +123,7 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
             if (emptyInvalidation == EmptyInvalidation::Yes && !rightmostCompoundContainsEmpty(selector))
                 continue;
 
-            if (isFirst && invalidationRuleSet.isNegation == IsNegation::No) {
-                // If this :has() matches ignoring this mutation, nothing actually changes and we don't need to invalidate.
+            if (hasAlreadyMatchedAndMutationIsIrrelevant(invalidationRuleSet)) {
                 // FIXME: We could cache this state across invalidations instead of just testing a single sibling.
                 RefPtr sibling = m_childChange.previousSiblingElement ? m_childChange.previousSiblingElement : m_childChange.nextSiblingElement;
                 if (sibling && selectorChecker.match(selector, *sibling, checkingContext)) {

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -41,6 +41,8 @@
 namespace WebCore {
 namespace Style {
 
+enum class CanBreakScope : bool { No, Yes };
+
 static bool NODELETE isSiblingOrSubject(MatchElement::Relation relation)
 {
     switch (relation) {
@@ -202,6 +204,24 @@ MatchElement::HasRelation computeHasArgumentRelation(const CSSSelector& hasSelec
     return toHasRelation(relation);
 }
 
+static bool isSiblingCombinator(CSSSelector::Relation relation)
+{
+    return relation == CSSSelector::Relation::DirectAdjacent || relation == CSSSelector::Relation::IndirectAdjacent;
+}
+
+// Whether a combinator inside a logical combination (:is()/:not()) within :has()
+// reaches outside the :has() scope.
+static bool isHasScopeBreakingCombinator(CSSSelector::Relation relation, MatchElement::HasRelation hasRelation)
+{
+    if (hasRelation == MatchElement::HasRelation::ScopeBreaking)
+        return false;
+    if (relation == CSSSelector::Relation::DescendantSpace || relation == CSSSelector::Relation::Child)
+        return hasRelation != MatchElement::HasRelation::Child || relation != CSSSelector::Relation::Child;
+    if (isSiblingCombinator(relation))
+        return isSiblingOrSubject(hasRelation);
+    return false;
+}
+
 static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, const CSSSelector& selector, const CSSSelector& childSelector)
 {
     if (selector.match() == CSSSelector::Match::PseudoClass) {
@@ -238,6 +258,8 @@ struct RuleFeatureSet::RecursiveCollectionContext {
     IsNegation isNegation { IsNegation::No };
     CanBreakScope canBreakScope { CanBreakScope::No };
     const CSSSelector* outerCompoundSelector { nullptr };
+    // When walking the direct :has() argument chain. Not set inside nested :is()/:not().
+    const CSSSelector* hasPseudoClass { nullptr };
 };
 
 void RuleFeatureSet::collectFeaturesFromSelector(SelectorFeatures& selectorFeatures, const CSSSelector& selector, MatchElement matchElement)
@@ -245,13 +267,27 @@ void RuleFeatureSet::collectFeaturesFromSelector(SelectorFeatures& selectorFeatu
     recursivelyCollectFeaturesFromSelector(selectorFeatures, selector, { matchElement });
 }
 
-DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& selectorFeatures, const CSSSelector& firstSelector, const RecursiveCollectionContext& context)
+void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& selectorFeatures, const CSSSelector& firstSelector, const RecursiveCollectionContext& context)
 {
     auto matchElement = context.matchElement;
-    auto doesBreakScope = DoesBreakScope::No;
     const CSSSelector* selector = &firstSelector;
+    bool isRightmostCompound = true;
+
+    // When walking a direct :has() argument chain, emit hasPseudoClasses entries for the rightmost
+    // compound and compounds whose combinator to the left is a sibling combinator. Child mutations
+    // can break sibling adjacency, so ChildChangeInvalidation needs entries keyed on these compounds.
+    auto collectHasPseudoClassFeatureIfNeeded = [&] {
+        if (!context.hasPseudoClass || selector->match() == CSSSelector::Match::HasScope)
+            return;
+        if (!isRightmostCompound && !isSiblingCombinator(selector->relation()))
+            return;
+        auto scopeSource = context.outerCompoundSelector ? context.outerCompoundSelector : context.hasPseudoClass;
+        selectorFeatures.hasPseudoClasses.append({ selector, matchElement, context.isNegation, scopeSource });
+    };
+
     while (true) {
         auto canBreakScope = context.canBreakScope;
+
         if (selector->match() == CSSSelector::Match::Id) {
             idsInRules.add(selector->value());
             if (matchElement.relation == MatchElement::Relation::Parent || matchElement.relation == MatchElement::Relation::Ancestor)
@@ -277,6 +313,8 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
                 canBreakScope = CanBreakScope::Yes;
         }
 
+        collectHasPseudoClassFeatureIfNeeded();
+
         if (const CSSSelectorList* selectorList = selector->selectorList()) {
             auto subSelectorIsNegation = context.isNegation;
             if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Not)
@@ -285,24 +323,22 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
             for (auto& subSelector : *selectorList) {
                 auto subResult = computeSubSelectorMatchElement(matchElement, *selector, subSelector);
 
-                RecursiveCollectionContext subContext { subResult, subSelectorIsNegation, canBreakScope, context.outerCompoundSelector };
+                RecursiveCollectionContext subContext { subResult, subSelectorIsNegation, canBreakScope, context.outerCompoundSelector, context.hasPseudoClass };
 
                 // When entering a logical combination (not :has() itself), record the outer compound
                 // so nested :has() can use it for scope selector extraction.
+                // Also clear hasPseudoClass so per-compound entries are only emitted at the
+                // direct :has() argument level, not inside nested :is()/:not().
                 if (selector->match() == CSSSelector::Match::PseudoClass && isLogicalCombinationPseudoClass(selector->pseudoClass()) && selector->pseudoClass() != CSSSelector::PseudoClass::Has) {
                     if (!subContext.outerCompoundSelector)
                         subContext.outerCompoundSelector = selector;
+                    subContext.hasPseudoClass = nullptr;
                 }
 
-                auto pseudoClassDoesBreakScope = recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, subContext);
+                if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Has)
+                    subContext.hasPseudoClass = selector;
 
-                if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Has) {
-                    auto scopeSource = context.outerCompoundSelector ? context.outerCompoundSelector : selector;
-                    selectorFeatures.hasPseudoClasses.append({ &subSelector, subResult, context.isNegation, pseudoClassDoesBreakScope, scopeSource });
-                }
-
-                if (pseudoClassDoesBreakScope == DoesBreakScope::Yes)
-                    doesBreakScope = DoesBreakScope::Yes;
+                recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, subContext);
             }
         }
 
@@ -310,34 +346,17 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
             break;
 
         auto relation = selector->relation();
+        isRightmostCompound = false;
+
         matchElement.relation = computeNextRelation(matchElement.relation, relation);
 
-        // Detect scope-breaking inside :has() arguments.
-        // When inside :has() and a logical combinator like :is() allows scope breaking,
-        // combinators can reach outside the :has() scope.
-        if (matchElement.hasRelation && *matchElement.hasRelation != MatchElement::HasRelation::ScopeBreaking && context.canBreakScope == CanBreakScope::Yes) {
-            if (relation == CSSSelector::Relation::DescendantSpace || relation == CSSSelector::Relation::Child) {
-                // For :has(> :is(.x > .y)), the child combinator inside :is() is still scoped to the direct child's tree.
-                // Only mark as scope-breaking if the has argument isn't a direct child, or the combinator is a descendant space.
-                if (matchElement.hasRelation != MatchElement::HasRelation::Child || relation != CSSSelector::Relation::Child) {
-                    matchElement.hasRelation = MatchElement::HasRelation::ScopeBreaking;
-                    doesBreakScope = DoesBreakScope::Yes;
-                }
-            }
-            if (relation == CSSSelector::Relation::IndirectAdjacent || relation == CSSSelector::Relation::DirectAdjacent) {
-                // :has(~ :is(.x ~ .y)) — sibling combinator inside :is() when :has() has sibling traversal.
-                // Widens to any-sibling search and is scope-breaking (elements outside :has() scope can be affected).
-                if (isSiblingOrSubject(*matchElement.hasRelation)) {
-                    matchElement.hasRelation = MatchElement::HasRelation::ScopeBreaking;
-                    doesBreakScope = DoesBreakScope::Yes;
-                }
-            }
+        if (matchElement.hasRelation && context.canBreakScope == CanBreakScope::Yes && isHasScopeBreakingCombinator(relation, *matchElement.hasRelation)) {
+            matchElement.hasRelation = MatchElement::HasRelation::ScopeBreaking;
+            selectorFeatures.containsScopeBreakingHasPseudoClass = true;
         }
 
         selector = selector->precedingInComplexSelector();
     };
-
-    return doesBreakScope;
 }
 
 PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::PseudoClass pseudoClass, InvalidationKeyType keyType, const AtomString& keyString)
@@ -489,7 +508,7 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
     }
 
     for (auto& entry : selectorFeatures.hasPseudoClasses) {
-        auto& [selector, matchElement, isNegation, doesBreakScope, hasPseudoClass] = entry;
+        auto& [selector, matchElement, isNegation, hasPseudoClass] = entry;
         // The selector argument points to a selector inside :has() selector list instead of :has() itself.
         auto& featureVector = *hasPseudoClassRules.ensure(makePseudoClassInvalidationKey(CSSSelector::PseudoClass::Has, *selector), [] {
             return makeUnique<Vector<RuleFeatureWithInvalidationSelector>>();
@@ -503,12 +522,12 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
             CSSSelectorParser::makeHasScopeSelector(*hasPseudoClass)
         });
 
-        if (doesBreakScope == DoesBreakScope::Yes)
-            scopeBreakingHasPseudoClassRules.append({ ruleData });
-
         setUsesRelation(matchElement.relation);
         usesHasPseudoClass = true;
     }
+
+    if (selectorFeatures.containsScopeBreakingHasPseudoClass)
+        scopeBreakingHasPseudoClassRules.append({ ruleData });
 }
 
 void RuleFeatureSet::collectPseudoElementFeatures(const RuleData& ruleData)

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -81,8 +81,6 @@ struct MatchElement {
 constexpr unsigned matchRelationCount = static_cast<unsigned>(MatchElement::Relation::HostChild) + 1;
 
 enum class IsNegation : bool { No, Yes };
-enum class CanBreakScope : bool { No, Yes }; // Are we inside a logical combination pseudo-class like :is() or :not(), which if we were inside a :has(), could break out of its scope?
-enum class DoesBreakScope : bool { No, Yes }; // Did we find a logical combination pseudo-class like :is() or :not() with selector combinators that do break out of a :has() scope?
 
 // For MSVC.
 #pragma pack(push, 4)
@@ -168,17 +166,18 @@ struct RuleFeatureSet {
 private:
     struct SelectorFeatures {
         using InvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation>;
-        using HasInvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation, DoesBreakScope, const CSSSelector*>;
+        using HasInvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation, const CSSSelector*>;
 
         Vector<InvalidationFeature> ids;
         Vector<InvalidationFeature> classes;
         Vector<InvalidationFeature> attributes;
         Vector<InvalidationFeature> pseudoClasses;
         Vector<HasInvalidationFeature> hasPseudoClasses;
+        bool containsScopeBreakingHasPseudoClass { false };
     };
     struct RecursiveCollectionContext;
     void collectFeaturesFromSelector(SelectorFeatures&, const CSSSelector&, MatchElement = { MatchElement::Relation::Subject, { } });
-    DoesBreakScope recursivelyCollectFeaturesFromSelector(SelectorFeatures&, const CSSSelector&, const RecursiveCollectionContext&);
+    void recursivelyCollectFeaturesFromSelector(SelectorFeatures&, const CSSSelector&, const RecursiveCollectionContext&);
     void NODELETE collectPseudoElementFeatures(const RuleData&);
 };
 


### PR DESCRIPTION
#### a7c33784e49fd6e3078d55d53e5f005feb9270d8
<pre>
[:has()] Fix failures in css/selectors/invalidation/has-sibling-insertion-removal.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=313151">https://bugs.webkit.org/show_bug.cgi?id=313151</a>
&lt;<a href="https://rdar.apple.com/problem/175441568">rdar://problem/175441568</a>&gt;

Reviewed by Alan Baradlay.

Invalidation fixes for sibling combinators.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-sibling-insertion-removal-expected.txt:
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::isSiblingHasRelation):
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):

Optimization that tries to detect that :has() state doesn&apos;t change does not work
with sibling combinators. Don&apos;t use it in this case.

* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::isSiblingCombinator):
(WebCore::Style::isHasScopeBreakingCombinator):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):

Besides the subject selector also collect :has() invalidation selectors for compounds that start a sibling combinator.
Sibling changes can affect elements in subtrees that are not part of the mutation.

Reorganize and simplify the code.

(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/style/RuleFeature.h:

Canonical link: <a href="https://commits.webkit.org/311893@main">https://commits.webkit.org/311893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c2651df252e76c96fc1c002757ba3f95e1bbe5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167148 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160190 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/31814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31675 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161278 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/31814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103290 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/31814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14921 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/31814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169640 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/15262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21625 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/31436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130918 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35442 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/31374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141794 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/31374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30893 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/96673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30413 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->