### PR TITLE
Render name of RenderMultiColumnFlow should be RenderMultiColumnFlow

### DIFF
--- a/LayoutTests/fast/block/float/float-not-removed-from-next-sibling4-expected.txt
+++ b/LayoutTests/fast/block/float/float-not-removed-from-next-sibling4-expected.txt
@@ -19,7 +19,7 @@ layer at (8,8) size 15x200
   RenderBlock {DIV} at (0,0) size 15x200
     RenderMultiColumnSet at (0,0) size 15x200
 layer at (8,8) size 0x200
-  RenderMultiColumnFlowThread at (0,0) size 0x200
+  RenderMultiColumnFlow at (0,0) size 0x200
     RenderImage {IMG} at (0,0) size 15x200 [bgcolor=#C0C0C0]
 layer at (8,208) size 16x96
   RenderBlock (positioned) {DIV} at (0,200) size 16x96

--- a/LayoutTests/fast/multicol/pagination-h-horizontal-bt-expected.txt
+++ b/LayoutTests/fast/multicol/pagination-h-horizontal-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1600x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,-337) size 800x922 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
-  RenderMultiColumnFlowThread at (0,0) size 800x922
+  RenderMultiColumnFlow at (0,0) size 800x922
 layer at (0,-337) size 800x922 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
   RenderBlock {HTML} at (0,0) size 800x922
     RenderBody {BODY} at (8,8) size 784x906

--- a/LayoutTests/fast/multicol/pagination-h-horizontal-tb-expected.txt
+++ b/LayoutTests/fast/multicol/pagination-h-horizontal-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1600x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 800x922 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
-  RenderMultiColumnFlowThread at (0,0) size 800x922
+  RenderMultiColumnFlow at (0,0) size 800x922
 layer at (0,0) size 800x922 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
   RenderBlock {HTML} at (0,0) size 800x922
     RenderBody {BODY} at (8,8) size 784x906

--- a/LayoutTests/fast/multicol/pagination-h-vertical-lr-expected.txt
+++ b/LayoutTests/fast/multicol/pagination-h-vertical-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1600x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 1222x585
-  RenderMultiColumnFlowThread at (0,0) size 1222x585
+  RenderMultiColumnFlow at (0,0) size 1222x585
 layer at (0,0) size 1222x585
   RenderBlock {HTML} at (0,0) size 1222x585
     RenderBody {BODY} at (8,8) size 1206x569

--- a/LayoutTests/fast/multicol/pagination-h-vertical-rl-expected.txt
+++ b/LayoutTests/fast/multicol/pagination-h-vertical-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1600x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-422,0) size 1222x585 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
-  RenderMultiColumnFlowThread at (0,0) size 1222x585
+  RenderMultiColumnFlow at (0,0) size 1222x585
 layer at (-422,0) size 1222x585 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
   RenderBlock {HTML} at (0,0) size 1222x585
     RenderBody {BODY} at (8,8) size 1206x569

--- a/LayoutTests/fast/multicol/pagination-v-horizontal-bt-expected.txt
+++ b/LayoutTests/fast/multicol/pagination-v-horizontal-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1200
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,-322) size 785x922 backgroundClip at (0,0) size 785x1200 clip at (0,0) size 785x1200
-  RenderMultiColumnFlowThread at (0,0) size 785x922
+  RenderMultiColumnFlow at (0,0) size 785x922
 layer at (0,-322) size 785x922 backgroundClip at (0,0) size 785x1200 clip at (0,0) size 785x1200
   RenderBlock {HTML} at (0,0) size 785x922
     RenderBody {BODY} at (8,8) size 769x906

--- a/LayoutTests/fast/multicol/pagination-v-horizontal-tb-expected.txt
+++ b/LayoutTests/fast/multicol/pagination-v-horizontal-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1200
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x922
-  RenderMultiColumnFlowThread at (0,0) size 785x922
+  RenderMultiColumnFlow at (0,0) size 785x922
 layer at (0,0) size 785x922
   RenderBlock {HTML} at (0,0) size 785x922
     RenderBody {BODY} at (8,8) size 769x906

--- a/LayoutTests/fast/multicol/pagination-v-vertical-lr-expected.txt
+++ b/LayoutTests/fast/multicol/pagination-v-vertical-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1200
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 1222x600 backgroundClip at (0,0) size 785x1200 clip at (0,0) size 785x1200
-  RenderMultiColumnFlowThread at (0,0) size 1222x600
+  RenderMultiColumnFlow at (0,0) size 1222x600
 layer at (0,0) size 1222x600 backgroundClip at (0,0) size 785x1200 clip at (0,0) size 785x1200
   RenderBlock {HTML} at (0,0) size 1222x600
     RenderBody {BODY} at (8,8) size 1206x584

--- a/LayoutTests/fast/multicol/pagination-v-vertical-rl-expected.txt
+++ b/LayoutTests/fast/multicol/pagination-v-vertical-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1200
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (-437,0) size 1222x600 backgroundClip at (0,0) size 785x1200 clip at (0,0) size 785x1200
-  RenderMultiColumnFlowThread at (0,0) size 1222x600
+  RenderMultiColumnFlow at (0,0) size 1222x600
 layer at (-437,0) size 1222x600 backgroundClip at (0,0) size 785x1200 clip at (0,0) size 785x1200
   RenderBlock {HTML} at (0,0) size 1222x600
     RenderBody {BODY} at (8,8) size 1206x584

--- a/LayoutTests/fast/multicol/pagination/LeftToRight-tb-hittest-expected.txt
+++ b/LayoutTests/fast/multicol/pagination/LeftToRight-tb-hittest-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 2460x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 385x3122 backgroundClip at (0,0) size 2460x585 clip at (0,0) size 2460x585
-  RenderMultiColumnFlowThread at (0,0) size 385x3122
+  RenderMultiColumnFlow at (0,0) size 385x3122
 layer at (0,0) size 385x3122 backgroundClip at (0,0) size 2460x585 clip at (0,0) size 2460x585
   RenderBlock {HTML} at (0,0) size 385x3122 [border: (1px solid #008000)]
     RenderBody {BODY} at (4,4) size 377x3114 [border: (1px solid #000000)]

--- a/LayoutTests/fast/multicol/pagination/RightToLeft-rl-hittest-expected.txt
+++ b/LayoutTests/fast/multicol/pagination/RightToLeft-rl-hittest-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 2460x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-1294,0) size 2094x585 backgroundClip at (0,0) size 2460x585 clip at (0,0) size 2460x585
-  RenderMultiColumnFlowThread at (0,0) size 2094x585
+  RenderMultiColumnFlow at (0,0) size 2094x585
 layer at (-1294,0) size 2094x585 backgroundClip at (0,0) size 2460x585 clip at (0,0) size 2460x585
   RenderBlock {HTML} at (0,0) size 2094x585 [border: (1px solid #008000)]
     RenderBody {BODY} at (4,4) size 2086x577 [border: (1px solid #000000)]

--- a/LayoutTests/fast/multicol/progression-reverse-expected.txt
+++ b/LayoutTests/fast/multicol/progression-reverse-expected.txt
@@ -11,7 +11,7 @@ layer at (104,48) size 71x35
   RenderBlock {DIV} at (96,0) size 71x35 [border: (2px solid #C0C0C0) (4px solid #C0C0C0) (1px solid #C0C0C0) (3px solid #C0C0C0)]
     RenderMultiColumnSet at (3,2) size 64x32
 layer at (107,50) size 30x96
-  RenderMultiColumnFlowThread at (3,2) size 30x96
+  RenderMultiColumnFlow at (3,2) size 30x96
     RenderBlock {DIV} at (0,0) size 30x24 [bgcolor=#770077] [border: (4px dotted #000000) none (2px dotted #FFFFFF)]
     RenderBlock {DIV} at (0,24) size 30x24 [bgcolor=#0000FF] [border: (4px dotted #000000) none (2px dotted #FFFFFF)]
     RenderBlock {DIV} at (0,48) size 30x24 [bgcolor=#00BBFF] [border: (4px dotted #000000) none (2px dotted #FFFFFF)]
@@ -20,7 +20,7 @@ layer at (8,179) size 71x35
   RenderBlock {DIV} at (0,131) size 71x35 [border: (2px solid #C0C0C0) (4px solid #C0C0C0) (1px solid #C0C0C0) (3px solid #C0C0C0)]
     RenderMultiColumnSet at (3,2) size 64x32
 layer at (11,181) size 64x96
-  RenderMultiColumnFlowThread at (3,2) size 64x96
+  RenderMultiColumnFlow at (3,2) size 64x96
     RenderBlock {DIV} at (0,0) size 64x24 [bgcolor=#770077] [border: (4px dotted #000000) none (2px dotted #FFFFFF)]
     RenderBlock {DIV} at (0,24) size 64x24 [bgcolor=#0000FF] [border: (4px dotted #000000) none (2px dotted #FFFFFF)]
     RenderBlock {DIV} at (0,48) size 64x24 [bgcolor=#00BBFF] [border: (4px dotted #000000) none (2px dotted #FFFFFF)]
@@ -29,7 +29,7 @@ layer at (104,262) size 71x35
   RenderBlock {DIV} at (96,0) size 71x35 [border: (1px solid #C0C0C0) (4px solid #C0C0C0) (2px solid #C0C0C0) (3px solid #C0C0C0)]
     RenderMultiColumnSet at (3,2) size 64x32
 layer at (107,199) size 30x96
-  RenderMultiColumnFlowThread at (3,2) size 30x96
+  RenderMultiColumnFlow at (3,2) size 30x96
     RenderBlock {DIV} at (0,0) size 30x24 [bgcolor=#770077] [border: none (4px dotted #000000) (2px dotted #FFFFFF)]
     RenderBlock {DIV} at (0,24) size 30x24 [bgcolor=#0000FF] [border: none (4px dotted #000000) (2px dotted #FFFFFF)]
     RenderBlock {DIV} at (0,48) size 30x24 [bgcolor=#00BBFF] [border: none (4px dotted #000000) (2px dotted #FFFFFF)]
@@ -38,7 +38,7 @@ layer at (8,313) size 71x35
   RenderBlock {DIV} at (0,51) size 71x35 [border: (1px solid #C0C0C0) (4px solid #C0C0C0) (2px solid #C0C0C0) (3px solid #C0C0C0)]
     RenderMultiColumnSet at (3,2) size 64x32
 layer at (11,250) size 64x96
-  RenderMultiColumnFlowThread at (3,2) size 64x96
+  RenderMultiColumnFlow at (3,2) size 64x96
     RenderBlock {DIV} at (0,0) size 64x24 [bgcolor=#770077] [border: none (4px dotted #000000) (2px dotted #FFFFFF)]
     RenderBlock {DIV} at (0,24) size 64x24 [bgcolor=#0000FF] [border: none (4px dotted #000000) (2px dotted #FFFFFF)]
     RenderBlock {DIV} at (0,48) size 64x24 [bgcolor=#00BBFF] [border: none (4px dotted #000000) (2px dotted #FFFFFF)]
@@ -47,7 +47,7 @@ layer at (104,444) size 35x71
   RenderBlock {DIV} at (96,0) size 35x71 [border: (3px solid #C0C0C0) (1px solid #C0C0C0) (4px solid #C0C0C0) (2px solid #C0C0C0)]
     RenderMultiColumnSet at (2,3) size 32x64
 layer at (106,447) size 96x64
-  RenderMultiColumnFlowThread at (2,3) size 96x64
+  RenderMultiColumnFlow at (2,3) size 96x64
     RenderBlock {DIV} at (0,0) size 24x64 [bgcolor=#770077] [border: (2px dotted #FFFFFF) none (4px dotted #000000)]
     RenderBlock {DIV} at (24,0) size 24x64 [bgcolor=#0000FF] [border: (2px dotted #FFFFFF) none (4px dotted #000000)]
     RenderBlock {DIV} at (48,0) size 24x64 [bgcolor=#00BBFF] [border: (2px dotted #FFFFFF) none (4px dotted #000000)]
@@ -56,7 +56,7 @@ layer at (8,563) size 35x71
   RenderBlock {DIV} at (0,119) size 35x71 [border: (3px solid #C0C0C0) (1px solid #C0C0C0) (4px solid #C0C0C0) (2px solid #C0C0C0)]
     RenderMultiColumnSet at (2,3) size 32x64
 layer at (10,566) size 96x30
-  RenderMultiColumnFlowThread at (2,3) size 96x30
+  RenderMultiColumnFlow at (2,3) size 96x30
     RenderBlock {DIV} at (0,0) size 24x30 [bgcolor=#770077] [border: (2px dotted #FFFFFF) none (4px dotted #000000)]
     RenderBlock {DIV} at (24,0) size 24x30 [bgcolor=#0000FF] [border: (2px dotted #FFFFFF) none (4px dotted #000000)]
     RenderBlock {DIV} at (48,0) size 24x30 [bgcolor=#00BBFF] [border: (2px dotted #FFFFFF) none (4px dotted #000000)]
@@ -65,7 +65,7 @@ layer at (24,650) size 35x71
   RenderBlock {DIV} at (16,0) size 35x71 [border: (3px solid #C0C0C0) (2px solid #C0C0C0) (4px solid #C0C0C0) (1px solid #C0C0C0)]
     RenderMultiColumnSet at (2,3) size 32x64
 layer at (-39,653) size 96x64 backgroundClip at (0,0) size 785x856 clip at (0,0) size 785x856
-  RenderMultiColumnFlowThread at (2,3) size 96x64
+  RenderMultiColumnFlow at (2,3) size 96x64
     RenderBlock {DIV} at (0,0) size 24x64 [bgcolor=#770077] [border: (2px dotted #FFFFFF) (4px dotted #000000) none]
     RenderBlock {DIV} at (24,0) size 24x64 [bgcolor=#0000FF] [border: (2px dotted #FFFFFF) (4px dotted #000000) none]
     RenderBlock {DIV} at (48,0) size 24x64 [bgcolor=#00BBFF] [border: (2px dotted #FFFFFF) (4px dotted #000000) none]
@@ -74,7 +74,7 @@ layer at (8,769) size 35x71
   RenderBlock {DIV} at (0,119) size 35x71 [border: (3px solid #C0C0C0) (2px solid #C0C0C0) (4px solid #C0C0C0) (1px solid #C0C0C0)]
     RenderMultiColumnSet at (2,3) size 32x64
 layer at (-55,772) size 96x30 backgroundClip at (0,0) size 785x856 clip at (0,0) size 785x856
-  RenderMultiColumnFlowThread at (2,3) size 96x30
+  RenderMultiColumnFlow at (2,3) size 96x30
     RenderBlock {DIV} at (0,0) size 24x30 [bgcolor=#770077] [border: (2px dotted #FFFFFF) (4px dotted #000000) none]
     RenderBlock {DIV} at (24,0) size 24x30 [bgcolor=#0000FF] [border: (2px dotted #FFFFFF) (4px dotted #000000) none]
     RenderBlock {DIV} at (48,0) size 24x30 [bgcolor=#00BBFF] [border: (2px dotted #FFFFFF) (4px dotted #000000) none]

--- a/LayoutTests/fast/multicol/span/before-child-anonymous-column-block-expected.txt
+++ b/LayoutTests/fast/multicol/span/before-child-anonymous-column-block-expected.txt
@@ -8,7 +8,7 @@ layer at (16,16) size 768x20
     RenderBlock {DIV} at (0,0) size 768x0
     RenderMultiColumnSet at (0,0) size 768x20
 layer at (16,16) size 374x40
-  RenderMultiColumnFlowThread at (0,0) size 374x40
+  RenderMultiColumnFlow at (0,0) size 374x40
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (0,0) size 374x20
       RenderText {#text} at (0,0) size 20x20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/change-abspos-width-in-second-column-crash-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/change-abspos-width-in-second-column-crash-expected.txt
@@ -10,7 +10,7 @@ layer at (8,50) size 784x100
   RenderBlock {DIV} at (0,34) size 784x100
     RenderMultiColumnSet at (0,0) size 784x100
 layer at (8,50) size 384x150
-  RenderMultiColumnFlowThread at (0,0) size 384x150
+  RenderMultiColumnFlow at (0,0) size 384x150
 layer at (8,50) size 384x150
   RenderBlock (relative positioned) {DIV} at (0,0) size 384x150
     RenderBlock {DIV} at (0,0) size 384x150

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/change-out-of-flow-type-and-remove-inner-multicol-crash-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/change-out-of-flow-type-and-remove-inner-multicol-crash-expected.txt
@@ -8,7 +8,7 @@ layer at (8,8) size 784x25
     RenderBlock {DIV} at (0,25) size 784x0
     RenderMultiColumnSet at (0,25) size 784x0
 layer at (8,8) size 384x50
-  RenderMultiColumnFlowThread at (0,0) size 384x50
+  RenderMultiColumnFlow at (0,0) size 384x50
     RenderBlock {P} at (0,16) size 384x18
       RenderText {#text} at (0,0) size 113x18
         text run at (0,0) width 113: "PASS if no crash."

--- a/LayoutTests/platform/glib/css3/unicode-bidi-isolate-basic-expected.txt
+++ b/LayoutTests/platform/glib/css3/unicode-bidi-isolate-basic-expected.txt
@@ -14,7 +14,7 @@ layer at (8,62) size 27x400
   RenderBlock (positioned) {DIV} at (0,0) size 27x400 [color=#FF0000]
     RenderMultiColumnSet at (0,0) size 27x400
 layer at (8,62) size 27x1960 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 27x1960
+  RenderMultiColumnFlow at (0,0) size 27x1960
     RenderBlock {DIV} at (0,0) size 27x18
       RenderText {#text} at (0,0) size 7x18
         text run at (0,0) width 7: "\""
@@ -883,7 +883,7 @@ layer at (8,62) size 27x400
   RenderBlock (positioned) {DIV} at (0,0) size 27x400 [color=#008000]
     RenderMultiColumnSet at (0,0) size 27x400
 layer at (8,62) size 27x1960 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 27x1960
+  RenderMultiColumnFlow at (0,0) size 27x1960
     RenderBlock {DIV} at (0,0) size 27x18
       RenderText {#text} at (0,0) size 7x18
         text run at (0,0) width 7: "\""

--- a/LayoutTests/platform/glib/fast/borders/border-antialiasing-expected.txt
+++ b/LayoutTests/platform/glib/fast/borders/border-antialiasing-expected.txt
@@ -165,7 +165,7 @@ layer at (28,179) size 600x100
   RenderBlock {DIV} at (10,159) size 600x100
     RenderMultiColumnSet at (0,0) size 600x100
 layer at (28,179) size 11x1190 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 11x1190
+  RenderMultiColumnFlow at (0,0) size 11x1190
     RenderText {#text} at (0,0) size 8x1190
       text run at (0,0) width 8: "_"
       text run at (0,18) width 8: "_"

--- a/LayoutTests/platform/glib/fast/line-grid/line-grid-inside-columns-expected.txt
+++ b/LayoutTests/platform/glib/fast/line-grid/line-grid-inside-columns-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x504
   RenderBlock {DIV} at (0,0) size 784x504 [border: (2px solid #FF0000)]
     RenderMultiColumnSet at (2,2) size 780x500
 layer at (10,10) size 382x1538 backgroundClip at (0,0) size 1586x585 clip at (0,0) size 1586x585
-  RenderMultiColumnFlowThread at (2,2) size 382x1538
+  RenderMultiColumnFlow at (2,2) size 382x1538
     RenderBlock {DIV} at (0,0) size 382x1538
       RenderBlock {DIV} at (0,0) size 382x373
         RenderText {#text} at (0,19) size 352x101

--- a/LayoutTests/platform/glib/fast/line-grid/line-grid-into-columns-expected.txt
+++ b/LayoutTests/platform/glib/fast/line-grid/line-grid-into-columns-expected.txt
@@ -51,7 +51,7 @@ layer at (0,0) size 800x540
   RenderBlock {DIV} at (0,0) size 800x540
     RenderMultiColumnSet at (20,20) size 760x500
 layer at (20,20) size 362x977 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (20,20) size 362x977
+  RenderMultiColumnFlow at (20,20) size 362x977
     RenderBlock {DIV} at (0,0) size 362x395
       RenderText {#text} at (0,41) size 352x101
         text run at (0,41) width 350: "All of this text even though it's smaller should be on the"

--- a/LayoutTests/platform/glib/fast/multicol/block-axis-horizontal-bt-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/block-axis-horizontal-bt-expected.txt
@@ -7,7 +7,7 @@ layer at (20,360) size 200x170
   RenderBlock {DIV} at (20,0) size 200x170 [border: none (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (0,20) size 200x150
 layer at (20,66) size 200x444
-  RenderMultiColumnFlowThread at (0,20) size 200x444
+  RenderMultiColumnFlow at (0,20) size 200x444
     RenderText {#text} at (0,0) size 185x90
       text run at (0,0) width 177: "Lorem ipsum dolor sit amet,"
       text run at (0,18) width 75: "consectetur "

--- a/LayoutTests/platform/glib/fast/multicol/block-axis-horizontal-tb-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/block-axis-horizontal-tb-expected.txt
@@ -7,7 +7,7 @@ layer at (20,0) size 200x170
   RenderBlock {DIV} at (20,0) size 200x170 [border: (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (0,20) size 200x150
 layer at (20,20) size 200x444
-  RenderMultiColumnFlowThread at (0,20) size 200x444
+  RenderMultiColumnFlow at (0,20) size 200x444
     RenderText {#text} at (0,0) size 185x90
       text run at (0,0) width 177: "Lorem ipsum dolor sit amet,"
       text run at (0,18) width 75: "consectetur "

--- a/LayoutTests/platform/glib/fast/multicol/block-axis-vertical-lr-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/block-axis-vertical-lr-expected.txt
@@ -7,7 +7,7 @@ layer at (0,20) size 170x200
   RenderBlock {DIV} at (0,0) size 170x200 [border: none (20px solid #C0C0C0)]
     RenderMultiColumnSet at (20,0) size 150x200
 layer at (20,20) size 444x200
-  RenderMultiColumnFlowThread at (20,0) size 444x200
+  RenderMultiColumnFlow at (20,0) size 444x200
     RenderText {#text} at (0,0) size 90x185
       text run at (0,0) width 178: "Lorem ipsum dolor sit amet,"
       text run at (18,0) width 76: "consectetur "

--- a/LayoutTests/platform/glib/fast/multicol/block-axis-vertical-rl-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/block-axis-vertical-rl-expected.txt
@@ -7,7 +7,7 @@ layer at (360,20) size 170x200
   RenderBlock {DIV} at (360,0) size 170x200 [border: none (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (20,0) size 150x200
 layer at (66,20) size 444x200
-  RenderMultiColumnFlowThread at (20,0) size 444x200
+  RenderMultiColumnFlow at (20,0) size 444x200
     RenderText {#text} at (0,0) size 90x185
       text run at (0,0) width 178: "Lorem ipsum dolor sit amet,"
       text run at (18,0) width 76: "consectetur "

--- a/LayoutTests/platform/glib/fast/multicol/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x160
   RenderBlock {DIV} at (0,0) size 784x160 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 780x156
 layer at (10,10) size 382x312
-  RenderMultiColumnFlowThread at (2,2) size 382x312
+  RenderMultiColumnFlow at (2,2) size 382x312
     RenderBlock {DIV} at (0,0) size 382x110
     RenderBlock {DIV} at (0,156) size 379x156 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (12,2) size 355x152 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/glib/fast/multicol/client-rects-spanners-complex-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/client-rects-spanners-complex-expected.txt
@@ -63,7 +63,7 @@ layer at (8,63) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (16,71) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x105
@@ -78,7 +78,7 @@ layer at (128,63) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (136,71) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x105
@@ -95,7 +95,7 @@ layer at (248,63) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (256,71) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -111,7 +111,7 @@ layer at (368,63) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (376,71) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -127,7 +127,7 @@ layer at (488,81) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (496,89) size 48x94
-  RenderMultiColumnFlowThread at (8,8) size 48x94
+  RenderMultiColumnFlow at (8,8) size 48x94
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -144,7 +144,7 @@ layer at (608,83) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (616,91) size 48x90
-  RenderMultiColumnFlowThread at (8,8) size 48x90
+  RenderMultiColumnFlow at (8,8) size 48x90
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -158,7 +158,7 @@ layer at (8,209) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (16,217) size 48x75
-  RenderMultiColumnFlowThread at (8,8) size 48x75
+  RenderMultiColumnFlow at (8,8) size 48x75
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock {DIV} at (0,50) size 25x25 [bgcolor=#ADD8E6]
@@ -168,7 +168,7 @@ layer at (138,209) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (146,217) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -183,7 +183,7 @@ layer at (268,209) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (276,217) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -200,7 +200,7 @@ layer at (398,209) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (406,217) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -216,7 +216,7 @@ layer at (528,209) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (536,217) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -232,7 +232,7 @@ layer at (658,209) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (666,217) size 94x48
-  RenderMultiColumnFlowThread at (8,8) size 94x48
+  RenderMultiColumnFlow at (8,8) size 94x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -249,7 +249,7 @@ layer at (18,328) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (26,336) size 90x48
-  RenderMultiColumnFlowThread at (8,8) size 90x48
+  RenderMultiColumnFlow at (8,8) size 90x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -263,7 +263,7 @@ layer at (148,328) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (156,336) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock {DIV} at (50,0) size 25x25 [bgcolor=#ADD8E6]
@@ -273,7 +273,7 @@ layer at (278,328) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (261,336) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -288,7 +288,7 @@ layer at (408,328) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (391,336) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -305,7 +305,7 @@ layer at (538,328) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (521,336) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -321,7 +321,7 @@ layer at (668,328) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (651,336) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -337,7 +337,7 @@ layer at (18,448) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (22,456) size 94x48
-  RenderMultiColumnFlowThread at (8,8) size 94x48
+  RenderMultiColumnFlow at (8,8) size 94x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -354,7 +354,7 @@ layer at (148,448) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (156,456) size 90x48
-  RenderMultiColumnFlowThread at (8,8) size 90x48
+  RenderMultiColumnFlow at (8,8) size 90x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -368,7 +368,7 @@ layer at (278,448) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (301,456) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock {DIV} at (50,0) size 25x25 [bgcolor=#ADD8E6]

--- a/LayoutTests/platform/glib/fast/multicol/client-rects-spanners-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/client-rects-spanners-expected.txt
@@ -62,7 +62,7 @@ layer at (8,63) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (16,71) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x100
       RenderBR {BR} at (0,0) size 0x25
@@ -75,7 +75,7 @@ layer at (128,63) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (136,71) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x100
       RenderBR {BR} at (0,0) size 0x25
@@ -90,7 +90,7 @@ layer at (248,63) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (256,71) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -104,7 +104,7 @@ layer at (368,63) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (376,71) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -118,7 +118,7 @@ layer at (488,81) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (496,89) size 48x79
-  RenderMultiColumnFlowThread at (8,8) size 48x79
+  RenderMultiColumnFlow at (8,8) size 48x79
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -133,7 +133,7 @@ layer at (608,83) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (616,91) size 48x75
-  RenderMultiColumnFlowThread at (8,8) size 48x75
+  RenderMultiColumnFlow at (8,8) size 48x75
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -145,7 +145,7 @@ layer at (8,199) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (16,207) size 48x65
-  RenderMultiColumnFlowThread at (8,8) size 48x65
+  RenderMultiColumnFlow at (8,8) size 48x65
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (0,40) size 25x25 [bgcolor=#ADD8E6]
 layer at (138,169) size 76x116
@@ -153,7 +153,7 @@ layer at (138,169) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (146,177) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -166,7 +166,7 @@ layer at (238,169) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (246,177) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -181,7 +181,7 @@ layer at (338,169) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (346,177) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -195,7 +195,7 @@ layer at (438,169) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (446,177) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -209,7 +209,7 @@ layer at (538,169) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (546,177) size 79x48
-  RenderMultiColumnFlowThread at (8,8) size 79x48
+  RenderMultiColumnFlow at (8,8) size 79x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -224,7 +224,7 @@ layer at (638,169) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (646,177) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -236,7 +236,7 @@ layer at (18,289) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (26,297) size 65x48
-  RenderMultiColumnFlowThread at (8,8) size 65x48
+  RenderMultiColumnFlow at (8,8) size 65x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (40,0) size 25x25 [bgcolor=#ADD8E6]
 layer at (118,289) size 76x116
@@ -244,7 +244,7 @@ layer at (118,289) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (86,297) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -257,7 +257,7 @@ layer at (218,289) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (186,297) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -272,7 +272,7 @@ layer at (318,289) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (286,297) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -286,7 +286,7 @@ layer at (418,289) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (386,297) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -300,7 +300,7 @@ layer at (518,289) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (507,297) size 79x48
-  RenderMultiColumnFlowThread at (8,8) size 79x48
+  RenderMultiColumnFlow at (8,8) size 79x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -315,7 +315,7 @@ layer at (618,289) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (611,297) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -327,7 +327,7 @@ layer at (18,408) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (21,416) size 65x48
-  RenderMultiColumnFlowThread at (8,8) size 65x48
+  RenderMultiColumnFlow at (8,8) size 65x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (40,0) size 25x25 [bgcolor=#ADD8E6]
 layer at (16,106) size 25x25

--- a/LayoutTests/platform/glib/fast/multicol/column-rules-stacking-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/column-rules-stacking-expected.txt
@@ -15,7 +15,7 @@ layer at (8,44) size 769x586 layerType: foreground only
   RenderBlock (relative positioned) {DIV} at (0,36) size 769x586 [bgcolor=#FF0000] [border: (5px solid #000000)]
     RenderMultiColumnSet at (35,5) size 699x576
 layer at (43,49) size 222x1692 backgroundClip at (0,0) size 785x638 clip at (0,0) size 785x638
-  RenderMultiColumnFlowThread at (35,5) size 223x1692
+  RenderMultiColumnFlow at (35,5) size 223x1692
     RenderText {#text} at (0,0) size 223x1692
       text run at (0,0) width 177: "Lorem ipsum dolor sit amet,"
       text run at (0,18) width 212: "consectetuer adipiscing elit. Nulla"

--- a/LayoutTests/platform/glib/fast/multicol/columns-shorthand-parsing-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/columns-shorthand-parsing-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 769x648
   RenderBlock {DIV} at (0,0) size 769x648
     RenderMultiColumnSet at (0,0) size 769x648
 layer at (8,8) size 377x1296 backgroundClip at (0,0) size 785x664 clip at (0,0) size 785x664
-  RenderMultiColumnFlowThread at (0,0) size 377x1296
+  RenderMultiColumnFlow at (0,0) size 377x1296
     RenderText {#text} at (0,0) size 376x1296
       text run at (0,0) width 372: "This content should be split into two columns. This content"
       text run at (0,18) width 355: "should be split into two columns. This content should be"

--- a/LayoutTests/platform/glib/fast/multicol/float-paginate-empty-lines-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/float-paginate-empty-lines-expected.txt
@@ -12,7 +12,7 @@ layer at (8,78) size 784x400
   RenderBlock {DIV} at (0,70) size 784x400
     RenderMultiColumnSet at (0,0) size 784x400
 layer at (8,78) size 384x600 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 384x600
+  RenderMultiColumnFlow at (0,0) size 384x600
     RenderBlock {DIV} at (0,0) size 384x236 [border: (10px dashed #800000)]
       RenderText {#text} at (10,10) size 110x18
         text run at (10,10) width 110: "This is some text."

--- a/LayoutTests/platform/glib/fast/multicol/max-height-columns-block-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/max-height-columns-block-expected.txt
@@ -17,7 +17,7 @@ layer at (8,80) size 404x64
   RenderBlock {DIV} at (0,72) size 404x64 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x60
 layer at (10,82) size 61x594 backgroundClip at (0,0) size 834x585 clip at (0,0) size 834x585
-  RenderMultiColumnFlowThread at (2,2) size 61x594
+  RenderMultiColumnFlow at (2,2) size 61x594
     RenderText {#text} at (0,0) size 51x114
       text run at (0,0) width 43: "This"
       text run at (0,27) width 16: "is"

--- a/LayoutTests/platform/glib/fast/multicol/overflow-across-columns-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/overflow-across-columns-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 506x505
   RenderBlock {DIV} at (0,0) size 506x505 [border: (3px solid #000000)]
     RenderMultiColumnSet at (3,3) size 500x499
 layer at (11,11) size 159x1454 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (3,3) size 159x1454
+  RenderMultiColumnFlow at (3,3) size 159x1454
 layer at (11,11) size 159x1454 backgroundClip at (11,11) size 159x589 clip at (11,11) size 159x589
   RenderBlock {DIV} at (0,0) size 159x1454
     RenderText {#text} at (0,5) size 159x1444

--- a/LayoutTests/platform/glib/fast/multicol/overflow-across-columns-percent-height-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/overflow-across-columns-percent-height-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 506x505
   RenderBlock {DIV} at (0,0) size 506x505 [border: (3px solid #000000)]
     RenderMultiColumnSet at (3,3) size 500x499
 layer at (11,11) size 159x1454 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (3,3) size 159x1454
+  RenderMultiColumnFlow at (3,3) size 159x1454
     RenderBlock {DIV} at (0,0) size 159x1454
 layer at (11,11) size 159x1454 backgroundClip at (11,11) size 159x589 clip at (11,11) size 159x589
   RenderBlock {DIV} at (0,0) size 159x1454

--- a/LayoutTests/platform/glib/fast/multicol/paginate-block-replaced-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/paginate-block-replaced-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x404
   RenderBlock {DIV} at (0,0) size 784x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 780x400
 layer at (10,10) size 382x1254 backgroundClip at (0,0) size 1586x585 clip at (0,0) size 1586x585
-  RenderMultiColumnFlowThread at (2,2) size 382x1254
+  RenderMultiColumnFlow at (2,2) size 382x1254
     RenderBlock (anonymous) at (0,0) size 382x180
       RenderText {#text} at (0,0) size 110x18
         text run at (0,0) width 110: "This is some text."

--- a/LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-bt-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1580
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,-668) size 785x1268 backgroundClip at (0,0) size 785x1580 clip at (0,0) size 785x1580
-  RenderMultiColumnFlowThread at (0,0) size 785x1268
+  RenderMultiColumnFlow at (0,0) size 785x1268
 layer at (0,-668) size 785x1268 backgroundClip at (0,0) size 785x1580 clip at (0,0) size 785x1580
   RenderBlock {HTML} at (0,0) size 785x1268
     RenderBody {BODY} at (8,8) size 769x1244

--- a/LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-lr-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 3444x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 3444x180
+  RenderMultiColumnFlow at (0,0) size 3444x180
 layer at (0,0) size 3444x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 3444x180
     RenderBody {BODY} at (8,8) size 3420x164

--- a/LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-rl-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (-2659,0) size 3444x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 3444x180
+  RenderMultiColumnFlow at (0,0) size 3444x180
 layer at (-2659,0) size 3444x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 3444x180
     RenderBody {BODY} at (8,8) size 3420x164

--- a/LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-tb-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x1268 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 785x1268
+  RenderMultiColumnFlow at (0,0) size 785x1268
 layer at (0,0) size 785x1268 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 785x1268
     RenderBody {BODY} at (8,8) size 769x1244

--- a/LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-bt-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1180x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,-2870) size 180x3455 backgroundClip at (0,0) size 1180x585 clip at (0,0) size 1180x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3455
+  RenderMultiColumnFlow at (0,0) size 180x3455
 layer at (0,-2870) size 180x3455 backgroundClip at (0,0) size 1180x585 clip at (0,0) size 1180x585
   RenderBlock {HTML} at (0,0) size 180x3455
     RenderBody {BODY} at (8,8) size 164x3431

--- a/LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-lr-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1780x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 1564x585
-  RenderMultiColumnFlowThread at (0,0) size 1564x585
+  RenderMultiColumnFlow at (0,0) size 1564x585
 layer at (0,0) size 1564x585
   RenderBlock {HTML} at (0,0) size 1564x585
     RenderBody {BODY} at (8,8) size 1540x569

--- a/LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-rl-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 1564x585
+  RenderMultiColumnFlow at (0,0) size 1564x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 1564x585
     RenderBody {BODY} at (8,8) size 1540x569

--- a/LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-tb-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1180x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 180x3455 backgroundClip at (0,0) size 1180x585 clip at (0,0) size 1180x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3455
+  RenderMultiColumnFlow at (0,0) size 180x3455
 layer at (0,0) size 180x3455 backgroundClip at (0,0) size 1180x585 clip at (0,0) size 1180x585
   RenderBlock {HTML} at (0,0) size 180x3455
     RenderBody {BODY} at (8,8) size 164x3431

--- a/LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-bt-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,-2870) size 180x3455 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3455
+  RenderMultiColumnFlow at (0,0) size 180x3455
 layer at (0,-2870) size 180x3455 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 180x3455
     RenderBody {BODY} at (8,8) size 164x3431

--- a/LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-lr-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 1564x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 1564x585
+  RenderMultiColumnFlow at (0,0) size 1564x585
 layer at (0,0) size 1564x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 1564x585
     RenderBody {BODY} at (8,8) size 1540x569

--- a/LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1780x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
-  RenderMultiColumnFlowThread at (0,0) size 1564x585
+  RenderMultiColumnFlow at (0,0) size 1564x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
   RenderBlock {HTML} at (0,0) size 1564x585
     RenderBody {BODY} at (8,8) size 1540x569

--- a/LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-rl-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1780x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
-  RenderMultiColumnFlowThread at (0,0) size 1564x585
+  RenderMultiColumnFlow at (0,0) size 1564x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
   RenderBlock {HTML} at (0,0) size 1564x585
     RenderBody {BODY} at (8,8) size 1540x569

--- a/LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-tb-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 180x3455 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3455
+  RenderMultiColumnFlow at (0,0) size 180x3455
 layer at (0,0) size 180x3455 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 180x3455
     RenderBody {BODY} at (8,8) size 164x3431

--- a/LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-bt-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,-668) size 785x1268 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 785x1268
+  RenderMultiColumnFlow at (0,0) size 785x1268
 layer at (0,-668) size 785x1268 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 785x1268
     RenderBody {BODY} at (8,8) size 769x1244

--- a/LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-lr-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x980
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 3444x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
-  RenderMultiColumnFlowThread at (0,0) size 3444x180
+  RenderMultiColumnFlow at (0,0) size 3444x180
 layer at (0,0) size 3444x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
   RenderBlock {HTML} at (0,0) size 3444x180
     RenderBody {BODY} at (8,8) size 3420x164

--- a/LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-rl-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x980
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (-2659,0) size 3444x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
-  RenderMultiColumnFlowThread at (0,0) size 3444x180
+  RenderMultiColumnFlow at (0,0) size 3444x180
 layer at (-2659,0) size 3444x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
   RenderBlock {HTML} at (0,0) size 3444x180
     RenderBody {BODY} at (8,8) size 3420x164

--- a/LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-tb-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1580
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x1268
-  RenderMultiColumnFlowThread at (0,0) size 785x1268
+  RenderMultiColumnFlow at (0,0) size 785x1268
 layer at (0,0) size 785x1268
   RenderBlock {HTML} at (0,0) size 785x1268
     RenderBody {BODY} at (8,8) size 769x1244

--- a/LayoutTests/platform/glib/fast/multicol/pagination/nested-transforms-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/pagination/nested-transforms-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 180x600
-  RenderMultiColumnFlowThread at (0,0) size 180x600
+  RenderMultiColumnFlow at (0,0) size 180x600
 layer at (0,0) size 180x600
   RenderBlock {HTML} at (0,0) size 180x600
     RenderBody {BODY} at (8,8) size 164x584

--- a/LayoutTests/platform/glib/fast/multicol/scrolling-column-rules-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/scrolling-column-rules-expected.txt
@@ -15,5 +15,5 @@ layer at (8,50) size 784x100 scrollX 200 scrollWidth 2572
   RenderBlock {DIV} at (0,34) size 784x100
     RenderMultiColumnSet at (0,0) size 784x100
 layer at (-192,50) size 337x600 backgroundClip at (8,50) size 784x100 clip at (8,50) size 784x100
-  RenderMultiColumnFlowThread at (0,0) size 337x600
+  RenderMultiColumnFlow at (0,0) size 337x600
     RenderBlock {DIV} at (0,0) size 337x600 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/glib/fast/multicol/scrolling-overflow-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/scrolling-overflow-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x300
   RenderBlock {DIV} at (0,0) size 784x300
     RenderMultiColumnSet at (0,0) size 784x300
 layer at (8,8) size 251x5242 backgroundClip at (0,0) size 4792x585 clip at (0,0) size 4792x585
-  RenderMultiColumnFlowThread at (0,0) size 251x5242
+  RenderMultiColumnFlow at (0,0) size 251x5242
     RenderBlock {P} at (0,16) size 251x554
       RenderText {#text} at (0,0) size 250x554
         text run at (0,0) width 177: "Lorem ipsum dolor sit amet,"

--- a/LayoutTests/platform/glib/fast/multicol/shadow-breaking-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/shadow-breaking-expected.txt
@@ -8,7 +8,7 @@ layer at (20,36) size 424x265
   RenderBlock (positioned) {P} at (20,36) size 424x265 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 420x261
 layer at (22,38) size 200x508
-  RenderMultiColumnFlowThread at (2,2) size 200x508
+  RenderMultiColumnFlow at (2,2) size 200x508
     RenderBlock (floating) at (0,0) size 24x42
       RenderText at (0,1) size 24x40
         text run at (0,1) width 24: "L"

--- a/LayoutTests/platform/glib/fast/multicol/shrink-to-column-height-for-pagination-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/shrink-to-column-height-for-pagination-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (384,0) size 416x600
-  RenderMultiColumnFlowThread at (0,0) size 416x600
+  RenderMultiColumnFlow at (0,0) size 416x600
 layer at (384,0) size 416x600
   RenderBlock {HTML} at (0,0) size 416x600
     RenderBody {BODY} at (8,8) size 400x600

--- a/LayoutTests/platform/glib/fast/multicol/span/anonymous-style-inheritance-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/anonymous-style-inheritance-expected.txt
@@ -10,7 +10,7 @@ layer at (8,18) size 835x463
         text run at (0,0) width 740: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,79) size 825x379
 layer at (13,23) size 404x756 backgroundClip at (0,0) size 843x585 clip at (0,0) size 843x585
-  RenderMultiColumnFlowThread at (5,5) size 404x756
+  RenderMultiColumnFlow at (5,5) size 404x756
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 404x756
       RenderText {#text} at (0,0) size 403x756

--- a/LayoutTests/platform/glib/fast/multicol/span/clone-flexbox-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/clone-flexbox-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x16
   RenderBlock {DIV} at (0,0) size 784x16
     RenderMultiColumnSet at (0,0) size 784x16
 layer at (8,8) size 117x16
-  RenderMultiColumnFlowThread at (0,0) size 118x16
+  RenderMultiColumnFlow at (0,0) size 118x16
     RenderFlexibleBox {DIV} at (0,0) size 118x16 [color=#FFFFFF]
       RenderBlock (anonymous) at (0,0) size 16x16
         RenderText {#text} at (0,0) size 16x16

--- a/LayoutTests/platform/glib/fast/multicol/span/clone-summary-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/clone-summary-expected.txt
@@ -9,7 +9,7 @@ layer at (8,8) size 784x32
     RenderBlock {DIV} at (0,16) size 784x0 [color=#FFFFFF]
     RenderMultiColumnSet at (0,16) size 784x16
 layer at (8,8) size 117x32
-  RenderMultiColumnFlowThread at (0,0) size 118x32
+  RenderMultiColumnFlow at (0,0) size 118x32
     RenderTable at (0,0) size 16x32
       RenderTableSection (anonymous) at (0,0) size 16x32
         RenderTableRow {SUMMARY} at (0,0) size 16x32 [color=#FFFFFF]

--- a/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt
@@ -15,7 +15,7 @@ layer at (8,16) size 760x486
         text run at (0,0) width 219: "This is a second span."
     RenderMultiColumnSet at (5,354) size 750x127
 layer at (13,21) size 367x666
-  RenderMultiColumnFlowThread at (5,5) size 367x666
+  RenderMultiColumnFlow at (5,5) size 367x666
     RenderBlock (anonymous) at (0,0) size 367x396
       RenderText {#text} at (0,0) size 363x396
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -75,7 +75,7 @@ layer at (8,518) size 760x499
         text run at (0,0) width 219: "This is a second span."
     RenderMultiColumnSet at (5,368) size 750x127
 layer at (13,523) size 367x694
-  RenderMultiColumnFlowThread at (5,5) size 367x694
+  RenderMultiColumnFlow at (5,5) size 367x694
     RenderBlock {P} at (0,16) size 367x207
       RenderText {#text} at (0,0) size 362x207
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -132,7 +132,7 @@ layer at (8,1033) size 760x493
         text run at (0,0) width 219: "This is a second span."
     RenderMultiColumnSet at (5,361) size 750x127
 layer at (13,1038) size 367x662 backgroundClip at (0,0) size 785x1542 clip at (0,0) size 785x1542
-  RenderMultiColumnFlowThread at (5,5) size 367x662
+  RenderMultiColumnFlow at (5,5) size 367x662
     RenderBlock (anonymous) at (0,0) size 367x198
       RenderInline {SPAN} at (0,0) size 367x198
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x419
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,89) size 750x325
 layer at (13,21) size 367x650
-  RenderMultiColumnFlowThread at (5,5) size 367x650
+  RenderMultiColumnFlow at (5,5) size 367x650
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 166x18
         text run at (0,0) width 166: "Before Generated Content"
@@ -65,7 +65,7 @@ layer at (8,451) size 760x419
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,395) size 750x19
 layer at (13,456) size 367x650
-  RenderMultiColumnFlowThread at (5,5) size 367x650
+  RenderMultiColumnFlow at (5,5) size 367x650
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 166x18
         text run at (0,0) width 166: "Before Generated Content"
@@ -119,7 +119,7 @@ layer at (8,886) size 760x450
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,213) size 750x233
 layer at (13,891) size 367x732
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 166x18
         text run at (0,0) width 166: "Before Generated Content"
@@ -176,7 +176,7 @@ layer at (8,1352) size 760x435
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,197) size 750x233
 layer at (13,1357) size 367x700
-  RenderMultiColumnFlowThread at (5,5) size 367x700
+  RenderMultiColumnFlow at (5,5) size 367x700
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 166x18
         text run at (0,0) width 166: "Before Generated Content"
@@ -237,7 +237,7 @@ layer at (8,1803) size 760x437
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,305) size 750x127
 layer at (13,1808) size 367x702
-  RenderMultiColumnFlowThread at (5,5) size 367x702
+  RenderMultiColumnFlow at (5,5) size 367x702
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 166x18
         text run at (0,0) width 166: "Before Generated Content"
@@ -298,7 +298,7 @@ layer at (8,2256) size 760x460
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,328) size 750x127
 layer at (13,2261) size 367x750 backgroundClip at (0,0) size 785x2732 clip at (0,0) size 785x2732
-  RenderMultiColumnFlowThread at (5,5) size 367x750
+  RenderMultiColumnFlow at (5,5) size 367x750
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 166x18
         text run at (0,0) width 166: "Before Generated Content"

--- a/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt
@@ -12,7 +12,7 @@ layer at (8,60) size 760x352
   RenderBlock {DIV} at (0,52) size 760x352 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x342
 layer at (13,65) size 367x684
-  RenderMultiColumnFlowThread at (5,5) size 367x684
+  RenderMultiColumnFlow at (5,5) size 367x684
     RenderBlock {H2} at (0,19) size 367x28 [bgcolor=#EEEEEE]
       RenderText {#text} at (0,0) size 276x27
         text run at (0,0) width 276: "This is a spanning element."
@@ -58,7 +58,7 @@ layer at (8,428) size 760x352
   RenderBlock {DIV} at (0,420) size 760x352 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x342
 layer at (13,433) size 367x679
-  RenderMultiColumnFlowThread at (5,5) size 367x679
+  RenderMultiColumnFlow at (5,5) size 367x679
     RenderBlock (anonymous) at (0,0) size 367x612
       RenderText {#text} at (0,0) size 363x612
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -104,7 +104,7 @@ layer at (8,796) size 760x381
   RenderBlock {DIV} at (0,788) size 760x381 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x371
 layer at (13,801) size 367x729
-  RenderMultiColumnFlowThread at (5,5) size 367x729
+  RenderMultiColumnFlow at (5,5) size 367x729
     RenderBlock {P} at (0,16) size 367x234
       RenderText {#text} at (0,0) size 363x234
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -153,7 +153,7 @@ layer at (8,1193) size 760x383
   RenderBlock {DIV} at (0,1184) size 760x384 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x373
 layer at (13,1198) size 367x729
-  RenderMultiColumnFlowThread at (5,5) size 367x729
+  RenderMultiColumnFlow at (5,5) size 367x729
     RenderBlock (anonymous) at (0,0) size 367x234
       RenderText {#text} at (0,0) size 363x234
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -206,7 +206,7 @@ layer at (8,1592) size 760x370
   RenderBlock {DIV} at (0,1583) size 760x371 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x360
 layer at (13,1597) size 367x713
-  RenderMultiColumnFlowThread at (5,5) size 367x713
+  RenderMultiColumnFlow at (5,5) size 367x713
     RenderBlock (anonymous) at (0,0) size 367x432
       RenderInline {SPAN} at (0,0) size 367x252
         RenderText {#text} at (0,0) size 362x198
@@ -259,7 +259,7 @@ layer at (8,1978) size 760x400
   RenderBlock {DIV} at (0,1969) size 760x401 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x390
 layer at (13,1983) size 367x763 backgroundClip at (0,0) size 785x2394 clip at (0,0) size 785x2394
-  RenderMultiColumnFlowThread at (5,5) size 367x763
+  RenderMultiColumnFlow at (5,5) size 367x763
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 362x198
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt
@@ -10,7 +10,7 @@ layer at (8,16) size 760x383
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,71) size 750x307
 layer at (13,21) size 367x612
-  RenderMultiColumnFlowThread at (5,5) size 367x612
+  RenderMultiColumnFlow at (5,5) size 367x612
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x612
       RenderText {#text} at (0,0) size 363x612
@@ -58,7 +58,7 @@ layer at (8,415) size 760x383
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,377) size 750x0
 layer at (13,420) size 367x612
-  RenderMultiColumnFlowThread at (5,5) size 367x612
+  RenderMultiColumnFlow at (5,5) size 367x612
     RenderBlock (anonymous) at (0,0) size 367x612
       RenderText {#text} at (0,0) size 363x612
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -106,7 +106,7 @@ layer at (8,814) size 760x423
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,204) size 750x215
 layer at (13,819) size 367x694
-  RenderMultiColumnFlowThread at (5,5) size 367x694
+  RenderMultiColumnFlow at (5,5) size 367x694
     RenderBlock {P} at (0,16) size 367x243
       RenderText {#text} at (0,0) size 363x243
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -157,7 +157,7 @@ layer at (8,1253) size 760x417
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,197) size 750x215
 layer at (13,1258) size 367x662
-  RenderMultiColumnFlowThread at (5,5) size 367x662
+  RenderMultiColumnFlow at (5,5) size 367x662
     RenderBlock (anonymous) at (0,0) size 367x234
       RenderText {#text} at (0,0) size 363x234
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -212,7 +212,7 @@ layer at (8,1686) size 760x417
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,287) size 750x125
 layer at (13,1691) size 367x662
-  RenderMultiColumnFlowThread at (5,5) size 367x662
+  RenderMultiColumnFlow at (5,5) size 367x662
     RenderBlock (anonymous) at (0,0) size 367x432
       RenderInline {SPAN} at (0,0) size 367x252
         RenderText {#text} at (0,0) size 362x198
@@ -267,7 +267,7 @@ layer at (8,2119) size 760x433
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,319) size 750x109
 layer at (13,2124) size 367x712 backgroundClip at (0,0) size 785x2568 clip at (0,0) size 785x2568
-  RenderMultiColumnFlowThread at (5,5) size 367x712
+  RenderMultiColumnFlow at (5,5) size 367x712
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 362x198
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-columns-child-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-columns-child-expected.txt
@@ -10,7 +10,7 @@ layer at (8,16) size 760x383
         text run at (0,0) width 664: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,71) size 750x307
 layer at (13,21) size 367x612
-  RenderMultiColumnFlowThread at (5,5) size 367x612
+  RenderMultiColumnFlow at (5,5) size 367x612
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x612
       RenderText {#text} at (0,0) size 363x612
@@ -58,7 +58,7 @@ layer at (8,415) size 760x383
         text run at (0,0) width 600: "This is a spanning element at the end of the columns block."
     RenderMultiColumnSet at (5,377) size 750x0
 layer at (13,420) size 367x612
-  RenderMultiColumnFlowThread at (5,5) size 367x612
+  RenderMultiColumnFlow at (5,5) size 367x612
     RenderBlock (anonymous) at (0,0) size 367x612
       RenderText {#text} at (0,0) size 363x612
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -106,7 +106,7 @@ layer at (8,814) size 760x400
         text run at (0,0) width 634: "This is a spanning element in the middle of the columns block."
     RenderMultiColumnSet at (5,197) size 750x199
 layer at (13,819) size 367x630
-  RenderMultiColumnFlowThread at (5,5) size 367x630
+  RenderMultiColumnFlow at (5,5) size 367x630
     RenderBlock (anonymous) at (0,0) size 367x234
       RenderText {#text} at (0,0) size 363x234
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -153,7 +153,7 @@ layer at (8,1230) size 760x361
   RenderBlock {DIV} at (0,1214) size 760x362 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x351
 layer at (13,1235) size 367x693
-  RenderMultiColumnFlowThread at (5,5) size 367x693
+  RenderMultiColumnFlow at (5,5) size 367x693
     RenderText {#text} at (0,0) size 363x241
       text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,18) width 351: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -203,7 +203,7 @@ layer at (8,1607) size 760x383
   RenderBlock {DIV} at (0,1591) size 760x384 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x373
 layer at (13,1612) size 367x733
-  RenderMultiColumnFlowThread at (5,5) size 367x733
+  RenderMultiColumnFlow at (5,5) size 367x733
     RenderText {#text} at (0,0) size 363x234
       text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,18) width 351: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -256,7 +256,7 @@ layer at (8,2006) size 760x442
         text run at (0,27) width 145: "block siblings."
     RenderMultiColumnSet at (5,98) size 750x339
 layer at (13,2011) size 367x658
-  RenderMultiColumnFlowThread at (5,5) size 367x658
+  RenderMultiColumnFlow at (5,5) size 367x658
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 362x198
@@ -306,7 +306,7 @@ layer at (8,2464) size 760x433
         text run at (0,27) width 83: "siblings."
     RenderMultiColumnSet at (5,427) size 750x0
 layer at (13,2469) size 367x658
-  RenderMultiColumnFlowThread at (5,5) size 367x658
+  RenderMultiColumnFlow at (5,5) size 367x658
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 362x198
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -356,7 +356,7 @@ layer at (8,2913) size 760x450
         text run at (0,27) width 83: "siblings."
     RenderMultiColumnSet at (5,320) size 750x125
 layer at (13,2918) size 367x666 backgroundClip at (0,0) size 785x3379 clip at (0,0) size 785x3379
-  RenderMultiColumnFlowThread at (5,5) size 367x666
+  RenderMultiColumnFlow at (5,5) size 367x666
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 362x198
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt
@@ -7,7 +7,7 @@ layer at (8,16) size 760x316
   RenderBlock {DIV} at (0,0) size 760x316 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x306
 layer at (13,21) size 367x612
-  RenderMultiColumnFlowThread at (5,5) size 367x612
+  RenderMultiColumnFlow at (5,5) size 367x612
     RenderText {#text} at (0,0) size 363x612
       text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,18) width 351: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -49,7 +49,7 @@ layer at (8,348) size 760x316
   RenderBlock {DIV} at (0,332) size 760x316 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x306
 layer at (13,353) size 367x612
-  RenderMultiColumnFlowThread at (5,5) size 367x612
+  RenderMultiColumnFlow at (5,5) size 367x612
     RenderText {#text} at (0,0) size 363x612
       text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,18) width 351: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -91,7 +91,7 @@ layer at (8,680) size 760x366
   RenderBlock {DIV} at (0,664) size 760x366 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x356
 layer at (13,685) size 367x678
-  RenderMultiColumnFlowThread at (5,5) size 367x678
+  RenderMultiColumnFlow at (5,5) size 367x678
     RenderBlock {P} at (0,16) size 367x234
       RenderText {#text} at (0,0) size 363x234
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -137,7 +137,7 @@ layer at (8,1062) size 760x334
   RenderBlock {DIV} at (0,1046) size 760x334 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x324
 layer at (13,1067) size 367x644
-  RenderMultiColumnFlowThread at (5,5) size 367x644
+  RenderMultiColumnFlow at (5,5) size 367x644
     RenderBlock (anonymous) at (0,0) size 367x414
       RenderText {#text} at (0,0) size 363x234
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -186,7 +186,7 @@ layer at (8,1412) size 760x352
   RenderBlock {DIV} at (0,1396) size 760x352 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x342
 layer at (13,1417) size 367x662
-  RenderMultiColumnFlowThread at (5,5) size 367x662
+  RenderMultiColumnFlow at (5,5) size 367x662
     RenderBlock (anonymous) at (0,0) size 367x432
       RenderInline {SPAN} at (0,0) size 367x252
         RenderText {#text} at (0,0) size 362x198
@@ -236,7 +236,7 @@ layer at (8,1780) size 760x368
   RenderBlock {DIV} at (0,1764) size 760x368 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x358
 layer at (13,1785) size 367x716 backgroundClip at (0,0) size 785x2164 clip at (0,0) size 785x2164
-  RenderMultiColumnFlowThread at (5,5) size 367x716
+  RenderMultiColumnFlow at (5,5) size 367x716
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 362x198
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/glib/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x407
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,79) size 750x323
 layer at (13,21) size 367x636
-  RenderMultiColumnFlowThread at (5,5) size 367x636
+  RenderMultiColumnFlow at (5,5) size 367x636
     RenderBlock {SPAN} at (0,8) size 367x198 [color=#FFFFFF] [bgcolor=#000000]
       RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
       RenderBlock (anonymous) at (0,0) size 367x198
@@ -66,7 +66,7 @@ layer at (8,439) size 760x407
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,393) size 750x9
 layer at (13,444) size 367x660
-  RenderMultiColumnFlowThread at (5,5) size 367x660
+  RenderMultiColumnFlow at (5,5) size 367x660
     RenderBlock (anonymous) at (0,0) size 367x592
       RenderText {#text} at (0,0) size 363x592
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -117,7 +117,7 @@ layer at (8,862) size 760x440
         text run at (0,0) width 276: "This is a spanning element."
     RenderMultiColumnSet at (5,213) size 750x223
 layer at (13,867) size 367x702 backgroundClip at (0,0) size 785x1318 clip at (0,0) size 785x1318
-  RenderMultiColumnFlowThread at (5,5) size 367x702
+  RenderMultiColumnFlow at (5,5) size 367x702
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 362x198
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/glib/fast/multicol/span/span-as-nested-columns-child-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/span-as-nested-columns-child-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x407
         text run at (0,0) width 664: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,79) size 750x323
 layer at (13,21) size 367x636
-  RenderMultiColumnFlowThread at (5,5) size 367x636
+  RenderMultiColumnFlow at (5,5) size 367x636
     RenderBlock {SPAN} at (0,8) size 367x198 [color=#FFFFFF] [bgcolor=#000000]
       RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
       RenderBlock (anonymous) at (0,0) size 367x198
@@ -62,7 +62,7 @@ layer at (8,439) size 760x409
         text run at (0,0) width 600: "This is a spanning element at the end of the columns block."
     RenderMultiColumnSet at (5,395) size 750x9
 layer at (13,444) size 367x662
-  RenderMultiColumnFlowThread at (5,5) size 367x662
+  RenderMultiColumnFlow at (5,5) size 367x662
     RenderBlock (anonymous) at (0,0) size 367x396
       RenderText {#text} at (0,0) size 363x396
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -114,7 +114,7 @@ layer at (8,864) size 760x408
         text run at (0,0) width 634: "This is a spanning element in the middle of the columns block."
     RenderMultiColumnSet at (5,197) size 750x207
 layer at (13,869) size 367x654 backgroundClip at (0,0) size 785x1288 clip at (0,0) size 785x1288
-  RenderMultiColumnFlowThread at (5,5) size 367x654
+  RenderMultiColumnFlow at (5,5) size 367x654
     RenderBlock (anonymous) at (0,0) size 367x198
       RenderText {#text} at (0,0) size 362x198
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/glib/fast/multicol/span/span-as-nested-inline-block-child-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/span-as-nested-inline-block-child-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x102
   RenderBlock {DIV} at (0,0) size 784x102
     RenderMultiColumnSet at (0,0) size 784x102
 layer at (8,8) size 384x192
-  RenderMultiColumnFlowThread at (0,0) size 384x192
+  RenderMultiColumnFlow at (0,0) size 384x192
     RenderBlock {DIV} at (0,0) size 384x102
       RenderBlock {P} at (0,16) size 384x18
         RenderText {#text} at (0,0) size 332x18

--- a/LayoutTests/platform/glib/fast/multicol/span/span-margin-collapsing-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/span/span-margin-collapsing-expected.txt
@@ -12,7 +12,7 @@ layer at (8,16) size 750x400
         text run at (0,27) width 527: "should collapse its margins with the top of the page."
     RenderMultiColumnSet at (0,93) size 750x307
 layer at (8,16) size 367x612
-  RenderMultiColumnFlowThread at (0,0) size 367x612
+  RenderMultiColumnFlow at (0,0) size 367x612
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x612
       RenderText {#text} at (0,0) size 363x612
@@ -62,7 +62,7 @@ layer at (8,432) size 750x400
         text run at (0,27) width 504: "collapse its margins with the h2 in the next block."
     RenderMultiColumnSet at (0,399) size 750x0
 layer at (8,432) size 367x612
-  RenderMultiColumnFlowThread at (0,0) size 367x612
+  RenderMultiColumnFlow at (0,0) size 367x612
     RenderBlock (anonymous) at (0,0) size 367x612
       RenderText {#text} at (0,0) size 363x612
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -111,7 +111,7 @@ layer at (8,848) size 750x399
         text run at (0,27) width 621: "should collapse its margins with the h2 in the previous block."
     RenderMultiColumnSet at (0,93) size 750x307
 layer at (8,848) size 367x612
-  RenderMultiColumnFlowThread at (0,0) size 367x612
+  RenderMultiColumnFlow at (0,0) size 367x612
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x612
       RenderText {#text} at (0,0) size 363x612
@@ -167,7 +167,7 @@ layer at (8,1263) size 750x564
         text run at (0,27) width 569: "collapse its margins with the spanning element above it."
     RenderMultiColumnSet at (0,365) size 750x199
 layer at (8,1263) size 367x792 backgroundClip at (0,0) size 785x1843 clip at (0,0) size 785x1843
-  RenderMultiColumnFlowThread at (0,0) size 367x792
+  RenderMultiColumnFlow at (0,0) size 367x792
     RenderBlock (anonymous) at (0,0) size 367x396
       RenderText {#text} at (0,0) size 363x396
         text run at (0,0) width 354: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/glib/fast/multicol/table-margin-collapse-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/table-margin-collapse-expected.txt
@@ -12,7 +12,7 @@ layer at (8,44) size 784x304
   RenderBlock {DIV} at (0,36) size 784x304 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 780x300
 layer at (10,46) size 382x500
-  RenderMultiColumnFlowThread at (2,2) size 382x500
+  RenderMultiColumnFlow at (2,2) size 382x500
     RenderTable {TABLE} at (0,0) size 382x500
       RenderTableSection {TBODY} at (0,0) size 382x500
         RenderTableRow {TR} at (0,0) size 382x500

--- a/LayoutTests/platform/glib/fast/multicol/table-vertical-align-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/table-vertical-align-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 769x350
   RenderBlock {DIV} at (0,0) size 769x350
     RenderMultiColumnSet at (0,0) size 769x350
 layer at (8,8) size 377x1179 backgroundClip at (0,0) size 1562x1010 clip at (0,0) size 1562x1010
-  RenderMultiColumnFlowThread at (0,0) size 377x1179
+  RenderMultiColumnFlow at (0,0) size 377x1179
     RenderTable {TABLE} at (0,0) size 377x1179 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 375x1177
         RenderTableRow {TR} at (0,0) size 375x1177
@@ -143,7 +143,7 @@ layer at (8,376) size 769x300
   RenderBlock {DIV} at (0,368) size 769x300
     RenderMultiColumnSet at (0,0) size 769x300
 layer at (8,376) size 377x1166 backgroundClip at (0,0) size 1562x1010 clip at (0,0) size 1562x1010
-  RenderMultiColumnFlowThread at (0,0) size 377x1166
+  RenderMultiColumnFlow at (0,0) size 377x1166
     RenderTable {TABLE} at (0,0) size 377x1166 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 375x1164
         RenderTableRow {TR} at (0,0) size 375x1164
@@ -279,7 +279,7 @@ layer at (8,702) size 769x300
   RenderBlock {DIV} at (0,694) size 769x300
     RenderMultiColumnSet at (0,0) size 769x300
 layer at (8,702) size 377x1129 backgroundClip at (0,0) size 1562x1010 clip at (0,0) size 1562x1010
-  RenderMultiColumnFlowThread at (0,0) size 377x1129
+  RenderMultiColumnFlow at (0,0) size 377x1129
     RenderTable {TABLE} at (0,0) size 377x1129 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 375x1127
         RenderTableRow {TR} at (0,0) size 375x1127

--- a/LayoutTests/platform/glib/fast/multicol/tall-image-behavior-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/tall-image-behavior-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x304
   RenderBlock {DIV} at (0,0) size 784x304 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 780x300
 layer at (10,10) size 382x650 backgroundClip at (0,0) size 1188x585 clip at (0,0) size 1188x585
-  RenderMultiColumnFlowThread at (2,2) size 382x650
+  RenderMultiColumnFlow at (2,2) size 382x650
     RenderBlock {P} at (0,16) size 382x64
       RenderText {#text} at (0,-2) size 293x17
         text run at (0,-2) width 293: "This image should not be split across columns."

--- a/LayoutTests/platform/glib/fast/multicol/tall-image-behavior-lr-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/tall-image-behavior-lr-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 304x584
   RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (10,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
+  RenderMultiColumnFlow at (2,2) size 650x282
     RenderBlock {P} at (16,0) size 108x282
       RenderText {#text} at (0,0) size 36x232
         text run at (0,0) width 233: "This image should not be split across"

--- a/LayoutTests/platform/glib/fast/multicol/tall-image-behavior-lr-mixed-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/tall-image-behavior-lr-mixed-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 304x584
   RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (10,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
+  RenderMultiColumnFlow at (2,2) size 650x282
     RenderBlock {P} at (16,0) size 108x282
       RenderText {#text} at (0,0) size 36x232
         text run at (0,0) width 233: "This image should not be split across"

--- a/LayoutTests/platform/glib/fast/multicol/tall-image-behavior-rl-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/tall-image-behavior-rl-expected.txt
@@ -7,7 +7,7 @@ layer at (473,8) size 304x584
   RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (125,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
+  RenderMultiColumnFlow at (2,2) size 650x282
     RenderBlock {P} at (16,0) size 108x282
       RenderText {#text} at (0,0) size 36x232
         text run at (0,0) width 233: "This image should not be split across"

--- a/LayoutTests/platform/glib/fast/multicol/vertical-lr/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/vertical-lr/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 160x584
   RenderBlock {DIV} at (0,0) size 160x584 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 156x580
 layer at (10,10) size 312x282
-  RenderMultiColumnFlowThread at (2,2) size 312x282
+  RenderMultiColumnFlow at (2,2) size 312x282
     RenderBlock {DIV} at (0,0) size 110x282
     RenderBlock {DIV} at (156,0) size 156x379 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (2,12) size 152x355 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/glib/fast/multicol/vertical-rl/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/vertical-rl/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (632,8) size 160x584
   RenderBlock {DIV} at (0,0) size 160x584 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 156x580
 layer at (478,10) size 312x282
-  RenderMultiColumnFlowThread at (2,2) size 312x282
+  RenderMultiColumnFlow at (2,2) size 312x282
     RenderBlock {DIV} at (0,0) size 110x282
     RenderBlock {DIV} at (156,0) size 156x379 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (2,12) size 152x355 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/glib/fast/overflow/paged-x-div-expected.txt
+++ b/LayoutTests/platform/glib/fast/overflow/paged-x-div-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x385 scrollWidth 2480
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x385
 layer at (10,10) size 400x2195 backgroundClip at (10,10) size 400x385 clip at (10,10) size 400x385
-  RenderMultiColumnFlowThread at (2,2) size 400x2195
+  RenderMultiColumnFlow at (2,2) size 400x2195
     RenderText {#text} at (0,0) size 399x2195
       text run at (0,0) width 347: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       text run at (0,18) width 388: "Maecenas lacinia massa in lectus pretium vulputate. Curabitur"

--- a/LayoutTests/platform/glib/fast/overflow/paged-x-div-with-column-gap-expected.txt
+++ b/LayoutTests/platform/glib/fast/overflow/paged-x-div-with-column-gap-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x385 scrollX 200 scrollWidth
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x385
 layer at (-190,10) size 400x2195 backgroundClip at (10,10) size 400x385 clip at (10,10) size 400x385
-  RenderMultiColumnFlowThread at (2,2) size 400x2195
+  RenderMultiColumnFlow at (2,2) size 400x2195
     RenderText {#text} at (0,0) size 399x2195
       text run at (0,0) width 347: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       text run at (0,18) width 388: "Maecenas lacinia massa in lectus pretium vulputate. Curabitur"

--- a/LayoutTests/platform/glib/fast/overflow/paged-x-on-root-expected.txt
+++ b/LayoutTests/platform/glib/fast/overflow/paged-x-on-root-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1600x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 800x1079 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
-  RenderMultiColumnFlowThread at (0,0) size 800x1079
+  RenderMultiColumnFlow at (0,0) size 800x1079
 layer at (0,0) size 800x1079 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
   RenderBlock {HTML} at (0,0) size 800x1079
     RenderBody {BODY} at (8,8) size 784x1063

--- a/LayoutTests/platform/glib/fast/overflow/paged-x-with-column-gap-expected.txt
+++ b/LayoutTests/platform/glib/fast/overflow/paged-x-with-column-gap-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1700x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 800x1079 backgroundClip at (0,0) size 1700x585 clip at (0,0) size 1700x585
-  RenderMultiColumnFlowThread at (0,0) size 800x1079
+  RenderMultiColumnFlow at (0,0) size 800x1079
 layer at (0,0) size 800x1079 backgroundClip at (0,0) size 1700x585 clip at (0,0) size 1700x585
   RenderBlock {HTML} at (0,0) size 800x1079
     RenderBody {BODY} at (8,8) size 784x1063

--- a/LayoutTests/platform/glib/fast/overflow/paged-y-div-expected.txt
+++ b/LayoutTests/platform/glib/fast/overflow/paged-y-div-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x400 scrollHeight 2480
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x400
 layer at (10,10) size 400x2180 backgroundClip at (10,10) size 400x400 clip at (10,10) size 400x400
-  RenderMultiColumnFlowThread at (2,2) size 400x2180
+  RenderMultiColumnFlow at (2,2) size 400x2180
     RenderText {#text} at (0,0) size 399x2180
       text run at (0,0) width 347: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       text run at (0,18) width 388: "Maecenas lacinia massa in lectus pretium vulputate. Curabitur"

--- a/LayoutTests/platform/glib/fast/overflow/paged-y-on-root-expected.txt
+++ b/LayoutTests/platform/glib/fast/overflow/paged-y-on-root-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1200
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x1112
-  RenderMultiColumnFlowThread at (0,0) size 785x1112
+  RenderMultiColumnFlow at (0,0) size 785x1112
 layer at (0,0) size 785x1112
   RenderBlock {HTML} at (0,0) size 785x1112
     RenderBody {BODY} at (8,8) size 769x1096

--- a/LayoutTests/platform/glib/fast/repaint/multicol-repaint-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/multicol-repaint-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 402x102
   RenderBlock {DIV} at (0,0) size 402x102 [border: (1px solid #000000)]
     RenderMultiColumnSet at (1,1) size 400x100
 layer at (9,9) size 175x158
-  RenderMultiColumnFlowThread at (1,1) size 175x158
+  RenderMultiColumnFlow at (1,1) size 175x158
     RenderText {#text} at (0,1) size 13x56
       text run at (0,1) width 13: " "
     RenderBR {BR} at (13,1) size 0x56

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-multicol/change-abspos-width-in-second-column-crash-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-multicol/change-abspos-width-in-second-column-crash-expected.txt
@@ -10,7 +10,7 @@ layer at (8,50) size 784x100
   RenderBlock {DIV} at (0,34) size 784x100
     RenderMultiColumnSet at (0,0) size 784x100
 layer at (8,50) size 384x150
-  RenderMultiColumnFlowThread at (0,0) size 384x150
+  RenderMultiColumnFlow at (0,0) size 384x150
 layer at (8,50) size 384x150
   RenderBlock (relative positioned) {DIV} at (0,0) size 384x150
     RenderBlock {DIV} at (0,0) size 384x150

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-multicol/change-out-of-flow-type-and-remove-inner-multicol-crash-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-multicol/change-out-of-flow-type-and-remove-inner-multicol-crash-expected.txt
@@ -8,7 +8,7 @@ layer at (8,8) size 784x25
     RenderBlock {DIV} at (0,25) size 784x0
     RenderMultiColumnSet at (0,25) size 784x0
 layer at (8,8) size 384x50
-  RenderMultiColumnFlowThread at (0,0) size 384x50
+  RenderMultiColumnFlow at (0,0) size 384x50
     RenderBlock {P} at (0,16) size 384x18
       RenderText {#text} at (0,0) size 112x17
         text run at (0,0) width 112: "PASS if no crash."

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-transforms/crashtests/preserve3d-scene-002-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-transforms/crashtests/preserve3d-scene-002-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 769x16777216
   RenderBlock {DIV} at (0,0) size 769x16777216
     RenderMultiColumnSet at (0,0) size 769x16777216
 layer at (8,8) size 0x33554431
-  RenderMultiColumnFlowThread at (0,0) size 0x33554431
+  RenderMultiColumnFlow at (0,0) size 0x33554431
     RenderButton {BUTTON} at (2,1) size 83x33554430 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
       RenderBlock (anonymous) at (8,4) size 67x33554427
 layer at (18,13) size 66x33554431 backgroundClip at (0,0) size 785x16777232 clip at (0,0) size 785x16777232

--- a/LayoutTests/platform/ios/css3/unicode-bidi-isolate-basic-expected.txt
+++ b/LayoutTests/platform/ios/css3/unicode-bidi-isolate-basic-expected.txt
@@ -14,7 +14,7 @@ layer at (8,68) size 25x400
   RenderBlock (positioned) {DIV} at (0,0) size 26x400 [color=#FF0000]
     RenderMultiColumnSet at (0,0) size 26x400
 layer at (8,68) size 25x2160 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 26x2160
+  RenderMultiColumnFlow at (0,0) size 26x2160
     RenderBlock {DIV} at (0,0) size 26x20
       RenderText {#text} at (0,0) size 7x20
         text run at (0,0) width 7: "\""
@@ -883,7 +883,7 @@ layer at (8,68) size 25x400
   RenderBlock (positioned) {DIV} at (0,0) size 26x400 [color=#008000]
     RenderMultiColumnSet at (0,0) size 26x400
 layer at (8,68) size 25x2160 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 26x2160
+  RenderMultiColumnFlow at (0,0) size 26x2160
     RenderBlock {DIV} at (0,0) size 26x20
       RenderText {#text} at (0,0) size 7x20
         text run at (0,0) width 7: "\""

--- a/LayoutTests/platform/ios/fast/block/float/float-not-removed-from-next-sibling4-expected.txt
+++ b/LayoutTests/platform/ios/fast/block/float/float-not-removed-from-next-sibling4-expected.txt
@@ -19,7 +19,7 @@ layer at (8,8) size 15x200
   RenderBlock {DIV} at (0,0) size 15x200
     RenderMultiColumnSet at (0,0) size 15x200
 layer at (8,8) size 0x200
-  RenderMultiColumnFlowThread at (0,0) size 0x200
+  RenderMultiColumnFlow at (0,0) size 0x200
     RenderImage {IMG} at (0,0) size 15x200 [bgcolor=#C0C0C0]
 layer at (8,208) size 16x96
   RenderBlock (positioned) {DIV} at (0,200) size 16x96

--- a/LayoutTests/platform/ios/fast/borders/border-antialiasing-expected.txt
+++ b/LayoutTests/platform/ios/fast/borders/border-antialiasing-expected.txt
@@ -165,7 +165,7 @@ layer at (28,179) size 600x100
   RenderBlock {DIV} at (10,159) size 600x100
     RenderMultiColumnSet at (0,0) size 600x100
 layer at (28,179) size 11x1200 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 11x1200
+  RenderMultiColumnFlow at (0,0) size 11x1200
     RenderText {#text} at (0,0) size 8x1200
       text run at (0,0) width 8: "_"
       text run at (0,20) width 8: "_"

--- a/LayoutTests/platform/ios/fast/line-grid/line-grid-inside-columns-expected.txt
+++ b/LayoutTests/platform/ios/fast/line-grid/line-grid-inside-columns-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x504
   RenderBlock {DIV} at (0,0) size 784x504 [border: (2px solid #FF0000)]
     RenderMultiColumnSet at (2,2) size 780x500
 layer at (10,10) size 382x1625 backgroundClip at (0,0) size 1586x600 clip at (0,0) size 1586x600
-  RenderMultiColumnFlowThread at (2,2) size 382x1625
+  RenderMultiColumnFlow at (2,2) size 382x1625
     RenderBlock {DIV} at (0,0) size 382x1625
       RenderBlock {DIV} at (0,0) size 382x383
         RenderText {#text} at (0,19) size 359x105

--- a/LayoutTests/platform/ios/fast/line-grid/line-grid-into-columns-expected.txt
+++ b/LayoutTests/platform/ios/fast/line-grid/line-grid-into-columns-expected.txt
@@ -51,7 +51,7 @@ layer at (0,0) size 800x540
   RenderBlock {DIV} at (0,0) size 800x540
     RenderMultiColumnSet at (20,20) size 760x500
 layer at (20,20) size 362x990 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (20,20) size 362x990
+  RenderMultiColumnFlow at (20,20) size 362x990
     RenderBlock {DIV} at (0,0) size 362x406
       RenderText {#text} at (0,42) size 359x105
         text run at (0,42) width 358: "All of this text even though it's smaller should be on the"

--- a/LayoutTests/platform/ios/fast/multicol/block-axis-horizontal-bt-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/block-axis-horizontal-bt-expected.txt
@@ -7,7 +7,7 @@ layer at (20,360) size 200x170
   RenderBlock {DIV} at (20,0) size 200x170 [border: none (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (0,20) size 200x150
 layer at (20,0) size 200x510
-  RenderMultiColumnFlowThread at (0,20) size 200x510
+  RenderMultiColumnFlow at (0,20) size 200x510
     RenderText {#text} at (0,0) size 190x100
       text run at (0,0) width 182: "Lorem ipsum dolor sit amet,"
       text run at (0,20) width 77: "consectetur "

--- a/LayoutTests/platform/ios/fast/multicol/block-axis-horizontal-tb-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/block-axis-horizontal-tb-expected.txt
@@ -7,7 +7,7 @@ layer at (20,0) size 200x170
   RenderBlock {DIV} at (20,0) size 200x170 [border: (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (0,20) size 200x150
 layer at (20,20) size 200x510
-  RenderMultiColumnFlowThread at (0,20) size 200x510
+  RenderMultiColumnFlow at (0,20) size 200x510
     RenderText {#text} at (0,0) size 190x100
       text run at (0,0) width 182: "Lorem ipsum dolor sit amet,"
       text run at (0,20) width 77: "consectetur "

--- a/LayoutTests/platform/ios/fast/multicol/block-axis-vertical-lr-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/block-axis-vertical-lr-expected.txt
@@ -7,7 +7,7 @@ layer at (0,20) size 170x200
   RenderBlock {DIV} at (0,0) size 170x200 [border: none (20px solid #C0C0C0)]
     RenderMultiColumnSet at (20,0) size 150x200
 layer at (20,20) size 510x200
-  RenderMultiColumnFlowThread at (20,0) size 510x200
+  RenderMultiColumnFlow at (20,0) size 510x200
     RenderText {#text} at (0,0) size 100x190
       text run at (0,0) width 183: "Lorem ipsum dolor sit amet,"
       text run at (20,0) width 78: "consectetur "

--- a/LayoutTests/platform/ios/fast/multicol/block-axis-vertical-rl-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/block-axis-vertical-rl-expected.txt
@@ -7,7 +7,7 @@ layer at (360,20) size 170x200
   RenderBlock {DIV} at (360,0) size 170x200 [border: none (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (20,0) size 150x200
 layer at (0,20) size 510x200
-  RenderMultiColumnFlowThread at (20,0) size 510x200
+  RenderMultiColumnFlow at (20,0) size 510x200
     RenderText {#text} at (0,0) size 100x190
       text run at (0,0) width 183: "Lorem ipsum dolor sit amet,"
       text run at (20,0) width 78: "consectetur "

--- a/LayoutTests/platform/ios/fast/multicol/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x162
   RenderBlock {DIV} at (0,0) size 784x162 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 780x158
 layer at (10,10) size 382x316
-  RenderMultiColumnFlowThread at (2,2) size 382x316
+  RenderMultiColumnFlow at (2,2) size 382x316
     RenderBlock {DIV} at (0,0) size 382x110
     RenderBlock {DIV} at (0,158) size 379x158 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (12,2) size 355x154 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/ios/fast/multicol/client-rects-spanners-complex-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/client-rects-spanners-complex-expected.txt
@@ -63,7 +63,7 @@ layer at (8,64) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (16,72) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x105
@@ -78,7 +78,7 @@ layer at (128,64) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (136,72) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x105
@@ -95,7 +95,7 @@ layer at (248,64) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (256,72) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -111,7 +111,7 @@ layer at (368,64) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (376,72) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -127,7 +127,7 @@ layer at (488,82) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (496,90) size 48x94
-  RenderMultiColumnFlowThread at (8,8) size 48x94
+  RenderMultiColumnFlow at (8,8) size 48x94
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -144,7 +144,7 @@ layer at (608,84) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (616,92) size 48x90
-  RenderMultiColumnFlowThread at (8,8) size 48x90
+  RenderMultiColumnFlow at (8,8) size 48x90
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -158,7 +158,7 @@ layer at (8,210) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (16,218) size 48x75
-  RenderMultiColumnFlowThread at (8,8) size 48x75
+  RenderMultiColumnFlow at (8,8) size 48x75
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock {DIV} at (0,50) size 25x25 [bgcolor=#ADD8E6]
@@ -168,7 +168,7 @@ layer at (138,210) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (146,218) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -183,7 +183,7 @@ layer at (268,210) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (276,218) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -200,7 +200,7 @@ layer at (398,210) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (406,218) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -216,7 +216,7 @@ layer at (528,210) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (536,218) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -232,7 +232,7 @@ layer at (658,210) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (666,218) size 94x48
-  RenderMultiColumnFlowThread at (8,8) size 94x48
+  RenderMultiColumnFlow at (8,8) size 94x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -249,7 +249,7 @@ layer at (18,330) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (26,338) size 90x48
-  RenderMultiColumnFlowThread at (8,8) size 90x48
+  RenderMultiColumnFlow at (8,8) size 90x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -263,7 +263,7 @@ layer at (148,330) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (156,338) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock {DIV} at (50,0) size 25x25 [bgcolor=#ADD8E6]
@@ -273,7 +273,7 @@ layer at (278,330) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (261,338) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -288,7 +288,7 @@ layer at (408,330) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (391,338) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -305,7 +305,7 @@ layer at (538,330) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (521,338) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -321,7 +321,7 @@ layer at (668,330) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (651,338) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -337,7 +337,7 @@ layer at (18,451) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (22,459) size 94x48
-  RenderMultiColumnFlowThread at (8,8) size 94x48
+  RenderMultiColumnFlow at (8,8) size 94x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -354,7 +354,7 @@ layer at (148,451) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (156,459) size 90x48
-  RenderMultiColumnFlowThread at (8,8) size 90x48
+  RenderMultiColumnFlow at (8,8) size 90x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -368,7 +368,7 @@ layer at (278,451) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (301,459) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock {DIV} at (50,0) size 25x25 [bgcolor=#ADD8E6]

--- a/LayoutTests/platform/ios/fast/multicol/client-rects-spanners-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/client-rects-spanners-expected.txt
@@ -62,7 +62,7 @@ layer at (8,64) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (16,72) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x100
       RenderBR {BR} at (0,0) size 0x25
@@ -75,7 +75,7 @@ layer at (128,64) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (136,72) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x100
       RenderBR {BR} at (0,0) size 0x25
@@ -90,7 +90,7 @@ layer at (248,64) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (256,72) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -104,7 +104,7 @@ layer at (368,64) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (376,72) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -118,7 +118,7 @@ layer at (488,82) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (496,90) size 48x79
-  RenderMultiColumnFlowThread at (8,8) size 48x79
+  RenderMultiColumnFlow at (8,8) size 48x79
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -133,7 +133,7 @@ layer at (608,84) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (616,92) size 48x75
-  RenderMultiColumnFlowThread at (8,8) size 48x75
+  RenderMultiColumnFlow at (8,8) size 48x75
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -145,7 +145,7 @@ layer at (8,201) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (16,209) size 48x65
-  RenderMultiColumnFlowThread at (8,8) size 48x65
+  RenderMultiColumnFlow at (8,8) size 48x65
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (0,40) size 25x25 [bgcolor=#ADD8E6]
 layer at (138,171) size 76x116
@@ -153,7 +153,7 @@ layer at (138,171) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (146,179) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -166,7 +166,7 @@ layer at (238,171) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (246,179) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -181,7 +181,7 @@ layer at (338,171) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (346,179) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -195,7 +195,7 @@ layer at (438,171) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (446,179) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -209,7 +209,7 @@ layer at (538,171) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (546,179) size 79x48
-  RenderMultiColumnFlowThread at (8,8) size 79x48
+  RenderMultiColumnFlow at (8,8) size 79x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -224,7 +224,7 @@ layer at (638,171) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (646,179) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -236,7 +236,7 @@ layer at (18,292) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (26,300) size 65x48
-  RenderMultiColumnFlowThread at (8,8) size 65x48
+  RenderMultiColumnFlow at (8,8) size 65x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (40,0) size 25x25 [bgcolor=#ADD8E6]
 layer at (118,292) size 76x116
@@ -244,7 +244,7 @@ layer at (118,292) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (86,300) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -257,7 +257,7 @@ layer at (218,292) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (186,300) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -272,7 +272,7 @@ layer at (318,292) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (286,300) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -286,7 +286,7 @@ layer at (418,292) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (386,300) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -300,7 +300,7 @@ layer at (518,292) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (507,300) size 79x48
-  RenderMultiColumnFlowThread at (8,8) size 79x48
+  RenderMultiColumnFlow at (8,8) size 79x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -315,7 +315,7 @@ layer at (618,292) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (611,300) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -327,7 +327,7 @@ layer at (18,412) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (21,420) size 65x48
-  RenderMultiColumnFlowThread at (8,8) size 65x48
+  RenderMultiColumnFlow at (8,8) size 65x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (40,0) size 25x25 [bgcolor=#ADD8E6]
 layer at (16,107) size 25x25

--- a/LayoutTests/platform/ios/fast/multicol/column-rules-stacking-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/column-rules-stacking-expected.txt
@@ -15,7 +15,7 @@ layer at (8,48) size 784x650 layerType: foreground only
   RenderBlock (relative positioned) {DIV} at (0,40) size 784x650 [bgcolor=#FF0000] [border: (5px solid #000000)]
     RenderMultiColumnSet at (35,5) size 714x640
 layer at (43,53) size 227x1880 backgroundClip at (0,0) size 800x706 clip at (0,0) size 800x706
-  RenderMultiColumnFlowThread at (35,5) size 228x1880
+  RenderMultiColumnFlow at (35,5) size 228x1880
     RenderText {#text} at (0,0) size 227x1880
       text run at (0,0) width 182: "Lorem ipsum dolor sit amet,"
       text run at (0,20) width 218: "consectetuer adipiscing elit. Nulla"

--- a/LayoutTests/platform/ios/fast/multicol/columns-shorthand-parsing-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/columns-shorthand-parsing-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x760
   RenderBlock {DIV} at (0,0) size 784x760
     RenderMultiColumnSet at (0,0) size 784x760
 layer at (8,8) size 384x1500 backgroundClip at (0,0) size 800x776 clip at (0,0) size 800x776
-  RenderMultiColumnFlowThread at (0,0) size 384x1500
+  RenderMultiColumnFlow at (0,0) size 384x1500
     RenderText {#text} at (0,0) size 380x1500
       text run at (0,0) width 380: "This content should be split into two columns. This content"
       text run at (0,20) width 362: "should be split into two columns. This content should be"

--- a/LayoutTests/platform/ios/fast/multicol/float-paginate-empty-lines-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/float-paginate-empty-lines-expected.txt
@@ -12,7 +12,7 @@ layer at (8,84) size 784x400
   RenderBlock {DIV} at (0,76) size 784x400
     RenderMultiColumnSet at (0,0) size 784x400
 layer at (8,84) size 384x600 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 384x600
+  RenderMultiColumnFlow at (0,0) size 384x600
     RenderBlock {DIV} at (0,0) size 384x260 [border: (10px dashed #800000)]
       RenderText {#text} at (10,10) size 113x20
         text run at (10,10) width 113: "This is some text."

--- a/LayoutTests/platform/ios/fast/multicol/max-height-columns-block-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/max-height-columns-block-expected.txt
@@ -17,7 +17,7 @@ layer at (8,88) size 404x64
   RenderBlock {DIV} at (0,80) size 404x64 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x60
 layer at (10,90) size 61x600 backgroundClip at (0,0) size 834x600 clip at (0,0) size 834x600
-  RenderMultiColumnFlowThread at (2,2) size 61x600
+  RenderMultiColumnFlow at (2,2) size 61x600
     RenderText {#text} at (0,1) size 51x118
       text run at (0,1) width 43: "This"
       text run at (0,31) width 17: "is"

--- a/LayoutTests/platform/ios/fast/multicol/overflow-across-columns-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/overflow-across-columns-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 506x505
   RenderBlock {DIV} at (0,0) size 506x505 [border: (3px solid #000000)]
     RenderMultiColumnSet at (3,3) size 500x499
 layer at (11,11) size 159x1478 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (3,3) size 159x1478
+  RenderMultiColumnFlow at (3,3) size 159x1478
 layer at (11,11) size 159x1478 backgroundClip at (11,11) size 159x589 clip at (11,11) size 159x589
   RenderBlock {DIV} at (0,0) size 159x1478
     RenderText {#text} at (0,5) size 159x1468

--- a/LayoutTests/platform/ios/fast/multicol/overflow-across-columns-percent-height-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/overflow-across-columns-percent-height-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 506x505
   RenderBlock {DIV} at (0,0) size 506x505 [border: (3px solid #000000)]
     RenderMultiColumnSet at (3,3) size 500x499
 layer at (11,11) size 159x1478 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (3,3) size 159x1478
+  RenderMultiColumnFlow at (3,3) size 159x1478
     RenderBlock {DIV} at (0,0) size 159x1478
 layer at (11,11) size 159x1478 backgroundClip at (11,11) size 159x589 clip at (11,11) size 159x589
   RenderBlock {DIV} at (0,0) size 159x1478

--- a/LayoutTests/platform/ios/fast/multicol/paginate-block-replaced-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/paginate-block-replaced-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x404
   RenderBlock {DIV} at (0,0) size 784x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 780x400
 layer at (10,10) size 382x1300 backgroundClip at (0,0) size 1586x600 clip at (0,0) size 1586x600
-  RenderMultiColumnFlowThread at (2,2) size 382x1300
+  RenderMultiColumnFlow at (2,2) size 382x1300
     RenderBlock (anonymous) at (0,0) size 382x200
       RenderText {#text} at (0,0) size 113x20
         text run at (0,0) width 113: "This is some text."

--- a/LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-bt-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x1580
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,-756) size 800x1356 backgroundClip at (0,0) size 800x1580 clip at (0,0) size 800x1580
-  RenderMultiColumnFlowThread at (0,0) size 800x1356
+  RenderMultiColumnFlow at (0,0) size 800x1356
 layer at (0,-756) size 800x1356 backgroundClip at (0,0) size 800x1580 clip at (0,0) size 800x1580
   RenderBlock {HTML} at (0,0) size 800x1356
     RenderBody {BODY} at (8,8) size 784x1332

--- a/LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-lr-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 4096x180 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 4096x180
+  RenderMultiColumnFlow at (0,0) size 4096x180
 layer at (0,0) size 4096x180 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 4096x180
     RenderBody {BODY} at (8,8) size 4072x164

--- a/LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-rl-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (-3296,0) size 4096x180 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 4096x180
+  RenderMultiColumnFlow at (0,0) size 4096x180
 layer at (-3296,0) size 4096x180 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 4096x180
     RenderBody {BODY} at (8,8) size 4072x164

--- a/LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-tb-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 800x1356 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 800x1356
+  RenderMultiColumnFlow at (0,0) size 800x1356
 layer at (0,0) size 800x1356 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x1356
     RenderBody {BODY} at (8,8) size 784x1332

--- a/LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-bt-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1380x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,-3500) size 180x4100 backgroundClip at (0,0) size 1380x600 clip at (0,0) size 1380x600
-  RenderMultiColumnFlowThread at (0,0) size 180x4100
+  RenderMultiColumnFlow at (0,0) size 180x4100
 layer at (0,-3500) size 180x4100 backgroundClip at (0,0) size 1380x600 clip at (0,0) size 1380x600
   RenderBlock {HTML} at (0,0) size 180x4100
     RenderBody {BODY} at (8,8) size 164x4076

--- a/LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-lr-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1980x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 1696x600
-  RenderMultiColumnFlowThread at (0,0) size 1696x600
+  RenderMultiColumnFlow at (0,0) size 1696x600
 layer at (0,0) size 1696x600
   RenderBlock {HTML} at (0,0) size 1696x600
     RenderBody {BODY} at (8,8) size 1672x584

--- a/LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-rl-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (-896,0) size 1696x600 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 1696x600
+  RenderMultiColumnFlow at (0,0) size 1696x600
 layer at (-896,0) size 1696x600 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 1696x600
     RenderBody {BODY} at (8,8) size 1672x584

--- a/LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-tb-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1380x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 180x4100 backgroundClip at (0,0) size 1380x600 clip at (0,0) size 1380x600
-  RenderMultiColumnFlowThread at (0,0) size 180x4100
+  RenderMultiColumnFlow at (0,0) size 180x4100
 layer at (0,0) size 180x4100 backgroundClip at (0,0) size 1380x600 clip at (0,0) size 1380x600
   RenderBlock {HTML} at (0,0) size 180x4100
     RenderBody {BODY} at (8,8) size 164x4076

--- a/LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-bt-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,-3500) size 180x4100 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 180x4100
+  RenderMultiColumnFlow at (0,0) size 180x4100
 layer at (0,-3500) size 180x4100 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 180x4100
     RenderBody {BODY} at (8,8) size 164x4076

--- a/LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-lr-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 1696x600 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 1696x600
+  RenderMultiColumnFlow at (0,0) size 1696x600
 layer at (0,0) size 1696x600 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 1696x600
     RenderBody {BODY} at (8,8) size 1672x584

--- a/LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1980x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (-896,0) size 1696x600 backgroundClip at (0,0) size 1980x600 clip at (0,0) size 1980x600
-  RenderMultiColumnFlowThread at (0,0) size 1696x600
+  RenderMultiColumnFlow at (0,0) size 1696x600
 layer at (-896,0) size 1696x600 backgroundClip at (0,0) size 1980x600 clip at (0,0) size 1980x600
   RenderBlock {HTML} at (0,0) size 1696x600
     RenderBody {BODY} at (8,8) size 1672x584

--- a/LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-rl-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1980x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (-896,0) size 1696x600 backgroundClip at (0,0) size 1980x600 clip at (0,0) size 1980x600
-  RenderMultiColumnFlowThread at (0,0) size 1696x600
+  RenderMultiColumnFlow at (0,0) size 1696x600
 layer at (-896,0) size 1696x600 backgroundClip at (0,0) size 1980x600 clip at (0,0) size 1980x600
   RenderBlock {HTML} at (0,0) size 1696x600
     RenderBody {BODY} at (8,8) size 1672x584

--- a/LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-tb-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 180x4100 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 180x4100
+  RenderMultiColumnFlow at (0,0) size 180x4100
 layer at (0,0) size 180x4100 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 180x4100
     RenderBody {BODY} at (8,8) size 164x4076

--- a/LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-bt-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,-756) size 800x1356 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 800x1356
+  RenderMultiColumnFlow at (0,0) size 800x1356
 layer at (0,-756) size 800x1356 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x1356
     RenderBody {BODY} at (8,8) size 784x1332

--- a/LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-lr-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x1180
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 4096x180 backgroundClip at (0,0) size 800x1180 clip at (0,0) size 800x1180
-  RenderMultiColumnFlowThread at (0,0) size 4096x180
+  RenderMultiColumnFlow at (0,0) size 4096x180
 layer at (0,0) size 4096x180 backgroundClip at (0,0) size 800x1180 clip at (0,0) size 800x1180
   RenderBlock {HTML} at (0,0) size 4096x180
     RenderBody {BODY} at (8,8) size 4072x164

--- a/LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-rl-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x1180
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (-3296,0) size 4096x180 backgroundClip at (0,0) size 800x1180 clip at (0,0) size 800x1180
-  RenderMultiColumnFlowThread at (0,0) size 4096x180
+  RenderMultiColumnFlow at (0,0) size 4096x180
 layer at (-3296,0) size 4096x180 backgroundClip at (0,0) size 800x1180 clip at (0,0) size 800x1180
   RenderBlock {HTML} at (0,0) size 4096x180
     RenderBody {BODY} at (8,8) size 4072x164

--- a/LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-tb-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x1580
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 800x1356
-  RenderMultiColumnFlowThread at (0,0) size 800x1356
+  RenderMultiColumnFlow at (0,0) size 800x1356
 layer at (0,0) size 800x1356
   RenderBlock {HTML} at (0,0) size 800x1356
     RenderBody {BODY} at (8,8) size 784x1332

--- a/LayoutTests/platform/ios/fast/multicol/pagination/nested-transforms-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/pagination/nested-transforms-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 180x600
-  RenderMultiColumnFlowThread at (0,0) size 180x600
+  RenderMultiColumnFlow at (0,0) size 180x600
 layer at (0,0) size 180x600
   RenderBlock {HTML} at (0,0) size 180x600
     RenderBody {BODY} at (8,8) size 164x584

--- a/LayoutTests/platform/ios/fast/multicol/scrolling-column-rules-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/scrolling-column-rules-expected.txt
@@ -15,5 +15,5 @@ layer at (8,52) size 784x100 scrollX 200 scrollWidth 2572
   RenderBlock {DIV} at (0,36) size 784x100
     RenderMultiColumnSet at (0,0) size 784x100
 layer at (-192,52) size 337x600 backgroundClip at (8,52) size 784x100 clip at (8,52) size 784x100
-  RenderMultiColumnFlowThread at (0,0) size 337x600
+  RenderMultiColumnFlow at (0,0) size 337x600
     RenderBlock {DIV} at (0,0) size 337x600 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/ios/fast/multicol/scrolling-overflow-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/scrolling-overflow-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x300
   RenderBlock {DIV} at (0,0) size 784x300
     RenderMultiColumnSet at (0,0) size 784x300
 layer at (8,8) size 251x5816 backgroundClip at (0,0) size 5325x600 clip at (0,0) size 5325x600
-  RenderMultiColumnFlowThread at (0,0) size 251x5816
+  RenderMultiColumnFlow at (0,0) size 251x5816
     RenderBlock {P} at (0,16) size 251x624
       RenderText {#text} at (0,0) size 250x624
         text run at (0,0) width 182: "Lorem ipsum dolor sit amet,"

--- a/LayoutTests/platform/ios/fast/multicol/shadow-breaking-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/shadow-breaking-expected.txt
@@ -8,7 +8,7 @@ layer at (20,36) size 424x291
   RenderBlock (positioned) {P} at (20,36) size 424x291 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 420x287
 layer at (22,38) size 200x560
-  RenderMultiColumnFlowThread at (2,2) size 200x560
+  RenderMultiColumnFlow at (2,2) size 200x560
     RenderBlock (floating) at (0,0) size 25x43
       RenderText at (0,1) size 25x41
         text run at (0,1) width 25: "L"

--- a/LayoutTests/platform/ios/fast/multicol/span/anonymous-style-inheritance-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/anonymous-style-inheritance-expected.txt
@@ -10,7 +10,7 @@ layer at (8,18) size 836x465
         text run at (0,1) width 732: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,81) size 826x379
 layer at (14,23) size 403x735 backgroundClip at (0,0) size 844x600 clip at (0,0) size 844x600
-  RenderMultiColumnFlowThread at (5,5) size 405x736
+  RenderMultiColumnFlow at (5,5) size 405x736
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 404x735
       RenderText {#text} at (0,0) size 403x735

--- a/LayoutTests/platform/ios/fast/multicol/span/clone-flexbox-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/clone-flexbox-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x16
   RenderBlock {DIV} at (0,0) size 784x16
     RenderMultiColumnSet at (0,0) size 784x16
 layer at (8,8) size 117x16
-  RenderMultiColumnFlowThread at (0,0) size 118x16
+  RenderMultiColumnFlow at (0,0) size 118x16
     RenderFlexibleBox {DIV} at (0,0) size 118x16 [color=#FFFFFF]
       RenderBlock (anonymous) at (0,0) size 16x16
         RenderText {#text} at (0,0) size 16x16

--- a/LayoutTests/platform/ios/fast/multicol/span/clone-summary-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/clone-summary-expected.txt
@@ -9,7 +9,7 @@ layer at (8,8) size 784x32
     RenderBlock {DIV} at (0,16) size 784x0 [color=#FFFFFF]
     RenderMultiColumnSet at (0,16) size 784x16
 layer at (8,8) size 117x32
-  RenderMultiColumnFlowThread at (0,0) size 118x32
+  RenderMultiColumnFlow at (0,0) size 118x32
     RenderTable at (0,0) size 16x32
       RenderTableSection (anonymous) at (0,0) size 16x32
         RenderTableRow {SUMMARY} at (0,0) size 16x32 [color=#FFFFFF]

--- a/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt
@@ -15,7 +15,7 @@ layer at (8,16) size 760x530
         text run at (0,1) width 221: "This is a second span."
     RenderMultiColumnSet at (5,384) size 750x141
 layer at (13,21) size 367x740
-  RenderMultiColumnFlowThread at (5,5) size 367x740
+  RenderMultiColumnFlow at (5,5) size 367x740
     RenderBlock (anonymous) at (0,0) size 367x440
       RenderText {#text} at (0,0) size 367x440
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -75,7 +75,7 @@ layer at (8,562) size 760x541
         text run at (0,1) width 221: "This is a second span."
     RenderMultiColumnSet at (5,396) size 750x141
 layer at (13,567) size 367x764
-  RenderMultiColumnFlowThread at (5,5) size 367x764
+  RenderMultiColumnFlow at (5,5) size 367x764
     RenderBlock {P} at (0,16) size 367x230
       RenderText {#text} at (0,0) size 367x230
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -132,7 +132,7 @@ layer at (8,1119) size 760x536
         text run at (0,1) width 221: "This is a second span."
     RenderMultiColumnSet at (5,390) size 750x141
 layer at (13,1124) size 367x732 backgroundClip at (0,0) size 800x1671 clip at (0,0) size 800x1671
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock (anonymous) at (0,0) size 367x220
       RenderInline {SPAN} at (0,0) size 367x220
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x460
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,94) size 750x361
 layer at (13,21) size 367x740
-  RenderMultiColumnFlowThread at (5,5) size 367x740
+  RenderMultiColumnFlow at (5,5) size 367x740
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x20
         text run at (0,0) width 168: "Before Generated Content"
@@ -67,7 +67,7 @@ layer at (8,492) size 760x460
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,434) size 750x21
 layer at (13,497) size 367x740
-  RenderMultiColumnFlowThread at (5,5) size 367x740
+  RenderMultiColumnFlow at (5,5) size 367x740
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x20
         text run at (0,0) width 168: "Before Generated Content"
@@ -123,7 +123,7 @@ layer at (8,968) size 760x491
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,230) size 750x257
 layer at (13,973) size 367x804
-  RenderMultiColumnFlowThread at (5,5) size 367x804
+  RenderMultiColumnFlow at (5,5) size 367x804
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x20
         text run at (0,0) width 168: "Before Generated Content"
@@ -180,7 +180,7 @@ layer at (8,1475) size 760x476
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,214) size 750x257
 layer at (13,1480) size 367x772
-  RenderMultiColumnFlowThread at (5,5) size 367x772
+  RenderMultiColumnFlow at (5,5) size 367x772
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x20
         text run at (0,0) width 168: "Before Generated Content"
@@ -241,7 +241,7 @@ layer at (8,1967) size 760x476
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,334) size 750x137
 layer at (13,1972) size 367x772
-  RenderMultiColumnFlowThread at (5,5) size 367x772
+  RenderMultiColumnFlow at (5,5) size 367x772
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x20
         text run at (0,0) width 168: "Before Generated Content"
@@ -302,7 +302,7 @@ layer at (8,2459) size 760x502
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,356) size 750x141
 layer at (13,2464) size 367x824 backgroundClip at (0,0) size 800x2977 clip at (0,0) size 800x2977
-  RenderMultiColumnFlowThread at (5,5) size 367x824
+  RenderMultiColumnFlow at (5,5) size 367x824
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x20
         text run at (0,0) width 168: "Before Generated Content"

--- a/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt
@@ -12,7 +12,7 @@ layer at (8,64) size 760x400
   RenderBlock {DIV} at (0,56) size 760x400 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x390
 layer at (13,69) size 367x770
-  RenderMultiColumnFlowThread at (5,5) size 367x770
+  RenderMultiColumnFlow at (5,5) size 367x770
     RenderBlock {H2} at (0,19) size 367x31 [bgcolor=#EEEEEE]
       RenderText {#text} at (0,1) size 277x28
         text run at (0,1) width 277: "This is a spanning element."
@@ -60,7 +60,7 @@ layer at (8,480) size 760x410
   RenderBlock {DIV} at (0,471) size 760x411 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x400
 layer at (13,485) size 367x770
-  RenderMultiColumnFlowThread at (5,5) size 367x770
+  RenderMultiColumnFlow at (5,5) size 367x770
     RenderBlock (anonymous) at (0,0) size 367x700
       RenderText {#text} at (0,0) size 367x700
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -108,7 +108,7 @@ layer at (8,906) size 760x416
   RenderBlock {DIV} at (0,897) size 760x417 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x406
 layer at (13,911) size 367x802
-  RenderMultiColumnFlowThread at (5,5) size 367x802
+  RenderMultiColumnFlow at (5,5) size 367x802
     RenderBlock {P} at (0,16) size 367x260
       RenderText {#text} at (0,0) size 367x260
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -157,7 +157,7 @@ layer at (8,1338) size 760x419
   RenderBlock {DIV} at (0,1329) size 760x421 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x410
 layer at (13,1343) size 367x802
-  RenderMultiColumnFlowThread at (5,5) size 367x802
+  RenderMultiColumnFlow at (5,5) size 367x802
     RenderBlock (anonymous) at (0,0) size 367x260
       RenderText {#text} at (0,0) size 367x260
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -210,7 +210,7 @@ layer at (8,1773) size 760x410
   RenderBlock {DIV} at (0,1765) size 760x411 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x400
 layer at (13,1778) size 367x786
-  RenderMultiColumnFlowThread at (5,5) size 367x786
+  RenderMultiColumnFlow at (5,5) size 367x786
     RenderBlock (anonymous) at (0,0) size 367x480
       RenderInline {SPAN} at (0,0) size 367x280
         RenderText {#text} at (0,0) size 367x220
@@ -263,7 +263,7 @@ layer at (8,2199) size 760x438
   RenderBlock {DIV} at (0,2191) size 760x439 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x428
 layer at (13,2204) size 367x838 backgroundClip at (0,0) size 800x2653 clip at (0,0) size 800x2653
-  RenderMultiColumnFlowThread at (5,5) size 367x838
+  RenderMultiColumnFlow at (5,5) size 367x838
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x220
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt
@@ -10,7 +10,7 @@ layer at (8,16) size 760x440
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,74) size 750x361
 layer at (13,21) size 367x700
-  RenderMultiColumnFlowThread at (5,5) size 367x700
+  RenderMultiColumnFlow at (5,5) size 367x700
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x700
       RenderText {#text} at (0,0) size 367x700
@@ -60,7 +60,7 @@ layer at (8,472) size 760x440
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,434) size 750x0
 layer at (13,477) size 367x700
-  RenderMultiColumnFlowThread at (5,5) size 367x700
+  RenderMultiColumnFlow at (5,5) size 367x700
     RenderBlock (anonymous) at (0,0) size 367x700
       RenderText {#text} at (0,0) size 367x700
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -110,7 +110,7 @@ layer at (8,928) size 760x461
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,220) size 750x237
 layer at (13,933) size 367x764
-  RenderMultiColumnFlowThread at (5,5) size 367x764
+  RenderMultiColumnFlow at (5,5) size 367x764
     RenderBlock {P} at (0,16) size 367x270
       RenderText {#text} at (0,0) size 367x270
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -161,7 +161,7 @@ layer at (8,1405) size 760x456
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,214) size 750x237
 layer at (13,1410) size 367x732
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock (anonymous) at (0,0) size 367x260
       RenderText {#text} at (0,0) size 367x260
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -216,7 +216,7 @@ layer at (8,1877) size 760x456
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,314) size 750x137
 layer at (13,1882) size 367x732
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock (anonymous) at (0,0) size 367x480
       RenderInline {SPAN} at (0,0) size 367x280
         RenderText {#text} at (0,0) size 367x220
@@ -271,7 +271,7 @@ layer at (8,2349) size 760x472
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,346) size 750x121
 layer at (13,2354) size 367x784 backgroundClip at (0,0) size 800x2837 clip at (0,0) size 800x2837
-  RenderMultiColumnFlowThread at (5,5) size 367x784
+  RenderMultiColumnFlow at (5,5) size 367x784
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x220
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-columns-child-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-columns-child-expected.txt
@@ -10,7 +10,7 @@ layer at (8,16) size 760x440
         text run at (0,1) width 666: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,74) size 750x361
 layer at (13,21) size 367x700
-  RenderMultiColumnFlowThread at (5,5) size 367x700
+  RenderMultiColumnFlow at (5,5) size 367x700
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x700
       RenderText {#text} at (0,0) size 367x700
@@ -60,7 +60,7 @@ layer at (8,472) size 760x440
         text run at (0,1) width 602: "This is a spanning element at the end of the columns block."
     RenderMultiColumnSet at (5,434) size 750x0
 layer at (13,477) size 367x700
-  RenderMultiColumnFlowThread at (5,5) size 367x700
+  RenderMultiColumnFlow at (5,5) size 367x700
     RenderBlock (anonymous) at (0,0) size 367x700
       RenderText {#text} at (0,0) size 367x700
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -110,7 +110,7 @@ layer at (8,928) size 760x439
         text run at (0,1) width 635: "This is a spanning element in the middle of the columns block."
     RenderMultiColumnSet at (5,214) size 750x221
 layer at (13,933) size 367x700
-  RenderMultiColumnFlowThread at (5,5) size 367x700
+  RenderMultiColumnFlow at (5,5) size 367x700
     RenderBlock (anonymous) at (0,0) size 367x260
       RenderText {#text} at (0,0) size 367x260
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -157,7 +157,7 @@ layer at (8,1383) size 760x400
   RenderBlock {DIV} at (0,1367) size 760x401 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x390
 layer at (13,1388) size 367x770
-  RenderMultiColumnFlowThread at (5,5) size 367x770
+  RenderMultiColumnFlow at (5,5) size 367x770
     RenderText {#text} at (0,0) size 367x267
       text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,20) width 362: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -206,7 +206,7 @@ layer at (8,1799) size 760x420
   RenderBlock {DIV} at (0,1783) size 760x421 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x410
 layer at (13,1804) size 367x810
-  RenderMultiColumnFlowThread at (5,5) size 367x810
+  RenderMultiColumnFlow at (5,5) size 367x810
     RenderText {#text} at (0,0) size 367x260
       text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,20) width 362: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -258,7 +258,7 @@ layer at (8,2235) size 760x482
         text run at (0,31) width 146: "block siblings."
     RenderMultiColumnSet at (5,104) size 750x373
 layer at (13,2240) size 367x724
-  RenderMultiColumnFlowThread at (5,5) size 367x724
+  RenderMultiColumnFlow at (5,5) size 367x724
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x220
@@ -308,7 +308,7 @@ layer at (8,2733) size 760x472
         text run at (0,31) width 84: "siblings."
     RenderMultiColumnSet at (5,466) size 750x0
 layer at (13,2738) size 367x724
-  RenderMultiColumnFlowThread at (5,5) size 367x724
+  RenderMultiColumnFlow at (5,5) size 367x724
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x220
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -358,7 +358,7 @@ layer at (8,3221) size 760x490
         text run at (0,31) width 84: "siblings."
     RenderMultiColumnSet at (5,348) size 750x137
 layer at (13,3226) size 367x732 backgroundClip at (0,0) size 800x3727 clip at (0,0) size 800x3727
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x220
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt
@@ -7,7 +7,7 @@ layer at (8,16) size 760x370
   RenderBlock {DIV} at (0,0) size 760x370 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x360
 layer at (13,21) size 367x700
-  RenderMultiColumnFlowThread at (5,5) size 367x700
+  RenderMultiColumnFlow at (5,5) size 367x700
     RenderText {#text} at (0,0) size 367x700
       text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,20) width 362: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -51,7 +51,7 @@ layer at (8,402) size 760x370
   RenderBlock {DIV} at (0,386) size 760x370 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x360
 layer at (13,407) size 367x700
-  RenderMultiColumnFlowThread at (5,5) size 367x700
+  RenderMultiColumnFlow at (5,5) size 367x700
     RenderText {#text} at (0,0) size 367x700
       text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,20) width 362: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -95,7 +95,7 @@ layer at (8,788) size 760x402
   RenderBlock {DIV} at (0,772) size 760x402 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x392
 layer at (13,793) size 367x748
-  RenderMultiColumnFlowThread at (5,5) size 367x748
+  RenderMultiColumnFlow at (5,5) size 367x748
     RenderBlock {P} at (0,16) size 367x260
       RenderText {#text} at (0,0) size 367x260
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -141,7 +141,7 @@ layer at (8,1206) size 760x370
   RenderBlock {DIV} at (0,1190) size 760x370 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x360
 layer at (13,1211) size 367x712
-  RenderMultiColumnFlowThread at (5,5) size 367x712
+  RenderMultiColumnFlow at (5,5) size 367x712
     RenderBlock (anonymous) at (0,0) size 367x460
       RenderText {#text} at (0,0) size 367x260
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -190,7 +190,7 @@ layer at (8,1592) size 760x390
   RenderBlock {DIV} at (0,1576) size 760x390 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x380
 layer at (13,1597) size 367x732
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock (anonymous) at (0,0) size 367x480
       RenderInline {SPAN} at (0,0) size 367x280
         RenderText {#text} at (0,0) size 367x220
@@ -240,7 +240,7 @@ layer at (8,1998) size 760x406
   RenderBlock {DIV} at (0,1982) size 760x406 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x396
 layer at (13,2003) size 367x792 backgroundClip at (0,0) size 800x2420 clip at (0,0) size 800x2420
-  RenderMultiColumnFlowThread at (5,5) size 367x792
+  RenderMultiColumnFlow at (5,5) size 367x792
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x220
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/ios/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x448
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,82) size 750x361
 layer at (13,21) size 367x728
-  RenderMultiColumnFlowThread at (5,5) size 367x728
+  RenderMultiColumnFlow at (5,5) size 367x728
     RenderBlock {SPAN} at (0,8) size 367x220 [color=#FFFFFF] [bgcolor=#000000]
       RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
       RenderBlock (anonymous) at (0,0) size 367x220
@@ -67,7 +67,7 @@ layer at (8,480) size 760x448
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,434) size 750x9
 layer at (13,485) size 367x732
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock (anonymous) at (0,0) size 367x660
       RenderText {#text} at (0,0) size 367x660
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -119,7 +119,7 @@ layer at (8,944) size 760x479
         text run at (0,1) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,230) size 750x245
 layer at (13,949) size 367x772 backgroundClip at (0,0) size 800x1439 clip at (0,0) size 800x1439
-  RenderMultiColumnFlowThread at (5,5) size 367x772
+  RenderMultiColumnFlow at (5,5) size 367x772
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x220
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/ios/fast/multicol/span/span-as-nested-columns-child-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/span-as-nested-columns-child-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x448
         text run at (0,1) width 666: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,82) size 750x361
 layer at (13,21) size 367x728
-  RenderMultiColumnFlowThread at (5,5) size 367x728
+  RenderMultiColumnFlow at (5,5) size 367x728
     RenderBlock {SPAN} at (0,8) size 367x220 [color=#FFFFFF] [bgcolor=#000000]
       RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
       RenderBlock (anonymous) at (0,0) size 367x220
@@ -63,7 +63,7 @@ layer at (8,480) size 760x448
         text run at (0,1) width 602: "This is a spanning element at the end of the columns block."
     RenderMultiColumnSet at (5,434) size 750x9
 layer at (13,485) size 367x732
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock (anonymous) at (0,0) size 367x440
       RenderText {#text} at (0,0) size 367x440
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -115,7 +115,7 @@ layer at (8,944) size 760x447
         text run at (0,1) width 635: "This is a spanning element in the middle of the columns block."
     RenderMultiColumnSet at (5,214) size 750x229
 layer at (13,949) size 367x724 backgroundClip at (0,0) size 800x1407 clip at (0,0) size 800x1407
-  RenderMultiColumnFlowThread at (5,5) size 367x724
+  RenderMultiColumnFlow at (5,5) size 367x724
     RenderBlock (anonymous) at (0,0) size 367x220
       RenderText {#text} at (0,0) size 367x220
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/ios/fast/multicol/span/span-as-nested-inline-block-child-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/span-as-nested-inline-block-child-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x108
   RenderBlock {DIV} at (0,0) size 784x108
     RenderMultiColumnSet at (0,0) size 784x108
 layer at (8,8) size 384x208
-  RenderMultiColumnFlowThread at (0,0) size 384x208
+  RenderMultiColumnFlow at (0,0) size 384x208
     RenderBlock {DIV} at (0,0) size 384x108
       RenderBlock {P} at (0,16) size 384x20
         RenderText {#text} at (0,0) size 338x20

--- a/LayoutTests/platform/ios/fast/multicol/span/span-margin-collapsing-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/span/span-margin-collapsing-expected.txt
@@ -12,7 +12,7 @@ layer at (8,16) size 750x460
         text run at (0,31) width 529: "should collapse its margins with the top of the page."
     RenderMultiColumnSet at (0,99) size 750x361
 layer at (8,16) size 367x700
-  RenderMultiColumnFlowThread at (0,0) size 367x700
+  RenderMultiColumnFlow at (0,0) size 367x700
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x700
       RenderText {#text} at (0,0) size 367x700
@@ -64,7 +64,7 @@ layer at (8,492) size 750x460
         text run at (0,31) width 505: "collapse its margins with the h2 in the next block."
     RenderMultiColumnSet at (0,459) size 750x0
 layer at (8,492) size 367x700
-  RenderMultiColumnFlowThread at (0,0) size 367x700
+  RenderMultiColumnFlow at (0,0) size 367x700
     RenderBlock (anonymous) at (0,0) size 367x700
       RenderText {#text} at (0,0) size 367x700
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -115,7 +115,7 @@ layer at (8,968) size 750x459
         text run at (0,31) width 622: "should collapse its margins with the h2 in the previous block."
     RenderMultiColumnSet at (0,99) size 750x361
 layer at (8,968) size 367x700
-  RenderMultiColumnFlowThread at (0,0) size 367x700
+  RenderMultiColumnFlow at (0,0) size 367x700
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x700
       RenderText {#text} at (0,0) size 367x700
@@ -173,7 +173,7 @@ layer at (8,1443) size 750x620
         text run at (0,31) width 569: "collapse its margins with the spanning element above it."
     RenderMultiColumnSet at (0,399) size 750x221
 layer at (8,1443) size 367x880 backgroundClip at (0,0) size 800x2079 clip at (0,0) size 800x2079
-  RenderMultiColumnFlowThread at (0,0) size 367x880
+  RenderMultiColumnFlow at (0,0) size 367x880
     RenderBlock (anonymous) at (0,0) size 367x440
       RenderText {#text} at (0,0) size 367x440
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/ios/fast/multicol/table-margin-collapse-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/table-margin-collapse-expected.txt
@@ -13,7 +13,7 @@ layer at (8,48) size 784x304
   RenderBlock {DIV} at (0,40) size 784x304 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 780x300
 layer at (10,50) size 382x500
-  RenderMultiColumnFlowThread at (2,2) size 382x500
+  RenderMultiColumnFlow at (2,2) size 382x500
     RenderTable {TABLE} at (0,0) size 382x500
       RenderTableSection {TBODY} at (0,0) size 382x500
         RenderTableRow {TR} at (0,0) size 382x500

--- a/LayoutTests/platform/ios/fast/multicol/table-vertical-align-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/table-vertical-align-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x350
   RenderBlock {DIV} at (0,0) size 784x350
     RenderMultiColumnSet at (0,0) size 784x350
 layer at (8,8) size 384x1307 backgroundClip at (0,0) size 1992x1010 clip at (0,0) size 1992x1010
-  RenderMultiColumnFlowThread at (0,0) size 384x1307
+  RenderMultiColumnFlow at (0,0) size 384x1307
     RenderTable {TABLE} at (0,0) size 384x1307 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 382x1305
         RenderTableRow {TR} at (0,0) size 382x1305
@@ -143,7 +143,7 @@ layer at (8,376) size 784x300
   RenderBlock {DIV} at (0,368) size 784x300
     RenderMultiColumnSet at (0,0) size 784x300
 layer at (8,376) size 384x1293 backgroundClip at (0,0) size 1992x1010 clip at (0,0) size 1992x1010
-  RenderMultiColumnFlowThread at (0,0) size 384x1293
+  RenderMultiColumnFlow at (0,0) size 384x1293
     RenderTable {TABLE} at (0,0) size 384x1293 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 382x1291
         RenderTableRow {TR} at (0,0) size 382x1291
@@ -279,7 +279,7 @@ layer at (8,702) size 784x300
   RenderBlock {DIV} at (0,694) size 784x300
     RenderMultiColumnSet at (0,0) size 784x300
 layer at (8,702) size 384x1288 backgroundClip at (0,0) size 1992x1010 clip at (0,0) size 1992x1010
-  RenderMultiColumnFlowThread at (0,0) size 384x1288
+  RenderMultiColumnFlow at (0,0) size 384x1288
     RenderTable {TABLE} at (0,0) size 384x1288 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 382x1286
         RenderTableRow {TR} at (0,0) size 382x1286

--- a/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x304
   RenderBlock {DIV} at (0,0) size 784x304 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 780x300
 layer at (10,10) size 382x650 backgroundClip at (0,0) size 1188x600 clip at (0,0) size 1188x600
-  RenderMultiColumnFlowThread at (2,2) size 382x650
+  RenderMultiColumnFlow at (2,2) size 382x650
     RenderBlock {P} at (0,16) size 382x59
       RenderText {#text} at (0,-4) size 300x20
         text run at (0,-3) width 300: "This image should not be split across columns."

--- a/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-lr-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-lr-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 304x584
   RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (10,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
+  RenderMultiColumnFlow at (2,2) size 650x282
     RenderBlock {P} at (16,0) size 120x282
       RenderText {#text} at (0,0) size 40x238
         text run at (0,0) width 238: "This image should not be split across"

--- a/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-lr-mixed-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-lr-mixed-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 304x584
   RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (10,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
+  RenderMultiColumnFlow at (2,2) size 650x282
     RenderBlock {P} at (16,0) size 120x282
       RenderText {#text} at (0,0) size 40x238
         text run at (0,0) width 238: "This image should not be split across"

--- a/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-rl-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/tall-image-behavior-rl-expected.txt
@@ -7,7 +7,7 @@ layer at (488,8) size 304x584
   RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (140,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
+  RenderMultiColumnFlow at (2,2) size 650x282
     RenderBlock {P} at (16,0) size 120x282
       RenderText {#text} at (0,0) size 40x238
         text run at (0,0) width 238: "This image should not be split across"

--- a/LayoutTests/platform/ios/fast/multicol/vertical-lr/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/vertical-lr/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 162x584
   RenderBlock {DIV} at (0,0) size 162x584 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 158x580
 layer at (10,10) size 316x282
-  RenderMultiColumnFlowThread at (2,2) size 316x282
+  RenderMultiColumnFlow at (2,2) size 316x282
     RenderBlock {DIV} at (0,0) size 110x282
     RenderBlock {DIV} at (158,0) size 158x379 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (2,12) size 154x355 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/ios/fast/multicol/vertical-rl/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/vertical-rl/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (630,8) size 162x584
   RenderBlock {DIV} at (0,0) size 162x584 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 158x580
 layer at (474,10) size 316x282
-  RenderMultiColumnFlowThread at (2,2) size 316x282
+  RenderMultiColumnFlow at (2,2) size 316x282
     RenderBlock {DIV} at (0,0) size 110x282
     RenderBlock {DIV} at (158,0) size 158x379 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (2,12) size 154x355 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/ios/fast/overflow/paged-x-div-expected.txt
+++ b/LayoutTests/platform/ios/fast/overflow/paged-x-div-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x385 scrollWidth 2896
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x385
 layer at (10,10) size 400x2450 backgroundClip at (10,10) size 400x385 clip at (10,10) size 400x385
-  RenderMultiColumnFlowThread at (2,2) size 400x2450
+  RenderMultiColumnFlow at (2,2) size 400x2450
     RenderText {#text} at (0,0) size 399x2450
       text run at (0,0) width 357: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       text run at (0,20) width 399: "Maecenas lacinia massa in lectus pretium vulputate. Curabitur"

--- a/LayoutTests/platform/ios/fast/overflow/paged-x-div-with-column-gap-expected.txt
+++ b/LayoutTests/platform/ios/fast/overflow/paged-x-div-with-column-gap-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x385 scrollX 200 scrollWidth
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x385
 layer at (-190,10) size 400x2450 backgroundClip at (10,10) size 400x385 clip at (10,10) size 400x385
-  RenderMultiColumnFlowThread at (2,2) size 400x2450
+  RenderMultiColumnFlow at (2,2) size 400x2450
     RenderText {#text} at (0,0) size 399x2450
       text run at (0,0) width 357: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       text run at (0,20) width 399: "Maecenas lacinia massa in lectus pretium vulputate. Curabitur"

--- a/LayoutTests/platform/ios/fast/overflow/paged-x-on-root-expected.txt
+++ b/LayoutTests/platform/ios/fast/overflow/paged-x-on-root-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 2400x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 800x1228 backgroundClip at (0,0) size 2400x600 clip at (0,0) size 2400x600
-  RenderMultiColumnFlowThread at (0,0) size 800x1228
+  RenderMultiColumnFlow at (0,0) size 800x1228
 layer at (0,0) size 800x1228 backgroundClip at (0,0) size 2400x600 clip at (0,0) size 2400x600
   RenderBlock {HTML} at (0,0) size 800x1228
     RenderBody {BODY} at (8,8) size 784x1212

--- a/LayoutTests/platform/ios/fast/overflow/paged-x-with-column-gap-expected.txt
+++ b/LayoutTests/platform/ios/fast/overflow/paged-x-with-column-gap-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 2600x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 800x1228 backgroundClip at (0,0) size 2600x600 clip at (0,0) size 2600x600
-  RenderMultiColumnFlowThread at (0,0) size 800x1228
+  RenderMultiColumnFlow at (0,0) size 800x1228
 layer at (0,0) size 800x1228 backgroundClip at (0,0) size 2600x600 clip at (0,0) size 2600x600
   RenderBlock {HTML} at (0,0) size 800x1228
     RenderBody {BODY} at (8,8) size 784x1212

--- a/LayoutTests/platform/ios/fast/overflow/paged-y-div-expected.txt
+++ b/LayoutTests/platform/ios/fast/overflow/paged-y-div-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x400 scrollHeight 2896
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x400
 layer at (10,10) size 400x2420 backgroundClip at (10,10) size 400x400 clip at (10,10) size 400x400
-  RenderMultiColumnFlowThread at (2,2) size 400x2420
+  RenderMultiColumnFlow at (2,2) size 400x2420
     RenderText {#text} at (0,0) size 399x2420
       text run at (0,0) width 357: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       text run at (0,20) width 399: "Maecenas lacinia massa in lectus pretium vulputate. Curabitur"

--- a/LayoutTests/platform/ios/fast/overflow/paged-y-on-root-expected.txt
+++ b/LayoutTests/platform/ios/fast/overflow/paged-y-on-root-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x1800
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 800x1228
-  RenderMultiColumnFlowThread at (0,0) size 800x1228
+  RenderMultiColumnFlow at (0,0) size 800x1228
 layer at (0,0) size 800x1228
   RenderBlock {HTML} at (0,0) size 800x1228
     RenderBody {BODY} at (8,8) size 784x1212

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-multicol/change-abspos-width-in-second-column-crash-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-multicol/change-abspos-width-in-second-column-crash-expected.txt
@@ -10,7 +10,7 @@ layer at (8,52) size 784x100
   RenderBlock {DIV} at (0,36) size 784x100
     RenderMultiColumnSet at (0,0) size 784x100
 layer at (8,52) size 384x150
-  RenderMultiColumnFlowThread at (0,0) size 384x150
+  RenderMultiColumnFlow at (0,0) size 384x150
 layer at (8,52) size 384x150
   RenderBlock (relative positioned) {DIV} at (0,0) size 384x150
     RenderBlock {DIV} at (0,0) size 384x150

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-multicol/change-out-of-flow-type-and-remove-inner-multicol-crash-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-multicol/change-out-of-flow-type-and-remove-inner-multicol-crash-expected.txt
@@ -8,7 +8,7 @@ layer at (8,8) size 784x26
     RenderBlock {DIV} at (0,26) size 784x0
     RenderMultiColumnSet at (0,26) size 784x0
 layer at (8,8) size 384x52
-  RenderMultiColumnFlowThread at (0,0) size 384x52
+  RenderMultiColumnFlow at (0,0) size 384x52
     RenderBlock {P} at (0,16) size 384x20
       RenderText {#text} at (0,0) size 113x19
         text run at (0,0) width 113: "PASS if no crash."

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-transforms/crashtests/preserve3d-scene-002-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-transforms/crashtests/preserve3d-scene-002-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x16777216
   RenderBlock {DIV} at (0,0) size 784x16777216
     RenderMultiColumnSet at (0,0) size 784x16777216
 layer at (8,8) size 0x33554431
-  RenderMultiColumnFlowThread at (0,0) size 0x33554431
+  RenderMultiColumnFlow at (0,0) size 0x33554431
     RenderButton {BUTTON} at (2,1) size 95x33554430 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
       RenderBlock (anonymous) at (14,1) size 67x33554430
 layer at (24,10) size 66x33554431 backgroundClip at (0,0) size 800x16777232 clip at (0,0) size 800x16777232

--- a/LayoutTests/platform/mac-sonoma/css3/unicode-bidi-isolate-basic-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/css3/unicode-bidi-isolate-basic-expected.txt
@@ -14,7 +14,7 @@ layer at (8,62) size 28x400
   RenderBlock (positioned) {DIV} at (0,0) size 29x400 [color=#FF0000]
     RenderMultiColumnSet at (0,0) size 29x400
 layer at (8,62) size 28x2055 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 29x2055
+  RenderMultiColumnFlow at (0,0) size 29x2055
     RenderBlock {DIV} at (0,0) size 29x18
       RenderText {#text} at (0,0) size 7x18
         text run at (0,0) width 7: "\""
@@ -883,7 +883,7 @@ layer at (8,62) size 28x400
   RenderBlock (positioned) {DIV} at (0,0) size 29x400 [color=#008000]
     RenderMultiColumnSet at (0,0) size 29x400
 layer at (8,62) size 28x2055 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 29x2055
+  RenderMultiColumnFlow at (0,0) size 29x2055
     RenderBlock {DIV} at (0,0) size 29x18
       RenderText {#text} at (0,0) size 7x18
         text run at (0,0) width 7: "\""

--- a/LayoutTests/platform/mac/css3/unicode-bidi-isolate-basic-expected.txt
+++ b/LayoutTests/platform/mac/css3/unicode-bidi-isolate-basic-expected.txt
@@ -14,7 +14,7 @@ layer at (8,62) size 25x400
   RenderBlock (positioned) {DIV} at (0,0) size 26x400 [color=#FF0000]
     RenderMultiColumnSet at (0,0) size 26x400
 layer at (8,62) size 25x2054 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 26x2055
+  RenderMultiColumnFlow at (0,0) size 26x2055
     RenderBlock {DIV} at (0,0) size 26x18
       RenderText {#text} at (0,0) size 7x18
         text run at (0,0) width 7: "\""
@@ -883,7 +883,7 @@ layer at (8,62) size 25x400
   RenderBlock (positioned) {DIV} at (0,0) size 26x400 [color=#008000]
     RenderMultiColumnSet at (0,0) size 26x400
 layer at (8,62) size 25x2054 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 26x2055
+  RenderMultiColumnFlow at (0,0) size 26x2055
     RenderBlock {DIV} at (0,0) size 26x18
       RenderText {#text} at (0,0) size 7x18
         text run at (0,0) width 7: "\""

--- a/LayoutTests/platform/mac/fast/borders/border-antialiasing-expected.txt
+++ b/LayoutTests/platform/mac/fast/borders/border-antialiasing-expected.txt
@@ -165,7 +165,7 @@ layer at (28,179) size 600x100
   RenderBlock {DIV} at (10,159) size 600x100
     RenderMultiColumnSet at (0,0) size 600x100
 layer at (28,179) size 11x1190 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 11x1190
+  RenderMultiColumnFlow at (0,0) size 11x1190
     RenderText {#text} at (0,0) size 8x1190
       text run at (0,0) width 8: "_"
       text run at (0,18) width 8: "_"

--- a/LayoutTests/platform/mac/fast/line-grid/line-grid-inside-columns-expected.txt
+++ b/LayoutTests/platform/mac/fast/line-grid/line-grid-inside-columns-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x504
   RenderBlock {DIV} at (0,0) size 784x504 [border: (2px solid #FF0000)]
     RenderMultiColumnSet at (2,2) size 780x500
 layer at (10,10) size 382x1488 backgroundClip at (0,0) size 1188x585 clip at (0,0) size 1188x585
-  RenderMultiColumnFlowThread at (2,2) size 382x1488
+  RenderMultiColumnFlow at (2,2) size 382x1488
     RenderBlock {DIV} at (0,0) size 382x1488
       RenderBlock {DIV} at (0,0) size 382x364
         RenderText {#text} at (0,18) size 359x100

--- a/LayoutTests/platform/mac/fast/line-grid/line-grid-into-columns-expected.txt
+++ b/LayoutTests/platform/mac/fast/line-grid/line-grid-into-columns-expected.txt
@@ -51,7 +51,7 @@ layer at (0,0) size 800x540
   RenderBlock {DIV} at (0,0) size 800x540
     RenderMultiColumnSet at (20,20) size 760x500
 layer at (20,20) size 362x966 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (20,20) size 362x966
+  RenderMultiColumnFlow at (20,20) size 362x966
     RenderBlock {DIV} at (0,0) size 362x385
       RenderText {#text} at (0,39) size 359x100
         text run at (0,39) width 358: "All of this text even though it's smaller should be on the"

--- a/LayoutTests/platform/mac/fast/multicol/block-axis-horizontal-bt-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/block-axis-horizontal-bt-expected.txt
@@ -7,7 +7,7 @@ layer at (20,360) size 200x170
   RenderBlock {DIV} at (20,0) size 200x170 [border: none (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (0,20) size 200x150
 layer at (20,66) size 200x444
-  RenderMultiColumnFlowThread at (0,20) size 200x444
+  RenderMultiColumnFlow at (0,20) size 200x444
     RenderText {#text} at (0,0) size 190x90
       text run at (0,0) width 182: "Lorem ipsum dolor sit amet,"
       text run at (0,18) width 77: "consectetur "

--- a/LayoutTests/platform/mac/fast/multicol/block-axis-horizontal-tb-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/block-axis-horizontal-tb-expected.txt
@@ -7,7 +7,7 @@ layer at (20,0) size 200x170
   RenderBlock {DIV} at (20,0) size 200x170 [border: (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (0,20) size 200x150
 layer at (20,20) size 200x444
-  RenderMultiColumnFlowThread at (0,20) size 200x444
+  RenderMultiColumnFlow at (0,20) size 200x444
     RenderText {#text} at (0,0) size 190x90
       text run at (0,0) width 182: "Lorem ipsum dolor sit amet,"
       text run at (0,18) width 77: "consectetur "

--- a/LayoutTests/platform/mac/fast/multicol/block-axis-vertical-lr-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/block-axis-vertical-lr-expected.txt
@@ -7,7 +7,7 @@ layer at (0,20) size 170x200
   RenderBlock {DIV} at (0,0) size 170x200 [border: none (20px solid #C0C0C0)]
     RenderMultiColumnSet at (20,0) size 150x200
 layer at (20,20) size 444x200
-  RenderMultiColumnFlowThread at (20,0) size 444x200
+  RenderMultiColumnFlow at (20,0) size 444x200
     RenderText {#text} at (0,0) size 90x190
       text run at (0,0) width 182: "Lorem ipsum dolor sit amet,"
       text run at (18,0) width 77: "consectetur "

--- a/LayoutTests/platform/mac/fast/multicol/block-axis-vertical-rl-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/block-axis-vertical-rl-expected.txt
@@ -7,7 +7,7 @@ layer at (360,20) size 170x200
   RenderBlock {DIV} at (360,0) size 170x200 [border: none (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (20,0) size 150x200
 layer at (66,20) size 444x200
-  RenderMultiColumnFlowThread at (20,0) size 444x200
+  RenderMultiColumnFlow at (20,0) size 444x200
     RenderText {#text} at (0,0) size 90x190
       text run at (0,0) width 182: "Lorem ipsum dolor sit amet,"
       text run at (18,0) width 77: "consectetur "

--- a/LayoutTests/platform/mac/fast/multicol/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x160
   RenderBlock {DIV} at (0,0) size 784x160 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 780x156
 layer at (10,10) size 382x312
-  RenderMultiColumnFlowThread at (2,2) size 382x312
+  RenderMultiColumnFlow at (2,2) size 382x312
     RenderBlock {DIV} at (0,0) size 382x110
     RenderBlock {DIV} at (0,156) size 379x156 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (12,2) size 355x152 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/mac/fast/multicol/client-rects-spanners-complex-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/client-rects-spanners-complex-expected.txt
@@ -63,7 +63,7 @@ layer at (8,63) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (16,71) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x105
@@ -78,7 +78,7 @@ layer at (128,63) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (136,71) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x105
@@ -95,7 +95,7 @@ layer at (248,63) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (256,71) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -111,7 +111,7 @@ layer at (368,63) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (376,71) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -127,7 +127,7 @@ layer at (488,81) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (496,89) size 48x94
-  RenderMultiColumnFlowThread at (8,8) size 48x94
+  RenderMultiColumnFlow at (8,8) size 48x94
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -144,7 +144,7 @@ layer at (608,83) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (616,91) size 48x90
-  RenderMultiColumnFlowThread at (8,8) size 48x90
+  RenderMultiColumnFlow at (8,8) size 48x90
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -158,7 +158,7 @@ layer at (8,209) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (16,217) size 48x75
-  RenderMultiColumnFlowThread at (8,8) size 48x75
+  RenderMultiColumnFlow at (8,8) size 48x75
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock {DIV} at (0,50) size 25x25 [bgcolor=#ADD8E6]
@@ -168,7 +168,7 @@ layer at (138,209) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (146,217) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -183,7 +183,7 @@ layer at (268,209) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (276,217) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -200,7 +200,7 @@ layer at (398,209) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (406,217) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -216,7 +216,7 @@ layer at (528,209) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (536,217) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -232,7 +232,7 @@ layer at (658,209) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (666,217) size 94x48
-  RenderMultiColumnFlowThread at (8,8) size 94x48
+  RenderMultiColumnFlow at (8,8) size 94x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -249,7 +249,7 @@ layer at (18,329) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (26,337) size 90x48
-  RenderMultiColumnFlowThread at (8,8) size 90x48
+  RenderMultiColumnFlow at (8,8) size 90x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -263,7 +263,7 @@ layer at (148,329) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (156,337) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock {DIV} at (50,0) size 25x25 [bgcolor=#ADD8E6]
@@ -273,7 +273,7 @@ layer at (278,329) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (261,337) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -288,7 +288,7 @@ layer at (408,329) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (391,337) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -305,7 +305,7 @@ layer at (538,329) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (521,337) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -321,7 +321,7 @@ layer at (668,329) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (651,337) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -337,7 +337,7 @@ layer at (18,449) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (22,457) size 94x48
-  RenderMultiColumnFlowThread at (8,8) size 94x48
+  RenderMultiColumnFlow at (8,8) size 94x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -354,7 +354,7 @@ layer at (148,449) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (156,457) size 90x48
-  RenderMultiColumnFlowThread at (8,8) size 90x48
+  RenderMultiColumnFlow at (8,8) size 90x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -368,7 +368,7 @@ layer at (278,449) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (301,457) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock {DIV} at (50,0) size 25x25 [bgcolor=#ADD8E6]

--- a/LayoutTests/platform/mac/fast/multicol/client-rects-spanners-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/client-rects-spanners-expected.txt
@@ -62,7 +62,7 @@ layer at (8,63) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (16,71) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x100
       RenderBR {BR} at (0,0) size 0x25
@@ -75,7 +75,7 @@ layer at (128,63) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (136,71) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x100
       RenderBR {BR} at (0,0) size 0x25
@@ -90,7 +90,7 @@ layer at (248,63) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (256,71) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -104,7 +104,7 @@ layer at (368,63) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (376,71) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -118,7 +118,7 @@ layer at (488,81) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (496,89) size 48x79
-  RenderMultiColumnFlowThread at (8,8) size 48x79
+  RenderMultiColumnFlow at (8,8) size 48x79
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -133,7 +133,7 @@ layer at (608,83) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (616,91) size 48x75
-  RenderMultiColumnFlowThread at (8,8) size 48x75
+  RenderMultiColumnFlow at (8,8) size 48x75
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -145,7 +145,7 @@ layer at (8,200) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (16,208) size 48x65
-  RenderMultiColumnFlowThread at (8,8) size 48x65
+  RenderMultiColumnFlow at (8,8) size 48x65
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (0,40) size 25x25 [bgcolor=#ADD8E6]
 layer at (138,170) size 76x116
@@ -153,7 +153,7 @@ layer at (138,170) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (146,178) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -166,7 +166,7 @@ layer at (238,170) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (246,178) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -181,7 +181,7 @@ layer at (338,170) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (346,178) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -195,7 +195,7 @@ layer at (438,170) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (446,178) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -209,7 +209,7 @@ layer at (538,170) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (546,178) size 79x48
-  RenderMultiColumnFlowThread at (8,8) size 79x48
+  RenderMultiColumnFlow at (8,8) size 79x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -224,7 +224,7 @@ layer at (638,170) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (646,178) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -236,7 +236,7 @@ layer at (18,290) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (26,298) size 65x48
-  RenderMultiColumnFlowThread at (8,8) size 65x48
+  RenderMultiColumnFlow at (8,8) size 65x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (40,0) size 25x25 [bgcolor=#ADD8E6]
 layer at (118,290) size 76x116
@@ -244,7 +244,7 @@ layer at (118,290) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (86,298) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -257,7 +257,7 @@ layer at (218,290) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (186,298) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -272,7 +272,7 @@ layer at (318,290) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (286,298) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -286,7 +286,7 @@ layer at (418,290) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (386,298) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -300,7 +300,7 @@ layer at (518,290) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (507,298) size 79x48
-  RenderMultiColumnFlowThread at (8,8) size 79x48
+  RenderMultiColumnFlow at (8,8) size 79x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -315,7 +315,7 @@ layer at (618,290) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (611,298) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -327,7 +327,7 @@ layer at (18,410) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (21,418) size 65x48
-  RenderMultiColumnFlowThread at (8,8) size 65x48
+  RenderMultiColumnFlow at (8,8) size 65x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (40,0) size 25x25 [bgcolor=#ADD8E6]
 layer at (16,106) size 25x25

--- a/LayoutTests/platform/mac/fast/multicol/column-rules-stacking-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/column-rules-stacking-expected.txt
@@ -15,7 +15,7 @@ layer at (8,44) size 769x586 layerType: foreground only
   RenderBlock (relative positioned) {DIV} at (0,36) size 769x586 [bgcolor=#FF0000] [border: (5px solid #000000)]
     RenderMultiColumnSet at (35,5) size 699x576
 layer at (43,49) size 222x1728 backgroundClip at (0,0) size 785x638 clip at (0,0) size 785x638
-  RenderMultiColumnFlowThread at (35,5) size 223x1728
+  RenderMultiColumnFlow at (35,5) size 223x1728
     RenderText {#text} at (0,0) size 223x1728
       text run at (0,0) width 182: "Lorem ipsum dolor sit amet,"
       text run at (0,18) width 218: "consectetuer adipiscing elit. Nulla"

--- a/LayoutTests/platform/mac/fast/multicol/columns-shorthand-parsing-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/columns-shorthand-parsing-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 769x702
   RenderBlock {DIV} at (0,0) size 769x702
     RenderMultiColumnSet at (0,0) size 769x702
 layer at (8,8) size 377x1404 backgroundClip at (0,0) size 785x718 clip at (0,0) size 785x718
-  RenderMultiColumnFlowThread at (0,0) size 377x1404
+  RenderMultiColumnFlow at (0,0) size 377x1404
     RenderText {#text} at (0,0) size 362x1404
       text run at (0,0) width 329: "This content should be split into two columns. This"
       text run at (0,18) width 348: "content should be split into two columns. This content"

--- a/LayoutTests/platform/mac/fast/multicol/float-paginate-empty-lines-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/float-paginate-empty-lines-expected.txt
@@ -12,7 +12,7 @@ layer at (8,78) size 784x400
   RenderBlock {DIV} at (0,70) size 784x400
     RenderMultiColumnSet at (0,0) size 784x400
 layer at (8,78) size 384x600 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 384x600
+  RenderMultiColumnFlow at (0,0) size 384x600
     RenderBlock {DIV} at (0,0) size 384x236 [border: (10px dashed #800000)]
       RenderText {#text} at (10,10) size 113x18
         text run at (10,10) width 113: "This is some text."

--- a/LayoutTests/platform/mac/fast/multicol/max-height-columns-block-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/max-height-columns-block-expected.txt
@@ -17,7 +17,7 @@ layer at (8,80) size 404x64
   RenderBlock {DIV} at (0,72) size 404x64 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x60
 layer at (10,82) size 61x596 backgroundClip at (0,0) size 834x585 clip at (0,0) size 834x585
-  RenderMultiColumnFlowThread at (2,2) size 61x596
+  RenderMultiColumnFlow at (2,2) size 61x596
     RenderText {#text} at (0,0) size 51x116
       text run at (0,0) width 43: "This"
       text run at (0,28) width 17: "is"

--- a/LayoutTests/platform/mac/fast/multicol/overflow-across-columns-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/overflow-across-columns-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 506x505
   RenderBlock {DIV} at (0,0) size 506x505 [border: (3px solid #000000)]
     RenderMultiColumnSet at (3,3) size 500x499
 layer at (11,11) size 159x1478 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (3,3) size 159x1478
+  RenderMultiColumnFlow at (3,3) size 159x1478
 layer at (11,11) size 159x1478 backgroundClip at (11,11) size 159x589 clip at (11,11) size 159x589
   RenderBlock {DIV} at (0,0) size 159x1478
     RenderText {#text} at (0,5) size 159x1468

--- a/LayoutTests/platform/mac/fast/multicol/overflow-across-columns-percent-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/overflow-across-columns-percent-height-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 506x505
   RenderBlock {DIV} at (0,0) size 506x505 [border: (3px solid #000000)]
     RenderMultiColumnSet at (3,3) size 500x499
 layer at (11,11) size 159x1478 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (3,3) size 159x1478
+  RenderMultiColumnFlow at (3,3) size 159x1478
     RenderBlock {DIV} at (0,0) size 159x1478
 layer at (11,11) size 159x1478 backgroundClip at (11,11) size 159x589 clip at (11,11) size 159x589
   RenderBlock {DIV} at (0,0) size 159x1478

--- a/LayoutTests/platform/mac/fast/multicol/paginate-block-replaced-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/paginate-block-replaced-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x404
   RenderBlock {DIV} at (0,0) size 784x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 780x400
 layer at (10,10) size 382x1254 backgroundClip at (0,0) size 1586x585 clip at (0,0) size 1586x585
-  RenderMultiColumnFlowThread at (2,2) size 382x1254
+  RenderMultiColumnFlow at (2,2) size 382x1254
     RenderBlock (anonymous) at (0,0) size 382x180
       RenderText {#text} at (0,0) size 113x18
         text run at (0,0) width 113: "This is some text."

--- a/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-bt-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1580
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,-668) size 785x1268 backgroundClip at (0,0) size 785x1580 clip at (0,0) size 785x1580
-  RenderMultiColumnFlowThread at (0,0) size 785x1268
+  RenderMultiColumnFlow at (0,0) size 785x1268
 layer at (0,-668) size 785x1268 backgroundClip at (0,0) size 785x1580 clip at (0,0) size 785x1580
   RenderBlock {HTML} at (0,0) size 785x1268
     RenderBody {BODY} at (8,8) size 769x1244

--- a/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-lr-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 3724x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 3724x180
+  RenderMultiColumnFlow at (0,0) size 3724x180
 layer at (0,0) size 3724x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 3724x180
     RenderBody {BODY} at (8,8) size 3700x164

--- a/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-rl-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (-2939,0) size 3724x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 3724x180
+  RenderMultiColumnFlow at (0,0) size 3724x180
 layer at (-2939,0) size 3724x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 3724x180
     RenderBody {BODY} at (8,8) size 3700x164

--- a/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-tb-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x1268 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 785x1268
+  RenderMultiColumnFlow at (0,0) size 785x1268
 layer at (0,0) size 785x1268 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 785x1268
     RenderBody {BODY} at (8,8) size 769x1244

--- a/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-bt-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1380
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,-601) size 785x1201 backgroundClip at (0,0) size 785x1380 clip at (0,0) size 785x1380 outlineClip at (0,0) size 785x1380
-  RenderMultiColumnFlowThread at (0,0) size 785x1201
+  RenderMultiColumnFlow at (0,0) size 785x1201
 layer at (0,-601) size 785x1201 backgroundClip at (0,0) size 785x1380 clip at (0,0) size 785x1380 outlineClip at (0,0) size 785x1380
   RenderBlock {HTML} at (0,0) size 785x1201
     RenderBody {BODY} at (8,8) size 769x1179

--- a/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-lr-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 3190x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600 outlineClip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 3190x180
+  RenderMultiColumnFlow at (0,0) size 3190x180
 layer at (0,0) size 3190x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600 outlineClip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 3190x180
     RenderBody {BODY} at (8,8) size 3168x164

--- a/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-rl-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (-2403,0) size 3189x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600 outlineClip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 3189x180
+  RenderMultiColumnFlow at (0,0) size 3189x180
 layer at (-2403,0) size 3189x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600 outlineClip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 3189x180
     RenderBody {BODY} at (8,8) size 3167x164

--- a/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-tb-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x1201 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600 outlineClip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 785x1201
+  RenderMultiColumnFlow at (0,0) size 785x1201
 layer at (0,0) size 785x1201 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600 outlineClip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 785x1201
     RenderBody {BODY} at (8,8) size 769x1179

--- a/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-bt-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1380x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,-3193) size 180x3778 backgroundClip at (0,0) size 1380x585 clip at (0,0) size 1380x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3778
+  RenderMultiColumnFlow at (0,0) size 180x3778
 layer at (0,-3193) size 180x3778 backgroundClip at (0,0) size 1380x585 clip at (0,0) size 1380x585
   RenderBlock {HTML} at (0,0) size 180x3778
     RenderBody {BODY} at (8,8) size 164x3754

--- a/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-lr-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1780x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 1564x585
-  RenderMultiColumnFlowThread at (0,0) size 1564x585
+  RenderMultiColumnFlow at (0,0) size 1564x585
 layer at (0,0) size 1564x585
   RenderBlock {HTML} at (0,0) size 1564x585
     RenderBody {BODY} at (8,8) size 1540x569

--- a/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-rl-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 1564x585
+  RenderMultiColumnFlow at (0,0) size 1564x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 1564x585
     RenderBody {BODY} at (8,8) size 1540x569

--- a/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-tb-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1380x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 180x3778 backgroundClip at (0,0) size 1380x585 clip at (0,0) size 1380x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3778
+  RenderMultiColumnFlow at (0,0) size 180x3778
 layer at (0,0) size 180x3778 backgroundClip at (0,0) size 1380x585 clip at (0,0) size 1380x585
   RenderBlock {HTML} at (0,0) size 180x3778
     RenderBody {BODY} at (8,8) size 164x3754

--- a/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-bt-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1180x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,-2622) size 180x3208 backgroundClip at (0,0) size 1180x585 clip at (0,0) size 1180x585 outlineClip at (0,0) size 1180x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3208
+  RenderMultiColumnFlow at (0,0) size 180x3208
 layer at (0,-2622) size 180x3208 backgroundClip at (0,0) size 1180x585 clip at (0,0) size 1180x585 outlineClip at (0,0) size 1180x585
   RenderBlock {HTML} at (0,0) size 180x3208
     RenderBody {BODY} at (8,8) size 164x3186

--- a/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-lr-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1580x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 1364x585
-  RenderMultiColumnFlowThread at (0,0) size 1364x585
+  RenderMultiColumnFlow at (0,0) size 1364x585
 layer at (0,0) size 1364x585
   RenderBlock {HTML} at (0,0) size 1364x585
     RenderBody {BODY} at (8,8) size 1342x569

--- a/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-rl-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-599,0) size 1399x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585 outlineClip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 1399x585
+  RenderMultiColumnFlow at (0,0) size 1399x585
 layer at (-599,0) size 1399x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585 outlineClip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 1399x585
     RenderBody {BODY} at (8,8) size 1377x569

--- a/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-tb-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1180x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 180x3208 backgroundClip at (0,0) size 1180x585 clip at (0,0) size 1180x585 outlineClip at (0,0) size 1180x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3208
+  RenderMultiColumnFlow at (0,0) size 180x3208
 layer at (0,0) size 180x3208 backgroundClip at (0,0) size 1180x585 clip at (0,0) size 1180x585 outlineClip at (0,0) size 1180x585
   RenderBlock {HTML} at (0,0) size 180x3208
     RenderBody {BODY} at (8,8) size 164x3186

--- a/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-bt-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,-3193) size 180x3778 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3778
+  RenderMultiColumnFlow at (0,0) size 180x3778
 layer at (0,-3193) size 180x3778 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 180x3778
     RenderBody {BODY} at (8,8) size 164x3754

--- a/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-lr-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 1564x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 1564x585
+  RenderMultiColumnFlow at (0,0) size 1564x585
 layer at (0,0) size 1564x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 1564x585
     RenderBody {BODY} at (8,8) size 1540x569

--- a/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1780x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
-  RenderMultiColumnFlowThread at (0,0) size 1564x585
+  RenderMultiColumnFlow at (0,0) size 1564x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
   RenderBlock {HTML} at (0,0) size 1564x585
     RenderBody {BODY} at (8,8) size 1540x569

--- a/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-rl-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1780x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
-  RenderMultiColumnFlowThread at (0,0) size 1564x585
+  RenderMultiColumnFlow at (0,0) size 1564x585
 layer at (-764,0) size 1564x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
   RenderBlock {HTML} at (0,0) size 1564x585
     RenderBody {BODY} at (8,8) size 1540x569

--- a/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-tb-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 180x3778 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3778
+  RenderMultiColumnFlow at (0,0) size 180x3778
 layer at (0,0) size 180x3778 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 180x3778
     RenderBody {BODY} at (8,8) size 164x3754

--- a/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-bt-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,-2622) size 180x3208 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585 outlineClip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3208
+  RenderMultiColumnFlow at (0,0) size 180x3208
 layer at (0,-2622) size 180x3208 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585 outlineClip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 180x3208
     RenderBody {BODY} at (8,8) size 164x3186

--- a/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-lr-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 1364x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585 outlineClip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 1364x585
+  RenderMultiColumnFlow at (0,0) size 1364x585
 layer at (0,0) size 1364x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585 outlineClip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 1364x585
     RenderBody {BODY} at (8,8) size 1342x569

--- a/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-rl-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1580x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-599,0) size 1399x585 backgroundClip at (0,0) size 1580x585 clip at (0,0) size 1580x585 outlineClip at (0,0) size 1580x585
-  RenderMultiColumnFlowThread at (0,0) size 1399x585
+  RenderMultiColumnFlow at (0,0) size 1399x585
 layer at (-599,0) size 1399x585 backgroundClip at (0,0) size 1580x585 clip at (0,0) size 1580x585 outlineClip at (0,0) size 1580x585
   RenderBlock {HTML} at (0,0) size 1399x585
     RenderBody {BODY} at (8,8) size 1377x569

--- a/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-tb-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 180x3208 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585 outlineClip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3208
+  RenderMultiColumnFlow at (0,0) size 180x3208
 layer at (0,0) size 180x3208 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585 outlineClip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 180x3208
     RenderBody {BODY} at (8,8) size 164x3186

--- a/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-bt-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,-668) size 785x1268 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 785x1268
+  RenderMultiColumnFlow at (0,0) size 785x1268
 layer at (0,-668) size 785x1268 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 785x1268
     RenderBody {BODY} at (8,8) size 769x1244

--- a/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-lr-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x980
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 3724x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
-  RenderMultiColumnFlowThread at (0,0) size 3724x180
+  RenderMultiColumnFlow at (0,0) size 3724x180
 layer at (0,0) size 3724x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
   RenderBlock {HTML} at (0,0) size 3724x180
     RenderBody {BODY} at (8,8) size 3700x164

--- a/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-rl-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x980
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (-2939,0) size 3724x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
-  RenderMultiColumnFlowThread at (0,0) size 3724x180
+  RenderMultiColumnFlow at (0,0) size 3724x180
 layer at (-2939,0) size 3724x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
   RenderBlock {HTML} at (0,0) size 3724x180
     RenderBody {BODY} at (8,8) size 3700x164

--- a/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-tb-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1580
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x1268
-  RenderMultiColumnFlowThread at (0,0) size 785x1268
+  RenderMultiColumnFlow at (0,0) size 785x1268
 layer at (0,0) size 785x1268
   RenderBlock {HTML} at (0,0) size 785x1268
     RenderBody {BODY} at (8,8) size 769x1244

--- a/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-bt-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,-601) size 785x1201 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600 outlineClip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 785x1201
+  RenderMultiColumnFlow at (0,0) size 785x1201
 layer at (0,-601) size 785x1201 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600 outlineClip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 785x1201
     RenderBody {BODY} at (8,8) size 769x1179

--- a/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-lr-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x980
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 3190x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980 outlineClip at (0,0) size 785x980
-  RenderMultiColumnFlowThread at (0,0) size 3190x180
+  RenderMultiColumnFlow at (0,0) size 3190x180
 layer at (0,0) size 3190x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980 outlineClip at (0,0) size 785x980
   RenderBlock {HTML} at (0,0) size 3190x180
     RenderBody {BODY} at (8,8) size 3168x164

--- a/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-rl-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x980
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (-2403,0) size 3189x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980 outlineClip at (0,0) size 785x980
-  RenderMultiColumnFlowThread at (0,0) size 3189x180
+  RenderMultiColumnFlow at (0,0) size 3189x180
 layer at (-2403,0) size 3189x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980 outlineClip at (0,0) size 785x980
   RenderBlock {HTML} at (0,0) size 3189x180
     RenderBody {BODY} at (8,8) size 3167x164

--- a/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-tb-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1380
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x1201
-  RenderMultiColumnFlowThread at (0,0) size 785x1201
+  RenderMultiColumnFlow at (0,0) size 785x1201
 layer at (0,0) size 785x1201
   RenderBlock {HTML} at (0,0) size 785x1201
     RenderBody {BODY} at (8,8) size 769x1179

--- a/LayoutTests/platform/mac/fast/multicol/pagination/nested-transforms-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/pagination/nested-transforms-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 180x600
-  RenderMultiColumnFlowThread at (0,0) size 180x600
+  RenderMultiColumnFlow at (0,0) size 180x600
 layer at (0,0) size 180x600
   RenderBlock {HTML} at (0,0) size 180x600
     RenderBody {BODY} at (8,8) size 164x584

--- a/LayoutTests/platform/mac/fast/multicol/scrolling-column-rules-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/scrolling-column-rules-expected.txt
@@ -15,5 +15,5 @@ layer at (8,50) size 784x100 scrollX 200 scrollWidth 2572
   RenderBlock {DIV} at (0,34) size 784x100
     RenderMultiColumnSet at (0,0) size 784x100
 layer at (-192,50) size 337x600 backgroundClip at (8,50) size 784x100 clip at (8,50) size 784x100
-  RenderMultiColumnFlowThread at (0,0) size 337x600
+  RenderMultiColumnFlow at (0,0) size 337x600
     RenderBlock {DIV} at (0,0) size 337x600 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/mac/fast/multicol/scrolling-overflow-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/scrolling-overflow-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x300
   RenderBlock {DIV} at (0,0) size 784x300
     RenderMultiColumnSet at (0,0) size 784x300
 layer at (8,8) size 251x5434 backgroundClip at (0,0) size 5058x585 clip at (0,0) size 5058x585
-  RenderMultiColumnFlowThread at (0,0) size 251x5434
+  RenderMultiColumnFlow at (0,0) size 251x5434
     RenderBlock {P} at (0,16) size 251x572
       RenderText {#text} at (0,0) size 250x572
         text run at (0,0) width 182: "Lorem ipsum dolor sit amet,"

--- a/LayoutTests/platform/mac/fast/multicol/shadow-breaking-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/shadow-breaking-expected.txt
@@ -8,7 +8,7 @@ layer at (20,36) size 424x266
   RenderBlock (positioned) {P} at (20,36) size 424x266 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 420x262
 layer at (22,38) size 200x509
-  RenderMultiColumnFlowThread at (2,2) size 200x509
+  RenderMultiColumnFlow at (2,2) size 200x509
     RenderBlock (floating) at (0,0) size 25x41
       RenderText at (0,0) size 25x41
         text run at (0,0) width 25: "L"

--- a/LayoutTests/platform/mac/fast/multicol/shrink-to-column-height-for-pagination-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/shrink-to-column-height-for-pagination-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (384,0) size 416x600
-  RenderMultiColumnFlowThread at (0,0) size 416x600
+  RenderMultiColumnFlow at (0,0) size 416x600
 layer at (384,0) size 416x600
   RenderBlock {HTML} at (0,0) size 416x600
     RenderBody {BODY} at (8,8) size 400x600

--- a/LayoutTests/platform/mac/fast/multicol/span/anonymous-style-inheritance-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/anonymous-style-inheritance-expected.txt
@@ -10,7 +10,7 @@ layer at (8,18) size 835x445
         text run at (0,0) width 732: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,79) size 825x362
 layer at (13,23) size 404x701 backgroundClip at (0,0) size 843x585 clip at (0,0) size 843x585
-  RenderMultiColumnFlowThread at (5,5) size 404x701
+  RenderMultiColumnFlow at (5,5) size 404x701
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 404x701
       RenderText {#text} at (0,-1) size 403x702

--- a/LayoutTests/platform/mac/fast/multicol/span/clone-flexbox-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/clone-flexbox-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x16
   RenderBlock {DIV} at (0,0) size 784x16
     RenderMultiColumnSet at (0,0) size 784x16
 layer at (8,8) size 117x16
-  RenderMultiColumnFlowThread at (0,0) size 118x16
+  RenderMultiColumnFlow at (0,0) size 118x16
     RenderFlexibleBox {DIV} at (0,0) size 118x16 [color=#FFFFFF]
       RenderBlock (anonymous) at (0,0) size 16x16
         RenderText {#text} at (0,0) size 16x16

--- a/LayoutTests/platform/mac/fast/multicol/span/clone-summary-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/clone-summary-expected.txt
@@ -9,7 +9,7 @@ layer at (8,8) size 784x32
     RenderBlock {DIV} at (0,16) size 784x0 [color=#FFFFFF]
     RenderMultiColumnSet at (0,16) size 784x16
 layer at (8,8) size 117x32
-  RenderMultiColumnFlowThread at (0,0) size 118x32
+  RenderMultiColumnFlow at (0,0) size 118x32
     RenderTable at (0,0) size 16x32
       RenderTableSection (anonymous) at (0,0) size 16x32
         RenderTableRow {SUMMARY} at (0,0) size 16x32 [color=#FFFFFF]

--- a/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt
@@ -15,7 +15,7 @@ layer at (8,16) size 760x488
         text run at (0,0) width 221: "This is a second span."
     RenderMultiColumnSet at (5,356) size 750x127
 layer at (13,21) size 367x666
-  RenderMultiColumnFlowThread at (5,5) size 367x666
+  RenderMultiColumnFlow at (5,5) size 367x666
     RenderBlock (anonymous) at (0,0) size 367x396
       RenderText {#text} at (0,0) size 367x396
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -75,7 +75,7 @@ layer at (8,520) size 760x501
         text run at (0,0) width 221: "This is a second span."
     RenderMultiColumnSet at (5,370) size 750x127
 layer at (13,525) size 367x694
-  RenderMultiColumnFlowThread at (5,5) size 367x694
+  RenderMultiColumnFlow at (5,5) size 367x694
     RenderBlock {P} at (0,16) size 367x207
       RenderText {#text} at (0,0) size 367x207
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -132,7 +132,7 @@ layer at (8,1037) size 760x495
         text run at (0,0) width 221: "This is a second span."
     RenderMultiColumnSet at (5,363) size 750x127
 layer at (13,1042) size 367x662 backgroundClip at (0,0) size 785x1548 clip at (0,0) size 785x1548
-  RenderMultiColumnFlowThread at (5,5) size 367x662
+  RenderMultiColumnFlow at (5,5) size 367x662
     RenderBlock (anonymous) at (0,0) size 367x198
       RenderInline {SPAN} at (0,0) size 367x198
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x422
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,90) size 750x327
 layer at (13,21) size 367x670
-  RenderMultiColumnFlowThread at (5,5) size 367x670
+  RenderMultiColumnFlow at (5,5) size 367x670
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x18
         text run at (0,0) width 168: "Before Generated Content"
@@ -67,7 +67,7 @@ layer at (8,454) size 760x420
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,396) size 750x19
 layer at (13,459) size 367x668
-  RenderMultiColumnFlowThread at (5,5) size 367x668
+  RenderMultiColumnFlow at (5,5) size 367x668
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x18
         text run at (0,0) width 168: "Before Generated Content"
@@ -123,7 +123,7 @@ layer at (8,890) size 760x451
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,214) size 750x233
 layer at (13,895) size 367x732
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x18
         text run at (0,0) width 168: "Before Generated Content"
@@ -180,7 +180,7 @@ layer at (8,1357) size 760x436
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,198) size 750x233
 layer at (13,1362) size 367x700
-  RenderMultiColumnFlowThread at (5,5) size 367x700
+  RenderMultiColumnFlow at (5,5) size 367x700
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x18
         text run at (0,0) width 168: "Before Generated Content"
@@ -241,7 +241,7 @@ layer at (8,1809) size 760x438
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,306) size 750x127
 layer at (13,1814) size 367x702
-  RenderMultiColumnFlowThread at (5,5) size 367x702
+  RenderMultiColumnFlow at (5,5) size 367x702
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x18
         text run at (0,0) width 168: "Before Generated Content"
@@ -302,7 +302,7 @@ layer at (8,2263) size 760x461
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,329) size 750x127
 layer at (13,2268) size 367x750 backgroundClip at (0,0) size 785x2740 clip at (0,0) size 785x2740
-  RenderMultiColumnFlowThread at (5,5) size 367x750
+  RenderMultiColumnFlow at (5,5) size 367x750
     RenderBlock (generated) at (0,0) size 367x18 [bgcolor=#FFFF00]
       RenderText at (0,0) size 168x18
         text run at (0,0) width 168: "Before Generated Content"

--- a/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt
@@ -12,7 +12,7 @@ layer at (8,60) size 760x366
   RenderBlock {DIV} at (0,52) size 760x366 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x356
 layer at (13,65) size 367x698
-  RenderMultiColumnFlowThread at (5,5) size 367x698
+  RenderMultiColumnFlow at (5,5) size 367x698
     RenderBlock {H2} at (0,19) size 367x29 [bgcolor=#EEEEEE]
       RenderText {#text} at (0,0) size 277x28
         text run at (0,0) width 277: "This is a spanning element."
@@ -60,7 +60,7 @@ layer at (8,442) size 760x370
   RenderBlock {DIV} at (0,433) size 760x371 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x360
 layer at (13,447) size 367x698
-  RenderMultiColumnFlowThread at (5,5) size 367x698
+  RenderMultiColumnFlow at (5,5) size 367x698
     RenderBlock (anonymous) at (0,0) size 367x630
       RenderText {#text} at (0,0) size 367x630
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -108,7 +108,7 @@ layer at (8,828) size 760x382
   RenderBlock {DIV} at (0,819) size 760x383 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x372
 layer at (13,833) size 367x730
-  RenderMultiColumnFlowThread at (5,5) size 367x730
+  RenderMultiColumnFlow at (5,5) size 367x730
     RenderBlock {P} at (0,16) size 367x234
       RenderText {#text} at (0,0) size 367x234
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -157,7 +157,7 @@ layer at (8,1226) size 760x383
   RenderBlock {DIV} at (0,1217) size 760x385 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x374
 layer at (13,1231) size 367x730
-  RenderMultiColumnFlowThread at (5,5) size 367x730
+  RenderMultiColumnFlow at (5,5) size 367x730
     RenderBlock (anonymous) at (0,0) size 367x234
       RenderText {#text} at (0,0) size 367x234
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -210,7 +210,7 @@ layer at (8,1625) size 760x370
   RenderBlock {DIV} at (0,1617) size 760x371 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x360
 layer at (13,1630) size 367x714
-  RenderMultiColumnFlowThread at (5,5) size 367x714
+  RenderMultiColumnFlow at (5,5) size 367x714
     RenderBlock (anonymous) at (0,0) size 367x432
       RenderInline {SPAN} at (0,0) size 367x252
         RenderText {#text} at (0,0) size 367x198
@@ -263,7 +263,7 @@ layer at (8,2011) size 760x400
   RenderBlock {DIV} at (0,2003) size 760x401 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x390
 layer at (13,2016) size 367x764 backgroundClip at (0,0) size 785x2427 clip at (0,0) size 785x2427
-  RenderMultiColumnFlowThread at (5,5) size 367x764
+  RenderMultiColumnFlow at (5,5) size 367x764
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 367x198
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt
@@ -10,7 +10,7 @@ layer at (8,16) size 760x402
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,72) size 750x325
 layer at (13,21) size 367x630
-  RenderMultiColumnFlowThread at (5,5) size 367x630
+  RenderMultiColumnFlow at (5,5) size 367x630
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x630
       RenderText {#text} at (0,0) size 367x630
@@ -60,7 +60,7 @@ layer at (8,434) size 760x402
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,396) size 750x0
 layer at (13,439) size 367x630
-  RenderMultiColumnFlowThread at (5,5) size 367x630
+  RenderMultiColumnFlow at (5,5) size 367x630
     RenderBlock (anonymous) at (0,0) size 367x630
       RenderText {#text} at (0,0) size 367x630
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -110,7 +110,7 @@ layer at (8,852) size 760x424
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,205) size 750x215
 layer at (13,857) size 367x694
-  RenderMultiColumnFlowThread at (5,5) size 367x694
+  RenderMultiColumnFlow at (5,5) size 367x694
     RenderBlock {P} at (0,16) size 367x243
       RenderText {#text} at (0,0) size 367x243
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -161,7 +161,7 @@ layer at (8,1292) size 760x418
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,198) size 750x215
 layer at (13,1297) size 367x662
-  RenderMultiColumnFlowThread at (5,5) size 367x662
+  RenderMultiColumnFlow at (5,5) size 367x662
     RenderBlock (anonymous) at (0,0) size 367x234
       RenderText {#text} at (0,0) size 367x234
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -216,7 +216,7 @@ layer at (8,1726) size 760x418
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,288) size 750x125
 layer at (13,1731) size 367x662
-  RenderMultiColumnFlowThread at (5,5) size 367x662
+  RenderMultiColumnFlow at (5,5) size 367x662
     RenderBlock (anonymous) at (0,0) size 367x432
       RenderInline {SPAN} at (0,0) size 367x252
         RenderText {#text} at (0,0) size 367x198
@@ -271,7 +271,7 @@ layer at (8,2160) size 760x434
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,320) size 750x109
 layer at (13,2165) size 367x712 backgroundClip at (0,0) size 785x2610 clip at (0,0) size 785x2610
-  RenderMultiColumnFlowThread at (5,5) size 367x712
+  RenderMultiColumnFlow at (5,5) size 367x712
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 367x198
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-columns-child-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-columns-child-expected.txt
@@ -10,7 +10,7 @@ layer at (8,16) size 760x402
         text run at (0,0) width 666: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,72) size 750x325
 layer at (13,21) size 367x630
-  RenderMultiColumnFlowThread at (5,5) size 367x630
+  RenderMultiColumnFlow at (5,5) size 367x630
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x630
       RenderText {#text} at (0,0) size 367x630
@@ -60,7 +60,7 @@ layer at (8,434) size 760x402
         text run at (0,0) width 602: "This is a spanning element at the end of the columns block."
     RenderMultiColumnSet at (5,396) size 750x0
 layer at (13,439) size 367x630
-  RenderMultiColumnFlowThread at (5,5) size 367x630
+  RenderMultiColumnFlow at (5,5) size 367x630
     RenderBlock (anonymous) at (0,0) size 367x630
       RenderText {#text} at (0,0) size 367x630
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -110,7 +110,7 @@ layer at (8,852) size 760x401
         text run at (0,0) width 635: "This is a spanning element in the middle of the columns block."
     RenderMultiColumnSet at (5,198) size 750x199
 layer at (13,857) size 367x630
-  RenderMultiColumnFlowThread at (5,5) size 367x630
+  RenderMultiColumnFlow at (5,5) size 367x630
     RenderBlock (anonymous) at (0,0) size 367x234
       RenderText {#text} at (0,0) size 367x234
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -157,7 +157,7 @@ layer at (8,1269) size 760x364
   RenderBlock {DIV} at (0,1253) size 760x365 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x354
 layer at (13,1274) size 367x696
-  RenderMultiColumnFlowThread at (5,5) size 367x696
+  RenderMultiColumnFlow at (5,5) size 367x696
     RenderText {#text} at (0,0) size 367x242
       text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,18) width 362: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -206,7 +206,7 @@ layer at (8,1649) size 760x386
   RenderBlock {DIV} at (0,1633) size 760x387 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x376
 layer at (13,1654) size 367x736
-  RenderMultiColumnFlowThread at (5,5) size 367x736
+  RenderMultiColumnFlow at (5,5) size 367x736
     RenderText {#text} at (0,0) size 367x234
       text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,18) width 362: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -258,7 +258,7 @@ layer at (8,2051) size 760x444
         text run at (0,28) width 146: "block siblings."
     RenderMultiColumnSet at (5,100) size 750x339
 layer at (13,2056) size 367x658
-  RenderMultiColumnFlowThread at (5,5) size 367x658
+  RenderMultiColumnFlow at (5,5) size 367x658
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 367x198
@@ -308,7 +308,7 @@ layer at (8,2511) size 760x435
         text run at (0,28) width 84: "siblings."
     RenderMultiColumnSet at (5,429) size 750x0
 layer at (13,2516) size 367x658
-  RenderMultiColumnFlowThread at (5,5) size 367x658
+  RenderMultiColumnFlow at (5,5) size 367x658
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 367x198
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -358,7 +358,7 @@ layer at (8,2962) size 760x452
         text run at (0,28) width 84: "siblings."
     RenderMultiColumnSet at (5,322) size 750x125
 layer at (13,2967) size 367x666 backgroundClip at (0,0) size 785x3430 clip at (0,0) size 785x3430
-  RenderMultiColumnFlowThread at (5,5) size 367x666
+  RenderMultiColumnFlow at (5,5) size 367x666
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 367x198
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt
@@ -7,7 +7,7 @@ layer at (8,16) size 760x334
   RenderBlock {DIV} at (0,0) size 760x334 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x324
 layer at (13,21) size 367x630
-  RenderMultiColumnFlowThread at (5,5) size 367x630
+  RenderMultiColumnFlow at (5,5) size 367x630
     RenderText {#text} at (0,0) size 367x630
       text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,18) width 362: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -51,7 +51,7 @@ layer at (8,366) size 760x334
   RenderBlock {DIV} at (0,350) size 760x334 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x324
 layer at (13,371) size 367x630
-  RenderMultiColumnFlowThread at (5,5) size 367x630
+  RenderMultiColumnFlow at (5,5) size 367x630
     RenderText {#text} at (0,0) size 367x630
       text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,18) width 362: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis"
@@ -95,7 +95,7 @@ layer at (8,716) size 760x366
   RenderBlock {DIV} at (0,700) size 760x366 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x356
 layer at (13,721) size 367x678
-  RenderMultiColumnFlowThread at (5,5) size 367x678
+  RenderMultiColumnFlow at (5,5) size 367x678
     RenderBlock {P} at (0,16) size 367x234
       RenderText {#text} at (0,0) size 367x234
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -141,7 +141,7 @@ layer at (8,1098) size 760x334
   RenderBlock {DIV} at (0,1082) size 760x334 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x324
 layer at (13,1103) size 367x644
-  RenderMultiColumnFlowThread at (5,5) size 367x644
+  RenderMultiColumnFlow at (5,5) size 367x644
     RenderBlock (anonymous) at (0,0) size 367x414
       RenderText {#text} at (0,0) size 367x234
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -190,7 +190,7 @@ layer at (8,1448) size 760x352
   RenderBlock {DIV} at (0,1432) size 760x352 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x342
 layer at (13,1453) size 367x662
-  RenderMultiColumnFlowThread at (5,5) size 367x662
+  RenderMultiColumnFlow at (5,5) size 367x662
     RenderBlock (anonymous) at (0,0) size 367x432
       RenderInline {SPAN} at (0,0) size 367x252
         RenderText {#text} at (0,0) size 367x198
@@ -240,7 +240,7 @@ layer at (8,1816) size 760x368
   RenderBlock {DIV} at (0,1800) size 760x368 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x358
 layer at (13,1821) size 367x716 backgroundClip at (0,0) size 785x2200 clip at (0,0) size 785x2200
-  RenderMultiColumnFlowThread at (5,5) size 367x716
+  RenderMultiColumnFlow at (5,5) size 367x716
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 367x198
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/mac/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x410
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,80) size 750x325
 layer at (13,21) size 367x656
-  RenderMultiColumnFlowThread at (5,5) size 367x656
+  RenderMultiColumnFlow at (5,5) size 367x656
     RenderBlock {SPAN} at (0,8) size 367x198 [color=#FFFFFF] [bgcolor=#000000]
       RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
       RenderBlock (anonymous) at (0,0) size 367x198
@@ -67,7 +67,7 @@ layer at (8,442) size 760x410
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,396) size 750x9
 layer at (13,447) size 367x662
-  RenderMultiColumnFlowThread at (5,5) size 367x662
+  RenderMultiColumnFlow at (5,5) size 367x662
     RenderBlock (anonymous) at (0,0) size 367x594
       RenderText {#text} at (0,0) size 367x594
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -119,7 +119,7 @@ layer at (8,868) size 760x441
         text run at (0,0) width 277: "This is a spanning element."
     RenderMultiColumnSet at (5,214) size 750x223
 layer at (13,873) size 367x702 backgroundClip at (0,0) size 785x1325 clip at (0,0) size 785x1325
-  RenderMultiColumnFlowThread at (5,5) size 367x702
+  RenderMultiColumnFlow at (5,5) size 367x702
     RenderBlock {P} at (0,16) size 367x198
       RenderText {#text} at (0,0) size 367x198
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/mac/fast/multicol/span/span-as-nested-columns-child-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/span-as-nested-columns-child-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x410
         text run at (0,0) width 666: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,80) size 750x325
 layer at (13,21) size 367x656
-  RenderMultiColumnFlowThread at (5,5) size 367x656
+  RenderMultiColumnFlow at (5,5) size 367x656
     RenderBlock {SPAN} at (0,8) size 367x198 [color=#FFFFFF] [bgcolor=#000000]
       RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
       RenderBlock (anonymous) at (0,0) size 367x198
@@ -63,7 +63,7 @@ layer at (8,442) size 760x410
         text run at (0,0) width 602: "This is a spanning element at the end of the columns block."
     RenderMultiColumnSet at (5,396) size 750x9
 layer at (13,447) size 367x662
-  RenderMultiColumnFlowThread at (5,5) size 367x662
+  RenderMultiColumnFlow at (5,5) size 367x662
     RenderBlock (anonymous) at (0,0) size 367x396
       RenderText {#text} at (0,0) size 367x396
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -115,7 +115,7 @@ layer at (8,868) size 760x409
         text run at (0,0) width 635: "This is a spanning element in the middle of the columns block."
     RenderMultiColumnSet at (5,198) size 750x207
 layer at (13,873) size 367x654 backgroundClip at (0,0) size 785x1293 clip at (0,0) size 785x1293
-  RenderMultiColumnFlowThread at (5,5) size 367x654
+  RenderMultiColumnFlow at (5,5) size 367x654
     RenderBlock (anonymous) at (0,0) size 367x198
       RenderText {#text} at (0,0) size 367x198
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/mac/fast/multicol/span/span-as-nested-inline-block-child-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/span-as-nested-inline-block-child-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x102
   RenderBlock {DIV} at (0,0) size 784x102
     RenderMultiColumnSet at (0,0) size 784x102
 layer at (8,8) size 384x192
-  RenderMultiColumnFlowThread at (0,0) size 384x192
+  RenderMultiColumnFlow at (0,0) size 384x192
     RenderBlock {DIV} at (0,0) size 384x102
       RenderBlock {P} at (0,16) size 384x18
         RenderText {#text} at (0,0) size 338x18

--- a/LayoutTests/platform/mac/fast/multicol/span/span-margin-collapsing-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/span-margin-collapsing-expected.txt
@@ -12,7 +12,7 @@ layer at (8,16) size 750x420
         text run at (0,28) width 529: "should collapse its margins with the top of the page."
     RenderMultiColumnSet at (0,95) size 750x325
 layer at (8,16) size 367x630
-  RenderMultiColumnFlowThread at (0,0) size 367x630
+  RenderMultiColumnFlow at (0,0) size 367x630
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x630
       RenderText {#text} at (0,0) size 367x630
@@ -64,7 +64,7 @@ layer at (8,452) size 750x420
         text run at (0,28) width 505: "collapse its margins with the h2 in the next block."
     RenderMultiColumnSet at (0,419) size 750x0
 layer at (8,452) size 367x630
-  RenderMultiColumnFlowThread at (0,0) size 367x630
+  RenderMultiColumnFlow at (0,0) size 367x630
     RenderBlock (anonymous) at (0,0) size 367x630
       RenderText {#text} at (0,0) size 367x630
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -115,7 +115,7 @@ layer at (8,888) size 750x419
         text run at (0,28) width 622: "should collapse its margins with the h2 in the previous block."
     RenderMultiColumnSet at (0,95) size 750x325
 layer at (8,888) size 367x630
-  RenderMultiColumnFlowThread at (0,0) size 367x630
+  RenderMultiColumnFlow at (0,0) size 367x630
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x630
       RenderText {#text} at (0,0) size 367x630
@@ -173,7 +173,7 @@ layer at (8,1323) size 750x568
         text run at (0,28) width 569: "collapse its margins with the spanning element above it."
     RenderMultiColumnSet at (0,369) size 750x199
 layer at (8,1323) size 367x792 backgroundClip at (0,0) size 785x1907 clip at (0,0) size 785x1907
-  RenderMultiColumnFlowThread at (0,0) size 367x792
+  RenderMultiColumnFlow at (0,0) size 367x792
     RenderBlock (anonymous) at (0,0) size 367x396
       RenderText {#text} at (0,0) size 367x396
         text run at (0,0) width 364: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/mac/fast/multicol/table-margin-collapse-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/table-margin-collapse-expected.txt
@@ -13,7 +13,7 @@ layer at (8,44) size 784x304
   RenderBlock {DIV} at (0,36) size 784x304 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 780x300
 layer at (10,46) size 382x500
-  RenderMultiColumnFlowThread at (2,2) size 382x500
+  RenderMultiColumnFlow at (2,2) size 382x500
     RenderTable {TABLE} at (0,0) size 382x500
       RenderTableSection {TBODY} at (0,0) size 382x500
         RenderTableRow {TR} at (0,0) size 382x500

--- a/LayoutTests/platform/mac/fast/multicol/table-vertical-align-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/table-vertical-align-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 769x350
   RenderBlock {DIV} at (0,0) size 769x350
     RenderMultiColumnSet at (0,0) size 769x350
 layer at (8,8) size 377x1179 backgroundClip at (0,0) size 1562x1010 clip at (0,0) size 1562x1010
-  RenderMultiColumnFlowThread at (0,0) size 377x1179
+  RenderMultiColumnFlow at (0,0) size 377x1179
     RenderTable {TABLE} at (0,0) size 377x1179 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 375x1177
         RenderTableRow {TR} at (0,0) size 375x1177
@@ -143,7 +143,7 @@ layer at (8,376) size 769x300
   RenderBlock {DIV} at (0,368) size 769x300
     RenderMultiColumnSet at (0,0) size 769x300
 layer at (8,376) size 377x1166 backgroundClip at (0,0) size 1562x1010 clip at (0,0) size 1562x1010
-  RenderMultiColumnFlowThread at (0,0) size 377x1166
+  RenderMultiColumnFlow at (0,0) size 377x1166
     RenderTable {TABLE} at (0,0) size 377x1166 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 375x1164
         RenderTableRow {TR} at (0,0) size 375x1164
@@ -279,7 +279,7 @@ layer at (8,702) size 769x300
   RenderBlock {DIV} at (0,694) size 769x300
     RenderMultiColumnSet at (0,0) size 769x300
 layer at (8,702) size 377x1129 backgroundClip at (0,0) size 1562x1010 clip at (0,0) size 1562x1010
-  RenderMultiColumnFlowThread at (0,0) size 377x1129
+  RenderMultiColumnFlow at (0,0) size 377x1129
     RenderTable {TABLE} at (0,0) size 377x1129 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 375x1127
         RenderTableRow {TR} at (0,0) size 375x1127

--- a/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x304
   RenderBlock {DIV} at (0,0) size 784x304 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 780x300
 layer at (10,10) size 382x650 backgroundClip at (0,0) size 1188x585 clip at (0,0) size 1188x585
-  RenderMultiColumnFlowThread at (2,2) size 382x650
+  RenderMultiColumnFlow at (2,2) size 382x650
     RenderBlock {P} at (0,16) size 382x58
       RenderText {#text} at (0,-4) size 300x19
         text run at (0,-3) width 300: "This image should not be split across columns."

--- a/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-lr-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-lr-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 304x584
   RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (10,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
+  RenderMultiColumnFlow at (2,2) size 650x282
     RenderBlock {P} at (16,0) size 108x282
       RenderText {#text} at (0,0) size 36x238
         text run at (0,0) width 238: "This image should not be split across"

--- a/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-lr-mixed-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-lr-mixed-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 304x584
   RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (10,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
+  RenderMultiColumnFlow at (2,2) size 650x282
     RenderBlock {P} at (16,0) size 108x282
       RenderText {#text} at (0,0) size 36x238
         text run at (0,0) width 238: "This image should not be split across"

--- a/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-rl-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/tall-image-behavior-rl-expected.txt
@@ -7,7 +7,7 @@ layer at (473,8) size 304x584
   RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (125,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
+  RenderMultiColumnFlow at (2,2) size 650x282
     RenderBlock {P} at (16,0) size 108x282
       RenderText {#text} at (0,0) size 36x238
         text run at (0,0) width 238: "This image should not be split across"

--- a/LayoutTests/platform/mac/fast/multicol/vertical-lr/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/vertical-lr/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 160x584
   RenderBlock {DIV} at (0,0) size 160x584 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 156x580
 layer at (10,10) size 312x282
-  RenderMultiColumnFlowThread at (2,2) size 312x282
+  RenderMultiColumnFlow at (2,2) size 312x282
     RenderBlock {DIV} at (0,0) size 110x282
     RenderBlock {DIV} at (156,0) size 156x379 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (2,12) size 152x355 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/mac/fast/multicol/vertical-rl/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/vertical-rl/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (632,8) size 160x584
   RenderBlock {DIV} at (0,0) size 160x584 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 156x580
 layer at (478,10) size 312x282
-  RenderMultiColumnFlowThread at (2,2) size 312x282
+  RenderMultiColumnFlow at (2,2) size 312x282
     RenderBlock {DIV} at (0,0) size 110x282
     RenderBlock {DIV} at (156,0) size 156x379 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (2,12) size 152x355 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/mac/fast/overflow/paged-x-div-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/paged-x-div-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x385 scrollWidth 2480
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x385
 layer at (10,10) size 400x2213 backgroundClip at (10,10) size 400x385 clip at (10,10) size 400x385
-  RenderMultiColumnFlowThread at (2,2) size 400x2213
+  RenderMultiColumnFlow at (2,2) size 400x2213
     RenderText {#text} at (0,0) size 399x2213
       text run at (0,0) width 357: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       text run at (0,18) width 399: "Maecenas lacinia massa in lectus pretium vulputate. Curabitur"

--- a/LayoutTests/platform/mac/fast/overflow/paged-x-div-with-column-gap-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/paged-x-div-with-column-gap-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x385 scrollX 200 scrollWidth
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x385
 layer at (-190,10) size 400x2213 backgroundClip at (10,10) size 400x385 clip at (10,10) size 400x385
-  RenderMultiColumnFlowThread at (2,2) size 400x2213
+  RenderMultiColumnFlow at (2,2) size 400x2213
     RenderText {#text} at (0,0) size 399x2213
       text run at (0,0) width 357: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       text run at (0,18) width 399: "Maecenas lacinia massa in lectus pretium vulputate. Curabitur"

--- a/LayoutTests/platform/mac/fast/overflow/paged-x-on-root-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/paged-x-on-root-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1600x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 800x1097 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
-  RenderMultiColumnFlowThread at (0,0) size 800x1097
+  RenderMultiColumnFlow at (0,0) size 800x1097
 layer at (0,0) size 800x1097 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
   RenderBlock {HTML} at (0,0) size 800x1097
     RenderBody {BODY} at (8,8) size 784x1081

--- a/LayoutTests/platform/mac/fast/overflow/paged-x-with-column-gap-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/paged-x-with-column-gap-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1700x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 800x1097 backgroundClip at (0,0) size 1700x585 clip at (0,0) size 1700x585
-  RenderMultiColumnFlowThread at (0,0) size 800x1097
+  RenderMultiColumnFlow at (0,0) size 800x1097
 layer at (0,0) size 800x1097 backgroundClip at (0,0) size 1700x585 clip at (0,0) size 1700x585
   RenderBlock {HTML} at (0,0) size 800x1097
     RenderBody {BODY} at (8,8) size 784x1081

--- a/LayoutTests/platform/mac/fast/overflow/paged-y-div-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/paged-y-div-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x400 scrollHeight 2480
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x400
 layer at (10,10) size 400x2198 backgroundClip at (10,10) size 400x400 clip at (10,10) size 400x400
-  RenderMultiColumnFlowThread at (2,2) size 400x2198
+  RenderMultiColumnFlow at (2,2) size 400x2198
     RenderText {#text} at (0,0) size 399x2198
       text run at (0,0) width 357: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       text run at (0,18) width 399: "Maecenas lacinia massa in lectus pretium vulputate. Curabitur"

--- a/LayoutTests/platform/mac/fast/overflow/paged-y-on-root-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/paged-y-on-root-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1200
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x1130
-  RenderMultiColumnFlowThread at (0,0) size 785x1130
+  RenderMultiColumnFlow at (0,0) size 785x1130
 layer at (0,0) size 785x1130
   RenderBlock {HTML} at (0,0) size 785x1130
     RenderBody {BODY} at (8,8) size 769x1114

--- a/LayoutTests/platform/mac/fast/repaint/multicol-repaint-expected.txt
+++ b/LayoutTests/platform/mac/fast/repaint/multicol-repaint-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 402x102
   RenderBlock {DIV} at (0,0) size 402x102 [border: (1px solid #000000)]
     RenderMultiColumnSet at (1,1) size 400x100
 layer at (9,9) size 175x159
-  RenderMultiColumnFlowThread at (1,1) size 175x159
+  RenderMultiColumnFlow at (1,1) size 175x159
     RenderText {#text} at (0,0) size 13x59
       text run at (0,0) width 13: " "
     RenderBR {BR} at (12,0) size 1x59

--- a/LayoutTests/platform/win/css3/unicode-bidi-isolate-basic-expected.txt
+++ b/LayoutTests/platform/win/css3/unicode-bidi-isolate-basic-expected.txt
@@ -14,7 +14,7 @@ layer at (8,62) size 25x400
   RenderBlock (positioned) {DIV} at (0,0) size 26x400 [color=#FF0000]
     RenderMultiColumnSet at (0,0) size 26x400
 layer at (8,62) size 25x1960 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 26x1960
+  RenderMultiColumnFlow at (0,0) size 26x1960
     RenderBlock {DIV} at (0,0) size 26x18
       RenderText {#text} at (0,0) size 7x17
         text run at (0,0) width 7: "\""
@@ -883,7 +883,7 @@ layer at (8,62) size 25x400
   RenderBlock (positioned) {DIV} at (0,0) size 26x400 [color=#008000]
     RenderMultiColumnSet at (0,0) size 26x400
 layer at (8,62) size 25x1960 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 26x1960
+  RenderMultiColumnFlow at (0,0) size 26x1960
     RenderBlock {DIV} at (0,0) size 26x18
       RenderText {#text} at (0,0) size 7x17
         text run at (0,0) width 7: "\""

--- a/LayoutTests/platform/win/fast/block/float/float-not-removed-from-next-sibling4-expected.txt
+++ b/LayoutTests/platform/win/fast/block/float/float-not-removed-from-next-sibling4-expected.txt
@@ -19,7 +19,7 @@ layer at (8,8) size 15x200
   RenderBlock {DIV} at (0,0) size 15x200
     RenderMultiColumnSet at (0,0) size 15x200
 layer at (8,8) size 0x200
-  RenderMultiColumnFlowThread at (0,0) size 0x200
+  RenderMultiColumnFlow at (0,0) size 0x200
     RenderImage {IMG} at (0,0) size 15x200 [bgcolor=#C0C0C0]
 layer at (8,208) size 16x96
   RenderBlock (positioned) {DIV} at (0,200) size 16x96

--- a/LayoutTests/platform/win/fast/borders/border-antialiasing-expected.txt
+++ b/LayoutTests/platform/win/fast/borders/border-antialiasing-expected.txt
@@ -165,7 +165,7 @@ layer at (28,179) size 600x100
   RenderBlock {DIV} at (10,159) size 600x100
     RenderMultiColumnSet at (0,0) size 600x100
 layer at (28,179) size 11x1200 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 11x1200
+  RenderMultiColumnFlow at (0,0) size 11x1200
     RenderText {#text} at (0,0) size 8x1199
       text run at (0,0) width 8: "_"
       text run at (0,20) width 8: "_"

--- a/LayoutTests/platform/win/fast/line-grid/line-grid-inside-columns-expected.txt
+++ b/LayoutTests/platform/win/fast/line-grid/line-grid-inside-columns-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x504
   RenderBlock {DIV} at (0,0) size 784x504 [border: (2px solid #FF0000)]
     RenderMultiColumnSet at (2,2) size 780x500
 layer at (10,10) size 382x1538 backgroundClip at (0,0) size 1586x585 clip at (0,0) size 1586x585
-  RenderMultiColumnFlowThread at (2,2) size 382x1538
+  RenderMultiColumnFlow at (2,2) size 382x1538
     RenderBlock {DIV} at (0,0) size 382x1538
       RenderBlock {DIV} at (0,0) size 382x373
         RenderText {#text} at (0,19) size 352x101

--- a/LayoutTests/platform/win/fast/line-grid/line-grid-into-columns-expected.txt
+++ b/LayoutTests/platform/win/fast/line-grid/line-grid-into-columns-expected.txt
@@ -51,7 +51,7 @@ layer at (0,0) size 800x540
   RenderBlock {DIV} at (0,0) size 800x540
     RenderMultiColumnSet at (20,20) size 760x500
 layer at (20,20) size 362x977 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (20,20) size 362x977
+  RenderMultiColumnFlow at (20,20) size 362x977
     RenderBlock {DIV} at (0,0) size 362x395
       RenderText {#text} at (0,41) size 352x101
         text run at (0,41) width 350: "All of this text even though it's smaller should be on the"

--- a/LayoutTests/platform/win/fast/multicol/block-axis-horizontal-bt-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/block-axis-horizontal-bt-expected.txt
@@ -7,7 +7,7 @@ layer at (20,360) size 200x170
   RenderBlock {DIV} at (20,0) size 200x170 [border: none (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (0,20) size 200x150
 layer at (20,20) size 200x490
-  RenderMultiColumnFlowThread at (0,20) size 200x490
+  RenderMultiColumnFlow at (0,20) size 200x490
     RenderText {#text} at (0,0) size 173x99
       text run at (0,0) width 169: "Lorem ipsum dolor sit amet,"
       text run at (0,20) width 73: "consectetur "

--- a/LayoutTests/platform/win/fast/multicol/block-axis-horizontal-tb-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/block-axis-horizontal-tb-expected.txt
@@ -7,7 +7,7 @@ layer at (20,0) size 200x170
   RenderBlock {DIV} at (20,0) size 200x170 [border: (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (0,20) size 200x150
 layer at (20,20) size 200x490
-  RenderMultiColumnFlowThread at (0,20) size 200x490
+  RenderMultiColumnFlow at (0,20) size 200x490
     RenderText {#text} at (0,0) size 173x99
       text run at (0,0) width 169: "Lorem ipsum dolor sit amet,"
       text run at (0,20) width 73: "consectetur "

--- a/LayoutTests/platform/win/fast/multicol/block-axis-vertical-lr-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/block-axis-vertical-lr-expected.txt
@@ -7,7 +7,7 @@ layer at (0,20) size 170x200
   RenderBlock {DIV} at (0,0) size 170x200 [border: none (20px solid #C0C0C0)]
     RenderMultiColumnSet at (20,0) size 150x200
 layer at (20,20) size 490x200
-  RenderMultiColumnFlowThread at (20,0) size 490x200
+  RenderMultiColumnFlow at (20,0) size 490x200
     RenderText {#text} at (0,0) size 99x173
       text run at (0,0) width 169: "Lorem ipsum dolor sit amet,"
       text run at (20,0) width 73: "consectetur "

--- a/LayoutTests/platform/win/fast/multicol/block-axis-vertical-rl-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/block-axis-vertical-rl-expected.txt
@@ -7,7 +7,7 @@ layer at (360,20) size 170x200
   RenderBlock {DIV} at (360,0) size 170x200 [border: none (20px solid #C0C0C0) none]
     RenderMultiColumnSet at (20,0) size 150x200
 layer at (20,20) size 490x200
-  RenderMultiColumnFlowThread at (20,0) size 490x200
+  RenderMultiColumnFlow at (20,0) size 490x200
     RenderText {#text} at (0,0) size 99x173
       text run at (0,0) width 169: "Lorem ipsum dolor sit amet,"
       text run at (20,0) width 73: "consectetur "

--- a/LayoutTests/platform/win/fast/multicol/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x194
   RenderBlock {DIV} at (0,0) size 784x194 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 780x190
 layer at (10,10) size 382x270
-  RenderMultiColumnFlowThread at (2,2) size 382x270
+  RenderMultiColumnFlow at (2,2) size 382x270
     RenderBlock {DIV} at (0,0) size 382x110
     RenderBlock {DIV} at (0,110) size 379x160 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (12,2) size 355x156 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/win/fast/multicol/client-rects-spanners-complex-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/client-rects-spanners-complex-expected.txt
@@ -63,7 +63,7 @@ layer at (8,64) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (16,72) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x105
@@ -78,7 +78,7 @@ layer at (128,64) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (136,72) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x105
@@ -95,7 +95,7 @@ layer at (248,64) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (256,72) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -111,7 +111,7 @@ layer at (368,64) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (376,72) size 48x115
-  RenderMultiColumnFlowThread at (8,8) size 48x115
+  RenderMultiColumnFlow at (8,8) size 48x115
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -127,7 +127,7 @@ layer at (488,82) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (496,90) size 48x94
-  RenderMultiColumnFlowThread at (8,8) size 48x94
+  RenderMultiColumnFlow at (8,8) size 48x94
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -144,7 +144,7 @@ layer at (608,84) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (616,92) size 48x90
-  RenderMultiColumnFlowThread at (8,8) size 48x90
+  RenderMultiColumnFlow at (8,8) size 48x90
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock (anonymous) at (0,10) size 48x25
@@ -158,7 +158,7 @@ layer at (8,210) size 116x106
     RenderBlock {DIV} at (8,13) size 100x30 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,43) size 100x55
 layer at (16,218) size 48x75
-  RenderMultiColumnFlowThread at (8,8) size 48x75
+  RenderMultiColumnFlow at (8,8) size 48x75
     RenderBlock {DIV} at (0,0) size 48x10 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (0,10) size 0x0
     RenderBlock {DIV} at (0,50) size 25x25 [bgcolor=#ADD8E6]
@@ -168,7 +168,7 @@ layer at (138,210) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (146,218) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -183,7 +183,7 @@ layer at (268,210) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (276,218) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -200,7 +200,7 @@ layer at (398,210) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (406,218) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -216,7 +216,7 @@ layer at (528,210) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (536,218) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -232,7 +232,7 @@ layer at (658,210) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (666,218) size 94x48
-  RenderMultiColumnFlowThread at (8,8) size 94x48
+  RenderMultiColumnFlow at (8,8) size 94x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -249,7 +249,7 @@ layer at (18,331) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (26,339) size 90x48
-  RenderMultiColumnFlowThread at (8,8) size 90x48
+  RenderMultiColumnFlow at (8,8) size 90x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -263,7 +263,7 @@ layer at (148,331) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (156,339) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock {DIV} at (50,0) size 25x25 [bgcolor=#ADD8E6]
@@ -273,7 +273,7 @@ layer at (278,331) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (261,339) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -288,7 +288,7 @@ layer at (408,331) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (391,339) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 105x48
@@ -305,7 +305,7 @@ layer at (538,331) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (521,339) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -321,7 +321,7 @@ layer at (668,331) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (651,339) size 115x48
-  RenderMultiColumnFlowThread at (8,8) size 115x48
+  RenderMultiColumnFlow at (8,8) size 115x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -337,7 +337,7 @@ layer at (18,452) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (22,460) size 94x48
-  RenderMultiColumnFlowThread at (8,8) size 94x48
+  RenderMultiColumnFlow at (8,8) size 94x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -354,7 +354,7 @@ layer at (148,452) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (156,460) size 90x48
-  RenderMultiColumnFlowThread at (8,8) size 90x48
+  RenderMultiColumnFlow at (8,8) size 90x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock (anonymous) at (10,0) size 25x48
@@ -368,7 +368,7 @@ layer at (278,452) size 106x116
     RenderBlock {DIV} at (13,8) size 30x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (43,8) size 55x100
 layer at (301,460) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderBlock {DIV} at (0,0) size 10x48 [bgcolor=#000080]
     RenderMultiColumnSpannerPlaceholder at (10,0) size 0x0
     RenderBlock {DIV} at (50,0) size 25x25 [bgcolor=#ADD8E6]

--- a/LayoutTests/platform/win/fast/multicol/client-rects-spanners-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/client-rects-spanners-expected.txt
@@ -64,7 +64,7 @@ layer at (8,64) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (16,72) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x100
       RenderBR {BR} at (0,0) size 0x25
@@ -77,7 +77,7 @@ layer at (128,64) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (136,72) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x100
       RenderBR {BR} at (0,0) size 0x25
@@ -92,7 +92,7 @@ layer at (248,64) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (256,72) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -106,7 +106,7 @@ layer at (368,64) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (376,72) size 48x100
-  RenderMultiColumnFlowThread at (8,8) size 48x100
+  RenderMultiColumnFlow at (8,8) size 48x100
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -120,7 +120,7 @@ layer at (488,82) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (496,90) size 48x79
-  RenderMultiColumnFlowThread at (8,8) size 48x79
+  RenderMultiColumnFlow at (8,8) size 48x79
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -135,7 +135,7 @@ layer at (608,84) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (616,92) size 48x75
-  RenderMultiColumnFlowThread at (8,8) size 48x75
+  RenderMultiColumnFlow at (8,8) size 48x75
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 48x25
       RenderBR {BR} at (0,0) size 0x25
@@ -147,7 +147,7 @@ layer at (8,202) size 116x76
     RenderBlock {DIV} at (8,8) size 100x10 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (8,18) size 100x50
 layer at (16,210) size 48x65
-  RenderMultiColumnFlowThread at (8,8) size 48x65
+  RenderMultiColumnFlow at (8,8) size 48x65
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (0,40) size 25x25 [bgcolor=#ADD8E6]
 layer at (138,172) size 76x116
@@ -155,7 +155,7 @@ layer at (138,172) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (146,180) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -168,7 +168,7 @@ layer at (238,172) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (246,180) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -183,7 +183,7 @@ layer at (338,172) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (346,180) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -197,7 +197,7 @@ layer at (438,172) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (446,180) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -211,7 +211,7 @@ layer at (538,172) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (546,180) size 79x48
-  RenderMultiColumnFlowThread at (8,8) size 79x48
+  RenderMultiColumnFlow at (8,8) size 79x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -226,7 +226,7 @@ layer at (638,172) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (646,180) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -238,7 +238,7 @@ layer at (18,293) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (26,301) size 65x48
-  RenderMultiColumnFlowThread at (8,8) size 65x48
+  RenderMultiColumnFlow at (8,8) size 65x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (40,0) size 25x25 [bgcolor=#ADD8E6]
 layer at (118,293) size 76x116
@@ -246,7 +246,7 @@ layer at (118,293) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (86,301) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -259,7 +259,7 @@ layer at (218,293) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (186,301) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 100x48
       RenderBR {BR} at (0,0) size 25x0
@@ -274,7 +274,7 @@ layer at (318,293) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (286,301) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -288,7 +288,7 @@ layer at (418,293) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (386,301) size 100x48
-  RenderMultiColumnFlowThread at (8,8) size 100x48
+  RenderMultiColumnFlow at (8,8) size 100x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -302,7 +302,7 @@ layer at (518,293) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (507,301) size 79x48
-  RenderMultiColumnFlowThread at (8,8) size 79x48
+  RenderMultiColumnFlow at (8,8) size 79x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -317,7 +317,7 @@ layer at (618,293) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (611,301) size 75x48
-  RenderMultiColumnFlowThread at (8,8) size 75x48
+  RenderMultiColumnFlow at (8,8) size 75x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 25x48
       RenderBR {BR} at (0,0) size 25x0
@@ -329,7 +329,7 @@ layer at (18,414) size 76x116
     RenderBlock {DIV} at (8,8) size 10x100 [bgcolor=#C0C0C0]
     RenderMultiColumnSet at (18,8) size 50x100
 layer at (21,422) size 65x48
-  RenderMultiColumnFlowThread at (8,8) size 65x48
+  RenderMultiColumnFlow at (8,8) size 65x48
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {DIV} at (40,0) size 25x25 [bgcolor=#ADD8E6]
 layer at (16,107) size 25x25

--- a/LayoutTests/platform/win/fast/multicol/column-rules-stacking-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/column-rules-stacking-expected.txt
@@ -15,7 +15,7 @@ layer at (8,48) size 769x610 layerType: foreground only
   RenderBlock (relative positioned) {DIV} at (0,40) size 769x610 [bgcolor=#FF0000] [border: (5px solid #000000)]
     RenderMultiColumnSet at (35,5) size 699x600
 layer at (43,53) size 222x1760 backgroundClip at (0,0) size 785x666 clip at (0,0) size 785x666
-  RenderMultiColumnFlowThread at (35,5) size 223x1760
+  RenderMultiColumnFlow at (35,5) size 223x1760
     RenderText {#text} at (0,0) size 222x1759
       text run at (0,0) width 169: "Lorem ipsum dolor sit amet,"
       text run at (0,20) width 200: "consectetuer adipiscing elit. Nulla"

--- a/LayoutTests/platform/win/fast/multicol/columns-shorthand-parsing-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/columns-shorthand-parsing-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 769x680
   RenderBlock {DIV} at (0,0) size 769x680
     RenderMultiColumnSet at (0,0) size 769x680
 layer at (8,8) size 377x1360 backgroundClip at (0,0) size 785x696 clip at (0,0) size 785x696
-  RenderMultiColumnFlowThread at (0,0) size 377x1360
+  RenderMultiColumnFlow at (0,0) size 377x1360
     RenderText {#text} at (0,0) size 373x1359
       text run at (0,0) width 350: "This content should be split into two columns. This content"
       text run at (0,20) width 363: "should be split into two columns. This content should be split"

--- a/LayoutTests/platform/win/fast/multicol/float-paginate-empty-lines-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/float-paginate-empty-lines-expected.txt
@@ -11,7 +11,7 @@ layer at (8,64) size 784x400
   RenderBlock {DIV} at (0,56) size 784x400
     RenderMultiColumnSet at (0,0) size 784x400
 layer at (8,64) size 384x600 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (0,0) size 384x600
+  RenderMultiColumnFlow at (0,0) size 384x600
     RenderBlock {DIV} at (0,0) size 384x260 [border: (10px dashed #800000)]
       RenderText {#text} at (10,10) size 104x19
         text run at (10,10) width 104: "This is some text."

--- a/LayoutTests/platform/win/fast/multicol/max-height-columns-block-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/max-height-columns-block-expected.txt
@@ -17,7 +17,7 @@ layer at (8,88) size 404x64
   RenderBlock {DIV} at (0,80) size 404x64 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x60
 layer at (10,90) size 61x596 backgroundClip at (0,0) size 834x585 clip at (0,0) size 834x585
-  RenderMultiColumnFlowThread at (2,2) size 61x596
+  RenderMultiColumnFlow at (2,2) size 61x596
     RenderText {#text} at (0,0) size 50x115
       text run at (0,0) width 41: "This"
       text run at (0,28) width 15: "is"

--- a/LayoutTests/platform/win/fast/multicol/overflow-across-columns-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/overflow-across-columns-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 506x505
   RenderBlock {DIV} at (0,0) size 506x505 [border: (3px solid #000000)]
     RenderMultiColumnSet at (3,3) size 500x499
 layer at (11,11) size 159x1454 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (3,3) size 159x1454
+  RenderMultiColumnFlow at (3,3) size 159x1454
 layer at (11,11) size 159x1454 backgroundClip at (11,11) size 159x589 clip at (11,11) size 159x589
   RenderBlock {DIV} at (0,0) size 159x1454
     RenderText {#text} at (0,4) size 159x1445

--- a/LayoutTests/platform/win/fast/multicol/overflow-across-columns-percent-height-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/overflow-across-columns-percent-height-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 506x505
   RenderBlock {DIV} at (0,0) size 506x505 [border: (3px solid #000000)]
     RenderMultiColumnSet at (3,3) size 500x499
 layer at (11,11) size 159x1454 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderMultiColumnFlowThread at (3,3) size 159x1454
+  RenderMultiColumnFlow at (3,3) size 159x1454
     RenderBlock {DIV} at (0,0) size 159x1454
 layer at (11,11) size 159x1454 backgroundClip at (11,11) size 159x589 clip at (11,11) size 159x589
   RenderBlock {DIV} at (0,0) size 159x1454

--- a/LayoutTests/platform/win/fast/multicol/paginate-block-replaced-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/paginate-block-replaced-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x404
   RenderBlock {DIV} at (0,0) size 784x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 780x400
 layer at (10,10) size 382x1300 backgroundClip at (0,0) size 1586x585 clip at (0,0) size 1586x585
-  RenderMultiColumnFlowThread at (2,2) size 382x1300
+  RenderMultiColumnFlow at (2,2) size 382x1300
     RenderBlock (anonymous) at (0,0) size 382x200
       RenderText {#text} at (0,0) size 104x19
         text run at (0,0) width 104: "This is some text."

--- a/LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-bt-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1580
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,-756) size 785x1356 backgroundClip at (0,0) size 785x1580 clip at (0,0) size 785x1580
-  RenderMultiColumnFlowThread at (0,0) size 785x1356
+  RenderMultiColumnFlow at (0,0) size 785x1356
 layer at (0,-756) size 785x1356 backgroundClip at (0,0) size 785x1580 clip at (0,0) size 785x1580
   RenderBlock {HTML} at (0,0) size 785x1356
     RenderBody {BODY} at (8,8) size 769x1332

--- a/LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-lr-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 3718x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 3718x180
+  RenderMultiColumnFlow at (0,0) size 3718x180
 layer at (0,0) size 3718x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 3718x180
     RenderBody {BODY} at (8,8) size 3694x164

--- a/LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-rl-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (-2933,0) size 3718x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 3718x180
+  RenderMultiColumnFlow at (0,0) size 3718x180
 layer at (-2933,0) size 3718x180 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 3718x180
     RenderBody {BODY} at (8,8) size 3694x164

--- a/LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-tb-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x1356 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 785x1356
+  RenderMultiColumnFlow at (0,0) size 785x1356
 layer at (0,0) size 785x1356 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 785x1356
     RenderBody {BODY} at (8,8) size 769x1332

--- a/LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-bt-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1380x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,-3141) size 180x3726 backgroundClip at (0,0) size 1380x585 clip at (0,0) size 1380x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3726
+  RenderMultiColumnFlow at (0,0) size 180x3726
 layer at (0,-3141) size 180x3726 backgroundClip at (0,0) size 1380x585 clip at (0,0) size 1380x585
   RenderBlock {HTML} at (0,0) size 180x3726
     RenderBody {BODY} at (8,8) size 164x3702

--- a/LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-lr-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1780x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 1442x585
-  RenderMultiColumnFlowThread at (0,0) size 1442x585
+  RenderMultiColumnFlow at (0,0) size 1442x585
 layer at (0,0) size 1442x585
   RenderBlock {HTML} at (0,0) size 1442x585
     RenderBody {BODY} at (8,8) size 1418x569

--- a/LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-rl-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-642,0) size 1442x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 1442x585
+  RenderMultiColumnFlow at (0,0) size 1442x585
 layer at (-642,0) size 1442x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 1442x585
     RenderBody {BODY} at (8,8) size 1418x569

--- a/LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-tb-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1380x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 180x3726 backgroundClip at (0,0) size 1380x585 clip at (0,0) size 1380x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3726
+  RenderMultiColumnFlow at (0,0) size 180x3726
 layer at (0,0) size 180x3726 backgroundClip at (0,0) size 1380x585 clip at (0,0) size 1380x585
   RenderBlock {HTML} at (0,0) size 180x3726
     RenderBody {BODY} at (8,8) size 164x3702

--- a/LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-bt-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,-3141) size 180x3726 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3726
+  RenderMultiColumnFlow at (0,0) size 180x3726
 layer at (0,-3141) size 180x3726 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 180x3726
     RenderBody {BODY} at (8,8) size 164x3702

--- a/LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-lr-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 1442x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 1442x585
+  RenderMultiColumnFlow at (0,0) size 1442x585
 layer at (0,0) size 1442x585 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 1442x585
     RenderBody {BODY} at (8,8) size 1418x569

--- a/LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1780x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-642,0) size 1442x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
-  RenderMultiColumnFlowThread at (0,0) size 1442x585
+  RenderMultiColumnFlow at (0,0) size 1442x585
 layer at (-642,0) size 1442x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
   RenderBlock {HTML} at (0,0) size 1442x585
     RenderBody {BODY} at (8,8) size 1418x569

--- a/LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-rl-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1780x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (-642,0) size 1442x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
-  RenderMultiColumnFlowThread at (0,0) size 1442x585
+  RenderMultiColumnFlow at (0,0) size 1442x585
 layer at (-642,0) size 1442x585 backgroundClip at (0,0) size 1780x585 clip at (0,0) size 1780x585
   RenderBlock {HTML} at (0,0) size 1442x585
     RenderBody {BODY} at (8,8) size 1418x569

--- a/LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-tb-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 180x3726 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
-  RenderMultiColumnFlowThread at (0,0) size 180x3726
+  RenderMultiColumnFlow at (0,0) size 180x3726
 layer at (0,0) size 180x3726 backgroundClip at (0,0) size 800x585 clip at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 180x3726
     RenderBody {BODY} at (8,8) size 164x3702

--- a/LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-bt-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-bt-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x600
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,-756) size 785x1356 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
-  RenderMultiColumnFlowThread at (0,0) size 785x1356
+  RenderMultiColumnFlow at (0,0) size 785x1356
 layer at (0,-756) size 785x1356 backgroundClip at (0,0) size 785x600 clip at (0,0) size 785x600
   RenderBlock {HTML} at (0,0) size 785x1356
     RenderBody {BODY} at (8,8) size 769x1332

--- a/LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-lr-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-lr-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x980
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 3718x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
-  RenderMultiColumnFlowThread at (0,0) size 3718x180
+  RenderMultiColumnFlow at (0,0) size 3718x180
 layer at (0,0) size 3718x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
   RenderBlock {HTML} at (0,0) size 3718x180
     RenderBody {BODY} at (8,8) size 3694x164

--- a/LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-rl-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-rl-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x980
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (-2933,0) size 3718x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
-  RenderMultiColumnFlowThread at (0,0) size 3718x180
+  RenderMultiColumnFlow at (0,0) size 3718x180
 layer at (-2933,0) size 3718x180 backgroundClip at (0,0) size 785x980 clip at (0,0) size 785x980
   RenderBlock {HTML} at (0,0) size 3718x180
     RenderBody {BODY} at (8,8) size 3694x164

--- a/LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-tb-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-tb-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1580
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x1356
-  RenderMultiColumnFlowThread at (0,0) size 785x1356
+  RenderMultiColumnFlow at (0,0) size 785x1356
 layer at (0,0) size 785x1356
   RenderBlock {HTML} at (0,0) size 785x1356
     RenderBody {BODY} at (8,8) size 769x1332

--- a/LayoutTests/platform/win/fast/multicol/pagination/nested-transforms-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/pagination/nested-transforms-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
     RenderMultiColumnSet at (0,0) size 800x600
 layer at (0,0) size 180x600
-  RenderMultiColumnFlowThread at (0,0) size 180x600
+  RenderMultiColumnFlow at (0,0) size 180x600
 layer at (0,0) size 180x600
   RenderBlock {HTML} at (0,0) size 180x600
     RenderBody {BODY} at (8,8) size 164x584

--- a/LayoutTests/platform/win/fast/multicol/scrolling-column-rules-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/scrolling-column-rules-expected.txt
@@ -15,5 +15,5 @@ layer at (8,52) size 784x100 scrollX 200 scrollWidth 2572
   RenderBlock {DIV} at (0,36) size 784x100
     RenderMultiColumnSet at (0,0) size 784x100
 layer at (-192,52) size 337x600 backgroundClip at (8,52) size 784x100 clip at (8,52) size 784x100
-  RenderMultiColumnFlowThread at (0,0) size 337x600
+  RenderMultiColumnFlow at (0,0) size 337x600
     RenderBlock {DIV} at (0,0) size 337x600 [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/win/fast/multicol/scrolling-overflow-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/scrolling-overflow-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x300
   RenderBlock {DIV} at (0,0) size 784x300
     RenderMultiColumnSet at (0,0) size 784x300
 layer at (8,8) size 251x5316 backgroundClip at (0,0) size 4792x585 clip at (0,0) size 4792x585
-  RenderMultiColumnFlowThread at (0,0) size 251x5316
+  RenderMultiColumnFlow at (0,0) size 251x5316
     RenderBlock {P} at (0,16) size 251x564
       RenderText {#text} at (0,0) size 250x563
         text run at (0,0) width 242: "Lorem ipsum dolor sit amet, consectetur"

--- a/LayoutTests/platform/win/fast/multicol/shadow-breaking-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/shadow-breaking-expected.txt
@@ -8,7 +8,7 @@ layer at (20,36) size 424x291
   RenderBlock (positioned) {P} at (20,36) size 424x291 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 420x287
 layer at (22,38) size 200x560
-  RenderMultiColumnFlowThread at (2,2) size 200x560
+  RenderMultiColumnFlow at (2,2) size 200x560
     RenderBlock (floating) at (0,0) size 24x43
       RenderText at (0,1) size 24x41
         text run at (0,1) width 24: "L"

--- a/LayoutTests/platform/win/fast/multicol/span/anonymous-style-inheritance-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/anonymous-style-inheritance-expected.txt
@@ -10,7 +10,7 @@ layer at (8,18) size 835x463
         text run at (0,0) width 743: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,79) size 825x379
 layer at (13,23) size 404x756 backgroundClip at (0,0) size 843x585 clip at (0,0) size 843x585
-  RenderMultiColumnFlowThread at (5,5) size 404x756
+  RenderMultiColumnFlow at (5,5) size 404x756
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 404x756
       RenderText {#text} at (0,0) size 403x755

--- a/LayoutTests/platform/win/fast/multicol/span/clone-flexbox-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/clone-flexbox-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x16
   RenderBlock {DIV} at (0,0) size 784x16
     RenderMultiColumnSet at (0,0) size 784x16
 layer at (8,8) size 117x16
-  RenderMultiColumnFlowThread at (0,0) size 118x16
+  RenderMultiColumnFlow at (0,0) size 118x16
     RenderFlexibleBox {DIV} at (0,0) size 118x16 [color=#FFFFFF]
       RenderBlock (anonymous) at (0,0) size 16x16
         RenderText {#text} at (0,0) size 16x16

--- a/LayoutTests/platform/win/fast/multicol/span/clone-summary-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/clone-summary-expected.txt
@@ -9,7 +9,7 @@ layer at (8,8) size 784x32
     RenderBlock {DIV} at (0,16) size 784x0 [color=#FFFFFF]
     RenderMultiColumnSet at (0,16) size 784x16
 layer at (8,8) size 117x32
-  RenderMultiColumnFlowThread at (0,0) size 118x32
+  RenderMultiColumnFlow at (0,0) size 118x32
     RenderBlock {SUMMARY} at (0,0) size 118x32 [color=#FFFFFF]
       RenderBlock (anonymous) at (0,0) size 118x16
         RenderText {#text} at (0,0) size 16x16

--- a/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt
@@ -15,7 +15,7 @@ layer at (8,16) size 760x504
         text run at (0,0) width 218: "This is a second span."
     RenderMultiColumnSet at (5,378) size 750x121
 layer at (13,21) size 367x680
-  RenderMultiColumnFlowThread at (5,5) size 367x680
+  RenderMultiColumnFlow at (5,5) size 367x680
     RenderBlock (anonymous) at (0,0) size 367x420
       RenderText {#text} at (0,0) size 367x419
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -72,7 +72,7 @@ layer at (8,536) size 760x515
         text run at (0,0) width 218: "This is a second span."
     RenderMultiColumnSet at (5,390) size 750x121
 layer at (13,541) size 367x744
-  RenderMultiColumnFlowThread at (5,5) size 367x744
+  RenderMultiColumnFlow at (5,5) size 367x744
     RenderBlock {P} at (0,16) size 367x230
       RenderText {#text} at (0,0) size 367x229
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -128,7 +128,7 @@ layer at (8,1067) size 760x510
         text run at (0,0) width 218: "This is a second span."
     RenderMultiColumnSet at (5,384) size 750x121
 layer at (13,1072) size 367x712 backgroundClip at (0,0) size 785x1593 clip at (0,0) size 785x1593
-  RenderMultiColumnFlowThread at (5,5) size 367x712
+  RenderMultiColumnFlow at (5,5) size 367x712
     RenderBlock (anonymous) at (0,0) size 367x0
       RenderInline {SPAN} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x437
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,91) size 750x341
 layer at (13,21) size 367x680
-  RenderMultiColumnFlowThread at (5,5) size 367x680
+  RenderMultiColumnFlow at (5,5) size 367x680
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 160x19
         text run at (0,0) width 160: "Before Generated Content"
@@ -64,7 +64,7 @@ layer at (8,469) size 760x437
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,411) size 750x21
 layer at (13,474) size 367x680
-  RenderMultiColumnFlowThread at (5,5) size 367x680
+  RenderMultiColumnFlow at (5,5) size 367x680
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 160x19
         text run at (0,0) width 160: "Before Generated Content"
@@ -117,7 +117,7 @@ layer at (8,922) size 760x458
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,217) size 750x237
 layer at (13,927) size 367x764
-  RenderMultiColumnFlowThread at (5,5) size 367x764
+  RenderMultiColumnFlow at (5,5) size 367x764
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 160x19
         text run at (0,0) width 160: "Before Generated Content"
@@ -172,7 +172,7 @@ layer at (8,1396) size 760x473
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,211) size 750x257
 layer at (13,1401) size 367x752
-  RenderMultiColumnFlowThread at (5,5) size 367x752
+  RenderMultiColumnFlow at (5,5) size 367x752
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 160x19
         text run at (0,0) width 160: "Before Generated Content"
@@ -232,7 +232,7 @@ layer at (8,1885) size 760x473
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,331) size 750x137
 layer at (13,1890) size 367x772
-  RenderMultiColumnFlowThread at (5,5) size 367x772
+  RenderMultiColumnFlow at (5,5) size 367x772
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 160x19
         text run at (0,0) width 160: "Before Generated Content"
@@ -296,7 +296,7 @@ layer at (8,2374) size 760x479
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,353) size 750x121
 layer at (13,2379) size 367x804 backgroundClip at (0,0) size 785x2869 clip at (0,0) size 785x2869
-  RenderMultiColumnFlowThread at (5,5) size 367x804
+  RenderMultiColumnFlow at (5,5) size 367x804
     RenderBlock (generated) at (0,0) size 367x20 [bgcolor=#FFFF00]
       RenderText at (0,0) size 160x19
         text run at (0,0) width 160: "Before Generated Content"

--- a/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt
@@ -11,7 +11,7 @@ layer at (8,44) size 760x370
   RenderBlock {DIV} at (0,36) size 760x370 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x360
 layer at (13,49) size 367x720
-  RenderMultiColumnFlowThread at (5,5) size 367x720
+  RenderMultiColumnFlow at (5,5) size 367x720
     RenderBlock {H2} at (0,19) size 367x28 [bgcolor=#EEEEEE]
       RenderText {#text} at (0,0) size 274x26
         text run at (0,0) width 274: "This is a spanning element."
@@ -56,7 +56,7 @@ layer at (8,430) size 760x370
   RenderBlock {DIV} at (0,422) size 760x370 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x360
 layer at (13,435) size 367x707
-  RenderMultiColumnFlowThread at (5,5) size 367x707
+  RenderMultiColumnFlow at (5,5) size 367x707
     RenderBlock (anonymous) at (0,0) size 367x640
       RenderText {#text} at (0,0) size 367x639
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -101,7 +101,7 @@ layer at (8,816) size 760x393
   RenderBlock {DIV} at (0,808) size 760x393 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x383
 layer at (13,821) size 367x759
-  RenderMultiColumnFlowThread at (5,5) size 367x759
+  RenderMultiColumnFlow at (5,5) size 367x759
     RenderBlock {P} at (0,16) size 367x240
       RenderText {#text} at (0,0) size 367x239
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -148,7 +148,7 @@ layer at (8,1225) size 760x417
   RenderBlock {DIV} at (0,1216) size 760x418 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x407
 layer at (13,1230) size 367x779
-  RenderMultiColumnFlowThread at (5,5) size 367x779
+  RenderMultiColumnFlow at (5,5) size 367x779
     RenderBlock (anonymous) at (0,0) size 367x240
       RenderText {#text} at (0,0) size 367x239
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -200,7 +200,7 @@ layer at (8,1658) size 760x410
   RenderBlock {DIV} at (0,1649) size 760x411 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x400
 layer at (13,1663) size 367x783
-  RenderMultiColumnFlowThread at (5,5) size 367x783
+  RenderMultiColumnFlow at (5,5) size 367x783
     RenderBlock (anonymous) at (0,0) size 367x220
       RenderInline {SPAN} at (0,0) size 367x219
         RenderText {#text} at (0,0) size 367x219
@@ -256,7 +256,7 @@ layer at (8,2084) size 760x418
   RenderBlock {DIV} at (0,2075) size 760x419 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x408
 layer at (13,2089) size 367x815 backgroundClip at (0,0) size 785x2518 clip at (0,0) size 785x2518
-  RenderMultiColumnFlowThread at (5,5) size 367x815
+  RenderMultiColumnFlow at (5,5) size 367x815
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x219
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt
@@ -10,7 +10,7 @@ layer at (8,16) size 760x397
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,71) size 750x321
 layer at (13,21) size 367x640
-  RenderMultiColumnFlowThread at (5,5) size 367x640
+  RenderMultiColumnFlow at (5,5) size 367x640
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x640
       RenderText {#text} at (0,0) size 367x639
@@ -57,7 +57,7 @@ layer at (8,429) size 760x397
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,391) size 750x0
 layer at (13,434) size 367x640
-  RenderMultiColumnFlowThread at (5,5) size 367x640
+  RenderMultiColumnFlow at (5,5) size 367x640
     RenderBlock (anonymous) at (0,0) size 367x640
       RenderText {#text} at (0,0) size 367x639
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -104,7 +104,7 @@ layer at (8,842) size 760x448
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,207) size 750x237
 layer at (13,847) size 367x724
-  RenderMultiColumnFlowThread at (5,5) size 367x724
+  RenderMultiColumnFlow at (5,5) size 367x724
     RenderBlock {P} at (0,16) size 367x240
       RenderText {#text} at (0,0) size 367x239
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -153,7 +153,7 @@ layer at (8,1306) size 760x433
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,191) size 750x237
 layer at (13,1311) size 367x712
-  RenderMultiColumnFlowThread at (5,5) size 367x712
+  RenderMultiColumnFlow at (5,5) size 367x712
     RenderBlock (anonymous) at (0,0) size 367x240
       RenderText {#text} at (0,0) size 367x239
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -207,7 +207,7 @@ layer at (8,1755) size 760x453
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,311) size 750x137
 layer at (13,1760) size 367x732
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock (anonymous) at (0,0) size 367x220
       RenderInline {SPAN} at (0,0) size 367x219
         RenderText {#text} at (0,0) size 367x219
@@ -265,7 +265,7 @@ layer at (8,2224) size 760x469
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,343) size 750x121
 layer at (13,2229) size 367x764 backgroundClip at (0,0) size 785x2709 clip at (0,0) size 785x2709
-  RenderMultiColumnFlowThread at (5,5) size 367x764
+  RenderMultiColumnFlow at (5,5) size 367x764
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x219
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-columns-child-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-columns-child-expected.txt
@@ -10,7 +10,7 @@ layer at (8,16) size 760x397
         text run at (0,0) width 660: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,71) size 750x321
 layer at (13,21) size 367x640
-  RenderMultiColumnFlowThread at (5,5) size 367x640
+  RenderMultiColumnFlow at (5,5) size 367x640
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x640
       RenderText {#text} at (0,0) size 367x639
@@ -57,7 +57,7 @@ layer at (8,429) size 760x397
         text run at (0,0) width 596: "This is a spanning element at the end of the columns block."
     RenderMultiColumnSet at (5,391) size 750x0
 layer at (13,434) size 367x640
-  RenderMultiColumnFlowThread at (5,5) size 367x640
+  RenderMultiColumnFlow at (5,5) size 367x640
     RenderBlock (anonymous) at (0,0) size 367x640
       RenderText {#text} at (0,0) size 367x639
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -104,7 +104,7 @@ layer at (8,842) size 760x416
         text run at (0,0) width 629: "This is a spanning element in the middle of the columns block."
     RenderMultiColumnSet at (5,191) size 750x221
 layer at (13,847) size 367x660
-  RenderMultiColumnFlowThread at (5,5) size 367x660
+  RenderMultiColumnFlow at (5,5) size 367x660
     RenderBlock (anonymous) at (0,0) size 367x240
       RenderText {#text} at (0,0) size 367x239
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -149,7 +149,7 @@ layer at (8,1274) size 760x378
   RenderBlock {DIV} at (0,1258) size 760x379 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x368
 layer at (13,1279) size 367x728
-  RenderMultiColumnFlowThread at (5,5) size 367x728
+  RenderMultiColumnFlow at (5,5) size 367x728
     RenderText {#text} at (0,0) size 367x245
       text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,20) width 367: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis lectus."
@@ -197,7 +197,7 @@ layer at (8,1668) size 760x410
   RenderBlock {DIV} at (0,1652) size 760x411 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x400
 layer at (13,1673) size 367x800
-  RenderMultiColumnFlowThread at (5,5) size 367x800
+  RenderMultiColumnFlow at (5,5) size 367x800
     RenderText {#text} at (0,0) size 367x239
       text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,20) width 367: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis lectus."
@@ -249,7 +249,7 @@ layer at (8,2094) size 760x476
         text run at (0,27) width 145: "block siblings."
     RenderMultiColumnSet at (5,98) size 750x373
 layer at (13,2099) size 367x724
-  RenderMultiColumnFlowThread at (5,5) size 367x724
+  RenderMultiColumnFlow at (5,5) size 367x724
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x219
@@ -299,7 +299,7 @@ layer at (8,2586) size 760x466
         text run at (0,27) width 83: "siblings."
     RenderMultiColumnSet at (5,460) size 750x0
 layer at (13,2591) size 367x724
-  RenderMultiColumnFlowThread at (5,5) size 367x724
+  RenderMultiColumnFlow at (5,5) size 367x724
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x219
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -349,7 +349,7 @@ layer at (8,3068) size 760x484
         text run at (0,27) width 83: "siblings."
     RenderMultiColumnSet at (5,342) size 750x137
 layer at (13,3073) size 367x732 backgroundClip at (0,0) size 785x3568 clip at (0,0) size 785x3568
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x219
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt
@@ -7,7 +7,7 @@ layer at (8,16) size 760x330
   RenderBlock {DIV} at (0,0) size 760x330 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x320
 layer at (13,21) size 367x640
-  RenderMultiColumnFlowThread at (5,5) size 367x640
+  RenderMultiColumnFlow at (5,5) size 367x640
     RenderText {#text} at (0,0) size 367x639
       text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,20) width 367: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis lectus."
@@ -48,7 +48,7 @@ layer at (8,362) size 760x330
   RenderBlock {DIV} at (0,346) size 760x330 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x320
 layer at (13,367) size 367x640
-  RenderMultiColumnFlowThread at (5,5) size 367x640
+  RenderMultiColumnFlow at (5,5) size 367x640
     RenderText {#text} at (0,0) size 367x639
       text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
       text run at (0,20) width 367: "Nulla varius enim ac mi. Curabitur sollicitudin felis quis lectus."
@@ -89,7 +89,7 @@ layer at (8,708) size 760x382
   RenderBlock {DIV} at (0,692) size 760x382 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x372
 layer at (13,713) size 367x708
-  RenderMultiColumnFlowThread at (5,5) size 367x708
+  RenderMultiColumnFlow at (5,5) size 367x708
     RenderBlock {P} at (0,16) size 367x240
       RenderText {#text} at (0,0) size 367x239
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -133,7 +133,7 @@ layer at (8,1106) size 760x370
   RenderBlock {DIV} at (0,1090) size 760x370 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x360
 layer at (13,1111) size 367x692
-  RenderMultiColumnFlowThread at (5,5) size 367x692
+  RenderMultiColumnFlow at (5,5) size 367x692
     RenderBlock (anonymous) at (0,0) size 367x440
       RenderText {#text} at (0,0) size 367x239
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -181,7 +181,7 @@ layer at (8,1492) size 760x390
   RenderBlock {DIV} at (0,1476) size 760x390 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x380
 layer at (13,1497) size 367x732
-  RenderMultiColumnFlowThread at (5,5) size 367x732
+  RenderMultiColumnFlow at (5,5) size 367x732
     RenderBlock (anonymous) at (0,0) size 367x220
       RenderInline {SPAN} at (0,0) size 367x219
         RenderText {#text} at (0,0) size 367x219
@@ -234,7 +234,7 @@ layer at (8,1898) size 760x398
   RenderBlock {DIV} at (0,1882) size 760x398 [border: (5px solid #800000)]
     RenderMultiColumnSet at (5,5) size 750x388
 layer at (13,1903) size 367x764 backgroundClip at (0,0) size 785x2312 clip at (0,0) size 785x2312
-  RenderMultiColumnFlowThread at (5,5) size 367x764
+  RenderMultiColumnFlow at (5,5) size 367x764
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x219
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/win/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x425
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,79) size 750x341
 layer at (13,21) size 367x688
-  RenderMultiColumnFlowThread at (5,5) size 367x688
+  RenderMultiColumnFlow at (5,5) size 367x688
     RenderBlock {SPAN} at (0,8) size 367x220 [color=#FFFFFF] [bgcolor=#000000]
       RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
       RenderBlock (anonymous) at (0,0) size 367x220
@@ -65,7 +65,7 @@ layer at (8,457) size 760x425
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,411) size 750x9
 layer at (13,462) size 367x692
-  RenderMultiColumnFlowThread at (5,5) size 367x692
+  RenderMultiColumnFlow at (5,5) size 367x692
     RenderBlock (anonymous) at (0,0) size 367x620
       RenderText {#text} at (0,0) size 367x619
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -115,7 +115,7 @@ layer at (8,898) size 760x476
         text run at (0,0) width 274: "This is a spanning element."
     RenderMultiColumnSet at (5,227) size 750x245
 layer at (13,903) size 367x772 backgroundClip at (0,0) size 785x1390 clip at (0,0) size 785x1390
-  RenderMultiColumnFlowThread at (5,5) size 367x772
+  RenderMultiColumnFlow at (5,5) size 367x772
     RenderBlock {P} at (0,16) size 367x220
       RenderText {#text} at (0,0) size 367x219
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/win/fast/multicol/span/span-as-nested-columns-child-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/span-as-nested-columns-child-expected.txt
@@ -11,7 +11,7 @@ layer at (8,16) size 760x425
         text run at (0,0) width 660: "This is a spanning element at the beginning of the columns block."
     RenderMultiColumnSet at (5,79) size 750x341
 layer at (13,21) size 367x688
-  RenderMultiColumnFlowThread at (5,5) size 367x688
+  RenderMultiColumnFlow at (5,5) size 367x688
     RenderBlock {SPAN} at (0,8) size 367x220 [color=#FFFFFF] [bgcolor=#000000]
       RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
       RenderBlock (anonymous) at (0,0) size 367x220
@@ -61,7 +61,7 @@ layer at (8,457) size 760x425
         text run at (0,0) width 596: "This is a spanning element at the end of the columns block."
     RenderMultiColumnSet at (5,411) size 750x9
 layer at (13,462) size 367x692
-  RenderMultiColumnFlowThread at (5,5) size 367x692
+  RenderMultiColumnFlow at (5,5) size 367x692
     RenderBlock (anonymous) at (0,0) size 367x420
       RenderText {#text} at (0,0) size 367x419
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -111,7 +111,7 @@ layer at (8,898) size 760x444
         text run at (0,0) width 629: "This is a spanning element in the middle of the columns block."
     RenderMultiColumnSet at (5,211) size 750x229
 layer at (13,903) size 367x724 backgroundClip at (0,0) size 785x1358 clip at (0,0) size 785x1358
-  RenderMultiColumnFlowThread at (5,5) size 367x724
+  RenderMultiColumnFlow at (5,5) size 367x724
     RenderBlock (anonymous) at (0,0) size 367x220
       RenderText {#text} at (0,0) size 367x219
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/win/fast/multicol/span/span-as-nested-inline-block-child-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/span-as-nested-inline-block-child-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x100
   RenderBlock {DIV} at (0,0) size 784x100
     RenderMultiColumnSet at (0,0) size 784x100
 layer at (8,8) size 384x200
-  RenderMultiColumnFlowThread at (0,0) size 384x200
+  RenderMultiColumnFlow at (0,0) size 384x200
     RenderBlock {DIV} at (0,0) size 374x88
       RenderBlock {P} at (0,16) size 374x20
         RenderText {#text} at (0,0) size 317x19

--- a/LayoutTests/platform/win/fast/multicol/span/span-margin-collapsing-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/span/span-margin-collapsing-expected.txt
@@ -12,7 +12,7 @@ layer at (8,16) size 750x414
         text run at (0,27) width 525: "should collapse its margins with the top of the page."
     RenderMultiColumnSet at (0,93) size 750x321
 layer at (8,16) size 367x640
-  RenderMultiColumnFlowThread at (0,0) size 367x640
+  RenderMultiColumnFlow at (0,0) size 367x640
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x640
       RenderText {#text} at (0,0) size 367x639
@@ -61,7 +61,7 @@ layer at (8,446) size 750x414
         text run at (0,27) width 503: "collapse its margins with the h2 in the next block."
     RenderMultiColumnSet at (0,413) size 750x0
 layer at (8,446) size 367x640
-  RenderMultiColumnFlowThread at (0,0) size 367x640
+  RenderMultiColumnFlow at (0,0) size 367x640
     RenderBlock (anonymous) at (0,0) size 367x640
       RenderText {#text} at (0,0) size 367x639
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
@@ -109,7 +109,7 @@ layer at (8,876) size 750x413
         text run at (0,27) width 619: "should collapse its margins with the h2 in the previous block."
     RenderMultiColumnSet at (0,93) size 750x321
 layer at (8,876) size 367x640
-  RenderMultiColumnFlowThread at (0,0) size 367x640
+  RenderMultiColumnFlow at (0,0) size 367x640
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 367x640
       RenderText {#text} at (0,0) size 367x639
@@ -164,7 +164,7 @@ layer at (8,1305) size 750x608
         text run at (0,27) width 566: "collapse its margins with the spanning element above it."
     RenderMultiColumnSet at (0,387) size 750x221
 layer at (8,1305) size 367x840 backgroundClip at (0,0) size 785x1929 clip at (0,0) size 785x1929
-  RenderMultiColumnFlowThread at (0,0) size 367x840
+  RenderMultiColumnFlow at (0,0) size 367x840
     RenderBlock (anonymous) at (0,0) size 367x420
       RenderText {#text} at (0,0) size 367x419
         text run at (0,0) width 337: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit."

--- a/LayoutTests/platform/win/fast/multicol/table-margin-collapse-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/table-margin-collapse-expected.txt
@@ -13,7 +13,7 @@ layer at (8,48) size 784x304
   RenderBlock {DIV} at (0,40) size 784x304 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 780x300
 layer at (10,50) size 382x500
-  RenderMultiColumnFlowThread at (2,2) size 382x500
+  RenderMultiColumnFlow at (2,2) size 382x500
     RenderTable {TABLE} at (0,0) size 382x500
       RenderTableSection {TBODY} at (0,0) size 382x500
         RenderTableRow {TR} at (0,0) size 382x500

--- a/LayoutTests/platform/win/fast/multicol/table-vertical-align-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/table-vertical-align-expected.txt
@@ -9,7 +9,7 @@ layer at (8,8) size 769x350
   RenderBlock {DIV} at (0,0) size 769x350
     RenderMultiColumnSet at (0,0) size 769x350
 layer at (8,8) size 377x1307 backgroundClip at (0,0) size 1955x1010 clip at (0,0) size 1955x1010
-  RenderMultiColumnFlowThread at (0,0) size 377x1307
+  RenderMultiColumnFlow at (0,0) size 377x1307
     RenderTable {TABLE} at (0,0) size 377x1307 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 375x1305
         RenderTableRow {TR} at (0,0) size 375x1305
@@ -143,7 +143,7 @@ layer at (8,376) size 769x300
   RenderBlock {DIV} at (0,368) size 769x300
     RenderMultiColumnSet at (0,0) size 769x300
 layer at (8,376) size 377x1294 backgroundClip at (0,0) size 1955x1010 clip at (0,0) size 1955x1010
-  RenderMultiColumnFlowThread at (0,0) size 377x1294
+  RenderMultiColumnFlow at (0,0) size 377x1294
     RenderTable {TABLE} at (0,0) size 377x1294 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 375x1292
         RenderTableRow {TR} at (0,0) size 375x1292
@@ -277,7 +277,7 @@ layer at (8,702) size 769x300
   RenderBlock {DIV} at (0,694) size 769x300
     RenderMultiColumnSet at (0,0) size 769x300
 layer at (8,702) size 377x1289 backgroundClip at (0,0) size 1955x1010 clip at (0,0) size 1955x1010
-  RenderMultiColumnFlowThread at (0,0) size 377x1289
+  RenderMultiColumnFlow at (0,0) size 377x1289
     RenderTable {TABLE} at (0,0) size 377x1289 [border: (1px outset #000000)]
       RenderTableSection {TBODY} at (1,1) size 375x1287
         RenderTableRow {TR} at (0,0) size 375x1287

--- a/LayoutTests/platform/win/fast/multicol/tall-image-behavior-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/tall-image-behavior-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 784x304
   RenderBlock {DIV} at (0,0) size 784x304 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 780x300
 layer at (10,10) size 382x650 backgroundClip at (0,0) size 1188x585 clip at (0,0) size 1188x585
-  RenderMultiColumnFlowThread at (2,2) size 382x650
+  RenderMultiColumnFlow at (2,2) size 382x650
     RenderBlock {P} at (0,16) size 382x52
       RenderText {#text} at (0,-4) size 277x19
         text run at (0,-4) width 277: "This image should not be split across columns."

--- a/LayoutTests/platform/win/fast/multicol/tall-image-behavior-lr-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/tall-image-behavior-lr-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 304x584
   RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (10,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
+  RenderMultiColumnFlow at (2,2) size 650x282
     RenderBlock {P} at (16,0) size 76x282
       RenderText {#text} at (0,0) size 19x277
         text run at (0,0) width 277: "This image should not be split across columns."

--- a/LayoutTests/platform/win/fast/multicol/tall-image-behavior-rl-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/tall-image-behavior-rl-expected.txt
@@ -7,7 +7,7 @@ layer at (473,8) size 304x584
   RenderBlock {DIV} at (0,0) size 304x584 [border: (2px solid #0000FF)]
     RenderMultiColumnSet at (2,2) size 300x580
 layer at (125,10) size 650x282
-  RenderMultiColumnFlowThread at (2,2) size 650x282
+  RenderMultiColumnFlow at (2,2) size 650x282
     RenderBlock {P} at (16,0) size 76x282
       RenderText {#text} at (0,0) size 19x277
         text run at (0,0) width 277: "This image should not be split across columns."

--- a/LayoutTests/platform/win/fast/multicol/vertical-lr/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/vertical-lr/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 194x584
   RenderBlock {DIV} at (0,0) size 194x584 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 190x580
 layer at (10,10) size 270x282
-  RenderMultiColumnFlowThread at (2,2) size 270x282
+  RenderMultiColumnFlow at (2,2) size 270x282
     RenderBlock {DIV} at (0,0) size 110x282
     RenderBlock {DIV} at (110,0) size 160x379 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (2,12) size 156x355 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/win/fast/multicol/vertical-rl/border-padding-pagination-expected.txt
+++ b/LayoutTests/platform/win/fast/multicol/vertical-rl/border-padding-pagination-expected.txt
@@ -7,7 +7,7 @@ layer at (598,8) size 194x584
   RenderBlock {DIV} at (0,0) size 194x584 [border: (2px solid #800000)]
     RenderMultiColumnSet at (2,2) size 190x580
 layer at (520,10) size 270x282
-  RenderMultiColumnFlowThread at (2,2) size 270x282
+  RenderMultiColumnFlow at (2,2) size 270x282
     RenderBlock {DIV} at (0,0) size 110x282
     RenderBlock {DIV} at (110,0) size 160x379 [bgcolor=#00FF00] [border: (2px solid #000000)]
       RenderBlock {DIV} at (2,12) size 156x355 [bgcolor=#008000] [border: (2px solid #0000FF)]

--- a/LayoutTests/platform/win/fast/overflow/paged-x-div-expected.txt
+++ b/LayoutTests/platform/win/fast/overflow/paged-x-div-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x385 scrollWidth 2480
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x385
 layer at (10,10) size 400x2265 backgroundClip at (10,10) size 400x385 clip at (10,10) size 400x385
-  RenderMultiColumnFlowThread at (2,2) size 400x2265
+  RenderMultiColumnFlow at (2,2) size 400x2265
     RenderText {#text} at (0,0) size 400x2264
       text run at (0,0) width 396: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas"
       text run at (0,20) width 400: "lacinia massa in lectus pretium vulputate. Curabitur viverra augue in"

--- a/LayoutTests/platform/win/fast/overflow/paged-x-div-with-column-gap-expected.txt
+++ b/LayoutTests/platform/win/fast/overflow/paged-x-div-with-column-gap-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x385 scrollX 200 scrollWidth
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x385
 layer at (-190,10) size 400x2265 backgroundClip at (10,10) size 400x385 clip at (10,10) size 400x385
-  RenderMultiColumnFlowThread at (2,2) size 400x2265
+  RenderMultiColumnFlow at (2,2) size 400x2265
     RenderText {#text} at (0,0) size 400x2264
       text run at (0,0) width 396: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas"
       text run at (0,20) width 400: "lacinia massa in lectus pretium vulputate. Curabitur viverra augue in"

--- a/LayoutTests/platform/win/fast/overflow/paged-x-on-root-expected.txt
+++ b/LayoutTests/platform/win/fast/overflow/paged-x-on-root-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1600x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 800x1133 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
-  RenderMultiColumnFlowThread at (0,0) size 800x1133
+  RenderMultiColumnFlow at (0,0) size 800x1133
 layer at (0,0) size 800x1133 backgroundClip at (0,0) size 1600x585 clip at (0,0) size 1600x585
   RenderBlock {HTML} at (0,0) size 800x1133
     RenderBody {BODY} at (8,8) size 784x1117

--- a/LayoutTests/platform/win/fast/overflow/paged-x-with-column-gap-expected.txt
+++ b/LayoutTests/platform/win/fast/overflow/paged-x-with-column-gap-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 1700x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 800x1133 backgroundClip at (0,0) size 1700x585 clip at (0,0) size 1700x585
-  RenderMultiColumnFlowThread at (0,0) size 800x1133
+  RenderMultiColumnFlow at (0,0) size 800x1133
 layer at (0,0) size 800x1133 backgroundClip at (0,0) size 1700x585 clip at (0,0) size 1700x585
   RenderBlock {HTML} at (0,0) size 800x1133
     RenderBody {BODY} at (8,8) size 784x1117

--- a/LayoutTests/platform/win/fast/overflow/paged-y-div-expected.txt
+++ b/LayoutTests/platform/win/fast/overflow/paged-y-div-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 404x404 clip at (10,10) size 400x400 scrollHeight 2480
   RenderBlock {DIV} at (0,0) size 404x404 [border: (2px solid #000000)]
     RenderMultiColumnSet at (2,2) size 400x400
 layer at (10,10) size 400x2240 backgroundClip at (10,10) size 400x400 clip at (10,10) size 400x400
-  RenderMultiColumnFlowThread at (2,2) size 400x2240
+  RenderMultiColumnFlow at (2,2) size 400x2240
     RenderText {#text} at (0,0) size 400x2239
       text run at (0,0) width 396: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas"
       text run at (0,20) width 400: "lacinia massa in lectus pretium vulputate. Curabitur viverra augue in"

--- a/LayoutTests/platform/win/fast/overflow/paged-y-on-root-expected.txt
+++ b/LayoutTests/platform/win/fast/overflow/paged-y-on-root-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 785x1200
   RenderView at (0,0) size 785x600
     RenderMultiColumnSet at (0,0) size 785x600
 layer at (0,0) size 785x1168
-  RenderMultiColumnFlowThread at (0,0) size 785x1168
+  RenderMultiColumnFlow at (0,0) size 785x1168
 layer at (0,0) size 785x1168
   RenderBlock {HTML} at (0,0) size 785x1168
     RenderBody {BODY} at (8,8) size 769x1152

--- a/LayoutTests/platform/win/fast/repaint/multicol-repaint-expected.txt
+++ b/LayoutTests/platform/win/fast/repaint/multicol-repaint-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 402x102
   RenderBlock {DIV} at (0,0) size 402x102 [border: (1px solid #000000)]
     RenderMultiColumnSet at (1,1) size 400x100
 layer at (9,9) size 175x159
-  RenderMultiColumnFlowThread at (1,1) size 175x159
+  RenderMultiColumnFlow at (1,1) size 175x159
     RenderText {#text} at (0,1) size 13x57
       text run at (0,1) width 13: " "
     RenderBR {BR} at (13,1) size 0x57

--- a/LayoutTests/platform/wpe/fast/multicol/pagination/LeftToRight-tb-hittest-expected.txt
+++ b/LayoutTests/platform/wpe/fast/multicol/pagination/LeftToRight-tb-hittest-expected.txt
@@ -2,7 +2,7 @@ layer at (0,0) size 2460x585
   RenderView at (0,0) size 800x585
     RenderMultiColumnSet at (0,0) size 800x585
 layer at (0,0) size 385x3116 backgroundClip at (0,0) size 2460x585 clip at (0,0) size 2460x585
-  RenderMultiColumnFlowThread at (0,0) size 385x3116
+  RenderMultiColumnFlow at (0,0) size 385x3116
 layer at (0,0) size 385x3116 backgroundClip at (0,0) size 2460x585 clip at (0,0) size 2460x585
   RenderBlock {HTML} at (0,0) size 385x3116 [border: (1px solid #008000)]
     RenderBody {BODY} at (4,4) size 377x3108 [border: (1px solid #000000)]

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-transforms/crashtests/preserve3d-scene-002-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-transforms/crashtests/preserve3d-scene-002-expected.txt
@@ -7,7 +7,7 @@ layer at (8,8) size 769x16777216
   RenderBlock {DIV} at (0,0) size 769x16777216
     RenderMultiColumnSet at (0,0) size 769x16777216
 layer at (8,8) size 0x33554431
-  RenderMultiColumnFlowThread at (0,0) size 0x33554431
+  RenderMultiColumnFlow at (0,0) size 0x33554431
     RenderButton {BUTTON} at (2,1) size 97x33554430 [color=#2E3436] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
       RenderBlock (anonymous) at (8,4) size 81x33554427
 layer at (18,13) size 81x33554431 backgroundClip at (0,0) size 785x16777232 clip at (0,0) size 785x16777232

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
@@ -55,7 +55,7 @@ RenderMultiColumnFlow::~RenderMultiColumnFlow() = default;
 
 ASCIILiteral RenderMultiColumnFlow::renderName() const
 {    
-    return "RenderMultiColumnFlowThread"_s;
+    return "RenderMultiColumnFlow"_s;
 }
 
 RenderMultiColumnSet* RenderMultiColumnFlow::firstMultiColumnSet() const


### PR DESCRIPTION
#### b49a09b13cf1c613123faf1c140a1d17283ae927
<pre>
Render name of RenderMultiColumnFlow should be RenderMultiColumnFlow
<a href="https://rdar.apple.com/175473751">rdar://175473751</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313199">https://bugs.webkit.org/show_bug.cgi?id=313199</a>

Reviewed by NOBODY (OOPS!).

RenderMultiColumnFlow::renderName() was &quot;RenderMultiColumnFlowThread&quot;,
which I suppose is the old name. Change it to &quot;RenderMultiColumnFlowThread&quot;

* LayoutTests/fast/block/float/float-not-removed-from-next-sibling4-expected.txt:
* LayoutTests/fast/multicol/pagination-h-horizontal-bt-expected.txt:
* LayoutTests/fast/multicol/pagination-h-horizontal-tb-expected.txt:
* LayoutTests/fast/multicol/pagination-h-vertical-lr-expected.txt:
* LayoutTests/fast/multicol/pagination-h-vertical-rl-expected.txt:
* LayoutTests/fast/multicol/pagination-v-horizontal-bt-expected.txt:
* LayoutTests/fast/multicol/pagination-v-horizontal-tb-expected.txt:
* LayoutTests/fast/multicol/pagination-v-vertical-lr-expected.txt:
* LayoutTests/fast/multicol/pagination-v-vertical-rl-expected.txt:
* LayoutTests/fast/multicol/pagination/LeftToRight-tb-hittest-expected.txt:
* LayoutTests/fast/multicol/pagination/RightToLeft-rl-hittest-expected.txt:
* LayoutTests/fast/multicol/progression-reverse-expected.txt:
* LayoutTests/fast/multicol/span/before-child-anonymous-column-block-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/change-abspos-width-in-second-column-crash-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/change-out-of-flow-type-and-remove-inner-multicol-crash-expected.txt:
* LayoutTests/platform/glib/css3/unicode-bidi-isolate-basic-expected.txt:
* LayoutTests/platform/glib/fast/borders/border-antialiasing-expected.txt:
* LayoutTests/platform/glib/fast/line-grid/line-grid-inside-columns-expected.txt:
* LayoutTests/platform/glib/fast/line-grid/line-grid-into-columns-expected.txt:
* LayoutTests/platform/glib/fast/multicol/block-axis-horizontal-bt-expected.txt:
* LayoutTests/platform/glib/fast/multicol/block-axis-horizontal-tb-expected.txt:
* LayoutTests/platform/glib/fast/multicol/block-axis-vertical-lr-expected.txt:
* LayoutTests/platform/glib/fast/multicol/block-axis-vertical-rl-expected.txt:
* LayoutTests/platform/glib/fast/multicol/border-padding-pagination-expected.txt:
* LayoutTests/platform/glib/fast/multicol/client-rects-spanners-complex-expected.txt:
* LayoutTests/platform/glib/fast/multicol/client-rects-spanners-expected.txt:
* LayoutTests/platform/glib/fast/multicol/column-rules-stacking-expected.txt:
* LayoutTests/platform/glib/fast/multicol/columns-shorthand-parsing-expected.txt:
* LayoutTests/platform/glib/fast/multicol/float-paginate-empty-lines-expected.txt:
* LayoutTests/platform/glib/fast/multicol/max-height-columns-block-expected.txt:
* LayoutTests/platform/glib/fast/multicol/overflow-across-columns-expected.txt:
* LayoutTests/platform/glib/fast/multicol/overflow-across-columns-percent-height-expected.txt:
* LayoutTests/platform/glib/fast/multicol/paginate-block-replaced-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-bt-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-lr-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-rl-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/BottomToTop-tb-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-bt-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-lr-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-rl-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/LeftToRight-tb-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-bt-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-lr-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-rl-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/RightToLeft-tb-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-bt-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-lr-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-rl-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/TopToBottom-tb-expected.txt:
* LayoutTests/platform/glib/fast/multicol/pagination/nested-transforms-expected.txt:
* LayoutTests/platform/glib/fast/multicol/scrolling-column-rules-expected.txt:
* LayoutTests/platform/glib/fast/multicol/scrolling-overflow-expected.txt:
* LayoutTests/platform/glib/fast/multicol/shadow-breaking-expected.txt:
* LayoutTests/platform/glib/fast/multicol/shrink-to-column-height-for-pagination-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/anonymous-style-inheritance-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/clone-flexbox-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/clone-summary-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-columns-child-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/span-as-nested-columns-child-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/span-as-nested-inline-block-child-expected.txt:
* LayoutTests/platform/glib/fast/multicol/span/span-margin-collapsing-expected.txt:
* LayoutTests/platform/glib/fast/multicol/table-margin-collapse-expected.txt:
* LayoutTests/platform/glib/fast/multicol/table-vertical-align-expected.txt:
* LayoutTests/platform/glib/fast/multicol/tall-image-behavior-expected.txt:
* LayoutTests/platform/glib/fast/multicol/tall-image-behavior-lr-expected.txt:
* LayoutTests/platform/glib/fast/multicol/tall-image-behavior-lr-mixed-expected.txt:
* LayoutTests/platform/glib/fast/multicol/tall-image-behavior-rl-expected.txt:
* LayoutTests/platform/glib/fast/multicol/vertical-lr/border-padding-pagination-expected.txt:
* LayoutTests/platform/glib/fast/multicol/vertical-rl/border-padding-pagination-expected.txt:
* LayoutTests/platform/glib/fast/overflow/paged-x-div-expected.txt:
* LayoutTests/platform/glib/fast/overflow/paged-x-div-with-column-gap-expected.txt:
* LayoutTests/platform/glib/fast/overflow/paged-x-on-root-expected.txt:
* LayoutTests/platform/glib/fast/overflow/paged-x-with-column-gap-expected.txt:
* LayoutTests/platform/glib/fast/overflow/paged-y-div-expected.txt:
* LayoutTests/platform/glib/fast/overflow/paged-y-on-root-expected.txt:
* LayoutTests/platform/glib/fast/repaint/multicol-repaint-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-multicol/change-abspos-width-in-second-column-crash-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-multicol/change-out-of-flow-type-and-remove-inner-multicol-crash-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-transforms/crashtests/preserve3d-scene-002-expected.txt:
* LayoutTests/platform/ios/css3/unicode-bidi-isolate-basic-expected.txt:
* LayoutTests/platform/ios/fast/block/float/float-not-removed-from-next-sibling4-expected.txt:
* LayoutTests/platform/ios/fast/borders/border-antialiasing-expected.txt:
* LayoutTests/platform/ios/fast/line-grid/line-grid-inside-columns-expected.txt:
* LayoutTests/platform/ios/fast/line-grid/line-grid-into-columns-expected.txt:
* LayoutTests/platform/ios/fast/multicol/block-axis-horizontal-bt-expected.txt:
* LayoutTests/platform/ios/fast/multicol/block-axis-horizontal-tb-expected.txt:
* LayoutTests/platform/ios/fast/multicol/block-axis-vertical-lr-expected.txt:
* LayoutTests/platform/ios/fast/multicol/block-axis-vertical-rl-expected.txt:
* LayoutTests/platform/ios/fast/multicol/border-padding-pagination-expected.txt:
* LayoutTests/platform/ios/fast/multicol/client-rects-spanners-complex-expected.txt:
* LayoutTests/platform/ios/fast/multicol/client-rects-spanners-expected.txt:
* LayoutTests/platform/ios/fast/multicol/column-rules-stacking-expected.txt:
* LayoutTests/platform/ios/fast/multicol/columns-shorthand-parsing-expected.txt:
* LayoutTests/platform/ios/fast/multicol/float-paginate-empty-lines-expected.txt:
* LayoutTests/platform/ios/fast/multicol/max-height-columns-block-expected.txt:
* LayoutTests/platform/ios/fast/multicol/overflow-across-columns-expected.txt:
* LayoutTests/platform/ios/fast/multicol/overflow-across-columns-percent-height-expected.txt:
* LayoutTests/platform/ios/fast/multicol/paginate-block-replaced-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-bt-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-lr-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-rl-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/BottomToTop-tb-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-bt-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-lr-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-rl-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/LeftToRight-tb-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-bt-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-lr-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-rl-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/RightToLeft-tb-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-bt-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-lr-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-rl-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/TopToBottom-tb-expected.txt:
* LayoutTests/platform/ios/fast/multicol/pagination/nested-transforms-expected.txt:
* LayoutTests/platform/ios/fast/multicol/scrolling-column-rules-expected.txt:
* LayoutTests/platform/ios/fast/multicol/scrolling-overflow-expected.txt:
* LayoutTests/platform/ios/fast/multicol/shadow-breaking-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/anonymous-style-inheritance-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/clone-flexbox-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/clone-summary-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-columns-child-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/span-as-nested-columns-child-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/span-as-nested-inline-block-child-expected.txt:
* LayoutTests/platform/ios/fast/multicol/span/span-margin-collapsing-expected.txt:
* LayoutTests/platform/ios/fast/multicol/table-margin-collapse-expected.txt:
* LayoutTests/platform/ios/fast/multicol/table-vertical-align-expected.txt:
* LayoutTests/platform/ios/fast/multicol/tall-image-behavior-expected.txt:
* LayoutTests/platform/ios/fast/multicol/tall-image-behavior-lr-expected.txt:
* LayoutTests/platform/ios/fast/multicol/tall-image-behavior-lr-mixed-expected.txt:
* LayoutTests/platform/ios/fast/multicol/tall-image-behavior-rl-expected.txt:
* LayoutTests/platform/ios/fast/multicol/vertical-lr/border-padding-pagination-expected.txt:
* LayoutTests/platform/ios/fast/multicol/vertical-rl/border-padding-pagination-expected.txt:
* LayoutTests/platform/ios/fast/overflow/paged-x-div-expected.txt:
* LayoutTests/platform/ios/fast/overflow/paged-x-div-with-column-gap-expected.txt:
* LayoutTests/platform/ios/fast/overflow/paged-x-on-root-expected.txt:
* LayoutTests/platform/ios/fast/overflow/paged-x-with-column-gap-expected.txt:
* LayoutTests/platform/ios/fast/overflow/paged-y-div-expected.txt:
* LayoutTests/platform/ios/fast/overflow/paged-y-on-root-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-multicol/change-abspos-width-in-second-column-crash-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-multicol/change-out-of-flow-type-and-remove-inner-multicol-crash-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-transforms/crashtests/preserve3d-scene-002-expected.txt:
* LayoutTests/platform/mac-sonoma/css3/unicode-bidi-isolate-basic-expected.txt:
* LayoutTests/platform/mac/css3/unicode-bidi-isolate-basic-expected.txt:
* LayoutTests/platform/mac/fast/borders/border-antialiasing-expected.txt:
* LayoutTests/platform/mac/fast/line-grid/line-grid-inside-columns-expected.txt:
* LayoutTests/platform/mac/fast/line-grid/line-grid-into-columns-expected.txt:
* LayoutTests/platform/mac/fast/multicol/block-axis-horizontal-bt-expected.txt:
* LayoutTests/platform/mac/fast/multicol/block-axis-horizontal-tb-expected.txt:
* LayoutTests/platform/mac/fast/multicol/block-axis-vertical-lr-expected.txt:
* LayoutTests/platform/mac/fast/multicol/block-axis-vertical-rl-expected.txt:
* LayoutTests/platform/mac/fast/multicol/border-padding-pagination-expected.txt:
* LayoutTests/platform/mac/fast/multicol/client-rects-spanners-complex-expected.txt:
* LayoutTests/platform/mac/fast/multicol/client-rects-spanners-expected.txt:
* LayoutTests/platform/mac/fast/multicol/column-rules-stacking-expected.txt:
* LayoutTests/platform/mac/fast/multicol/columns-shorthand-parsing-expected.txt:
* LayoutTests/platform/mac/fast/multicol/float-paginate-empty-lines-expected.txt:
* LayoutTests/platform/mac/fast/multicol/max-height-columns-block-expected.txt:
* LayoutTests/platform/mac/fast/multicol/overflow-across-columns-expected.txt:
* LayoutTests/platform/mac/fast/multicol/overflow-across-columns-percent-height-expected.txt:
* LayoutTests/platform/mac/fast/multicol/paginate-block-replaced-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-bt-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-lr-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-rl-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/BottomToTop-tb-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-bt-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-lr-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-rl-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/BottomToTopGrid-tb-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-bt-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-lr-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-rl-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/LeftToRight-tb-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-bt-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-lr-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-rl-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/LeftToRightGrid-tb-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-bt-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-lr-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-rl-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/RightToLeft-tb-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-bt-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-lr-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-rl-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/RightToLeftGrid-tb-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-bt-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-lr-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-rl-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/TopToBottom-tb-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-bt-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-lr-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-rl-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/TopToBottomGrid-tb-expected.txt:
* LayoutTests/platform/mac/fast/multicol/pagination/nested-transforms-expected.txt:
* LayoutTests/platform/mac/fast/multicol/scrolling-column-rules-expected.txt:
* LayoutTests/platform/mac/fast/multicol/scrolling-overflow-expected.txt:
* LayoutTests/platform/mac/fast/multicol/shadow-breaking-expected.txt:
* LayoutTests/platform/mac/fast/multicol/shrink-to-column-height-for-pagination-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/anonymous-style-inheritance-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/clone-flexbox-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/clone-summary-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-columns-child-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/span-as-nested-columns-child-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/span-as-nested-inline-block-child-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/span-margin-collapsing-expected.txt:
* LayoutTests/platform/mac/fast/multicol/table-margin-collapse-expected.txt:
* LayoutTests/platform/mac/fast/multicol/table-vertical-align-expected.txt:
* LayoutTests/platform/mac/fast/multicol/tall-image-behavior-expected.txt:
* LayoutTests/platform/mac/fast/multicol/tall-image-behavior-lr-expected.txt:
* LayoutTests/platform/mac/fast/multicol/tall-image-behavior-lr-mixed-expected.txt:
* LayoutTests/platform/mac/fast/multicol/tall-image-behavior-rl-expected.txt:
* LayoutTests/platform/mac/fast/multicol/vertical-lr/border-padding-pagination-expected.txt:
* LayoutTests/platform/mac/fast/multicol/vertical-rl/border-padding-pagination-expected.txt:
* LayoutTests/platform/mac/fast/overflow/paged-x-div-expected.txt:
* LayoutTests/platform/mac/fast/overflow/paged-x-div-with-column-gap-expected.txt:
* LayoutTests/platform/mac/fast/overflow/paged-x-on-root-expected.txt:
* LayoutTests/platform/mac/fast/overflow/paged-x-with-column-gap-expected.txt:
* LayoutTests/platform/mac/fast/overflow/paged-y-div-expected.txt:
* LayoutTests/platform/mac/fast/overflow/paged-y-on-root-expected.txt:
* LayoutTests/platform/mac/fast/repaint/multicol-repaint-expected.txt:
* LayoutTests/platform/win/css3/unicode-bidi-isolate-basic-expected.txt:
* LayoutTests/platform/win/fast/block/float/float-not-removed-from-next-sibling4-expected.txt:
* LayoutTests/platform/win/fast/borders/border-antialiasing-expected.txt:
* LayoutTests/platform/win/fast/line-grid/line-grid-inside-columns-expected.txt:
* LayoutTests/platform/win/fast/line-grid/line-grid-into-columns-expected.txt:
* LayoutTests/platform/win/fast/multicol/block-axis-horizontal-bt-expected.txt:
* LayoutTests/platform/win/fast/multicol/block-axis-horizontal-tb-expected.txt:
* LayoutTests/platform/win/fast/multicol/block-axis-vertical-lr-expected.txt:
* LayoutTests/platform/win/fast/multicol/block-axis-vertical-rl-expected.txt:
* LayoutTests/platform/win/fast/multicol/border-padding-pagination-expected.txt:
* LayoutTests/platform/win/fast/multicol/client-rects-spanners-complex-expected.txt:
* LayoutTests/platform/win/fast/multicol/client-rects-spanners-expected.txt:
* LayoutTests/platform/win/fast/multicol/column-rules-stacking-expected.txt:
* LayoutTests/platform/win/fast/multicol/columns-shorthand-parsing-expected.txt:
* LayoutTests/platform/win/fast/multicol/float-paginate-empty-lines-expected.txt:
* LayoutTests/platform/win/fast/multicol/max-height-columns-block-expected.txt:
* LayoutTests/platform/win/fast/multicol/overflow-across-columns-expected.txt:
* LayoutTests/platform/win/fast/multicol/overflow-across-columns-percent-height-expected.txt:
* LayoutTests/platform/win/fast/multicol/paginate-block-replaced-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-bt-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-lr-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-rl-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/BottomToTop-tb-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-bt-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-lr-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-rl-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/LeftToRight-tb-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-bt-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-lr-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-rl-dynamic-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-rl-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/RightToLeft-tb-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-bt-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-lr-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-rl-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/TopToBottom-tb-expected.txt:
* LayoutTests/platform/win/fast/multicol/pagination/nested-transforms-expected.txt:
* LayoutTests/platform/win/fast/multicol/scrolling-column-rules-expected.txt:
* LayoutTests/platform/win/fast/multicol/scrolling-overflow-expected.txt:
* LayoutTests/platform/win/fast/multicol/shadow-breaking-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/anonymous-style-inheritance-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/clone-flexbox-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/clone-summary-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/span-as-immediate-child-complex-splitting-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/span-as-immediate-child-generated-content-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/span-as-immediate-child-property-removal-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/span-as-immediate-columns-child-dynamic-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/span-as-immediate-columns-child-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/span-as-immediate-columns-child-removal-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/span-as-nested-columns-child-dynamic-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/span-as-nested-columns-child-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/span-as-nested-inline-block-child-expected.txt:
* LayoutTests/platform/win/fast/multicol/span/span-margin-collapsing-expected.txt:
* LayoutTests/platform/win/fast/multicol/table-margin-collapse-expected.txt:
* LayoutTests/platform/win/fast/multicol/table-vertical-align-expected.txt:
* LayoutTests/platform/win/fast/multicol/tall-image-behavior-expected.txt:
* LayoutTests/platform/win/fast/multicol/tall-image-behavior-lr-expected.txt:
* LayoutTests/platform/win/fast/multicol/tall-image-behavior-rl-expected.txt:
* LayoutTests/platform/win/fast/multicol/vertical-lr/border-padding-pagination-expected.txt:
* LayoutTests/platform/win/fast/multicol/vertical-rl/border-padding-pagination-expected.txt:
* LayoutTests/platform/win/fast/overflow/paged-x-div-expected.txt:
* LayoutTests/platform/win/fast/overflow/paged-x-div-with-column-gap-expected.txt:
* LayoutTests/platform/win/fast/overflow/paged-x-on-root-expected.txt:
* LayoutTests/platform/win/fast/overflow/paged-x-with-column-gap-expected.txt:
* LayoutTests/platform/win/fast/overflow/paged-y-div-expected.txt:
* LayoutTests/platform/win/fast/overflow/paged-y-on-root-expected.txt:
* LayoutTests/platform/win/fast/repaint/multicol-repaint-expected.txt:
* LayoutTests/platform/wpe/fast/multicol/pagination/LeftToRight-tb-hittest-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-transforms/crashtests/preserve3d-scene-002-expected.txt:
* Source/WebCore/rendering/RenderMultiColumnFlow.cpp:
(WebCore::RenderMultiColumnFlow::renderName const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b49a09b13cf1c613123faf1c140a1d17283ae927

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167260 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112515 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122703 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86121 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103373 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24010 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22404 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15031 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133698 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169750 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15425 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130891 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131005 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31492 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141883 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89367 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25695 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18689 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31003 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96841 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30523 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30796 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30677 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->