### PR TITLE
git-webkit create-bug --see-also causes cc_radar() to prompt about overwriting the wrong bug

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -745,7 +745,11 @@ class Tracker(GenericTracker):
                 comment_to_make = '<rdar://problem/{}>'.format(radar.id)
             keyword_to_add = 'InRadar'
             if not user_to_cc and comment_to_make:
-                tracked_bug = issue.references[0] if issue.references else None
+                tracked_bug = None
+                for ref in (issue.references or []):
+                    if isinstance(ref.tracker, RadarTracker):
+                        tracked_bug = ref
+                        break
                 if tracked_bug:
                     sys.stderr.write("{} already CCed '{}' and tracking a different bug\n".format(
                         self.radar_importer.name,

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -265,7 +265,7 @@ class Bugzilla(Base, mocks.Requests):
                 id=id,
                 see_also=[
                     'https://{}/show_bug.cgi?id={}'.format(self.hosts[0], n) for n in issue.get('references', [])
-                ],
+                ] + issue.get('related_links', []),
             )],
         ), url=url)
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -719,7 +719,7 @@ What component in 'WebKit' should the bug be associated with?:
                 self.assertIn('already CCed but no Radar was imported', captured.stderr.getvalue())
 
     def test_cc_radar_importer_already_cced_different_tracked_bug(self):
-        """When the importer is already CC'd and a different bug is already
+        """When the importer is already CC'd and a different radar is already
         tracked, cc_radar should prompt to overwrite and proceed when user says Yes."""
         issues_with_tracked = [
             dict(
@@ -728,7 +728,7 @@ What component in 'WebKit' should the bug be associated with?:
                 opened=True,
                 creator=mocks.USERS['Tim Contributor'],
                 assignee=mocks.USERS['Tim Contributor'],
-                description='A test issue',
+                description='A test issue\n<rdar://problem/2>',
                 project='WebKit',
                 component='Text',
                 version='Other',
@@ -738,21 +738,6 @@ What component in 'WebKit' should the bug be associated with?:
                     mocks.USERS['Tim Contributor'],
                     mocks.USERS['Radar WebKit Bug Importer'],
                 ],
-                references=[2],
-            ),
-            dict(
-                title='Referenced bug',
-                timestamp=1639536160,
-                opened=True,
-                creator=mocks.USERS['Tim Contributor'],
-                assignee=mocks.USERS['Tim Contributor'],
-                description='Referenced',
-                project='WebKit',
-                component='Text',
-                version='Other',
-                keywords=[],
-                comments=[],
-                watchers=[mocks.USERS['Tim Contributor']],
             ),
         ]
         with wkmocks.Terminal.input('Yes'), OutputCapture(level=logging.INFO) as captured, mocks.Bugzilla(
@@ -772,6 +757,195 @@ What component in 'WebKit' should the bug be associated with?:
                 self.assertIsNotNone(result)
                 self.assertEqual(issue.comments[-1].content, '<rdar://problem/1>')
                 # Should have prompted about overwriting
+                self.assertIn('tracking a different bug', captured.stderr.getvalue())
+
+    def test_cc_radar_see_also_not_confused_as_tracked_radar(self):
+        """When the importer is already CC'd and see-also links reference other
+        bugzilla bugs, cc_radar should not treat those as tracked radars.
+        Regression test: see-also bugzilla references in issue.references[0]
+        caused cc_radar to prompt 'tracking a different bug' for a non-radar."""
+        issues_with_see_also = [
+            dict(
+                title='Security bug with see-also',
+                timestamp=1639536160,
+                opened=True,
+                creator=mocks.USERS['Tim Contributor'],
+                assignee=mocks.USERS['Tim Contributor'],
+                description='A security issue',
+                project='WebKit',
+                component='Text',
+                version='Other',
+                keywords=['InRadar'],
+                comments=[],
+                watchers=[
+                    mocks.USERS['Tim Contributor'],
+                    mocks.USERS['Radar WebKit Bug Importer'],
+                ],
+                references=[2],
+            ),
+            dict(
+                title='Related bug via see-also',
+                timestamp=1639536160,
+                opened=True,
+                creator=mocks.USERS['Tim Contributor'],
+                assignee=mocks.USERS['Tim Contributor'],
+                description='Another bug',
+                project='WebKit',
+                component='Text',
+                version='Other',
+                keywords=[],
+                comments=[],
+                watchers=[mocks.USERS['Tim Contributor']],
+            ),
+        ]
+        with OutputCapture(level=logging.INFO) as captured, mocks.Bugzilla(
+            self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ), users=mocks.USERS, issues=issues_with_see_also, projects=mocks.PROJECTS,
+        ), mocks.Radar(
+            users=mocks.USERS, issues=mocks.ISSUES, projects=mocks.PROJECTS,
+        ), wkmocks.Time:
+            radar_tracker = radar.Tracker()
+            bugzilla_tracker = bugzilla.Tracker(self.URL, radar_importer=mocks.USERS['Radar WebKit Bug Importer'])
+
+            with patch('webkitbugspy.Tracker._trackers', [radar_tracker, bugzilla_tracker]):
+                issue = bugzilla_tracker.issue(1)
+                self.assertIn(mocks.USERS['Radar WebKit Bug Importer'], issue.watchers)
+                self.assertTrue(len(issue.references) > 0)
+                result = issue.cc_radar(block=True, radar=Tracker.from_string('<rdar://1>'))
+                self.assertIsNotNone(result)
+                self.assertEqual(issue.comments[-1].content, '<rdar://problem/1>')
+                self.assertNotIn('tracking a different bug', captured.stderr.getvalue())
+
+    def test_cc_radar_multiple_see_also_no_radar_references(self):
+        """When the importer is already CC'd and multiple see-also links reference
+        other bugzilla bugs (no radars), cc_radar should not prompt about tracking
+        a different bug."""
+        issues_with_multiple_see_also = [
+            dict(
+                title='Bug with multiple see-also',
+                timestamp=1639536160,
+                opened=True,
+                creator=mocks.USERS['Tim Contributor'],
+                assignee=mocks.USERS['Tim Contributor'],
+                description='A test issue',
+                project='WebKit',
+                component='Text',
+                version='Other',
+                keywords=['InRadar'],
+                comments=[],
+                watchers=[
+                    mocks.USERS['Tim Contributor'],
+                    mocks.USERS['Radar WebKit Bug Importer'],
+                ],
+                references=[2, 3],
+            ),
+            dict(
+                title='Related bug one',
+                timestamp=1639536160,
+                opened=True,
+                creator=mocks.USERS['Tim Contributor'],
+                assignee=mocks.USERS['Tim Contributor'],
+                description='First related bug',
+                project='WebKit',
+                component='Text',
+                version='Other',
+                keywords=[],
+                comments=[],
+                watchers=[mocks.USERS['Tim Contributor']],
+            ),
+            dict(
+                title='Related bug two',
+                timestamp=1639536160,
+                opened=True,
+                creator=mocks.USERS['Tim Contributor'],
+                assignee=mocks.USERS['Tim Contributor'],
+                description='Second related bug',
+                project='WebKit',
+                component='Text',
+                version='Other',
+                keywords=[],
+                comments=[],
+                watchers=[mocks.USERS['Tim Contributor']],
+            ),
+        ]
+        with OutputCapture(level=logging.INFO) as captured, mocks.Bugzilla(
+            self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ), users=mocks.USERS, issues=issues_with_multiple_see_also, projects=mocks.PROJECTS,
+        ), mocks.Radar(
+            users=mocks.USERS, issues=mocks.ISSUES, projects=mocks.PROJECTS,
+        ), wkmocks.Time:
+            radar_tracker = radar.Tracker()
+            bugzilla_tracker = bugzilla.Tracker(self.URL, radar_importer=mocks.USERS['Radar WebKit Bug Importer'])
+
+            with patch('webkitbugspy.Tracker._trackers', [radar_tracker, bugzilla_tracker]):
+                issue = bugzilla_tracker.issue(1)
+                self.assertIn(mocks.USERS['Radar WebKit Bug Importer'], issue.watchers)
+                self.assertTrue(len(issue.references) >= 2)
+                result = issue.cc_radar(block=True, radar=Tracker.from_string('<rdar://1>'))
+                self.assertIsNotNone(result)
+                self.assertEqual(issue.comments[-1].content, '<rdar://problem/1>')
+                self.assertNotIn('tracking a different bug', captured.stderr.getvalue())
+
+    def test_cc_radar_multiple_references_with_one_radar(self):
+        """When the importer is already CC'd and references include both bugzilla
+        see-also links and a tracked radar, cc_radar should prompt about the
+        tracked radar and ignore the bugzilla references."""
+        issues_with_mixed_refs = [
+            dict(
+                title='Bug with see-also and radar',
+                timestamp=1639536160,
+                opened=True,
+                creator=mocks.USERS['Tim Contributor'],
+                assignee=mocks.USERS['Tim Contributor'],
+                description='A test issue\n<rdar://problem/2>',
+                project='WebKit',
+                component='Text',
+                version='Other',
+                keywords=[],
+                comments=[],
+                watchers=[
+                    mocks.USERS['Tim Contributor'],
+                    mocks.USERS['Radar WebKit Bug Importer'],
+                ],
+                references=[2],
+            ),
+            dict(
+                title='Related bug via see-also',
+                timestamp=1639536160,
+                opened=True,
+                creator=mocks.USERS['Tim Contributor'],
+                assignee=mocks.USERS['Tim Contributor'],
+                description='Another bug',
+                project='WebKit',
+                component='Text',
+                version='Other',
+                keywords=[],
+                comments=[],
+                watchers=[mocks.USERS['Tim Contributor']],
+            ),
+        ]
+        with wkmocks.Terminal.input('Yes'), OutputCapture(level=logging.INFO) as captured, mocks.Bugzilla(
+            self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ), users=mocks.USERS, issues=issues_with_mixed_refs, projects=mocks.PROJECTS,
+        ), mocks.Radar(
+            users=mocks.USERS, issues=mocks.ISSUES, projects=mocks.PROJECTS,
+        ), wkmocks.Time:
+            radar_tracker = radar.Tracker()
+            bugzilla_tracker = bugzilla.Tracker(self.URL, radar_importer=mocks.USERS['Radar WebKit Bug Importer'])
+
+            with patch('webkitbugspy.Tracker._trackers', [radar_tracker, bugzilla_tracker]):
+                issue = bugzilla_tracker.issue(1)
+                self.assertIn(mocks.USERS['Radar WebKit Bug Importer'], issue.watchers)
+                self.assertTrue(len(issue.references) >= 2)
+                result = issue.cc_radar(block=True, radar=Tracker.from_string('<rdar://1>'))
+                self.assertIsNotNone(result)
+                self.assertEqual(issue.comments[-1].content, '<rdar://problem/1>')
                 self.assertIn('tracking a different bug', captured.stderr.getvalue())
 
     def test_milestone(self):


### PR DESCRIPTION
#### 00845d94ab4d5f41477ae5056b5a20d4f1f0906e
<pre>
git-webkit create-bug --see-also causes cc_radar() to prompt about overwriting the wrong bug
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313182">https://bugs.webkit.org/show_bug.cgi?id=313182</a>&gt;
&lt;<a href="https://rdar.apple.com/175465077">rdar://175465077</a>&gt;

Reviewed by Pascoe and Jonathan Bedard.

When create-bug adds --see-also URLs pointing to other bugzilla bugs,
those links appear in issue.references alongside any radar references.
cc_radar() blindly used references[0] to check for an already-tracked
radar, so a see-also bugzilla link in that position caused the
&quot;tracking a different bug&quot; prompt -- targeting the wrong bug entirely.

Filter issue.references to only consider RadarTracker instances when
checking for an already-tracked radar. This matches the pattern used
by every other consumer of issue.references (clone.py, branch.py,
and the polling loop in cc_radar itself).

Also fix the existing test_cc_radar_importer_already_cced_different_-
tracked_bug test, which was asserting the buggy behavior: it used a
bugzilla see-also reference (references=[2]) but expected the
&quot;tracking a different bug&quot; prompt. Replace with a radar reference
via the issue description (&lt;<a href="https://rdar.apple.com/problem/2">rdar://problem/2</a>&gt;) to properly test the
legitimate &quot;different tracked radar&quot; scenario.

Fix the _see_also() mock endpoint to include related_links (see-also
URLs added via tracker.set()), matching the full bug response that
already includes them. Without this, see-also links added after bug
creation were invisible when populate() re-fetched references.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.cc_radar):

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla._see_also):

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(BugzillaTrackerTest.test_cc_radar_importer_already_cced_different_tracked_bug):
(BugzillaTrackerTest.test_cc_radar_see_also_not_confused_as_tracked_radar):
(BugzillaTrackerTest.test_cc_radar_multiple_see_also_no_radar_references): Add.
(BugzillaTrackerTest.test_cc_radar_multiple_references_with_one_radar): Add.

Canonical link: <a href="https://commits.webkit.org/312172@main">https://commits.webkit.org/312172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ccc5412d286193b83e91f050ff6bbe420847c97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167953 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123273 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103939 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/158444 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15726 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170447 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131467 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32241 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131579 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142509 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90235 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24220 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26277 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19318 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31696 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31216 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31489 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31371 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->