### PR TITLE
[iOS] MediaPlayer volume is not propagated to MediaDeviceRoute

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/volume-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/volume-expected.txt
@@ -1,0 +1,14 @@
+
+Test that setting video.volume propagates to a MediaDeviceRoute.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+RUN(internals.setPageMediaVolume(1))
+RUN(internals.setMediaElementVolumeLocked(video, false))
+RUN(video.volume = 0.5)
+EXPECTED (route.volume == '0.5') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/volume-locked-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/volume-locked-expected.txt
@@ -1,0 +1,14 @@
+
+Test that setVolumeLocked prevents video.volume from being propagated to a MediaDeviceRoute.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+RUN(internals.setPageMediaVolume(1))
+RUN(internals.setMediaElementVolumeLocked(video, true))
+RUN(video.volume = 0.5)
+EXPECTED (route.volume == '1') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/volume-locked.html
+++ b/LayoutTests/media/wireless-playback-media-player/volume-locked.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                route.volume = 1;
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                run(`internals.setPageMediaVolume(1)`);
+                run(`internals.setMediaElementVolumeLocked(video, true)`);
+                run(`video.volume = 0.5`);
+                testExpected(`route.volume`, 1);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that setVolumeLocked prevents video.volume from being propagated to a MediaDeviceRoute.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/volume.html
+++ b/LayoutTests/media/wireless-playback-media-player/volume.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                route.volume = 1;
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                run(`internals.setPageMediaVolume(1)`);
+                run(`internals.setMediaElementVolumeLocked(video, false)`);
+                run(`video.volume = 0.5`);
+                testExpected(`route.volume`, 0.5);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that setting video.volume propagates to a MediaDeviceRoute.</p>
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -329,6 +329,35 @@ double MediaPlayerPrivateWirelessPlayback::rate() const
     return 0;
 }
 
+void MediaPlayerPrivateWirelessPlayback::setVolumeLocked(bool volumeLocked)
+{
+    if (m_volumeLocked == volumeLocked)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, volumeLocked);
+    m_volumeLocked = volumeLocked;
+}
+
+void MediaPlayerPrivateWirelessPlayback::setVolume(float volume)
+{
+    if (m_volumeLocked)
+        return;
+
+    RefPtr route = this->route();
+    if (!route || route->volume() == volume)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, volume);
+    route->setVolume(volume);
+}
+
+float MediaPlayerPrivateWirelessPlayback::volume() const
+{
+    if (RefPtr route = this->route())
+        return route->volume();
+    return 1;
+}
+
 void MediaPlayerPrivateWirelessPlayback::setNetworkState(MediaPlayer::NetworkState networkState)
 {
     if (networkState == m_networkState)

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -116,8 +116,9 @@ private:
     bool setCurrentTimeDidChangeCallback(MediaPlayer::CurrentTimeDidChangeCallback&&) final;
     void setRate(float) final;
     double rate() const final;
-    void setVolume(float) final { }
-    float volume() const final { return 0; }
+    void setVolumeLocked(bool) final;
+    void setVolume(float) final;
+    float volume() const final;
     void setMuted(bool) final { }
     String engineDescription() const final;
 
@@ -144,6 +145,7 @@ private:
     MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
     bool m_didLoadingProgress { false };
     bool m_allowsWirelessVideoPlayback { true };
+    bool m_volumeLocked { false };
     ShouldPlayToTarget m_shouldPlayToTarget { ShouldPlayToTarget::Unknown };
     RefPtr<MediaPlaybackTarget> m_playbackTarget;
     MediaPlayer::CurrentTimeDidChangeCallback m_currentTimeDidChangeCallback;

--- a/Source/WebCore/testing/MockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.h
@@ -73,6 +73,9 @@ public:
     TimeRange timeRange() const;
     void setTimeRange(const TimeRange&);
 
+    float volume() const;
+    void setVolume(float);
+
 private:
     MockMediaDeviceRoute();
 

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -37,6 +37,7 @@
     attribute float playbackRate;
     attribute float currentPlaybackPosition;
     attribute MockMediaDeviceRouteTimeRange timeRange;
+    attribute float volume;
 };
 
 [

--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -142,6 +142,16 @@ void MockMediaDeviceRoute::setTimeRange(const MockMediaDeviceRoute::TimeRange& t
     [m_platformRoute setTimeRange:CMTimeRangeMake(start, duration)];
 }
 
+float MockMediaDeviceRoute::volume() const
+{
+    return [m_platformRoute volume];
+}
+
+void MockMediaDeviceRoute::setVolume(float volume)
+{
+    [m_platformRoute setVolume:volume];
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)


### PR DESCRIPTION
#### 86805bf658f77a4e3d793ce625609fc28d8a6e07
<pre>
[iOS] MediaPlayer volume is not propagated to MediaDeviceRoute
<a href="https://bugs.webkit.org/show_bug.cgi?id=313211">https://bugs.webkit.org/show_bug.cgi?id=313211</a>
<a href="https://rdar.apple.com/174340256">rdar://174340256</a>

Reviewed by Eric Carlson.

When a wireless playback media player&apos;s volume changes (and volume is not locked), that change
should be propagated to its corresponding MediaDeviceRoute.

Tests: media/wireless-playback-media-player/volume-locked.html
       media/wireless-playback-media-player/volume.html

* LayoutTests/media/wireless-playback-media-player/volume-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/volume-locked-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/volume-locked.html: Added.
* LayoutTests/media/wireless-playback-media-player/volume.html: Added.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::setVolumeLocked):
(WebCore::MediaPlayerPrivateWirelessPlayback::setVolume):
(WebCore::MediaPlayerPrivateWirelessPlayback::volume const):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:
* Source/WebCore/testing/MockMediaDeviceRoute.h:
* Source/WebCore/testing/MockMediaDeviceRoute.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::volume const):
(WebCore::MockMediaDeviceRoute::setVolume):

Canonical link: <a href="https://commits.webkit.org/311967@main">https://commits.webkit.org/311967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ee9bd57be4fb3a1081cac86fdc18c18d0c76677

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167294 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112549 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122728 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86141 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103398 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24042 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22436 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15065 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169784 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19298 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15491 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130917 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31580 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131031 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35487 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141916 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89401 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25725 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18722 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31037 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96913 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30557 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30830 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30711 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->