### PR TITLE
Tests that try to simulate `wheel` events on iOS hit an assertion

### DIFF
--- a/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
+++ b/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
@@ -252,7 +252,7 @@ void UIScriptControllerMac::sendEventStream(JSStringRef eventsJSON, JSValueRef c
 
         id eventType = event[EventTypeKey];
         if (!event[EventTypeKey]) {
-            WTFLogAlways("Missing event type");
+            WTFLogAlways("Failed to find `%@` key in %@", EventTypeKey, event);
             break;
         }
         

--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
@@ -282,8 +282,8 @@ static IOHIDDigitizerTransducerType transducerTypeFromString(NSString * transduc
 
     if ([transducerTypeString isEqualToString:HIDEventInputTypeStylus])
         return kIOHIDDigitizerTransducerTypeStylus;
-    
-    ASSERT_NOT_REACHED();
+
+    NSLog(@"Unsupported transducer type %@", transducerTypeString);
     return 0;
 }
 
@@ -360,8 +360,14 @@ static InterpolationType interpolationFromString(NSString *string)
     // touch is 1 if a finger is down.
     CFIndex touch = [self touchFromEventInfo:info];
 
+    NSString *inputType = info[HIDEventInputType];
+    if (!inputType) {
+        NSLog(@"Failed to find `%@` in event info %@", HIDEventInputType, info);
+        return nullptr;
+    }
+
     IOHIDEventRef eventRef = IOHIDEventCreateDigitizerEvent(kCFAllocatorDefault, machTime,
-        transducerTypeFromString(info[HIDEventInputType]),  // transducerType
+        transducerTypeFromString(inputType),                // transducerType
         0,                                                  // index
         0,                                                  // identifier
         eventMask,                                          // event mask
@@ -1130,6 +1136,9 @@ RetainPtr<IOHIDEventRef> createHIDKeyEvent(NSString *character, uint64_t timesta
     ASSERT([NSThread isMainThread]);
 
     auto eventRef = adoptCF([self _createIOHIDEventWithInfo:eventInfo]);
+    if (!eventRef)
+        return;
+
     [self _sendHIDEvent:eventRef.get()];
 }
 

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -419,7 +419,7 @@ void UIScriptControllerMac::sendEventStream(JSStringRef eventsJSON, JSValueRef c
 
         id eventType = event[EventTypeKey];
         if (!event[EventTypeKey]) {
-            WTFLogAlways("Missing event type");
+            WTFLogAlways("Failed to find `%@` key in %@", EventTypeKey, event);
             break;
         }
         


### PR DESCRIPTION
#### 02729f4c462998c9c639efe3d97763b03187547c
<pre>
Tests that try to simulate `wheel` events on iOS hit an assertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=313183">https://bugs.webkit.org/show_bug.cgi?id=313183</a>
<a href="https://rdar.apple.com/175465357">rdar://175465357</a>

Reviewed by Abrar Rahman Protyasha.

Some imported scroll-snap tests trigger simulated &apos;wheel&apos; events. On iOs, these
would hit an assertion in `transducerTypeFromString`. This is annoying; let&apos;s
just log instead of asserting.

On macOS we just logged, but we didn&apos;t log enough to diagnose, so fix that
so both platforms log similarly.

* Tools/DumpRenderTree/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::sendEventStream):
* Tools/WebKitTestRunner/ios/HIDEventGenerator.mm:
(transducerTypeFromString):
(-[HIDEventGenerator _createIOHIDEventWithInfo:]):
(-[HIDEventGenerator dispatchEventWithInfo:]):
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::sendEventStream):

Canonical link: <a href="https://commits.webkit.org/311949@main">https://commits.webkit.org/311949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d298ed8fb4770ac1de059241e53b8183651aed41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158407 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112490 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122685 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86111 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103355 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23990 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22383 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15008 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169727 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130871 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31523 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26447 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130985 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35473 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141864 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89344 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18670 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30980 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30500 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30773 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30654 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->