### PR TITLE
[macOS] Limit some sandbox read accesses to internal builds

### DIFF
--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -473,20 +473,22 @@
     "com.apple.security.revocation")
 
 (allow file-read*
-       (subpath "/private/var/db/mds")
+   (subpath "/private/var/db/mds"))
 
-       ; The following are needed until the causes of <rdar://problem/41487786> are resolved.
-       (literal "/Library/Preferences/com.apple.security.plist")
-       (home-literal "/Library/Preferences/com.apple.security.plist")
+; The following are needed until the causes of <rdar://problem/41487786> are resolved.
+(allow file-read*
+    (literal "/Library/Preferences/com.apple.security.plist")
+    (home-literal "/Library/Preferences/com.apple.security.plist"))
 
-       ; Likewise for <rdar://problem/43310000>
-       (literal "/Library/Preferences/com.apple.ist.ds.appleconnect2.plist")
-       (literal "/Library/Preferences/com.apple.ist.ds.appleconnect2.production.plist")
-       (home-literal "/Library/Preferences/com.apple.ist.ds.appleconnect2.plist")
-       (home-literal "/Library/Preferences/com.apple.ist.ds.appleconnect2.production.plist")
-       (home-regex (string-append "/Library/Preferences/ByHost/com\.apple\.ist\.ds\.appleconnect2\." (uuid-regex-string) "\.plist$"))
-       (home-regex (string-append "/Library/Preferences/ByHost/com\.apple\.ist\.ds\.appleconnect2\.production\." (uuid-regex-string) "\.plist$"))
-)
+; Likewise for <rdar://problem/43310000>
+(with-filter (system-attribute apple-internal)
+    (allow file-read*
+        (literal "/Library/Preferences/com.apple.ist.ds.appleconnect2.plist")
+        (literal "/Library/Preferences/com.apple.ist.ds.appleconnect2.production.plist")
+        (home-literal "/Library/Preferences/com.apple.ist.ds.appleconnect2.plist")
+        (home-literal "/Library/Preferences/com.apple.ist.ds.appleconnect2.production.plist")
+        (home-regex (string-append "/Library/Preferences/ByHost/com\.apple\.ist\.ds\.appleconnect2\." (uuid-regex-string) "\.plist$"))
+        (home-regex (string-append "/Library/Preferences/ByHost/com\.apple\.ist\.ds\.appleconnect2\.production\." (uuid-regex-string) "\.plist$"))))
 
 (allow ipc-posix-shm-read* ipc-posix-shm-write-create ipc-posix-shm-write-data
        (ipc-posix-name "com.apple.AppleDatabaseChanged"))


### PR DESCRIPTION
#### b02f885f1da2da4dec369af255f0b562e8ef132f
<pre>
[macOS] Limit some sandbox read accesses to internal builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=313244">https://bugs.webkit.org/show_bug.cgi?id=313244</a>
<a href="https://rdar.apple.com/175523373">rdar://175523373</a>

Reviewed by Brent Fulgham.

* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/312088@main">https://commits.webkit.org/312088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dd53417e83d5a185799574397ff1f07b3cf1e76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112626 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16f60c0d-265e-467e-93be-ff339a78ac18) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122803 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86176 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/412189dc-70c6-410d-b4eb-5add1b40e06b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103473 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26eea2f2-2ede-41c6-8308-cb254f3e312b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24117 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22511 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15142 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133804 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169861 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15606 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130991 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131105 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141993 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89509 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24168 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25806 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18801 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31114 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97128 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30634 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30907 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30788 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->