### PR TITLE
REGRESSION(306364@main): PDF scrollbar does not adapt to dark appearance

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -668,6 +668,9 @@ void ScrollingStateScrollingNode::dumpProperties(TextStream& ts, OptionSet<Scrol
         ts.dumpProperty("Scrolling on main thread because:"_s, ScrollingCoordinator::synchronousScrollingReasonsAsText(m_synchronousScrollingReasons));
 #endif
 
+    if (m_useDarkAppearanceForScrollbars)
+        ts.dumpProperty("uses dark appearance for scrollbars"_s, m_useDarkAppearanceForScrollbars);
+
     if (m_isMonitoringWheelEvents)
         ts.dumpProperty("expects wheel event test trigger"_s, m_isMonitoringWheelEvents);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -322,6 +322,7 @@ private:
     bool isFullMainFramePlugin() const;
 
     void scrollbarStyleChanged(WebCore::ScrollbarStyle, bool forceUpdate) override;
+    void updateScrollbarOverlayStyle();
     void updateScrollbars() override;
     void willAttachScrollingNode() final;
     void didAttachScrollingNode() final;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1650,6 +1650,7 @@ void UnifiedPDFPlugin::createScrollbarsController()
         return;
 
     page->chrome().client().ensureScrollbarsController(*page, *this);
+    updateScrollbarOverlayStyle();
 }
 
 DelegatedScrollingMode UnifiedPDFPlugin::scrollingMode() const
@@ -1709,6 +1710,24 @@ void UnifiedPDFPlugin::scrollbarStyleChanged(WebCore::ScrollbarStyle, bool force
         return;
 
     updateLayout();
+}
+
+void UnifiedPDFPlugin::updateScrollbarOverlayStyle()
+{
+    if (!isFullMainFramePlugin())
+        return;
+
+    RefPtr page = this->page();
+    if (!page)
+        return;
+
+    using enum WebCore::ScrollbarOverlayStyle;
+    setScrollbarOverlayStyle(page->useDarkAppearance() ? Light : Default);
+
+    if (m_scrollingNodeID) {
+        if (RefPtr scrollingCoordinator = page->scrollingCoordinator())
+            scrollingCoordinator->setScrollingNodeScrollableAreaGeometry(*m_scrollingNodeID, *this);
+    }
 }
 
 void UnifiedPDFPlugin::updateScrollbars()
@@ -4921,6 +4940,8 @@ void UnifiedPDFPlugin::effectiveAppearanceDidChange()
 
     if (RefPtr rootLayer = m_rootLayer)
         rootLayer->setBackgroundColor(pluginBackgroundColor());
+
+    updateScrollbarOverlayStyle();
 }
 
 ViewportConfiguration::Parameters UnifiedPDFPlugin::viewportParameters()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -1483,6 +1483,46 @@ UNIFIED_PDF_TEST(BackgroundDoesNotAdaptToColorSchemeOnEmbeddedDocuments)
 }
 #endif
 
+static RetainPtr<NSString> pluginScrollingNodeSubstring(NSString *tree)
+{
+    NSRange range = [tree rangeOfString:@"(Plugin scrolling node"];
+    if (range.location == NSNotFound)
+        return @"";
+    return [tree substringFromIndex:range.location];
+}
+
+UNIFIED_PDF_TEST(MainFramePDFScrollbarAdaptsToDarkMode)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"multiple-pages" withExtension:@"pdf"]]];
+    [webView waitForNextPresentationUpdate];
+
+    [webView forceLightMode];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr lightModeTree = pluginScrollingNodeSubstring([webView stringByEvaluatingJavaScript:@"internals.scrollingStateTreeAsText()"]);
+    EXPECT_FALSE([lightModeTree containsString:@"uses dark appearance for scrollbars"]);
+
+    [webView forceDarkMode];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr darkModeTree = pluginScrollingNodeSubstring([webView stringByEvaluatingJavaScript:@"internals.scrollingStateTreeAsText()"]);
+    EXPECT_TRUE([darkModeTree containsString:@"uses dark appearance for scrollbars"]);
+}
+
+UNIFIED_PDF_TEST(EmbeddedPDFScrollbarDoesNotAdaptToDarkMode)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
+    [webView synchronouslyLoadHTMLString:@"<embed src='multiple-pages.pdf' width='600' height='600'>"];
+    [webView waitForNextPresentationUpdate];
+
+    [webView forceDarkMode];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr pluginNode = pluginScrollingNodeSubstring([webView stringByEvaluatingJavaScript:@"internals.scrollingStateTreeAsText()"]);
+    EXPECT_FALSE([pluginNode containsString:@"uses dark appearance for scrollbars"]);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(UNIFIED_PDF)


### PR DESCRIPTION
#### cc5fbc12b447d665a94dcda52727f944c3cd50c7
<pre>
REGRESSION(306364@main): PDF scrollbar does not adapt to dark appearance
<a href="https://bugs.webkit.org/show_bug.cgi?id=313216">https://bugs.webkit.org/show_bug.cgi?id=313216</a>
<a href="https://rdar.apple.com/174763396">rdar://174763396</a>

Reviewed by Aditya Keerthi.

In 306364@main, we taught the PDF plugin to be aware of the system&apos;s
effective appearance (and of its changes), but we forgot to plumb this
over to the scrollbar overlay style. Since the plugin&apos;s ScrollableArea
isn&apos;t a LocalFrameView - it doesn&apos;t participate in style recalculation
or compositing geometry updates in the same way a frame view for web
content does. That&apos;s why we explicitly wire it up in this patch.

Note that we limit this behavior change to full main frame PDF plugins
only, in the same manner that embedded PDFs were generally opted out of
appearance adaptations to begin with.

Test: TestWebKitAPI.UnifiedPDF.MainFramePDFScrollbarAdaptsToDarkMode
      TestWebKitAPI.UnifiedPDF.EmbeddedPDFScrollbarDoesNotAdaptToDarkMode

* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::dumpProperties const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::layerForVerticalScrollbar const):
(WebKit::UnifiedPDFPlugin::scrollingMode const):
(WebKit::UnifiedPDFPlugin::isFullMainFramePlugin const):
(WebKit::UnifiedPDFPlugin::handleSyntheticClick):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):
(TestWebKitAPI::pluginScrollingNodeSubstring):

Canonical link: <a href="https://commits.webkit.org/311985@main">https://commits.webkit.org/311985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/376219eac7f4cb3bbf1b366cef53a6adda3baba2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112587 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122765 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86151 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103435 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24081 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22473 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15103 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133768 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169822 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15567 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130953 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131067 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31564 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141956 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89440 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24115 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18762 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31075 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97089 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30595 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30868 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30749 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->