### PR TITLE
media/media-source/media-managedmse-resume-after-stall.html is an intermittent failure

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -476,7 +476,10 @@ void SourceBufferPrivate::reenqueueMediaIfNeeded(const MediaTime& currentTime)
 
             if (trackBuffer.needsReenqueueing()) {
                 DEBUG_LOG_WITH_THIS(&buffer, LOGIDENTIFIER_WITH_THIS(&buffer), "reenqueuing at time ", currentTime);
-                buffer.reenqueueMediaForTime(trackBuffer, trackID, currentTime);
+                // Flush has already been issued by flushTracksThatNeedReenqueueing()
+                // at the end of the operation that set needsReenqueueing (append /
+                // removeCodedFramesInternal). Skip the redundant flush here.
+                buffer.reenqueueMediaForTime(trackBuffer, trackID, currentTime, NeedsFlush::No);
             } else
                 buffer.provideMediaData(trackBuffer, trackID);
         }
@@ -546,6 +549,7 @@ void SourceBufferPrivate::removeCodedFramesInternal(const MediaTime& start, cons
     }
     ASSERT(contentSize() == totalTrackBufferSizeInBytes());
 
+    flushTracksThatNeedReenqueueing();
     reenqueueMediaIfNeeded(currentTime);
 
     // 4. If buffer full flag equals true and this object is ready to accept more bytes, then set the buffer full flag to false.
@@ -1000,6 +1004,12 @@ Ref<MediaPromise> SourceBufferPrivate::append(Ref<SharedBuffer>&& buffer)
         if (!protectedThis || !result)
             return OperationPromise::createAndReject(!result ? result.error() : PlatformMediaError::BufferRemoved);
         assertIsCurrent(protectedThis->m_dispatcher.get());
+
+        // Flush any tracks marked needsReenqueueing during this append (overlap detection
+        // in didReceiveSample) before the main thread reacts to bufferedChanged. The flush
+        // IPC must reach the renderer queue ahead of any subsequent play()/setRate() IPC
+        // dispatched in response to the readyState change.
+        protectedThis->flushTracksThatNeedReenqueueing();
 
         protectedThis->computeEvictionData();
 
@@ -1640,6 +1650,21 @@ void SourceBufferPrivate::iterateTrackBuffers(NOESCAPE const Function<void(const
     assertIsCurrent(m_dispatcher.get());
     for (auto& pair : m_trackBufferMap)
         func(pair.second);
+}
+
+// Issue flushTrack IPCs now (still on m_dispatcher) for any track whose
+// renderer holds samples about to be re-enqueued. Done at the end of an
+// append (or removal) operation so the flush IPC reaches the renderer
+// queue before any play()/setRate() that the main thread may dispatch
+// in response to the resulting bufferedChanged/readyState notifications.
+void SourceBufferPrivate::flushTracksThatNeedReenqueueing()
+{
+    assertIsCurrent(m_dispatcher.get());
+    for (auto& trackBufferPair : m_trackBufferMap) {
+        TrackBuffer& trackBuffer = trackBufferPair.second;
+        if (trackBuffer.needsReenqueueing())
+            flush(trackBufferPair.first);
+    }
 }
 
 RefPtr<SourceBufferPrivateClient> SourceBufferPrivate::client() const

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -242,6 +242,8 @@ private:
     void iterateTrackBuffers(NOESCAPE const Function<void(const TrackBuffer&)>&) const;
     bool isReenqueuePending() const;
 
+    void flushTracksThatNeedReenqueueing();
+
     using OperationPromise = NativePromise<void, PlatformMediaError, WTF::PromiseOption::Default | WTF::PromiseOption::NonExclusive>;
 
     void ensureWeakOnDispatcher(Function<void(SourceBufferPrivate&)>&&);

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -213,6 +213,12 @@ private:
 #endif
 
     void setSynchronizerRate(float, std::optional<MonotonicTime>);
+    // Returns the rate we last passed to [m_synchronizer setRate:]. Cached
+    // because [m_synchronizer rate] is heavy (dispatch_sync), and querying
+    // it can interact poorly with AVF's internal serialization of rate
+    // changes. The cached value reflects the rate we set, not the actual
+    // timebase rate.
+    float synchronizerRate() const { return m_lastSetSyncRate; }
     bool updateLastPixelBuffer();
     void maybePurgeLastPixelBuffer();
     void setNeedsPlaceholderImage(bool);
@@ -282,6 +288,10 @@ private:
 
     bool m_isPlaying { false };
     double m_rate { 1 };
+    // Cached value of the rate last passed to [m_synchronizer setRate:].
+    // Avoid querying [m_synchronizer rate] (heavy dispatch_sync) — read this
+    // via synchronizerRate() instead.
+    float m_lastSetSyncRate { 0 };
     RetainPtr<CVPixelBufferRef> m_lastPixelBuffer;
     bool m_needsPlaceholderImage { false };
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -459,7 +459,7 @@ bool AudioVideoRendererAVFObjC::paused() const
 
 bool AudioVideoRendererAVFObjC::timeIsProgressing() const
 {
-    return m_isPlaying && [m_synchronizer rate];
+    return m_isPlaying && synchronizerRate();
 }
 
 MediaTime AudioVideoRendererAVFObjC::currentTime() const
@@ -487,8 +487,10 @@ void AudioVideoRendererAVFObjC::setRate(double rate)
         setAudioTimePitchAlgorithm(renderer, algorithm.get());
     });
 
-    if (shouldBePlaying())
+    if (shouldBePlaying()) {
         [m_synchronizer setRate:m_rate];
+        m_lastSetSyncRate = m_rate;
+    }
 }
 
 double AudioVideoRendererAVFObjC::effectiveRate() const
@@ -522,6 +524,7 @@ void AudioVideoRendererAVFObjC::notifyTimeReachedAndStall(const MediaTime& timeB
 
         // Experimentation shows that between the time the boundary time observer is called, the time have progressed by a few milliseconds. Re-adjust time. This seek doesn't require re-enqueuing/flushing.
         [protectedThis->m_synchronizer setRate:0 time:PAL::toCMTime(timeBoundary)];
+        protectedThis->m_lastSetSyncRate = 0;
 
         callback(now);
     }).get()];
@@ -620,6 +623,7 @@ Ref<MediaTimePromise> AudioVideoRendererAVFObjC::prepareToSeek(const MediaTime& 
     m_lastSeekTime = seekTime;
     m_isSynchronizerSeeking = isSynchronizerSeeking;
     [m_synchronizer setRate:0 time:PAL::toCMTime(seekTime)];
+    m_lastSetSyncRate = 0;
     return MediaTimePromise::createAndResolve(MediaTime::indefiniteTime());
 }
 
@@ -1079,9 +1083,10 @@ void AudioVideoRendererAVFObjC::updateAllRenderersHaveAvailableSamples()
 
     if (allRenderersHaveAvailableSamples)
         maybeCompleteSeek();
-    if (shouldBePlaying() && [m_synchronizer rate] != m_rate)
+    if (shouldBePlaying() && synchronizerRate() != m_rate) {
         [m_synchronizer setRate:m_rate];
-    else if (!shouldBePlaying() && [m_synchronizer rate])
+        m_lastSetSyncRate = m_rate;
+    } else if (!shouldBePlaying() && synchronizerRate())
         stall();
 }
 
@@ -1782,6 +1787,7 @@ void AudioVideoRendererAVFObjC::setSynchronizerRate(float rate, std::optional<Mo
         [m_synchronizer setRate:rate time:PAL::kCMTimeInvalid atHostTime:cmHostTime];
     } else
         [m_synchronizer setRate:rate];
+    m_lastSetSyncRate = rate;
 
     // If we are pausing the synchronizer, update the last image to ensure we have something
     // to display if and when the decoders are purged while in the background. And vice-versa,

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -333,6 +333,8 @@ private:
 
     static Ref<AudioVideoRenderer> createRenderer(LoggerHelper&, HTMLMediaElementIdentifier, MediaPlayerIdentifier);
 
+    void dispatchToRendererQueue(Function<void(AudioVideoRenderer&)>&&);
+
     const ThreadSafeWeakPtr<MediaPlayer> m_player;
     RefPtr<MediaSourcePrivateAVFObjC> m_mediaSourcePrivate; // set on load, immutable after.
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -128,7 +128,9 @@ MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC()
 
     cancelPendingSeek();
     m_seekTimer.stop();
-    m_renderer->pause();
+    dispatchToRendererQueue([](auto& renderer) {
+        renderer.pause();
+    });
 }
 
 #pragma mark -
@@ -351,7 +353,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::playInternal(std::optional<MonotonicT
     ALWAYS_LOG(LOGIDENTIFIER);
     flushVideoIfNeeded();
 
-    m_renderer->play(hostTime);
+    dispatchToRendererQueue([hostTime](auto& renderer) {
+        renderer.play(hostTime);
+    });
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::pause()
@@ -363,7 +367,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::pause()
 void MediaPlayerPrivateMediaSourceAVFObjC::pauseInternal(std::optional<MonotonicTime>&& hostTime)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_renderer->pause(hostTime);
+    dispatchToRendererQueue([hostTime](auto& renderer) {
+        renderer.pause(hostTime);
+    });
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::paused() const
@@ -488,7 +494,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::timeChanged()
 void MediaPlayerPrivateMediaSourceAVFObjC::stall()
 {
     assertIsMainThread();
-    m_renderer->stall();
+    dispatchToRendererQueue([](auto& renderer) {
+        renderer.stall();
+    });
     if (shouldBePlaying())
         timeChanged();
 }
@@ -546,7 +554,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::seekInternal()
 
     cancelPendingSeek();
 
-    m_renderer->stall();
+    dispatchToRendererQueue([](auto& renderer) {
+        renderer.stall();
+    });
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
@@ -572,7 +582,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::continueSeek(const MediaTime& seekTim
     ALWAYS_LOG(LOGIDENTIFIER, seekTime);
 
     m_lastSeekTime = seekTime;
-    m_renderer->prepareToSeek(seekTime)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, seekTime] (auto&& result) {
+    invokeAsync(MediaSourcePrivateAVFObjC::queueSingleton(), [renderer = m_renderer, seekTime] -> Ref<MediaTimePromise> {
+        return renderer->prepareToSeek(seekTime);
+    })->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, seekTime] (auto&& result) {
         assertIsMainThread();
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
@@ -600,7 +612,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::reenqueueMediaForTimeAndFinishSeek(co
 
     GenericPromise::all({
         protect(m_mediaSourcePrivate)->reenqueueMediaForTime(seekTime),
-        m_renderer->finishSeek(seekTime)
+        invokeAsync(MediaSourcePrivateAVFObjC::queueSingleton(), [renderer = m_renderer, seekTime] -> Ref<GenericPromise> {
+            return renderer->finishSeek(seekTime);
+        })
     })->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, seekTime](auto&& result) {
         assertIsMainThread();
         RefPtr protectedThis = weakThis.get();
@@ -661,7 +675,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setRateDouble(double rate)
     assertIsMainThread();
     // AVSampleBufferRenderSynchronizer does not support negative rate yet.
     m_rate = std::max<double>(rate, 0);
-    m_renderer->setRate(m_rate);
+    dispatchToRendererQueue([rate = m_rate](auto& renderer) {
+        renderer.setRate(rate);
+    });
 }
 
 double MediaPlayerPrivateMediaSourceAVFObjC::rate() const
@@ -755,7 +771,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged()
                 return;
             if (protect(protectedThis->m_mediaSourcePrivate)->hasFutureTime(stallTime) && protectedThis->shouldBePlaying()) {
                 ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "Data now available at ", stallTime, " resuming");
-                protectedThis->m_renderer->play(); // New data was added, resume. Can't happen in practice, action would have been cancelled once buffered changed.
+                protectedThis->dispatchToRendererQueue([](auto& renderer) {
+                    renderer.play(); // New data was added, resume. Can't happen in practice, action would have been cancelled once buffered changed.
+                });
                 return;
             }
             MediaTime now = protectedThis->currentTime();
@@ -901,6 +919,18 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setPresentationSize(const IntSize& ne
 Ref<AudioVideoRenderer> MediaPlayerPrivateMediaSourceAVFObjC::audioVideoRenderer() const
 {
     return m_renderer;
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::dispatchToRendererQueue(Function<void(AudioVideoRenderer&)>&& task)
+{
+    Ref queue = MediaSourcePrivateAVFObjC::queueSingleton();
+    if (queue->isCurrent()) {
+        task(m_renderer);
+        return;
+    }
+    queue->dispatch([renderer = m_renderer, task = WTF::move(task)] {
+        task(renderer);
+    });
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged()
@@ -1123,7 +1153,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateStateFromReadyState()
 {
     assertIsMainThread();
     if (shouldBePlaying()) {
-        m_renderer->play();
+        dispatchToRendererQueue([](auto& renderer) {
+            renderer.play();
+        });
         timeChanged();
     } else
         stall();


### PR DESCRIPTION
#### 09ea5e2ced877aeeea2d6e369e1aa953f33bcc8f
<pre>
media/media-source/media-managedmse-resume-after-stall.html is an intermittent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=313098">https://bugs.webkit.org/show_bug.cgi?id=313098</a>
<a href="https://rdar.apple.com/175395328">rdar://175395328</a>

Reviewed by Jer Noble.

The test intermittently failed when the AVSampleBufferRenderSynchronizer
and its associated AVSampleBufferAudioRenderer entered a state in which
the timebase will no longer progress despite being later flushed correctly
and samples being enqueued appropriately.

While the reason for this broken state to occur is yet unexplained,
several pre-condition symptoms were identified that trigger the ultimate
failure.

1- After setting the rate to the AVSampleBufferRenderSynchronizer, reading
the rate attribute may still return the old, stale value. This could cause
the AudioVideoRenderer to incorrectly assume time was progressing when it wasn&apos;t.
2- The AudioVideoRendererAVFObjC was receiving commands in an unexpected order:
instead of doing play() -&gt; stall() -&gt; flush() -&gt; enqueueSamples() -&gt; play()
we would see instead: play() -&gt; stall() -&gt; play() -&gt; flush() -&gt; enqueueSamples()

To address 1, we stop reading the AVSampleBufferRenderSynchronizer&apos;s rate attribute
and instead cache the rate last set. It achieves two things: it avoids the
internal sync dispatch the AVSampleBufferRenderSynchronizer makes to its
rate queue, and ensure the value read is always correct.

Condition 2 was due to several races between the MediaPlayerPrivateMediaSourceAVFObjC
and SourceBufferPrivateAVFObjC.
The MediaPlayerPrivateMediaSourceAVFObjC sends commands to the AudioVideoRenderer
on the main thread, while the SourceBuffer interacts with the renderer&apos;s track
on its dedicated queue. The could lead commands reaching the renderer out of
assumed order.

To pre-emptively avoice such race in the MediaPlayer, we now ensure that
any commands in the media player related to the renderer&apos;s data flow (seek, flush, setRate, play, pause, stall)
only occurs on the MediaSourcePrivate/SourceBufferPrivate&apos;s queue.

The primary race and cause for the test to fail was
  1- monitorSourceBuffers() ran first → synchronously fires the readyState change → updateStateFromReadyState → play() at time T1
  2- reenqueueMediaIfNeeded() dispatches the reenqueue lambda (which will call flush) at time T2

The call to play() which should occur after the flush() could run before.

When a buffered GOP containing the currentTime was being overwritten,
we would mark the track with setNeedsReenqueueing(true) and then notify
the MediaSource that the buffered changed, which triggered a called to
monitorSourceBuffers and in turn call play() as data was now available.
At the same time, we had
```
  // SourceBufferPrivate::reenqueueMediaIfNeeded body
  if (trackBuffer.needsReenqueueing()) {
      DEBUG_LOG_WITH_THIS(...);
      buffer.reenqueueMediaForTime(trackBuffer, trackID, currentTime);
  }
```

Resulting IPC order in the GPU process to become:
1. flushTrack (issued from didReceiveSample on m_dispatcher, before appendInternal even returns)
2. …appendBuffer finishes; main thread reacts → updateStateFromReadyState dispatches play() to the queue…
3. play() (issued from the queue after m_dispatcher finishes the rest of its work)

we now enforce the serialization of the tasks by flushing the tracks early before notifying the
MediaSource that the buffered had changed.

Covered by existing tests.

* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::reenqueueMediaIfNeeded):
(WebCore::SourceBufferPrivate::removeCodedFramesInternal):
(WebCore::SourceBufferPrivate::append):
(WebCore::SourceBufferPrivate::flushTracksThatNeedReenqueueing):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
(WebCore::AudioVideoRendererAVFObjC::synchronizerRate const):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::timeIsProgressing const):
(WebCore::AudioVideoRendererAVFObjC::setRate):
(WebCore::AudioVideoRendererAVFObjC::notifyTimeReachedAndStall):
(WebCore::AudioVideoRendererAVFObjC::prepareToSeek):
(WebCore::AudioVideoRendererAVFObjC::updateAllRenderersHaveAvailableSamples):
(WebCore::AudioVideoRendererAVFObjC::setSynchronizerRate):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::playInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::pauseInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::stall):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::continueSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::reenqueueMediaForTimeAndFinishSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setRateDouble):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::dispatchToRendererQueue):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateStateFromReadyState):

Canonical link: <a href="https://commits.webkit.org/311992@main">https://commits.webkit.org/311992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f55fb79dabb0bf18a8709daf34826c88bf256c25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112485 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122684 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86108 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103354 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23991 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22378 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15003 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133679 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169722 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15369 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130870 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130984 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35498 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141860 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89339 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25672 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18666 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30975 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96785 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30495 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30768 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30649 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->