### PR TITLE
[JSC] Clean up V8's JSBigInt::cachedMod with more detailed comments

### DIFF
--- a/JSTests/stress/bigint-cached-mod-edge-cases.js
+++ b/JSTests/stress/bigint-cached-mod-edge-cases.js
@@ -1,0 +1,366 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+// cachedMod is activated after 100 uses of the same divisor.
+// It requires: divisor has 2-32 64-bit digits, dividend has n to 2n digits.
+// multiplySpecialHigh computes only digits from startPos = 2n-2 upward.
+// All expected values verified against V8 (Node.js).
+
+// --- n=2 (128-bit divisor, minimum for cachedMod) ---
+// startPos = 2*2-2 = 2, tightest interaction between highSpan and productLow.
+
+// n=2: squaring produces 2n-digit dividend (maximum for cached path).
+{
+    const p = (1n << 128n) - 159n;
+    let x = (1n << 200n) + 7n;
+    for (let i = 0; i < 200; i++)
+        x = (x * x) % p;
+    shouldBe(x, 177278552475415211552762206261272111601n);
+}
+
+// n=2: multiply-by-small produces n+1 digit dividend.
+{
+    const p = (1n << 128n) - 159n;
+    let x = (1n << 127n) + 1n;
+    for (let i = 0; i < 200; i++)
+        x = (x * 3n) % p;
+    shouldBe(x, 270852476855807815921471953649862209043n);
+}
+
+// n=2: multiply-by-(p-1) produces exactly 2n digit dividend every iteration.
+{
+    const p = (1n << 128n) - 159n;
+    let x = (1n << 127n) + 1n;
+    for (let i = 0; i < 200; i++)
+        x = (x * (p - 1n)) % p;
+    shouldBe(x, 170141183460469231731687303715884105729n);
+}
+
+// n=2: dividend < divisor (same n digits, |x| < |y| returns early before cachedMod).
+{
+    const p = (1n << 128n) - 159n;
+    let x = p - 1n;
+    for (let i = 0; i < 150; i++)
+        x = x % p;
+    shouldBe(x, p - 1n);
+}
+
+// n=2: exact multiple gives 0.
+{
+    const p = (1n << 128n) - 159n;
+    let x = p * 3n;
+    for (let i = 0; i < 150; i++)
+        x = x % p;
+    shouldBe(x, 0n);
+}
+
+// n=2: dividend = divisor + 1.
+{
+    const p = (1n << 128n) - 159n;
+    let x = p + 1n;
+    for (let i = 0; i < 150; i++)
+        x = x % p;
+    shouldBe(x, 1n);
+}
+
+// n=2: all-ones divisor (maximize internal carries in multiply).
+{
+    const p = (1n << 128n) - 1n;
+    let x = (1n << 255n) + 123456789n;
+    for (let i = 0; i < 200; i++)
+        x = (x * 3n) % p;
+    shouldBe(x, 78817515762451186854519328032592602042n);
+}
+
+// n=2: Mersenne-like divisor, squaring.
+{
+    const p = (1n << 128n) - 1n;
+    let x = (1n << 255n) - 1n;
+    for (let i = 0; i < 200; i++)
+        x = (x * x) % p;
+    shouldBe(x, 1n);
+}
+
+// n=2: divisor 2^64 + 1 (smallest 2-digit divisor).
+{
+    const p = (1n << 64n) + 1n;
+    let x = (1n << 127n) + 1n;
+    for (let i = 0; i < 200; i++)
+        x = (x * x) % p;
+    shouldBe(x, 4831328171988212771n);
+}
+
+// n=2: divisor 2^127 + 1 (close to digit boundary).
+{
+    const p = (1n << 127n) + 1n;
+    let x = (1n << 200n) + 99n;
+    for (let i = 0; i < 200; i++)
+        x = (x * x) % p;
+    shouldBe(x, 150824840280771579839960814384354169801n);
+}
+
+// n=2: carry-stress divisor pattern.
+{
+    const p = (1n << 127n) + (1n << 64n) - 1n;
+    let x = (1n << 200n) + 12345n;
+    for (let i = 0; i < 200; i++)
+        x = (x * x) % p;
+    shouldBe(x, 11609820357105566628172548015849534484n);
+}
+
+// n=2: forced exactly-2n digit dividend every iteration.
+{
+    const p = (1n << 128n) - 159n;
+    let x = (1n << 200n) + 1n;
+    for (let i = 0; i < 200; i++) {
+        x = x % p;
+        x = x * (p >> 1n);
+    }
+    shouldBe(x % p, 314748738897955976014696882727821759065n);
+}
+
+// n=2: >2n digit dividend bypasses cachedMod (falls to textbook).
+// Verify correctness at the boundary between cached and non-cached paths.
+{
+    const p = (1n << 128n) - 159n;
+    let x = (1n << 320n) + 1n;
+    for (let i = 0; i < 200; i++) {
+        x = x % p;
+        x = x * (1n << 250n) + 1n;
+    }
+    shouldBe(x % p, 291926710485922420603726882946018966276n);
+}
+
+// n=2: alternating between cached (<=2n digits) and non-cached (>2n digits) dividend sizes.
+{
+    const p = (1n << 128n) - 159n;
+    let x = (1n << 200n) + 1n;
+    for (let i = 0; i < 200; i++) {
+        if (i % 3 === 0)
+            x = (x * x) % p;
+        else if (i % 3 === 1)
+            x = (x * 3n) % p;
+        else {
+            x = x % p;
+            x = x * (1n << 250n) + BigInt(i);
+        }
+    }
+    shouldBe(x % p, 115432987156021975549902458353369394892n);
+}
+
+// --- n=3 (192-bit divisor, startPos = 4) ---
+
+// n=3: squaring produces 2n-digit dividend.
+{
+    const p = (1n << 192n) - 237n;
+    let x = (1n << 300n) + 42n;
+    for (let i = 0; i < 200; i++)
+        x = (x * x) % p;
+    shouldBe(x, 4783151374147123437769052551498427100842950442371165078084n);
+}
+
+// n=3: multiply-by-small produces n+1 digit dividend.
+{
+    const p = (1n << 192n) - 237n;
+    let x = (1n << 191n) + 1n;
+    for (let i = 0; i < 200; i++)
+        x = (x * 5n) % p;
+    shouldBe(x, 5416697097689928077577136525344415119217528154785858185433n);
+}
+
+// n=3: same-size dividend stays unchanged.
+{
+    const p = (1n << 192n) - 237n;
+    let x = p - 7n;
+    for (let i = 0; i < 150; i++)
+        x = x % p;
+    shouldBe(x, p - 7n);
+}
+
+// --- n=4 (256-bit divisor, common crypto size, startPos = 6) ---
+
+// n=4: multiply-by-constant produces n+1 digit dividend.
+{
+    const p = 2n ** 255n - 19n;
+    let x = 2n ** 510n - 1n;
+    for (let i = 0; i < 200; i++)
+        x = (x * 7n) % p;
+    shouldBe(x, 20199529111670185067226509400580693219090559440950920314010470048972233890619n);
+}
+
+// n=4: multiply-by-small produces n+1 digit dividend.
+{
+    const p = 2n ** 255n - 19n;
+    let x = (1n << 280n) + 999n;
+    for (let i = 0; i < 200; i++)
+        x = (x * 3n) % p;
+    shouldBe(x, 15996362973740392162448859893859295679701168986134187252638248410264421490236n);
+}
+
+// n=4: mixed dividend sizes within the same loop.
+{
+    const p = 2n ** 255n - 19n;
+    let x = (1n << 400n) + 1n;
+    for (let i = 0; i < 200; i++) {
+        x = x % p;
+        if (i % 2 === 0)
+            x = x * x;
+        else
+            x = x * 5n;
+    }
+    shouldBe(x % p, 27989761200312039329451992067769596918851024311859999205911201460129320658795n);
+}
+
+// n=4: dividend exactly 2n digits (maximum for cached path).
+{
+    const p = 2n ** 255n - 19n;
+    let x = 2n ** 510n - 1n;
+    for (let i = 0; i < 150; i++) {
+        x = x % p;
+        x = x * (1n << 254n) + 1n;
+    }
+    shouldBe(x >= 0n, true);
+    shouldBe(x % p, 24510358332628122011763128125706199547846894726910051373319518975690675744707n);
+}
+
+// --- n=8 (512-bit divisor, startPos = 14) ---
+
+{
+    const p = (1n << 512n) - 38117n;
+    let x = (1n << 1000n) + 1n;
+    for (let i = 0; i < 200; i++)
+        x = (x * x) % p;
+    shouldBe(x, 3259050154561516332303492723294531008767950455989810480963402987785461964981764930977751014809157529428079184366202236463921664022928513497208112346500620n);
+}
+
+// --- n=16 (1024-bit divisor, startPos = 30) ---
+
+{
+    const p = (1n << 1024n) - 105n;
+    let x = (1n << 2000n) + 999n;
+    for (let i = 0; i < 200; i++)
+        x = (x * x) % p;
+    shouldBe(x, 178640561875409494929959031951624405717939340969517783329258186957487830890452848788419238713797232807467856250187421907180187905237092645402923409446182195299760241272859355506076099790889384520936258763333705405745006328840429412195813753120246479007446433879238586201467087653339820638869436278379447077794n);
+}
+
+// --- n=32 (2048-bit divisor, maximum allowed, startPos = 62) ---
+
+{
+    const p = (1n << 2048n) - 1189n;
+    let x = (1n << 4000n) + 77n;
+    for (let i = 0; i < 200; i++)
+        x = (x * x) % p;
+    shouldBe(x, 12501303954234731296448305243218988457206472929459428325391125443525616770649464934923442478929335110320775381860379284470818061433235087642149480108602109741325437864117022440644834656017346537017296922710715260139268429585823463895889358743920640589646953755200915797622448646367060771335000636804296992123842316933423259427755033853591118477421542532328149250860266938827537500361258798796555009465639219810429378537679375462752876788798667730576909971366882045210212101958659351598990798365193220298815896698704445967436601475994366721210115982085568357494806430993248085312179545300746077781068475543829440968113n);
+}
+
+// --- Negative dividends ---
+
+{
+    const p2 = (1n << 128n) - 159n;
+    let x2 = -(1n << 200n);
+    for (let i = 0; i < 150; i++)
+        x2 = x2 % p2;
+    shouldBe(x2 <= 0n, true);
+    shouldBe(-x2 < p2, true);
+
+    const p4 = 2n ** 255n - 19n;
+    let x4 = -(1n << 500n);
+    for (let i = 0; i < 150; i++)
+        x4 = x4 % p4;
+    shouldBe(x4 <= 0n, true);
+    shouldBe(-x4 < p4, true);
+}
+
+// --- Divisor size boundaries ---
+
+// Dividend = 1 stays 1 for any divisor > 1.
+{
+    const primes = [
+        (1n << 128n) - 159n,
+        (1n << 192n) - 237n,
+        2n ** 255n - 19n,
+        (1n << 512n) - 38117n,
+    ];
+    for (const p of primes) {
+        let x = 1n;
+        for (let i = 0; i < 150; i++)
+            x = x % p;
+        shouldBe(x, 1n);
+    }
+}
+
+// Dividend = divisor - 1 stays unchanged for all sizes.
+{
+    const sizes = [128n, 192n, 256n, 512n];
+    for (const bits of sizes) {
+        const p = (1n << bits) - 1n;
+        let x = p - 1n;
+        for (let i = 0; i < 150; i++)
+            x = x % p;
+        shouldBe(x, p - 1n);
+    }
+}
+
+// --- Cache invalidation ---
+
+// Switch divisors at same n=2 size.
+{
+    const p1 = (1n << 128n) - 159n;
+    const p2 = (1n << 128n) - 173n;
+    let x = (1n << 200n) + 1n;
+    for (let i = 0; i < 150; i++)
+        x = (x * x) % p1;
+    for (let i = 0; i < 150; i++)
+        x = (x * x) % p2;
+    shouldBe(x >= 0n && x < p2, true);
+}
+
+// Switch divisors across sizes: n=2 then n=4.
+{
+    const p1 = (1n << 128n) - 159n;
+    const p2 = 2n ** 255n - 19n;
+    let x = (1n << 200n) + 1n;
+    for (let i = 0; i < 150; i++)
+        x = (x * x) % p1;
+    for (let i = 0; i < 150; i++)
+        x = (x * x) % p2;
+    shouldBe(x >= 0n && x < p2, true);
+}
+
+// --- Division identity: x === (x / p) * p + (x % p) ---
+
+{
+    const p = (1n << 256n) - 189n;
+    let dummy = 0n;
+    for (let i = 0; i < 150; i++)
+        dummy = ((1n << 300n) + BigInt(i)) % p;
+
+    for (let i = 0; i < 50; i++) {
+        let x = (1n << (256n + BigInt(i))) + BigInt(i * 997);
+        let result = x % p;
+        shouldBe(result >= 0n && result < p, true);
+        shouldBe(x - result === (x / p) * p, true);
+    }
+}
+
+// --- Exact multiples ---
+
+{
+    const p = (1n << 128n) - 159n;
+    for (let i = 0; i < 150; i++) {
+        let x = p * BigInt(i + 1);
+        shouldBe(x % p, 0n);
+    }
+}
+
+// --- Consecutive values near divisor boundary ---
+
+{
+    const p = (1n << 128n) - 159n;
+    for (let i = 0; i < 150; i++) {
+        let x = p * 2n + BigInt(i);
+        shouldBe(x % p, BigInt(i));
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -911,6 +911,56 @@ void JSBigInt::multiplySpecialLow(std::span<const Digit> xSpan, std::span<const 
     }
 }
 
+// For the needs of cachedMod, computes only product digits from startPosition and onward.
+// result[startPosition] corresponds to product digit startPosition.
+// The accumulator state (next, carry, nextCarry) from positions below startPosition is
+// lost, so the computed digits are an *approximate* value.
+void JSBigInt::multiplySpecialHigh(std::span<const Digit> xSpan, std::span<const Digit> ySpan, std::span<Digit> resultSpan, size_t startPosition)
+{
+    RELEASE_ASSERT(xSpan.size() >= ySpan.size());
+    RELEASE_ASSERT(ySpan.size() >= 1);
+    size_t fullSize = xSpan.size() + ySpan.size();
+    RELEASE_ASSERT(startPosition < fullSize);
+    RELEASE_ASSERT(resultSpan.size() >= fullSize);
+
+    const auto* x = xSpan.data();
+    const auto* y = ySpan.data();
+    auto* result = resultSpan.data();
+
+    Digit next = 0, nextCarry = 0, carry = 0;
+
+    size_t i = startPosition;
+
+    // Expanding phase: i < ySpan.size(), j ranges 0..i.
+    for (; i < ySpan.size(); i++) {
+        Digit temp = 0;
+        Digit zi = digitAdd(next, carry, temp);
+        next = nextCarry + temp;
+        carry = 0;
+        nextCarry = 0;
+        MULTIPLY_BODY(0, i);
+    }
+
+    // Shrinking phase: i >= ySpan.size(), j range is clipped.
+    size_t loopEnd = xSpan.size() + ySpan.size() - 2;
+    for (; i <= loopEnd; i++) {
+        size_t maxXIndex = std::min<size_t>(i, xSpan.size() - 1);
+        size_t maxYIndex = ySpan.size() - 1;
+        size_t minXIndex = i - maxYIndex;
+        Digit temp = 0;
+        Digit zi = digitAdd(next, carry, temp);
+        next = nextCarry + temp;
+        carry = 0;
+        nextCarry = 0;
+        MULTIPLY_BODY(minXIndex, maxXIndex);
+    }
+
+    // Final carry digit.
+    Digit temp = 0;
+    result[i] = digitAdd(next, carry, temp);
+    ASSERT(!temp);
+}
+
 #undef MULTIPLY_BODY
 
 template <typename BigIntImpl1, typename BigIntImpl2>
@@ -1606,6 +1656,9 @@ JSValue JSBigInt::unaryMinus(JSGlobalObject* globalObject, JSBigInt* x)
 // Given divisor B with n digits, the inverse has n+1 digits.
 // Uses V8's bit-negation trick to avoid a (2n+1)-digit dividend:
 //   A = ~(B << n) ≈ 2^(2n) - B*2^n - 1, then Inv = A/B + 2^n (undo the subtraction).
+//
+// This is computing I in Algorithm 2.5 in the following reference.
+// R. P. Brent and P. Zimmermann, Modern Computer Arithmetic. Cambridge, U.K.: Cambridge University Press, 2010.
 void JSBigInt::cachedModMakeInverse(VM& vm, std::span<const Digit> b)
 {
     size_t n = b.size();
@@ -1653,6 +1706,7 @@ void JSBigInt::cachedModMakeInverse(VM& vm, std::span<const Digit> b)
 // Cached modulo: R = A mod B, using precomputed inverse Inv.
 // A must have between n and 2n digits (where n = B.size()).
 // Returns the normalized result span within r.
+// R. P. Brent and P. Zimmermann, Modern Computer Arithmetic. Cambridge, U.K.: Cambridge University Press, 2010.
 std::span<const JSBigInt::Digit> JSBigInt::cachedMod(VM& vm, std::span<Digit> r, std::span<const Digit> a, std::span<const Digit> b)
 {
     size_t n = b.size();
@@ -1663,19 +1717,75 @@ std::span<const JSBigInt::Digit> JSBigInt::cachedMod(VM& vm, std::span<Digit> r,
     r = r.first(n);
     auto inv = vm.m_bigIntCachedInverse.span().first(n + 1);
 
-    // Step 1: Compute full product A * Inv into scratch.
+    // Step 1: Compute only the high digits of A * Inv via multiplySpecialHigh.
+    //
+    // Longhand multiplication of A (m digits) x Inv (k = n+1 digits):
+    // Each a_j * i_r produces a two-digit result (H:L). The low part L
+    // goes to column j+r, the high part H carries into column j+r+1.
+    //
+    // Example: n = 2, A = (a3 a2 a1 a0), Inv = (i2 i1 i0).
+    //
+    //        +------+------+------+------+------+------+------+
+    //        | col6 | col5 | col4 | col3 | col2 | col1 | col0 |
+    //        +------+------+------+------+------+------+------+
+    //  A*i0  |      |      |      | a3i0 | a2i0 | a1i0 | a0i0 |
+    //  A*i1  |      |      | a3i1 | a2i1 | a1i1 | a0i1 |      |
+    //  A*i2  |      | a3i2 | a2i2 | a1i2 | a0i2 |      |      |
+    //        +------+------+------+------+------+------+------+
+    //  Sum   |  P6  |  P5  |  P4  |  P3  |  P2  |  P1  |  P0  |
+    //        +------+------+------+------+------+------+------+
+    //        |<-- Q = floor(P/B^(2n)) -->|      |             |
+    //        |<--- multiplySpecialHigh -------->|<-- skip --->|
+    //                                           ^
+    //                                      startPos = 2
+    //
+    // The code accumulates columns left-to-right. Three registers carry
+    // state from column i to column i+1:
+    //
+    //     next      <= B-1  (accumulated high parts, one full Digit)
+    //     carry     <= 1    (overflow bit from low-part additions)
+    //     nextCarry <= 1    (overflow bit from high-part additions)
+    //
+    // multiplySpecialHigh starts at column startPos with these zeroed,
+    // losing the carry from columns [0..startPos-1]. All pair-sums
+    // within columns >= startPos are exact; only the incoming carry
+    // is lost.
+    //
+    // Error bound (general n, s = startPos = 2n-2):
+    //
+    //   Lost value E = (next + carry) * B^s + nextCarry * B^(s+1)
+    //              E <= B * B^s + 1 * B^(s+1) = 2 * B^(s+1)
+    //   With s = 2n-2:  E <= 2 * B^(2n-1)
+    //
+    //   True quotient:  Q_true   = floor(P     / B^(2n))
+    //   Our quotient:   Q_approx = floor((P-E) / B^(2n))
+    //
+    //   Write P = Q_true * B^(2n) + R,  0 <= R < B^(2n).
+    //
+    //     If R >= E:  P-E = Q_true * B^(2n) + (R-E)
+    //                 => Q_approx = Q_true               (error = 0)
+    //
+    //     If R < E:   P-E = (Q_true-1) * B^(2n) + (B^(2n) + R - E)
+    //                 Since E <= 2*B^(2n-1) < B^(2n) (because B >= 4),
+    //                 the remainder B^(2n) + R - E >= 0.
+    //                 => Q_approx = Q_true - 1           (error = 1)
+    //
+    //   Therefore: 0 <= Q_true - Q_approx <= 1.
+    //   Step 5's corrective loop handles Q being off by 1.
+    size_t startPos = 2 * n - 2;
     size_t scratchSpace = a.size() + inv.size();
     Vector<Digit, 64> scratch(scratchSpace);
     if (a.size() >= inv.size())
-        multiplyTextbook(a, inv, scratch.mutableSpan());
+        multiplySpecialHigh(a, inv, scratch.mutableSpan(), startPos);
     else
-        multiplyTextbook(inv, a, scratch.mutableSpan());
+        multiplySpecialHigh(inv, a, scratch.mutableSpan(), startPos);
 
     // Step 2: Extract estimated quotient Q from position 2n in the product.
+    // This means right-shifting 2n digits.
     auto qSpan = scratch.span().subspan(2 * n);
 
     // Step 3: Compute product_low = B * Q (only low n+1 digits needed).
-    // Reuse the low part of scratch for product_low (overlapping the full product).
+    // Reuse the low part of scratch for product_low (no overlap with qSpan).
     auto productLow = scratch.mutableSpan().first(n + 1);
     multiplySpecialLow(b, qSpan, productLow);
 

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -535,6 +535,7 @@ private:
     static std::span<Digit> multiplySingle(std::span<const Digit> multiplicand, Digit multiplier, std::span<Digit> result);
     static std::span<Digit> multiplyTextbook(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
     static void multiplySpecialLow(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
+    static void multiplySpecialHigh(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result, size_t startPosition);
     template<size_t N>
     static std::span<Digit, N * 2> multiplyComba(std::span<const Digit, N> x, std::span<const Digit, N> y, std::span<Digit, N * 2> result);
 


### PR DESCRIPTION
#### 8f585979f1b4ed32e0cf6df10eecae6ea9a5ab66
<pre>
[JSC] Clean up V8&apos;s JSBigInt::cachedMod with more detailed comments
<a href="https://bugs.webkit.org/show_bug.cgi?id=313218">https://bugs.webkit.org/show_bug.cgi?id=313218</a>
<a href="https://rdar.apple.com/175496917">rdar://175496917</a>

Reviewed by Yijia Huang.

Adding a bit more comments and cleaned up special methods to make the
intent clear as JSBigInt::cachedMod is complicated algorithm (this is
basically `BarrettDivRem` algorithm).

Test: JSTests/stress/bigint-cached-mod-edge-cases.js

* JSTests/stress/bigint-cached-mod-edge-cases.js: Added.
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::multiplySpecialHigh):
(JSC::JSBigInt::cachedMod):
* Source/JavaScriptCore/runtime/JSBigInt.h:

Canonical link: <a href="https://commits.webkit.org/311980@main">https://commits.webkit.org/311980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/549f13fc821bb5505dea1d6d5508905104d9eff9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158588 "6 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/32014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25121 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/32082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/32002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/167418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161546 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/32082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/32082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/32002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15189 "Failed to checkout and rebase branch from PR 63513") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/150638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/32082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/169909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/19422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/15653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/169909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/31704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/32002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/169909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/31650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/142033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24111 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/31650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/190870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/31161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/97175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/190870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/30681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->