### PR TITLE
[GTK][WPE] Skia Compositor: Extract filter helpers to SkiaCompositingLayerFilters

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -18,6 +18,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/SkiaBackingStore.h
     platform/graphics/skia/SkiaCompositingLayer.h
     platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.h
+    platform/graphics/skia/SkiaCompositingLayerFilters.h
     platform/graphics/skia/SkiaCompositingLayerOverlapRegions.h
     platform/graphics/skia/SkiaGPUAtlas.h
     platform/graphics/skia/SkiaHarfBuzzFont.h

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -61,6 +61,7 @@ platform/graphics/skia/ShareableBitmapSkia.cpp
 platform/graphics/skia/SkiaBackingStore.cpp
 platform/graphics/skia/SkiaCompositingLayer.cpp
 platform/graphics/skia/SkiaCompositingLayer3DRenderingContext.cpp
+platform/graphics/skia/SkiaCompositingLayerFilters.cpp
 platform/graphics/skia/SkiaCompositingLayerOverlapRegions.cpp
 platform/graphics/skia/SkiaGPUAtlas.cpp
 platform/graphics/skia/SkiaHarfBuzzFont.cpp

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -27,7 +27,6 @@
 #include "SkiaCompositingLayer.h"
 
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
-#include "ColorMatrix.h"
 #include "CoordinatedAnimatedBackingStoreClient.h"
 #include "CoordinatedImageBackingStore.h"
 #include "CoordinatedPlatformLayerBuffer.h"
@@ -38,6 +37,7 @@
 #include "Region.h"
 #include "SkiaBackingStore.h"
 #include "SkiaCompositingLayer3DRenderingContext.h"
+#include "SkiaCompositingLayerFilters.h"
 #include "SkiaCompositingLayerOverlapRegions.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkFont.h>
@@ -192,78 +192,17 @@ void SkiaCompositingLayer::setReplica(RefPtr<SkiaCompositingLayer>&& replica)
         m_replica->m_replicatedLayer = this;
 }
 
-static sk_sp<SkImageFilter> createFilter(const FilterOperation& filterOperation, sk_sp<SkImageFilter> input, SkTileMode blurTileMode = SkTileMode::kDecal)
-{
-    switch (filterOperation.type()) {
-    case FilterOperation::Type::Grayscale: {
-        ColorMatrix<5, 4> matrix(grayscaleColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
-        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
-    }
-    case FilterOperation::Type::Sepia: {
-        ColorMatrix<5, 4> matrix(sepiaColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
-        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
-    }
-    case FilterOperation::Type::Saturate: {
-        ColorMatrix<5, 4> matrix(saturationColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
-        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
-    }
-    case FilterOperation::Type::HueRotate: {
-        ColorMatrix<5, 4> matrix(hueRotateColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
-        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
-    }
-    case FilterOperation::Type::Invert: {
-        const auto matrix = invertColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount());
-        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
-    }
-    case FilterOperation::Type::Opacity: {
-        const auto matrix = opacityColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount());
-        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
-    }
-    case FilterOperation::Type::Brightness: {
-        ColorMatrix<5, 4> matrix(brightnessColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount()));
-        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
-    }
-    case FilterOperation::Type::Contrast: {
-        const auto matrix = contrastColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount());
-        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
-    }
-    case FilterOperation::Type::Blur: {
-        auto sigma = downcast<BlurFilterOperation>(filterOperation).stdDeviation();
-        // FIXME: do we need to add crop rect?
-        return SkImageFilters::Blur(sigma, sigma, blurTileMode, input);
-    }
-    case FilterOperation::Type::DropShadow: {
-        auto& dropShadow = downcast<DropShadowFilterOperation>(filterOperation);
-        return SkImageFilters::DropShadow(dropShadow.x(), dropShadow.y(), dropShadow.stdDeviation(), dropShadow.stdDeviation(), dropShadow.color(), input);
-    }
-    case FilterOperation::Type::Passthrough:
-    case FilterOperation::Type::Default:
-    case FilterOperation::Type::None:
-        break;
-    }
-
-    return nullptr;
-}
-
-static sk_sp<SkImageFilter> createFilters(const FilterOperations& filterOperations, SkTileMode blurTileMode = SkTileMode::kDecal)
-{
-    sk_sp<SkImageFilter> filter;
-    for (const auto& filterOperation : filterOperations)
-        filter = createFilter(filterOperation, filter, blurTileMode);
-    return filter;
-}
-
 void SkiaCompositingLayer::setFilters(const FilterOperations& filterOperations)
 {
     if (filterOperations.isEmpty())
         m_filter = std::nullopt;
     else
-        m_filter = { createFilters(filterOperations), filterOperations.outsets() };
+        m_filter = { SkiaCompositingLayerFilters::create(filterOperations), filterOperations.outsets() };
 }
 
 void SkiaCompositingLayer::setBackdropFilters(const FilterOperations& filterOperations)
 {
-    m_backdrop.filter = createFilters(filterOperations, SkTileMode::kClamp);
+    m_backdrop.filter = SkiaCompositingLayerFilters::create(filterOperations, SkTileMode::kClamp);
 }
 
 void SkiaCompositingLayer::setBackdropFiltersRect(const FloatRoundedRect& clipRect)
@@ -384,7 +323,7 @@ std::optional<SkiaCompositingLayer::AnimationsState> SkiaCompositingLayer::syncA
     }
 #endif
     if (applicationResults.filters)
-        state.filter = { createFilters(*applicationResults.filters), applicationResults.filters->outsets() };
+        state.filter = { SkiaCompositingLayerFilters::create(*applicationResults.filters), applicationResults.filters->outsets() };
     state.isRunning = applicationResults.hasRunningAnimations;
     return state;
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerFilters.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerFilters.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaCompositingLayerFilters.h"
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "ColorMatrix.h"
+#include "FilterOperations.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorFilter.h>
+#include <skia/effects/SkImageFilters.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+namespace WebCore {
+
+namespace SkiaCompositingLayerFilters {
+
+sk_sp<SkImageFilter> create(const FilterOperation& filterOperation, sk_sp<SkImageFilter> input, SkTileMode blurTileMode)
+{
+    switch (filterOperation.type()) {
+    case FilterOperation::Type::Grayscale: {
+        ColorMatrix<5, 4> matrix(grayscaleColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Sepia: {
+        ColorMatrix<5, 4> matrix(sepiaColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Saturate: {
+        ColorMatrix<5, 4> matrix(saturationColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::HueRotate: {
+        ColorMatrix<5, 4> matrix(hueRotateColorMatrix(downcast<BasicColorMatrixFilterOperation>(filterOperation).amount()));
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Invert: {
+        const auto matrix = invertColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount());
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Opacity: {
+        const auto matrix = opacityColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount());
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Brightness: {
+        ColorMatrix<5, 4> matrix(brightnessColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount()));
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Contrast: {
+        const auto matrix = contrastColorMatrix(downcast<BasicComponentTransferFilterOperation>(filterOperation).amount());
+        return SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix.data().data()), input);
+    }
+    case FilterOperation::Type::Blur: {
+        auto sigma = downcast<BlurFilterOperation>(filterOperation).stdDeviation();
+        // FIXME: do we need to add crop rect?
+        return SkImageFilters::Blur(sigma, sigma, blurTileMode, input);
+    }
+    case FilterOperation::Type::DropShadow: {
+        auto& dropShadow = downcast<DropShadowFilterOperation>(filterOperation);
+        return SkImageFilters::DropShadow(dropShadow.x(), dropShadow.y(), dropShadow.stdDeviation(), dropShadow.stdDeviation(), dropShadow.color(), input);
+    }
+    case FilterOperation::Type::Passthrough:
+    case FilterOperation::Type::Default:
+    case FilterOperation::Type::None:
+        break;
+    }
+
+    return nullptr;
+}
+
+sk_sp<SkImageFilter> create(const FilterOperations& filterOperations, SkTileMode blurTileMode)
+{
+    sk_sp<SkImageFilter> filter;
+    for (const auto& filterOperation : filterOperations)
+        filter = create(filterOperation, filter, blurTileMode);
+    return filter;
+}
+
+} // namespace SkiaCompositingLayerFilters
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerFilters.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerFilters.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkRefCnt.h>
+#include <skia/core/SkTileMode.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+class SkImageFilter;
+
+namespace WebCore {
+
+class FilterOperation;
+class FilterOperations;
+
+namespace SkiaCompositingLayerFilters {
+
+sk_sp<SkImageFilter> create(const FilterOperation&, sk_sp<SkImageFilter> input, SkTileMode blurTileMode = SkTileMode::kDecal);
+sk_sp<SkImageFilter> create(const FilterOperations&, SkTileMode blurTileMode = SkTileMode::kDecal);
+
+} // namespace SkiaCompositingLayerFilters
+} // namespace WebCore
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)


### PR DESCRIPTION
#### 19f31355903c21f25b83b85e3dd03ca8d1ebc3dc
<pre>
[GTK][WPE] Skia Compositor: Extract filter helpers to SkiaCompositingLayerFilters
<a href="https://bugs.webkit.org/show_bug.cgi?id=313162">https://bugs.webkit.org/show_bug.cgi?id=313162</a>

Reviewed by Carlos Garcia Campos.

Move the filter-building helpers out of SkiaCompositingLayer into a separate
file and its own namespace. They depend only on FilterOperation and
FilterOperations, not on layer state, so scoping them separately makes
SkiaCompositingLayer leaner.

* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::setFilters):
(WebCore::SkiaCompositingLayer::setBackdropFilters):
(WebCore::SkiaCompositingLayer::syncAnimations):
(WebCore::createFilter): Deleted.
(WebCore::createFilters): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayerFilters.cpp: Added.
(WebCore::SkiaCompositingLayerFilters::create):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayerFilters.h: Added.

Canonical link: <a href="https://commits.webkit.org/311933@main">https://commits.webkit.org/311933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5597ddac1fdc5f00e1cc0d6c855bed59d9e4a9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167311 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122746 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25003 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103416 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15082 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169801 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15546 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21765 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31597 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131049 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35466 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31543 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141934 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89418 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25741 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18740 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97068 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->