### PR TITLE
[css-anchor-position-1] Position anchor-positioned element relative to transformed anchor box

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7558,14 +7558,7 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 # general failures
 
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-012.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/transform-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/transform-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/transform-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/transform-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/transform-006.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/transform-007.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/transform-008.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/transform-009.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-015.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-016.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/transform-012-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/transform-012-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Animation being updated
+FAIL Animation being updated assert_true: animation frame somewhere in the middle expected true got false
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -444,7 +444,7 @@ static LayoutRect boxBoundingBoxInContainer(const RenderBoxModelObject& box, con
 {
     bool wasFixed = false;
     // FIXME: figure out if OverscrollClamp is still needed.
-    auto boxQuadInContainer = box.localToContainerQuad(FloatQuad { box.borderBoundingBox() }, &container, { MapCoordinatesMode::ClampOverscroll }, &wasFixed);
+    auto boxQuadInContainer = box.localToContainerQuad(FloatQuad { box.borderBoundingBox() }, &container, { MapCoordinatesMode::UseTransforms, MapCoordinatesMode::ClampOverscroll }, &wasFixed);
     LayoutRect boundingBox { boxQuadInContainer.boundingBox() };
 
     if (wasFixed) {
@@ -495,10 +495,12 @@ static LayoutRect boundingRectForFragmentedAnchor(const RenderBoxModelObject& an
     CheckedPtr anchorRenderBox = dynamicDowncast<RenderBox>(&anchorBox);
     if (!anchorRenderBox)
         anchorRenderBox = anchorBox.containingBlock();
+
     LayoutPoint offsetRelativeToFragmentedFlow = fragmentedFlow.mapFromLocalToFragmentedFlow(anchorRenderBox.get(), { }).location();
     auto unfragmentedBorderBox = anchorBox.borderBoundingBox();
     unfragmentedBorderBox.moveBy(offsetRelativeToFragmentedFlow);
     fragmentedFlow.flipForWritingMode(unfragmentedBorderBox); // Convert to RenderLayer coords.
+
     auto fragmentsBoundingBox = fragmentedFlow.fragmentsBoundingBox(unfragmentedBorderBox);
     fragmentedFlow.flipForWritingMode(fragmentsBoundingBox); // Convert to RenderBox coords.
 
@@ -988,13 +990,12 @@ std::optional<double> AnchorPositionEvaluator::evaluateSize(BuilderState& builde
         }
     }
 
-    auto anchorBorderBoundingBox = anchorRenderer->borderBoundingBox();
-    if (CheckedPtr fragmentedFlow = anchorRenderer->enclosingFragmentedFlow()) {
-        CheckedPtr containingBlock = anchorPositionedRenderer->containingBlock();
-        if (fragmentedFlow && containingBlock
-            && fragmentedFlow->isDescendantOf(containingBlock.get()))
-            anchorBorderBoundingBox = boundingRectForFragmentedAnchor(*anchorRenderer, *containingBlock, *fragmentedFlow);
-    }
+    auto anchorBorderBoundingBox = [&]() {
+        CheckedPtr container = dynamicDowncast<RenderLayerModelObject>(anchorPositionedRenderer->container());
+        ASSERT(container);
+
+        return AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(*anchorRenderer, *container, *anchorPositionedRenderer);
+    }();
 
     // Adjust for CSS `zoom` property and page zoom.
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -1058,7 +1058,7 @@ bool Scope::invalidateForAnchorDependencies(LayoutDependencyUpdateContext& conte
 
     auto makeAnchorPosition = [&](const RenderBoxModelObject& anchorRenderer) {
         AnchorPosition result;
-        result.absoluteRect = anchorRenderer.absoluteBoundingBoxRectIgnoringTransforms();
+        result.absoluteRect = anchorRenderer.absoluteBoundingBoxRect();
         // Include containing block sizes as anchor function insets may be computed against any side and if they change
         // we need to invalidate.
         for (auto* containingBlock = anchorRenderer.containingBlock(); containingBlock; containingBlock = containingBlock->containingBlock()) {


### PR DESCRIPTION
#### f0a7b53a2373c20188d6e2572bb7028cbc034a52
<pre>
[css-anchor-position-1] Position anchor-positioned element relative to transformed anchor box
<a href="https://rdar.apple.com/175401339">rdar://175401339</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313104">https://bugs.webkit.org/show_bug.cgi?id=313104</a>

Reviewed by Antti Koivisto.

This patch changes boxBoundingBoxInContainer (in AnchorPositionEvaluator.cpp)
to apply transforms to the computed bounding box. This makes
AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock returns
the transformed anchor rect, which allows anchor-positioning features to position
elements relative to the transformed anchor rect.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/transform-001.html
       imported/w3c/web-platform-tests/css/css-anchor-position/transform-002.html
       imported/w3c/web-platform-tests/css/css-anchor-position/transform-003.html
       imported/w3c/web-platform-tests/css/css-anchor-position/transform-004.html
       imported/w3c/web-platform-tests/css/css-anchor-position/transform-007.html
       imported/w3c/web-platform-tests/css/css-anchor-position/transform-008.html
       imported/w3c/web-platform-tests/css/css-anchor-position/transform-009.html

* LayoutTests/TestExpectations:
    - Some anchor position x transform tests are now passing.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/transform-012-expected.txt:
    - Rebaseline. This tests anchor position x animated transforms,
      which shouldn&apos;t pass in the first place.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::boxBoundingBoxInContainer):
    - Apply transforms to the computed bounding box.

(WebCore::Style::boundingRectForFragmentedAnchor):
(WebCore::Style::AnchorPositionEvaluator::evaluateSize):
    - Use AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock to
      compute the anchor bounding box instead of getting it directly from the
      anchor renderer. This ensures the resulting size is after transforms, if any.

* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::invalidateForAnchorDependencies):
    - Use absoluteBoundingBoxRect() to capture the anchor bounding box rect,
      as it includes transforms.

Canonical link: <a href="https://commits.webkit.org/312317@main">https://commits.webkit.org/312317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c3313d9179b5edea9ccf3e75aed6eee5b09987c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112557 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122737 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86139 "1 flakes 7 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103407 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24052 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22443 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15073 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133739 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169792 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15507 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130926 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131040 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35706 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141926 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89409 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25733 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18732 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96978 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30565 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30838 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30719 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->