### PR TITLE
ANGLE: WebGL2CompatibilityTest.DrawWithInstancedAndNonInstancedAttributes fails validation

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES.h
@@ -909,14 +909,62 @@ ANGLE_INLINE bool ValidateDrawInstancedAttribs(const Context *context,
         return true;
     }
 
-    // Validate that the buffers bound for the attributes can hold enough vertices for this
-    // instanced draw.  For attributes with a divisor of 0, ValidateDrawAttribs already checks this.
-    // Thus, the following only checks attributes with a non-zero divisor (i.e. "instanced").
-    const GLint64 limit = context->getInstancedVertexElementLimit();
-    if (baseinstance >= limit || primcount > limit - baseinstance)
+    // For each instance, attribute element index = floor(instance / attrib.divisor) + baseinstance.
+    // The instance runs [0..primcount - 1], so max instance is primcount - 1.
+    // For all attribs with attrib.divisor != 0, check max element index < attrib.elementIndex:
+    //    floor((primcount - 1) / attrib.divisor) + baseinstance < attrib.elementLimit.
+
+    if (ANGLE_LIKELY(baseinstance == 0))
     {
-        RecordDrawAttribsError(context, entryPoint);
-        return false;
+        // Fast path when baseinstance == 0:
+        // floor((primcount - 1) / attrib.divisor) < attrib.elementLimit
+        // ->
+        // primcount <= min(attrib.elementLimit * divisor)
+        const GLint64 limit = context->getInstancedVertexElementLimit();
+        if (primcount > limit)
+        {
+            RecordDrawAttribsError(context, entryPoint);
+            return false;
+        }
+        return true;
+    }
+
+    const VertexArray *vao = context->getState().getVertexArray();
+    if (!vao)
+    {
+        return true;
+    }
+
+    const auto &vertexAttribs  = vao->getVertexAttributes();
+    const auto &vertexBindings = vao->getVertexBindings();
+
+    for (size_t attributeIndex : context->getActiveBufferedAttribsMask())
+    {
+        const VertexAttribute &attrib = vertexAttribs[attributeIndex];
+        const VertexBinding &binding  = vertexBindings[attrib.bindingIndex];
+
+        GLuint divisor = binding.getDivisor();
+        if (divisor == 0)
+        {
+            // Non-instanced attributes are validated by ValidateDrawAttribs.
+            continue;
+        }
+
+        GLint64 elementLimit = attrib.getCachedElementLimit();
+        if (elementLimit == VertexAttribute::kIntegerOverflow || elementLimit < 0)
+        {
+            RecordDrawAttribsError(context, entryPoint);
+            return false;
+        }
+        // Compute max instance attribute index = floor(instance / divisor) + baseinstance.
+        GLint64 lastIndex =
+            static_cast<GLint64>((static_cast<GLuint>(primcount) - 1u) / divisor) + baseinstance;
+
+        if (lastIndex >= elementLimit)
+        {
+            RecordDrawAttribsError(context, entryPoint);
+            return false;
+        }
     }
 
     return true;

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBaseVertexBaseInstanceTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBaseVertexBaseInstanceTest.cpp
@@ -7,6 +7,10 @@
 // DrawBaseVertexBaseInstanceTest: Tests of GL_ANGLE_base_vertex_base_instance
 // DrawBaseInstanceTest: Tests of GL_EXT_base_instance
 
+#ifdef UNSAFE_BUFFERS_BUILD
+#    pragma allow_unsafe_buffers
+#endif
+
 #include "gpu_info_util/SystemInfo.h"
 #include "test_utils/ANGLETest.h"
 #include "test_utils/gl_raii.h"
@@ -1306,6 +1310,111 @@ void main()
                                                        1, 2, 0);
     EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::white);
     ASSERT_GL_NO_ERROR();
+}
+
+TEST_P(DrawBaseVertexBaseInstanceTest_ES3, BaseInstanceDivisorIndexing)
+{
+    ANGLE_SKIP_TEST_IF(!EnsureGLExtensionEnabled("GL_ANGLE_base_vertex_base_instance"));
+
+    // Vertex shader: pass per-instance integer value through a flat varying.
+    constexpr char kVS[] = R"(#version 300 es
+#extension GL_ANGLE_base_vertex_base_instance_shader_builtin : require
+in vec4 a_position;
+in int a_instValue;
+flat out int v_instValue;
+flat out int v_instanceID;
+flat out int v_baseInstance;
+void main()
+{
+    v_instValue = a_instValue;
+    v_instanceID = gl_InstanceID;
+    v_baseInstance = gl_BaseInstance;
+    gl_Position = a_position;
+})";
+
+    // Fragment shader: output the instanced value as an integer.
+    constexpr char kFS[] = R"(#version 300 es
+precision highp int;
+flat in int v_instValue;
+flat in int v_instanceID;
+flat in int v_baseInstance;
+out ivec4 o_color;
+void main()
+{
+    o_color = ivec4(v_instValue, v_instanceID, v_baseInstance, 1);
+})";
+
+    ANGLE_GL_PROGRAM(program, kVS, kFS);
+    glUseProgram(program);
+
+    GLint posLoc  = glGetAttribLocation(program, "a_position");
+    GLint instLoc = glGetAttribLocation(program, "a_instValue");
+    ASSERT_NE(-1, posLoc);
+    ASSERT_NE(-1, instLoc);
+
+    // Render to a GL_RGBA32I texture via FBO for exact integer readback.
+    GLTexture intTex;
+    glBindTexture(GL_TEXTURE_2D, intTex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32I, getWindowWidth(), getWindowHeight(), 0,
+                 GL_RGBA_INTEGER, GL_INT, nullptr);
+
+    GLFramebuffer fbo;
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, intTex, 0);
+    ASSERT_GLENUM_EQ(GL_FRAMEBUFFER_COMPLETE, glCheckFramebufferStatus(GL_FRAMEBUFFER));
+
+    // Position: a full-viewport triangle strip (4 vertices).
+    const float positions[] = {
+        -1.0f, -1.0f, 0.0f, 1.0f, 1.0f, -1.0f, 0.0f, 1.0f,
+        -1.0f, 1.0f,  0.0f, 1.0f, 1.0f, 1.0f,  0.0f, 1.0f,
+    };
+    GLBuffer posBuffer;
+    glBindBuffer(GL_ARRAY_BUFFER, posBuffer);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(positions), positions, GL_STATIC_DRAW);
+    glEnableVertexAttribArray(posLoc);
+    glVertexAttribPointer(posLoc, 4, GL_FLOAT, GL_FALSE, 0, nullptr);
+
+    // Per-instance attribute: 8 distinct integer values, divisor = 3.
+    // Each value is a unique identifier for its buffer index.
+    const GLint instValues[] = {0, 1, 2, 3, 4, 5, 6, 7};
+    GLBuffer instBuffer;
+    glBindBuffer(GL_ARRAY_BUFFER, instBuffer);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(instValues), instValues, GL_STATIC_DRAW);
+    glEnableVertexAttribArray(instLoc);
+    glVertexAttribIPointer(instLoc, 1, GL_INT, 0, nullptr);
+    glVertexAttribDivisor(instLoc, 3);
+    ASSERT_GL_NO_ERROR();
+
+    glViewport(0, 0, getWindowWidth(), getWindowHeight());
+    struct Subcase
+    {
+        GLsizei instanceCount;
+        GLuint baseInstance;
+    } subcases[]{
+        {.instanceCount = 1, .baseInstance = 0},
+        {.instanceCount = 1, .baseInstance = 4},
+        {.instanceCount = 1, .baseInstance = 7},
+        {.instanceCount = 6, .baseInstance = 3},
+    };
+
+    for (auto const &subcase : subcases)
+    {
+        SCOPED_TRACE(testing::Message()
+                     << "Subcase subcase{.instanceCount = " << subcase.instanceCount
+                     << ", .baseInstance = " << subcase.baseInstance << "}");
+        const GLint clearValue[] = {0, 0, 0, 0};
+        glClearBufferiv(GL_COLOR, 0, clearValue);
+        glDrawArraysInstancedBaseInstanceANGLE(GL_TRIANGLE_STRIP, 0, 4, subcase.instanceCount,
+                                               subcase.baseInstance);
+        ASSERT_GL_NO_ERROR();
+        GLint lastInstanceAttrIndex = subcase.baseInstance + (subcase.instanceCount - 1) / 3;
+        GLint lastInstValue         = instValues[lastInstanceAttrIndex];
+        GLint lastInstanceID        = subcase.instanceCount - 1;
+        // R == instValue (per-instance attribute), G == gl_InstanceID, B == gl_BaseInstance.
+        GLColor32I expected(lastInstValue, lastInstanceID, static_cast<GLint>(subcase.baseInstance),
+                            1);
+        EXPECT_PIXEL_32I_COLOR(0, 0, expected);
+    }
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DrawBaseVertexBaseInstanceTest);

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
@@ -7104,23 +7104,35 @@ void main()
 
     if (hasBaseInstance)
     {
-        // The following passes because attribute 1 accesses vertices [0, 3)
+        // instanced attrib index = floor(instance / divisor) + baseInstance
+        // instance = 0..primcount - 1
+        // Attribute 1 has divisor=5 and buffer fits 5 elements (indices 0-4).
+        // The following passes because attribute 1 max index = floor(14/5)+0 = 2. In bounds.
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 15, 0);
         EXPECT_GL_NO_ERROR();
-        // The following passes because attribute 1 accesses vertices [1, 4)
+        // The following fails because attribute 1 max index = floor(14/5)+5 = 7, OOB (>4).
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 15, 5);
-        EXPECT_GL_NO_ERROR();
-        // The following passes because attribute 1 accesses vertices [0, 4)
+        EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+        // The following fails because attribute 1 max index = floor(16/5)+3 = 6, OOB (>4).
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 17, 3);
-        EXPECT_GL_NO_ERROR();
-        // The following passes because attribute 1 accesses vertices [3, 5)
+        EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+        // The following fails because attribute 1 max index = floor(9/5)+15 = 16, OOB (>4).
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 10, 15);
-        EXPECT_GL_NO_ERROR();
-        // The following fails because attribute 1 accesses vertices [3, 6)
+        EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+        // The following fails because attribute 1 max index = floor(10/5)+15 = 17, OOB (>4).
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 11, 15);
         EXPECT_GL_ERROR(GL_INVALID_OPERATION);
-        // The following fails because attribute 1 accesses vertex 6
+        // The following fails because attribute 1 max index = floor(0/5)+25 = 25, OOB (>4).
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 1, 25);
+        EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+        // The following passes because attribute 1 max index = floor(0/5)+0 = 0. In bounds.
+        glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 1, 0);
+        EXPECT_GL_NO_ERROR();
+        // The following passes because attribute 1 max index = floor(0/5)+4 = 4. In bounds.
+        glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 1, 4);
+        EXPECT_GL_NO_ERROR();
+        // The following fails because attribute 1 max index = floor(0/5)+5 = 5. OOB (>4).
+        glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 1, 5);
         EXPECT_GL_ERROR(GL_INVALID_OPERATION);
     }
 
@@ -7175,21 +7187,26 @@ void main()
 
     if (hasBaseInstance)
     {
-        // The following passes because attribute 1 accesses vertices [0, 4), and attribute 3
-        // accesses vertices [0, 6)
+        // instanced attrib index = floor(instance / divisor) + baseInstance
+        // Attribute 1 has divisor=5, buffer fits 5 elements (indices 0-4). Attribute
+        // 3 has divisor=3, buffer fits 6 elements (indices 0-5).
+        //
+        // attr1 max index = floor(17/5)+0 = 3, attr3 max index = floor(17/3)+0 = 5. Both in
+        // bounds.
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 18, 0);
         EXPECT_GL_NO_ERROR();
-        // The following fails because attribute 3 accesses vertices [0, 7)
+        // attr1 max index = floor(18/5)+0 = 3, attr3 max index = floor(18/3)+0 = 6. Attr3 OOB.
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 19, 0);
         EXPECT_GL_ERROR(GL_INVALID_OPERATION);
-        // The following fails because attribute 3 accesses vertices [1, 7)
+        // attr1 max index = floor(17/5)+1 = 4, attr3 max index = floor(17/3)+1 = 6. Attr3 OOB (>5).
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 18, 1);
         EXPECT_GL_ERROR(GL_INVALID_OPERATION);
-        // The following passes because attribute 3 accesses vertices [3, 6)
-        glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 7, 11);
+        // With baseInstance=3:
+        // attr1 max index = floor(0/5)+3 = 3, attr3 max index = floor(0/3)+3 = 3. Both in bounds.
+        glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 1, 3);
         EXPECT_GL_NO_ERROR();
-        // The following fails because attribute 3 accesses vertices [3, 7)
-        glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 8, 11);
+        // attr1 max index = floor(0/5)+5 = 5 (OOB for attr1 which fits 5 elements)
+        glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 2, 4, 1, 5);
         EXPECT_GL_ERROR(GL_INVALID_OPERATION);
     }
 
@@ -7244,17 +7261,121 @@ void main()
 
     if (hasBaseInstance)
     {
+        // instanced attrib index = floor(instance / divisor) + baseInstance
+        // Attribute 1: divisor=5, buffer fits 5 elements (max index 4)
+        // Attribute 2: divisor=3, buffer fits 8 elements (max index 7)
+        // Attribute 3: divisor=3, buffer fits 6 elements (max index 5)
+        // Attribute 4: divisor=1, buffer fits 12 elements (max index 11)
+        //
+        //   attr1: floor(11/5)+0=2, attr2: floor(11/3)+0=3, attr3: floor(11/3)+0=3, attr4:
+        //   floor(11/1)+0=11 All in bounds.
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 120, 359, 12, 0);
         EXPECT_GL_NO_ERROR();
+        //   attr1: floor(10/5)+1=3, attr2: floor(10/3)+1=4, attr3: floor(10/3)+1=4, attr4:
+        //   floor(10/1)+1=11. All in bounds.
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 120, 359, 11, 1);
         EXPECT_GL_NO_ERROR();
+        //   attr1: floor(0/5)+11=11 (OOB, >4)
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 120, 359, 1, 11);
-        EXPECT_GL_NO_ERROR();
+        EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+        //   attr1: floor(1/5)+11=11 (OOB, >4)
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 120, 359, 2, 11);
         EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+        //   attr4: floor(0/1)+14=14 (OOB, >11)
         glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 120, 359, 1, 14);
         EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+        //   attr1: floor(11/5)+0=2, attr2: floor(11/3)+0=3, attr3: floor(11/3)+0=3, attr4:
+        //    floor(11/1)+0=11. All in bounds.
+        glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 120, 359, 12, 0);
+        EXPECT_GL_NO_ERROR();
+        //   attr1: floor(0/5)+4=4, attr2: floor(0/3)+4=4, attr3: floor(0/3)+4=4, attr4:
+        //   floor(0/1)+4=4. All in bounds.
+        glDrawArraysInstancedBaseInstanceANGLE(GL_POINTS, 120, 359, 1, 4);
+        EXPECT_GL_NO_ERROR();
     }
+}
+
+// Isolated regression test from the above.
+TEST_P(WebGL2CompatibilityTest, BaseInstancePerInstanceAttributeOOB)
+{
+    ANGLE_SKIP_TEST_IF(!EnsureGLExtensionEnabled("GL_ANGLE_base_vertex_base_instance"));
+
+    // The vertex shader passes the instanced color attribute to the fragment shader.
+    // The non-instanced attribute provides the vertex position for a full-viewport triangle strip.
+    constexpr char kVS[] = R"(#version 300 es
+in vec4 a_position;
+in vec4 a_instColor;
+out vec4 v_color;
+void main()
+{
+    v_color = a_instColor;
+    gl_Position = a_position;
+})";
+
+    constexpr char kFS[] = R"(#version 300 es
+precision mediump float;
+in vec4 v_color;
+out vec4 fragColor;
+void main()
+{
+    fragColor = v_color;
+})";
+
+    ANGLE_GL_PROGRAM(program, kVS, kFS);
+    glUseProgram(program);
+
+    GLint posLoc   = glGetAttribLocation(program, "a_position");
+    GLint colorLoc = glGetAttribLocation(program, "a_instColor");
+    ASSERT_NE(-1, posLoc);
+    ASSERT_NE(-1, colorLoc);
+
+    // Non-instanced position attribute: full-viewport quad as triangle strip.
+    const float positions[] = {
+        -1.0f, -1.0f, 0.0f, 1.0f, 1.0f, -1.0f, 0.0f, 1.0f,
+        -1.0f, 1.0f,  0.0f, 1.0f, 1.0f, 1.0f,  0.0f, 1.0f,
+    };
+    GLBuffer posBuffer;
+    glBindBuffer(GL_ARRAY_BUFFER, posBuffer);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(positions), positions, GL_STATIC_DRAW);
+    glEnableVertexAttribArray(posLoc);
+    glVertexAttribPointer(posLoc, 4, GL_FLOAT, GL_FALSE, 0, nullptr);
+
+    // Instanced color attribute: GL_SHORT*4, divisor=5, stride=12, offset=124.
+    // Buffer data region = 64 bytes -> fits 5 vertices (attrib=8 bytes, (64-8)/12+1=5).
+    // Total buffer = 64 + 124 = 188 bytes.
+    std::vector<uint8_t> instData(188, 0);
+    // Write GL_SHORT×4 green values (0, 0x7FFF, 0, 0x7FFF) at offset=124, stride=12 for 5 entries.
+    for (int i = 0; i < 5; ++i)
+    {
+        size_t base         = 124 + i * 12;
+        int16_t *components = reinterpret_cast<int16_t *>(&instData[base]);
+        components[0]       = 0;       // R = 0
+        components[1]       = 0x7FFF;  // G = 1.0 (normalized)
+        components[2]       = 0;       // B = 0
+        components[3]       = 0x7FFF;  // A = 1.0 (normalized)
+    }
+    GLBuffer instBuffer;
+    glBindBuffer(GL_ARRAY_BUFFER, instBuffer);
+    glBufferData(GL_ARRAY_BUFFER, instData.size(), instData.data(), GL_STATIC_DRAW);
+    glEnableVertexAttribArray(colorLoc);
+    glVertexAttribPointer(colorLoc, 4, GL_SHORT, GL_TRUE, 12, reinterpret_cast<void *>(124));
+    glVertexAttribDivisor(colorLoc, 5);
+    ASSERT_GL_NO_ERROR();
+
+    // Verify baseInstance=0 draw works and produces output.
+    // instanceCount=15, divisor=5 -> max instanced index = floor(14/5) = 2. Within bounds.
+    glClear(GL_COLOR_BUFFER_BIT);
+    glDrawArraysInstancedBaseInstanceANGLE(GL_TRIANGLE_STRIP, 0, 4, 15, 0);
+    ASSERT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
+
+    // baseInstance=5, instanceCount=15, divisor=5.
+    // instanced attribute index = floor(instance / divisor) + baseInstance
+    // Max instanced index = floor(14/5) + 5 = 2 + 5 = 7. Buffer fits 5 elements (indices 0-4).
+    // Index 7 is out of bounds, so this must generate GL_INVALID_OPERATION.
+    glClear(GL_COLOR_BUFFER_BIT);
+    glDrawArraysInstancedBaseInstanceANGLE(GL_TRIANGLE_STRIP, 0, 4, 15, 5);
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
 }
 
 // Tests that indexing with primitive restart index produces error, even


### PR DESCRIPTION
#### 2267d02509a726e02caa8d13b7b5cbbf6fb8efbd
<pre>
ANGLE: WebGL2CompatibilityTest.DrawWithInstancedAndNonInstancedAttributes fails validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=313229">https://bugs.webkit.org/show_bug.cgi?id=313229</a>
<a href="https://rdar.apple.com/175507506">rdar://175507506</a>

Reviewed by Dan Glastonbury.

The validation and the tests were written based on incorrect instance
element index formula.

The OpenGL instanced draw attribute element computation is:
    element_index = floor(instance / attrib.divisor) + baseinstance

The instance runs from 0..primcount-1.

Max element_index is produced by max instance,
which is primcount - 1.

The validation and the tests were written based on the formula:
 const GLint64 limit = context-&gt;getInstancedVertexElementLimit();
 if (baseinstance &gt;= limit || primcount &gt; limit - baseinstance)

This was equivalent of:
    element_index = floor((primcount - 1 + baseinstance) / attrib.divisor)

Fix by using the cached instanced max element index value only if
baseinstance is 0. Otherwise, check each attribute individually.

* Source/ThirdParty/ANGLE/src/libANGLE/validationES.h:
(gl::ValidateDrawInstancedAttribs):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBaseVertexBaseInstanceTest.cpp:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp:

Canonical link: <a href="https://commits.webkit.org/312510@main">https://commits.webkit.org/312510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1984f7f3e6c762c98fb3bc2442ee520f1ca485a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169143 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114622 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7c34209-fb80-4a36-85da-d1251e831e8e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124227 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cd0f07c-2817-47a8-b617-36ec7c618173) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104826 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42196d21-d530-4365-8437-574c853da84a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/25526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24020 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16863 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135218 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171621 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132479 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132505 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35818 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143493 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91655 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27125 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20307 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32881 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32379 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32625 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32529 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->