### PR TITLE
[Site Isolation] Replace parentFrameSecurityOrigin with precomputed bool in NavigationRequester

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5141,9 +5141,7 @@ bool Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking(const Navig
     // Also require the parent that set the sandbox to be same-origin with the target.
     bool sandboxIsFromElementAttribute = !requester.sandboxFlags.isEmpty() && requester.frameSandboxFlags == requester.sandboxFlags;
     if (sandboxIsFromElementAttribute) {
-        RefPtr targetOrigin = targetFrame.frameDocumentSecurityOrigin();
-        bool parentIsFirstParty = requester.parentFrameSecurityOrigin && targetOrigin && requester.parentFrameSecurityOrigin->isSameOriginDomain(*targetOrigin);
-        if (parentIsFirstParty)
+        if (requester.parentOriginIsSameAsTopOrigin)
             return false;
     }
 

--- a/Source/WebCore/loader/NavigationRequester.cpp
+++ b/Source/WebCore/loader/NavigationRequester.cpp
@@ -51,7 +51,10 @@ NavigationRequester NavigationRequester::from(Document& document)
         document.hasLoadedThirdPartyScript(),
         document.hasLoadedThirdPartyFrame(),
         frame ? frame->hasHadUserInteraction() : false,
-        parentFrame ? parentFrame->frameDocumentSecurityOrigin() : nullptr
+        [&] {
+            RefPtr parentOrigin = parentFrame ? parentFrame->frameDocumentSecurityOrigin() : nullptr;
+            return parentOrigin && parentOrigin->isSameOriginDomain(protect(document.topOrigin()));
+        }()
     };
 }
 

--- a/Source/WebCore/loader/NavigationRequester.h
+++ b/Source/WebCore/loader/NavigationRequester.h
@@ -51,7 +51,7 @@ struct NavigationRequester {
     bool hasLoadedThirdPartyScript { false };
     bool hasLoadedThirdPartyFrame { false };
     bool hasHadUserInteraction { false };
-    RefPtr<SecurityOrigin> parentFrameSecurityOrigin;
+    bool parentOriginIsSameAsTopOrigin { false };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4802,7 +4802,7 @@ struct WebCore::NavigationRequester {
     bool hasLoadedThirdPartyScript;
     bool hasLoadedThirdPartyFrame;
     bool hasHadUserInteraction;
-    RefPtr<WebCore::SecurityOrigin> parentFrameSecurityOrigin;
+    bool parentOriginIsSameAsTopOrigin;
 };
 
 struct WebCore::PolicyContainer {


### PR DESCRIPTION
#### fac0cb3cde15ef7c60bedd67d5a2be0f6028eebd
<pre>
[Site Isolation] Replace parentFrameSecurityOrigin with precomputed bool in NavigationRequester
<a href="https://bugs.webkit.org/show_bug.cgi?id=313181">https://bugs.webkit.org/show_bug.cgi?id=313181</a>
<a href="https://rdar.apple.com/175463992">rdar://175463992</a>

Reviewed by Sihui Liu.

Follows up on <a href="https://commits.webkit.org/311805@main">https://commits.webkit.org/311805@main</a> by replacing the RefPtr&lt;SecurityOrigin&gt;
parentFrameSecurityOrigin field with a bool parentOriginIsSameAsTopOrigin.

The origin was only used in
isNavigationBlockedByThirdPartyIFrameRedirectBlocking to check
isSameOriginDomain against the top frame&apos;s origin. Since
NavigationRequester already carries topOrigin, precompute the
comparison at capture time in NavigationRequester::from() instead
of carrying a RefPtr&lt;SecurityOrigin&gt;.

No new tests, since this is an optimization.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking):
* Source/WebCore/loader/NavigationRequester.cpp:
(WebCore::NavigationRequester::from):
* Source/WebCore/loader/NavigationRequester.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/312002@main">https://commits.webkit.org/312002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f27cd6642b561f8df438032357b5f3f8d193dfac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112658 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1d81627-3d9e-43a0-a79d-c7258e5b5e1c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122828 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86191 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/484ac1c2-c0fe-4531-89cb-f3991b08ae04) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103497 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/558f2eb7-b0d8-468c-a594-00912137830c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24144 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22540 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15174 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169893 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15638 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131014 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131128 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35504 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31635 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142021 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89541 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25825 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18829 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97160 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30666 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30939 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30820 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->