### PR TITLE
[CMake] Need to guard DEVELOPER_MODE_CXX_FLAGS from Swift targets

### DIFF
--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -192,7 +192,7 @@ macro(_WEBKIT_TARGET_SETUP _target _logical_name)
     target_include_directories(${_target} PRIVATE "$<BUILD_INTERFACE:${${_logical_name}_PRIVATE_INCLUDE_DIRECTORIES}>")
 
     if (DEVELOPER_MODE_CXX_FLAGS)
-        target_compile_options(${_target} PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
+        target_compile_options(${_target} PRIVATE $<$<NOT:$<COMPILE_LANGUAGE:Swift>>:${DEVELOPER_MODE_CXX_FLAGS}>)
     endif ()
 
     target_compile_definitions(${_target} PRIVATE "BUILDING_${_logical_name}")


### PR DESCRIPTION
#### dd04f20f21c1817f5fa428487138d18887f54054
<pre>
[CMake] Need to guard DEVELOPER_MODE_CXX_FLAGS from Swift targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=313191">https://bugs.webkit.org/show_bug.cgi?id=313191</a>

Reviewed by NOBODY (OOPS!).

DEVELOPER_MODE_CXX_FLAGS were originally applied to all languages via
via target_compile_options. When a target like PAL contains both C++
and Swift sources, CMake passes all flags to both compilers. Most
C flags are harmlessly ignored by Swift, but -Werror is particularly
problematic: Swift 6 parses it as -W with argument &quot;error&quot; (a warning
group name), then consumes the next flag as another -W argument.
This caused -output-file-map to be swallowed as a warning group name,
and its .json path to become an orphaned &quot;unexpected input file&quot;,
breaking the build.

Guard the flag to exclude Swift targets, consistent with how other C/C++
flags are already guarded in OptionsMac.cmake.

No new tests. This modifies our build tools only.

* Source/cmake/WebKitMacros.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd04f20f21c1817f5fa428487138d18887f54054

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158419 "Failed to checkout and rebase branch from PR 63489") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31845 "Failed to checkout and rebase branch from PR 63489") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24952 "Failed to checkout and rebase branch from PR 63489") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31913 "Failed to checkout and rebase branch from PR 63489") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31832 "Failed to checkout and rebase branch from PR 63489") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/167249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161377 "Failed to checkout and rebase branch from PR 63489") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/31913 "Failed to checkout and rebase branch from PR 63489") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/24952 "Failed to checkout and rebase branch from PR 63489") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/31913 "Failed to checkout and rebase branch from PR 63489") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/31832 "Failed to checkout and rebase branch from PR 63489") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/150469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/31913 "Failed to checkout and rebase branch from PR 63489") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/24952 "Failed to checkout and rebase branch from PR 63489") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169739 "Failed to checkout and rebase branch from PR 63489") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/19253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/24952 "Failed to checkout and rebase branch from PR 63489") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/169739 "Failed to checkout and rebase branch from PR 63489") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/31535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/31832 "Failed to checkout and rebase branch from PR 63489") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/169739 "Failed to checkout and rebase branch from PR 63489") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/31481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/24952 "Failed to checkout and rebase branch from PR 63489") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/31481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/24952 "Failed to checkout and rebase branch from PR 63489") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/190547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/30992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/190547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/30512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->