### PR TITLE
[LBSE] Introduce DOM-order children cache infrastructure for SVG layers

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3013,6 +3013,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/RenderLayerBacking.h
     rendering/RenderLayerCompositor.h
     rendering/RenderLayerModelObject.h
+    rendering/RenderLayerSVGAdditions.h
     rendering/RenderLayerScrollableArea.h
     rendering/RenderLayoutState.h
     rendering/RenderLineBoxList.h

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1195,6 +1195,15 @@ void RenderElement::styleDidChange(Style::Difference diff, const RenderStyle* ol
         LayoutIntegration::LineLayout::updateStyle(*this);
 }
 
+void RenderElement::dirtyEnclosingLayerSVGChildrenIfNeeded()
+{
+    ASSERT(isSVGLayerAwareRenderer());
+    if (!hasLayer() && document().settings().layerBasedSVGEngineEnabled()) {
+        if (CheckedPtr layer = enclosingLayer())
+            layer->dirtyChildrenInDOMOrderForSVG();
+    }
+}
+
 void RenderElement::insertedIntoTree()
 {
     // Keep our layer hierarchy updated. Optimize for the common case where we don't have any children
@@ -1210,6 +1219,11 @@ void RenderElement::insertedIntoTree()
         if (CheckedPtr parentLayer = layerParent())
             parentLayer->dirtyVisibleContentStatus();
     }
+
+    // Dirty the enclosing layer's SVG children list when a non-layer SVG renderer is inserted.
+    // Layer children are handled by RenderLayer::addChild -> dirtyPaintOrderListsOnChildChange.
+    if (isSVGLayerAwareRenderer())
+        dirtyEnclosingLayerSVGChildrenIfNeeded();
 
     RenderObject::insertedIntoTree();
 }
@@ -1227,6 +1241,12 @@ void RenderElement::willBeRemovedFromTree()
         if (CheckedPtr enclosingLayer = parent()->enclosingLayer())
             enclosingLayer->dirtyVisibleContentStatus();
     }
+
+    // Dirty the enclosing layer's SVG children list when a non-layer SVG renderer is removed.
+    // Layer children are handled by RenderLayer::removeChild -> dirtyPaintOrderListsOnChildChange.
+    if (isSVGLayerAwareRenderer())
+        dirtyEnclosingLayerSVGChildrenIfNeeded();
+
     // Keep our layer hierarchy updated.
     if (firstChild() || hasLayer())
         removeLayers();

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -366,6 +366,8 @@ protected:
     virtual void styleWillChange(Style::Difference, const RenderStyle& newStyle);
     virtual void styleDidChange(Style::Difference, const RenderStyle* oldStyle);
 
+    void dirtyEnclosingLayerSVGChildrenIfNeeded();
+
     void insertedIntoTree() override;
     void willBeRemovedFromTree() override;
     void willBeDestroyed() override;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -537,6 +537,14 @@ void RenderLayer::dirtyPaintOrderListsOnChildChange(RenderLayer& child)
         // off dirty in that case anyway.
         child.dirtyStackingContextZOrderLists();
     }
+
+    // SVG layers that are not normal-flow-only still need to dirty the parent's
+    // SVG children DOM order list. dirtyNormalFlowList() handles this for normal-flow
+    // children, and dirtyStackingContextZOrderLists() dirties the stacking context
+    // ancestor (not necessarily this layer). Without this, adding a new child layer
+    // to an SVG container would leave the container's SVG children list stale.
+    if (m_svgData && child.renderer().isSVGLayerAwareRenderer() && !child.isNormalFlowOnly())
+        dirtyChildrenInDOMOrderForSVG();
 }
 
 void RenderLayer::insertOnlyThisLayer()
@@ -742,6 +750,9 @@ void RenderLayer::dirtyZOrderLists()
         m_negZOrderList->clear();
     m_zOrderListsDirty = true;
 
+    if (m_svgData)
+        dirtyChildrenInDOMOrderForSVG();
+
     // FIXME: Ideally, we'd only dirty if the lists changed.
     if (hasCompositingDescendant())
         setNeedsCompositingPaintOrderChildrenUpdate();
@@ -783,6 +794,9 @@ void RenderLayer::dirtyNormalFlowList()
     if (m_normalFlowList)
         m_normalFlowList->clear();
     m_normalFlowListDirty = true;
+
+    if (m_svgData)
+        dirtyChildrenInDOMOrderForSVG();
 
     if (hasCompositingDescendant())
         setNeedsCompositingPaintOrderChildrenUpdate();
@@ -6146,6 +6160,9 @@ void RenderLayer::styleChanged(Style::Difference diff, const RenderStyle* oldSty
             dirtyStackingContextZOrderLists();
             if (isStackingContext())
                 dirtyZOrderLists();
+            // Also dirty the parent layer's SVG children list since z-index affects sort order.
+            if (auto* parentLayer = parent(); parentLayer && parentLayer->m_svgData)
+                parentLayer->dirtyChildrenInDOMOrderForSVG();
         }
 
         if (!oldStyle->viewTransitionName().isNone() != renderer().hasViewTransitionName())

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -51,6 +51,7 @@
 #include <WebCore/PaintFrequencyTracker.h>
 #include <WebCore/PaintInfo.h>
 #include <WebCore/RenderBox.h>
+#include <WebCore/RenderLayerSVGAdditions.h>
 #include <WebCore/RenderObjectDocument.h>
 #include <WebCore/RenderPtr.h>
 #include <WebCore/RenderSVGModelObject.h>
@@ -468,6 +469,7 @@ public:
     inline bool isPaintingResourceLayerForSVG() const;
     inline RenderSVGHiddenContainer* enclosingHiddenOrResourceContainerForSVG() const;
     void paintResourceLayerForSVG(GraphicsContext&, const AffineTransform&);
+    void dirtyChildrenInDOMOrderForSVG();
     bool shouldSkipRepaintAfterLayoutForSVG() const;
     bool hasFailedFilterForSVG() const;
     bool shouldSkipHitTestForSVG() const;
@@ -1029,6 +1031,13 @@ private:
     bool setupClipPathIfNeededForSVG(OptionSet<PaintLayerFlag>&);
     bool paintForegroundForFragmentsForSVG(const LayerFragments&, GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, RenderObject*);
 
+    void collectChildrenInDOMOrderForSVG();
+    // Returns true if this subtree contains any child that must be painted as
+    // an independent list entry (layered children or transformed non-layer
+    // children), signaling that the parent needs a "split" entry.
+    bool appendChildrenInDOMOrderForSVG(RenderElement& parent, LayoutSize ancestorOffset, bool& anyNonZeroZIndex);
+    const Vector<SVGPaintOrderLayerItem>& childrenInDOMOrderForSVG();
+
     void dirtyPaintOrderListsOnChildChange(RenderLayer&);
 
     bool shouldBeNormalFlowOnly() const;
@@ -1503,7 +1512,9 @@ private:
     struct SVGData {
         WTF_MAKE_STRUCT_TZONE_ALLOCATED(SVGData);
         bool isPaintingResourceLayer { false };
+        bool childrenInDOMOrderDirty { true };
         SingleThreadWeakPtr<RenderSVGHiddenContainer> enclosingHiddenOrResourceContainer;
+        Vector<SVGPaintOrderLayerItem> childrenInDOMOrder;
     };
     std::unique_ptr<SVGData> m_svgData;
 

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -455,9 +455,20 @@ void RenderLayerModelObject::updateHasSVGTransformFlags()
 {
     ASSERT(document().settings().layerBasedSVGEngineEnabled());
 
+    bool wasTransformed = isTransformed();
     bool hasSVGTransform = needsHasSVGTransformFlags();
     setHasTransformRelatedProperty(hasSVGTransform || style().hasTransformRelatedProperty());
     setHasSVGTransform(hasSVGTransform);
+
+    // When the isTransformed() state changes, the enclosing layer's SVG children order cache
+    // must be rebuilt. A transformed non-layer renderer is collected as a single atomic entry
+    // without recursing into its subtree, so any layered descendants are not registered in
+    // the DOM-order list. A stale classification either drops those descendants (when toggled
+    // to transformed) or leaves them un-wrapped by the new transform (when toggled away).
+    if (isTransformed() != wasTransformed) {
+        if (CheckedPtr layer = enclosingLayer())
+            layer->dirtyChildrenInDOMOrderForSVG();
+    }
 }
 
 RenderSVGResourceClipper* RenderLayerModelObject::svgClipperResourceFromStyle() const

--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
@@ -22,13 +22,17 @@
 #include "CSSFilterRenderer.h"
 #include "ReferencedSVGResources.h"
 #include "RenderAncestorIterator.h"
+#include "RenderDescendantIterator.h"
+#include "RenderElementInlines.h"
 #include "RenderLayerFilters.h"
 #include "RenderLayerInlines.h"
 #include "RenderLayerModelObject.h"
 #include "RenderLayerSVGAdditionsInlines.h"
+#include "RenderObjectInlines.h"
 #include "RenderSVGContainer.h"
 #include "RenderSVGHiddenContainer.h"
 #include "RenderSVGModelObject.h"
+#include "RenderSVGModelObjectInlines.h"
 #include "RenderSVGResourceClipper.h"
 #include "RenderSVGResourceContainer.h"
 #include "RenderSVGRoot.h"
@@ -174,6 +178,132 @@ void RenderLayer::updateAncestorDependentStateForSVG()
     ASSERT(m_svgData);
     ASSERT(renderer().document().settings().layerBasedSVGEngineEnabled());
     m_svgData->enclosingHiddenOrResourceContainer = ancestorsOfType<RenderSVGHiddenContainer>(renderer()).first();
+}
+
+void RenderLayer::dirtyChildrenInDOMOrderForSVG()
+{
+    ASSERT(m_svgData);
+    m_svgData->childrenInDOMOrder.shrink(0); // Use shrink(0) instead of clear() to retain our capacity.
+    m_svgData->childrenInDOMOrderDirty = true;
+}
+
+void RenderLayer::collectChildrenInDOMOrderForSVG()
+{
+    ASSERT(m_svgData);
+    m_svgData->childrenInDOMOrderDirty = false;
+    m_svgData->childrenInDOMOrder.shrink(0); // Use shrink(0) instead of clear() to retain our capacity.
+
+    bool anyNonZeroZIndex = false;
+    appendChildrenInDOMOrderForSVG(renderer(), { }, anyNonZeroZIndex);
+
+    // Sort by z-index; for equal z-index, stable_sort preserves DOM order.
+    // Skip entirely when no child uses z-index — collection order already matches DOM order.
+    if (anyNonZeroZIndex) {
+        std::stable_sort(m_svgData->childrenInDOMOrder.begin(), m_svgData->childrenInDOMOrder.end(),
+            [](const SVGPaintOrderLayerItem& a, const SVGPaintOrderLayerItem& b) {
+                return a.zIndex < b.zIndex;
+            });
+    }
+}
+
+// Recursively collect children, splitting non-layered containers that have
+// layered descendants to ensure proper DOM-order interleaving. Returns true
+// if any layered child was found in this subtree.
+bool RenderLayer::appendChildrenInDOMOrderForSVG(RenderElement& parent, LayoutSize ancestorOffset, bool& anyNonZeroZIndex)
+{
+    auto& allChildren = m_svgData->childrenInDOMOrder;
+    bool hasIndependentlyPaintedDescendant = false;
+    for (CheckedRef child : childrenOfType<RenderElement>(parent)) {
+        // Never directly paint children of <defs>, <linearGradient>, etc.
+        if (child->isRenderSVGHiddenContainer())
+            continue;
+
+        if (child->hasSelfPaintingLayer()) {
+            CheckedRef layerModelObject = downcast<RenderLayerModelObject>(child.get());
+            CheckedRef childLayer = *layerModelObject->layer();
+            int zIndex = childLayer->zIndex();
+            if (zIndex)
+                anyNonZeroZIndex = true;
+            allChildren.append(SVGPaintOrderLayerItem::makeLayered(child.get(), childLayer.get(), zIndex));
+            hasIndependentlyPaintedDescendant = true;
+            continue;
+        }
+
+        // Transformed non-layer children are painted atomically by the consumer:
+        // its transform is applied and children are painted recursively.
+        if (child->isTransformed()) {
+            allChildren.append(SVGPaintOrderLayerItem::makeAtomic(child.get(), ancestorOffset));
+            hasIndependentlyPaintedDescendant = true;
+            continue;
+        }
+
+        // Leaf nodes (no children) are always painted atomically.
+        if (!child->firstChild()) {
+            allChildren.append(SVGPaintOrderLayerItem::makeAtomic(child.get(), ancestorOffset));
+            continue;
+        }
+
+        // Compute the offset that this child contributes to its descendants.
+        LayoutSize childOffset = ancestorOffset;
+        if (CheckedPtr svgModel = dynamicDowncast<RenderSVGModelObject>(child.get()))
+            childOffset += toLayoutSize(svgModel->currentSVGLayoutLocation());
+
+        // We don't yet know whether this non-layered container has any
+        // independently painted descendants (layered or transformed non-layer
+        // children), so recurse speculatively and decide what to keep based on
+        // the result.
+        //
+        // Example:
+        //   <g id="A">
+        //     <rect id="r1"/>
+        //     <g id="B" style="z-index: 5; opacity: 0.5;"/>   <!-- layered -->
+        //     <rect id="r2"/>
+        //   </g>
+        //
+        //   When recursing into A, the inner walk visits r1 (leaf, append), then B
+        //   (layered, append, mark independently-painted), then r2 (leaf, append).
+        //   The speculative segment is now [r1, B, r2] and
+        //   subtreeHasIndependentlyPaintedDescendant=true, so we fall into Case B
+        //   and additionally append A with the split flag. After z-sort the final
+        //   list is [r1, r2, A(split), B] — B last because z=5. The consumer then
+        //   paints r1 and r2 at A's offset, then A(split) which paints only A's
+        //   own outline (no child recursion), then B on top. Without the split
+        //   flag, A's normal paint would recurse into r1/B/r2 and all three would
+        //   be painted twice — once via A's recursion, once via their own list
+        //   entries.
+        //
+        // Case A — no independently painted descendants: the subtree paints
+        // atomically as part of the container's own normal paint walk. Discard
+        // the speculative entries (shrink to startIndex) and append a single
+        // entry for the container. Without the shrink, A's normal recursive
+        // paint would visit children that are still present in the list,
+        // causing the same double-paint problem.
+        //
+        // Case B — independently painted descendants exist: keep their entries
+        // (so they sort into the overall z-order) and append a "split" entry
+        // for the container itself. The consumer paints only the container's
+        // own non-content contribution (outlines) and skips child recursion,
+        // since each independently painted descendant is painted from the
+        // sorted list.
+        size_t startIndex = allChildren.size();
+        bool subtreeHasIndependentlyPaintedDescendant = appendChildrenInDOMOrderForSVG(child.get(), childOffset, anyNonZeroZIndex);
+        if (subtreeHasIndependentlyPaintedDescendant) {
+            allChildren.append(SVGPaintOrderLayerItem::makeOutlineOnly(child.get(), ancestorOffset));
+            hasIndependentlyPaintedDescendant = true;
+        } else {
+            allChildren.shrink(startIndex);
+            allChildren.append(SVGPaintOrderLayerItem::makeAtomic(child.get(), ancestorOffset));
+        }
+    }
+    return hasIndependentlyPaintedDescendant;
+}
+
+const Vector<SVGPaintOrderLayerItem>& RenderLayer::childrenInDOMOrderForSVG()
+{
+    ASSERT(m_svgData);
+    if (m_svgData->childrenInDOMOrderDirty)
+        collectChildrenInDOMOrderForSVG();
+    return m_svgData->childrenInDOMOrder;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.h
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#include <WebCore/LayoutRect.h>
+#include <WebCore/PaintPhase.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/OptionSet.h>
+
+namespace WebCore {
+
+class RenderElement;
+class RenderLayer;
+
+class SVGPaintOrderLayerItem {
+public:
+    static SVGPaintOrderLayerItem makeLayered(RenderElement& renderer, RenderLayer& layer, int zIndex)
+    {
+        return SVGPaintOrderLayerItem { &renderer, &layer, zIndex, { }, { } };
+    }
+
+    static SVGPaintOrderLayerItem makeAtomic(RenderElement& renderer, LayoutSize ancestorOffset)
+    {
+        return SVGPaintOrderLayerItem { &renderer, nullptr, 0, { PaintPhase::Foreground, PaintPhase::Outline }, ancestorOffset };
+    }
+
+    static SVGPaintOrderLayerItem makeOutlineOnly(RenderElement& renderer, LayoutSize ancestorOffset)
+    {
+        return SVGPaintOrderLayerItem { &renderer, nullptr, 0, { PaintPhase::SelfOutline }, ancestorOffset };
+    }
+
+    CheckedPtr<RenderElement> renderer;
+    CheckedPtr<RenderLayer> layer; // null for non-layer children
+    int zIndex { 0 };
+    OptionSet<PaintPhase> phasesToPaint; // Empty for layered children; drives the non-layer paint loop.
+    LayoutSize accumulatedAncestorOffset; // Precomputed offset from non-layered ancestors between child and layer's renderer.
+
+private:
+    SVGPaintOrderLayerItem(RenderElement* renderer, RenderLayer* layer, int zIndex, OptionSet<PaintPhase> phasesToPaint, LayoutSize accumulatedAncestorOffset)
+        : renderer(renderer)
+        , layer(layer)
+        , zIndex(zIndex)
+        , phasesToPaint(phasesToPaint)
+        , accumulatedAncestorOffset(accumulatedAncestorOffset)
+    {
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -1035,8 +1035,13 @@ RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement
     ASSERT(parent.canHaveChildren() || parent.canHaveGeneratedChildren());
     ASSERT(child.parent() == &parent);
 
-    if (parent.renderTreeBeingDestroyed() || m_tearDownType == TearDownType::SubtreeWithRootAlreadyDetached)
+    if (parent.renderTreeBeingDestroyed() || m_tearDownType == TearDownType::SubtreeWithRootAlreadyDetached) {
+        if (parent.document().settings().layerBasedSVGEngineEnabled() && parent.isSVGLayerAwareRenderer()) {
+            if (CheckedPtr parentLayer = parent.enclosingLayer())
+                parentLayer->dirtyChildrenInDOMOrderForSVG();
+        }
         return parent.detachRendererInternal(child);
+    }
 
     if (child.everHadLayout())
         resetRendererStateOnDetach(parent, child, willBeDestroyed, m_internalMovesType);


### PR DESCRIPTION
#### 315fb715d136d0057225087b703abe6bffac7a82
<pre>
[LBSE] Introduce DOM-order children cache infrastructure for SVG layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=313177">https://bugs.webkit.org/show_bug.cgi?id=313177</a>

Reviewed by Simon Fraser.

Introduce the storage, invalidation, and collection of a cached, DOM-order
list of children for SVG layers. This infrastructure prepares for upcoming
SVG-specific painting and hit-testing that needs to walk children in DOM
order while interleaving layered and non-layered subtrees, and while
honoring z-index.

A new RenderLayerSVGAdditions.h header defines SVGPaintOrderLayerItem,
which classifies each entry via three factories:

 1) makeLayered: the child has its own RenderLayer; the consumer will
    delegate to the layer&apos;s own paint/hit-test machinery.
 2) makeAtomic: a transformed non-layer SVG renderer, or any leaf - painted
    in a single recursive pass at the precomputed ancestor offset.
 3) makeOutlineOnly: a non-layer container whose subtree contains
    independently painted descendants. The container is kept in the list
    so its own self-outline still paints in DOM order, while its
    descendants appear as separate entries; the container&apos;s own paint
    must therefore skip child recursion to avoid double-painting.

RenderLayer::SVGData gains the cached vector plus a dirty flag.
childrenInDOMOrderForSVG() is the lazy accessor and rebuilds via
collectChildrenInDOMOrderForSVG() when dirty. Collection walks the render
tree recursively: layered descendants and transformed non-layer descendants
are appended directly, while non-layer containers are recursed
speculatively — kept as a split makeOutlineOnly entry if the subtree contains
any independently painted descendants, otherwise collapsed into a single
makeAtomic entry. The final list is stable-sorted by z-index only when at
least one child uses a non-zero z-index, so the common case stays in DOM
order without sort overhead. Storage uses Vector::shrink(0) on
invalidation and rebuild to retain capacity across churn.

The cache is dirtied via dirtyChildrenInDOMOrderForSVG(), wired into every
site that can change the list&apos;s membership, classification, or sort order:

  - RenderLayer::dirtyPaintOrderListsOnChildChange, dirtyZOrderLists, and
    dirtyNormalFlowList — layer-children changes within an SVG ancestor.
    Note that the existing dirtyStackingContextZOrderLists() only dirties
    the stacking context ancestor, not necessarily the immediate parent,
    so an explicit dirty is required.
  - The z-index branch of RenderLayer::styleChanged — z-index drives sort
    order, so the parent layer&apos;s cache must be dirtied when it changes.
  - RenderElement::insertedIntoTree and willBeRemovedFromTree, via the
    new dirtyEnclosingLayerSVGChildrenIfNeeded() helper — non-layer SVG
    renderers do not go through RenderLayer::addChild/removeChild, so
    their insertion and removal must be intercepted at the RenderElement
    level.
  - RenderLayerModelObject::updateHasSVGTransformFlags and
    repaintOrRelayoutAfterSVGTransformChange — when isTransformed() flips
    on a non-layer renderer, its classification flips between Atomic and
    the container path, requiring a rebuild of the enclosing layer&apos;s
    cache.
  - RenderTreeBuilder::detachFromRenderElement on the early-teardown
    path, where resetRendererStateOnDetach() does not run and would
    otherwise leave stale entries pointing into the detached subtree.

The cache has no consumers yet; they follow in subsequent patches.
Covered by existing tests once conditional-layer support is enabled.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::dirtyEnclosingLayerSVGChildrenIfNeeded):
(WebCore::RenderElement::insertedIntoTree):
(WebCore::RenderElement::willBeRemovedFromTree):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::dirtyPaintOrderListsOnChildChange):
(WebCore::RenderLayer::dirtyZOrderLists):
(WebCore::RenderLayer::dirtyNormalFlowList):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::updateHasSVGTransformFlags):
(WebCore::RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange):
* Source/WebCore/rendering/RenderLayerSVGAdditions.cpp:
(WebCore::RenderLayer::dirtyChildrenInDOMOrderForSVG):
(WebCore::RenderLayer::collectChildrenInDOMOrderForSVG):
(WebCore::RenderLayer::appendChildrenInDOMOrderForSVG):
(WebCore::RenderLayer::childrenInDOMOrderForSVG):
* Source/WebCore/rendering/RenderLayerSVGAdditions.h: Added.
(WebCore::SVGPaintOrderLayerItem::makeLayered):
(WebCore::SVGPaintOrderLayerItem::makeAtomic):
(WebCore::SVGPaintOrderLayerItem::makeOutlineOnly):
(WebCore::SVGPaintOrderLayerItem::SVGPaintOrderLayerItem):
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::detachFromRenderElement):

Canonical link: <a href="https://commits.webkit.org/312337@main">https://commits.webkit.org/312337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1fabfb8b82ccb0d328e4bc4962e42ea5348ade2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168435 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123653 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104305 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16200 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170922 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16956 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131880 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32734 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27494 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131966 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35715 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32719 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142907 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90801 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26609 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19721 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32228 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98624 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31725 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31972 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->