### PR TITLE
[JSC] Drop ThreadSpecificAssemblerData heap buffer under memory pressure

### DIFF
--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -148,6 +148,18 @@ void JITWorklist::wakeThreads(const AbstractLocker& locker, unsigned enqueuedTie
     ASSERT(m_numberOfActiveThreads >= 1);
 }
 
+// Ask all underlying threads to exit, so that they can clean up any
+// thread-local data they have saved. Used when under memory pressure.
+void JITWorklist::requestTemporaryStop()
+{
+    Locker locker { *m_lock };
+    for (auto& thread : m_threads) {
+        if (!thread->hasUnderlyingThread(locker))
+            continue;
+        thread->requestTemporaryStop(locker);
+    }
+}
+
 CompilationResult JITWorklist::enqueue(Ref<JITPlan> plan)
 {
     if (!Options::useConcurrentJIT()) {

--- a/Source/JavaScriptCore/jit/JITWorklist.h
+++ b/Source/JavaScriptCore/jit/JITWorklist.h
@@ -63,6 +63,7 @@ public:
     State compilationState(VM&, JITCompilationKey);
 
     State completeAllReadyPlansForVM(VM&, JITCompilationKey = JITCompilationKey());
+    void requestTemporaryStop();
 
     // This is equivalent to:
     // worklist->waitUntilAllPlansForVMAreReady(vm);

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -149,6 +149,7 @@
 #include "WeakGCMapInlines.h"
 #include "WideningNumberPredictionFuzzerAgent.h"
 #include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/MemoryPressureHandler.h>
 #include <wtf/ProcessID.h>
 #include <wtf/ReadWriteLock.h>
 #include <wtf/SimpleStats.h>
@@ -986,6 +987,21 @@ void VM::deleteAllCode(DeleteAllCodeEffort effort)
         heap.deleteAllCodeBlocks(effort);
         heap.deleteAllUnlinkedCodeBlocks(effort);
         heap.reportAbandonedObjectGraph();
+
+        if (MemoryPressureHandler::singleton().memoryPressureStatus() == SystemMemoryPressureStatus::Normal)
+            return;
+        // If we're deleting all code as a response to memory pressure, allow
+        // worklist threads to temporarily stop, which frees any thread-local
+        // data (specifically, any bulky heap-allocated data for the assembler
+        // buffer).
+#if ENABLE(JIT)
+        if (auto worklist = JITWorklist::existingGlobalWorklistOrNull())
+            worklist->requestTemporaryStop();
+#if ENABLE(WEBASSEMBLY)
+        if (auto worklist = Wasm::existingWorklistOrNull())
+            worklist->requestTemporaryStop();
+#endif // ENABLE(WEBASSEMBLY)
+#endif // ENABLE(JIT)
     });
 }
 

--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -238,6 +238,18 @@ Worklist::~Worklist()
         Ref { m_threads[i] }->join();
 }
 
+// Ask all underlying threads to exit, so that they can clean up any
+// thread-local data they have saved. Used when under memory pressure.
+void Worklist::requestTemporaryStop()
+{
+    Locker locker { *m_lock };
+    for (auto& thread : m_threads) {
+        if (!thread->hasUnderlyingThread(locker))
+            continue;
+        thread->requestTemporaryStop(locker);
+    }
+}
+
 static Worklist* globalWorklist;
 
 Worklist* existingWorklistOrNull() { return globalWorklist; }

--- a/Source/JavaScriptCore/wasm/WasmWorklist.h
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.h
@@ -53,6 +53,7 @@ public:
 
     JS_EXPORT_PRIVATE void enqueue(Ref<Plan>);
     void stopAllPlansForContext(VM&);
+    void requestTemporaryStop();
 
     JS_EXPORT_PRIVATE void completePlanSynchronously(Plan&);
 

--- a/Source/WTF/wtf/AutomaticThread.cpp
+++ b/Source/WTF/wtf/AutomaticThread.cpp
@@ -141,6 +141,12 @@ bool AutomaticThread::tryStop(const AbstractLocker&)
     return true;
 }
 
+void AutomaticThread::requestTemporaryStop(const AbstractLocker& locker)
+{
+    m_temporaryStopRequested = true;
+    notify(locker);
+}
+
 bool AutomaticThread::isWaiting(const AbstractLocker& locker)
 {
     return hasUnderlyingThread(locker) && m_isWaiting;
@@ -204,15 +210,26 @@ void AutomaticThread::start(const AbstractLocker&)
                 m_isRunningCondition.notifyAll();
                 stopImpl(locker);
             };
-            
+
+            auto stopTemporarily = [&](const AbstractLocker& locker) {
+                m_temporaryStopRequested = false;
+                stopImpl(locker);
+            };
+
             auto stopForTimeout = [&] (const AbstractLocker& locker) {
                 stopImpl(locker);
             };
-            
+
             for (;;) {
                 {
                     Locker locker { *m_lock };
                     for (;;) {
+                        // We may have been woken up in order to stop; if that's
+                        // the case, stop before calling poll
+                        // (JITWorklistThread:poll makes assumptions about there
+                        // being work available).
+                        if (m_temporaryStopRequested)
+                            return stopTemporarily(locker);
                         PollResult result = poll(locker);
                         if (result == PollResult::Work)
                             break;
@@ -224,6 +241,8 @@ void AutomaticThread::start(const AbstractLocker&)
                         m_isWaiting = true;
                         bool awokenByNotify =
                             m_waitCondition.waitFor(*m_lock, m_timeout);
+                        if (m_temporaryStopRequested)
+                            return stopTemporarily(locker);
                         if (verbose && !awokenByNotify && !m_isWaiting)
                             dataLog(RawPointer(this), ": waitFor timed out, but notified via m_isWaiting flag!\n");
                         if (m_isWaiting && shouldSleep(locker)) {

--- a/Source/WTF/wtf/AutomaticThread.h
+++ b/Source/WTF/wtf/AutomaticThread.h
@@ -119,6 +119,7 @@ public:
     
     // Sometimes it's possible to optimize for the case that there is no underlying thread.
     bool hasUnderlyingThread(const AbstractLocker&) const { return m_hasUnderlyingThread; }
+    void requestTemporaryStop(const AbstractLocker&);
     
     // This attempts to quickly stop the thread. This will succeed if the thread happens to not be
     // running. Returns true if the thread has been stopped. A good idiom for stopping your automatic
@@ -201,6 +202,7 @@ protected:
     bool m_isRunning { true };
     bool m_isWaiting { false };
     bool m_hasUnderlyingThread { false };
+    bool m_temporaryStopRequested { false };
     Condition m_waitCondition;
     Condition m_isRunningCondition;
 };

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -31,6 +31,7 @@ set(TestWTF_SOURCES
     Helpers/Utilities.cpp
 
     Tests/WTF/AtomString.cpp
+    Tests/WTF/AutomaticThread.cpp
     Tests/WTF/Base64.cpp
     Tests/WTF/BitSet.cpp
     Tests/WTF/BitVector.cpp

--- a/Tools/TestWebKitAPI/Tests/WTF/AutomaticThread.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/AutomaticThread.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2026 Igalia, S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/AutomaticThread.h>
+
+#include <wtf/Condition.h>
+#include <wtf/DataMutex.h>
+#include <wtf/Deque.h>
+#include <wtf/ThreadSpecific.h>
+#include <wtf/Variant.h>
+
+struct Invalid { };
+struct Trivial { };
+struct Exit { };
+struct WaitOn {
+    WaitOn(Box<Lock> lock, Condition* condition)
+        : m_lock(WTF::move(lock))
+        , m_condition(condition)
+    {
+    }
+    Box<Lock> m_lock;
+    Condition* m_condition;
+};
+using WorkItem = WTF::Variant<Invalid, Trivial, Exit, struct WaitOn*>;
+
+struct CachedData {
+    CachedData()
+    {
+        Locker locker { s_lock };
+        s_numberOfCachedData++;
+        s_condition.notifyAll();
+    }
+    ~CachedData()
+    {
+        Locker locker { s_lock };
+        --s_numberOfCachedData;
+        s_condition.notifyAll();
+    }
+    static void waitUntil(size_t count)
+    {
+        Locker locker { s_lock };
+        while (s_numberOfCachedData != count)
+            s_condition.wait(s_lock);
+    }
+    int m_value;
+    static Lock s_lock;
+    static size_t s_numberOfCachedData WTF_GUARDED_BY_LOCK(s_lock);
+    static Condition s_condition;
+};
+using ThreadSpecificCachedData = ThreadSpecific<CachedData>;
+
+size_t CachedData::s_numberOfCachedData;
+Lock CachedData::s_lock;
+Condition CachedData::s_condition { };
+
+ThreadSpecificCachedData& threadSpecificCachedData()
+{
+    static ThreadSpecificCachedData* data;
+    static std::once_flag flag;
+    std::call_once(
+        flag,
+        []() {
+            data = new ThreadSpecificCachedData();
+        });
+    return *data;
+}
+
+class WorkItemConsumerThread : public AutomaticThread {
+    WTF_MAKE_TZONE_ALLOCATED(WorkItemConsumerThread);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkItemConsumerThread);
+public:
+    WorkItemConsumerThread(const AbstractLocker& locker, Box<Lock> lock, Ref<AutomaticThreadCondition>&& condition, Seconds timeout)
+        : AutomaticThread(locker, WTF::move(lock), WTF::move(condition), timeout)
+        , m_started(0)
+        , m_stopped(0)
+        , m_lock()
+        , m_runningCondition()
+        , m_currentItem(Invalid { })
+        , m_numberOfSubmittedItems(0)
+        , m_numberOfProcessedItems(0)
+    {
+    }
+    void waitUntilHasStopped(unsigned times)
+    {
+        for (;;) {
+            Locker locker { m_lock };
+            if (m_stopped >= times)
+                return;
+            m_runningCondition.wait(m_lock);
+        }
+    }
+    void waitUntilHasStarted(unsigned times)
+    {
+        for (;;) {
+            Locker locker { m_lock };
+            if (m_started >= times)
+                return;
+            m_runningCondition.wait(m_lock);
+        }
+    }
+    void appendWorkItem(WorkItem item)
+    {
+        DataMutexLocker workItems { m_workItems };
+        workItems->append(item);
+        ++m_numberOfSubmittedItems;
+    }
+private:
+    PollResult poll(const AbstractLocker&)
+    {
+        DataMutexLocker workItems { m_workItems };
+        if (workItems->isEmpty())
+            return PollResult::Wait;
+        m_currentItem = workItems->takeFirst();
+        return PollResult::Work;
+    }
+    WorkResult work()
+    {
+        threadSpecificCachedData()->m_value++;
+        RELEASE_ASSERT(!std::get_if<Invalid>(&m_currentItem));
+        ++m_numberOfProcessedItems;
+        if (std::get_if<Trivial>(&m_currentItem)) {
+            m_currentItem = Invalid { };
+            return WorkResult::Continue;
+        }
+        if (std::get_if<Exit>(&m_currentItem))
+            return WorkResult::Stop;
+        if (auto waitOn = std::get_if<WaitOn*>(&m_currentItem)) {
+            Locker locker { *(*waitOn)->m_lock };
+            (*waitOn)->m_condition->wait(*(*waitOn)->m_lock);
+            // Wait twice. This gives outsiders the chance to do things knowing
+            // we're waiting here.
+            (*waitOn)->m_condition->wait(*(*waitOn)->m_lock);
+            return WorkResult::Continue;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+    void threadDidStart()
+    {
+        Locker locker { m_lock };
+
+        ++m_started;
+        m_runningCondition.notifyAll();
+    }
+    void threadIsStopping(const AbstractLocker&)
+    {
+        Locker locker { m_lock };
+        ++m_stopped;
+        RELEASE_ASSERT(m_started == m_stopped);
+        m_runningCondition.notifyAll();
+        ASSERT_EQ(m_numberOfSubmittedItems, m_numberOfProcessedItems);
+    }
+    unsigned m_started;
+    unsigned m_stopped;
+    DataMutex<Deque<WorkItem>> m_workItems;
+    Lock m_lock;
+    Condition m_runningCondition;
+    WorkItem m_currentItem;
+    size_t m_numberOfSubmittedItems;
+    size_t m_numberOfProcessedItems;
+
+};
+
+TEST(WTF, AutomaticThreadStopsWhenNotGivenWork)
+{
+    auto lock = Box<Lock>::create();
+    auto condition = AutomaticThreadCondition::create();
+    RefPtr<WorkItemConsumerThread> thread;
+    {
+        Locker locker { *lock };
+        thread = adoptRef(new WorkItemConsumerThread(locker, lock, condition.copyRef(), 1_s));
+        condition->notifyOne(locker);
+    }
+    // Test that the thread stops when it hasn't ever been given work.
+    thread->waitUntilHasStopped(1);
+    CachedData::waitUntil(0);
+
+    // Test that the thread stops after processing work.
+    thread->appendWorkItem(Trivial { });
+    {
+        Locker locker { *lock };
+        condition->notifyOne(locker);
+    }
+    thread->waitUntilHasStopped(2);
+
+    thread->appendWorkItem(Exit { });
+    {
+        Locker locker { *lock };
+        condition->notifyOne(locker);
+    }
+    thread->waitUntilHasStopped(3);
+    CachedData::waitUntil(0);
+    thread = nullptr;
+}
+
+TEST(WTF, AutomaticThreadTemporaryStop)
+{
+    auto lock = Box<Lock>::create();
+    auto condition = AutomaticThreadCondition::create();
+    RefPtr<WorkItemConsumerThread> thread;
+    CachedData::waitUntil(0);
+
+    {
+        Locker locker { *lock };
+        // Note the timeout: will never stop on its own.
+        thread = adoptRef(new WorkItemConsumerThread(locker, lock, condition.copyRef(), Seconds::infinity()));
+        thread->appendWorkItem(Trivial { });
+        condition->notifyOne(locker);
+    }
+    thread->waitUntilHasStarted(1);
+    CachedData::waitUntil(1); // ::work has run, i.e. we should have an underlying thread.
+    {
+        Locker locker { *lock };
+        ASSERT_TRUE(thread->hasUnderlyingThread(locker));
+        thread->requestTemporaryStop(locker);
+    }
+    thread->waitUntilHasStopped(1);
+    CachedData::waitUntil(0);
+
+    {
+        Locker locker { *lock };
+        ASSERT_FALSE(thread->hasUnderlyingThread(locker));
+    }
+
+    // Does it start again?
+    thread->appendWorkItem(Trivial { });
+    {
+        Locker locker { *lock };
+        condition->notifyOne(locker);
+    }
+    thread->waitUntilHasStarted(2);
+
+    // Shut it down.
+    thread->appendWorkItem(Exit { });
+    {
+        Locker locker { *lock };
+        condition->notifyOne(locker);
+    }
+    thread->waitUntilHasStopped(2);
+    CachedData::waitUntil(0);
+    thread = nullptr;
+}
+
+TEST(WTF, AutomaticThreadTemporaryStopWhileRunning)
+{
+    auto lock = Box<Lock>::create();
+    auto condition = AutomaticThreadCondition::create();
+    auto itemLock = Box<Lock>::create();
+    Condition* itemCondition = new Condition();
+    RefPtr<WorkItemConsumerThread> thread;
+    CachedData::waitUntil(0);
+    {
+        Locker locker { *lock };
+        // Note the timeout: will never stop on its own.
+        thread = adoptRef(new WorkItemConsumerThread(locker, lock, condition.copyRef(), Seconds::infinity()));
+        Locker itemLocker { *itemLock };
+        thread->appendWorkItem(new WaitOn { itemLock, itemCondition });
+        condition->notifyOne(locker);
+    }
+    thread->waitUntilHasStarted(1);
+
+    // The thread should block on the WaitOn item in its ::work soon.
+    while (!itemCondition->notifyOne())
+        Thread::yield();
+
+    // OK, now we know the thread is in ::work.
+
+    // It must have created thread-specific data.
+    {
+        Locker locker { CachedData::s_lock };
+        ASSERT_EQ(CachedData::s_numberOfCachedData, 1);
+    }
+    // Request the temporary stop.
+    {
+        Locker locker { *lock };
+        thread->requestTemporaryStop(locker);
+    }
+
+    // Allow the thread to complete its work.
+    while (!itemCondition->notifyOne())
+        Thread::yield();
+
+    // Now the thread should stop. This can only happen as a result of our
+    // request (timeout is set to infinity).
+    thread->waitUntilHasStopped(1);
+    CachedData::waitUntil(0);
+
+    // Shut it down.
+    thread->appendWorkItem(Exit { });
+    {
+        Locker locker { *lock };
+        condition->notifyOne(locker);
+    }
+    thread->waitUntilHasStopped(2);
+    CachedData::waitUntil(0);
+    thread = nullptr;
+}


### PR DESCRIPTION
#### 32f4eefc78ef3e45964502ac5e8d00afacd32b5d
<pre>
[JSC] Drop ThreadSpecificAssemblerData heap buffer under memory pressure
<a href="https://bugs.webkit.org/show_bug.cgi?id=313213">https://bugs.webkit.org/show_bug.cgi?id=313213</a>

Reviewed by Justin Michaud.

Implement AutomaticThread::requestTemporaryStop, so that code can ask
that the underlying thread stops in a restartable way. Add a similar
method to the JIT/Wasm worklists and call it in VM::deleteAllCode.

The destruction of the thread should enough to clear any thread-local
data on all platforms (tested for in
TestWebKitAPI/Tests/WTF/AutomaticThread.cpp).

Canonical link: <a href="https://commits.webkit.org/313140@main">https://commits.webkit.org/313140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82c4e358a3fe7fe5a0cd61b0239220a84d024fab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167783 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123163 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86489 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103831 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24495 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22892 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15555 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151004 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170276 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19787 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16018 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131352 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131464 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36227 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142374 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90065 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26170 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19183 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191236 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97540 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49155 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31046 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31319 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31201 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->