### PR TITLE
[Site Isolation] Web Inspector: Need a way to gate partially implemented frame target domains and agents

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -3230,6 +3230,10 @@ WI.engineeringSettingsAllowed = function() {
     return WI.isEngineeringBuild || WI.inspectorFrontendHostAllowsEngineeringSettings;
 }
 
+WI.isSiteIsolationEnabled = function() {
+    return WI.targets.some((t) => t.type === WI.TargetType.Frame);
+};
+
 // OpenResourceDialog delegate
 
 WI.dialogWasDismissedWithRepresentedObject = function(dialog, representedObject)

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -261,6 +261,7 @@ WI.settings = {
     engineeringShowInternalObjectsInHeapSnapshot: new WI.EngineeringSetting("engineering-show-internal-objects-in-heap-snapshot", false),
     engineeringShowPrivateSymbolsInHeapSnapshot: new WI.EngineeringSetting("engineering-show-private-symbols-in-heap-snapshot", false),
     engineeringAllowEditingUserAgentShadowTrees: new WI.EngineeringSetting("engineering-allow-editing-user-agent-shadow-trees", false),
+    engineeringEnableFrameTargetDomains: new WI.EngineeringSetting("engineering-enable-frame-target-domains", false),
 
     // Debug
     debugShowConsoleEvaluations: new WI.DebugSetting("debug-show-console-evaluations", false),

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -407,8 +407,6 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
     {
         let experimentalSettingsView = new WI.SettingsView("experimental", WI.UIString("Experimental"));
 
-        let initialValues = new Map;
-        
         let consoleGroup = experimentalSettingsView.addGroup(WI.UIString("Console:"));
         consoleGroup.addSetting(WI.settings.experimentalGroupSourceMapErrors, WI.UIString("Group source map network errors"));
         
@@ -455,38 +453,24 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         diagnosticsGroup.addSetting(WI.settings.experimentalAllowInspectingInspector, WI.UIString("Allow Inspecting Web Inspector", "Allow Inspecting Web Inspector @ Experimental Settings", "Label for setting that allows the user to inspect the Web Inspector user interface."));
         experimentalSettingsView.addSeparator();
 
-        let reloadInspectorButton = document.createElement("button");
-        reloadInspectorButton.textContent = WI.UIString("Reload Web Inspector");
-        reloadInspectorButton.addEventListener("click", (event) => {
-            InspectorFrontendHost.reopen();
-        });
-
-        let reloadInspectorContainerElement = experimentalSettingsView.addCenteredContainer(reloadInspectorButton, WI.UIString("for changes to take effect"));
-        reloadInspectorContainerElement.classList.add("hidden");
-
-        function listenForChange(setting) {
-            initialValues.set(setting, setting.value);
-            setting.addEventListener(WI.Setting.Event.Changed, function(event) {
-                this.classList.toggle("hidden", Array.from(initialValues).every(([setting, initialValue]) => setting.value === initialValue));
-            }, reloadInspectorContainerElement);
-        }
-
-        listenForChange(WI.settings.experimentalGroupSourceMapErrors);
+        let reloadRequiredSettings = [WI.settings.experimentalGroupSourceMapErrors];
 
         if (hasCSSDomain) {
-            listenForChange(WI.settings.experimentalEnableStylesJumpToEffective);
-            listenForChange(WI.settings.experimentalEnableStylesJumpToVariableDeclaration);
-            listenForChange(WI.settings.experimentalCSSSortPropertyNameAutocompletionByUsage);
+            reloadRequiredSettings.push(WI.settings.experimentalEnableStylesJumpToEffective);
+            reloadRequiredSettings.push(WI.settings.experimentalEnableStylesJumpToVariableDeclaration);
+            reloadRequiredSettings.push(WI.settings.experimentalCSSSortPropertyNameAutocompletionByUsage);
         }
 
         if (InspectorBackend.hasCommand("LayerTree.requestContent"))
-            listenForChange(WI.settings.experimentalLayers3DShowLayerContents);
+            reloadRequiredSettings.push(WI.settings.experimentalLayers3DShowLayerContents);
 
         if (hasNetworkEmulatedCondition)
-            listenForChange(WI.settings.experimentalEnableNetworkEmulatedCondition);
+            reloadRequiredSettings.push(WI.settings.experimentalEnableNetworkEmulatedCondition);
 
-        listenForChange(WI.settings.experimentalLimitSourceCodeHighlighting);
-        listenForChange(WI.settings.experimentalUseFuzzyMatchingForCSSCodeCompletion);
+        reloadRequiredSettings.push(WI.settings.experimentalLimitSourceCodeHighlighting);
+        reloadRequiredSettings.push(WI.settings.experimentalUseFuzzyMatchingForCSSCodeCompletion);
+
+        experimentalSettingsView.addReloadRequiredFooter(reloadRequiredSettings);
 
         this._createReferenceLink(experimentalSettingsView);
 
@@ -515,10 +499,19 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         heapSnapshotGroup.addSetting(WI.settings.engineeringShowInternalObjectsInHeapSnapshot, WI.unlocalizedString("Show Internal Objects"));
         heapSnapshotGroup.addSetting(WI.settings.engineeringShowPrivateSymbolsInHeapSnapshot, WI.unlocalizedString("Show Private Symbols"));
 
+        if (WI.isSiteIsolationEnabled()) {
+            engineeringSettingsView.addSeparator();
+
+            let siteIsolationGroup = engineeringSettingsView.addGroup(WI.unlocalizedString("Site Isolation:"));
+            siteIsolationGroup.addSetting(WI.settings.engineeringEnableFrameTargetDomains, WI.unlocalizedString("Enable experimental frame-target domains"));
+        }
+
         if (WI.isEngineeringBuild) {
             engineeringSettingsView.addSeparator();
             engineeringSettingsView.addSetting(WI.unlocalizedString("Debug UI:"), WI.showDebugUISetting, WI.unlocalizedString("Show Debug UI"));
         }
+
+        engineeringSettingsView.addReloadRequiredFooter([WI.settings.engineeringEnableFrameTargetDomains]);
 
         this.addSettingsView(engineeringSettingsView);
     }

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsView.js
@@ -84,6 +84,27 @@ WI.SettingsView = class SettingsView extends WI.View
 
         return containerElement;
     }
+
+    addReloadRequiredFooter(settings)
+    {
+        let reloadButton = document.createElement("button");
+        reloadButton.textContent = WI.UIString("Reload Web Inspector");
+        reloadButton.addEventListener("click", function() {
+            InspectorFrontendHost.reopen();
+        });
+
+        let container = this.addCenteredContainer(reloadButton, WI.UIString("for changes to take effect"));
+        container.classList.add("hidden");
+
+        let initialValues = new Map;
+        for (let setting of settings) {
+            initialValues.set(setting, setting.value);
+            setting.addEventListener(WI.Setting.Event.Changed, function() {
+                let allUnchanged = initialValues.entries().every(([s, v]) => s.value === v);
+                container.classList.toggle("hidden", allUnchanged);
+            });
+        }
+    }
 };
 
 WI.SettingsView.EditorType = {


### PR DESCRIPTION
#### 76d6bbc3a177754455fecd577a0474c4c52f24b6
<pre>
[Site Isolation] Web Inspector: Need a way to gate partially implemented frame target domains and agents
<a href="https://bugs.webkit.org/show_bug.cgi?id=313079">https://bugs.webkit.org/show_bug.cgi?id=313079</a>

Given we&apos;re incrementally implementing frame-target versions of
inspector domains, during this incremental development, partially
implemented frame target domains risk interfering with existing domains
in the page target that are fully functional. Specifically, for the main
web process, both the page and frames&apos; agents see the same data in the
same process, leading to duplicated events being handled and potential
conflicts in the frontend state.

- For example, once we implement element discovery for a
  newly-introduced FrameDOMAgent, under site isolation, the main
  frame target will start reporting the same elements to the frontend
  that were already reported by the page target. However, we can&apos;t
  easily just avoid using the page target for DOM altogether because
  FrameDOMAgent at that time may have limited support, so that would
  behave like a regression as functionalities appear to be removed
  for elements originally covered by the page target.

Solve this development timing problem with an engineering setting,
&quot;Enable experimental frame-target domains,&quot; to gate whether the frontend
makes use of any partially implemented domains on frame targets.
With the setting off (by default), frame targets are treated
as if the gated domains were entirely missing, and we use the page
target like with SI off. With the setting on, the frontend uses
frame-target agents instead of page-target agents for gated domains,
allowing engineers to test in-progress implementations under SI.

- In the case of the FrameDOMAgent example, we may use this new setting
  to gate its partial implementation. Sample usage in DOMManager:
        initializeTarget(target)
        {
            if (!target.hasDomain(&quot;DOM&quot;))
                return;

  +         // Normally off for site isolation engineers and customers,
  +         // on for Web Inspector frame-target engineers
  +         let useFrameTarget = WI.settings.engineeringEnableFrameTargetDomains.value;

            if (target.type === WI.TargetType.Frame) {
  +             if (!useFrameTarget)
  +                 return;

                // Perform frame-specific initialization work
                // ...
                return;
            }

  +         if (useFrameTarget)
  +             return;

            // Perform page-specific initialization work
            this.ensureDocument();
        }

Since the setting requires a reload of the inspector to take full
effect, extract the reload button from the Experimental settings tab
into a shared SettingsView.addReloadRequiredFooter helper and use it
in both tabs.

No new tests. Observable behavior has not changed, and upcoming patches
implementing new frame target features will use this setting in
new tests, by setting WI.isEngineeringBuild before using the setting:
    WI.isEngineeringBuild = true;
    WI.settings.engineeringEnableFrameTargetDomains.value = true;

- Note that in the test harness, the page target is already initialized
  by the time test code runs, so the setting only takes effect for frame
  targets created later during the test. This means tests can verify
  that frame-target domain features work, but cannot fully exercise the
  mode switch where page-target domains are suppressed. That behavior
  is only testable manually via the Engineering settings UI + reload.

* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createExperimentalSettingsView):
(WI.SettingsTabContentView.prototype._createEngineeringSettingsView):
* Source/WebInspectorUI/UserInterface/Views/SettingsView.js:
(WI.SettingsView.prototype.addReloadRequiredFooter):
   - Introduce the engineering setting to gate partial frame target
     agent implementations.
   - Add addReloadRequiredFooter helper to share the reload inspector
     button in two tabs.

* Source/WebInspectorUI/UserInterface/Base/Main.js:
(WI.isSiteIsolationEnabled):
   Make this helper from Test.js available for use in production code.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76d6bbc3a177754455fecd577a0474c4c52f24b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112617 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8aed116c-928e-455f-aef0-940766f3ce4a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122793 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86167 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8fc0ecc4-2be6-4d89-ac13-73acba093bf3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103463 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7689487-1838-4179-99c6-28d5c3058b62) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24110 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22502 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15133 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169852 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15597 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130980 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131094 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141985 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89496 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25791 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18791 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31105 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97119 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30625 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30779 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->