### PR TITLE
[LBSE] Add test for nested stacking contexts via z-index on SVG <g> elements

### DIFF
--- a/LayoutTests/svg/dom-paint-order/nested-stacking-context-expected.html
+++ b/LayoutTests/svg/dom-paint-order/nested-stacking-context-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Reference: rects painted in expected visual stacking order (back to front).
+     g(z:1) is drawn first (red, then its scoped-high-z-index green),
+     then g(z:2) (its scoped-low-z-index orange, then blue). -->
+<svg width="400" height="200" viewBox="0 0 400 200">
+  <rect x="50"  y="40" width="100" height="100" fill="red"/>
+  <rect x="80"  y="60" width="100" height="100" fill="green"/>
+  <rect x="140" y="70" width="100" height="100" fill="orange"/>
+  <rect x="110" y="50" width="100" height="100" fill="blue"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom-paint-order/nested-stacking-context.html
+++ b/LayoutTests/svg/dom-paint-order/nested-stacking-context.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<link rel="match" href="nested-stacking-context-expected.html">
+<style>body { margin: 0; }</style>
+</head>
+<body>
+<!-- Tests that a <g> with a positive z-index establishes a new stacking context,
+     so its descendants' z-indexes are scoped to the <g> and cannot escape above
+     (or sink below) sibling groups with different z-indexes. -->
+<svg width="400" height="200" viewBox="0 0 400 200">
+  <!-- Bottom group (z-index: 1). Its child has a very HIGH inner z-index —
+       if the <g> is a proper stacking context, that child must NOT climb above
+       the sibling group with z-index: 2. -->
+  <g style="z-index: 1;">
+    <rect x="50"  y="40" width="100" height="100" fill="red"/>
+    <rect x="80"  y="60" width="100" height="100" fill="green" style="z-index: 999;"/>
+  </g>
+
+  <!-- Top group (z-index: 2). Its child has a very LOW inner z-index —
+       if the <g> is a proper stacking context, that child must NOT sink below
+       the sibling group with z-index: 1. -->
+  <g style="z-index: 2;">
+    <rect x="110" y="50" width="100" height="100" fill="blue"/>
+    <rect x="140" y="70" width="100" height="100" fill="orange" style="z-index: -999;"/>
+  </g>
+</svg>
+</body>
+</html>


### PR DESCRIPTION
#### ad28a2c634384aaa65cddb9a77f7883c7439bc72
<pre>
[LBSE] Add test for nested stacking contexts via z-index on SVG &lt;g&gt; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=313221">https://bugs.webkit.org/show_bug.cgi?id=313221</a>

Reviewed by Rob Buis.

Verify that a &lt;g&gt; with a positive z-index establishes a proper stacking
context, so a child&apos;s extreme inner z-index cannot escape above (or sink
below) a sibling group with a different z-index.

* LayoutTests/svg/dom-paint-order/nested-stacking-context-expected.html: Added.
* LayoutTests/svg/dom-paint-order/nested-stacking-context.html: Added.

Canonical link: <a href="https://commits.webkit.org/311946@main">https://commits.webkit.org/311946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdad708257afad5e1b43979520a1b055cd3d2d23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167328 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122762 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103432 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15099 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169818 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130950 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31614 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131064 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35471 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141951 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89436 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25760 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18757 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31071 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30591 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->