### PR TITLE
Race network loads against service worker registration import

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -593,20 +593,9 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
 
     CONNECTION_RELEASE_LOG(Loading, "scheduleResourceLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ", existingLoaderToResume=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0, existingLoaderToResume ? existingLoaderToResume->toUInt64() : 0);
 
-    if (CheckedPtr session = networkSession()) {
-        if (Ref server = session->ensureSWServer(); !server->isImportCompleted()) {
-            server->whenImportIsCompleted([this, protectedThis = Ref { *this }, loadParameters = WTF::move(loadParameters), existingLoaderToResume]() mutable {
-                if (!m_networkProcess->webProcessConnection(webProcessIdentifier()))
-                    return;
-
-                ASSERT(networkSession());
-                ASSERT(networkSession()->swServer());
-                ASSERT(networkSession()->swServer()->isImportCompleted());
-                scheduleResourceLoad(WTF::move(loadParameters), existingLoaderToResume);
-            });
-            return;
-        }
-    }
+    // Ensure the SWServer is lazily created so that service worker registration import starts.
+    if (CheckedPtr session = networkSession())
+        session->ensureSWServer();
 
     auto identifier = loadParameters.identifier;
     RELEASE_ASSERT(identifier);

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -74,6 +74,7 @@
 #include <WebCore/OriginAccessPatterns.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ReportingScope.h>
+#include <WebCore/SWServer.h>
 #include <WebCore/SameSiteInfo.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityPolicy.h>
@@ -619,6 +620,8 @@ void NetworkResourceLoader::abort()
     LOADER_RELEASE_LOG("abort: (hasNetworkLoad=%d)", !!m_networkLoad);
     ASSERT(RunLoop::isMain());
 
+    m_isRacingNetworkAgainstServiceWorkerImport = false;
+
     if (m_parameters.options.keepAlive && m_response.isNull() && !m_isKeptAlive) {
         m_isKeptAlive = true;
         LOADER_RELEASE_LOG("abort: Keeping network load alive due to keepalive option");
@@ -897,6 +900,8 @@ void NetworkResourceLoader::didReceiveInformationalResponse(ResourceResponse&& r
 
 void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedResponse, PrivateRelayed privateRelayed, ResponseCompletionHandler&& completionHandler)
 {
+    cancelServiceWorkerFetchTaskIfNetworkWonRace();
+
     LOADER_RELEASE_LOG("didReceiveResponse: (httpStatusCode=%d, MIMEType=%" PUBLIC_LOG_STRING ", expectedContentLength=%lld, hasCachedEntryForValidation=%d, hasNetworkLoadChecker=%d)", receivedResponse.httpStatusCode(), receivedResponse.mimeType().utf8().data(), receivedResponse.expectedContentLength(), !!m_cacheEntryForValidation, !!m_networkLoadChecker);
 
 #if ENABLE(CONTENT_FILTERING)
@@ -1184,6 +1189,8 @@ void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLo
 
 void NetworkResourceLoader::didFailLoading(const ResourceError& error)
 {
+    cancelServiceWorkerFetchTaskIfNetworkWonRace();
+
     bool wasServiceWorkerLoad = false;
     wasServiceWorkerLoad = !!m_serviceWorkerFetchTask;
     LOADER_RELEASE_LOG_ERROR("didFailLoading: (wasServiceWorkerLoad=%d, isTimeout=%d, isCancellation=%d, isAccessControl=%d, errorCode=%d)", wasServiceWorkerLoad, error.isTimeout(), error.isCancellation(), error.isAccessControl(), error.errorCode());
@@ -1254,11 +1261,14 @@ std::optional<Seconds> NetworkResourceLoader::validateCacheEntryForMaxAgeCapVali
 
 void NetworkResourceLoader::willSendRedirectedRequest(ResourceRequest&& request, ResourceRequest&& redirectRequest, ResourceResponse&& redirectResponse, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)
 {
+    cancelServiceWorkerFetchTaskIfNetworkWonRace();
+
     willSendRedirectedRequestInternal(WTF::move(request), WTF::move(redirectRequest), WTF::move(redirectResponse), IsFromServiceWorker::No, WTF::move(completionHandler));
 }
 
 void NetworkResourceLoader::willSendServiceWorkerRedirectedRequest(ResourceRequest&& request, ResourceRequest&& redirectRequest, ResourceResponse&& redirectResponse)
 {
+    cancelNetworkLoadIfServiceWorkerWonRace();
     willSendRedirectedRequestInternal(WTF::move(request), WTF::move(redirectRequest), WTF::move(redirectResponse), IsFromServiceWorker::Yes, [] (auto) { });
 }
 
@@ -2104,6 +2114,27 @@ void NetworkResourceLoader::startWithServiceWorker()
         if (request.isNull())
             return;
 
+        if (protectedThis->m_parameters.serviceWorkersMode != ServiceWorkersMode::None) {
+            if (CheckedPtr session = protectedThis->connectionToWebProcess().networkSession()) {
+                if (RefPtr server = session->swServer(); server && !server->isImportCompleted()) {
+                    if (protectedThis->m_parameters.serviceWorkersMode == ServiceWorkersMode::Only) {
+                        LOADER_RELEASE_LOG_WITH_THIS(protectedThis, "startWithServiceWorker: SW import not complete, deferring ServiceWorkersMode::Only load");
+                        server->whenImportIsCompleted([protectedThis]() mutable {
+                            protectedThis->startWithServiceWorker();
+                        });
+                        return;
+                    }
+                    LOADER_RELEASE_LOG_WITH_THIS(protectedThis, "startWithServiceWorker: SW import not complete, racing network against import");
+                    protectedThis->m_isRacingNetworkAgainstServiceWorkerImport = true;
+                    server->whenImportIsCompleted([protectedThis]() mutable {
+                        protectedThis->serviceWorkerImportCompletedWhileRacingNetwork();
+                    });
+                    protectedThis->startRequest(WTF::move(request));
+                    return;
+                }
+            }
+        }
+
         ASSERT(!protectedThis->m_serviceWorkerFetchTask);
         protectedThis->m_serviceWorkerFetchTask = protect(protectedThis->connectionToWebProcess())->createFetchTask(protectedThis, request);
         if (protectedThis->m_serviceWorkerFetchTask) {
@@ -2125,6 +2156,48 @@ void NetworkResourceLoader::startWithServiceWorker()
 #endif
 }
 
+void NetworkResourceLoader::serviceWorkerImportCompletedWhileRacingNetwork()
+{
+    if (!m_isRacingNetworkAgainstServiceWorkerImport)
+        return;
+
+    LOADER_RELEASE_LOG("serviceWorkerImportCompletedWhileRacingNetwork:");
+
+    auto serviceWorkerFetchTask = protect(connectionToWebProcess())->createFetchTask(*this, originalRequest());
+    if (!serviceWorkerFetchTask) {
+        LOADER_RELEASE_LOG("serviceWorkerImportCompletedWhileRacingNetwork: No matching service worker, continuing network load");
+        m_isRacingNetworkAgainstServiceWorkerImport = false;
+        return;
+    }
+
+    LOADER_RELEASE_LOG("serviceWorkerImportCompletedWhileRacingNetwork: Service worker matched, racing fetch handler against network load (fetchIdentifier=%" PRIu64 ")", serviceWorkerFetchTask->fetchIdentifier().toUInt64());
+    m_serviceWorkerFetchTask = WTF::move(serviceWorkerFetchTask);
+}
+
+void NetworkResourceLoader::cancelServiceWorkerFetchTaskIfNetworkWonRace()
+{
+    if (!m_isRacingNetworkAgainstServiceWorkerImport)
+        return;
+    m_isRacingNetworkAgainstServiceWorkerImport = false;
+    if (auto task = std::exchange(m_serviceWorkerFetchTask, nullptr)) {
+        LOADER_RELEASE_LOG("cancelServiceWorkerFetchTaskIfNetworkWonRace: Network won the race, cancelling service worker fetch task (fetchIdentifier=%" PRIu64 ")", task->fetchIdentifier().toUInt64());
+        task->cancelFromClient();
+    }
+}
+
+void NetworkResourceLoader::cancelNetworkLoadIfServiceWorkerWonRace()
+{
+    if (!m_isRacingNetworkAgainstServiceWorkerImport)
+        return;
+    m_isRacingNetworkAgainstServiceWorkerImport = false;
+
+    LOADER_RELEASE_LOG("cancelNetworkLoadIfServiceWorkerWonRace:");
+    if (RefPtr networkLoad = std::exchange(m_networkLoad, nullptr)) {
+        networkLoad->cancel();
+        networkLoad->clearClient();
+    }
+}
+
 bool NetworkResourceLoader::abortIfServiceWorkersOnly()
 {
     if (m_parameters.serviceWorkersMode != ServiceWorkersMode::Only)
@@ -2143,6 +2216,13 @@ void NetworkResourceLoader::serviceWorkerDidNotHandle(ServiceWorkerFetchTask* fe
 
     if (abortIfServiceWorkersOnly())
         return;
+
+    if (m_isRacingNetworkAgainstServiceWorkerImport) {
+        LOADER_RELEASE_LOG("serviceWorkerDidNotHandle: Network load already in progress, letting it continue");
+        m_isRacingNetworkAgainstServiceWorkerImport = false;
+        m_serviceWorkerFetchTask = nullptr;
+        return;
+    }
 
     if (RefPtr serviceWorkerFetchTask = m_serviceWorkerFetchTask) {
         auto newRequest = serviceWorkerFetchTask->takeRequest();

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -167,6 +167,8 @@ public:
 
     void startWithServiceWorker();
     void serviceWorkerDidNotHandle(ServiceWorkerFetchTask*);
+    void cancelNetworkLoadIfServiceWorkerWonRace();
+    bool isRacingServiceWorkerAgainstNetwork() const { return m_isRacingNetworkAgainstServiceWorkerImport; }
     void setServiceWorkerRegistration(WebCore::SWServerRegistration& serviceWorkerRegistration) { m_serviceWorkerRegistration = serviceWorkerRegistration; }
     void NODELETE setWorkerStart(MonotonicTime);
 
@@ -289,6 +291,8 @@ private:
 
     void startRequest(const WebCore::ResourceRequest&);
     bool abortIfServiceWorkersOnly();
+    void serviceWorkerImportCompletedWhileRacingNetwork();
+    void cancelServiceWorkerFetchTaskIfNetworkWonRace();
 
     bool NODELETE shouldSendResourceLoadMessages() const;
 
@@ -343,6 +347,7 @@ private:
     RefPtr<ServiceWorkerFetchTask> m_serviceWorkerFetchTask;
     WeakPtr<WebCore::SWServerRegistration> m_serviceWorkerRegistration;
     std::optional<ServiceWorkerTimingInfo> m_serviceWorkerTimingInfo;
+    bool m_isRacingNetworkAgainstServiceWorkerImport { false };
 
     NetworkResourceLoadIdentifier m_resourceLoadID;
     WebCore::ResourceResponse m_redirectResponse;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -285,6 +285,8 @@ void ServiceWorkerFetchTask::processResponse(ResourceResponse&& response, bool n
         return;
 
     Ref loader = *m_loader;
+    loader->cancelNetworkLoadIfServiceWorkerWonRace();
+
 #if ENABLE(CONTENT_FILTERING)
     if (!loader->continueAfterServiceWorkerReceivedResponse(response))
         return;
@@ -385,7 +387,13 @@ void ServiceWorkerFetchTask::didFail(const ResourceError& error)
     cancelPreloadIfNecessary();
 
     SWFETCH_RELEASE_LOG_ERROR("didFail: (error.domain=%" PUBLIC_LOG_STRING ", error.code=%d)", error.domain().utf8().data(), error.errorCode());
-    protect(m_loader)->didFailLoading(error);
+    Ref loader = *m_loader;
+    if (loader->isRacingServiceWorkerAgainstNetwork()) {
+        SWFETCH_RELEASE_LOG("didFail: Racing against network, treating as didNotHandle");
+        loader->serviceWorkerDidNotHandle(this);
+        return;
+    }
+    loader->didFailLoading(error);
 }
 
 void ServiceWorkerFetchTask::didNotHandle()


### PR DESCRIPTION
#### e1bcca47a7161345540f88e57c940a56c00360cd
<pre>
Race network loads against service worker registration import
<a href="https://bugs.webkit.org/show_bug.cgi?id=313231">https://bugs.webkit.org/show_bug.cgi?id=313231</a>

Reviewed by NOBODY (OOPS!).

Some users have over a thousand service worker registrations persisted to
disk, for hundreds of origins. For those users, the first navigation in
WebKit may be delayed by ~10 seconds because navigations are blocked on
importing the service worker registrations from disk first.

To address this, instead of blocking resource loads until the import
completes, we now race the network load against the import:
  - Start the network load immediately, even if the import is pending.
  - If the import completes and a matching service worker is found, start
    a service worker fetch task alongside the already-running network load.
    Whichever responds first wins: if the service worker handles it, the
    network load is cancelled; if the network responds first, the service
    worker fetch task is cancelled; if the service worker calls didNotHandle
    or fails, the network load simply continues without restart.
  - If no service worker matches after import, the network load is already
    in progress and continues uninterrupted.
  - ServiceWorkersMode::Only loads still wait for import completion since
    they cannot fall back to network.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::abort):
(WebKit::NetworkResourceLoader::didReceiveResponse):
(WebKit::NetworkResourceLoader::didFailLoading):
(WebKit::NetworkResourceLoader::willSendRedirectedRequest):
(WebKit::NetworkResourceLoader::willSendServiceWorkerRedirectedRequest):
(WebKit::NetworkResourceLoader::startWithServiceWorker):
(WebKit::NetworkResourceLoader::serviceWorkerImportCompletedWhileRacingNetwork):
(WebKit::NetworkResourceLoader::cancelServiceWorkerFetchTaskIfNetworkWonRace):
(WebKit::NetworkResourceLoader::cancelNetworkLoadIfServiceWorkerWonRace):
(WebKit::NetworkResourceLoader::serviceWorkerDidNotHandle):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::processResponse):
(WebKit::ServiceWorkerFetchTask::didFail):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1bcca47a7161345540f88e57c940a56c00360cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167347 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112602 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40d51a9d-a9d8-43e2-9462-e5b49e847b98) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122780 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86159 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Passed layout tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49619178-1c28-4992-a59e-21b6ade7d48d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103450 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2d40b77-9fe5-4bf5-9074-d9ea33c77b2a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24096 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22488 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15118 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133783 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169837 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15582 "Found 2 new failures in NetworkProcess/NetworkResourceLoader.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130967 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131081 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141971 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89470 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25777 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18777 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31090 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97104 "Found 2 new failures in NetworkProcess/NetworkResourceLoader.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30610 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30883 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30764 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->