### PR TITLE
Remove xros exclusion for Swift memory safety flags in WebKit

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -103,8 +103,6 @@ WK_SWIFT_MEMORY_SAFETY_FLAGS = -strict-memory-safety -enable-experimental-featur
 
 // Treat memory safety warnings as errors.
 WK_SWIFT_MEMORY_SAFETY_ERROR_FLAGS = -Werror StrictMemorySafety -Werror ForeignReferenceType;
-// Keep it turned off on VisionOS until rdar://164555610 and rdar://164559261 are fixed.
-WK_SWIFT_MEMORY_SAFETY_ERROR_FLAGS[sdk=xr*] = ;
 // rdar://164903024: Work around false positives in some SDK versions.
 WK_SWIFT_MEMORY_SAFETY_ERROR_FLAGS[sdk=*26.3*] = ;
 

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
@@ -65,7 +65,8 @@ extension WKRKEntity {
     class func load(from data: Data, withAttributionTaskID attributionTaskId: String?, entityMemoryLimit: Int) async -> WKRKEntity? {
         #if canImport(RealityKit, _version: "403.0.3")
         do {
-            var loadOptions = Entity.__LoadOptions()
+            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+            var loadOptions = unsafe Entity.__LoadOptions()
             if let attributionTaskId {
                 loadOptions.memoryAttributionID = attributionTaskId
             }
@@ -90,11 +91,13 @@ extension WKRKEntity {
 
     @nonobjc
     convenience init(_ rkEntity: Entity) {
-        self.init(coreEntity: rkEntity.coreEntity)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+        unsafe self.init(coreEntity: rkEntity.coreEntity)
     }
 
     init(coreEntity: REEntityRef) {
-        entity = Entity.fromCore(coreEntity)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+        entity = unsafe Entity.fromCore(coreEntity)
     }
 
     var name: String {
@@ -322,7 +325,8 @@ extension WKRKEntity {
         }
 
         guard
-            let context = CGContext(
+            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+            let context = unsafe CGContext(
                 data: nil,
                 width: targetWidth,
                 height: targetHeight,
@@ -365,8 +369,10 @@ extension WKRKEntity {
             )
             let environment = try await EnvironmentResource(cube: textureResource, options: .init())
 
-            if let coreEnvironmentResourceAsset = environment.coreIBLAsset?.__as(REAssetRef.self) {
-                attributionHandler(coreEnvironmentResourceAsset)
+            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+            if let coreEnvironmentResourceAsset = unsafe environment.coreIBLAsset?.__as(REAssetRef.self) {
+                // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+                unsafe attributionHandler(coreEnvironmentResourceAsset)
             }
 
             applyIBL(environment)
@@ -400,7 +406,8 @@ extension WKRKEntity {
 
     @objc(setParentCoreEntity:preservingWorldTransform:)
     func setParentCore(_ coreEntity: REEntityRef, preservingWorldTransform: Bool) {
-        let parentEntity = Entity.fromCore(coreEntity)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+        let parentEntity = unsafe Entity.fromCore(coreEntity)
         entity.setParent(parentEntity, preservingWorldTransform: preservingWorldTransform)
     }
 

--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
@@ -62,7 +62,8 @@ extension WKStageModeInteractionDriver {
 
     // MARK: ObjC Exposed API
     var interactionContainerRef: REEntityRef {
-        interactionContainer.coreEntity
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+        unsafe interactionContainer.coreEntity
     }
 
     var stageModeInteractionInProgress: Bool {
@@ -77,7 +78,8 @@ extension WKStageModeInteractionDriver {
         self.turntableInteractionContainer.name = "WebKit:TurntableContainerEntity"
         self.delegate = delegate
 
-        let containerEntity = Entity.fromCore(container)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+        let containerEntity = unsafe Entity.fromCore(container)
         self.interactionContainer.setParent(containerEntity, preservingWorldTransform: true)
         self.turntableInteractionContainer.setPosition(self.interactionContainer.position(relativeTo: nil), relativeTo: nil)
         self.turntableInteractionContainer.setParent(self.interactionContainer, preservingWorldTransform: true)
@@ -86,7 +88,8 @@ extension WKStageModeInteractionDriver {
     func setContainerTransformInPortal() {
         // Configure entity hierarchy after we have correctly positioned the model
         interactionContainer.setPosition(modelEntity.interactionPivotPoint, relativeTo: nil)
-        modelEntity.setParentCore(turntableInteractionContainer.coreEntity, preservingWorldTransform: true)
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+        unsafe modelEntity.setParentCore(turntableInteractionContainer.coreEntity, preservingWorldTransform: true)
     }
 
     func removeInteractionContainerFromSceneOrParent() {
@@ -159,10 +162,12 @@ extension WKStageModeInteractionDriver {
 
     private func applySimulatorState() {
         let pitchRotation = Rotation3D(angle: .init(radians: simulator.currentPitch), axis: .x)
-        interactionContainer.orientation = pitchRotation.quaternion.quatf
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+        interactionContainer.orientation = unsafe pitchRotation.quaternion.quatf
 
         let yawRotation = Rotation3D(angle: .init(radians: simulator.currentYaw), axis: .y)
-        turntableInteractionContainer.orientation = yawRotation.quaternion.quatf
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=313180
+        turntableInteractionContainer.orientation = unsafe yawRotation.quaternion.quatf
     }
 }
 


### PR DESCRIPTION
#### a1224b6007d128a19121af136f1029818f4baee6
<pre>
Remove xros exclusion for Swift memory safety flags in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=313176">https://bugs.webkit.org/show_bug.cgi?id=313176</a>
<a href="https://rdar.apple.com/173236391">rdar://173236391</a>

Reviewed by Elliott Williams.

Remove visionOS strict safety exclusion and update WKRKEntity and
WKStageMode to compile with strict safety enabled.

* Configurations/CommonBase.xcconfig:
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift:
(WKRKEntity.load(from:withAttributionTaskID:entityMemoryLimit:)):
(WKRKEntity.resizedImage(_:)):
(WKRKEntity.applyIBLData(_:attributionHandler:)):
(WKRKEntity.setParentCore(_:preservingWorldTransform:)):
* Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift:
(WKStageModeInteractionDriver.interactionContainerRef):
(WKStageModeInteractionDriver.setContainerTransformInPortal):
(WKStageModeInteractionDriver.applySimulatorState):

Canonical link: <a href="https://commits.webkit.org/311978@main">https://commits.webkit.org/311978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/615b330462856beb6ab90e7900ce929cd1b1cd51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158386 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112469 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122669 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86100 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103339 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23977 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22363 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14987 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133665 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169706 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130854 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130968 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35493 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141861 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89323 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18667 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30959 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96753 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30479 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30752 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30633 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->