### PR TITLE
Avoid blocking resource loads on service worker registration import for origins without service workers

### DIFF
--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -83,7 +83,7 @@ static constexpr std::array<ASCIILiteral, 4> swRegistrationUpdatesV2 {
 
 static constexpr int currentSWRegistrationVersion = 2;
 
-static String databaseFilePath(const String& directory)
+String SWRegistrationDatabase::databaseFilePath(const String& directory)
 {
     if (directory.isEmpty())
         return emptyString();

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
@@ -45,7 +45,9 @@ public:
 
     WEBCORE_EXPORT SWRegistrationDatabase(const String& path);
     WEBCORE_EXPORT ~SWRegistrationDatabase();
-    
+
+    WEBCORE_EXPORT static String databaseFilePath(const String& directory);
+
     WEBCORE_EXPORT std::optional<Vector<ServiceWorkerContextData>> importRegistrations();
     WEBCORE_EXPORT std::optional<Vector<ServiceWorkerScripts>> updateRegistrations(const Vector<ServiceWorkerContextData>&, const Vector<ServiceWorkerRegistrationKey>&);
     WEBCORE_EXPORT std::optional<ServiceWorkerScripts> retrieveWorkerScripts(ServiceWorkerIdentifier, const ServiceWorkerRegistrationKey&, const URL& mainScriptURL, const Vector<URL>& importedScriptURLs);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -595,13 +595,31 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
 
     if (CheckedPtr session = networkSession()) {
         if (Ref server = session->ensureSWServer(); !server->isImportCompleted()) {
-            server->whenImportIsCompleted([this, protectedThis = Ref { *this }, loadParameters = WTF::move(loadParameters), existingLoaderToResume]() mutable {
+            auto topOrigin = loadParameters.isMainFrameNavigation
+                ? WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(loadParameters.request.url())
+                : loadParameters.topOrigin ? loadParameters.topOrigin->data() : WebCore::SecurityOriginData { };
+            auto clientOrigin = WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(loadParameters.request.url());
+            // Fast path: quickly check on a concurrent work queue whether a service worker database
+            // exists for this origin, to avoid blocking the load on the full registration import when
+            // the origin has no service workers.
+            CONNECTION_RELEASE_LOG(ServiceWorker, "scheduleResourceLoad: SW registration import not complete, checking if origin has a service worker database");
+            auto startTime = MonotonicTime::now();
+            session->storageManager().hasServiceWorkerRegistrationForOrigin(WebCore::ClientOrigin { WTF::move(topOrigin), WTF::move(clientOrigin) }, [this, protectedThis = Ref { *this }, loadParameters = WTF::move(loadParameters), existingLoaderToResume, startTime](bool hasRegistration) mutable {
+                CONNECTION_RELEASE_LOG(ServiceWorker, "scheduleResourceLoad: hasServiceWorkerRegistrationForOrigin completed in %.0f ms, hasRegistration=%d", (MonotonicTime::now() - startTime).milliseconds(), hasRegistration);
                 if (!m_networkProcess->webProcessConnection(webProcessIdentifier()))
                     return;
 
-                ASSERT(networkSession());
-                ASSERT(networkSession()->swServer());
-                ASSERT(networkSession()->swServer()->isImportCompleted());
+                CheckedPtr session = networkSession();
+                if (hasRegistration && session) {
+                    if (Ref server = session->ensureSWServer(); !server->isImportCompleted()) {
+                        server->whenImportIsCompleted([this, protectedThis = WTF::move(protectedThis), loadParameters = WTF::move(loadParameters), existingLoaderToResume]() mutable {
+                            if (!m_networkProcess->webProcessConnection(webProcessIdentifier()))
+                                return;
+                            scheduleResourceLoad(WTF::move(loadParameters), existingLoaderToResume);
+                        });
+                        return;
+                    }
+                }
                 scheduleResourceLoad(WTF::move(loadParameters), existingLoaderToResume);
             });
             return;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -54,6 +54,7 @@
 #include "WebsiteDataType.h"
 #include <WebCore/DOMCacheEngine.h>
 #include <WebCore/IDBRequestData.h>
+#include <WebCore/SWRegistrationDatabase.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/ServiceWorkerContextData.h>
 #include <WebCore/StorageBlockingPolicy.h>
@@ -66,6 +67,7 @@
 #include <ranges>
 #include <wtf/SuspendableWorkQueue.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/WorkQueue.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
 
@@ -2231,6 +2233,30 @@ void NetworkStorageManager::clearServiceWorkerRegistrations(CompletionHandler<vo
 
         RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler();
+        });
+    });
+}
+
+void NetworkStorageManager::hasServiceWorkerRegistrationForOrigin(const WebCore::ClientOrigin& origin, CompletionHandler<void(bool)>&& completionHandler)
+{
+    ASSERT(RunLoop::isMain());
+
+    if (m_closed || m_unifiedOriginStorageLevel < UnifiedOriginStorageLevel::Standard)
+        return completionHandler(true); // Conservative fallback.
+
+    auto originPath = originDirectoryPath(m_path, origin, m_salt);
+    if (originPath.isEmpty())
+        return completionHandler(true); // Conservative fallback.
+
+    // Use a dedicated concurrent work queue rather than the NetworkStorageManager's serial work
+    // queue, because the serial queue may be blocked by the ongoing full registration import —
+    // which is exactly what we are trying to avoid waiting on.
+    static NeverDestroyed<Ref<ConcurrentWorkQueue>> fileCheckQueue = ConcurrentWorkQueue::create("com.apple.WebKit.SWOriginCheck"_s, WorkQueue::QOS::UserInteractive);
+    auto swDatabasePath = WebCore::SWRegistrationDatabase::databaseFilePath(FileSystem::pathByAppendingComponent(originPath, OriginStorageManager::serviceWorkerStorageIdentifier()));
+    fileCheckQueue.get()->dispatch([swDatabasePath = crossThreadCopy(WTF::move(swDatabasePath)), completionHandler = WTF::move(completionHandler)]() mutable {
+        bool hasRegistration = FileSystem::fileExists(swDatabasePath);
+        RunLoop::mainSingleton().dispatch([hasRegistration, completionHandler = WTF::move(completionHandler)]() mutable {
+            completionHandler(hasRegistration);
         });
     });
 }

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -152,6 +152,7 @@ public:
     void closeServiceWorkerRegistrationFiles(CompletionHandler<void()>&&);
     void clearServiceWorkerRegistrations(CompletionHandler<void()>&&);
     void importServiceWorkerRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&&);
+    void hasServiceWorkerRegistrationForOrigin(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&);
     void updateServiceWorkerRegistrations(Vector<WebCore::ServiceWorkerContextData>&&, Vector<WebCore::ServiceWorkerRegistrationKey>&&, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerScripts>>)>&&);
     void retrieveServiceWorkerScripts(WebCore::ServiceWorkerIdentifier, const WebCore::ServiceWorkerRegistrationKey&, const URL& mainScriptURL, Vector<URL>&& importedScriptURLs, CompletionHandler<void(std::optional<WebCore::ServiceWorkerScripts>&&)>&&);
     const String& path() const LIFETIME_BOUND { return m_pathNormalizedMainThread; }

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -196,7 +196,7 @@ String OriginStorageManager::StorageBucket::toStorageIdentifier(StorageType type
     case StorageType::BackgroundFetchStorage:
         return "BackgroundFetchStorage"_s;
     case StorageType::ServiceWorkerStorage:
-        return "ServiceWorkers"_s;
+        return serviceWorkerStorageIdentifier();
     default:
         break;
     }
@@ -623,6 +623,11 @@ void OriginStorageManager::StorageBucket::closeCacheStorageManager()
 String OriginStorageManager::originFileIdentifier()
 {
     return originFileName;
+}
+
+ASCIILiteral OriginStorageManager::serviceWorkerStorageIdentifier()
+{
+    return "ServiceWorkers"_s;
 }
 
 Ref<OriginQuotaManager> OriginStorageManager::createQuotaManager(OriginQuotaManager::Parameters&& parameters)

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -62,6 +62,7 @@ class OriginStorageManager final : public CanMakeWeakPtr<OriginStorageManager>, 
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(OriginStorageManager);
 public:
     static String originFileIdentifier();
+    static ASCIILiteral serviceWorkerStorageIdentifier();
 
     OriginStorageManager(OriginQuotaManager::Parameters&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel);
     ~OriginStorageManager();


### PR DESCRIPTION
#### cc86a23e19d9a2d81820d607fd8cad0d7cf03413
<pre>
Avoid blocking resource loads on service worker registration import for origins without service workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=313246">https://bugs.webkit.org/show_bug.cgi?id=313246</a>
<a href="https://rdar.apple.com/175432466">rdar://175432466</a>

Reviewed by NOBODY (OOPS!).

Previously, NetworkConnectionToWebProcess::scheduleResourceLoad() would block ALL resource
loads until the full service worker registration import completed. For users with 1000+
registrations across hundreds of origins, this could delay the first navigation by ~10 seconds,
even when navigating to an origin that has no service workers at all.

To address this, when the SW registration import is not yet complete, we now dispatch a fast
file-existence check on a dedicated concurrent UserInteractive-QoS work queue to determine
whether the origin actually has a service worker database on disk. If no database file exists,
the load proceeds immediately without waiting for the full import. If a database does exist,
we fall back to the previous behavior of waiting for the import to complete.

This optimization only applies to the modern per-origin storage path
(UnifiedOriginStorageLevel::Standard). The legacy shared-database path conservatively falls
back to waiting for the full import.

* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp:
(WebCore::SWRegistrationDatabase::databaseFilePath):
(WebCore::databaseFilePath): Deleted.
* Source/WebCore/workers/service/server/SWRegistrationDatabase.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::hasServiceWorkerRegistrationForOrigin):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::toStorageIdentifier const):
(WebKit::OriginStorageManager::serviceWorkerStorageIdentifier):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc86a23e19d9a2d81820d607fd8cad0d7cf03413

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167375 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112630 "Hash cc86a23e for PR 63533 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/122e23a4-3f53-43e6-840d-c3c321086261) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122807 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/112630 "Hash cc86a23e for PR 63533 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a5a8585-8716-4329-966e-e4f11fe62a61) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103477 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7dd6a37-b141-40f3-b2e2-cbe5494f3ddc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24121 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22513 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15146 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169865 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15610 "Found 1 new failure in NetworkProcess/storage/NetworkStorageManager.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130990 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131104 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142003 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89513 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25802 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18811 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31118 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97132 "Found 1 new failure in NetworkProcess/storage/NetworkStorageManager.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30638 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30911 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30792 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->