### PR TITLE
IPC values to createModel are not validated

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -317,6 +317,29 @@ void RemoteGPU::createModelBacking(unsigned width, unsigned height, const WebMod
 #if ENABLE(GPU_PROCESS_MODEL)
     assertIsCurrent(workQueue());
 
+    constexpr auto max2dTextureSize = 16384;
+    MESSAGE_CHECK(width <= max2dTextureSize && height <= max2dTextureSize);
+    auto& inputSpecularTexture = specularTexture;
+    auto& inputDiffuseTexture = diffuseTexture;
+    {
+#define loadData(...) { }
+        WEBMODEL_WEB_MODEL_PLAYER_DECLARE_DIFFUSE_AND_SPECULAR_TEXTURES
+#undef loadData
+#define equalIgnoringDataContents(a, b, dataSize) \
+            a.data.size() == dataSize && \
+            a.width == b.width && \
+            a.height == b.height && \
+            a.depth == b.depth && \
+            a.textureType == b.textureType && \
+            a.pixelFormat == b.pixelFormat && \
+            a.mipmapLevelCount == b.mipmapLevelCount && \
+            a.arrayLength == b.arrayLength && \
+            a.textureUsage == b.textureUsage
+
+        MESSAGE_CHECK(equalIgnoringDataContents(inputDiffuseTexture, diffuseTexture, 49152));
+        MESSAGE_CHECK(equalIgnoringDataContents(inputSpecularTexture, specularTexture, 1048572));
+#undef equalIgnoringDataContents
+    }
     Ref objectHeap = m_modelObjectHeap.get();
 
     auto gpuProcessConnection = m_gpuConnectionToWebProcess.get();

--- a/Source/WebKit/WebProcess/Model/Mesh.h
+++ b/Source/WebKit/WebProcess/Model/Mesh.h
@@ -112,4 +112,30 @@ private:
     String m_label;
 };
 
+#define WEBMODEL_WEB_MODEL_PLAYER_DECLARE_DIFFUSE_AND_SPECULAR_TEXTURES \
+WebModel::ImageAsset diffuseTexture { \
+    .data = loadData(adoptCF(static_cast<CFStringRef>(@"modelDefaultDiffuseData"))), \
+    .width = 64, \
+    .height = 64, \
+    .depth = 1, \
+    .textureType = WebCore::WebGPU::TextureViewDimension::Cube, \
+    .pixelFormat = WebCore::WebGPU::TextureFormat::R16float, \
+    .mipmapLevelCount = 1, \
+    .arrayLength = 6, \
+    .textureUsage = WebCore::WebGPU::TextureUsage::TextureBinding, \
+    .swizzle = { } \
+}; \
+WebModel::ImageAsset specularTexture { \
+    .data = loadData(adoptCF(static_cast<CFStringRef>(@"modelDefaultSpecularData"))), \
+    .width = 256, \
+    .height = 256, \
+    .depth = 1, \
+    .textureType = WebCore::WebGPU::TextureViewDimension::Cube, \
+    .pixelFormat = WebCore::WebGPU::TextureFormat::R16float, \
+    .mipmapLevelCount = 9, \
+    .arrayLength = 6, \
+    .textureUsage = WebCore::WebGPU::TextureUsage::TextureBinding, \
+    .swizzle = { } \
+};
+
 }

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -191,30 +191,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
     size.scale(document->deviceScaleFactor());
     m_currentPixelSize = WebCore::IntSize(size.width().toUnsigned(), size.height().toUnsigned());
 
-    WebModel::ImageAsset diffuseTexture {
-        .data = loadData(adoptCF(static_cast<CFStringRef>(@"modelDefaultDiffuseData"))),
-        .width = 64,
-        .height = 64,
-        .depth = 1,
-        .textureType = WebCore::WebGPU::TextureViewDimension::Cube,
-        .pixelFormat = WebCore::WebGPU::TextureFormat::R16float,
-        .mipmapLevelCount = 1,
-        .arrayLength = 6,
-        .textureUsage = WebCore::WebGPU::TextureUsage::TextureBinding,
-        .swizzle = { }
-    };
-    WebModel::ImageAsset specularTexture {
-        .data = loadData(adoptCF(static_cast<CFStringRef>(@"modelDefaultSpecularData"))),
-        .width = 256,
-        .height = 256,
-        .depth = 1,
-        .textureType = WebCore::WebGPU::TextureViewDimension::Cube,
-        .pixelFormat = WebCore::WebGPU::TextureFormat::R16float,
-        .mipmapLevelCount = 9,
-        .arrayLength = 6,
-        .textureUsage = WebCore::WebGPU::TextureUsage::TextureBinding,
-        .swizzle = { }
-    };
+    WEBMODEL_WEB_MODEL_PLAYER_DECLARE_DIFFUSE_AND_SPECULAR_TEXTURES
 
     m_currentModel = static_cast<RemoteGPUProxy&>(gpu->backing()).createModelBacking(m_currentPixelSize.width(), m_currentPixelSize.height(), diffuseTexture, specularTexture, [protectedThis = protect(*this)] (Vector<MachSendRight>&& surfaceHandles) {
         if (surfaceHandles.size())


### PR DESCRIPTION
#### ada244d0a262514205dd360a400aad546ec5b016
<pre>
IPC values to createModel are not validated
<a href="https://bugs.webkit.org/show_bug.cgi?id=313209">https://bugs.webkit.org/show_bug.cgi?id=313209</a>
<a href="https://rdar.apple.com/173321721">rdar://173321721</a>

Reviewed by Tadeu Zagallo.

Ensure the values sent over IPC are the ones expected.

We only send the values over IPC to begin with to avoid
file system operations in the GPU process.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::createModelBacking):
* Source/WebKit/WebProcess/Model/Mesh.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):

Canonical link: <a href="https://commits.webkit.org/312209@main">https://commits.webkit.org/312209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49c33ee70335f48cb1cba4635b71a024a23b4e75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112547 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122727 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86135 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103397 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24038 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22435 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15063 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133726 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169782 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15486 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130916 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131030 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35612 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141915 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89399 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25722 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18721 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31035 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96900 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30555 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30828 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30709 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->