### PR TITLE
[Images] Gate sizes=auto selection on img auto-sizes allowance

### DIFF
--- a/LayoutTests/fast/images/sizes-auto-allowance-expected.txt
+++ b/LayoutTests/fast/images/sizes-auto-allowance-expected.txt
@@ -1,0 +1,4 @@
+
+PASS img sizes starting with whitespace does not allow auto-sizes
+PASS source sizes=auto is ignored when img does not allow auto-sizes
+PASS source sizes=auto is honored when img allows auto-sizes

--- a/LayoutTests/fast/images/sizes-auto-allowance.html
+++ b/LayoutTests/fast/images/sizes-auto-allowance.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>sizes=auto allowance is gated on img allowing auto-sizes</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/embedded-content.html#allows-auto-sizes">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/images.html#sizes-attributes">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+  /* Keep all lazy images in the viewport. */
+  img { width: 10px; height: 10px; }
+</style>
+<div id="container"></div>
+<div id="log"></div>
+<script>
+"use strict";
+
+const container = document.getElementById('container');
+
+function waitLoad(img) {
+  return new Promise((resolve, reject) => {
+    img.addEventListener('load', resolve, {once: true});
+    img.addEventListener('error', reject, {once: true});
+  });
+}
+
+function makeSrcset(tag) {
+  return `/images/red-16x16.png?${tag} 50w, /images/green-16x16.png?${tag} 51w`;
+}
+
+function assertSmall(img, msg) {
+  assert_true(img.currentSrc.includes('red-16x16'), msg + ' (got: ' + img.currentSrc + ')');
+}
+
+function assertLarge(img, msg) {
+  assert_true(img.currentSrc.includes('green-16x16'), msg + ' (got: ' + img.currentSrc + ')');
+}
+
+async function makePicture({imgSizes, sourceSizes, tag}) {
+  const picture = document.createElement('picture');
+  const source = document.createElement('source');
+  const img = document.createElement('img');
+
+  img.loading = 'lazy';
+  if (imgSizes !== null)
+    img.setAttribute('sizes', imgSizes);
+
+  source.setAttribute('sizes', sourceSizes);
+  source.srcset = makeSrcset(`${tag}-initial`);
+
+  picture.append(source, img);
+  container.appendChild(picture);
+
+  await waitLoad(img);
+  return {source, img};
+}
+
+promise_test(async () => {
+  const img = document.createElement('img');
+  img.loading = 'lazy';
+  img.setAttribute('sizes', ' auto');
+  img.srcset = makeSrcset('img-leading-space');
+  container.appendChild(img);
+
+  await waitLoad(img);
+  assertLarge(img, 'img sizes=" auto" must not allow auto-sizes');
+}, 'img sizes starting with whitespace does not allow auto-sizes');
+
+promise_test(async () => {
+  const {source, img} = await makePicture({imgSizes: null, sourceSizes: '100vw', tag: 'source-no-img-auto'});
+  assertLarge(img, 'initial source sizes=100vw');
+
+  const reloaded = waitLoad(img);
+  source.setAttribute('sizes', 'auto');
+  source.srcset = makeSrcset('source-no-img-auto-after');
+  await reloaded;
+
+  assertLarge(img, 'source sizes=auto must be ignored when img does not allow auto-sizes');
+}, 'source sizes=auto is ignored when img does not allow auto-sizes');
+
+promise_test(async () => {
+  const {source, img} = await makePicture({imgSizes: 'auto', sourceSizes: '100vw', tag: 'source-img-auto'});
+  assertLarge(img, 'initial source sizes=100vw');
+
+  const reloaded = waitLoad(img);
+  source.setAttribute('sizes', 'auto');
+  source.srcset = makeSrcset('source-img-auto-after');
+  await reloaded;
+
+  assertSmall(img, 'source sizes=auto must be honored when img allows auto-sizes');
+}, 'source sizes=auto is honored when img allows auto-sizes');
+</script>

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -324,7 +324,7 @@ ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()
         m_dynamicMediaQueryResults.appendVector(sizesParser.dynamicMediaQueryResults());
 
         auto sourceSize = sizesParser.effectiveSize();
-        if (sizesParser.isAuto() && isLazyLoadable()) {
+        if (sizesParser.isAuto() && hasAutoSizes() && isLazyLoadable()) {
             if (auto layoutWidth = autoSizesLayoutWidth())
                 sourceSize = std::optional<float>(*layoutWidth);
         }
@@ -395,7 +395,7 @@ void HTMLImageElement::selectImageSource(RelevantMutation relevantMutation)
             SizesAttributeParser sizesParser(attributeWithoutSynchronization(sizesAttr).string(), document.get());
             m_dynamicMediaQueryResults.appendVector(sizesParser.dynamicMediaQueryResults());
             auto sourceSize = sizesParser.effectiveSize();
-            if (sizesParser.isAuto() && isLazyLoadable()) {
+            if (sizesParser.isAuto() && hasAutoSizes() && isLazyLoadable()) {
                 if (auto layoutWidth = autoSizesLayoutWidth())
                     sourceSize = std::optional<float>(*layoutWidth);
             }


### PR DESCRIPTION
## Summary
This change tightens `sizes=auto` handling so it is only applied when the **img element allows auto-sizes** (i.e. `loading=lazy` and the img's `sizes` starts with `auto` / `auto,`).

Spec alignment points:
- Avoid treating `sizes=" auto"` as auto-sizes (leading whitespace should not satisfy *allows auto-sizes*).
- Avoid applying `source[sizes=auto]` when the corresponding `<img>` does not allow auto-sizes.

## Changes
- `Source/WebCore/html/HTMLImageElement.cpp`
  - Gate `sizesParser.isAuto()` layout-width substitution behind `hasAutoSizes() && isLazyLoadable()` in both picture-source and img-srcset selection paths.
- `LayoutTests/fast/images/sizes-auto-allowance.html`
  - New test coverage for allowance-gating behavior.
- `LayoutTests/fast/images/sizes-auto-allowance-expected.txt`
  - Expected PASS results.

## Testing
- Added new layout test: `fast/images/sizes-auto-allowance.html`.
- Local full rebuild/test execution is currently blocked in this environment by Xcode/toolchain mismatch, but the test is deterministic and specifically targets allowance-gating behavior.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a920d1db9f921589b19c12e818fd6345d7103886

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167334 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112589 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31917 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122767 "Found 1 new test failure: fast/images/sizes-auto-allowance.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86153 "1 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161462 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25026 "Found 1 new test failure: fast/images/sizes-auto-allowance.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103437 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24083 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22479 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15105 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169824 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15569 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21789 "Found 1 new test failure: fast/images/sizes-auto-allowance.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130955 "Found 1 new test failure: fast/images/sizes-auto-allowance.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31620 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26543 "Found 1 new test failure: fast/images/sizes-auto-allowance.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131069 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31566 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141958 "Exiting early after 10 failures. 10 tests run. 1 failures") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89444 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25763 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18764 "Found 1 new test failure: fast/images/sizes-auto-allowance.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97091 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30597 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30870 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30751 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->