### PR TITLE
Web Inspector: REGRESSION(309194@main): Storage: Can't filter by storage type. Popup menu does not show.

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
@@ -104,10 +104,6 @@
     outline-offset: -1px;
 }
 
-.scope-bar > li.multiple:not(.selected) > select {
-    display: none;
-}
-
 .scope-bar > li.multiple > .arrows {
     width: 5px;
     height: 12px;


### PR DESCRIPTION
#### 968004a85d1dbc5298ea58951a36604dd251fbce
<pre>
Web Inspector: REGRESSION(309194@main): Storage: Can&apos;t filter by storage type. Popup menu does not show.
<a href="https://bugs.webkit.org/show_bug.cgi?id=313155">https://bugs.webkit.org/show_bug.cgi?id=313155</a>
<a href="https://rdar.apple.com/175444192">rdar://175444192</a>

Reviewed by Anne van Kesteren and Devin Rousso.

<a href="https://commits.webkit.org/309194@main">https://commits.webkit.org/309194@main</a> dropped support for handling synthetic events
(i.e. untrusted events) on `&lt;select&gt;` elements.

<a href="https://commits.webkit.org/310437@main">https://commits.webkit.org/310437@main</a> addressed this by relying on the invisible
`&lt;select&gt;` element within a `WI.MultipleScopeBarItem` to receive input directly
and reveal the options list.

However, the `&lt;select&gt;` is set to `display: none` if the `WI.MultipleScopeBarItem`
isn&apos;t marked as selected.

In a `WI.ScopeBar` where another item is marked as selected, the CSS rule is satisfied,
keeping the `&lt;select&gt;` hidden and not receiving input. This occurs in the Storage tab
where the standalone (i.e. exclusive) `WI.ScopeBarItem` is marked as selected by default.

This patch removes the obsolete CSS rule because the `&lt;select&gt;` element:
1) is already visually hidden by other styles.
2) has to be able to receive input at all times.

* Source/WebInspectorUI/UserInterface/Views/ScopeBar.css:
(.scope-bar &gt; li.multiple:not(.selected) &gt; select): Deleted.

Canonical link: <a href="https://commits.webkit.org/311945@main">https://commits.webkit.org/311945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d136c8b149bd995ccd03033dd0d934820b886de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112452 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122657 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86087 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103327 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23965 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22348 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14970 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133653 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169689 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15318 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130843 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130957 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35470 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141830 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89306 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25646 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18636 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96736 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30462 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30735 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30616 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->