### PR TITLE
[Site Isolation] http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html is failing

### DIFF
--- a/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html
+++ b/LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html
@@ -2,7 +2,6 @@
     if (window.testRunner) {
         testRunner.dumpAsText();
         testRunner.dumpChildFramesAsText();
-        testRunner.dumpResourceLoadCallbacks();
         testRunner.waitUntilDone();
     }
 

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -207,7 +207,6 @@ http/tests/resourceLoadStatistics/exemptDomains/third-party-cookie-blocking.html
 http/tests/resourceLoadStatistics/omit-document-referrer-nested-third-party-iframe-ephemeral.html [ Failure ]
 http/tests/resourceLoadStatistics/omit-document-referrer-third-party-iframe-ephemeral.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-ancestors-same-origin-deny.html [ Failure ]
-http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-multiple-headers-sameorigin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-parent-same-origin-deny.html [ Failure ]
 http/tests/security/allow-top-level-navigations-by-third-party-iframes-with-previous-user-activation.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -231,7 +231,6 @@ http/tests/resourceLoadStatistics/omit-document-referrer-nested-third-party-ifra
 http/tests/resourceLoadStatistics/omit-document-referrer-third-party-iframe-ephemeral.html [ Failure ]
 http/tests/resourceLoadStatistics/user-interaction-in-cross-origin-sub-frame.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-ancestors-same-origin-deny.html [ Failure ]
-http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-multiple-headers-sameorigin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-parent-same-origin-deny.html [ Failure ]
 http/tests/security/cross-origin-local-storage.html [ Failure ]

--- a/LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny-expected.txt
+++ b/LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny-expected.txt
@@ -1,6 +1,3 @@
-http://127.0.0.1:8000/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html - didFinishLoading
-http://localhost:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-parent-same-origin-deny.html - willSendRequest <NSURLRequest URL http://localhost:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-parent-same-origin-deny.html, main document URL http://127.0.0.1:8000/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html, http method GET> redirectResponse (null)
-http://localhost:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-parent-same-origin-deny.html - didReceiveResponse <NSURLResponse http://localhost:8000/security/XFrameOptions/resources/x-frame-options-deny-meta-tag-subframe-parent-same-origin-deny.html, http status code 200>
 CONSOLE MESSAGE: The X-Frame-Option 'sameorigin' supplied in a <meta> element was ignored. X-Frame-Options may only be provided by an HTTP header sent with the document.
 CONSOLE MESSAGE: SecurityError: Blocked a frame with origin "http://127.0.0.1:8000" from accessing a cross-origin frame. Protocols, domains, and ports must match.
 CONSOLE MESSAGE: FAIL: Could not read contentWindow.location.href


### PR DESCRIPTION
#### 07fca8af64294eb89b93aa73690725c4f7399821
<pre>
[Site Isolation] http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=313169">https://bugs.webkit.org/show_bug.cgi?id=313169</a>
<a href="https://rdar.apple.com/175456456">rdar://175456456</a>

Reviewed by Sihui Liu.

With site isolation enabled http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html
fails with a test diff.

First, it is missing the following two log messages which come
from enabling testRunner.dumpResourceLoadCallbacks()

  -<a href="http://localhost">http://localhost</a>:8000/.../x-frame-options-deny-meta-tag-subframe-parent-same-origin-deny.html - willSendRequest ...
  -<a href="http://localhost">http://localhost</a>:8000/.../x-frame-options-deny-meta-tag-subframe-parent-same-origin-deny.html - didReceiveResponse ...

This was because testRunner.dumpResourceLoadCallbacks() is enabled via
the InjectedBundle which doesn&apos;t work since InjectedBundle
state doesn&apos;t get synced between processes with site isolation enabled.

Originally, I tried moving the testRunner state to the UIProcess which
allows the resource load logs to show up. It follows the convention
from <a href="https://commits.webkit.org/291512@main">https://commits.webkit.org/291512@main</a>

Once the flag was working, the remaining issue was that the logs
printed out by dumpResourceLoadCallbacks would be printed out in different
ordering with site isolation enabled vs disabled. These logs include events
such as willSendRequest or didFinishLoading.

To have the site isolation behavior match pre site isolation behavior
we can remove the call to testRunner.dumpResourceLoadCallbacks so the
loading event logs don&apos;t get printed. This matches the convention
from <a href="https://commits.webkit.org/308790@main">https://commits.webkit.org/308790@main</a>

This test already has other passing criteria besides the
loading event logs. It checks if the iframe&apos;s location.href is readable.

This patch fixes http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html
with site isolation enabled.

* LayoutTests/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html:
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* LayoutTests/platform/wk2/http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny-expected.txt:

Canonical link: <a href="https://commits.webkit.org/312174@main">https://commits.webkit.org/312174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad66cf9f590e4a063c7d6c86d1987894fd4c849d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167920 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113175 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2d709b8-82b1-4047-afe9-2ce9183b9511) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123247 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86538 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/449f26d6-82c8-4dc9-93c8-89943e359312) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103913 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5f0d2f2-3652-427b-8b09-8762fd6ab87b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24573 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22991 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15693 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170413 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131437 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131549 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35582 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90202 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26252 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19286 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31663 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31183 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31456 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31338 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->