### PR TITLE
AX: All WebAccessibilityObjectWrappers should support AXIndexForTextMarker, AXTextMarkerForIndex, and AXTextMarkerIsValid

### DIFF
--- a/LayoutTests/accessibility/mac/bounds-for-range-expected.txt
+++ b/LayoutTests/accessibility/mac/bounds-for-range-expected.txt
@@ -71,6 +71,9 @@ AXLineTextMarkerRangeForTextMarker
 AXSelectTextWithCriteria
 AXSearchTextWithCriteria
 AXTextOperation
+AXTextMarkerForIndex
+AXTextMarkerIsValid
+AXIndexForTextMarker
 AXIntersectTextMarkerRanges
 
 ----------------------

--- a/LayoutTests/accessibility/mac/index-for-text-marker-on-non-webarea-element-expected.txt
+++ b/LayoutTests/accessibility/mac/index-for-text-marker-on-non-webarea-element-expected.txt
@@ -1,0 +1,14 @@
+This test ensures that non-WebArea elements advertise and support AXIndexForTextMarker, AXTextMarkerForIndex, and AXTextMarkerIsValid parameterized attributes.
+
+PASS: pParamAttrs.includes('AXIndexForTextMarker') === true
+PASS: pParamAttrs.includes('AXTextMarkerForIndex') === true
+PASS: pParamAttrs.includes('AXTextMarkerIsValid') === true
+PASS: webAreaParamAttrs.includes('AXIndexForTextMarker') === true
+PASS: webAreaParamAttrs.includes('AXTextMarkerForIndex') === true
+PASS: webAreaParamAttrs.includes('AXTextMarkerIsValid') === true
+PASS: pElement.indexForTextMarker(startMarker) >= 0 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello

--- a/LayoutTests/accessibility/mac/index-for-text-marker-on-non-webarea-element.html
+++ b/LayoutTests/accessibility/mac/index-for-text-marker-on-non-webarea-element.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="p">Hello</p>
+
+<script>
+output = "This test ensures that non-WebArea elements advertise and support AXIndexForTextMarker, AXTextMarkerForIndex, and AXTextMarkerIsValid parameterized attributes.\n\n";
+
+if (window.accessibilityController) {
+    webArea = accessibilityController.rootElement.childAtIndex(0);
+    pElement = accessibilityController.accessibleElementById("p");
+
+    // The p element is not a WebArea — it should still support index-for-marker attributes.
+    pParamAttrs = pElement.parameterizedAttributeNames();
+    output += expect("pParamAttrs.includes('AXIndexForTextMarker')", "true");
+    output += expect("pParamAttrs.includes('AXTextMarkerForIndex')", "true");
+    output += expect("pParamAttrs.includes('AXTextMarkerIsValid')", "true");
+
+    // Verify the WebArea also still supports them.
+    webAreaParamAttrs = webArea.parameterizedAttributeNames();
+    output += expect("webAreaParamAttrs.includes('AXIndexForTextMarker')", "true");
+    output += expect("webAreaParamAttrs.includes('AXTextMarkerForIndex')", "true");
+    output += expect("webAreaParamAttrs.includes('AXTextMarkerIsValid')", "true");
+
+    // Verify the attribute works: ask the p element for the index of its start marker.
+    range = pElement.textMarkerRangeForElement(pElement);
+    startMarker = pElement.startTextMarkerForTextMarkerRange(range);
+    output += expect("pElement.indexForTextMarker(startMarker) >= 0", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/menu-parameterized-attributes-expected.txt
+++ b/LayoutTests/accessibility/mac/menu-parameterized-attributes-expected.txt
@@ -39,6 +39,9 @@ AXLineTextMarkerRangeForTextMarker
 AXSelectTextWithCriteria
 AXSearchTextWithCriteria
 AXTextOperation
+AXTextMarkerForIndex
+AXTextMarkerIsValid
+AXIndexForTextMarker
 
 
 #menuitem supported paramterized attributes:
@@ -80,6 +83,9 @@ AXLineTextMarkerRangeForTextMarker
 AXSelectTextWithCriteria
 AXSearchTextWithCriteria
 AXTextOperation
+AXTextMarkerForIndex
+AXTextMarkerIsValid
+AXIndexForTextMarker
 
 
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2897,7 +2897,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         NSAccessibilityLineTextMarkerRangeForTextMarkerAttribute,
         NSAccessibilitySelectTextWithCriteriaParameterizedAttribute,
         NSAccessibilitySearchTextWithCriteriaParameterizedAttribute,
-        NSAccessibilityTextOperationParameterizedAttribute
+        NSAccessibilityTextOperationParameterizedAttribute,
+        NSAccessibilityTextMarkerForIndexAttribute,
+        NSAccessibilityTextMarkerIsValidAttribute,
+        NSAccessibilityIndexForTextMarkerAttribute
     ];
 
     static NeverDestroyed textParamAttrs = [] {
@@ -2924,13 +2927,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         [tempArray addObject:NSAccessibilityCellForColumnAndRowParameterizedAttribute];
         return tempArray;
     }();
-    static NeverDestroyed webAreaParamAttrs = [] {
-        auto tempArray = adoptNS([[NSMutableArray alloc] initWithArray:paramAttrs.get().get()]);
-        [tempArray addObject:NSAccessibilityTextMarkerForIndexAttribute];
-        [tempArray addObject:NSAccessibilityTextMarkerIsValidAttribute];
-        [tempArray addObject:NSAccessibilityIndexForTextMarkerAttribute];
-        return tempArray;
-    }();
     static NeverDestroyed secureFieldParamAttrs = [] {
         auto tempArray = adoptNS([[NSMutableArray alloc] init]);
         [tempArray addObject:NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute];
@@ -2950,9 +2946,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
     if (backingObject->isExposableTable())
         return tableParamAttrs.get().get();
-
-    if (backingObject->isWebArea())
-        return webAreaParamAttrs.get().get();
 
     if (backingObject->isStaticText())
         return staticTextParamAttrs.get().get();


### PR DESCRIPTION
#### 531a11acbe1b4e901bfde211a7f92d1a912674ea
<pre>
AX: All WebAccessibilityObjectWrappers should support AXIndexForTextMarker, AXTextMarkerForIndex, and AXTextMarkerIsValid
<a href="https://bugs.webkit.org/show_bug.cgi?id=313237">https://bugs.webkit.org/show_bug.cgi?id=313237</a>
&lt;<a href="https://rdar.apple.com/problem/175516847">rdar://problem/175516847</a>&gt;

Reviewed by Tyler Wilcock.

AXIndexForTextMarker, AXTextMarkerForIndex, and AXTextMarkerIsValid were
only advertised as supported parameterized attributes on WebArea elements.
Other elements (e.g., a &lt;br&gt; node with role AXUnknown inside a
contenteditable) did not include these attributes in their
accessibilityParameterizedAttributeNames list, even though the handlers
exist and work for any element.

This caused VoiceOver&apos;s braille cursor to fail in Mail compose: the braille
line navigator obtains a line range whose text markers are owned by an inner
element (the &lt;br&gt;), and later toIndexBased asks that element to resolve the
marker to an index. Because the element didn&apos;t advertise AXIndexForTextMarker,
the resolution returned NSNotFound, producing no selection and no blinking
cursor on the braille display.

Fix: move the three attributes into the base paramAttrs array so all WebKit
accessibility elements advertise them. Remove the now-redundant webAreaParamAttrs
and the isWebArea() special case.

Test: LayoutTests/accessibility/mac/index-for-text-marker-on-non-webarea-element.html

Test: accessibility/mac/index-for-text-marker-on-non-webarea-element.html
* LayoutTests/accessibility/mac/bounds-for-range-expected.txt:
* LayoutTests/accessibility/mac/index-for-text-marker-on-non-webarea-element-expected.txt: Added.
* LayoutTests/accessibility/mac/index-for-text-marker-on-non-webarea-element.html: Added.
* LayoutTests/accessibility/mac/menu-parameterized-attributes-expected.txt:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityParameterizedAttributeNames]):

Canonical link: <a href="https://commits.webkit.org/311991@main">https://commits.webkit.org/311991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5acc3be976b98f12e67ba23a8f7fa3ba939d2d47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167359 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112614 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea942881-de6b-4996-be4b-5894a5c577e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122790 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86166 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6917a343-5a52-4dd0-962a-0fba6ec60aea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142411 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103460 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85e57458-f8f9-4672-aefe-0e81697b0042) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24106 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22498 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15130 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169849 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15594 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21816 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130976 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131090 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35497 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141984 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89491 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25786 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18790 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31102 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97116 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30622 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30776 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->