### PR TITLE
Enhanced <select>: use self-* keywords for anchor positioning

### DIFF
--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
@@ -26,8 +26,8 @@
     <div style="border: 1px solid red">This should have 1px solid red border (default).</div>
     <div style="border: 2px dashed blue">This should have 2px dashed blue border (base).</div>
 
-    <div>block-start span-inline-end, block-end span-inline-start</div>
-    <div>block-end span-inline-end, block-start span-inline-start, block-start span-inline-start</div>
+    <div>start span-end, end span-start</div>
+    <div>end span-end, start span-start, start span-start</div>
 
     <div class="fake-base-select">This select should be green with white text. (base-select)</div>
     <div class="fake-base-select">This select should be green with white text. (base)</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
@@ -3,7 +3,7 @@ SIBLING
 
 FAIL UA styles of base appearance <select>. assert_equals: min-inline-size expected "calc-size(auto, max(size, 24px))" but got "0px"
 PASS UA styles of base appearance select::picker-icon.
-FAIL UA styles of base appearance ::picker(select) assert_equals: position-area expected "self-end span-self-end" but got "end span-end"
+PASS UA styles of base appearance ::picker(select)
 PASS UA styles of base appearance <option>.
 PASS UA styles of base appearance option::checkmark.
 PASS UA styles of base appearance <optgroup>.

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1129,17 +1129,14 @@ select::picker-icon {
     inset: auto;
     min-inline-size: -internal-auto-base(unset, anchor-size(self-inline));
     min-block-size: 1lh;
-    /* Go to the edge of the viewport, and add scrollbars if needed. */
     max-block-size: stretch;
     overflow: auto;
-    /* Below and span-right, by default. */
-    position-area: -internal-auto-base(unset, block-end span-inline-end);
+    position-area: -internal-auto-base(unset, self-block-end span-self-inline-end);
     position-try-order: -internal-auto-base(unset, most-block-size);
     position-try-fallbacks: -internal-auto-base(unset, {
-        block-start span-inline-end,   /* First try above and span-right. */
-        block-end span-inline-start,   /* Then below but span-left. */
-        block-start span-inline-start }); /* Then above and span-left. */
-
+        self-block-start span-self-inline-end,
+        self-block-end span-self-inline-start,
+        self-block-start span-self-inline-start });
     display: -internal-auto-base(contents, none);
 }
 

--- a/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
+++ b/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
@@ -27,6 +27,9 @@
 #include "config.h"
 #include "StylePositionTryFallback.h"
 
+#include "CSSKeywordValue.h"
+#include "CSSPropertyParserConsumer+Anchor.h"
+#include "CSSValuePair.h"
 #include "StyleBuilderChecking.h"
 #include "StyleCustomIdent.h"
 #include "StyleKeyword+CSSValueConversion.h"
@@ -146,16 +149,27 @@ auto CSSValueConversion<PositionTryFallback>::operator()(BuilderState& state, co
     };
 }
 
+static Ref<CSSValue> computedPositionAreaValue(const PositionTryFallback::PositionArea& value)
+{
+    RefPtr cssValue = RefPtr { value.properties }->getPropertyCSSValue(CSSPropertyPositionArea);
+    if (auto* pair = dynamicDowncast<CSSValuePair>(*cssValue)) {
+        auto dim1 = downcast<CSSKeywordValue>(pair->first()).valueID();
+        auto dim2 = downcast<CSSKeywordValue>(pair->second()).valueID();
+        return CSSPropertyParserHelpers::valueForPositionArea(dim1, dim2, CSSPropertyParserHelpers::ValueType::Computed).releaseNonNull();
+    }
+    return cssValue.releaseNonNull();
+}
+
 auto CSSValueCreation<PositionTryFallback::PositionArea>::operator()(CSSValuePool&, const RenderStyle&, const PositionTryFallback::PositionArea& value) -> Ref<CSSValue>
 {
-    return RefPtr { value.properties }->getPropertyCSSValue(CSSPropertyPositionArea).releaseNonNull();
+    return computedPositionAreaValue(value);
 }
 
 // MARK: - Serialization
 
 void Serialize<PositionTryFallback::PositionArea>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle&, const PositionTryFallback::PositionArea& value)
 {
-    builder.append(RefPtr { value.properties }->getPropertyCSSValue(CSSPropertyPositionArea)->cssText(context));
+    builder.append(computedPositionAreaValue(value)->cssText(context));
 }
 
 // MARK: - Logging


### PR DESCRIPTION
#### fbcd5cd04143c90c63583c05cbb16d21485e68bc
<pre>
Enhanced &lt;select&gt;: use self-* keywords for anchor positioning
<a href="https://bugs.webkit.org/show_bug.cgi?id=313157">https://bugs.webkit.org/show_bug.cgi?id=313157</a>

Reviewed by Tim Nguyen.

This follows a CSS WG resolution:

    <a href="https://github.com/w3c/csswg-drafts/issues/13738">https://github.com/w3c/csswg-drafts/issues/13738</a>

We also remove some unnecessary comments and correct the CSSOM and
computed style representation of position-try-fallbacks.

Canonical link: <a href="https://commits.webkit.org/311944@main">https://commits.webkit.org/311944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaa265c9ca936f068eeb76c86df71015fe4279b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112513 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122701 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86120 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142307 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103371 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24007 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15029 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169748 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15421 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130888 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31544 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131002 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141880 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89365 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24100 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25692 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18686 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31001 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96837 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30521 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30794 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30675 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->