### PR TITLE
Add RetainRef, a non-nullable version of RetainPtr

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		DD3DC91F27A4BF8E007E5B61 /* SortedArrayMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 93156C8D262C982200EAE27B /* SortedArrayMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC92027A4BF8E007E5B61 /* Range.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2AC5601E89F70C0001EE3F /* Range.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC92127A4BF8E007E5B61 /* RetainPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47305151A825B004123FF /* RetainPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2604010101010101010101AA /* RetainRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 2604010101010101010101AB /* RetainRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC92227A4BF8E007E5B61 /* ThreadMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 5311BD591EA81A9600525281 /* ThreadMessage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC92327A4BF8E007E5B61 /* WorkerPool.h in Headers */ = {isa = PBXBuildFile; fileRef = E388886E20C9095100E632BC /* WorkerPool.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC92427A4BF8E007E5B61 /* MessageQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472CC151A825B004123FF /* MessageQueue.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1638,6 +1639,7 @@
 		A8A472FF151A825B004123FF /* RefCounted.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RefCounted.h; sourceTree = "<group>"; };
 		A8A47303151A825B004123FF /* RefPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RefPtr.h; sourceTree = "<group>"; };
 		A8A47305151A825B004123FF /* RetainPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RetainPtr.h; sourceTree = "<group>"; };
+		2604010101010101010101AB /* RetainRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RetainRef.h; sourceTree = "<group>"; };
 		A8A47306151A825B004123FF /* SegmentedVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SegmentedVector.h; sourceTree = "<group>"; };
 		A8A47307151A825B004123FF /* SentinelLinkedList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentinelLinkedList.h; sourceTree = "<group>"; };
 		A8A47308151A825B004123FF /* SHA1.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SHA1.cpp; sourceTree = "<group>"; };
@@ -2681,6 +2683,7 @@
 				3A5BCFA2298768E300E0ABB2 /* RefVector.h */,
 				FE3842342325CC80009DD445 /* ResourceUsage.h */,
 				A8A47305151A825B004123FF /* RetainPtr.h */,
+				2604010101010101010101AB /* RetainRef.h */,
 				E3C583C826127ADD00C57568 /* RobinHoodHashMap.h */,
 				E32561122611B5B600A72CC5 /* RobinHoodHashSet.h */,
 				E31CF0A5261058580036E673 /* RobinHoodHashTable.h */,
@@ -3838,6 +3841,7 @@
 				3A5BCFA3298768E300E0ABB2 /* RefVector.h in Headers */,
 				DD3DC8C727A4BF8E007E5B61 /* ResourceUsage.h in Headers */,
 				DD3DC92127A4BF8E007E5B61 /* RetainPtr.h in Headers */,
+				2604010101010101010101AA /* RetainRef.h in Headers */,
 				DD3DC8A427A4BF8E007E5B61 /* RobinHoodHashMap.h in Headers */,
 				DD3DC88D27A4BF8E007E5B61 /* RobinHoodHashSet.h in Headers */,
 				DD3DC91A27A4BF8E007E5B61 /* RobinHoodHashTable.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -280,6 +280,7 @@ set(WTF_PUBLIC_HEADERS
     ReferenceWrapperVector.h
     ResourceUsage.h
     RetainPtr.h
+    RetainRef.h
     RobinHoodHashMap.h
     RobinHoodHashSet.h
     RobinHoodHashTable.h

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -28,6 +28,7 @@
 #if __has_feature(objc_arc)
 #define OSObjectPtr OSObjectPtrArc
 #define RetainPtr RetainPtrArc
+#define RetainRef RetainRefArc
 #endif
 #endif
 
@@ -148,6 +149,7 @@ template<typename T, typename = RawPtrTraits<T>> class CheckedPtr;
 template<typename T, typename = RawPtrTraits<T>, typename = DefaultRefDerefTraits<T>> class Ref;
 template<typename T, typename = RawPtrTraits<T>, typename = DefaultRefDerefTraits<T>> class RefPtr;
 template<typename> class RetainPtr;
+template<typename> class RetainRef;
 template<typename> class ScopedLambda;
 template<typename> class StringBuffer;
 template<typename> class StringParsingBuffer;
@@ -298,6 +300,7 @@ using WTF::RawValueTraits;
 using WTF::Ref;
 using WTF::RefPtr;
 using WTF::RetainPtr;
+using WTF::RetainRef;
 using WTF::SHA1;
 using WTF::ScopedLambda;
 using WTF::SerialFunctionDispatcher;

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -24,39 +24,8 @@
 
 #if USE(CF) || defined(__OBJC__)
 
-#include <algorithm>
-#include <cstddef>
-#include <wtf/HashTraits.h>
 #include <wtf/NeverDestroyed.h>
-
-#if USE(CF)
-#include <CoreFoundation/CoreFoundation.h>
-#include <wtf/cf/CFTypeTraits.h>
-#endif
-
-#ifdef __OBJC__
-#import <Foundation/Foundation.h>
-#endif
-
-#ifndef CF_BRIDGED_TYPE
-#define CF_BRIDGED_TYPE(T)
-#endif
-
-#ifndef CF_RELEASES_ARGUMENT
-#define CF_RELEASES_ARGUMENT
-#endif
-
-#ifndef CF_RETURNS_RETAINED
-#define CF_RETURNS_RETAINED
-#endif
-
-#ifndef NS_RELEASES_ARGUMENT
-#define NS_RELEASES_ARGUMENT
-#endif
-
-#ifndef NS_RETURNS_RETAINED
-#define NS_RETURNS_RETAINED
-#endif
+#include <wtf/RetainRef.h>
 
 // Because ARC enablement is a compile-time choice, and we compile this header
 // both ways, we need a separate copy of our code when ARC is enabled.
@@ -66,11 +35,6 @@
 #endif
 
 namespace WTF {
-
-template<typename T> class RetainPtr;
-
-template<typename T> constexpr bool IsNSType = std::is_convertible_v<T, id>;
-template<typename T> using RetainPtrType = std::conditional_t<IsNSType<T> && !std::is_same_v<T, id>, std::remove_pointer_t<T>, T>;
 
 template<typename T> [[nodiscard]] constexpr RetainPtr<RetainPtrType<T>> adoptCF(T CF_RELEASES_ARGUMENT);
 
@@ -132,6 +96,8 @@ public:
     constexpr RetainPtr(RetainPtr&& o) : m_ptr(o.leakRef()) { }
     template<typename U, typename = std::enable_if_t<std::is_convertible_v<typename RetainPtr<RetainPtrType<U>>::PtrType, PtrType>>>
     constexpr RetainPtr(RetainPtr<U>&& o) : m_ptr(o.leakRef()) { }
+    template<typename U, typename = std::enable_if_t<std::is_convertible_v<typename RetainRef<RetainPtrType<U>>::PtrType, PtrType>>>
+    constexpr RetainPtr(RetainRef<U>&& o) : m_ptr(o.leakRef()) { }
 
     // Hash table deleted values, which are only constructed and never copied or destroyed.
     constexpr RetainPtr(HashTableDeletedValueType) : m_ptr(hashTableDeletedValue()) { }
@@ -154,6 +120,14 @@ public:
     PtrType autorelease();
     PtrType getAutoreleased();
 
+    RetainRef<T> releaseNonNull()
+    {
+        ASSERT(m_ptr);
+        auto ptr = get();
+        m_ptr = nullptr;
+        return RetainRef<T>(ptr, RetainRef<T>::Adopt);
+    }
+
 #ifdef __OBJC__
     id bridgingAutorelease();
 #endif
@@ -173,6 +147,7 @@ public:
 
     RetainPtr& operator=(RetainPtr&&);
     template<typename U> RetainPtr& operator=(RetainPtr<U>&&);
+    template<typename U> RetainPtr& operator=(RetainRef<U>&&);
 
     void swap(RetainPtr&);
 
@@ -215,6 +190,7 @@ private:
 };
 
 template<typename T> RetainPtr(T) -> RetainPtr<RetainPtrType<T>>;
+template<typename U> RetainPtr(RetainRef<U>&&) -> RetainPtr<U>;
 
 // Helper function for creating a RetainPtr using template argument deduction.
 template<typename T> [[nodiscard]] RetainPtr<RetainPtrType<T>> retainPtr(T);
@@ -309,6 +285,13 @@ template<typename T> inline RetainPtr<T>& RetainPtr<T>::operator=(RetainPtr&& o)
 }
 
 template<typename T> template<typename U> inline RetainPtr<T>& RetainPtr<T>::operator=(RetainPtr<U>&& o)
+{
+    RetainPtr ptr = WTF::move(o);
+    swap(ptr);
+    return *this;
+}
+
+template<typename T> template<typename U> inline RetainPtr<T>& RetainPtr<T>::operator=(RetainRef<U>&& o)
 {
     RetainPtr ptr = WTF::move(o);
     swap(ptr);

--- a/Source/WTF/wtf/RetainRef.h
+++ b/Source/WTF/wtf/RetainRef.h
@@ -1,0 +1,386 @@
+/*
+ *  Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public License
+ *  along with this library; see the file COPYING.LIB.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <wtf/Platform.h>
+
+#if USE(CF) || defined(__OBJC__)
+
+#include <algorithm>
+#include <cstddef>
+#include <type_traits>
+#include <wtf/HashTraits.h>
+
+#if USE(CF)
+#include <CoreFoundation/CoreFoundation.h>
+#include <wtf/cf/CFTypeTraits.h>
+#endif
+
+#ifdef __OBJC__
+#import <Foundation/Foundation.h>
+#endif
+
+#ifndef CF_BRIDGED_TYPE
+#define CF_BRIDGED_TYPE(T)
+#endif
+
+#ifndef CF_RELEASES_ARGUMENT
+#define CF_RELEASES_ARGUMENT
+#endif
+
+#ifndef CF_RETURNS_RETAINED
+#define CF_RETURNS_RETAINED
+#endif
+
+#ifndef NS_RELEASES_ARGUMENT
+#define NS_RELEASES_ARGUMENT
+#endif
+
+#ifndef NS_RETURNS_RETAINED
+#define NS_RETURNS_RETAINED
+#endif
+
+// Because ARC enablement is a compile-time choice, and we compile this header
+// both ways, we need a separate copy of our code when ARC is enabled.
+#if __has_feature(objc_arc)
+#define RetainPtr RetainPtrArc
+#define RetainRef RetainRefArc
+#endif
+
+namespace WTF {
+
+template<typename T> class RetainPtr;
+template<typename T> class RetainRef;
+
+template<typename T> constexpr bool IsNSType = std::is_convertible_v<T, id>;
+template<typename T> using RetainPtrType = std::conditional_t<IsNSType<T> && !std::is_same_v<T, id>, std::remove_pointer_t<T>, T>;
+
+template<typename T> [[nodiscard]] constexpr RetainRef<RetainPtrType<T>> adoptCFRef(T CF_RELEASES_ARGUMENT);
+
+template<typename T> [[nodiscard]] constexpr RetainRef<RetainPtrType<T>> adoptNSRef(T NS_RELEASES_ARGUMENT);
+
+/**
+ * @brief RetainRef is the non-nullable variant of RetainPtr.
+ *
+ * Like RetainPtr, RetainRef is a reference-counting smart pointer for Objective-C and Core
+ * Foundation (CF) types. Unlike RetainPtr, it cannot hold a null value. The non-null invariant
+ * is established at construction (every constructor that takes a raw pointer asserts the
+ * pointer is non-null) and preserved by all subsequent operations.
+ *
+ * RetainRef has no default constructor, no clear() method, and no operator bool() / operator!()
+ * — it is always non-null. The only paths that may temporarily produce a null storage slot are
+ * the moved-from state and the special HashTable empty/deleted values, neither of which is
+ * observable through the public accessors.
+ *
+ * To create a RetainRef:
+ * @code
+ * RetainRef ref = retainRef(value);    // Retains the value (asserts value is non-null)
+ * RetainRef ref = adoptCFRef(x);       // Takes ownership without retaining (asserts non-null)
+ * RetainRef ref = adoptNSRef(x);       // Takes ownership without retaining (asserts non-null)
+ * RetainRef ref = ptr.releaseNonNull();// Convert from a non-null RetainPtr (asserts non-null)
+ * @endcode
+ *
+ * See RetainPtr for full documentation on retain/release semantics.
+ */
+template<typename T> class RetainRef {
+public:
+    using ValueType = std::remove_pointer_t<T>;
+    using PtrType = ValueType*;
+
+#ifdef __OBJC__
+    using StorageType = PtrType;
+#else
+    // Type pun id to CFTypeRef in C++ files. This is valid because they're ABI equivalent.
+    using StorageType = std::conditional_t<IsNSType<PtrType>, CFTypeRef, PtrType>;
+#endif
+
+    RetainRef() = delete;
+
+    RetainRef(PtrType);
+
+    RetainRef(const RetainRef&);
+    template<typename U> RetainRef(const RetainRef<U>&);
+
+    constexpr RetainRef(RetainRef&& o) : m_ptr(o.leakRef()) { ASSERT(m_ptr); }
+    template<typename U, typename = std::enable_if_t<std::is_convertible_v<typename RetainRef<RetainPtrType<U>>::PtrType, PtrType>>>
+    constexpr RetainRef(RetainRef<U>&& o) : m_ptr(o.leakRef()) { ASSERT(m_ptr); }
+
+    // Hash table deleted/empty values, which are only constructed and never copied or destroyed.
+    constexpr RetainRef(HashTableDeletedValueType) : m_ptr(hashTableDeletedValue()) { }
+    constexpr bool isHashTableDeletedValue() const { return m_ptr == hashTableDeletedValue(); }
+
+    constexpr RetainRef(HashTableEmptyValueType) : m_ptr(nullptr) { }
+    constexpr bool isHashTableEmptyValue() const { return !m_ptr; }
+    static constexpr StorageType hashTableEmptyValue() { return nullptr; }
+
+    ~RetainRef();
+
+    template<typename U = StorageType> requires (std::is_same_v<U, StorageType> && IsNSType<U>)
+    [[nodiscard]] StorageType leakRef() NS_RETURNS_RETAINED RETURNS_NONNULL {
+        ASSERT(m_ptr);
+        return std::exchange(m_ptr, nullptr);
+    }
+
+    template<typename U = StorageType> requires (std::is_same_v<U, StorageType> && !IsNSType<U>)
+    [[nodiscard]] StorageType leakRef() CF_RETURNS_RETAINED RETURNS_NONNULL {
+        ASSERT(m_ptr);
+        return std::exchange(m_ptr, nullptr);
+    }
+
+    PtrType autorelease() RETURNS_NONNULL;
+    PtrType getAutoreleased() RETURNS_NONNULL;
+
+#ifdef __OBJC__
+    id bridgingAutorelease();
+#endif
+
+    constexpr PtrType get() const LIFETIME_BOUND RETURNS_NONNULL { ASSERT(m_ptr); return static_cast<PtrType>(const_cast<std::remove_const_t<std::remove_pointer_t<StorageType>>*>(m_ptr)); }
+    constexpr PtrType ptrAllowingHashTableEmptyValue() const LIFETIME_BOUND { ASSERT(m_ptr || isHashTableEmptyValue()); return static_cast<PtrType>(const_cast<std::remove_const_t<std::remove_pointer_t<StorageType>>*>(m_ptr)); }
+    constexpr PtrType operator->() const LIFETIME_BOUND { ASSERT(m_ptr); return get(); }
+    constexpr operator PtrType() const LIFETIME_BOUND { ASSERT(m_ptr); return get(); }
+
+    RetainRef& operator=(const RetainRef&);
+    template<typename U> RetainRef& operator=(const RetainRef<U>&);
+    RetainRef& operator=(PtrType);
+    template<typename U> RetainRef& operator=(U*);
+
+    RetainRef& operator=(RetainRef&&);
+    template<typename U> RetainRef& operator=(RetainRef<U>&&);
+
+    void swap(RetainRef&);
+
+    template<typename U> friend constexpr RetainRef<RetainPtrType<U>> adoptCFRef(U CF_RELEASES_ARGUMENT);
+
+    template<typename U> friend constexpr RetainRef<RetainPtrType<U>> adoptNSRef(U NS_RELEASES_ARGUMENT);
+
+private:
+    template<typename U> friend class RetainRef;
+    template<typename U> friend class RetainPtr;
+
+    enum AdoptTag { Adopt };
+    constexpr RetainRef(PtrType ptr, AdoptTag) : m_ptr(ptr) { ASSERT(m_ptr); }
+
+#if __has_feature(objc_arc)
+    // ARC will try to retain/release this value, but it looks like a tagged immediate, so retain/release ends up being a no-op -- see _objc_isTaggedPointer() in <objc-internal.h>.
+    template<typename U = PtrType> requires (std::is_same_v<U, PtrType> && IsNSType<U>)
+    static constexpr PtrType hashTableDeletedValue() { return (__bridge PtrType)(void*)-1; }
+
+    template<typename U = PtrType> requires (std::is_same_v<U, PtrType> && !IsNSType<U>)
+    static constexpr PtrType hashTableDeletedValue() { return reinterpret_cast<PtrType>(-1); }
+#else
+    static constexpr PtrType hashTableDeletedValue() { return reinterpret_cast<PtrType>(-1); }
+#endif
+
+    static inline void retainFoundationPtr(CFTypeRef ptr) { CFRetain(ptr); }
+    static inline void releaseFoundationPtr(CFTypeRef ptr) { CFRelease(ptr); }
+    static inline void autoreleaseFoundationPtr(CFTypeRef ptr) { CFAutorelease(ptr); }
+
+#ifdef __OBJC__
+#if __has_feature(objc_arc)
+    static inline void retainFoundationPtr(id) { }
+    static inline void releaseFoundationPtr(id) { }
+    static inline void autoreleaseFoundationPtr(id) { }
+#else
+    static inline void retainFoundationPtr(id ptr) { [ptr retain]; }
+    static inline void releaseFoundationPtr(id ptr) { [ptr release]; }
+    static inline void autoreleaseFoundationPtr(id ptr) { [ptr autorelease]; }
+#endif
+#endif
+
+    StorageType m_ptr;
+};
+
+template<typename T> RetainRef(T) -> RetainRef<RetainPtrType<T>>;
+
+// Helper function for creating a RetainRef using template argument deduction.
+template<typename T> [[nodiscard]] RetainRef<RetainPtrType<T>> retainRef(T);
+
+template<typename T> inline RetainRef<T>::~RetainRef()
+{
+    SUPPRESS_UNRETAINED_LOCAL if (auto ptr = std::exchange(m_ptr, nullptr))
+        releaseFoundationPtr(ptr);
+}
+
+template<typename T> inline RetainRef<T>::RetainRef(PtrType ptr)
+    : m_ptr(ptr)
+{
+    ASSERT(m_ptr);
+    SUPPRESS_UNRETAINED_ARG retainFoundationPtr(m_ptr);
+}
+
+template<typename T> inline RetainRef<T>::RetainRef(const RetainRef& o)
+    : m_ptr(o.m_ptr)
+{
+    ASSERT(m_ptr);
+    SUPPRESS_UNRETAINED_ARG retainFoundationPtr(m_ptr);
+}
+
+template<typename T> template<typename U> inline RetainRef<T>::RetainRef(const RetainRef<U>& o)
+    : RetainRef(o.get())
+{
+}
+
+template<typename T> inline auto RetainRef<T>::autorelease() -> PtrType
+{
+    ASSERT(m_ptr);
+    auto ptr = std::exchange(m_ptr, nullptr);
+    autoreleaseFoundationPtr(ptr);
+    return ptr;
+}
+
+template<typename T> inline auto RetainRef<T>::getAutoreleased() -> PtrType
+{
+    RetainRef copy { *this };
+    return copy.autorelease();
+}
+
+#ifdef __OBJC__
+// FIXME: It would be better if we could base the return type on the type that is toll-free bridged with T rather than using id.
+template<typename T> inline id RetainRef<T>::bridgingAutorelease()
+{
+    static_assert(!IsNSType<PtrType>, "Don't use bridgingAutorelease for Objective-C pointer types.");
+    return CFBridgingRelease(leakRef());
+}
+#endif // __OBJC__
+
+template<typename T> inline RetainRef<T>& RetainRef<T>::operator=(const RetainRef& o)
+{
+    RetainRef ref = o;
+    swap(ref);
+    return *this;
+}
+
+template<typename T> template<typename U> inline RetainRef<T>& RetainRef<T>::operator=(const RetainRef<U>& o)
+{
+    RetainRef ref = o;
+    swap(ref);
+    return *this;
+}
+
+template<typename T> inline RetainRef<T>& RetainRef<T>::operator=(PtrType optr)
+{
+    RetainRef ref = optr;
+    swap(ref);
+    return *this;
+}
+
+template<typename T> template<typename U> inline RetainRef<T>& RetainRef<T>::operator=(U* optr)
+{
+    RetainRef ref = optr;
+    swap(ref);
+    return *this;
+}
+
+template<typename T> inline RetainRef<T>& RetainRef<T>::operator=(RetainRef&& o)
+{
+    RetainRef ref = WTF::move(o);
+    swap(ref);
+    return *this;
+}
+
+template<typename T> template<typename U> inline RetainRef<T>& RetainRef<T>::operator=(RetainRef<U>&& o)
+{
+    RetainRef ref = WTF::move(o);
+    swap(ref);
+    return *this;
+}
+
+template<typename T> inline void RetainRef<T>::swap(RetainRef& o)
+{
+    std::swap(m_ptr, o.m_ptr);
+}
+
+template<typename T> inline void swap(RetainRef<T>& a, RetainRef<T>& b)
+{
+    a.swap(b);
+}
+
+template<typename T, typename U> constexpr bool operator==(const RetainRef<T>& a, const RetainRef<U>& b)
+{
+    return a.get() == b.get();
+}
+
+template<typename T, typename U> constexpr bool operator==(const RetainRef<T>& a, U* b)
+{
+    return a.get() == b;
+}
+
+template<typename T> constexpr RetainRef<RetainPtrType<T>> adoptCFRef(T CF_RELEASES_ARGUMENT ptr)
+{
+    static_assert(!IsNSType<T>, "Don't use adoptCFRef with Objective-C pointer types, use adoptNSRef.");
+    ASSERT(ptr);
+    return { ptr, RetainRef<RetainPtrType<T>>::Adopt };
+}
+
+template<typename T> constexpr RetainRef<RetainPtrType<T>> adoptNSRef(T NS_RELEASES_ARGUMENT ptr)
+{
+    static_assert(IsNSType<T>, "Don't use adoptNSRef with Core Foundation pointer types, use adoptCFRef.");
+    ASSERT(ptr);
+    return { ptr, RetainRef<RetainPtrType<T>>::Adopt };
+}
+
+template<typename T> inline RetainRef<RetainPtrType<T>> retainRef(T ptr)
+{
+    return ptr;
+}
+
+template<typename T> struct IsSmartPtr<RetainRef<T>> {
+    static constexpr bool value = true;
+    static constexpr bool isNullable = false;
+};
+
+template<typename T> inline constexpr bool IsRetainRef = false;
+template<typename T> inline constexpr bool IsRetainRef<RetainRef<T>> = true;
+
+template<typename P> struct HashTraits<RetainRef<P>> : SimpleClassHashTraits<RetainRef<P>> {
+    static constexpr bool emptyValueIsZero = true;
+    static RetainRef<P> emptyValue() { return HashTableEmptyValue; }
+
+    template<typename>
+    static void constructEmptyValue(RetainRef<P>& slot)
+    {
+        new (NotNull, std::addressof(slot)) RetainRef<P>(HashTableEmptyValue);
+    }
+
+    static constexpr bool hasIsEmptyValueFunction = true;
+    static bool isEmptyValue(const RetainRef<P>& value) { return value.isHashTableEmptyValue(); }
+
+    using PeekType = RetainRef<P>::PtrType;
+    static PeekType peek(const RetainRef<P>& value) { return value.ptrAllowingHashTableEmptyValue(); }
+    static PeekType peek(P* value) { return value; }
+
+    using TakeType = RetainPtr<P>;
+    static TakeType take(RetainRef<P>&& value) { return isEmptyValue(value) ? RetainPtr<P>() : RetainPtr<P>(value.get()); }
+};
+
+template<typename P> struct DefaultHash<RetainRef<P>> : PtrHash<RetainRef<P>> { };
+
+} // namespace WTF
+
+using WTF::RetainRef;
+using WTF::adoptCFRef;
+using WTF::retainRef;
+
+#ifdef __OBJC__
+using WTF::adoptNSRef;
+#endif
+
+#endif // USE(CF) || defined(__OBJC__)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1278,6 +1278,7 @@
 				WTF/ScopedLambda.cpp = "-fno-elide-constructors";
 				WTF/cocoa/RetainPtrARC.mm = "-fobjc-arc";
 				WTF/cocoa/RetainPtrHashingCocoaARC.mm = "-fobjc-arc";
+				WTF/cocoa/RetainRefARC.mm = "-fobjc-arc";
 				WTF/cocoa/TypeCastsCocoaARC.mm = "-fobjc-arc";
 				WTF/darwin/OSObjectPtrCocoaARC.mm = "-fobjc-arc";
 				WTF/darwin/TypeCastsOSObjectCocoaARC.mm = "-fobjc-arc";
@@ -1293,6 +1294,7 @@
 				WTF/BumpPointerAllocator.cpp,
 				WTF/cf/RetainPtr.cpp,
 				WTF/cf/RetainPtrHashing.cpp,
+				WTF/cf/RetainRef.cpp,
 				WTF/cf/StringCF.cpp,
 				WTF/cf/VectorCF.cpp,
 				WTF/CharacterProperties.cpp,
@@ -1306,6 +1308,8 @@
 				WTF/cocoa/RetainPtrARC.mm,
 				WTF/cocoa/RetainPtrHashingCocoa.mm,
 				WTF/cocoa/RetainPtrHashingCocoaARC.mm,
+				WTF/cocoa/RetainRef.mm,
+				WTF/cocoa/RetainRefARC.mm,
 				WTF/cocoa/TextStreamCocoa.cpp,
 				WTF/cocoa/TextStreamCocoa.mm,
 				WTF/cocoa/TypeCastsCocoa.mm,

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/RetainRef.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/RetainRef.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/RetainRef.h>
+
+namespace TestWebKitAPI {
+
+TEST(RetainRef, AdoptCFRef)
+{
+    RetainRef<CFArrayRef> array = adoptCFRef(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    EXPECT_EQ(1, CFGetRetainCount(array.get()));
+    EXPECT_EQ(0, CFArrayGetCount(array.get()));
+}
+
+TEST(RetainRef, RetainRefFromValue)
+{
+    RetainPtr<CFArrayRef> source = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    EXPECT_EQ(1, CFGetRetainCount(source.get()));
+
+    {
+        RetainRef<CFArrayRef> ref = retainRef(source.get());
+        EXPECT_EQ(2, CFGetRetainCount(source.get()));
+        EXPECT_EQ(source.get(), ref.get());
+    }
+    EXPECT_EQ(1, CFGetRetainCount(source.get()));
+}
+
+TEST(RetainRef, CopyConstructor)
+{
+    RetainRef<CFArrayRef> a = adoptCFRef(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    EXPECT_EQ(1, CFGetRetainCount(a.get()));
+
+    {
+        RetainRef<CFArrayRef> b = a;
+        EXPECT_EQ(2, CFGetRetainCount(a.get()));
+        EXPECT_EQ(a.get(), b.get());
+    }
+    EXPECT_EQ(1, CFGetRetainCount(a.get()));
+}
+
+TEST(RetainRef, MoveConstructor)
+{
+    RetainRef<CFArrayRef> a = adoptCFRef(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    CFArrayRef raw = a.get();
+    EXPECT_EQ(1, CFGetRetainCount(raw));
+
+    RetainRef<CFArrayRef> b = WTF::move(a);
+    EXPECT_EQ(1, CFGetRetainCount(raw));
+    EXPECT_EQ(raw, b.get());
+}
+
+TEST(RetainRef, FromRetainPtrReleaseNonNull)
+{
+    RetainPtr<CFArrayRef> ptr = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    CFArrayRef raw = ptr.get();
+    EXPECT_EQ(1, CFGetRetainCount(raw));
+
+    RetainRef<CFArrayRef> ref = ptr.releaseNonNull();
+    EXPECT_EQ(1, CFGetRetainCount(raw));
+    EXPECT_EQ(raw, ref.get());
+    EXPECT_EQ(nullptr, ptr.get());
+}
+
+TEST(RetainRef, MoveToRetainPtr)
+{
+    RetainRef<CFArrayRef> ref = adoptCFRef(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    CFArrayRef raw = ref.get();
+    EXPECT_EQ(1, CFGetRetainCount(raw));
+
+    {
+        RetainPtr<CFArrayRef> ptr { WTF::move(ref) };
+        EXPECT_EQ(1, CFGetRetainCount(raw));
+        EXPECT_EQ(raw, ptr.get());
+    }
+}
+
+TEST(RetainRef, AssignToRetainPtr)
+{
+    RetainPtr<CFArrayRef> ptr = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    CFArrayRef rawOriginal = ptr.get();
+    EXPECT_EQ(1, CFGetRetainCount(rawOriginal));
+
+    RetainRef<CFArrayRef> ref = adoptCFRef(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    CFArrayRef rawNew = ref.get();
+    EXPECT_EQ(1, CFGetRetainCount(rawNew));
+
+    ptr = WTF::move(ref);
+    EXPECT_EQ(rawNew, ptr.get());
+    EXPECT_EQ(1, CFGetRetainCount(rawNew));
+}
+
+TEST(RetainRef, CtadFromRetainRef)
+{
+    RetainRef<CFArrayRef> ref = adoptCFRef(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    CFArrayRef raw = ref.get();
+    EXPECT_EQ(1, CFGetRetainCount(raw));
+
+    RetainPtr ptr { WTF::move(ref) };
+    static_assert(std::is_same_v<decltype(ptr), RetainPtr<CFArrayRef>>);
+    EXPECT_EQ(raw, ptr.get());
+    EXPECT_EQ(1, CFGetRetainCount(raw));
+}
+
+TEST(RetainRef, ExplicitFromRetainPtr)
+{
+    RetainPtr<CFArrayRef> ptr = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    EXPECT_EQ(1, CFGetRetainCount(ptr.get()));
+
+    {
+        RetainRef<CFArrayRef> ref { ptr.get() };
+        EXPECT_EQ(2, CFGetRetainCount(ptr.get()));
+        EXPECT_EQ(ptr.get(), ref.get());
+    }
+    EXPECT_EQ(1, CFGetRetainCount(ptr.get()));
+}
+
+TEST(RetainRef, Assignment)
+{
+    RetainRef<CFArrayRef> a = adoptCFRef(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    RetainRef<CFArrayRef> b = adoptCFRef(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    CFArrayRef rawB = b.get();
+
+    a = b;
+    EXPECT_EQ(rawB, a.get());
+    EXPECT_EQ(2, CFGetRetainCount(rawB));
+}
+
+TEST(RetainRef, HashMap)
+{
+    HashMap<RetainRef<CFArrayRef>, int> map;
+    RetainRef<CFArrayRef> key = adoptCFRef(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, nullptr));
+    map.add(key, 42);
+    EXPECT_EQ(1u, map.size());
+    EXPECT_EQ(42, map.get(key));
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainRef.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainRef.mm
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import <wtf/HashMap.h>
+#import <wtf/RetainRef.h>
+
+#if __has_feature(objc_arc)
+#ifndef RETAIN_REF_TEST_NAME
+#error This tests RetainRef.h with ARC disabled.
+#endif
+#endif
+
+#ifndef RETAIN_REF_TEST_NAME
+#define RETAIN_REF_TEST_NAME RetainRef
+#endif
+
+#if __has_feature(objc_arc) && !defined(NDEBUG)
+#define AUTORELEASEPOOL_FOR_ARC_DEBUG @autoreleasepool
+#else
+#define AUTORELEASEPOOL_FOR_ARC_DEBUG
+#endif
+
+namespace TestWebKitAPI {
+
+TEST(RETAIN_REF_TEST_NAME, AdoptNSRef)
+{
+    RetainRef<NSObject> object = adoptNSRef([[NSObject alloc] init]);
+    uintptr_t objectPtr = 0;
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        objectPtr = reinterpret_cast<uintptr_t>(object.get());
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+}
+
+TEST(RETAIN_REF_TEST_NAME, RetainRefFromValueNS)
+{
+    RetainPtr<NSObject> source = adoptNS([[NSObject alloc] init]);
+    uintptr_t sourcePtr = 0;
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        sourcePtr = reinterpret_cast<uintptr_t>(source.get());
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)sourcePtr));
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        RetainRef<NSObject> ref = retainRef(source.get());
+        EXPECT_EQ(sourcePtr, reinterpret_cast<uintptr_t>(ref.get()));
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)sourcePtr));
+}
+
+TEST(RETAIN_REF_TEST_NAME, CopyConstructorNS)
+{
+    RetainRef<NSObject> a = adoptNSRef([[NSObject alloc] init]);
+    uintptr_t rawPtr = 0;
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        rawPtr = reinterpret_cast<uintptr_t>(a.get());
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+    {
+        RetainRef<NSObject> b = a;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            EXPECT_EQ(rawPtr, reinterpret_cast<uintptr_t>(b.get()));
+        }
+        EXPECT_EQ(2L, CFGetRetainCount((CFTypeRef)rawPtr));
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+}
+
+TEST(RETAIN_REF_TEST_NAME, MoveConstructorNS)
+{
+    RetainRef<NSObject> a = adoptNSRef([[NSObject alloc] init]);
+    uintptr_t rawPtr = 0;
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        rawPtr = reinterpret_cast<uintptr_t>(a.get());
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+
+    RetainRef<NSObject> b = WTF::move(a);
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        EXPECT_EQ(rawPtr, reinterpret_cast<uintptr_t>(b.get()));
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+}
+
+TEST(RETAIN_REF_TEST_NAME, FromRetainPtrReleaseNonNullNS)
+{
+    RetainPtr<NSObject> ptr = adoptNS([[NSObject alloc] init]);
+    uintptr_t rawPtr = 0;
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        rawPtr = reinterpret_cast<uintptr_t>(ptr.get());
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+
+    RetainRef<NSObject> ref = ptr.releaseNonNull();
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        EXPECT_EQ(rawPtr, reinterpret_cast<uintptr_t>(ref.get()));
+        EXPECT_EQ(nullptr, ptr.get());
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+}
+
+TEST(RETAIN_REF_TEST_NAME, MoveToRetainPtrNS)
+{
+    RetainRef<NSObject> ref = adoptNSRef([[NSObject alloc] init]);
+    uintptr_t rawPtr = 0;
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        rawPtr = reinterpret_cast<uintptr_t>(ref.get());
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+
+    {
+        RetainPtr<NSObject> ptr { WTF::move(ref) };
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            EXPECT_EQ(rawPtr, reinterpret_cast<uintptr_t>(ptr.get()));
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+    }
+}
+
+TEST(RETAIN_REF_TEST_NAME, AssignToRetainPtrNS)
+{
+    RetainPtr<NSObject> ptr = adoptNS([[NSObject alloc] init]);
+    RetainRef<NSObject> ref = adoptNSRef([[NSObject alloc] init]);
+    uintptr_t rawNew = 0;
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        rawNew = reinterpret_cast<uintptr_t>(ref.get());
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawNew));
+
+    ptr = WTF::move(ref);
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        EXPECT_EQ(rawNew, reinterpret_cast<uintptr_t>(ptr.get()));
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawNew));
+}
+
+TEST(RETAIN_REF_TEST_NAME, CtadFromRetainRefNS)
+{
+    RetainRef<NSObject> ref = adoptNSRef([[NSObject alloc] init]);
+    uintptr_t rawPtr = 0;
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        rawPtr = reinterpret_cast<uintptr_t>(ref.get());
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+
+    RetainPtr ptr { WTF::move(ref) };
+    static_assert(std::is_same_v<decltype(ptr), RetainPtr<NSObject>>);
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        EXPECT_EQ(rawPtr, reinterpret_cast<uintptr_t>(ptr.get()));
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+}
+
+TEST(RETAIN_REF_TEST_NAME, ExplicitFromRetainPtrNS)
+{
+    RetainPtr<NSObject> ptr = adoptNS([[NSObject alloc] init]);
+    uintptr_t rawPtr = 0;
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        rawPtr = reinterpret_cast<uintptr_t>(ptr.get());
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        RetainRef<NSObject> ref { ptr.get() };
+        EXPECT_EQ(rawPtr, reinterpret_cast<uintptr_t>(ref.get()));
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)rawPtr));
+}
+
+TEST(RETAIN_REF_TEST_NAME, HashMapNS)
+{
+    HashMap<RetainRef<NSObject>, int> map;
+    RetainRef<NSObject> key = adoptNSRef([[NSObject alloc] init]);
+    map.add(key, 7);
+    EXPECT_EQ(1u, map.size());
+    EXPECT_EQ(7, map.get(key));
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainRefARC.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainRefARC.mm
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This tests RetainRef.h with ARC enabled.
+#endif
+
+#define RETAIN_REF_TEST_NAME RetainRefARC
+#include "RetainRef.mm"
+#undef RETAIN_REF_TEST_NAME


### PR DESCRIPTION
#### d814bd4d3a84e5b2eade4e8a2c9bfdbcc79a2f80
<pre>
Add RetainRef, a non-nullable version of RetainPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=313208">https://bugs.webkit.org/show_bug.cgi?id=313208</a>
<a href="https://rdar.apple.com/175479803">rdar://175479803</a>

Reviewed by Chris Dumez.

Introduce RetainRef, which is a non-nullable version of RetainPtr. This follows the pattern
established by Ref and RefPtr.

RetainRef should be used for Objective C pointer values which semantically cannot be nil.
This allows for this information to be encoded in the type system. The non-null guarantee is
established at construction (every constructor that takes a raw pointer asserts non-null) and preserved by all subsequent operations.

A future PR will add proper nullability annotations to both RetainRef and RetainPtr.

Ideally, `adoptNS` would be like `adoptNSRef` and return a `RetainRef`, however that is out of
scope for this PR; a future PR may do so.

Compared to RetainPtr, RetainRef intentionally removes:

- The default constructor
- `clear()`
- `operator bool()` / `operator!()`

A RetainPtr can be converted to a RetainRef using `releaseNonNull`.

Header organization mirrors Ref/RefPtr: RetainRef.h is the foundational header
and RetainPtr.h includes it. To support that direction without circular
includes, the shared type machinery (IsNSType, RetainPtrType, the CF/NS macro
shims) was moved into RetainRef.h, and releaseNonNull() is defined inline in
RetainPtr&apos;s class body.

ARC compatibility uses the same `#define RetainRef RetainRefArc` trick already
used by RetainPtr, so the same translation unit can be compiled with and
without ARC. Forward.h declares both types under the matching defines.

HashTraits&lt;RetainRef&lt;P&gt;&gt; mirrors RefHashTraits&lt;P&gt;: TakeType is RetainPtr&lt;P&gt;
(so taking from an empty slot yields a nullable type), constructEmptyValue and
isEmptyValue use RetainRef&apos;s HashTableEmptyValue ctor, and DefaultHash uses
PtrHash.

Tests: Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/WTF/cf/RetainRef.cpp
       Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainRef.mm
       Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainRefARC.mm

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtr::releaseNonNull):

- Include RetainRef.h
- Remove the now-shared IsNSType / RetainPtrType definitions and CF/NS macro shims
(which moved to RetainRef.h)
- Add releaseNonNull() inline.

* Source/WTF/wtf/RetainRef.h: Added.
(WTF::RetainRef::RetainRef):
(WTF::RetainRef::isHashTableDeletedValue const):
(WTF::RetainRef::isHashTableEmptyValue const):
(WTF::RetainRef::hashTableEmptyValue):
(WTF::RetainRef::hashTableDeletedValue):
(WTF::RetainRef::retainFoundationPtr):
(WTF::RetainRef::releaseFoundationPtr):
(WTF::RetainRef::autoreleaseFoundationPtr):
(WTF::RetainRef::~RetainRef):
(WTF::RetainRef::autorelease):
(WTF::RetainRef::getAutoreleased):
(WTF::RetainRef::bridgingAutorelease):
(WTF::RetainRef::operator=):
(WTF::RetainRef::swap):
(WTF::adoptCFRef):
(WTF::adoptNSRef):
(WTF::retainRef):

Implement RetainRef.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/cf/RetainRef.cpp: Added.
(TestWebKitAPI::TEST(RetainRef, AdoptCFRef)):
(TestWebKitAPI::TEST(RetainRef, RetainRefFromValue)):
(TestWebKitAPI::TEST(RetainRef, CopyConstructor)):
(TestWebKitAPI::TEST(RetainRef, MoveConstructor)):
(TestWebKitAPI::TEST(RetainRef, FromRetainPtrReleaseNonNull)):
(TestWebKitAPI::TEST(RetainRef, ExplicitFromRetainPtr)):
(TestWebKitAPI::TEST(RetainRef, Assignment)):
(TestWebKitAPI::TEST(RetainRef, HashMap)):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainRef.mm: Added.
(TestWebKitAPI::TEST(RETAIN_REF_TEST_NAME, AdoptNSRef)):
(TestWebKitAPI::TEST(RETAIN_REF_TEST_NAME, RetainRefFromValueNS)):
(TestWebKitAPI::TEST(RETAIN_REF_TEST_NAME, CopyConstructorNS)):
(TestWebKitAPI::TEST(RETAIN_REF_TEST_NAME, MoveConstructorNS)):
(TestWebKitAPI::TEST(RETAIN_REF_TEST_NAME, FromRetainPtrReleaseNonNullNS)):
(TestWebKitAPI::TEST(RETAIN_REF_TEST_NAME, ExplicitFromRetainPtrNS)):
(TestWebKitAPI::TEST(RETAIN_REF_TEST_NAME, HashMapNS)):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/RetainRefARC.mm: Added.

- NS tests, with the AUTORELEASEPOOL_FOR_ARC_DEBUG and uintptr_t pattern to keep retain-count assertions accurate when ARC&apos;s autoreleased copies inflate the count in debug builds.
- ARC variant via the RETAIN_REF_TEST_NAME macro pattern that RetainPtr&apos;s tests already use.

Canonical link: <a href="https://commits.webkit.org/311963@main">https://commits.webkit.org/311963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64c15249761a2a3fca6c79e6c1f90c97a18285af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158476 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112561 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122741 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86143 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103411 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24059 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15077 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150526 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169796 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19310 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15515 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130930 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31592 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131044 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35482 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141933 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89413 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25739 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18739 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190757 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31049 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97021 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49056 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30569 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30842 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30723 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->