### PR TITLE
innerText should not emit newlines for visibility:hidden block elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -174,7 +174,7 @@ PASS Blank lines around a <p> in its own block ("<div>abc<div><p>123</p></div>de
 PASS Blank line before <p> ("<div>abc<p>def")
 PASS Blank line after <p> ("<div><p>abc</p>def")
 PASS One blank line between <p>s, ignoring empty <p>s ("<div><p>abc<p></p><p></p><p>def")
-FAIL Invisible <p> doesn't induce extra line breaks ("<div style='visibility:hidden'><p><span style='visibility:visible'>abc</span></p>\n<div style='visibility:visible'>def</div>") assert_equals: innerText expected "abc\ndef" but got "abc\n\ndef"
+PASS Invisible <p> doesn't induce extra line breaks ("<div style='visibility:hidden'><p><span style='visibility:visible'>abc</span></p>\n<div style='visibility:visible'>def</div>")
 PASS <pre> trailing newlines don't suppress <p> blank line ("<div><pre>abc\n\n</pre><p>def")
 PASS No blank lines around <div> with margin ("<div>abc<div style='margin:2em'>def")
 PASS No newlines at display:inline-block boundary ("<div>123<span style='display:inline-block'>abc</span>def")

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1142,6 +1142,12 @@ void TextIterator::representNodeOffsetZero()
     // before encountering shouldRepresentNodeOffsetZero()s worse case behavior.
     RefPtr currentNode = m_currentNode;
     bool emitsNewlinesPerInnerTextSpec = m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec);
+
+    if (emitsNewlinesPerInnerTextSpec) {
+        if (auto* renderer = currentNode->renderer(); renderer && renderer->style().visibility() != Visibility::Visible)
+            return;
+    }
+
     if (shouldEmitTabBeforeNode(*currentNode)) {
         if (shouldRepresentNodeOffsetZero()) {
             RefPtr parentNode = currentNode->parentNode();
@@ -1214,9 +1220,14 @@ void TextIterator::exitNode(Node* exitedNode)
     // therefore look like a blank line.
     if (!m_hasEmitted)
         return;
-        
+    
+    if (m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec)) {
+        if (auto* renderer = m_currentNode->renderer(); renderer && renderer->style().visibility() != Visibility::Visible)
+            return;
+    }
+
     // Emit with a position *inside* m_currentNode, after m_currentNode's contents, in
-    // case it is a block, because the run should start where the 
+    // case it is a block, because the run should start where the
     // emitted character is positioned visually.
     RefPtr baseNode = exitedNode;
     // FIXME: This shouldn't require the m_lastTextNode to be true, but we can't change that without making


### PR DESCRIPTION
#### 1fb5ba86b2ce9efb9e27e0dc84bd06c9cc445e46
<pre>
innerText should not emit newlines for visibility:hidden block elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=313212">https://bugs.webkit.org/show_bug.cgi?id=313212</a>

Reviewed by Anne van Kesteren.

Per the WHATWG spec step 3 of the inner text collection steps: &quot;If node&apos;s
computed value of &apos;visibility&apos; is not &apos;visible&apos;, then return items.&quot; This
means visibility:hidden elements should not contribute their own block-level
formatting (newlines) — only their visible children&apos;s content should be
included. WebKit was incorrectly emitting block boundary newlines and extra
&lt;p&gt; newlines for visibility:hidden elements, causing a &lt;p&gt; with
visibility:hidden to produce a blank line instead of a single line break
between visible children.

The fix adds visibility checks in TextIterator::representNodeOffsetZero()
and TextIterator::exitNode() to skip newline emission for visibility:hidden
elements when in innerText mode (EmitsNewlinesPerInnerTextSpec).

No new tests, rebaselined existing WPT test. This subtest was already
passing in Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::representNodeOffsetZero):
(WebCore::TextIterator::exitNode):

Canonical link: <a href="https://commits.webkit.org/312010@main">https://commits.webkit.org/312010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e8044f1f5a69f7d0e28e5d4fc6a9af355edd6b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158666 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32092 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167496 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0207b9fd-45e4-449d-ac46-af2b83f5c5d0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32081 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c813fe51-536a-4e41-b7ac-31773d194947) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161624 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/25171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103580 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81444b74-e13a-4164-8c53-cb48b546116c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15268 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169988 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15731 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131098 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31783 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131212 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35512 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31728 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/142108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89643 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25904 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97253 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30759 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31032 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30913 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->