### PR TITLE
[Skia][GBM] Fix assertion in SkiaGPUAtlas::uploadImage(), trying to obtain a MemoryMappedGPUBuffer WriteScope

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
@@ -274,16 +274,20 @@ std::unique_ptr<MemoryMappedGPUBuffer> MemoryMappedGPUBuffer::create(const IntSi
         return nullptr;
     }
 
-    if (!buffer->createDMABufFromGBMBufferObject(bo)) {
-        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer::create(), failed to create dma-buf from GBM buffer object");
+    // Order matters: the RDWR mapping export must precede the GPU-sampling export.
+    // The kernel caches the dma-buf object per gem-handle on first export and locks
+    // its mode flags; older Mesas call gbm_bo_get_fd_for_plane() without DRM_RDWR,
+    // so if createDMABufFromGBMBufferObject() ran first every subsequent FD --
+    // including our DRMSystemCall RDWR fallback -- would alias that cached read-only
+    // dma-buf and SIGBUS on mmap(PROT_WRITE).
+    if (!buffer->exportFDForMappingFromGBMBufferObject(bo)) {
+        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer::create(), failed to export dma-buf FD for mapping: %s", safeStrerror(errno).data());
         gbm_bo_destroy(bo);
         return nullptr;
     }
 
-    // Must happen before gbm_bo_destroy() below.
-    buffer->m_exportedFDForMapping = UnixFileDescriptor { exportFDForPlane(bo, 0, FDExportPurpose::CPUMapping), UnixFileDescriptor::Adopt };
-    if (!buffer->m_exportedFDForMapping) {
-        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer::create(), failed to export dma-buf FD for mapping: %s", safeStrerror(errno).data());
+    if (!buffer->createDMABufFromGBMBufferObject(bo)) {
+        RELEASE_LOG_ERROR(GraphicsBuffer, "MemoryMappedGPUBuffer::create(), failed to create dma-buf from GBM buffer object");
         gbm_bo_destroy(bo);
         return nullptr;
     }
@@ -343,6 +347,13 @@ bool MemoryMappedGPUBuffer::createDMABufFromGBMBufferObject(struct gbm_bo* bo)
     ASSERT(!m_dmaBuf);
     m_dmaBuf = DMABufBuffer::create(WTF::move(*attributes));
     return true;
+}
+
+bool MemoryMappedGPUBuffer::exportFDForMappingFromGBMBufferObject(struct gbm_bo* bo)
+{
+    ASSERT(!m_exportedFDForMapping);
+    m_exportedFDForMapping = UnixFileDescriptor { exportFDForPlane(bo, 0, FDExportPurpose::CPUMapping), UnixFileDescriptor::Adopt };
+    return !!m_exportedFDForMapping;
 }
 
 uint32_t MemoryMappedGPUBuffer::primaryPlaneDmaBufStride() const

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
@@ -142,6 +142,7 @@ private:
 
     struct gbm_bo* allocate(struct gbm_device*, const GLDisplay::BufferFormat&);
     bool createDMABufFromGBMBufferObject(struct gbm_bo*);
+    bool exportFDForMappingFromGBMBufferObject(struct gbm_bo*);
 
     void updateContentsInLinearFormat(const void* srcData, const IntRect& targetRect, unsigned bytesPerLine);
     void updateContentsInVivanteSuperTiledFormat(const void* srcData, const IntRect& targetRect, unsigned bytesPerLine);


### PR DESCRIPTION
#### c3e5fd593a0430f64660069de186b0ced147748d
<pre>
[Skia][GBM] Fix assertion in SkiaGPUAtlas::uploadImage(), trying to obtain a MemoryMappedGPUBuffer WriteScope
<a href="https://bugs.webkit.org/show_bug.cgi?id=313171">https://bugs.webkit.org/show_bug.cgi?id=313171</a>

Reviewed by Carlos Garcia Campos.

Extract the CPUMapping FD export out of MemoryMappedGPUBuffer::create()
into a new exportFDForMappingFromGBMBufferObject() helper, mirroring
the existing createDMABufFromGBMBufferObject(), and invoke it *before*
createDMABufFromGBMBufferObject().

The kernel caches the dma-buf object per gem-handle on the first
export and locks its mode flags for the lifetime of that cache entry.
Older Mesas (the issue reproduces on Raspberry Pi 5 with Mesa 25.02)
call gbm_bo_get_fd_for_plane() without DRM_RDWR, so if
createDMABufFromGBMBufferObject() ran first, the kernel would cache
the dma-buf as read-only. Every subsequent FD -- including the
DRMSystemCall RDWR fallback we use for mapping -- would then alias
that cached read-only object and bail on mmap(PROT_WRITE).

Running the RDWR export first ensures the kernel caches the dma-buf
with DRM_RDWR, and the later gbm_bo_get_fd_for_plane() call in
createDMABufFromGBMBufferObject() receives an FD backed by that same
RDWR-capable object.

Not testable on CI.

* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp:
(WebCore::MemoryMappedGPUBuffer::create):
(WebCore::MemoryMappedGPUBuffer::exportFDForMappingFromGBMBufferObject):
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h:

Canonical link: <a href="https://commits.webkit.org/311927@main">https://commits.webkit.org/311927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15396d3a0488ab48b798833f8230e0cd5d7a6115

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31905 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167309 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31892 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161437 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/24999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/103414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169799 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/15523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31595 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/131047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31541 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/141932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24089 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/25738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31052 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97036 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30572 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30845 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->