### PR TITLE
Flexbox: calc(infinity) flex-grow factor fails to stretch item to 100% width.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-grow-009-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-grow-009-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-grow-009.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-grow-009.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="https://webkit.org">
+<link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#resolve-flexible-lengths">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<style>
+  .container {
+    background-color: red;
+    display: flex;
+    height: 100px;
+    width: 100px;
+  }
+  .infinite-grow {
+    flex: calc(infinity) 0 0px;
+    background: green;
+  }
+  .normal-grow {
+    flex: 1 0 0px;
+    background: red;
+  }
+</style>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="container">
+    <div class="infinite-grow"></div>
+    <div class="normal-grow"></div>
+  </div>
+</body>

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2106,7 +2106,7 @@ bool RenderFlexibleBox::resolveFlexibleLengths(FlexSign flexSign, FlexLayoutItem
         LayoutUnit flexItemSize = flexLayoutItem.flexBaseContentSize;
         double extraSpace = 0;
         if (remainingFreeSpace > 0 && totalFlexGrow > 0 && flexSign == FlexSign::PositiveFlexibility && std::isfinite(totalFlexGrow))
-            extraSpace = remainingFreeSpace * flexItemStyle.flexGrow().value / totalFlexGrow;
+            extraSpace = remainingFreeSpace * (flexItemStyle.flexGrow().value / totalFlexGrow);
         else if (remainingFreeSpace < 0 && totalWeightedFlexShrink > 0 && flexSign == FlexSign::NegativeFlexibility && std::isfinite(totalWeightedFlexShrink) && !flexItemStyle.flexShrink().isZero())
             extraSpace = remainingFreeSpace * flexItemStyle.flexShrink().value * flexLayoutItem.flexBaseContentSize / totalWeightedFlexShrink;
         if (std::isfinite(extraSpace))


### PR DESCRIPTION
#### 32309d175884210b8f289aa7c567903b31afa137
<pre>
Flexbox: calc(infinity) flex-grow factor fails to stretch item to 100% width.
<a href="https://bugs.webkit.org/show_bug.cgi?id=312477">https://bugs.webkit.org/show_bug.cgi?id=312477</a>
<a href="https://rdar.apple.com/175431146">rdar://175431146</a>

Reviewed by Alan Baradlay.

The CSS Flexbox spec (Section 9.7, &quot;Resolve Flexible Lengths&quot;) says to distribute
remaining free space proportionally: compute the ratio of each item&apos;s flex grow
factor to the sum of all flex grow factors, then multiply remaining free space by
that ratio.

For example, given a 100px wide flex container with two items:
  - Item A: flex: calc(infinity) 0 0px  (flex-grow: FLT_MAX)
  - Item B: flex: 1 0 0px              (flex-grow: 1)

Item A should receive essentially all 100px of free space, and Item B ~0px.

However, resolveFlexibleLengths computed the expression left-to-right:
remainingFreeSpace * flexGrow / totalFlexGrow. The LayoutUnit * float multiplication
returns a float, so remainingFreeSpace (100) * flexGrow (FLT_MAX) computes the
result to infinity. Then infinity / totalFlexGrow produces NaN. The existing
std::isfinite guard then discards the result, leaving both items stuck at their flex
basis with no free space distributed.

Fix this by computing the ratio first: remainingFreeSpace * (flexGrow / totalFlexGrow).
This gives a ratio of 1 for item A and ~0 for item B.

Test: imported/w3c/web-platform-tests/css/css-flexbox/flex-grow-009.html
Canonical link: <a href="https://commits.webkit.org/311956@main">https://commits.webkit.org/311956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f823e7fb2d0320cd657bf67b741a13bb19f8aad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112468 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122670 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86095 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103340 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23975 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22362 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14986 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169705 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19219 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130855 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130969 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35478 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89322 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25659 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18646 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96752 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30478 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30751 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30632 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->