### PR TITLE
Make fullscreen quirk clearer about what it does

### DIFF
--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -142,7 +142,7 @@ void DocumentFullscreen::requestFullscreen(Ref<Element>&& element, FullscreenChe
 
     if (protect(document())->quirks().shouldEnterNativeFullscreenWhenCallingElementRequestFullscreenQuirk()) {
         // Translate the request to enter fullscreen into requesting native fullscreen
-        // for the largest inner video element.
+        // for the last inner video element with a non-zero area.
         auto maybeVideoList = element->querySelectorAll("video"_s);
         if (maybeVideoList.hasException()) {
             completionHandler({ });
@@ -152,10 +152,8 @@ void DocumentFullscreen::requestFullscreen(Ref<Element>&& element, FullscreenChe
 #if ENABLE(VIDEO)
         Ref videoList = maybeVideoList.releaseReturnValue();
 
-        RefPtr<HTMLVideoElement> largestVideo = nullptr;
-        unsigned largestArea = 0;
-        for (unsigned index = 0; index < videoList->length(); ++index) {
-            RefPtr video = downcast<HTMLVideoElement>(videoList->item(index));
+        for (unsigned index = videoList->length(); index; --index) {
+            RefPtr video = downcast<HTMLVideoElement>(videoList->item(index - 1));
             if (!video)
                 continue;
 
@@ -164,14 +162,12 @@ void DocumentFullscreen::requestFullscreen(Ref<Element>&& element, FullscreenChe
                 continue;
 
             auto area = renderer->videoBox().area();
-            if (area.hasOverflowed())
+            if (!area || area.hasOverflowed())
                 continue;
 
-            if (area > largestArea)
-                largestVideo = video;
+            video->webkitRequestFullscreen();
+            break;
         }
-        if (largestVideo)
-            largestVideo->webkitRequestFullscreen();
 #endif
 
         completionHandler({ });


### PR DESCRIPTION
#### 1d70b354c959230e0dbd8e0190d3bfc8fc5a4f49
<pre>
Make fullscreen quirk clearer about what it does
<a href="https://bugs.webkit.org/show_bug.cgi?id=313168">https://bugs.webkit.org/show_bug.cgi?id=313168</a>

Reviewed by Jer Noble.

296749@main introduced a quirk for fullscreen, but the logic had some
flaws. However, as nothing was fixed the actual logic is probably fine
for the purposes of the quirk.

Canonical link: <a href="https://commits.webkit.org/312151@main">https://commits.webkit.org/312151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/704f57571650a00bfc49e38779d5c1a0552d869e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112431 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122641 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86077 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103310 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23953 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22333 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14949 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133641 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169668 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15297 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130826 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130940 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35569 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89285 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18622 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30921 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96715 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30441 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30714 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30595 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->