### PR TITLE
[Site Isolation] js/promise-isPromise.html fails

### DIFF
--- a/LayoutTests/js/promise-isPromise-expected.txt
+++ b/LayoutTests/js/promise-isPromise-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: EncodingError: Missing source URL.
 IDL promises should work with Promise.isPromise
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/js/promise-isPromise.html
+++ b/LayoutTests/js/promise-isPromise.html
@@ -12,7 +12,7 @@ window.jsTestIsAsync = true;
 window.addEventListener("unhandledrejection", (event) => {
     shouldBeTrue(`Promise.isPromise(event.promise)`);
 
-    finishJSTest();
+    setTimeout(finishJSTest, 0);
 });
 
 shouldBeTrue(`Promise.isPromise((new Blob).text())`);


### PR DESCRIPTION
#### 1593318ffde1f962fa892026e255196dc0d5bd96
<pre>
[Site Isolation] js/promise-isPromise.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313156">https://bugs.webkit.org/show_bug.cgi?id=313156</a>
<a href="https://rdar.apple.com/175446291">rdar://175446291</a>

Reviewed by Ryosuke Niwa.

This patch: <a href="https://commits.webkit.org/311150@main">https://commits.webkit.org/311150@main</a> adding reporting for
unhandled promise rejections, which show up as a console message in LayoutTests
expected files. In the non site isolation case, the tests finishes before the
message is reported. Site isolation&apos;s additional IPC overhead allows for enough
time for the message to be reported, causing the text failure.

To fix this issue, I added a 0s delay before calling finishJSTest in the
unhandledrejection eventListener, which allows the message to be reported first.

* LayoutTests/js/promise-isPromise-expected.txt:
* LayoutTests/js/promise-isPromise.html:

Canonical link: <a href="https://commits.webkit.org/311930@main">https://commits.webkit.org/311930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b39c52dae8f35c5be1829b4df812f82bd0546a1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167154 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112409 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122622 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86068 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103291 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23946 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22316 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14927 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150376 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169646 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19160 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130808 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130922 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35464 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141789 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89263 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25623 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18595 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190454 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30899 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48869 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30419 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30692 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30573 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->