### PR TITLE
[:has() perf] Split AffectedByHasWithSiblingRelationship bit into forward and backward direction bits

### DIFF
--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1630,8 +1630,10 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
     auto forwardStyleRelation = [&](const Style::Relation& relation) {
         switch (relation.type) {
         case Style::Relation::ChildrenAffectedByForwardPositionalRules:
+            checkingContext.styleRelations.append(Style::Relation { *relation.element, Style::Relation::AffectedByHasWithForwardSiblingRelationship });
+            return;
         case Style::Relation::ChildrenAffectedByBackwardPositionalRules:
-            checkingContext.styleRelations.append(Style::Relation { *relation.element, Style::Relation::AffectedByHasWithSiblingRelationship });
+            checkingContext.styleRelations.append(Style::Relation { *relation.element, Style::Relation::AffectedByHasWithBackwardSiblingRelationship });
             return;
         case Style::Relation::ChildrenAffectedByFirstChildRules:
         case Style::Relation::ChildrenAffectedByLastChildRules:
@@ -1646,7 +1648,7 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
             return;
         case Style::Relation::DescendantsAffectedByPreviousSibling:
             if (CheckedPtr parent = relation.element->parentElement())
-                checkingContext.styleRelations.append(Style::Relation { *parent, Style::Relation::AffectedByHasWithSiblingRelationship });
+                checkingContext.styleRelations.append(Style::Relation { *parent, Style::Relation::AffectedByHasWithForwardSiblingRelationship });
             return;
         case Style::Relation::DescendantsAffectedByForwardPositionalRules:
         case Style::Relation::DescendantsAffectedByBackwardPositionalRules:
@@ -1654,7 +1656,8 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
         case Style::Relation::LastChild:
         case Style::Relation::NthChildIndex:
             return;
-        case Style::Relation::AffectedByHasWithSiblingRelationship:
+        case Style::Relation::AffectedByHasWithBackwardSiblingRelationship:
+        case Style::Relation::AffectedByHasWithForwardSiblingRelationship:
         case Style::Relation::AffectedByHasWithAdjacentSiblingRelationship:
             ASSERT_NOT_REACHED();
             return;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5818,7 +5818,8 @@ void Element::resetComputedStyle()
 void Element::resetStyleRelations()
 {
     clearStyleFlags(NodeStyleFlag::StyleAffectedByEmpty);
-    clearStyleFlags(NodeStyleFlag::AffectedByHasWithSiblingRelationship);
+    clearStyleFlags(NodeStyleFlag::AffectedByHasWithBackwardSiblingRelationship);
+    clearStyleFlags(NodeStyleFlag::AffectedByHasWithForwardSiblingRelationship);
     clearStyleFlags(NodeStyleFlag::AffectedByHasWithAdjacentSiblingRelationship);
     if (!hasRareData())
         return;

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -545,7 +545,8 @@ public:
     bool descendantsAffectedByBackwardPositionalRules() const { return hasStyleFlag(NodeStyleFlag::DescendantsAffectedByBackwardPositionalRules); }
     bool affectsNextSiblingElementStyle() const { return hasStyleFlag(NodeStyleFlag::AffectsNextSiblingElementStyle); }
     bool styleIsAffectedByPreviousSibling() const { return hasStyleFlag(NodeStyleFlag::StyleIsAffectedByPreviousSibling); }
-    bool affectedByHasWithSiblingRelationship() const { return hasStyleFlag(NodeStyleFlag::AffectedByHasWithSiblingRelationship); }
+    bool affectedByHasWithBackwardSiblingRelationship() const { return hasStyleFlag(NodeStyleFlag::AffectedByHasWithBackwardSiblingRelationship); }
+    bool affectedByHasWithForwardSiblingRelationship() const { return hasStyleFlag(NodeStyleFlag::AffectedByHasWithForwardSiblingRelationship); }
     bool affectedByHasWithAdjacentSiblingRelationship() const { return hasStyleFlag(NodeStyleFlag::AffectedByHasWithAdjacentSiblingRelationship); }
     unsigned childIndex() const { return hasRareData() ? rareDataChildIndex() : 0; }
 
@@ -561,7 +562,8 @@ public:
     void setDescendantsAffectedByBackwardPositionalRules() { setStyleFlag(NodeStyleFlag::DescendantsAffectedByBackwardPositionalRules); }
     void setAffectsNextSiblingElementStyle() { setStyleFlag(NodeStyleFlag::AffectsNextSiblingElementStyle); }
     void setStyleIsAffectedByPreviousSibling() { setStyleFlag(NodeStyleFlag::StyleIsAffectedByPreviousSibling); }
-    void setAffectedByHasWithSiblingRelationship() { setStyleFlag(NodeStyleFlag::AffectedByHasWithSiblingRelationship); }
+    void setAffectedByHasWithBackwardSiblingRelationship() { setStyleFlag(NodeStyleFlag::AffectedByHasWithBackwardSiblingRelationship); }
+    void setAffectedByHasWithForwardSiblingRelationship() { setStyleFlag(NodeStyleFlag::AffectedByHasWithForwardSiblingRelationship); }
     void setAffectedByHasWithAdjacentSiblingRelationship() { setStyleFlag(NodeStyleFlag::AffectedByHasWithAdjacentSiblingRelationship); }
     void setChildIndex(unsigned);
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -714,20 +714,21 @@ protected:
     static constexpr uint32_t s_refCountMask = ~static_cast<uint32_t>(1);
 
     enum class NodeStyleFlag : uint16_t {
-        AffectedByHasWithSiblingRelationship                    = 1 << 0,
-        ChildrenAffectedByFirstChildRules                       = 1 << 1,
-        ChildrenAffectedByLastChildRules                        = 1 << 2,
-        AffectsNextSiblingElementStyle                          = 1 << 3,
-        StyleIsAffectedByPreviousSibling                        = 1 << 4,
-        DescendantsAffectedByPreviousSibling                    = 1 << 5,
-        StyleAffectedByEmpty                                    = 1 << 6,
+        AffectedByHasWithBackwardSiblingRelationship            = 1 << 0,
+        AffectedByHasWithForwardSiblingRelationship             = 1 << 1,
+        ChildrenAffectedByFirstChildRules                       = 1 << 2,
+        ChildrenAffectedByLastChildRules                        = 1 << 3,
+        AffectsNextSiblingElementStyle                          = 1 << 4,
+        StyleIsAffectedByPreviousSibling                        = 1 << 5,
+        DescendantsAffectedByPreviousSibling                    = 1 << 6,
+        StyleAffectedByEmpty                                    = 1 << 7,
         // We optimize for :first-child and :last-child. The other positional child selectors like nth-child or
         // *-child-of-type, we will just give up and re-evaluate whenever children change at all.
-        ChildrenAffectedByForwardPositionalRules                = 1 << 7,
-        DescendantsAffectedByForwardPositionalRules             = 1 << 8,
-        ChildrenAffectedByBackwardPositionalRules               = 1 << 9,
-        DescendantsAffectedByBackwardPositionalRules            = 1 << 10,
-        AffectedByHasWithAdjacentSiblingRelationship            = 1 << 11,
+        ChildrenAffectedByForwardPositionalRules                = 1 << 8,
+        DescendantsAffectedByForwardPositionalRules             = 1 << 9,
+        ChildrenAffectedByBackwardPositionalRules               = 1 << 10,
+        DescendantsAffectedByBackwardPositionalRules            = 1 << 11,
+        AffectedByHasWithAdjacentSiblingRelationship            = 1 << 12,
     };
 
     struct StyleBitfields {
@@ -745,8 +746,8 @@ protected:
 
     private:
         uint16_t m_styleValidity : 3 { 0 };
-        uint16_t m_flags : 12 { 0 };
-        // 1 bit free.
+        uint16_t m_flags : 13 { 0 };
+        // 0 bits free.
     };
 
     StyleBitfields styleBitfields() const { return m_styleBitfields; }

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -168,6 +168,43 @@ void ChildChangeInvalidation::invalidateForChangeOutsideHasScope()
         Invalidator::invalidateWithScopeBreakingHasPseudoClassRuleSet(parentElement(), invalidationRuleSet.get());
 }
 
+void ChildChangeInvalidation::invalidateForHasSiblings(MatchingHasSelectors& matchingHasSelectors, MutationPhase phase)
+{
+    bool affectedByBackwardSibling = parentElement().affectedByHasWithBackwardSiblingRelationship();
+    bool affectedByForwardSibling = parentElement().affectedByHasWithForwardSiblingRelationship();
+    bool affectedByAdjacentSibling = parentElement().affectedByHasWithAdjacentSiblingRelationship();
+
+    auto invalidateSibling = [&](auto& changedElement) {
+        invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::Sibling);
+    };
+    if (affectedByBackwardSibling || affectedByAdjacentSibling) {
+        for (RefPtr child = m_childChange.previousSiblingElement; child; child = child->previousElementSibling()) {
+            invalidateSibling(*child);
+            if (!affectedByBackwardSibling)
+                break;
+        }
+    }
+    if (affectedByForwardSibling || affectedByAdjacentSibling) {
+        for (RefPtr child = m_childChange.nextSiblingElement; child; child = child->nextElementSibling()) {
+            invalidateSibling(*child);
+            if (!affectedByForwardSibling)
+                break;
+        }
+    }
+
+    // For insertion, the pre-mutation :first/:last-child state of the neighbor will stop matching.
+    // For removal, the post-mutation state of the neighbor will start matching.
+    bool checkNow = phase == MutationPhase::Before ? m_childChange.isInsertion() : !m_childChange.isInsertion();
+    if (!checkNow)
+        return;
+
+    if (RefPtr next = m_childChange.nextSiblingElement; next && parentElement().childrenAffectedByFirstChildRules() && !next->previousElementSibling())
+        invalidateForChangedElement(*next, matchingHasSelectors, ChangedElementRelation::Sibling);
+
+    if (RefPtr previous = m_childChange.previousSiblingElement; previous && parentElement().childrenAffectedByLastChildRules() && !previous->nextElementSibling())
+        invalidateForChangedElement(*previous, matchingHasSelectors, ChangedElementRelation::Sibling);
+}
+
 void ChildChangeInvalidation::invalidateForHasBeforeMutation()
 {
     ASSERT(m_needsHasInvalidation);
@@ -189,48 +226,7 @@ void ChildChangeInvalidation::invalidateForHasBeforeMutation()
     if (emptyStateWillChange())
         invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant, EmptyInvalidation::Yes);
 
-    auto firstChildStateWillStopMatching = [&] {
-        if (!m_childChange.nextSiblingElement)
-            return false;
-
-        if (!parentElement().childrenAffectedByFirstChildRules())
-            return false;
-
-        if (m_childChange.isInsertion() && !m_childChange.nextSiblingElement->previousElementSibling())
-            return true;
-
-        return false;
-    };
-
-    auto lastChildStateWillStopMatching = [&] {
-        if (!m_childChange.previousSiblingElement)
-            return false;
-
-        if (!parentElement().childrenAffectedByLastChildRules())
-            return false;
-
-        if (m_childChange.isInsertion() && !m_childChange.previousSiblingElement->nextElementSibling())
-            return true;
-
-        return false;
-    };
-
-    if (parentElement().affectedByHasWithSiblingRelationship()) {
-        traverseRemainingExistingSiblings([&](auto& changedElement) {
-            invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::Sibling);
-        });
-    } else if (parentElement().affectedByHasWithAdjacentSiblingRelationship()) {
-        if (m_childChange.previousSiblingElement)
-            invalidateForChangedElement(*m_childChange.previousSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
-        if (m_childChange.nextSiblingElement)
-            invalidateForChangedElement(*m_childChange.nextSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
-    } else {
-        if (firstChildStateWillStopMatching())
-            invalidateForChangedElement(*m_childChange.nextSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
-
-        if (lastChildStateWillStopMatching())
-            invalidateForChangedElement(*m_childChange.previousSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
-    }
+    invalidateForHasSiblings(matchingHasSelectors, MutationPhase::Before);
 }
 
 void ChildChangeInvalidation::invalidateForHasAfterMutation()
@@ -254,48 +250,7 @@ void ChildChangeInvalidation::invalidateForHasAfterMutation()
     if (emptyStateDidChange())
         invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant, EmptyInvalidation::Yes);
 
-    auto firstChildStateWillStartMatching = [&](Element* elementAfterChange) {
-        if (!elementAfterChange)
-            return false;
-
-        if (!parentElement().childrenAffectedByFirstChildRules())
-            return false;
-
-        if (!m_childChange.isInsertion() && !elementAfterChange->previousElementSibling())
-            return true;
-
-        return false;
-    };
-
-    auto lastChildStateWillStartMatching = [&](Element* elementBeforeChange) {
-        if (!elementBeforeChange)
-            return false;
-
-        if (!parentElement().childrenAffectedByLastChildRules())
-            return false;
-
-        if (!m_childChange.isInsertion() && !elementBeforeChange->nextElementSibling())
-            return true;
-
-        return false;
-    };
-
-    if (parentElement().affectedByHasWithSiblingRelationship()) {
-        traverseRemainingExistingSiblings([&](auto& changedElement) {
-            invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::Sibling);
-        });
-    } else if (parentElement().affectedByHasWithAdjacentSiblingRelationship()) {
-        if (m_childChange.previousSiblingElement)
-            invalidateForChangedElement(*m_childChange.previousSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
-        if (m_childChange.nextSiblingElement)
-            invalidateForChangedElement(*m_childChange.nextSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
-    } else {
-        if (firstChildStateWillStartMatching(m_childChange.nextSiblingElement))
-            invalidateForChangedElement(*m_childChange.nextSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
-
-        if (lastChildStateWillStartMatching(m_childChange.previousSiblingElement))
-            invalidateForChangedElement(*m_childChange.previousSiblingElement, matchingHasSelectors, ChangedElementRelation::Sibling);
-    }
+    invalidateForHasSiblings(matchingHasSelectors, MutationPhase::After);
 }
 
 static bool NODELETE needsDescendantTraversal(const RuleFeatureSet& features)
@@ -353,19 +308,6 @@ void ChildChangeInvalidation::traverseAddedElements(Function&& function)
                 callFunctionOnInclusiveDescendants(*element);
         }
     }
-}
-
-template<typename Function>
-void ChildChangeInvalidation::traverseRemainingExistingSiblings(Function&& function)
-{
-    if (m_childChange.isInsertion() && m_childChange.type == ContainerNode::ChildChange::Type::AllChildrenReplaced)
-        return;
-
-    for (RefPtr child = m_childChange.previousSiblingElement; child; child = child->previousElementSibling())
-        function(*child);
-
-    for (RefPtr child = m_childChange.nextSiblingElement; child; child = child->nextElementSibling())
-        function(*child);
 }
 
 static void checkForEmptyStyleChange(Element& element)

--- a/Source/WebCore/style/ChildChangeInvalidation.h
+++ b/Source/WebCore/style/ChildChangeInvalidation.h
@@ -48,12 +48,13 @@ private:
     using MatchingHasSelectors = HashSet<const CSSSelector*>;
     enum class ChangedElementRelation : uint8_t { SelfOrDescendant, Sibling };
     enum class EmptyInvalidation : bool { No, Yes };
+    enum class MutationPhase : bool { Before, After };
     void invalidateForChangedElement(Element&, MatchingHasSelectors&, ChangedElementRelation, EmptyInvalidation = EmptyInvalidation::No);
+    void invalidateForHasSiblings(MatchingHasSelectors&, MutationPhase);
     void invalidateForChangeOutsideHasScope();
 
     template<typename Function> void traverseRemovedElements(Function&&);
     template<typename Function> void traverseAddedElements(Function&&);
-    template<typename Function> void traverseRemainingExistingSiblings(Function&&);
 
     Element& parentElement() { return *m_parentElement; }
 

--- a/Source/WebCore/style/StyleRelations.cpp
+++ b/Source/WebCore/style/StyleRelations.cpp
@@ -72,7 +72,8 @@ std::unique_ptr<Relations> commitRelationsToRenderStyle(RenderStyle& style, cons
         case Relation::ChildrenAffectedByFirstChildRules:
         case Relation::ChildrenAffectedByLastChildRules:
         case Relation::NthChildIndex:
-        case Relation::AffectedByHasWithSiblingRelationship:
+        case Relation::AffectedByHasWithBackwardSiblingRelationship:
+        case Relation::AffectedByHasWithForwardSiblingRelationship:
         case Relation::AffectedByHasWithAdjacentSiblingRelationship:
             appendStyleRelation(relation);
             break;
@@ -121,8 +122,11 @@ void commitRelations(std::unique_ptr<Relations> relations, Update& update)
         case Relation::ChildrenAffectedByLastChildRules:
             element.setChildrenAffectedByLastChildRules();
             break;
-        case Relation::AffectedByHasWithSiblingRelationship:
-            element.setAffectedByHasWithSiblingRelationship();
+        case Relation::AffectedByHasWithBackwardSiblingRelationship:
+            element.setAffectedByHasWithBackwardSiblingRelationship();
+            break;
+        case Relation::AffectedByHasWithForwardSiblingRelationship:
+            element.setAffectedByHasWithForwardSiblingRelationship();
             break;
         case Relation::AffectedByHasWithAdjacentSiblingRelationship:
             element.setAffectedByHasWithAdjacentSiblingRelationship();

--- a/Source/WebCore/style/StyleRelations.h
+++ b/Source/WebCore/style/StyleRelations.h
@@ -52,7 +52,8 @@ struct Relation {
         FirstChild,
         LastChild,
         NthChildIndex,
-        AffectedByHasWithSiblingRelationship,
+        AffectedByHasWithBackwardSiblingRelationship,
+        AffectedByHasWithForwardSiblingRelationship,
         AffectedByHasWithAdjacentSiblingRelationship,
     };
     const Element* element;


### PR DESCRIPTION
#### cb0399799e0723a1aba1802cb674c58e1379cc9a
<pre>
[:has() perf] Split AffectedByHasWithSiblingRelationship bit into forward and backward direction bits
<a href="https://bugs.webkit.org/show_bug.cgi?id=313235">https://bugs.webkit.org/show_bug.cgi?id=313235</a>
<a href="https://rdar.apple.com/175514604">rdar://175514604</a>

Reviewed by Alan Baradlay.

This reduces invalidation traversal with sibling combinators and nth-child pseudo classes in :has().
In the common case of appending children to the end it will typically be avoided completely.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchHasPseudoClass const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resetStyleRelations):
* Source/WebCore/dom/Element.h:
(WebCore::Element::affectedByHasWithBackwardSiblingRelationship const):
(WebCore::Element::affectedByHasWithForwardSiblingRelationship const):
(WebCore::Element::setAffectedByHasWithBackwardSiblingRelationship):
(WebCore::Element::setAffectedByHasWithForwardSiblingRelationship):
(WebCore::Element::affectedByHasWithSiblingRelationship const): Deleted.
(WebCore::Element::setAffectedByHasWithSiblingRelationship): Deleted.
* Source/WebCore/dom/Node.h:

Split the bit.

* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForHasSiblings):

Factor into a function.
Do a forward or a backward traversal based on the direction bit.

(WebCore::Style::ChildChangeInvalidation::invalidateForHasBeforeMutation):
(WebCore::Style::ChildChangeInvalidation::invalidateForHasAfterMutation):
(WebCore::Style::ChildChangeInvalidation::traverseRemainingExistingSiblings): Deleted.
* Source/WebCore/style/ChildChangeInvalidation.h:
* Source/WebCore/style/StyleRelations.cpp:
(WebCore::Style::commitRelationsToRenderStyle):
(WebCore::Style::commitRelations):
* Source/WebCore/style/StyleRelations.h:

Canonical link: <a href="https://commits.webkit.org/311957@main">https://commits.webkit.org/311957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a003d6589ea21db8f8b00837c3dedb280a9d8a5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167358 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160398 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31941 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25051 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103462 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15129 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169848 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15593 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21815 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130979 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31644 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131093 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35475 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141983 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89488 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25790 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18789 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31101 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97115 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30621 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30894 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30775 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->