### PR TITLE
Remove vestigial `hasAudio`/`isMuted`/`setIsMuted` from `<model>` after 310669@main

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -1482,56 +1482,6 @@ void HTMLModelElement::setAnimationCurrentTime(double currentTime, DOMPromiseDef
     });
 }
 
-// MARK: - Audio support.
-
-void HTMLModelElement::hasAudio(HasAudioPromise&& promise)
-{
-    RefPtr modelPlayer = m_modelPlayer;
-    if (!modelPlayer) {
-        promise.reject();
-        return;
-    }
-
-    modelPlayer->isPlayingAnimation([promise = WTF::move(promise)](std::optional<bool> hasAudio) mutable {
-        if (!hasAudio)
-            promise.reject();
-        else
-            promise.resolve(*hasAudio);
-    });
-}
-
-void HTMLModelElement::isMuted(IsMutedPromise&& promise)
-{
-    RefPtr modelPlayer = m_modelPlayer;
-    if (!modelPlayer) {
-        promise.reject();
-        return;
-    }
-
-    modelPlayer->isPlayingAnimation([promise = WTF::move(promise)](std::optional<bool> isMuted) mutable {
-        if (!isMuted)
-            promise.reject();
-        else
-            promise.resolve(*isMuted);
-    });
-}
-
-void HTMLModelElement::setIsMuted(bool isMuted, DOMPromiseDeferred<void>&& promise)
-{
-    RefPtr modelPlayer = m_modelPlayer;
-    if (!modelPlayer) {
-        promise.reject();
-        return;
-    }
-
-    modelPlayer->setIsMuted(isMuted, [promise = WTF::move(promise)](bool success) mutable {
-        if (success)
-            promise.resolve();
-        else
-            promise.reject();
-    });
-}
-
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
 
 bool HTMLModelElement::immersive() const

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -145,12 +145,6 @@ public:
     void animationCurrentTime(CurrentTimePromise&&);
     void setAnimationCurrentTime(double, DOMPromiseDeferred<void>&&);
 
-    using HasAudioPromise = DOMPromiseDeferred<IDLBoolean>;
-    void hasAudio(HasAudioPromise&&);
-    using IsMutedPromise = DOMPromiseDeferred<IDLBoolean>;
-    void isMuted(IsMutedPromise&&);
-    void setIsMuted(bool, DOMPromiseDeferred<void>&&);
-
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     bool immersive() const;
     void requestImmersive(DOMPromiseDeferred<void>&&);

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -123,10 +123,6 @@ public:
     virtual void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) = 0;
     virtual void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) = 0;
 
-    virtual void hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&) = 0;
-    virtual void isMuted(CompletionHandler<void(std::optional<bool>&&)>&&) = 0;
-    virtual void setIsMuted(bool, CompletionHandler<void(bool success)>&&) = 0;
-
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
     virtual ModelPlayerAccessibilityChildren accessibilityChildren() = 0;
 #endif

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
@@ -265,18 +265,6 @@ void PlaceholderModelPlayer::setAnimationCurrentTime(Seconds, CompletionHandler<
 {
 }
 
-void PlaceholderModelPlayer::hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&)
-{
-}
-
-void PlaceholderModelPlayer::isMuted(CompletionHandler<void(std::optional<bool>&&)>&&)
-{
-}
-
-void PlaceholderModelPlayer::setIsMuted(bool, CompletionHandler<void(bool success)>&&)
-{
-}
-
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
 
 ModelPlayerAccessibilityChildren PlaceholderModelPlayer::accessibilityChildren()

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
@@ -98,9 +98,6 @@ private:
     void NODELETE animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
     void NODELETE animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
     void NODELETE setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
-    void NODELETE hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void NODELETE isMuted(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void NODELETE setIsMuted(bool, CompletionHandler<void(bool success)>&&) final;
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
     ModelPlayerAccessibilityChildren accessibilityChildren() final;
 #endif

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
@@ -112,18 +112,6 @@ void DummyModelPlayer::setAnimationCurrentTime(Seconds, CompletionHandler<void(b
 {
 }
 
-void DummyModelPlayer::hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&)
-{
-}
-
-void DummyModelPlayer::isMuted(CompletionHandler<void(std::optional<bool>&&)>&&)
-{
-}
-
-void DummyModelPlayer::setIsMuted(bool, CompletionHandler<void(bool success)>&&)
-{
-}
-
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
 
 ModelPlayerAccessibilityChildren DummyModelPlayer::accessibilityChildren()

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
@@ -61,9 +61,6 @@ private:
     void NODELETE animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) override;
     void NODELETE animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) override;
     void NODELETE setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) override;
-    void NODELETE hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&) override;
-    void NODELETE isMuted(CompletionHandler<void(std::optional<bool>&&)>&&) override;
-    void NODELETE setIsMuted(bool, CompletionHandler<void(bool success)>&&) override;
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
     ModelPlayerAccessibilityChildren accessibilityChildren() override;
 #endif

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -120,9 +120,6 @@ public:
     void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
     void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
     void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
-    void hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void isMuted(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void setIsMuted(bool, CompletionHandler<void(bool success)>&&) final;
     WebCore::ModelPlayerAccessibilityChildren accessibilityChildren() final;
     void setAutoplay(bool) final;
     void setLoop(bool) final;

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -853,21 +853,6 @@ void ModelProcessModelPlayerProxy::setAnimationCurrentTime(Seconds currentTime, 
     completionHandler(false);
 }
 
-void ModelProcessModelPlayerProxy::hasAudio(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
-{
-    completionHandler(std::nullopt);
-}
-
-void ModelProcessModelPlayerProxy::isMuted(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
-{
-    completionHandler(std::nullopt);
-}
-
-void ModelProcessModelPlayerProxy::setIsMuted(bool isMuted, CompletionHandler<void(bool success)>&& completionHandler)
-{
-    completionHandler(false);
-}
-
 WebCore::ModelPlayerAccessibilityChildren ModelProcessModelPlayerProxy::accessibilityChildren()
 {
     return { };

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -345,21 +345,6 @@ void ModelProcessModelPlayer::setAnimationCurrentTime(Seconds currentTime, Compl
     completionHandler(false);
 }
 
-void ModelProcessModelPlayer::hasAudio(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
-{
-    completionHandler(std::nullopt);
-}
-
-void ModelProcessModelPlayer::isMuted(CompletionHandler<void(std::optional<bool>&&)>&& completionHandler)
-{
-    completionHandler(std::nullopt);
-}
-
-void ModelProcessModelPlayer::setIsMuted(bool isMuted, CompletionHandler<void(bool success)>&& completionHandler)
-{
-    completionHandler(false);
-}
-
 WebCore::ModelPlayerAccessibilityChildren ModelProcessModelPlayer::accessibilityChildren()
 {
     return { };

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -107,9 +107,6 @@ private:
     void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
     void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
     void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
-    void hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void isMuted(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void setIsMuted(bool, CompletionHandler<void(bool success)>&&) final;
     WebCore::ModelPlayerAccessibilityChildren accessibilityChildren() final;
     void setAutoplay(bool) final;
     void setLoop(bool) final;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -91,9 +91,6 @@ private:
     void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
     void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
     void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
-    void hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void isMuted(CompletionHandler<void(std::optional<bool>&&)>&&) final;
-    void setIsMuted(bool, CompletionHandler<void(bool success)>&&) final;
     WebCore::ModelPlayerAccessibilityChildren accessibilityChildren() final;
 #if PLATFORM(COCOA)
     std::optional<WebCore::TransformationMatrix> entityTransform() const final;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -422,18 +422,6 @@ void WebModelPlayer::setAnimationCurrentTime(Seconds, CompletionHandler<void(boo
 {
 }
 
-void WebModelPlayer::hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&)
-{
-}
-
-void WebModelPlayer::isMuted(CompletionHandler<void(std::optional<bool>&&)>&&)
-{
-}
-
-void WebModelPlayer::setIsMuted(bool, CompletionHandler<void(bool success)>&&)
-{
-}
-
 void WebModelPlayer::updateScene()
 {
 }


### PR DESCRIPTION
#### 179786d4aad8c80aa127bf16a4ecb411790f2522
<pre>
Remove vestigial `hasAudio`/`isMuted`/`setIsMuted` from `&lt;model&gt;` after 310669@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=313249">https://bugs.webkit.org/show_bug.cgi?id=313249</a>
<a href="https://rdar.apple.com/175526183">rdar://175526183</a>

Reviewed by Mike Wyrzykowski.

Commit 310669@main removed the ARKit inline preview feature including the
working `ASVInlinePreview` audio backend, the IDL exposure on
`HTMLModelElement`, and `WebPageProxy` IPC for the audio API. Left behind
were the wrapper methods on `HTMLModelElement`, the corresponding pure
virtuals on `ModelPlayer`, and 5 no-op subclass overrides.

No new tests needed (no behavioral change).

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::hasAudio): Deleted.
(WebCore::HTMLModelElement::isMuted): Deleted.
(WebCore::HTMLModelElement::setIsMuted): Deleted.
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp:
(WebCore::PlaceholderModelPlayer::hasAudio): Deleted.
(WebCore::PlaceholderModelPlayer::isMuted): Deleted.
(WebCore::PlaceholderModelPlayer::setIsMuted): Deleted.
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h:
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp:
(WebCore::DummyModelPlayer::hasAudio): Deleted.
(WebCore::DummyModelPlayer::isMuted): Deleted.
(WebCore::DummyModelPlayer::setIsMuted): Deleted.
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::hasAudio): Deleted.
(WebKit::ModelProcessModelPlayerProxy::isMuted): Deleted.
(WebKit::ModelProcessModelPlayerProxy::setIsMuted): Deleted.
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::hasAudio): Deleted.
(WebKit::ModelProcessModelPlayer::isMuted): Deleted.
(WebKit::ModelProcessModelPlayer::setIsMuted): Deleted.
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::hasAudio): Deleted.
(WebKit::WebModelPlayer::isMuted): Deleted.
(WebKit::WebModelPlayer::setIsMuted): Deleted.

Canonical link: <a href="https://commits.webkit.org/311995@main">https://commits.webkit.org/311995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/131a74d22d23c38843e8e68bde14333db952e26d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112637 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122808 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86182 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103478 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24124 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22519 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15153 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169872 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15617 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21826 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130995 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35500 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141994 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89520 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25804 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18802 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97139 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30645 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30918 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30799 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->