### PR TITLE
ANGLE: Metal: Drawing points without assigning to gl_PointSize produces undefined results

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/TranslatorMSL.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/TranslatorMSL.cpp
@@ -1249,12 +1249,21 @@ bool TranslatorMSL::translateImpl(TInfoSinkBase &sink,
     else if (getShaderType() == GL_VERTEX_SHADER)
     {
         DeclareRightBeforeMain(*root, *BuiltInVariable::gl_Position());
-
-        if (FindSymbolNode(root, BuiltInVariable::gl_PointSize()->name()))
+        // Always declare gl_PointSize to get [[point_size]] defined in case
+        // client draws with GL_POINTS.
         {
-            const TVariable *pointSize = static_cast<const TVariable *>(
-                getSymbolTable().findBuiltIn(ImmutableString("gl_PointSize"), getShaderVersion()));
+
+            const TVariable *pointSize = getShaderVersion() >= 300
+                                             ? BuiltInVariable::gl_PointSize300()
+                                             : BuiltInVariable::gl_PointSize();
             DeclareRightBeforeMain(*root, *pointSize);
+            TIntermBinary *defaultPointSize =
+                new TIntermBinary(TOperator::EOpAssign, new TIntermSymbol(pointSize),
+                                  CreateFloatNode(1.0f, pointSize->getType().getPrecision()));
+            if (!RunAtTheBeginningOfShader(this, root, defaultPointSize))
+            {
+                return false;
+            }
         }
 
         // Append a macro for transform feedback substitution prior to modifying depth.

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
@@ -7352,6 +7352,113 @@ void main()
     EXPECT_GL_ERROR(GL_INVALID_OPERATION);
 }
 
+// Test that drawing GL_POINTS without setting gl_PointSize in the vertex shader
+// renders points with a default size of 1.0 pixel.
+TEST_P(WebGLCompatibilityTest, PointSizeDefaultWhenNotSet)
+{
+    constexpr char kVSWithoutPointSize[] =
+        R"(attribute vec2 a_position;
+void main()
+{
+    gl_Position = vec4(a_position, 0.0, 1.0);
+})";
+
+    constexpr char kVSWithPointSize[] =
+        R"(attribute vec2 a_position;
+void main()
+{
+    gl_PointSize = 1.0;
+    gl_Position = vec4(a_position, 0.0, 1.0);
+})";
+    constexpr char kVSWithPointSize0[] =
+        R"(attribute vec2 a_position;
+void main()
+{
+    gl_PointSize = 0.0;
+    gl_Position = vec4(a_position, 0.0, 1.0);
+})";
+    constexpr char kVSWithPointSizeVarying[] =
+        R"(attribute vec2 a_position;
+varying float p;
+void main()
+{
+    gl_PointSize = p;
+    gl_Position = vec4(a_position, 0.0, 1.0);
+})";
+
+    constexpr char kFS[] =
+        R"(precision mediump float;
+void main()
+{
+    gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+})";
+
+    ANGLE_GL_PROGRAM(programWithoutPointSize, kVSWithoutPointSize, kFS);
+    ANGLE_GL_PROGRAM(programWithPointSize, kVSWithPointSize, kFS);
+    ANGLE_GL_PROGRAM(programWithPointSize0, kVSWithPointSize0, kFS);
+    ANGLE_GL_PROGRAM(programWithPointSizeVarying, kVSWithPointSizeVarying, kFS);
+
+    const int w = getWindowWidth();
+    const int h = getWindowHeight();
+
+    // Place points at pixels (1,1), (w-2,1), (1,h-2), (w-2,h-2).
+    // NDC for pixel center: (pixel + 0.5) / size * 2.0 - 1.0.
+    const int px0 = 1;
+    const int py0 = 1;
+    const int px1 = w - 2;
+    const int py1 = h - 2;
+
+    const GLfloat vertices[] = {
+        (px0 + 0.5f) / w * 2.0f - 1.0f, (py0 + 0.5f) / h * 2.0f - 1.0f,
+        (px1 + 0.5f) / w * 2.0f - 1.0f, (py0 + 0.5f) / h * 2.0f - 1.0f,
+        (px0 + 0.5f) / w * 2.0f - 1.0f, (py1 + 0.5f) / h * 2.0f - 1.0f,
+        (px1 + 0.5f) / w * 2.0f - 1.0f, (py1 + 0.5f) / h * 2.0f - 1.0f,
+    };
+
+    GLBuffer vertexBuffer;
+    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
+    struct Subcase
+    {
+        GLuint program;
+        const char *description;
+    } subcases[] = {
+        {programWithoutPointSize, "without gl_PointSize"},
+        {programWithPointSize, "with gl_PointSize = 1.0"},
+        {programWithPointSize0, "with gl_PointSize = 0.0"},
+        {programWithPointSizeVarying, "with gl_PointSize = v (unassigned varying == 0.0)"}};
+
+    for (const auto &subcase : subcases)
+    {
+        SCOPED_TRACE(testing::Message() << subcase.description);
+        glUseProgram(subcase.program);
+
+        GLint posLocation = glGetAttribLocation(subcase.program, "a_position");
+        ASSERT_NE(-1, posLocation);
+        glVertexAttribPointer(posLocation, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+        glEnableVertexAttribArray(posLocation);
+
+        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        glDrawArrays(GL_POINTS, 0, 4);
+        EXPECT_GL_NO_ERROR();
+
+        // Each point should be exactly 1 pixel.
+        EXPECT_PIXEL_COLOR_EQ(px0, py0, GLColor::green);
+        EXPECT_PIXEL_COLOR_EQ(px1, py0, GLColor::green);
+        EXPECT_PIXEL_COLOR_EQ(px0, py1, GLColor::green);
+        EXPECT_PIXEL_COLOR_EQ(px1, py1, GLColor::green);
+
+        // Neighbors should be black, confirming point size is 1.
+        EXPECT_PIXEL_COLOR_EQ(px0 - 1, py0, GLColor::black);
+        EXPECT_PIXEL_COLOR_EQ(px0 + 1, py0, GLColor::black);
+        EXPECT_PIXEL_COLOR_EQ(px0, py0 - 1, GLColor::black);
+        EXPECT_PIXEL_COLOR_EQ(px0, py0 + 1, GLColor::black);
+    }
+}
+
 ANGLE_INSTANTIATE_TEST_ES2_AND_ES3(WebGLCompatibilityTest);
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(WebGL2CompatibilityTest);


### PR DESCRIPTION
#### 0400b92243652cc28660950a604ef09c52a18b52
<pre>
ANGLE: Metal: Drawing points without assigning to gl_PointSize produces undefined results
<a href="https://bugs.webkit.org/show_bug.cgi?id=313227">https://bugs.webkit.org/show_bug.cgi?id=313227</a>
<a href="https://rdar.apple.com/166533373">rdar://166533373</a>

Reviewed by Dan Glastonbury.

Always define MSL [[point_size]] by always assigning gl_PointSize = 1.0.

It&apos;s better to have defined results. Matches Firefox behavior.
Undefined by the spec, discussed in
<a href="https://github.com/KhronosGroup/WebGL/issues/2818.">https://github.com/KhronosGroup/WebGL/issues/2818.</a>

* Source/ThirdParty/ANGLE/src/compiler/translator/msl/TranslatorMSL.cpp:
(sh::TranslatorMSL::translateImpl):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp:

Canonical link: <a href="https://commits.webkit.org/312343@main">https://commits.webkit.org/312343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/008245f1919cd4099a2e1c5e1931828803bbe473

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112596 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122774 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86155 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103444 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24090 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22482 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15112 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169831 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130961 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131075 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35721 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141966 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89452 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18772 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31084 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30604 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30877 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30758 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->