### PR TITLE
Use StaticStringImpl for EventNames to avoid per-thread heap allocations

### DIFF
--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -236,6 +236,37 @@ struct BufferFromStaticDataTranslator {
     }
 };
 
+template<typename CharType>
+struct StaticStringAtomBuffer {
+    SUPPRESS_UNCOUNTED_MEMBER const StringImpl& staticImpl;
+    std::span<const CharType> characters;
+    unsigned hash;
+};
+
+// Translator that stores a StaticStringImpl directly in the atom table without
+// heap-allocating a copy. The StaticStringImpl must have been constructed with
+// StringImpl::StringAtom so that isAtom() returns true. This enables global
+// atom strings that share the same StringImpl* across all threads.
+template<typename CharType>
+struct StaticStringAtomTranslator {
+    using Buffer = StaticStringAtomBuffer<CharType>;
+
+    static unsigned NODELETE hash(const Buffer& buf)
+    {
+        return buf.hash;
+    }
+
+    static bool equal(AtomStringTable::StringEntry const& str, const Buffer& buf)
+    {
+        return WTF::equal(str.get(), buf.characters);
+    }
+
+    static void translate(AtomStringTable::StringEntry& location, const Buffer& buf, unsigned)
+    {
+        location = const_cast<StringImpl*>(&buf.staticImpl);
+    }
+};
+
 RefPtr<AtomStringImpl> AtomStringImpl::add(HashTranslatorCharBuffer<Latin1Character>& buffer)
 {
     if (!buffer.characters.data())
@@ -289,6 +320,20 @@ static Ref<AtomStringImpl> addStatic(AtomStringTableLocker& locker, StringTableI
 {
     ASSERT(base.length());
     ASSERT(base.isStatic());
+
+    // StaticStringImpl with StringAtom: store the static pointer directly in the
+    // atom table with no heap allocation. The isAtom() flag is already set at
+    // construction time, enabling uncheckedDowncast<AtomStringImpl> and the
+    // dynamicDowncast fast path in add(StringImpl&). All threads that register
+    // the same StaticStringImpl share the same StringImpl pointer.
+    if (base.isAtom()) {
+        if (base.is8Bit()) {
+            StaticStringAtomBuffer<Latin1Character> buffer { base, base.span8(), base.hash() };
+            return addToStringTable<StaticStringAtomBuffer<Latin1Character>, StaticStringAtomTranslator<Latin1Character>>(locker, atomStringTable, buffer);
+        }
+        StaticStringAtomBuffer<char16_t> buffer { base, base.span16(), base.hash() };
+        return addToStringTable<StaticStringAtomBuffer<char16_t>, StaticStringAtomTranslator<char16_t>>(locker, atomStringTable, buffer);
+    }
 
     if (base.is8Bit()) {
         Latin1Buffer buffer { base.span8(), base.hash() };

--- a/Source/WTF/wtf/text/AtomStringTable.cpp
+++ b/Source/WTF/wtf/text/AtomStringTable.cpp
@@ -27,8 +27,13 @@ namespace WTF {
 
 AtomStringTable::~AtomStringTable()
 {
-    for (const auto& string : m_table)
-        string->setIsAtom(false);
+    for (const auto& string : m_table) {
+        // Static strings are immortal and their atom flag was set at construction
+        // time (via StringImpl::StringAtom), not by setIsAtom(). Skip them here
+        // since setIsAtom() asserts !isStatic().
+        if (!string->isStatic())
+            string->setIsAtom(false);
+    }
 }
 
 }

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -228,12 +228,14 @@ private:
     static constexpr const unsigned s_hashFlag8BitBuffer = 1u << 2;
     static constexpr const unsigned s_hashMaskBufferOwnership = (1u << 0) | (1u << 1);
 
+public:
     enum StringKind {
         StringNormal = 0u, // non-symbol, non-atomic
         StringAtom = s_hashFlagStringKindIsAtom, // non-symbol, atomic
         StringSymbol = s_hashFlagStringKindIsSymbol, // symbol, non-atomic
     };
 
+private:
     // Create a normal 8-bit string with internal storage (BufferInternal).
     enum Force8Bit { Force8BitConstructor };
     StringImpl(unsigned length, Force8Bit);

--- a/Source/WebCore/dom/make-event-names.py
+++ b/Source/WebCore/dom/make-event-names.py
@@ -214,18 +214,33 @@ inline EventTypeInfo EventNames::typeInfoForEvent(const AtomString& eventType) c
 #include "EventNames.h"
 
 namespace WebCore {
+''')
 
-EventNames::EventNames()''')
+        # Generate static constexpr StaticStringImpl declarations
+        for name in sorted(event_names_input.keys()):
+            conditional = event_names_input[name].get('conditional', None)
+            if conditional:
+                writeln(f'#if {conditional}')
+            writeln(f'static constexpr StringImpl::StaticStringImpl {name}Data("{name}", StringImpl::StringAtom);')
+            if conditional:
+                writeln('#endif')
+
+        writeln('')
+
+        # Generate constructor using StaticStringImpl references
+        writeln('EventNames::EventNames()')
 
         delimiter = ':'
         for name in sorted(event_names_input.keys()):
             conditional = event_names_input[name].get('conditional', None)
             if conditional:
                 writeln(f'#if {conditional}')
-            writeln(f'    {delimiter} {name}Event(\"{name}\"_s)')
+            writeln(f'    {delimiter} {name}Event({name}Data)')
             delimiter = ','
             if conditional:
                 writeln('#endif')
+
+        # m_typeInfoMap uses already-initialized member variables as keys
         writeln(f'    {delimiter} m_typeInfoMap({{')
         for name in sorted(event_names_input.keys()):
             entry = event_names_input[name]


### PR DESCRIPTION
#### 33bf00e7fc8ce2293431540c62b0f7fd08b89221
<pre>
Use StaticStringImpl for EventNames to avoid per-thread heap allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=313178">https://bugs.webkit.org/show_bug.cgi?id=313178</a>

Reviewed by Ryosuke Niwa and Yusuke Suzuki.

Previously, each thread&apos;s EventNames constructor initialized ~335 AtomString
members from ASCIILiteral. Each one heap-allocated a StringImpl via
`createWithoutCopying()` and computed the string hash at runtime.

Now, event names are declared as `static constexpr StaticStringImpl` with the
StringAtom flag, and `addStatic()` stores them directly in the atom table
without heap-allocating a copy. This means:
- ~335 heap allocations eliminated per thread
- String hashes are computed at compile time (constexpr)
- All threads share the same StringImpl* pointers for event names

The StringAtom flag (same mechanism used by `emptyAtom()`) ensures the
StaticStringImpl is recognized as a valid atom, enabling the
`dynamicDowncast&lt;AtomStringImpl&gt;` fast path in `add(StringImpl&amp;)`.

* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::StaticStringAtomTranslator::hash):
(WTF::StaticStringAtomTranslator::equal):
(WTF::StaticStringAtomTranslator::translate):
(WTF::addStatic):
* Source/WTF/wtf/text/AtomStringTable.cpp:
(WTF::AtomStringTable::~AtomStringTable):
* Source/WTF/wtf/text/StringImpl.h:
* Source/WebCore/dom/make-event-names.py:

Canonical link: <a href="https://commits.webkit.org/312329@main">https://commits.webkit.org/312329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4a96262e374f8c56ceeacf6b9ca88180ec75ac6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167253 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112508 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122698 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86118 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103368 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24005 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22401 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15024 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150473 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133693 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169743 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19257 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15404 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130884 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130998 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35712 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141894 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89360 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18700 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190551 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30996 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96824 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48889 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30516 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30789 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30670 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->