### PR TITLE
[Gardening]: New-tests: 2x TestWebKitAPI.FullscreenVideoTextRecognition.NoOverlayInstalled* (api-tests) are constant timeouts

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm
@@ -382,9 +382,9 @@ TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterSeekAndExitingFullsc
     Util::run(&doneWaiting);
 }
 
+// FIXME when webkit.org/b/313031 is resolved
 #if PLATFORM(MAC)
-
-TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterExitingVideoFullscreenViaEscape)
+TEST(FullscreenVideoTextRecognition, DISABLED_NoOverlayInstalledAfterExitingVideoFullscreenViaEscape)
 {
     auto webView = [FullscreenVideoTextRecognitionWebView createForVideoFullscreen];
     [webView loadVideoSource:@"test.mp4"];
@@ -407,7 +407,8 @@ TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterExitingVideoFullscre
     Util::run(&doneWaiting);
 }
 
-TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterSeekAndExitingVideoFullscreenViaEscape)
+// FIXME when webkit.org/b/313031 is resolved
+TEST(FullscreenVideoTextRecognition, DISABLED_NoOverlayInstalledAfterSeekAndExitingVideoFullscreenViaEscape)
 {
     auto webView = [FullscreenVideoTextRecognitionWebView createForVideoFullscreen];
     [webView loadVideoSource:@"test.mp4"];


### PR DESCRIPTION
#### e12667f99db18a75bc66092bb3f22108fa7116f6
<pre>
[Gardening]: New-tests: 2x TestWebKitAPI.FullscreenVideoTextRecognition.NoOverlayInstalled* (api-tests) are constant timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=313031">https://bugs.webkit.org/show_bug.cgi?id=313031</a>
<a href="https://rdar.apple.com/175370043">rdar://175370043</a>

Unreviewed test Gardening

Skipping API tests that are flaky timeouts.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm:
(TestWebKitAPI::TEST(FullscreenVideoTextRecognition, DISABLED_NoOverlayInstalledAfterExitingVideoFullscreenViaEscape)):
(TestWebKitAPI::TEST(FullscreenVideoTextRecognition, DISABLED_NoOverlayInstalledAfterSeekAndExitingVideoFullscreenViaEscape)):
(TestWebKitAPI::TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterExitingVideoFullscreenViaEscape)): Deleted.
(TestWebKitAPI::TEST(FullscreenVideoTextRecognition, NoOverlayInstalledAfterSeekAndExitingVideoFullscreenViaEscape)): Deleted.

Canonical link: <a href="https://commits.webkit.org/311968@main">https://commits.webkit.org/311968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6e821ec83588a35ab6f943f5307345cb086d665

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158548 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/31974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25081 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160418 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/32042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31961 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/167378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161506 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/32042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/142443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/32042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/15149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/32042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/20223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/169868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/21848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/169868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/31664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/169868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/31610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/142016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24107 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/31610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/31121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/30641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->