### PR TITLE
[JSC] Lazily resolve default calendar / numberingSystem in Intl constructors

### DIFF
--- a/JSTests/microbenchmarks/intl-constructor-collator.js
+++ b/JSTests/microbenchmarks/intl-constructor-collator.js
@@ -1,0 +1,10 @@
+function test() {
+    let count = 0;
+    for (let i = 0; i < 1e4; ++i)
+        count += new Intl.Collator("en-US").compare !== undefined;
+    return count;
+}
+
+const result = test();
+if (result !== 1e4)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/intl-constructor-datetimeformat.js
+++ b/JSTests/microbenchmarks/intl-constructor-datetimeformat.js
@@ -1,0 +1,10 @@
+function test() {
+    let count = 0;
+    for (let i = 0; i < 1e4; ++i)
+        count += new Intl.DateTimeFormat("en-US").format !== undefined;
+    return count;
+}
+
+const result = test();
+if (result !== 1e4)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/intl-constructor-durationformat.js
+++ b/JSTests/microbenchmarks/intl-constructor-durationformat.js
@@ -1,0 +1,10 @@
+function test() {
+    let count = 0;
+    for (let i = 0; i < 1e4; ++i)
+        count += new Intl.DurationFormat("en").format !== undefined;
+    return count;
+}
+
+const result = test();
+if (result !== 1e4)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/intl-constructor-numberformat.js
+++ b/JSTests/microbenchmarks/intl-constructor-numberformat.js
@@ -1,0 +1,10 @@
+function test() {
+    let count = 0;
+    for (let i = 0; i < 1e4; ++i)
+        count += new Intl.NumberFormat("en-US").format !== undefined;
+    return count;
+}
+
+const result = test();
+if (result !== 1e4)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/intl-constructor-relativetimeformat.js
+++ b/JSTests/microbenchmarks/intl-constructor-relativetimeformat.js
@@ -1,0 +1,10 @@
+function test() {
+    let count = 0;
+    for (let i = 0; i < 1e4; ++i)
+        count += new Intl.RelativeTimeFormat("en").format !== undefined;
+    return count;
+}
+
+const result = test();
+if (result !== 1e4)
+    throw new Error("Bad result: " + result);

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -693,19 +693,30 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
 
     {
         String calendar = resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Ca)];
-        if (auto mapped = mapICUCalendarKeywordToBCP47(calendar))
-            calendar = WTF::move(mapped.value());
-
+        if (!calendar.isNull()) {
+            if (auto mapped = mapICUCalendarKeywordToBCP47(calendar))
+                calendar = WTF::move(mapped.value());
+            // Handling "islamicc" candidate for backward compatibility.
+            if (calendar == "islamicc"_s)
+                calendar = "islamic-civil"_s;
+        }
         m_calendar = WTF::move(calendar);
-        // Handling "islamicc" candidate for backward compatibility.
-        if (m_calendar == "islamicc"_s)
-            m_calendar = "islamic-civil"_s;
     }
 
     hourCycle = parseHourCycle(resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Hc)]);
     m_numberingSystem = resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Nu)];
     m_dataLocale = resolved.dataLocale;
-    CString dataLocaleWithExtensions = makeString(m_dataLocale, "-u-ca-"_s, m_calendar, "-nu-"_s, m_numberingSystem).utf8();
+
+    StringBuilder localeBuilder;
+    localeBuilder.append(m_dataLocale);
+    if (!m_calendar.isNull() || !m_numberingSystem.isNull()) {
+        localeBuilder.append("-u"_s);
+        if (!m_calendar.isNull())
+            localeBuilder.append("-ca-"_s, m_calendar);
+        if (!m_numberingSystem.isNull())
+            localeBuilder.append("-nu-"_s, m_numberingSystem);
+    }
+    CString dataLocaleWithExtensions = localeBuilder.toString().utf8();
 
     JSValue tzValue = jsUndefined();
     if (options) {
@@ -1152,6 +1163,11 @@ JSObject* IntlDateTimeFormat::resolvedOptions(JSGlobalObject* globalObject) cons
 {
     VM& vm = globalObject->vm();
 
+    if (m_calendar.isNull())
+        m_calendar = defaultCalendarForLocale(m_dataLocale);
+    if (m_numberingSystem.isNull())
+        m_numberingSystem = defaultNumberingSystemForLocale(m_dataLocale);
+
     JSObject* options = constructEmptyObject(globalObject);
     options->putDirect(vm, vm.propertyNames->locale, jsNontrivialString(vm, m_locale));
     options->putDirect(vm, vm.propertyNames->calendar, jsNontrivialString(vm, m_calendar));
@@ -1405,9 +1421,16 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
     // While the pattern is including right HourCycle patterns, UDateIntervalFormat does not follow.
     // We need to enforce HourCycle by setting "hc" extension if it is specified.
     StringBuilder localeBuilder;
-    localeBuilder.append(m_dataLocale, "-u-ca-"_s, m_calendar, "-nu-"_s, m_numberingSystem);
-    if (m_hourCycle != HourCycle::None)
-        localeBuilder.append("-hc-"_s, hourCycleString(m_hourCycle));
+    localeBuilder.append(m_dataLocale);
+    if (!m_calendar.isNull() || !m_numberingSystem.isNull() || m_hourCycle != HourCycle::None) {
+        localeBuilder.append("-u"_s);
+        if (!m_calendar.isNull())
+            localeBuilder.append("-ca-"_s, m_calendar);
+        if (!m_numberingSystem.isNull())
+            localeBuilder.append("-nu-"_s, m_numberingSystem);
+        if (m_hourCycle != HourCycle::None)
+            localeBuilder.append("-hc-"_s, hourCycleString(m_hourCycle));
+    }
     CString dataLocaleWithExtensions = localeBuilder.toString().utf8();
 
     UErrorCode status = U_ZERO_ERROR;

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -132,8 +132,8 @@ private:
 
     String m_locale;
     String m_dataLocale;
-    String m_calendar;
-    String m_numberingSystem;
+    mutable String m_calendar;
+    mutable String m_numberingSystem;
     TimeZone m_timeZone;
     // Time zone string returned by resolvedOptions().timeZone. Per spec this is
     // [[Identifier]] (the case-normalized accepted form, e.g. "Asia/Calcutta"),

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -214,7 +214,8 @@ void IntlDurationFormat::initializeDurationFormat(JSGlobalObject* globalObject, 
     }
 
     m_numberingSystem = resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Nu)];
-    m_dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
+    m_dataLocale = resolved.dataLocale;
+    m_dataLocaleWithExtensions = m_numberingSystem.isNull() ? m_dataLocale.utf8() : makeString(m_dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
 
     m_style = intlOption<Style>(globalObject, options, vm.propertyNames->style, { { "long"_s, Style::Long }, { "short"_s, Style::Short }, { "narrow"_s, Style::Narrow }, { "digital"_s, Style::Digital } }, "style must be either \"long\", \"short\", \"narrow\", or \"digital\""_s, Style::Short);
     RETURN_IF_EXCEPTION(scope, void());
@@ -267,6 +268,13 @@ void IntlDurationFormat::initializeDurationFormat(JSGlobalObject* globalObject, 
             return;
         }
     }
+}
+
+const String& IntlDurationFormat::numberingSystem() const
+{
+    if (m_numberingSystem.isNull())
+        m_numberingSystem = defaultNumberingSystemForLocale(m_dataLocale);
+    return m_numberingSystem;
 }
 
 static String retrieveSeparator(const CString& locale, const String& numberingSystem)
@@ -842,7 +850,7 @@ JSObject* IntlDurationFormat::resolvedOptions(JSGlobalObject* globalObject) cons
     VM& vm = globalObject->vm();
     JSObject* options = constructEmptyObject(globalObject);
     options->putDirect(vm, vm.propertyNames->locale, jsString(vm, m_locale));
-    options->putDirect(vm, vm.propertyNames->numberingSystem, jsString(vm, m_numberingSystem));
+    options->putDirect(vm, vm.propertyNames->numberingSystem, jsString(vm, numberingSystem()));
     options->putDirect(vm, vm.propertyNames->style, jsNontrivialString(vm, styleString(m_style)));
 
     for (unsigned index = 0; index < numberOfTemporalUnits; ++index) {

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.h
@@ -90,7 +90,7 @@ public:
 
     const UnitData* units() const { return m_units; }
     unsigned fractionalDigits() const { return m_fractionalDigits; }
-    const String& numberingSystem() const LIFETIME_BOUND { return m_numberingSystem; }
+    const String& numberingSystem() const LIFETIME_BOUND;
     const CString& dataLocaleWithExtensions() const LIFETIME_BOUND { return m_dataLocaleWithExtensions; }
 
 private:
@@ -103,7 +103,8 @@ private:
 
     std::unique_ptr<UListFormatter, UListFormatterDeleter> m_listFormat;
     String m_locale;
-    String m_numberingSystem;
+    String m_dataLocale;
+    mutable String m_numberingSystem;
     CString m_dataLocaleWithExtensions;
     unsigned m_fractionalDigits { 0 };
     Style m_style { Style::Long };

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -326,6 +326,7 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
     }
 
     m_numberingSystem = resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Nu)];
+    m_dataLocale = resolved.dataLocale;
 
     m_style = intlOption<Style>(globalObject, options, vm.propertyNames->style, { { "decimal"_s, Style::Decimal }, { "percent"_s, Style::Percent }, { "currency"_s, Style::Currency }, { "unit"_s, Style::Unit } }, "style must be either \"decimal\", \"percent\", \"currency\", or \"unit\""_s, Style::Decimal);
     RETURN_IF_EXCEPTION(scope, void());
@@ -407,7 +408,7 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
     m_signDisplay = intlOption<SignDisplay>(globalObject, options, Identifier::fromString(vm, "signDisplay"_s), { { "auto"_s, SignDisplay::Auto }, { "never"_s, SignDisplay::Never }, { "always"_s, SignDisplay::Always }, { "exceptZero"_s, SignDisplay::ExceptZero }, { "negative"_s, SignDisplay::Negative } }, "signDisplay must be either \"auto\", \"never\", \"always\", \"exceptZero\", or \"negative\""_s, SignDisplay::Auto);
     RETURN_IF_EXCEPTION(scope, void());
 
-    CString dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
+    CString dataLocaleWithExtensions = m_numberingSystem.isNull() ? m_dataLocale.utf8() : makeString(m_dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
     dataLogLnIf(IntlNumberFormatInternal::verbose, "dataLocaleWithExtensions:(", dataLocaleWithExtensions , ")");
 
     // Options are obtained. Configure formatter here.
@@ -1222,6 +1223,8 @@ JSValue IntlNumberFormat::useGroupingValue(VM& vm, UseGrouping useGrouping)
 JSObject* IntlNumberFormat::resolvedOptions(JSGlobalObject* globalObject) const
 {
     VM& vm = globalObject->vm();
+    if (m_numberingSystem.isNull())
+        m_numberingSystem = defaultNumberingSystemForLocale(m_dataLocale);
     JSObject* options = constructEmptyObject(globalObject);
     options->putDirect(vm, vm.propertyNames->locale, jsString(vm, m_locale));
     options->putDirect(vm, vm.propertyNames->numberingSystem, jsString(vm, m_numberingSystem));

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -228,7 +228,8 @@ private:
     CString m_dataLocaleWithExtensions;
 
     String m_locale;
-    String m_numberingSystem;
+    String m_dataLocale;
+    mutable String m_numberingSystem;
     String m_currency;
     String m_unit;
     unsigned m_minimumIntegerDigits { 1 };

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1034,30 +1034,38 @@ ResolvedLocale resolveLocale(JSGlobalObject* globalObject, const LocaleSet& avai
     supportedExtension.append("-u"_s);
     for (RelevantExtensionKey key : relevantExtensionKeys) {
         ASCIILiteral keyString = relevantExtensionKeyString(key);
+
+        size_t keyPos = extensionSubtags.isEmpty() ? notFound : extensionSubtags.find(keyString);
+        auto& optionsValue = options[static_cast<unsigned>(key)];
+
+        // Avoid querying locale data when neither a Unicode extension nor an option requests
+        // a specific value. The locale-specific default is left as a null String so that
+        // callers can omit the corresponding -u-<key>-<value> when constructing ICU locales,
+        // and resolve the actual default lazily (e.g. in resolvedOptions()).
+        if (keyPos == notFound && !optionsValue)
+            continue;
+
         Vector<String> keyLocaleData = localeData(foundLocale, key);
         ASSERT(!keyLocaleData.isEmpty());
 
         String value = keyLocaleData[0];
         String supportedExtensionAddition;
 
-        if (!extensionSubtags.isEmpty()) {
-            size_t keyPos = extensionSubtags.find(keyString);
-            if (keyPos != notFound) {
-                if (keyPos + 1 < extensionSubtags.size() && extensionSubtags[keyPos + 1].length() > 2) {
-                    StringView requestedValue = extensionSubtags[keyPos + 1];
-                    auto dataPos = keyLocaleData.find(requestedValue);
-                    if (dataPos != notFound) {
-                        value = keyLocaleData[dataPos];
-                        supportedExtensionAddition = makeString('-', keyString, '-', value);
-                    }
-                } else if (keyLocaleData.contains("true"_s)) {
-                    value = "true"_s;
-                    supportedExtensionAddition = makeString('-', keyString);
+        if (keyPos != notFound) {
+            if (keyPos + 1 < extensionSubtags.size() && extensionSubtags[keyPos + 1].length() > 2) {
+                StringView requestedValue = extensionSubtags[keyPos + 1];
+                auto dataPos = keyLocaleData.find(requestedValue);
+                if (dataPos != notFound) {
+                    value = keyLocaleData[dataPos];
+                    supportedExtensionAddition = makeString('-', keyString, '-', value);
                 }
+            } else if (keyLocaleData.contains("true"_s)) {
+                value = "true"_s;
+                supportedExtensionAddition = makeString('-', keyString);
             }
         }
 
-        if (auto optionsValue = options[static_cast<unsigned>(key)]) {
+        if (optionsValue) {
             // Undefined should not get added to the options, it won't displace the extension.
             // Null will remove the extension.
             if ((optionsValue->isNull() || keyLocaleData.contains(*optionsValue)) && *optionsValue != value) {
@@ -1167,6 +1175,29 @@ Vector<String> numberingSystemsForLocale(const String& locale)
     Vector<String> numberingSystems({ defaultSystemName });
     numberingSystems.appendVector(availableNumberingSystems.get());
     return numberingSystems;
+}
+
+String defaultNumberingSystemForLocale(const String& dataLocale)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    auto defaultSystem = std::unique_ptr<UNumberingSystem, ICUDeleter<unumsys_close>>(unumsys_open(dataLocale.utf8().data(), &status));
+    ASSERT(U_SUCCESS(status));
+    return String::fromLatin1(unumsys_getName(defaultSystem.get()));
+}
+
+String defaultCalendarForLocale(const String& dataLocale)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    auto calendars = std::unique_ptr<UEnumeration, ICUDeleter<uenum_close>>(ucal_getKeywordValuesForLocale("calendar", dataLocale.utf8().data(), false, &status));
+    ASSERT(U_SUCCESS(status));
+    int32_t length;
+    const char* name = uenum_next(calendars.get(), &length, &status);
+    ASSERT(U_SUCCESS(status));
+    ASSERT(name);
+    String calendar(unsafeMakeSpan(name, static_cast<size_t>(length)));
+    if (auto mapped = mapICUCalendarKeywordToBCP47(calendar))
+        return mapped.value();
+    return calendar;
 }
 
 // unicode_language_subtag = alpha{2,3} | alpha{5,8} ;

--- a/Source/JavaScriptCore/runtime/IntlObject.h
+++ b/Source/JavaScriptCore/runtime/IntlObject.h
@@ -165,6 +165,8 @@ String extractNonUnicodeBCP47Extensions(StringView locale);
 String bestAvailableLocale(const LocaleSet& availableLocales, const String& requestedLocale);
 template<typename Predicate> String bestAvailableLocale(const String& requestedLocale, Predicate);
 Vector<String> numberingSystemsForLocale(const String& locale);
+String defaultNumberingSystemForLocale(const String& dataLocale);
+String defaultCalendarForLocale(const String& dataLocale);
 
 Vector<char, 32> canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(Vector<char, 32>&&);
 

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
@@ -112,7 +112,8 @@ void IntlRelativeTimeFormat::initializeRelativeTimeFormat(JSGlobalObject* global
     }
 
     m_numberingSystem = resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Nu)];
-    CString dataLocaleWithExtensions = makeString(resolved.dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
+    m_dataLocale = resolved.dataLocale;
+    CString dataLocaleWithExtensions = m_numberingSystem.isNull() ? m_dataLocale.utf8() : makeString(m_dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
 
     m_style = intlOption<Style>(globalObject, options, vm.propertyNames->style, { { "long"_s, Style::Long }, { "short"_s, Style::Short }, { "narrow"_s, Style::Narrow } }, "style must be either \"long\", \"short\", or \"narrow\""_s, Style::Long);
     RETURN_IF_EXCEPTION(scope, void());
@@ -200,6 +201,8 @@ JSObject* IntlRelativeTimeFormat::resolvedOptions(JSGlobalObject* globalObject) 
     options->putDirect(vm, vm.propertyNames->locale, jsNontrivialString(vm, m_locale));
     options->putDirect(vm, vm.propertyNames->style, jsNontrivialString(vm, styleString(m_style)));
     options->putDirect(vm, vm.propertyNames->numeric, jsNontrivialString(vm, m_numeric ? "always"_s : "auto"_s));
+    if (m_numberingSystem.isNull())
+        m_numberingSystem = defaultNumberingSystemForLocale(m_dataLocale);
     options->putDirect(vm, vm.propertyNames->numberingSystem, jsNontrivialString(vm, m_numberingSystem));
     return options;
 }

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h
@@ -83,7 +83,8 @@ private:
     mutable std::unique_ptr<UConstrainedFieldPosition, ICUDeleter<ucfpos_close>> m_cfpos;
 
     String m_locale;
-    String m_numberingSystem;
+    String m_dataLocale;
+    mutable String m_numberingSystem;
     Style m_style { Style::Long };
     bool m_numeric { true };
 };


### PR DESCRIPTION
#### 5da32d944f90991fa11c8a389de754831ac46a90
<pre>
[JSC] Lazily resolve default calendar / numberingSystem in Intl constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=313197">https://bugs.webkit.org/show_bug.cgi?id=313197</a>

Reviewed by Yusuke Suzuki.

resolveLocale() previously always called the localeData() callback for every
relevant extension key, even when neither a -u-&lt;key&gt; Unicode extension nor an
options property requested a specific value. For &quot;ca&quot; and &quot;nu&quot; this performs
expensive ICU lookups (ucal_getKeywordValuesForLocale / unumsys_open) on every
Intl constructor invocation just to obtain the locale-specific default.

This patch skips the localeData() lookup when nothing was requested for the
key, leaving the resolved extension as a null String. Callers omit the
corresponding -u-&lt;key&gt;-&lt;value&gt; when building the ICU locale, and resolve the
actual default lazily in resolvedOptions() via the new defaultCalendarForLocale
/ defaultNumberingSystemForLocale helpers.

A similar optimization was applied to SpiderMonkey: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=2027765">https://bugzilla.mozilla.org/show_bug.cgi?id=2027765</a>

                                             TipOfTree                  Patched

intl-constructor-relativetimeformat       89.3730+-0.4593     ^     52.9080+-2.1168        ^ definitely 1.6892x faster
intl-constructor-datetimeformat          222.0054+-6.4766     ^    135.7068+-7.1245        ^ definitely 1.6359x faster
intl-constructor-durationformat           20.1538+-0.1995     ^      8.6587+-0.1319        ^ definitely 2.3276x faster
intl-constructor-numberformat             70.9253+-0.7258     ^     20.8875+-1.0258        ^ definitely 3.3956x faster
intl-constructor-collator                 21.4439+-0.7733     ^     13.8002+-0.3970        ^ definitely 1.5539x faster

* JSTests/microbenchmarks/intl-constructor-collator.js: Added.
(test):
* JSTests/microbenchmarks/intl-constructor-datetimeformat.js: Added.
(test):
* JSTests/microbenchmarks/intl-constructor-durationformat.js: Added.
(test):
* JSTests/microbenchmarks/intl-constructor-numberformat.js: Added.
(test):
* JSTests/microbenchmarks/intl-constructor-relativetimeformat.js: Added.
(test):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):
(JSC::IntlDateTimeFormat::resolvedOptions const):
(JSC::IntlDateTimeFormat::createDateIntervalFormatIfNecessary):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.h:
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::IntlDurationFormat::initializeDurationFormat):
(JSC::IntlDurationFormat::numberingSystem const):
(JSC::IntlDurationFormat::resolvedOptions const):
* Source/JavaScriptCore/runtime/IntlDurationFormat.h:
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::initializeNumberFormat):
(JSC::IntlNumberFormat::resolvedOptions const):
* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::resolveLocale):
(JSC::defaultNumberingSystemForLocale):
(JSC::defaultCalendarForLocale):
* Source/JavaScriptCore/runtime/IntlObject.h:
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp:
(JSC::IntlRelativeTimeFormat::initializeRelativeTimeFormat):
(JSC::IntlRelativeTimeFormat::resolvedOptions const):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h:

Canonical link: <a href="https://commits.webkit.org/312029@main">https://commits.webkit.org/312029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f54673cba9b7d3ef3e1c902ca02614d78619c9ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167261 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112516 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122705 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86122 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103375 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24021 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22405 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15032 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150481 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169751 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19265 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15426 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130890 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131004 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35523 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89368 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25701 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18688 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190559 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31004 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96846 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48892 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30524 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->