### PR TITLE
Reduce use of C-style arrays in the codebase

### DIFF
--- a/Source/JavaScriptCore/bytecode/Opcode.cpp
+++ b/Source/JavaScriptCore/bytecode/Opcode.cpp
@@ -205,21 +205,21 @@ void OpcodeStats::resetLastInstruction()
 
 #endif
 
-static const unsigned metadataSizes[] = {
+static constexpr auto metadataSizes = std::to_array<unsigned>({
 
 #define METADATA_SIZE(size) size,
     FOR_EACH_BYTECODE_METADATA_SIZE(METADATA_SIZE)
 #undef METADATA_SIZE
 
-};
+});
 
-static const unsigned metadataAlignments[] = {
+static constexpr auto metadataAlignments = std::to_array<unsigned>({
 
 #define METADATA_ALIGNMENT(size) size,
     FOR_EACH_BYTECODE_METADATA_ALIGNMENT(METADATA_ALIGNMENT)
 #undef METADATA_ALIGNMENT
 
-};
+});
 
 unsigned metadataSize(OpcodeID opcodeID)
 {

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -58,6 +58,7 @@
 #include "Snippet.h"
 #include "StackAlignment.h"
 #include "StructureInlines.h"
+#include <array>
 #include <wtf/CommaPrinter.h>
 #include <wtf/ListDump.h>
 
@@ -68,11 +69,11 @@ namespace JSC { namespace DFG {
 static constexpr bool dumpOSRAvailabilityData = false;
 
 // Creates an array of stringized names.
-static constexpr ASCIILiteral dfgOpNames[] = {
+static constexpr auto dfgOpNames = std::to_array<ASCIILiteral>({
 #define STRINGIZE_DFG_OP_ENUM(opcode, flags) #opcode ## _s ,
     FOR_EACH_DFG_OP(STRINGIZE_DFG_OP_ENUM)
 #undef STRINGIZE_DFG_OP_ENUM
-};
+});
 
 Graph::Graph(VM& vm, Plan& plan)
     : m_vm(vm)

--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
@@ -28,6 +28,7 @@
 #include "InspectorBackendDispatcher.h"
 
 #include "InspectorFrontendRouter.h"
+#include <array>
 #include <wtf/JSONValues.h>
 #include <wtf/SetForScope.h>
 #include <wtf/text/MakeString.h>
@@ -229,14 +230,14 @@ void BackendDispatcher::sendResponse(long requestId, Ref<JSON::Object>&& result,
 void BackendDispatcher::sendPendingErrors()
 {
     // These error codes are specified in JSON-RPC 2.0, Section 5.1.
-    static const int errorCodes[] = {
+    static constexpr auto errorCodes = std::to_array<int>({
         -32700, // ParseError
         -32600, // InvalidRequest
         -32601, // MethodNotFound
         -32602, // InvalidParams
         -32603, // InternalError
         -32000, // ServerError
-    };
+    });
 
     // To construct the error object, only use the last error's code and message.
     // Per JSON-RPC 2.0, Section 5.1, the 'data' member may contain nested errors,

--- a/Source/JavaScriptCore/runtime/ErrorType.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorType.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ErrorType.h"
 
+#include <array>
 #include <wtf/PrintStream.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -39,11 +40,11 @@ ASCIILiteral errorTypeName(ErrorType errorType)
 
 ASCIILiteral errorTypeName(ErrorTypeWithExtension errorType)
 {
-    static const ASCIILiteral errorTypeNames[] = {
+    static constexpr auto errorTypeNames = std::to_array<ASCIILiteral>({
 #define DECLARE_ERROR_TYPES_STRING(name) #name ""_s,
         JSC_ERROR_TYPES_WITH_EXTENSION(DECLARE_ERROR_TYPES_STRING)
 #undef DECLARE_ERROR_TYPES_STRING
-    };
+    });
     return errorTypeNames[static_cast<unsigned>(errorType)];
 }
 

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
@@ -28,6 +28,7 @@
 #include "YarrErrorCode.h"
 
 #include "Error.h"
+#include <array>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -37,7 +38,7 @@ ASCIILiteral errorMessage(ErrorCode error)
 {
 #define REGEXP_ERROR_PREFIX "Invalid regular expression: "
     // The order of this array must match the ErrorCode enum.
-    static const ASCIILiteral errorMessages[] = {
+    static constexpr auto errorMessages = std::to_array<ASCIILiteral>({
         { },                                                                          // NoError
 
         // The following are hard errors.
@@ -75,7 +76,7 @@ ASCIILiteral errorMessage(ErrorCode error)
 
         // The following are NOT hard errors.
         REGEXP_ERROR_PREFIX "too many nested disjunctions"_s,                         // TooManyDisjunctions
-    };
+    });
 
     return errorMessages[static_cast<unsigned>(error)];
 }

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -55,6 +55,7 @@
 #endif
 
 #if OS(DARWIN)
+#include <array>
 #include <sys/sysctl.h>
 #include <unistd.h>
 #include <wtf/OSObjectPtr.h>
@@ -412,9 +413,9 @@ bool WTFIsDebuggerAttached()
 {
 #if OS(DARWIN)
     struct kinfo_proc info;
-    int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
+    std::array mib { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
     size_t size = sizeof(info);
-    if (sysctl(mib, sizeof(mib) / sizeof(mib[0]), &info, &size, nullptr, 0) == -1)
+    if (sysctl(mib.data(), mib.size(), &info, &size, nullptr, 0) == -1)
         return false;
     return info.kp_proc.p_flag & P_TRACED;
 #else

--- a/Source/WTF/wtf/AvailableMemory.cpp
+++ b/Source/WTF/wtf/AvailableMemory.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include <wtf/AvailableMemory.h>
 
+#include <array>
 #include <mutex>
 #include <wtf/PageBlock.h>
 #include <wtf/text/ParsingUtilities.h>
@@ -198,14 +199,10 @@ MemoryStatus memoryStatus()
     struct kinfo_proc info;
     size_t infolen = sizeof(info);
 
-    int mib[4];
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_PROC;
-    mib[2] = KERN_PROC_PID;
-    mib[3] = getpid();
+    std::array<int, 4> mib { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
 
     size_t memoryFootprint = 0;
-    if (!sysctl(mib, 4, &info, &infolen, nullptr, 0))
+    if (!sysctl(mib.data(), mib.size(), &info, &infolen, nullptr, 0))
         memoryFootprint = static_cast<size_t>(info.ki_rssize) * pageSize();
 #endif
 

--- a/Source/WTF/wtf/NumberOfCores.cpp
+++ b/Source/WTF/wtf/NumberOfCores.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include <wtf/NumberOfCores.h>
 
+#include <array>
 #include <cstdio>
 #include <wtf/text/StringToIntegerConversion.h>
 
@@ -60,11 +61,11 @@ int numberOfProcessorCores()
 #if OS(DARWIN)
     unsigned result;
     size_t length = sizeof(result);
-    int name[] = {
+    std::array name {
             CTL_HW,
             HW_AVAILCPU
     };
-    int sysctlResult = sysctl(name, sizeof(name) / sizeof(int), &result, &length, 0, 0);
+    int sysctlResult = sysctl(name.data(), name.size(), &result, &length, 0, 0);
 
     s_numberOfCores = sysctlResult < 0 ? defaultIfUnavailable : result;
 #elif OS(LINUX) || OS(AIX) || OS(OPENBSD) || OS(NETBSD) || OS(FREEBSD) || OS(HAIKU)

--- a/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
+++ b/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
@@ -40,6 +40,7 @@
 #elif OS(HAIKU)
 #include <wtf/haiku/CurrentProcessMemoryStatus.h>
 #elif OS(FREEBSD)
+#include <array>
 #include <sys/sysctl.h>
 #include <sys/types.h>
 #include <sys/user.h>
@@ -122,13 +123,9 @@ static size_t processMemoryUsage()
     struct kinfo_proc info;
     size_t infolen = sizeof(info);
 
-    int mib[4];
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_PROC;
-    mib[2] = KERN_PROC_PID;
-    mib[3] = getpid();
+    std::array<int, 4> mib { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
 
-    if (sysctl(mib, 4, &info, &infolen, nullptr, 0))
+    if (sysctl(mib.data(), mib.size(), &info, &infolen, nullptr, 0))
         return 0;
 
     return static_cast<size_t>(info.ki_rssize - info.ki_tsize) * pageSize;

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -48,6 +48,7 @@
 #include "WebCodecsVideoFrame.h"
 #include "WebGPUDevice.h"
 #include <JavaScriptCore/HeapCellInlines.h>
+#include <array>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/MallocSpan.h>
 
@@ -442,8 +443,8 @@ static void getImageBytesFromVideoFrame(WebGPU::Queue& backing, const RefPtr<Vid
         .width = width,
         .rowBytes = byteSpan.size() / height
     };
-    uint8_t permuteMap[4] = { 2, 1, 0, 3 };
-    vImagePermuteChannels_ARGB8888(&bgra, &bgra, permuteMap, kvImageNoFlags);
+    constexpr std::array<uint8_t, 4> permuteMap { 2, 1, 0, 3 };
+    vImagePermuteChannels_ARGB8888(&bgra, &bgra, permuteMap.data(), kvImageNoFlags);
 
     return callback(byteSpan.first(sizeInBytes), width, height);
 }

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -58,6 +58,7 @@
 #include <JavaScriptCore/MacroAssembler.h>
 #include <JavaScriptCore/Options.h>
 #include <JavaScriptCore/VM.h>
+#include <array>
 #include <limits>
 #include <wtf/Deque.h>
 #include <wtf/HashSet.h>
@@ -190,11 +191,11 @@ void dumpSelectorOperationStats()
 {
     constexpr bool resetStatsOnDump = true;
 
-    static const char* const selectorNames[] = {
+    static constexpr auto selectorNames = std::to_array<const char*>({
 #define SELECTOR_OPERATION_NAME(selector) #selector,
         FOR_EACH_SELECTOR_OPERATION(SELECTOR_OPERATION_NAME)
 #undef SELECTOR_OPERATION_NAME
-    };
+    });
 
     struct Entry {
         const char* name;

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -72,6 +72,7 @@
 #include "StyleRule.h"
 #include "StyledElement.h"
 #include "VisibleUnits.h"
+#include <array>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -1049,9 +1050,9 @@ bool EditingStyle::conflictsWithInlineStyleOfElement(StyledElement& element, Ref
     return conflicts;
 }
 
-static std::span<const HTMLElementEquivalent* const> NODELETE htmlElementEquivalents()
+SUPPRESS_NODELETE static std::span<const HTMLElementEquivalent* const> NODELETE htmlElementEquivalents()
 {
-    static const HTMLElementEquivalent* const equivalents[] = {
+    static const auto equivalents = std::to_array<const HTMLElementEquivalent*>({
         new HTMLFontWeightEquivalent(HTMLNames::bTag),
         new HTMLFontWeightEquivalent(HTMLNames::strongTag),
 
@@ -1063,7 +1064,7 @@ static std::span<const HTMLElementEquivalent* const> NODELETE htmlElementEquival
         new HTMLTextDecorationEquivalent(CSSValueUnderline, HTMLNames::uTag),
         new HTMLTextDecorationEquivalent(CSSValueLineThrough, HTMLNames::sTag),
         new HTMLTextDecorationEquivalent(CSSValueLineThrough, HTMLNames::strikeTag),
-    };
+    });
     return equivalents;
 }
 
@@ -1083,9 +1084,9 @@ bool EditingStyle::conflictsWithImplicitStyleOfElement(HTMLElement& element, Edi
     return false;
 }
 
-static std::span<const HTMLAttributeEquivalent* const> NODELETE htmlAttributeEquivalents()
+SUPPRESS_NODELETE static std::span<const HTMLAttributeEquivalent* const> NODELETE htmlAttributeEquivalents()
 {
-    static const HTMLAttributeEquivalent* const equivalents[] = {
+    static const auto equivalents = std::to_array<const HTMLAttributeEquivalent*>({
         // elementIsStyledSpanOrHTMLEquivalent depends on the fact each HTMLAttriuteEquivalent matches exactly one attribute
         // of exactly one element except dirAttr.
         new HTMLAttributeEquivalent(CSSPropertyColor, HTMLNames::fontTag, HTMLNames::colorAttr),
@@ -1094,7 +1095,7 @@ static std::span<const HTMLAttributeEquivalent* const> NODELETE htmlAttributeEqu
 
         new HTMLAttributeEquivalent(CSSPropertyDirection, HTMLNames::dirAttr),
         new HTMLAttributeEquivalent(CSSPropertyUnicodeBidi, HTMLNames::dirAttr),
-    };
+    });
     return equivalents;
 }
 

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -31,6 +31,7 @@
 #include "IntSize.h"
 #include "Logging.h"
 #include "PixelFormat.h"
+#include <array>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/TextStream.h>
@@ -147,8 +148,8 @@ static void convertImagePixelsAccelerated(const ConstPixelBufferConversionView& 
 
     if (source.format.pixelFormat != destination.format.pixelFormat) {
         // Swap pixel channels BGRA <-> RGBA.
-        const uint8_t map[4] = { 2, 1, 0, 3 };
-        vImagePermuteChannels_ARGB8888(&sourceVImageBuffer, &destinationVImageBuffer, map, kvImageNoFlags);
+        constexpr std::array<uint8_t, 4> map { 2, 1, 0, 3 };
+        vImagePermuteChannels_ARGB8888(&sourceVImageBuffer, &destinationVImageBuffer, map.data(), kvImageNoFlags);
     }
 }
 

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -49,6 +49,7 @@
 #include "Path.h"
 #include "ShadowBlur.h"
 #include <algorithm>
+#include <array>
 #include <cairo.h>
 #include <numbers>
 
@@ -452,8 +453,8 @@ void setStrokeThickness(GraphicsContextCairo& platformContext, float strokeThick
 
 void setStrokeStyle(GraphicsContextCairo& platformContext, StrokeStyle strokeStyle)
 {
-    static const double dashPattern[] = { 5.0, 5.0 };
-    static const double dotPattern[] = { 1.0, 1.0 };
+    static constexpr auto dashPattern = std::to_array<double>({ 5.0, 5.0 });
+    static constexpr auto dotPattern = std::to_array<double>({ 1.0, 1.0 });
 
     cairo_t* cr = platformContext.cr();
     switch (strokeStyle) {
@@ -468,10 +469,10 @@ void setStrokeStyle(GraphicsContextCairo& platformContext, StrokeStyle strokeSty
         cairo_set_dash(cr, 0, 0, 0);
         break;
     case StrokeStyle::DottedStroke:
-        cairo_set_dash(cr, dotPattern, 2, 0);
+        cairo_set_dash(cr, dotPattern.data(), dotPattern.size(), 0);
         break;
     case StrokeStyle::DashedStroke:
-        cairo_set_dash(cr, dashPattern, 2, 0);
+        cairo_set_dash(cr, dashPattern.data(), dashPattern.size(), 0);
         break;
     }
 }

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -32,6 +32,7 @@
 #include "CGUtilities.h"
 #include "GraphicsContextCG.h"
 #include "PathStream.h"
+#include <array>
 #include <mutex>
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 #include <wtf/NeverDestroyed.h>
@@ -588,9 +589,9 @@ static RetainPtr<CGContextRef> createScratchContext()
     auto consumer = adoptCF(CGDataConsumerCreate(0, &callbacks));
     auto context = adoptCF(CGPDFContextCreate(consumer.get(), 0, 0));
 
-    CGFloat black[4] = { 0, 0, 0, 1 };
-    CGContextSetFillColor(context.get(), black);
-    CGContextSetStrokeColor(context.get(), black);
+    constexpr std::array<CGFloat, 4> black { 0, 0, 0, 1 };
+    CGContextSetFillColor(context.get(), black.data());
+    CGContextSetStrokeColor(context.get(), black.data());
 
     return context;
 }

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -41,6 +41,7 @@
 #include "SystemFontDatabaseCoreText.h"
 #include "UnrealizedCoreTextFont.h"
 #include <CoreText/SFNTLayoutTypes.h>
+#include <array>
 #include <pal/spi/cf/CoreTextSPI.h>
 #include <pal/spi/cocoa/AccessibilitySupportSPI.h>
 #include <wtf/HashSet.h>
@@ -158,7 +159,7 @@ RefPtr<Font> FontCache::similarFont(const FontDescription& description, const St
         return fontForFamily(description, "verdana"_s);
 #endif
 
-    static constexpr ASCIILiteral matchWords[] = { "Arabic"_s, "Pashto"_s, "Urdu"_s };
+    static constexpr auto matchWords = std::to_array<ASCIILiteral>({ "Arabic"_s, "Pashto"_s, "Urdu"_s });
     auto familyMatcher = StringView(family);
     for (auto matchWord : matchWords) {
         if (equalIgnoringASCIICase(familyMatcher, matchWord))

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
@@ -23,6 +23,7 @@
 #include "FourCC.h"
 #include "GLContext.h"
 #include "Logging.h"
+#include <array>
 #include <wtf/Locker.h>
 #include <wtf/MainThread.h>
 #include <wtf/text/StringView.h>
@@ -250,13 +251,13 @@ const Vector<GLDisplay::BufferFormat>& GLDisplay::bufferFormats()
 
         // This list includes those formats supported by AHardwareBuffer which are suitable for rendering content, sorted by preference. See:
         // https://android.googlesource.com/platform/frameworks/native/+/4f463a6b1de9198963dc6aff74154a504ba3f8f6/libs/nativewindow/include/android/hardware_buffer.h#66
-        static constexpr FourCC drmFormats[] = {
+        static constexpr auto drmFormats = std::to_array<FourCC>({
             DRM_FORMAT_RGBA8888,
             DRM_FORMAT_RGBX8888,
             DRM_FORMAT_RGB565,
             DRM_FORMAT_RGBA1010102,
             DRM_FORMAT_RGB888,
-        };
+        });
 
         // The usage flags match the common set used in the usageToAHardwareBufferUsage() helper function
         // in AcceleratedSurface.cpp, under the assumption that the additional flag hinting that buffers

--- a/Source/WebCore/platform/graphics/mac/GraphicsChecksMac.cpp
+++ b/Source/WebCore/platform/graphics/mac/GraphicsChecksMac.cpp
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #if HAVE(APPLE_GRAPHICS_CONTROL)
+#include <array>
 #include <sys/sysctl.h>
 #endif
 
@@ -92,10 +93,10 @@ static bool hasMuxCapability()
         // Based on information from Apple's OpenGL team, such devices
         // have four or fewer processors.
         // <rdar://problem/30060378>
-        int names[2] = { CTL_HW, HW_NCPU };
+        std::array<int, 2> names { CTL_HW, HW_NCPU };
         int cpuCount;
         size_t cpuCountLength = sizeof(cpuCount);
-        sysctl(names, 2, &cpuCount, &cpuCountLength, nullptr, 0);
+        sysctl(names.data(), names.size(), &cpuCount, &cpuCountLength, nullptr, 0);
         result = cpuCount > 4;
     }
 

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
@@ -33,6 +33,7 @@
 #include "RealtimeMediaSourceSettings.h"
 #include <VideoFrame.h>
 #include <algorithm>
+#include <array>
 #include <wtf/JSONValues.h>
 #include <wtf/MediaTime.h>
 
@@ -69,9 +70,9 @@ void RealtimeVideoCaptureSource::setSupportedPresets(Vector<VideoPreset>&& prese
         preset.sortFrameRateRanges();
 }
 
-std::span<const IntSize> RealtimeVideoCaptureSource::standardVideoSizes()
+SUPPRESS_NODELETE std::span<const IntSize> RealtimeVideoCaptureSource::standardVideoSizes()
 {
-    static constexpr IntSize sizes[] = {
+    static constexpr auto sizes = std::to_array<IntSize>({
         { 112, 112 },
         { 160, 160 },
         { 160, 120 }, // 4:3, QQVGA
@@ -106,7 +107,7 @@ std::span<const IntSize> RealtimeVideoCaptureSource::standardVideoSizes()
         { 2592, 1936 },
         { 3264, 2448 }, // 3:4
         { 3840, 2160 }, // 16:9, 4K UHD
-    };
+    });
     return sizes;
 }
 

--- a/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
@@ -31,12 +31,13 @@
 #include "CurlContext.h"
 #include "CurlResponse.h"
 #include "HTTPParsers.h"
+#include <array>
 
 namespace WebCore {
 
 static bool isAppendableHeader(const String &key)
 {
-    static constexpr ASCIILiteral appendableHeaders[] = {
+    static constexpr auto appendableHeaders = std::to_array<ASCIILiteral>({
         "access-control-allow-headers"_s,
         "access-control-allow-methods"_s,
         "access-control-allow-origin"_s,
@@ -64,7 +65,7 @@ static bool isAppendableHeader(const String &key)
         "via"_s,
         "warning"_s,
         "www-authenticate"_s
-    };
+    });
 
     // Custom headers start with 'X-', and need no further checking.
     if (startsWithLettersIgnoringASCIICase(key, "x-"_s))

--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp
@@ -28,6 +28,7 @@
 
 #include <WebCore/RiceUtilities.h>
 #include <WebCore/RiceVersioning.h>
+#include <array>
 #include <rice-io.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/StdLibExtras.h>
@@ -397,7 +398,7 @@ void RiceBackend::gatherSocketAddresses(ScriptExecutionContextIdentifier identif
 
     g_source_set_callback(source.get(), static_cast<GSourceFunc>([](auto userData) -> gboolean {
         RiceIoRecv recv;
-        uint8_t data[16384];
+        std::array<uint8_t, 16384> data;
 
         auto sourceData = reinterpret_cast<RecvSourceData*>(userData);
         RefPtr backend = sourceData->backend.get();
@@ -409,7 +410,7 @@ void RiceBackend::gatherSocketAddresses(ScriptExecutionContextIdentifier identif
             return G_SOURCE_CONTINUE;
 
         while (true) {
-            rice_sockets_recv(sockets.get(), data, 16384, &recv);
+            rice_sockets_recv(sockets.get(), data.data(), data.size(), &recv);
             switch (recv.tag) {
             case RICE_IO_RECV_WOULD_BLOCK:
                 rice_recv_clear(&recv);
@@ -418,7 +419,7 @@ void RiceBackend::gatherSocketAddresses(ScriptExecutionContextIdentifier identif
                 auto from = riceAddressToString(recv.data.from);
                 auto to = riceAddressToString(recv.data.to);
                 auto protocol = toRTCIceProtocol(recv.data.transport);
-                auto handle = SharedMemoryHandle::createCopy(unsafeMakeSpan(data, recv.data.len), SharedMemoryProtection::ReadOnly);
+                auto handle = SharedMemoryHandle::createCopy(std::span { data }.first(recv.data.len), SharedMemoryProtection::ReadOnly);
                 if (!handle) [[unlikely]]
                     break;
                 backend->notifyIncomingData(sourceData->streamId, protocol, WTF::move(from), WTF::move(to), WTF::move(*handle));

--- a/Source/WebKit/Shared/gtk/WebKeyboardEventGtk.cpp
+++ b/Source/WebKit/Shared/gtk/WebKeyboardEventGtk.cpp
@@ -32,6 +32,7 @@
 
 #include "GtkVersioning.h"
 #include <WebCore/WindowsKeyboardCodes.h>
+#include <array>
 #include <gdk/gdk.h>
 #include <gdk/gdkkeysyms.h>
 #include <wtf/HexNumber.h>
@@ -435,9 +436,9 @@ String WebKeyboardEvent::keyValueStringForGdkKeyval(unsigned keyCode)
         guint32 unicodeCharacter = gdk_keyval_to_unicode(keyCode);
         if (unicodeCharacter) {
             // UTF-8 will use up to 6 bytes.
-            char utf8[7] = { 0 };
-            g_unichar_to_utf8(unicodeCharacter, utf8);
-            return String::fromUTF8(utf8);
+            std::array<char, 7> utf8 = { 0 };
+            g_unichar_to_utf8(unicodeCharacter, utf8.data());
+            return String::fromUTF8(utf8.data());
         }
         return "Unidentified"_s;
     }

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
@@ -33,6 +33,7 @@
 #include "WebKitWebViewBasePrivate.h"
 #include <WebCore/DragData.h>
 #include <WebCore/PasteboardCustomData.h>
+#include <array>
 #include <gtk/gtk.h>
 #include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
@@ -258,8 +259,8 @@ struct DropReadAsyncData {
 
 void DropTarget::loadData(const char* mimeType, CompletionHandler<void(GRefPtr<GBytes>&&)>&& completionHandler)
 {
-    const char* mimeTypes[] = { mimeType, nullptr };
-    gdk_drop_read_async(m_drop.get(), mimeTypes, G_PRIORITY_DEFAULT, m_cancellable.get(), [](GObject* gdkDrop, GAsyncResult* result, gpointer userData) {
+    auto mimeTypes = std::to_array<const char*>({ mimeType, nullptr });
+    gdk_drop_read_async(m_drop.get(), mimeTypes.data(), G_PRIORITY_DEFAULT, m_cancellable.get(), [](GObject* gdkDrop, GAsyncResult* result, gpointer userData) {
         std::unique_ptr<DropReadAsyncData<void(GRefPtr<GBytes>&&)>> data(static_cast<DropReadAsyncData<void(GRefPtr<GBytes>&&)>*>(userData));
         GRefPtr<GInputStream> inputStream = adoptGRef(gdk_drop_read_finish(GDK_DROP(gdkDrop), result, nullptr, nullptr));
         if (!inputStream) {

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -38,6 +38,7 @@
 #include "WebPageProxyIdentifier.h"
 #include "WebProcessProxy.h"
 #include <algorithm>
+#include <array>
 #include <ranges>
 #include <wtf/RunLoop.h>
 #include <wtf/Scope.h>
@@ -505,9 +506,9 @@ bool AuxiliaryProcessProxy::platformIsBeingDebugged() const
         return false;
 
     struct kinfo_proc info;
-    int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, processID() };
+    std::array mib { CTL_KERN, KERN_PROC, KERN_PROC_PID, processID() };
     size_t size = sizeof(info);
-    if (sysctl(mib, std::size(mib), &info, &size, nullptr, 0) == -1)
+    if (sysctl(mib.data(), mib.size(), &info, &size, nullptr, 0) == -1)
         return false;
 
     return info.kp_proc.p_flag & P_TRACED;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -43,6 +43,7 @@
 #include <WebCore/Pin.h>
 #include <WebCore/U2fCommandConstructor.h>
 #include <WebCore/WebAuthenticationUtils.h>
+#include <array>
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/RunLoop.h>
@@ -122,7 +123,7 @@ bool NODELETE isTerminalPinError(const CtapDeviceResponseCode& error)
 // Hash PRF input according to spec: SHA-256("WebAuthn PRF" || 0x00 || input)
 static Vector<uint8_t> hashPRFInput(const BufferSource& input)
 {
-    constexpr uint8_t prefix[] = { 'W', 'e', 'b', 'A', 'u', 't', 'h', 'n', ' ', 'P', 'R', 'F' };
+    constexpr auto prefix = std::to_array<uint8_t>({ 'W', 'e', 'b', 'A', 'u', 't', 'h', 'n', ' ', 'P', 'R', 'F' });
     constexpr uint8_t nullByte = 0x00;
     auto crypto = PAL::Crypto::CryptoDigest::create(PAL::Crypto::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(std::span { prefix });

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
@@ -33,6 +33,7 @@
 #include <WebCore/PasteboardCustomData.h>
 #include <WebCore/SelectionData.h>
 #include <WebCore/SharedBuffer.h>
+#include <array>
 #include <gtk/gtk.h>
 #include <wtf/RefCounted.h>
 #include <wtf/glib/GRefPtr.h>
@@ -133,8 +134,8 @@ public:
     {
         RefPtr protectedThis = RefPtr { this };
         m_completionHandler = WTF::move(completionHandler);
-        const char* mimeTypes[] = { format, nullptr };
-        gdk_clipboard_read_async(m_clipboard, mimeTypes, G_PRIORITY_DEFAULT, m_cancellable.get(), [](GObject* clipboard, GAsyncResult* result, gpointer userData) {
+        auto mimeTypes = std::to_array<const char*>({ format, nullptr });
+        gdk_clipboard_read_async(m_clipboard, mimeTypes.data(), G_PRIORITY_DEFAULT, m_cancellable.get(), [](GObject* clipboard, GAsyncResult* result, gpointer userData) {
             auto task = adoptRef(static_cast<ClipboardTask*>(userData));
             GUniqueOutPtr<GError> error;
             GRefPtr<GInputStream> inputStream = adoptGRef(gdk_clipboard_read_finish(GDK_CLIPBOARD(clipboard), result, nullptr, &error.outPtr()));

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -33,6 +33,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/Scrollbar.h>
 #include <WebCore/UserInterfaceLayoutDirection.h>
+#include <array>
 
 namespace WebKit {
 using namespace WebCore;
@@ -60,13 +61,13 @@ static const float swipeOverlayBorderOpacity = 0.05;
 static const float swipeOverlayOutlineOpacity = 0.05;
 static const float swipeOverlayDimmingOpacity = 0.12;
 static const float swipeOverlayShadowWidth = 57;
-static const GskColorStop swipeOverlayShadowStops[] = {
+static constexpr auto swipeOverlayShadowStops = std::to_array<GskColorStop>({
     { 0,     { 0, 0, 0, 0.08  } },
     { 0.125, { 0, 0, 0, 0.053 } },
     { 0.428, { 0, 0, 0, 0.026 } },
     { 0.714, { 0, 0, 0, 0.01  } },
     { 1,     { 0, 0, 0, 0     } }
-};
+});
 #endif
 
 static bool isEventStop(PlatformGtkScrollData* event)
@@ -523,7 +524,7 @@ void ViewGestureController::snapshot(GtkSnapshot* snapshot, GskRenderNode* pageR
     gtk_snapshot_append_color(snapshot, &outline, &outlineRect);
     gtk_snapshot_push_opacity(snapshot, shadowOpacity);
     gtk_snapshot_append_linear_gradient(snapshot, &shadowRect, &shadowStart, &shadowEnd,
-        swipeOverlayShadowStops, G_N_ELEMENTS(swipeOverlayShadowStops));
+        swipeOverlayShadowStops.data(), swipeOverlayShadowStops.size());
     gtk_snapshot_pop(snapshot);
 
     gtk_snapshot_pop(snapshot);

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -51,6 +51,7 @@
 #include <WebCore/NotImplemented.h>
 #include <WebCore/Region.h>
 #include <WebCore/WindowMessageBroadcaster.h>
+#include <array>
 #include <commctrl.h>
 #include <wtf/FileSystem.h>
 #include <wtf/SoftLinking.h>
@@ -768,15 +769,15 @@ bool WebView::shouldInitializeTrackPointHack()
         return shouldCreateScrollbars;
 
     hasRunTrackPointCheck = true;
-    const wchar_t* trackPointKeys[] = {
+    constexpr auto trackPointKeys = std::to_array<const wchar_t*>({
         L"Software\\Lenovo\\TrackPoint",
         L"Software\\Lenovo\\UltraNav",
         L"Software\\Alps\\Apoint\\TrackPoint",
         L"Software\\Synaptics\\SynTPEnh\\UltraNavUSB",
         L"Software\\Synaptics\\SynTPEnh\\UltraNavPS2"
-    };
+    });
 
-    for (size_t i = 0; i < std::size(trackPointKeys); ++i) {
+    for (size_t i = 0; i < trackPointKeys.size(); ++i) {
         HKEY trackPointKey;
         int readKeyResult = ::RegOpenKeyExW(HKEY_CURRENT_USER, trackPointKeys[i], 0, KEY_READ, &trackPointKey);
         ::RegCloseKey(trackPointKey);

--- a/Source/WebKit/WPEPlatform/wpe/WPECursorTheme.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPECursorTheme.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WPECursorTheme.h"
 
+#include <array>
 #include <stdio.h>
 #include <wtf/FileSystem.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -169,8 +170,8 @@ struct XcursorChunkHeader {
 
 static bool readUint32(FILE* file, uint32_t* value)
 {
-    unsigned char bytes[4];
-    if (fread(&bytes, 1, 4, file) != 4)
+    std::array<unsigned char, 4> bytes;
+    if (fread(bytes.data(), 1, 4, file) != 4)
         return false;
 
     *value = ((bytes[0] << 0) | (bytes[1] << 8) | (bytes[2] << 16) | (bytes[3] << 24));

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WPEScreen.h"
 
+#include <array>
 #include <wtf/glib/WTFGType.h>
 
 #if USE(LIBDRM)
@@ -204,8 +205,8 @@ static std::optional<uint32_t> findCrtc(WPEScreen* screen, int fd)
 
 static void wpeScreenTryEnsureSyncObserver(WPEScreen* screen)
 {
-    drmDevicePtr devices[64];
-    const int devicesNum = drmGetDevices2(0, devices, std::size(devices));
+    std::array<drmDevicePtr, 64> devices;
+    const int devicesNum = drmGetDevices2(0, devices.data(), devices.size());
     if (devicesNum <= 0)
         return;
 
@@ -225,7 +226,7 @@ static void wpeScreenTryEnsureSyncObserver(WPEScreen* screen)
         } else
             g_debug("WPEScreen %u: Failed to find a CRTC for device %s", screen->priv->id, devices[i]->nodes[DRM_NODE_PRIMARY]);
     }
-    drmFreeDevices(devices, devicesNum);
+    drmFreeDevices(devices.data(), devicesNum);
 
     if (!screen->priv->syncObserver)
         g_debug("WPEScreen %u: Could not create a WPEScreenSyncObserverDRM", screen->priv->id);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.cpp
@@ -28,6 +28,7 @@
 
 #include "WPEClipboardWaylandPrivate.h"
 #include "WPEDisplayWaylandPrivate.h"
+#include <array>
 #include <gio/gunixinputstream.h>
 #include <gio/gunixoutputstream.h>
 #include <glib-unix.h>
@@ -185,8 +186,8 @@ static GBytes* wpeClipboardWaylandRead(WPEClipboard* clipboard, const char* form
     if (!priv->offer)
         return nullptr;
 
-    int pipeFD[2];
-    if (!g_unix_open_pipe(pipeFD, O_CLOEXEC, nullptr))
+    std::array<int, 2> pipeFD;
+    if (!g_unix_open_pipe(pipeFD.data(), O_CLOEXEC, nullptr))
         return nullptr;
 
     wl_data_offer_receive(priv->offer, format, pipeFD[1]);

--- a/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
@@ -39,6 +39,7 @@
 #include <WebCore/NodeInlines.h>
 #include <WebCore/PlatformKeyboardEvent.h>
 #include <WebCore/WindowsKeyboardCodes.h>
+#include <array>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebKit {
@@ -65,7 +66,7 @@ struct KeyPressEntry {
     const char* name;
 };
 
-static constexpr KeyDownEntry keyDownEntries[] = {
+static constexpr auto keyDownEntries = std::to_array<KeyDownEntry>({
     { VK_LEFT,   0,                  "MoveLeft"                                },
     { VK_LEFT,   ShiftKey,           "MoveLeftAndModifySelection"              },
     { VK_LEFT,   CtrlKey,            "MoveWordLeft"                            },
@@ -127,9 +128,9 @@ static constexpr KeyDownEntry keyDownEntries[] = {
     { 'Z',         CtrlKey | ShiftKey, "Redo"                                  },
     { 'Y',         CtrlKey,          "Redo"                                    },
     { VK_INSERT, 0,                  "OverWrite"                               },
-};
+});
 
-static constexpr KeyPressEntry keyPressEntries[] = {
+static constexpr auto keyPressEntries = std::to_array<KeyPressEntry>({
     { '\t',   0,                  "InsertTab"                                  },
     { '\t',   ShiftKey,           "InsertBacktab"                              },
     { '\r',   0,                  "InsertNewline"                              },
@@ -137,7 +138,7 @@ static constexpr KeyPressEntry keyPressEntries[] = {
     { '\r',   ShiftKey,           "InsertLineBreak"                            },
     { '\r',   AltKey,             "InsertNewline"                              },
     { '\r',   AltKey | ShiftKey,  "InsertNewline"                              },
-};
+});
 
 static const char* interpretKeyEvent(const KeyboardEvent& event)
 {

--- a/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
+++ b/Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp
@@ -50,6 +50,7 @@
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/UserAgent.h>
 #include <WebCore/WindowsKeyboardCodes.h>
+#include <array>
 
 namespace WebKit {
 using namespace WebCore;
@@ -117,7 +118,7 @@ struct KeyPressEntry {
     const char* name;
 };
 
-static const KeyDownEntry keyDownEntries[] = {
+static constexpr auto keyDownEntries = std::to_array<KeyDownEntry>({
     { VK_LEFT,   0,                  "MoveLeft" },
     { VK_LEFT,   ShiftKey,           "MoveLeftAndModifySelection" },
     { VK_LEFT,   CtrlKey,            "MoveWordLeft" },
@@ -174,9 +175,9 @@ static const KeyDownEntry keyDownEntries[] = {
     { VK_INSERT, ShiftKey,           "Paste" },
     { 'Z',       CtrlKey,            "Undo" },
     { 'Z',       CtrlKey | ShiftKey, "Redo" },
-};
+});
 
-static const KeyPressEntry keyPressEntries[] = {
+static constexpr auto keyPressEntries = std::to_array<KeyPressEntry>({
     { '\t',   0,                  "InsertTab" },
     { '\t',   ShiftKey,           "InsertBacktab" },
     { '\r',   0,                  "InsertNewline" },
@@ -184,7 +185,7 @@ static const KeyPressEntry keyPressEntries[] = {
     { '\r',   AltKey,             "InsertNewline" },
     { '\r',   ShiftKey,           "InsertNewline" },
     { '\r',   AltKey | ShiftKey,  "InsertNewline" },
-};
+});
 
 const char* WebPage::interpretKeyEvent(const WebCore::KeyboardEvent* evt)
 {

--- a/Source/WebKitLegacy/Storage/StorageAreaSync.cpp
+++ b/Source/WebKitLegacy/Storage/StorageAreaSync.cpp
@@ -32,6 +32,7 @@
 #include <WebCore/SQLiteStatement.h>
 #include <WebCore/SQLiteTransaction.h>
 #include <WebCore/SuddenTermination.h>
+#include <array>
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
 
@@ -286,14 +287,14 @@ void StorageAreaSync::migrateItemTableIfNeeded()
     }
 
     // alter table for backward compliance, change the value type from TEXT to BLOB.
-    static const ASCIILiteral commands[] = {
+    static constexpr auto commands = std::to_array<ASCIILiteral>({
         "DROP TABLE IF EXISTS ItemTable2"_s,
         "CREATE TABLE ItemTable2 (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB NOT NULL ON CONFLICT FAIL)"_s,
         "INSERT INTO ItemTable2 SELECT * from ItemTable"_s,
         "DROP TABLE ItemTable"_s,
         "ALTER TABLE ItemTable2 RENAME TO ItemTable"_s,
         { },
-    };
+    });
 
     SQLiteTransaction transaction(m_database.get(), false);
     transaction.begin();

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -36,6 +36,7 @@
 
 #if BOS(DARWIN)
 #include <CommonCrypto/CommonHMAC.h>
+#include <array>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/sysctl.h>
@@ -211,10 +212,10 @@ void TZoneHeapManager::init()
 
     uint64_t primordialSeed;
     struct timeval timeValue;
-    int mib[2] = { CTL_KERN, KERN_BOOTTIME };
+    std::array<int, 2> mib { CTL_KERN, KERN_BOOTTIME };
     size_t size = sizeof(timeValue);
 
-    auto sysctlResult = sysctl(mib, 2, &timeValue, &size, nullptr, 0);
+    auto sysctlResult = sysctl(mib.data(), mib.size(), &timeValue, &size, nullptr, 0);
     if (sysctlResult) {
         TZONE_LOG_DEBUG("kern.boottime is required for TZoneHeap initialization: %d errno %d\n", sysctlResult, errno);
         RELEASE_BASSERT(!sysctlResult || !requirePerBootPrimordialSeed);


### PR DESCRIPTION
#### f6c0c3a4c8ed0e1a1fa9c6a43f7389e06f42fbb1
<pre>
Reduce use of C-style arrays in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=313193">https://bugs.webkit.org/show_bug.cgi?id=313193</a>

Reviewed by Keith Miller and Darin Adler.

Reduce use of C-style arrays in the codebase, leveraging std::array
instead.

* Source/JavaScriptCore/bytecode/Opcode.cpp:
(JSC::std::to_array&lt;unsigned&gt;):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::std::to_array&lt;ASCIILiteral&gt;):
* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp:
(Inspector::BackendDispatcher::sendPendingErrors):
* Source/JavaScriptCore/runtime/ErrorType.cpp:
(JSC::errorTypeName):
* Source/JavaScriptCore/yarr/YarrErrorCode.cpp:
(JSC::Yarr::errorMessage):
* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/AvailableMemory.cpp:
(WTF::memoryStatus):
* Source/WTF/wtf/NumberOfCores.cpp:
(WTF::numberOfProcessorCores):
* Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp:
(WTF::processMemoryUsage):
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::getImageBytesFromVideoFrame):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::dumpSelectorOperationStats):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::htmlElementEquivalents):
(WebCore::htmlAttributeEquivalents):
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::convertImagePixelsAccelerated):
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::State::setStrokeStyle):
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::createScratchContext):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::FontCache::similarFont):
* Source/WebCore/platform/graphics/egl/GLDisplay.cpp:
(WebCore::GLDisplay::bufferFormats):
* Source/WebCore/platform/graphics/mac/GraphicsChecksMac.cpp:
(WebCore::hasMuxCapability):
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::RealtimeVideoCaptureSource::standardVideoSizes):
* Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp:
(WebCore::isAppendableHeader):
* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp:
(WebKit::RiceBackend::gatherSocketAddresses):
* Source/WebKit/Shared/gtk/WebKeyboardEventGtk.cpp:
(WebKit::WebKeyboardEvent::keyValueStringForGdkKeyval):
* Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp:
(WebKit::DropTarget::loadData):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::platformIsBeingDebugged const):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
* Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp:
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp:
(WebKit::std::to_array&lt;GskColorStop&gt;):
(WebKit::ViewGestureController::snapshot):
* Source/WebKit/UIProcess/win/WebView.cpp:
(WebKit::WebView::shouldInitializeTrackPointHack):
* Source/WebKit/WPEPlatform/wpe/WPECursorTheme.cpp:
(WPE::readUint32):
* Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp:
(wpeScreenTryEnsureSyncObserver):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEClipboardWayland.cpp:
(wpeClipboardWaylandRead):
* Source/WebKit/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp:
(WebKit::std::to_array&lt;KeyDownEntry&gt;):
(WebKit::std::to_array&lt;KeyPressEntry&gt;):
* Source/WebKit/WebProcess/WebPage/win/WebPageWin.cpp:
(WebKit::std::to_array&lt;KeyDownEntry&gt;):
(WebKit::std::to_array&lt;KeyPressEntry&gt;):
* Source/WebKitLegacy/Storage/StorageAreaSync.cpp:
(WebKit::StorageAreaSync::migrateItemTableIfNeeded):
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::TZoneHeapManager::init):

Canonical link: <a href="https://commits.webkit.org/311966@main">https://commits.webkit.org/311966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/003864e02a1be757dd16e49e9f49be0173b7b033

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112546 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122726 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86133 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103396 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24039 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22434 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15062 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150511 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169781 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19295 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15484 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130914 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131028 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35486 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31523 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141914 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89398 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25721 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18720 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190589 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31034 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96898 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48898 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30554 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30827 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30708 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->