### PR TITLE
[GTK][WPE] Skia Compositor: avoid copies when getting the SkImage of a tile

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -118,6 +118,7 @@ bool SkiaBackingStore::Tile::tryEnsureSurface(const IntSize& size, CoordinatedTi
 
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
     auto texture = BitmapTexturePool::singleton().acquireTexture(size, flags);
+    unsigned textureID = texture->id();
     GrBackendTexture backendTexture = texture->createSkiaBackendTexture();
     auto surface = SkSurfaces::WrapBackendTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr, +[](void* userData) {
         static_cast<BitmapTexture*>(userData)->deref();
@@ -131,6 +132,8 @@ bool SkiaBackingStore::Tile::tryEnsureSurface(const IntSize& size, CoordinatedTi
 
     canvas->clear(SK_ColorTRANSPARENT);
     m_surface = WTF::move(surface);
+    m_textureID = textureID;
+    m_cachedImage = nullptr;
     return true;
 }
 
@@ -154,11 +157,13 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
         GrBackendTexture backendTexture = texture->createSkiaBackendTexture();
         if (dirtyRect.size() == tileRect.size()) {
             // Fast path: whole tile content changed -- take ownership of the incoming texture, replacing the existing tile buffer (avoiding texture copies).
+            m_textureID = texture->id();
+            m_cachedImage = nullptr;
+
             if (m_surface) {
                 m_surface->replaceBackendTexture(backendTexture, kTopLeft_GrSurfaceOrigin, SkSurface::kDiscard_ContentChangeMode, +[](void* userData) {
                     static_cast<BitmapTexture*>(userData)->deref();
                 }, &texture.leakRef());
-                m_surface->notifyContentWillChange(SkSurface::kDiscard_ContentChangeMode);
             } else {
                 auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
                 m_surface = SkSurfaces::WrapBackendTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr, +[](void* userData) {
@@ -182,7 +187,18 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
 
 sk_sp<SkImage> SkiaBackingStore::Tile::image()
 {
-    return m_surface ? m_surface->makeImageSnapshot() : nullptr;
+    // SkSurface::makeImageSnapshot() does a copy-on-write, but when the surface is wrapping an
+    // external texture, it always copies because it doesn't know if the texture will be modified
+    // externally. We know the texture won't change, so we can use our own cached image wihtout copying.
+    if (!m_cachedImage && m_surface) {
+        GrGLTextureInfo externalTexture;
+        externalTexture.fTarget = GL_TEXTURE_2D;
+        externalTexture.fID = m_textureID;
+        externalTexture.fFormat = GL_RGBA8;
+        auto backendTexture = GrBackendTextures::MakeGL(m_surface->width(), m_surface->height(), skgpu::Mipmapped::kNo, externalTexture);
+        m_cachedImage = SkImages::BorrowTextureFrom(PlatformDisplay::sharedDisplay().skiaGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    }
+    return m_cachedImage;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -69,6 +69,8 @@ private:
         float m_scale { 1. };
         FloatRect m_rect;
         sk_sp<SkSurface> m_surface;
+        unsigned m_textureID { 0 };
+        sk_sp<SkImage> m_cachedImage;
     };
 
     HashMap<uint32_t, Tile> m_tiles;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
@@ -29,13 +29,7 @@
 
 #if USE(SKIA)
 #include "BitmapTexture.h"
-#include "PlatformDisplay.h"
 #include "SkiaPaintingEngine.h"
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/gpu/ganesh/GrBackendSurface.h>
-#include <skia/gpu/ganesh/SkImageGanesh.h>
-#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 namespace WebCore {
@@ -58,11 +52,6 @@ void CoordinatedBackingStoreTile::processPendingUpdates()
     auto updatesCount = updates.size();
     if (!updatesCount)
         return;
-
-#if USE(SKIA)
-    // The underlying GL texture is about to be updated; the cached SkImage wrapping it is now stale.
-    m_cachedSkImage = nullptr;
-#endif
 
     WTFBeginSignpost(this, CoordinatedSwapBuffers, "%zu updates", updatesCount);
     for (unsigned updateIndex = 0; updateIndex < updatesCount; ++updateIndex) {
@@ -126,23 +115,6 @@ void CoordinatedBackingStoreTile::processPendingUpdates()
     }
     WTFEndSignpost(this, CoordinatedSwapBuffers);
 }
-
-#if USE(SKIA)
-const sk_sp<SkImage>& CoordinatedBackingStoreTile::ensureSkImage()
-{
-    if (!m_cachedSkImage && m_texture) {
-        auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-        GrGLTextureInfo externalTexture;
-        externalTexture.fTarget = GL_TEXTURE_2D;
-        externalTexture.fID = m_texture->id();
-        externalTexture.fFormat = GL_RGBA8;
-        const auto& size = m_texture->size();
-        auto backendTexture = GrBackendTextures::MakeGL(size.width(), size.height(), skgpu::Mipmapped::kNo, externalTexture);
-        m_cachedSkImage = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
-    }
-    return m_cachedSkImage;
-}
-#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
@@ -25,12 +25,6 @@
 #include "IntRect.h"
 #include <wtf/Vector.h>
 
-#if USE(SKIA)
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkImage.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-#endif
-
 namespace WebCore {
 class BitmapTexture;
 class CoordinatedTileBuffer;
@@ -56,18 +50,11 @@ public:
 
     bool canBePainted() const { return !!m_texture; }
 
-#if USE(SKIA)
-    const sk_sp<SkImage>& ensureSkImage();
-#endif
-
 private:
     RefPtr<BitmapTexture> m_texture;
     Vector<Update> m_updates;
     float m_scale { 1. };
     FloatRect m_rect;
-#if USE(SKIA)
-    sk_sp<SkImage> m_cachedSkImage;
-#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6961eee0cf14707c0d592cdfd099ba066217f3b7
<pre>
[GTK][WPE] Skia Compositor: avoid copies when getting the SkImage of a tile
<a href="https://bugs.webkit.org/show_bug.cgi?id=313217">https://bugs.webkit.org/show_bug.cgi?id=313217</a>

Reviewed by Nikolas Zimmermann.

SkSurface::makeImageSnapshot() does a copy-on-write, but when the
surface is wrapping an external texture, it always copies because it
doesn&apos;t know if the texture will be modified externally. We know the
texture won&apos;t change, so we can use our own cached image wihtout
copying. Also remove the now unsused code from CoordinatedBackingStoreTile
that was moved to SkiaBackingStore.

* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::Tile::tryEnsureSurface):
(WebCore::SkiaBackingStore::Tile::update):
(WebCore::SkiaBackingStore::Tile::image):
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp:
(WebCore::CoordinatedBackingStoreTile::processPendingUpdates):
(WebCore::CoordinatedBackingStoreTile::ensureSkImage): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h:

Canonical link: <a href="https://commits.webkit.org/311937@main">https://commits.webkit.org/311937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61a7dc7021262a80d1b39d2cae0fd1344f72490a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167322 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122754 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25013 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103424 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15093 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169812 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15557 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130944 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31608 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131058 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141945 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89430 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24094 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25751 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18751 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31065 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97079 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30585 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30739 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->