### PR TITLE
[CMake] PAL Crypto wrapping Swift code needs work to comply with strict Swift safety

### DIFF
--- a/Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift
@@ -25,8 +25,6 @@ import CryptoKit
 import Foundation
 import pal.Core.crypto.CryptoTypes
 
-// FIXME: (rdar://164560176) resolve the many 'unsafe' statements here
-
 private enum UnsafeErrors: Error {
     case invalidLength
     case emptySpan
@@ -34,7 +32,7 @@ private enum UnsafeErrors: Error {
 
 extension Data {
     fileprivate static func temporaryDataFromSpan(spanNoCopy: PAL.Crypto.SpanConstUInt8) -> Data {
-        guard unsafe spanNoCopy.empty() else {
+        guard spanNoCopy.empty() else {
             return unsafe Data(
                 bytesNoCopy: UnsafeMutablePointer(mutating: spanNoCopy.__dataUnsafe()),
                 count: spanNoCopy.size(),
@@ -49,7 +47,7 @@ extension Data {
 
 extension CryptoKit.HashFunction {
     mutating func update(data: PAL.Crypto.SpanConstUInt8) {
-        if unsafe data.empty() {
+        if data.empty() {
             self.update(data: Data())
         } else {
             unsafe self.update(
@@ -69,7 +67,7 @@ extension AES.GCM {
         iv: PAL.Crypto.SpanConstUInt8,
         ad: PAL.Crypto.SpanConstUInt8
     ) throws -> AES.GCM.SealedBox {
-        guard unsafe ad.size() > 0 else {
+        guard ad.size() > 0 else {
             return try unsafe AES.GCM.seal(
                 Data.temporaryDataFromSpan(spanNoCopy: message),
                 using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)),
@@ -105,7 +103,7 @@ extension AES.KeyWrap {
 
 extension P256.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -114,7 +112,7 @@ extension P256.Signing.ECDSASignature {
 
 extension P384.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -123,7 +121,7 @@ extension P384.Signing.ECDSASignature {
 
 extension P521.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -132,14 +130,14 @@ extension P521.Signing.ECDSASignature {
 
 extension P256.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe spanCompressed.empty() {
+        if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(
@@ -150,14 +148,14 @@ extension P256.Signing.PublicKey {
 
 extension P384.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe spanCompressed.empty() {
+        if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(
@@ -168,14 +166,14 @@ extension P384.Signing.PublicKey {
 
 extension P521.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe spanCompressed.empty() {
+        if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(
@@ -186,7 +184,7 @@ extension P521.Signing.PublicKey {
 
 extension P256.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -195,7 +193,7 @@ extension P256.Signing.PrivateKey {
 
 extension P384.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -204,7 +202,7 @@ extension P384.Signing.PrivateKey {
 
 extension P521.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -213,14 +211,14 @@ extension P521.Signing.PrivateKey {
 
 extension Curve25519.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func signature(span: PAL.Crypto.SpanConstUInt8) throws -> PAL.Crypto.VectorUInt8 {
-        if unsafe span.empty() {
+        if span.empty() {
             return try self.signature(for: Data()).copyToVectorUInt8()
         }
         return try unsafe self.signature(for: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -230,14 +228,14 @@ extension Curve25519.Signing.PrivateKey {
 
 extension Curve25519.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func isValidSignature(signature: PAL.Crypto.SpanConstUInt8, data: PAL.Crypto.SpanConstUInt8) -> Bool {
-        if unsafe (signature.empty() || data.empty()) {
+        if signature.empty() || data.empty() {
             return false
         }
 
@@ -250,14 +248,14 @@ extension Curve25519.Signing.PublicKey {
 
 extension Curve25519.KeyAgreement.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func sharedSecretFromKeyAgreement(pubSpan: PAL.Crypto.SpanConstUInt8) throws -> PAL.Crypto.VectorUInt8 {
-        if unsafe pubSpan.empty() {
+        if pubSpan.empty() {
             throw UnsafeErrors.emptySpan
         }
         let pub = try unsafe Curve25519.KeyAgreement.PublicKey(
@@ -269,7 +267,7 @@ extension Curve25519.KeyAgreement.PrivateKey {
 
 extension Curve25519.KeyAgreement.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))

--- a/Source/WebCore/PAL/pal/crypto/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/crypto/CryptoKitShim.swift
@@ -26,8 +26,6 @@ import Foundation
 
 public import pal.Core.crypto.CryptoTypes
 
-// FIXME: (rdar://164560176) resolve the many 'unsafe' statements here
-
 // FIXME: No symbols in this file should be `public`. Remove when support for compilers < 6.2.3 is no longer needed.
 
 private enum LocalErrors: Error {
@@ -46,7 +44,7 @@ public final class AesGcm {
     ) -> PAL.Crypto.CryptoOperationReturnValue {
         var returnValue = PAL.Crypto.CryptoOperationReturnValue()
         do {
-            if unsafe iv.size() == 0 {
+            if iv.size() == 0 {
                 returnValue.errorCode = .InvalidArgument
                 return returnValue
             }
@@ -529,7 +527,7 @@ public final class EdKey {
     ) -> PAL.Crypto.CryptoOperationReturnValue {
         var returnValue = PAL.Crypto.CryptoOperationReturnValue()
         do {
-            if unsafe privateKey.size() != 32 {
+            if privateKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
@@ -558,7 +556,7 @@ public final class EdKey {
     ) -> PAL.Crypto.CryptoOperationReturnValue {
         var returnValue = PAL.Crypto.CryptoOperationReturnValue()
         do {
-            if unsafe privateKey.size() != 32 {
+            if privateKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
@@ -587,7 +585,7 @@ public final class EdKey {
         publicKey: PAL.Crypto.SpanConstUInt8
     ) -> Bool {
         do {
-            if unsafe (privateKey.size() != 32 || publicKey.size() != 32) {
+            if privateKey.size() != 32 || publicKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
@@ -612,7 +610,7 @@ public final class EdKey {
         publicKey: PAL.Crypto.SpanConstUInt8
     ) -> Bool {
         do {
-            if unsafe (privateKey.size() != 32 || publicKey.size() != 32) {
+            if privateKey.size() != 32 || publicKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {


### PR DESCRIPTION
#### 8bc988a0e6404146828997aa27609a0db256cfc4
<pre>
[CMake] PAL Crypto wrapping Swift code needs work to comply with strict Swift safety
<a href="https://bugs.webkit.org/show_bug.cgi?id=313251">https://bugs.webkit.org/show_bug.cgi?id=313251</a>
<a href="https://rdar.apple.com/164560176">rdar://164560176</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift:
(Data.temporaryDataFromSpan(_:)):
(CryptoKit.update(_:)):
(Curve25519.signature(_:)):
(Curve25519.isValidSignature(_:data:)):
(Curve25519.sharedSecretFromKeyAgreement(_:)):
* Source/WebCore/PAL/pal/crypto/CryptoKitShim.swift:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bc988a0e6404146828997aa27609a0db256cfc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158558 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/31984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/25091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160428 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/32052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31971 "Hash 8bc988a0 for PR 63538 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/167388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161516 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/32052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/25091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/167388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/32052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/31971 "Hash 8bc988a0 for PR 63538 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15159 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/32052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/25091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/169878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/15623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/25091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/169878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/31674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/31971 "Hash 8bc988a0 for PR 63538 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/169878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/31620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/25091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/31620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/25091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31131 "Hash 8bc988a0 for PR 63538 does not build (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/97145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/30651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/30924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/30805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->