### PR TITLE
Speed up generate-bindings-all.pl by using fork() without exec()

### DIFF
--- a/Source/WebCore/bindings/scripts/generate-bindings-all.pl
+++ b/Source/WebCore/bindings/scripts/generate-bindings-all.pl
@@ -31,6 +31,12 @@ use lib $FindBin::Bin;
 use File::Basename;
 use File::Spec;
 use Getopt::Long;
+use Cwd;
+use English;
+BEGIN { eval { require JSON::XS; JSON::XS->import(); 1 } or do { require JSON::PP; JSON::PP->import() } }
+
+use IDLParser;
+use CodeGenerator;
 
 my $perl = $^X;
 my $scriptDir = $FindBin::Bin;
@@ -110,15 +116,6 @@ if ($supplementalDependencyFile) {
     readSupplementalDependencyFile($supplementalDependencyFile, \%newSupplements);
 }
 
-my @args = (File::Spec->catfile($scriptDir, 'generate-bindings.pl'),
-            '--defines', $defines,
-            '--generator', $generator,
-            '--outputDir', $outputDirectory,
-            '--idlAttributesFile', $idlAttributesFile,
-            '--idlFileNamesList', $idlFileNamesList,
-            '--write-dependencies');
-push @args, '--supplementalDependencyFile', $supplementalDependencyFile if $supplementalDependencyFile;
-
 my %directoryCache;
 buildDirectoryCache();
 
@@ -141,8 +138,48 @@ my @idlFilesToUpdate = grep &{sub {
     needsUpdate(\@output, \@deps);
 }}, @idlFiles;
 
+# Pre-parse shared data once in the parent process so forked children inherit it.
+my %supplementalDependencies;
+if ($supplementalDependencyFile) {
+    open my $sdFh, '<', $supplementalDependencyFile or die "Cannot open $supplementalDependencyFile\n";
+    while (my $line = <$sdFh>) {
+        my ($idlFile, @followingIdlFiles) = split(/\s+/, $line);
+        $supplementalDependencies{fileparse($idlFile)} = [sort @followingIdlFiles] if $idlFile;
+    }
+    close $sdFh;
+}
+
+my $idlAttributes;
+{
+    local $INPUT_RECORD_SEPARATOR;
+    open(my $jsonFh, '<', $idlAttributesFile) or die "Couldn't open $idlAttributesFile: $!";
+    my $input = <$jsonFh>;
+    close($jsonFh);
+
+    my $jsonDecoder = (eval { JSON::XS->new->utf8 } or JSON::PP->new->utf8);
+    my $jsonHashRef = $jsonDecoder->decode($input);
+    $idlAttributes = $jsonHashRef->{attributes};
+}
+
+# Pre-load the generator module so forked children don't need to compile it.
+my $generatorModuleName = "CodeGenerator$generator.pm";
+for my $dep (@generatorDependency) {
+    if (basename($dep) eq $generatorModuleName) {
+        my $dir = dirname($dep);
+        unshift @INC, $dir;
+        last;
+    }
+}
+require $generatorModuleName;
+
+# Pre-resolve realpath so forked children avoid per-file syscalls.
+my @resolvedIdlFilesToUpdate;
+for my $f (@idlFilesToUpdate) {
+    push @resolvedIdlFilesToUpdate, Cwd::realpath($f);
+}
+
 my $abort = 0;
-my $totalCount = @idlFilesToUpdate;
+my $totalCount = @resolvedIdlFilesToUpdate;
 my $currentCount = 0;
 
 spawnGenerateBindingsIfNeeded() for (1 .. $numOfJobs);
@@ -184,16 +221,27 @@ sub mtime
 sub spawnGenerateBindingsIfNeeded
 {
     return if $abort;
-    return unless @idlFilesToUpdate;
-    my $batchCount = 30;
-    # my $batchCount = int(($totalCount - $currentCount) / $numOfJobs) || 1;
-    my @files = splice(@idlFilesToUpdate, 0, $batchCount);
+    return unless @resolvedIdlFilesToUpdate;
+    my $batchCount = int(($totalCount + $numOfJobs - 1) / $numOfJobs) || 1;
+    my @files = splice(@resolvedIdlFilesToUpdate, 0, $batchCount);
     for (@files) {
         $currentCount++;
         my $basename = basename($_);
         printProgress("[$currentCount/$totalCount] $basename");
     }
-    my $pid = spawnCommand($perl, @args, @files);
+    my $pid = fork();
+    if ($pid == 0) {
+        my $suppressVerboseOutput = 1;
+        my $writeDependencies = 1;
+        my $verbose = 0;
+        for my $targetIdlFile (@files) {
+            my $targetParser = IDLParser->new($suppressVerboseOutput);
+            my $targetDocument = $targetParser->Parse($targetIdlFile, $defines, $idlAttributes);
+            my $codeGen = CodeGenerator->new($generator, $outputDirectory, $outputDirectory, $writeDependencies, $verbose, $targetIdlFile, $idlAttributes, \%supplementalDependencies, $idlFileNamesList);
+            $codeGen->ProcessDocument($targetDocument, $defines);
+        }
+        exit 0;
+    }
     $abort = 1 unless defined $pid;
 }
 
@@ -226,17 +274,6 @@ sub executeCommand
         return system(quoteCommand(@_));
     }
     return system(@_);
-}
-
-sub spawnCommand
-{
-    my $pid = fork();
-    if ($pid == 0) {
-        @_ = quoteCommand(@_) if ($^O eq 'MSWin32');
-        exec(@_);
-        die "Cannot exec";
-    }
-    return $pid;
 }
 
 sub quoteCommand


### PR DESCRIPTION
#### 43e9ce6d755a8d8ae6c2c175c93fa4793dbe9bd3
<pre>
Speed up generate-bindings-all.pl by using fork() without exec()
<a href="https://bugs.webkit.org/show_bug.cgi?id=313202">https://bugs.webkit.org/show_bug.cgi?id=313202</a>

Reviewed by Darin Adler (OOPS\!).

Previously, generate-bindings-all.pl spawned ~61 separate Perl
processes (batches of 30 files), each of which had to start a new
Perl interpreter, compile ~10K lines of modules (IDLParser,
CodeGenerator, CodeGeneratorJS), parse IDLAttributes.json, and
parse supplemental dependencies.

Now, modules and shared data are loaded once in the parent process,
and forked children inherit everything via copy-on-write memory.
Batch sizing is also changed from a fixed 30 to ceil(total/numOfJobs)
to create exactly numOfJobs equal batches. IDL file paths are also
pre-resolved via realpath in the parent to avoid per-file syscalls
in children.

Full regeneration of 1823 IDL files on a 16-core machine:
- Wall time: 4.2s -&gt; 2.1s (2x faster)
- User CPU: 11.7s -&gt; 6.1s
- System time: 8.7s -&gt; 3.7s

No-op builds are unaffected (~0.3s).

* Source/WebCore/bindings/scripts/generate-bindings-all.pl:
(spawnGenerateBindingsIfNeeded):
(spawnCommand): Deleted.

Canonical link: <a href="https://commits.webkit.org/311965@main">https://commits.webkit.org/311965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d10c7d0c4605306ec2fc9e94727dedf9ea84275b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112543 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122724 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86132 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103394 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24036 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22430 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15059 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169778 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15479 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21742 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130912 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31574 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26494 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131026 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35485 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141911 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89395 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18717 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31031 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96894 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30551 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30824 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->