### PR TITLE
[YARR] Just marking current FixedCount ParenContext incomplete and try using it again

### DIFF
--- a/JSTests/stress/yarr-jit-fixedcount-paren-context-free-on-skip.js
+++ b/JSTests/stress/yarr-jit-fixedcount-paren-context-free-on-skip.js
@@ -1,0 +1,363 @@
+//@ runDefault
+
+// FixedCount Begin.bt frees ParenContexts it skips over (combined approach of
+// 569dc94's reuse-in-place plus Gemini's End.bt mark). This is safe because
+// any outer ctx that could hold a snapshot pointing to a freed inner ctx is
+// itself already marked incomplete — either by its own End.bt mark
+// (Gemini's change) or by reuse-in-place at outer Begin.bt (569dc94) —
+// so the stale pointer is never restored.
+//
+// Invariant: FixedCount{N} allocates at most N ParenContexts across
+// arbitrary backtracking (freelist reuse during retries).
+//
+// These cases exercise deep nesting, large iteration counts, unanchored
+// multi-position retries, and captures across extensive backtracking —
+// paths that would have corrupted the freelist pre-Gemini's End.bt mark.
+//
+// Expected outputs were cross-checked against V8 and JSC's non-JIT
+// interpreter (both agree).
+
+function stringify(m) {
+    return m === null ? "null" : JSON.stringify(Array.from(m));
+}
+
+function test(re, input, expected) {
+    const actual = re.exec(input);
+    const actualStr = stringify(actual);
+    const expectedStr = stringify(expected);
+    if (actualStr !== expectedStr)
+        throw new Error(`FAIL: ${re} on ${JSON.stringify(input)}: expected ${expectedStr}, got ${actualStr}`);
+}
+
+// ------------------------------------------------------------------
+// Anchored / leading-position cases — outer End.bt mark propagation
+// ------------------------------------------------------------------
+
+test(/(((a){2}){2}){2}c/, "aaaaaaaa", null);
+test(/(((a){2}){2}){2}c/, "aaaaaaaab", null);
+test(/(((a){2}){2}){2}c/, "aaaaaaaac", ["aaaaaaaac", "aaaa", "aa", "a"]);
+
+test(/((((a){2}){2}){2}){2}z/, "a".repeat(16), null);
+test(/((((a){2}){2}){2}){2}z/, "a".repeat(16) + "z",
+    ["a".repeat(16) + "z", "a".repeat(8), "aaaa", "aa", "a"]);
+
+// ------------------------------------------------------------------
+// Large iteration counts — stress freelist reuse. FC{N} must remain
+// bounded at N ParenContexts even across retries.
+// ------------------------------------------------------------------
+
+test(/(a){20}z/, "a".repeat(20), null);
+test(/(a){20}z/, "a".repeat(20) + "z", ["a".repeat(20) + "z", "a"]);
+test(/(a){20}z/, "a".repeat(19) + "z", null);
+
+test(/((a){5}){4}z/, "a".repeat(20), null);
+test(/((a){5}){4}z/, "a".repeat(20) + "z", ["a".repeat(20) + "z", "aaaaa", "a"]);
+
+// ------------------------------------------------------------------
+// 5-level nesting. Every level's End.bt mark must propagate to let
+// every outer Begin.bt skip-and-free cleanly.
+// ------------------------------------------------------------------
+
+test(/(((((a){2}){2}){2}){2}){2}/, "a".repeat(31), null);
+test(/(((((a){2}){2}){2}){2}){2}/, "a".repeat(32),
+    ["a".repeat(32), "a".repeat(16), "a".repeat(8), "aaaa", "aa", "a"]);
+test(/(((((a){2}){2}){2}){2}){2}X/, "a".repeat(32), null);
+test(/(((((a){2}){2}){2}){2}){2}X/, "a".repeat(32) + "X",
+    ["a".repeat(32) + "X", "a".repeat(16), "a".repeat(8), "aaaa", "aa", "a"]);
+
+// ------------------------------------------------------------------
+// Unanchored: each failed position triggers another full FC traversal.
+// Position retries are where freelist corruption from the previous
+// position's backtrack would show up.
+// ------------------------------------------------------------------
+
+test(/(((a){2}){2}){2}c/, "xaaaaaaaac", ["aaaaaaaac", "aaaa", "aa", "a"]);
+test(/(((a){2}){2}){2}c/, "xxxaaaaaaaac", ["aaaaaaaac", "aaaa", "aa", "a"]);
+test(/(((a){2}){2}){2}c/, "aaaaaaaxaaaaaaaac", ["aaaaaaaac", "aaaa", "aa", "a"]);
+test(/(((a){2}){2}){2}c/, "xaaaaaaaa", null);
+
+test(/(((a){2}){2}){2}/, "a".repeat(20), ["aaaaaaaa", "aaaa", "aa", "a"]);
+test(/(((a){2}){2}){2}/, "xyz" + "a".repeat(8), ["aaaaaaaa", "aaaa", "aa", "a"]);
+
+test(/((((a){2}){2}){2}){2}z/, "xyz" + "a".repeat(16) + "z",
+    ["aaaaaaaaaaaaaaaaz", "aaaaaaaa", "aaaa", "aa", "a"]);
+test(/((((a){2}){2}){2}){2}z/, "a".repeat(32) + "z",
+    ["aaaaaaaaaaaaaaaaz", "aaaaaaaa", "aaaa", "aa", "a"]);
+
+test(/(a){20}z/, "xxxx" + "a".repeat(20) + "z",
+    ["aaaaaaaaaaaaaaaaaaaaz", "a"]);
+test(/((a){5}){4}z/, "bc" + "a".repeat(20) + "zzz",
+    ["aaaaaaaaaaaaaaaaaaaaz", "aaaaa", "a"]);
+
+test(/(((((a){2}){2}){2}){2}){2}X/, "aaa" + "a".repeat(32) + "X",
+    ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaX", "aaaaaaaaaaaaaaaa", "aaaaaaaa", "aaaa", "aa", "a"]);
+
+// ------------------------------------------------------------------
+// Unanchored with NonGreedy inside FixedCount (37465a7 bug class).
+// ------------------------------------------------------------------
+
+test(/(?:(a|b)*?.){2}xx/, "aabbcc", null);
+test(/(?:(a|b)*?.){2}xx/, "aabbxx", ["aabbxx", "b"]);
+test(/(?:(a|b)*?.){2}xx/, "cc" + "aabbxx", ["caabbxx", "b"]);
+test(/((a|b)*?(.)??.){3}cp/, "aabbbccc", null);
+test(/((a|b)*?(.)??.){3}cp/, "aabbcp", ["aabbcp", "bb", null, "b"]);
+test(/((a|b)*?(.)??.){3}cp/, "aabcp", ["aabcp", "b", null, null]);
+test(/((a|b)*?(.)??.){3}cp/, "zzzaabcp", ["zzzaabcp", "aab", "a", "a"]);
+test(/((a|b)*?(.)??.){3}cp/, "zzzaabbcp", ["zzzaabbcp", "aabb", "a", "b"]);
+
+// ------------------------------------------------------------------
+// Unanchored patterns where the engine must retry FC from MANY input
+// positions before succeeding or rejecting. Each position re-runs the
+// full FC allocation/free cycle, exercising freelist reuse across
+// independent match attempts.
+// ------------------------------------------------------------------
+
+test(/(a{2}){3}b/, "aabaab", null);
+test(/(a{2}){3}b/, "aaaaab", null);
+test(/(a{2}){3}b/, "aaaaaab", ["aaaaaab", "aa"]);
+test(/(a{2}){3}b/, "aaaaaaab", ["aaaaaab", "aa"]);
+test(/(a{2}){3}b/, "aaaaaaaab", ["aaaaaab", "aa"]);
+
+test(/((a|b){2}){3}c/, "ababc", null);
+test(/((a|b){2}){3}c/, "abababc", ["abababc", "ab", "b"]);
+test(/((a|b){2}){3}c/, "ababababc", ["abababc", "ab", "b"]);
+test(/((a|b){2}){3}c/, "ababababababc", ["abababc", "ab", "b"]);
+
+test(/((a){3}){4}X/, "b".repeat(10) + "a".repeat(12) + "X",
+    ["aaaaaaaaaaaaX", "aaa", "a"]);
+test(/((a){3}){4}X/, "b".repeat(10) + "a".repeat(11) + "X", null);
+test(/((a){3}){4}X/, "a".repeat(11) + "b" + "a".repeat(12) + "X",
+    ["aaaaaaaaaaaaX", "aaa", "a"]);
+
+// ------------------------------------------------------------------
+// Sibling FC subtrees under a single outer FC. Each outer iteration
+// independently builds two inner chains; freeing must keep them
+// from corrupting each other across iterations.
+// ------------------------------------------------------------------
+
+test(/(((a){3})(((b){3})){1}){2}z/, "aaabbbaaabbbz",
+    ["aaabbbaaabbbz", "aaabbb", "aaa", "a", "bbb", "bbb", "b"]);
+test(/(((a){3})(((b){3})){1}){2}z/, "xy" + "aaabbbaaabbbz",
+    ["aaabbbaaabbbz", "aaabbb", "aaa", "a", "bbb", "bbb", "b"]);
+test(/(((a){3})(((b){3})){1}){2}/, "aaabbbaaabbb",
+    ["aaabbbaaabbb", "aaabbb", "aaa", "a", "bbb", "bbb", "b"]);
+
+// ------------------------------------------------------------------
+// Parameterized: captures must stay correct for increasing N.
+// ------------------------------------------------------------------
+
+for (let n = 2; n <= 6; ++n) {
+    const re = new RegExp(`((a|b){2}){${n}}z`);
+    const input = "ab".repeat(n) + "z";
+    const match = re.exec(input);
+    if (match === null)
+        throw new Error(`FAIL: ${re} on ${JSON.stringify(input)}: got null`);
+    if (match[0] !== "ab".repeat(n) + "z")
+        throw new Error(`FAIL: ${re}: bad [0]`);
+    if (match[1] !== "ab")
+        throw new Error(`FAIL: ${re}: bad [1]`);
+    if (match[2] !== "b")
+        throw new Error(`FAIL: ${re}: bad [2]`);
+
+    // Unanchored variant: same result with junk prefix.
+    const input2 = "zzz".repeat(3) + input;
+    const match2 = re.exec(input2);
+    if (match2 === null || match2[0] !== "ab".repeat(n) + "z")
+        throw new Error(`FAIL: unanchored ${re} on ${JSON.stringify(input2)}`);
+}
+
+// ------------------------------------------------------------------
+// MIXED QUANTIFIERS: FC-outer + Greedy/NonGreedy-middle + FC-inner.
+//
+// This is the subtlest case. Greedy/NonGreedy save at Begin.forward,
+// which captures inner.parenContextHead at that moment. Since outer
+// FC's Begin.forward does NOT reset inner.parenContextHead (only its
+// own slots), middle's snapshot can capture a pointer to an inner ctx
+// that belonged to a PREVIOUS outer iteration. If inner Begin.bt later
+// frees that ctx, middle's snapshot becomes stale.
+//
+// Freeing is still safe because:
+//   1. After middle.Begin.bt restores a stale snapshot into the frame,
+//      any subsequent forward re-entry into inner runs inner.Begin.forward,
+//      which resets inner.parenContextHead=null — overwriting the stale
+//      pointer before any inner.End.bt could read it.
+//   2. If instead post-outer fails and we backtrack straight to
+//      inner.End.bt, the write to matchAmount lands at offset 12 of the
+//      pointed-to ctx. The freelist uses .next at offset 0, so the
+//      freelist structure remains intact even if that memory is now
+//      freelisted.
+//   3. If the ctx was already reallocated by inner.Begin.forward,
+//      that reallocation's initial mark (FC: store -1 to matchAmount)
+//      or saveParenContext overwrites matchAmount before the new owner
+//      ever reads it. The stale -1 write is redundant, not corrupting.
+//
+// These cases cross-check against non-JIT interpreter and V8.
+// ------------------------------------------------------------------
+
+test(/(((a){2})+){2}b/, "aaaab", ["aaaab", "aa", "aa", "a"]);
+test(/(((a){2})+){2}b/, "aaaaaab", ["aaaaaab", "aa", "aa", "a"]);
+test(/(((a){2})+){2}b/, "aaaaaaaab", ["aaaaaaaab", "aa", "aa", "a"]);
+test(/(((a){2})+){2}b/, "aaaaaaaaab", ["aaaaaaaab", "aa", "aa", "a"]);
+test(/(((a){2})+){2}b/, "aaaaaaaaaaaab", ["aaaaaaaaaaaab", "aa", "aa", "a"]);
+
+// NonGreedy middle variants.
+test(/(((a){2})+?){3}X/, "aaaaaaX", ["aaaaaaX", "aa", "aa", "a"]);
+test(/(((a){2})+?){3}X/, "aaaaaaaaaaaaX", ["aaaaaaaaaaaaX", "aaaaaaaa", "aa", "a"]);
+
+// Post-paren multi-char failure forces full outer content backtrack
+// AFTER Greedy middle's stale snapshot has entered the frame.
+test(/(((a){2})+){2}bc/, "aaaaaaaabc", ["aaaaaaaabc", "aa", "aa", "a"]);
+test(/(((a){2})+){2}bc/, "aaaaaaaabx", null);
+test(/(((a){2})+){2}bcd/, "aaaaaaaabcd", ["aaaaaaaabcd", "aa", "aa", "a"]);
+test(/(((a){2})+){2}bcd/, "aaaaaaaabcx", null);
+
+// Deeper: Greedy outer wrapping FC outer wrapping Greedy middle wrapping FC inner.
+test(/((((a){2})+){2})+b/, "aaaaaaaab",
+    ["aaaaaaaab", "aaaaaaaa", "aa", "aa", "a"]);
+test(/((((a){2})+){2})+b/, "aaaaaaaaaaaaaaaab",
+    ["aaaaaaaaaaaaaaaab", "aaaaaaaaaaaaaaaa", "aa", "aa", "a"]);
+
+// Alternatives inside inner with Greedy middle.
+test(/(((a|b){2})+){2}X/, "ababababX", ["ababababX", "ab", "ab", "b"]);
+test(/(((a|b){2})+){2}X/, "ababababababababX",
+    ["ababababababababX", "ab", "ab", "b"]);
+
+// Greedy-+ middle (not FC-wrapped) — a simpler shape of the same concern.
+test(/((a+)+){2}bc/, "aabc", ["aabc", "a", "a"]);
+test(/((a+)+){2}bcd/, "aaaabcd", ["aaaabcd", "a", "a"]);
+
+// Unanchored position retries after stale snapshots are in play.
+test(/(((a){2})+){2}b/, "xxxaaaaaaaab", ["aaaaaaaab", "aa", "aa", "a"]);
+test(/(((a){2})+){2}b/, "xaxxxaaaaaaaab", ["aaaaaaaab", "aa", "aa", "a"]);
+
+// ------------------------------------------------------------------
+// Greedy/NonGreedy multi-alt inside FC outer — exercises the
+// "uninitialized returnAddress captured at Begin.forward" path.
+//
+// Greedy/NonGreedy save at Begin.forward (before any alternative runs),
+// so their iter-1 ctx captures whatever returnAddress was in the frame
+// (removed null-init). When middle.Begin.bt later restores
+// iter-1 ctx, matchAmount==0 drives the zeroLengthMatch path which sets
+// beginIndex=-1. Subsequent middle.End.bt sees hadSkipped=true and jumps
+// to Begin.bt's noContext — bypassing body backtrack — so the garbage
+// returnAddress is never dereferenced.
+// ------------------------------------------------------------------
+
+test(/((a|b)+){2}z/, "abz", ["abz", "b", "b"]);
+test(/((a|b)+){2}z/, "aabz", ["aabz", "b", "b"]);
+test(/((a|b)+){2}z/, "abaz", ["abaz", "a", "a"]);
+test(/((a|b)+){2}z/, "ababz", ["ababz", "b", "b"]);
+test(/((a|b)+){2}z/, "abcz", null);
+test(/((a|b)+){2}z/, "ababcz", null);
+test(/((a|b|c)+){2}z/, "abcz", ["abcz", "c", "c"]);
+test(/((a|b|c)+){2}z/, "abcabcz", ["abcabcz", "c", "c"]);
+test(/((a|b|c)+){2}z/, "abcabx", null);
+test(/((a|b|c)+){2}zz/, "abcabcz", null);
+
+// NonGreedy multi-alt — exercises NonGreedy-specific first-entry skip path.
+test(/((a|b)+?){2}z/, "abz", ["abz", "b", "b"]);
+test(/((a|b)+?){2}z/, "ababz", ["ababz", "bab", "b"]);
+test(/((a|b)+?){2}z/, "ababcz", null);
+test(/((a|b|c)+?){2}z/, "abcabcz", ["abcabcz", "bcabc", "c"]);
+
+// ------------------------------------------------------------------
+// NonGreedy-outer + Greedy-middle + FC-inner: the quantifier
+// combination that wasn't covered elsewhere.
+// ------------------------------------------------------------------
+
+test(/(((a){2})+){2,}?z/, "aaaaz", ["aaaaz", "aa", "aa", "a"]);
+test(/(((a){2})+){2,}?z/, "aaaaaaz", ["aaaaaaz", "aa", "aa", "a"]);
+test(/(((a){2})+){2,}?z/, "aaaaaaaaz", ["aaaaaaaaz", "aa", "aa", "a"]);
+test(/(((a){2})+){2,}?z/, "aaaaaaaax", null);
+
+test(/((a+)+){2,}?z/, "aaaaz", ["aaaaz", "a", "a"]);
+test(/((a+)+){2,}?z/, "aaax", null);
+
+test(/(((a){2})+?){3,}?z/, "aaaaaaz", ["aaaaaaz", "aa", "aa", "a"]);
+test(/(((a){2})+?){3,}?z/, "aaaaaaaaaaaaz", ["aaaaaaaaaaaaz", "aa", "aa", "a"]);
+
+// ------------------------------------------------------------------
+// Large FC counts — confirm freelist reuse scales without leaks.
+// With free-on-skip, FC{N} stays bounded at N ParenContext allocations
+// regardless of backtrack depth.
+// ------------------------------------------------------------------
+
+test(/(a){50}z/, "a".repeat(50) + "z", ["a".repeat(50) + "z", "a"]);
+test(/(a){50}z/, "a".repeat(49) + "z", null);
+test(/(a){50}z/, "a".repeat(51) + "z", ["a".repeat(50) + "z", "a"]);
+test(/(a){50}z/, "a".repeat(50), null);
+test(/(a){100}z/, "a".repeat(100) + "z", ["a".repeat(100) + "z", "a"]);
+test(/(a){100}z/, "a".repeat(99) + "z", null);
+
+test(/((a){10}){10}z/, "a".repeat(100) + "z",
+    ["a".repeat(100) + "z", "a".repeat(10), "a"]);
+test(/((a){10}){10}z/, "a".repeat(99) + "z", null);
+
+// ------------------------------------------------------------------
+// Greedy/NonGreedy Begin.bt null-ctx invariant tests.
+//
+// The noContext null check at Greedy/NonGreedy Begin.bt is dead code:
+// currParenContextReg is always non-null by the time Begin.bt fires.
+// These cases exercise the code paths that the invariant relies on:
+//
+//   - Greedy chain exhaustion: repeated Begin.bt invocations unwind
+//     through all iterations, eventually hitting matchAmount=0
+//     (zero-length path, beginIndex=-1). Any further post-paren failure
+//     must route via End.bt's hadSkipped check → op.m_jumps → the
+//     shared handler (bypassing Begin.bt entry). If Begin.bt were
+//     re-entered with an empty chain, it would crash without the
+//     (now-removed) null check. These tests confirm the hadSkipped
+//     bypass works.
+//
+//   - NonGreedy first-entry skip: the initial skip path doesn't
+//     allocate a ctx. Begin.bt can only fire after End.bt's
+//     beginIndex==-1 branch re-enters forward, which DOES allocate.
+//     These tests exercise that re-entry + body failure path.
+//
+//   - Greedy * with zero iterations: matches zero-length successfully
+//     or fails depending on what follows.
+// ------------------------------------------------------------------
+
+// Greedy chain exhaustion: long chain, forced full unwind.
+test(/(a)+c/, "aaaaaaaaaab", null);
+test(/(a)+c/, "ab", null);
+test(/(a)+c/, "aab", null);
+test(/(a)+c/, "aaaab", null);
+test(/(a)+$/, "aaa", ["aaa", "a"]);
+test(/(a)+$/, "aaax", null);
+
+// Many-alternative Greedy chain exhaustion.
+test(/(a|b|c)+x/, "abcabcabcabcy", null);
+test(/(a|b|c)+x/, "abcabcabcabc", null);
+
+// Greedy {min, max} with full exhaustion.
+test(/(a){3,10}c/, "aaaab", null);
+test(/(a){3,10}c/, "aab", null);
+test(/(a){3,10}c/, "aaaaaaaaaab", null);
+
+// NonGreedy body entered via End.bt re-entry then failing.
+test(/(a)*?c/, "aaab", null);
+test(/(a)*?c/, "b", null);
+test(/(a)*?c/, "", null);
+test(/(a)+?c/, "aaab", null);
+test(/(a)+?c/, "b", null);
+
+// NonGreedy with multi-alt (combines first-entry skip + body re-entry
+// + chain unwind across multiple alternatives).
+test(/(a|b)*?c/, "abab", null);
+test(/(a|b)+?c/, "abab", null);
+test(/(a|b)+?c/, "b", null);
+
+// Greedy nested in FC — forces Begin.bt unwind in the inner Greedy
+// across different outer FC iterations.
+test(/((a)+){2}b/, "aaab", ["aaab", "a", "a"]);
+test(/((a)+){2}b/, "aaaab", ["aaaab", "a", "a"]);
+test(/((a)+){2}b/, "aab", ["aab", "a", "a"]);
+test(/((a)+){2}b/, "aaaaaaaaaab", ["aaaaaaaaaab", "a", "a"]);
+test(/((a)+){2}b/, "aaaaaaaaaax", null);
+
+// Greedy * zero-length: chain never grows past ctx_1 before unwind.
+test(/(a)*b/, "b", ["b", undefined]);
+test(/(a)*b/, "ab", ["ab", "a"]);
+test(/(a)*b/, "x", null);
+test(/(a)*b/, "", null);

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4075,7 +4075,6 @@ class YarrGenerator final : public YarrJITInfo {
 
                 storeToFrame(MacroAssembler::TrustedImm32(0), parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
                 storeToFrame(MacroAssembler::TrustedImmPtr(nullptr), parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
-                storeToFrame(MacroAssembler::TrustedImmPtr(nullptr), parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
 
                 // Quantifier-specific setup:
                 //
@@ -4699,38 +4698,11 @@ class YarrGenerator final : public YarrJITInfo {
                 if (op.m_op == YarrOpCode::NestedAlternativeEnd) {
                     m_backtrackingState.link(*this, op);
 
+                    // Jump to the return address stored by whichever alternative was taken.
+                    // For FixedCount multi-alt: returnAddress was stored by NestedAlternativeBegin/Next
+                    // For others: returnAddress was stored by NestedAlternativeEnd itself
                     unsigned parenthesesFrameLocation = term->frameLocation;
-
-                    // For Greedy/NonGreedy patterns, returnAddress may be null after
-                    // restoreParenContext. For NonGreedy, the body may never have been
-                    // entered (zero iterations). For Greedy, saveParenContext at BEGIN
-                    // captures returnAddress before the body runs (still null from
-                    // initialization). Jumping to a null address would crash, so check
-                    // first: if null, route directly to Begin.bt's noContext handler
-                    // via m_zeroLengthMatch, bypassing content backtrack handlers.
-                    // FixedCount always enters the body and sets returnAddress before
-                    // saveParenContext (which is at END), so the null case cannot arise.
-                    if (term->quantityType != QuantifierType::FixedCount) {
-                        loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex(), m_regs.regT0);
-                        auto nullReturnAddress = m_jit.branchTestPtr(MacroAssembler::Zero, m_regs.regT0);
-                        // Non-null: jump via the stored return address (uses proper PAC on ARM64E).
-                        loadFromFrameAndJump(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
-                        // Null returnAddress: body was never entered or saveParenContext
-                        // captured the pre-body state. Route directly to Begin.bt's
-                        // noContext handler via m_zeroLengthMatch, bypassing content
-                        // backtrack handlers that would operate on uninitialized state.
-                        nullReturnAddress.link(&m_jit);
-                        {
-                            YarrOp* walkOp = &op;
-                            while (walkOp->m_previousOp != notFound)
-                                walkOp = &m_ops[walkOp->m_previousOp];
-                            YarrOp& parenBeginOp = m_ops[walkOp->m_index - 1];
-                            parenBeginOp.m_zeroLengthMatch = m_jit.jump();
-                        }
-                    } else {
-                        // Jump to the return address stored by whichever alternative was taken.
-                        loadFromFrameAndJump(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
-                    }
+                    loadFromFrameAndJump(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
 
                     // Link the DataLabelPtr associated with the end of the last alternative to this point.
                     // For FixedCount multi-alt, op.m_returnAddress is not set (we preserve the one from Begin/Next),
@@ -4939,27 +4911,32 @@ class YarrGenerator final : public YarrJITInfo {
                         MacroAssembler::Address(currParenContextReg, ParenContext::matchAmountOffset()),
                         MacroAssembler::TrustedImm32(-1));
 
-                    // Incomplete context: advance past it without freeing. Outer
-                    // FixedCount layers may hold snapshots of this chain in their
-                    // own ParenContexts; freeing here would leave those snapshots
-                    // pointing into the freelist.
-                    m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), currParenContextReg);
+                    // Incomplete context: free it and advance to the next one.
+                    //
+                    // With the END.bt mark in ParenthesesSubpatternEnd.bt propagating up
+                    // through every enclosing FixedCount layer, any outer ParenContext
+                    // whose saved frame contains a pointer to this ctx is itself in one
+                    // of two states:
+                    //   (a) Already marked incomplete by its own END.bt, so outer Begin.bt
+                    //       will skip it (and free it here in turn), never reading the
+                    //       stale pointer.
+                    //   (b) About to be overwritten by outer END.forward's saveParenContext
+                    //       once its own content backtrack succeeds, replacing the stale
+                    //       pointer with the current post-retry state.
+                    // In neither case is the stale pointer read. Freeing is therefore safe,
+                    // and required to keep FixedCount{N} bounded at N ParenContext
+                    // allocations across arbitrary backtracking.
+                    m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
+                    freeParenContext(currParenContextReg);
+                    m_jit.move(newParenContextReg, currParenContextReg);
                     storeToFrame(currParenContextReg, parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex());
                     m_jit.jump(checkContext);
 
                     // Complete context found - restore from it
                     isComplete.link(&m_jit);
 
-                    // Restore state from ParenContext (captures, frame slots)
+                    // Restore state from ParenContext (captures, frame slots).
                     restoreParenContext(currParenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation);
-
-                    // Clear Greedy/NonGreedy patterns' stale parenContextHead
-                    // in the restored frame range. restoreParenContext restores ALL
-                    // frame slots from parenthesesFrameLocation to the end, including
-                    // sibling and ancestor-sibling groups. Those groups may have freed
-                    // their own contexts during a later iteration's execution.
-                    // See clearParenContextHeadSlotsInRange.
-                    clearParenContextHeadSlotsInRange(m_pattern.m_body, parenthesesFrameLocation + YarrStackSpaceForBackTrackInfoParentheses, m_parenContextSizes.frameSlots());
 
                     // FixedCount backtracking:
                     //
@@ -5090,18 +5067,8 @@ class YarrGenerator final : public YarrJITInfo {
                     break;
                 }
 
-                // Greedy/NonGreedy path: Restore from context and try fewer iterations
-                // If no context exists (non-greedy never entered, or greedy with zero iterations), propagate failure.
-                auto noContext = m_jit.branchTestPtr(MacroAssembler::Zero, currParenContextReg);
-
+                // Greedy/NonGreedy path: restore from context and try fewer iterations.
                 restoreParenContext(currParenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation);
-
-                // Clear Greedy/NonGreedy patterns' stale parenContextHead
-                // in the restored frame range. restoreParenContext restores ALL
-                // frame slots from parenthesesFrameLocation to the end, including
-                // sibling, ancestor-sibling, and isCopy groups.
-                // See clearParenContextHeadSlotsInRange.
-                clearParenContextHeadSlotsInRange(m_pattern.m_body, parenthesesFrameLocation + YarrStackSpaceForBackTrackInfoParentheses, m_parenContextSizes.frameSlots());
 
                 m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
                 freeParenContext(currParenContextReg);
@@ -5141,9 +5108,6 @@ class YarrGenerator final : public YarrJITInfo {
                 }
                 }
 
-                noContext.link(&m_jit);
-                if (op.m_zeroLengthMatch.isSet())
-                    op.m_zeroLengthMatch.link(&m_jit);
                 storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
                 m_backtrackingState.fallthrough();
 #else // !YARR_JIT_ALL_PARENS_EXPRESSIONS
@@ -5197,12 +5161,25 @@ class YarrGenerator final : public YarrJITInfo {
                 }
                 case QuantifierType::FixedCount: {
                     // Backtracking into the End means something after the parentheses failed.
-                    // For FixedCount, we fall through to content's backtrack code.
+                    // Mark the head context as incomplete (matchAmount = -1) so BEGIN.bt's
+                    // skip-incomplete loop discards it rather than restoring from it.
+                    //
+                    // The just-completed iteration's saved inner parenContextHead pointers
+                    // may reference ctxs that the upcoming content-backtrack cycle will
+                    // free (via inner Greedy/NonGreedy Begin.bt). If we restored this ctx,
+                    // those stale pointers would be written back to the frame. By marking
+                    // and skipping, BEGIN.bt advances to the previous iteration's ctx
+                    // whose saved pointers reference chains that are dangling-but-intact
+                    // (per-iteration inner chain isolation).
+                    //
+                    // If content backtrack succeeds, END.forward will re-save this ctx,
+                    // overwriting the -1 with a positive matchAmount (complete again).
+                    //
                     // BEGIN.bt handles the context manipulation and decrementing matchAmount,
                     // then jumps to m_contentBacktrackEntryLabel (set below after fallthrough).
-                    //
-                    // No special handling needed here - just fall through to set up
-                    // m_contentBacktrackEntryLabel which BEGIN.bt will jump to.
+                    const MacroAssembler::RegisterID parenContextReg = m_regs.regT0;
+                    loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::parenContextHeadIndex(), parenContextReg);
+                    m_jit.store32(MacroAssembler::TrustedImm32(-1), MacroAssembler::Address(parenContextReg, ParenContext::matchAmountOffset()));
                     break;
                 }
                 }
@@ -6663,51 +6640,6 @@ public:
             return m_compilationThreadStackChecker->isSafeToRecurse();
 
         return m_vm->isSafeToRecurse();
-    }
-
-    // Emit stores to null out parenContextHead of Greedy/NonGreedy
-    // ParenthesesSubpattern terms whose frame slots fall within the range
-    // restored by restoreParenContext.
-    //
-    // restoreParenContext restores ALL frame slots in
-    // [subpatternBaseFrameLocation + YarrStackSpaceForBackTrackInfoParentheses,
-    //  m_parenContextSizes.frameSlots()), which is a global range covering
-    // inner, sibling, and ancestor-sibling groups. Any Greedy/NonGreedy
-    // group in this range may have freed its own contexts between the save
-    // and restore points, leaving stale parenContextHead pointers after
-    // restoration. Walk the entire pattern tree and null every qualifying
-    // parenContextHead in the restored range.
-    //
-    // isCopy groups are always skipped: an isCopy group's contexts are
-    // allocated by the isCopy group itself and are never freed by the
-    // outer group's backtrack operations (which only free/reuse the outer
-    // group's own context). Between save and restore, new isCopy contexts
-    // may be pushed on top or popped by the isCopy's own backtracking,
-    // but the contexts from the save point remain deeper in the chain
-    // and are never freed. The restored parenContextHead always points
-    // to still-valid memory.
-    //
-    // FixedCount inner patterns are unaffected: their contexts become
-    // unreachable (Begin.forward sets parenContextHead=null) but are never
-    // freed, so they remain valid when restored.
-    void clearParenContextHeadSlotsInRange(PatternDisjunction* disjunction, unsigned minFrameLocation, unsigned maxFrameLocation)
-    {
-        for (auto& alternative : disjunction->m_alternatives) {
-            for (auto& term : alternative->m_terms) {
-                if (term.type != PatternTerm::Type::ParenthesesSubpattern && term.type != PatternTerm::Type::ParentheticalAssertion)
-                    continue;
-                if (term.type == PatternTerm::Type::ParenthesesSubpattern
-                    && term.quantityType != QuantifierType::FixedCount
-                    && term.quantityMaxCount != 1
-                    && !term.parentheses.isTerminal
-                    && !term.parentheses.isCopy) {
-                    unsigned headSlot = term.frameLocation + BackTrackInfoParentheses::parenContextHeadIndex();
-                    if (headSlot >= minFrameLocation && headSlot < maxFrameLocation)
-                        storeToFrame(MacroAssembler::TrustedImmPtr(nullptr), headSlot);
-                }
-                clearParenContextHeadSlotsInRange(term.parentheses.disjunction, minFrameLocation, maxFrameLocation);
-            }
-        }
     }
 
     // Check if a disjunction contains terms that could require within-iteration backtracking.


### PR DESCRIPTION
#### 282d55d7a1416497d8c2cbeb1997ea70656d1642
<pre>
[YARR] Just marking current FixedCount ParenContext incomplete and try using it again
<a href="https://bugs.webkit.org/show_bug.cgi?id=313173">https://bugs.webkit.org/show_bug.cgi?id=313173</a>
<a href="https://rdar.apple.com/175457494">rdar://175457494</a>

Reviewed by Geoffrey Garen and Sosuke Suzuki.

This patch makes FixedCount backtracking mechanism simplified. Instead
of restoring and nullifying ParenContext heads, we can just mark the
currently using ParenContext as incomplete, and using this again to
continue the backtracking. Since FixedCount Parentheses starts with
ParenContext with incomplete state, so basically this means that we will
again attempt to match with the current Frame&apos;s information with the
current ParenContext&apos;s state. So the ParenContexts heads in the saved store
is only modified after the restoration. So we no longer need to care
about the problem of reusing stale ParenContexts.

This allows us to recover freeing ParenContext when we failed to match
the current iteration&apos;s FixedCount. This guarantees that FixedCount
parentheses is using ParenContext strictly up-to-N for N iterations
(e.g. (...){N}).

Test: JSTests/stress/yarr-jit-fixedcount-paren-context-free-on-skip.js

* JSTests/stress/yarr-jit-fixedcount-paren-context-free-on-skip.js: Added.
(stringify):
(test):
(test.a.b):
(n.const.re.new.RegExp):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/311912@main">https://commits.webkit.org/311912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c312499c995f2d997d0462ae7daf818cf9b96d05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31865 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/24972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31852 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/167269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161397 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/24960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/150489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169759 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/19273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/15443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/31555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/131012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/31501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/141895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24078 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/31501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/190567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/31012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/96859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/190567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/30532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->