### PR TITLE
[JSC] `new DataView(buffer, byteOffset, byteLength)` should compliant the step 9-b of `25.3.2.1 DataView` abstract operation in the spec

### DIFF
--- a/JSTests/stress/dataview-constructor-bug-313230-weird-bytelength-detach-buffer-and-overrun.js
+++ b/JSTests/stress/dataview-constructor-bug-313230-weird-bytelength-detach-buffer-and-overrun.js
@@ -1,0 +1,66 @@
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const TEST_TARGET = [
+    DataView,
+];
+
+for (const targetCtor of TEST_TARGET) {
+    const name = targetCtor.name;
+
+    const buffer = new ArrayBuffer(4096);
+    const byteOffset = 2048;
+    const actualByteLength = 2048 + 1;
+    // https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength
+    assert((byteOffset + actualByteLength ) > buffer.byteLength, `25.3.2.1, step 9-b's condition not satisfied`);
+
+    const byteLength = {
+        valueOf: function () {
+            $.detachArrayBuffer(buffer);
+            $.gc();
+            return actualByteLength;
+        }
+    };
+
+    // By the spec (April 24, 2026),
+    // https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength defines:
+    //
+    //  1. The step 3 get _offset_ by ToIndex(byteOffset).
+    //      - We fix that in bug 311903 if the byteOffset is weird and this steps detachs the buffer.
+    //  2. Check IsDetachedBuffer(buffer), but ok.
+    //  3. The step 9-a get _viewByteLength_ by ToIndex(byteLength).
+    //      - This detach the buffer.
+    //  4. The step 9-b check whether `offset + viewByteLength > bufferByteLength` and throw RangeError.
+    shouldThrow(`${name}: should throw as the expected`, () => {
+        new targetCtor(buffer, byteOffset, byteLength);
+    }, RangeError, 'Length out of range of buffer');
+    sameValue(buffer.detached, true, `${name}: arrayBuffer is detached as expectedly`);
+
+    // The detached ArrayBuffer.byteLength should be set to 0.
+    //
+    //  - https://tc39.es/ecma262/#sec-detacharraybuffer
+    //  - https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength
+    sameValue(buffer.byteLength, 0, `${name}: arrayBuffer.byteLength is 0`);
+}

--- a/JSTests/stress/dataview-constructor-toindex-byteoffset-before-ordinarycreatefromctor-weird-byteoffset.js
+++ b/JSTests/stress/dataview-constructor-toindex-byteoffset-before-ordinarycreatefromctor-weird-byteoffset.js
@@ -1,0 +1,50 @@
+// The original is https://github.com/tc39/test262/blob/d0c1b4555b03dd404873fd6422a4b5da00136500/test/built-ins/DataView/byteOffset-validated-against-initial-buffer-length.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const newTarget = Object.defineProperty(function () { }.bind(), "prototype", {
+    get() {
+        throw new Error("GetPrototypeFromConstructor not executed");
+    }
+});
+
+class ExpectedError extends Error {
+    constructor(...args) {
+        super(...args);
+        this.name = new.target.name;
+    }
+}
+
+const TEST_TARGET = [
+    DataView,
+];
+
+for (const ctor of TEST_TARGET) {
+    const label = ctor.name;
+
+    const ab = new ArrayBuffer(0);
+    const weirdByteOffset = {
+        valueOf() {
+            throw new ExpectedError('step 3 happens');
+        }
+    };
+
+    // https://tc39.es/ecma262/2026/#sec-dataview-constructor
+    // The step 3 |ToIndex(byteOffset)| should happens before the step 10 |OrdinaryCreateFromConstructor|.
+    shouldThrow(label, () => {
+        Reflect.construct(ctor, [ab, weirdByteOffset], newTarget);
+    }, ExpectedError, 'step 3 happens');
+}

--- a/JSTests/stress/dataview-constructor-toindex-length-before-ordinarycreatefromctor-weird-length.js
+++ b/JSTests/stress/dataview-constructor-toindex-length-before-ordinarycreatefromctor-weird-length.js
@@ -1,0 +1,53 @@
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const newTarget = Object.defineProperty(function () { }.bind(), "prototype", {
+    get() {
+        throw new Error("GetPrototypeFromConstructor not executed");
+    }
+});
+
+class ExpectedError extends Error {
+    constructor(...args) {
+        super(...args);
+        this.name = new.target.name;
+    }
+}
+
+const TEST_TARGET = [
+    DataView,
+];
+
+for (const ctor of TEST_TARGET) {
+    const label = ctor.name;
+
+    const ab = new ArrayBuffer(0);
+    const weirdByteLength = {
+        valueOf() {
+            throw new ExpectedError('step 9-a happens');
+        }
+    };
+
+    // https://tc39.es/ecma262/2026/#sec-dataview-constructor
+    // The step 9-a |ToIndex(byteLength)| should happens before the step 10 |OrdinaryCreateFromConstructor|.
+    shouldThrow(label, () => {
+        Reflect.construct(ctor, [ab, 0, weirdByteLength], newTarget);
+    }, ExpectedError, 'step 9-a happens');
+}

--- a/JSTests/stress/dataview-constructor-toindex-length-before-ordinarycreatefromctor.js
+++ b/JSTests/stress/dataview-constructor-toindex-length-before-ordinarycreatefromctor.js
@@ -1,0 +1,52 @@
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const newTarget = Object.defineProperty(function () { }.bind(), "prototype", {
+    get() {
+        throw new Error("GetPrototypeFromConstructor not executed");
+    }
+});
+
+class ExpectedError extends Error {
+    constructor(...args) {
+        super(...args);
+        this.name = new.target.name;
+    }
+}
+
+const TEST_TARGET = [
+    DataView,
+];
+
+for (const ctor of TEST_TARGET) {
+    const label = ctor.name;
+
+    // Zero length buffer.
+    const ab = new ArrayBuffer(0);
+
+    const byteLength = 10;
+    assert(byteLength > ab.byteLength, "byteLength is larger than the buffer length");
+
+    // https://tc39.es/ecma262/2026/#sec-dataview-constructor
+    // The step 9-a |ToIndex(byteLength)| should happens before the step 10 |OrdinaryCreateFromConstructor|.
+    shouldThrow(label, () => {
+        Reflect.construct(ctor, [ab, 0, byteLength], newTarget);
+    }, RangeError, 'Length out of range of buffer');
+}

--- a/JSTests/stress/typedarray-constructor-bug-313230-weird-bytelength-detach-buffer-and-overrun.js
+++ b/JSTests/stress/typedarray-constructor-bug-313230-weird-bytelength-detach-buffer-and-overrun.js
@@ -1,0 +1,77 @@
+function assert(ok, message = '') {
+    if (!ok)
+        throw new Error(`Assertion!: ${message}`); 
+}
+
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const targetCtor of TEST_TARGET) {
+    const name = targetCtor.name;
+
+    const buffer = new ArrayBuffer(4096);
+    const byteOffset = 2048;
+    const actualByteLength = 2048 + 1;
+    // https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer
+    assert((byteOffset + actualByteLength ) > buffer.byteLength, `23.2.5.1.3, step 9-b-2's condition not satisfied`);
+
+    const byteLength = {
+        valueOf: function () {
+            $.detachArrayBuffer(buffer);
+            $.gc();
+            return actualByteLength;
+        }
+    };
+
+    // By the spec (April 24, 2026),
+    // https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer,
+    // which is invoked by the step 7-c of https://tc39.es/ecma262/#sec-typedarray, defines:
+    //
+    //  1. The step 3 get _offset_ by ToIndex(byteOffset).
+    //      - The weird `byteOffset ` detach the buffer here.
+    //  2. The step 7 check IsDetachedBuffer(buffer) and throw TypeError.
+    //  3. The step 9-b-2 checks whether `offset + newByteLength > bufferByteLength`,
+    //     but not reached to here by the step 7 in contrast to DataView()'s similar pattern.
+    shouldThrow(`${name}: should throw as the expected`, () => {
+        new targetCtor(buffer, byteOffset, byteLength);
+    }, TypeError, 'Buffer is already detached');
+    sameValue(buffer.detached, true, `${name}: arrayBuffer is detached as expectedly`);
+
+    // The detached ArrayBuffer.byteLength should be set to 0.
+    //
+    //  - https://tc39.es/ecma262/#sec-detacharraybuffer
+    //  - https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength
+    sameValue(buffer.byteLength, 0, `${name}: arrayBuffer.byteLength is 0`);
+}

--- a/Source/JavaScriptCore/runtime/JSDataView.cpp
+++ b/Source/JavaScriptCore/runtime/JSDataView.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "JSDataView.h"
+#include "JSGenericTypedArrayViewConstructor.h"
 
 #include "JSCInlines.h"
 #include "TypeError.h"
@@ -56,7 +57,7 @@ JSDataView* JSDataView::create(
     ASSERT(byteLength || buffer->isResizableOrGrowableShared());
 
     if (!ArrayBufferView::verifySubRangeLength(buffer->byteLength(), byteOffset, byteLength.value_or(0), sizeof(uint8_t))) {
-        throwRangeError(globalObject, scope, "Length out of range of buffer"_s);
+        throwRangeError(globalObject, scope, arrayBufferViewErrorMessageOutOfRangeOfBuffer);
         return nullptr;
     }
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/InternalFunction.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace JSC {
 
@@ -152,5 +153,7 @@ JSC_DECLARE_HOST_FUNCTION(uint8ArrayConstructorFromHex);
 
 [[nodiscard]] size_t decodeHex(std::span<const Latin1Character>, std::span<uint8_t> result);
 [[nodiscard]] size_t decodeHex(std::span<const char16_t>, std::span<uint8_t> result);
+
+constinit const ASCIILiteral arrayBufferViewErrorMessageOutOfRangeOfBuffer = "Length out of range of buffer"_s;
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -36,7 +36,9 @@
 #include "JSGenericTypedArrayViewConstructor.h"
 #include "JSGlobalObject.h"
 #include "JSTypedArrays.h"
+#include "MathCommon.h"
 #include "StructureCreateInlines.h"
+#include <wtf/Assertions.h>
 #include <wtf/text/ASCIILiteral.h>
 
 namespace JSC {
@@ -352,8 +354,23 @@ static EncodedJSValue constructDataViewImpl(JSGlobalObject* globalObject, CallFr
     if (argCount > 2) {
         // If the length value is present but undefined, treat it as missing.
         if (JSValue lengthValue = callFrame->uncheckedArgument(2); !lengthValue.isUndefined()) [[likely]] {
-            length = lengthValue.toIndex(globalObject, "byteLength"_s);
+            size_t viewByteLength = lengthValue.toIndex(globalObject, "byteLength"_s);
             RETURN_IF_EXCEPTION(scope, { });
+
+            // Accroding to the spec (April 24, 2026),
+            // https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength defines as the step 9-b that
+            // we should throw RangeError rather even if ToIndex(byteLength) happens to detach the buffer as:
+            // As user observable behavior, the sequence would be:
+            //
+            //  9-a: Let viewByteLength be ? ToIndex(byteLength): the weird object can detach the buffer at here.
+            //  9-b: If `(offset + viewByteLength) > bufferByteLength`, throw RangeError. <- here.
+            //  11: If the buffer is detached, throw TypeError.
+            ASSERT(offset <= maxSafeInteger());
+            ASSERT(viewByteLength <= maxSafeInteger());
+            if ((offset + viewByteLength) > bufferByteLength) [[unlikely]]
+                return throwVMRangeError(globalObject, scope, arrayBufferViewErrorMessageOutOfRangeOfBuffer);
+
+            length = viewByteLength;
         }
     }
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/JSArrayBufferViewInlines.h>
 #include <JavaScriptCore/JSCellInlines.h>
 #include <JavaScriptCore/JSGenericTypedArrayView.h>
+#include <JavaScriptCore/JSGenericTypedArrayViewConstructor.h>
 #include <JavaScriptCore/JSGenericTypedArrayViewInlinesLight.h>
 #include <JavaScriptCore/ToNativeFromValue.h>
 #include <JavaScriptCore/TypeError.h>
@@ -116,7 +117,7 @@ JSGenericTypedArrayView<Adaptor>* JSGenericTypedArrayView<Adaptor>::create(JSGlo
     ASSERT(length || buffer->isResizableOrGrowableShared());
 
     if (!ArrayBufferView::verifySubRangeLength(buffer->byteLength(), byteOffset, length.value_or(0), elementSize)) {
-        throwException(globalObject, scope, createRangeError(globalObject, "Length out of range of buffer"_s));
+        throwException(globalObject, scope, createRangeError(globalObject, arrayBufferViewErrorMessageOutOfRangeOfBuffer));
         return nullptr;
     }
 


### PR DESCRIPTION
#### bc59681571095d4c238aab49e33c533532e96399
<pre>
[JSC] `new DataView(buffer, byteOffset, byteLength)` should compliant the step 9-b of `25.3.2.1 DataView` abstract operation in the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=313230">https://bugs.webkit.org/show_bug.cgi?id=313230</a>

Reviewed by Yusuke Suzuki.

Accroding to the spec (April 24, 2026),
<a href="https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength">https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength</a> defines as the step 9-b that
we should throw RangeError rather even if ToIndex(byteLength) happens to detach the buffer as:
As user observable behavior related to byteLength, the sequence would be:

    9-a: Let viewByteLength be ? ToIndex(byteLength): the weird object can detach the buffer at here.
    9-b: If `(offset + viewByteLength) &gt; bufferByteLength`, throw RangeError.
    11: If the buffer is detached, throw TypeError.

On the other hand, %TypedArray%, which can take a similar form to `new DataView(buffer, byteOffset, byteLength)`,
they have a bit different step sequence. We should not do RangeError check immediately after ToIndex(byteLength).

The spec
 - <a href="https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer">https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer</a>
 - <a href="https://tc39.es/ecma262/#sec-typedarray">https://tc39.es/ecma262/#sec-typedarray</a>
defines the user observable behavior sequence related to byteLength as:

    5-a: Let newLength be ? ToIndex(length): the weird object can detach the buffer at here.
    6: If the buffer is detached, throw TypeError.
    ...(there are some steps but it&apos;s not related to newLength)
    9-b-ii: If `(offset + newLength) &gt; bufferByteLength`, throw RangeError.

Tests: JSTests/stress/dataview-constructor-bug-313230-weird-bytelength-detach-buffer-and-overrun.js
       JSTests/stress/dataview-constructor-toindex-byteoffset-before-ordinarycreatefromctor-weird-byteoffset.js
       JSTests/stress/dataview-constructor-toindex-length-before-ordinarycreatefromctor-weird-length.js
       JSTests/stress/dataview-constructor-toindex-length-before-ordinarycreatefromctor.js
       JSTests/stress/typedarray-constructor-bug-313230-weird-bytelength-detach-buffer-and-overrun.js

Canonical link: <a href="https://commits.webkit.org/312964@main">https://commits.webkit.org/312964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d70d8177412b2423bbd0db99672f2a27ebbe2b6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170489 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117957 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163455 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125368 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88292 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105964 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26716 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25226 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18210 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153643 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172977 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22424 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20018 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133658 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133663 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36120 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144702 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/96656 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21522 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193985 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34228 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101673 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49987 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33971 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33877 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->