### PR TITLE
Use protect() instead of Ref { } in permissions, highlight, and webauthn code

### DIFF
--- a/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
@@ -76,7 +76,7 @@ void HighlightRegistry::setHighlightVisibility(HighlightVisibility highlightVisi
     m_highlightVisibility = highlightVisibility;
     
     for (auto& highlight : m_map)
-        Ref { highlight.value }->repaint();
+        protect(highlight.value)->repaint();
 }
 #endif
 
@@ -88,7 +88,7 @@ static ASCIILiteral annotationHighlightKey()
 void HighlightRegistry::addAnnotationHighlightWithRange(Ref<StaticRange>&& value)
 {
     if (m_map.contains(annotationHighlightKey()))
-        Ref { *m_map.get(annotationHighlightKey()) }->addToSetLike(value);
+        protect(*m_map.get(annotationHighlightKey()))->addToSetLike(value);
     else
         setFromMapLike(annotationHighlightKey(), Highlight::create({ std::ref<AbstractRange>(value.get()) }));
 }

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -173,7 +173,7 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
             return;
         }
 
-        PermissionController::singleton().query(ClientOrigin { document->topOrigin().data(), WTF::move(originData) }, permissionDescriptor, *page, *source, [document = Ref { *document }, page, permissionDescriptor, promise = WTF::move(promise)](auto permissionState) mutable {
+        PermissionController::singleton().query(ClientOrigin { document->topOrigin().data(), WTF::move(originData) }, permissionDescriptor, *page, *source, [document = protect(*document), page, permissionDescriptor, promise = WTF::move(promise)](auto permissionState) mutable {
             if (!permissionState) {
                 promise.reject(Exception { ExceptionCode::NotSupportedError, "Permissions::query does not support this API"_s });
                 return;

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -150,7 +150,7 @@ static std::optional<AuthenticationExtensionsClientOutputs> parseAuthenticatorDa
 
             auto decryptedResponse = pin::HmacSecretResponse::parse(
                 hmacSecretRequest->protocol(),
-                Ref { hmacSecretRequest->sharedKey() }.get(),
+                protect(hmacSecretRequest->sharedKey()).get(),
                 encryptedOutput
             );
 


### PR DESCRIPTION
#### 93bc07f1e0c653f91430e28478b230da4feb81ad
<pre>
Use protect() instead of Ref { } in permissions, highlight, and webauthn code
<a href="https://bugs.webkit.org/show_bug.cgi?id=313256">https://bugs.webkit.org/show_bug.cgi?id=313256</a>
<a href="https://rdar.apple.com/175528813">rdar://175528813</a>

Reviewed by Anne van Kesteren.

Mechanical migration from Ref { expr } to protect(expr) in permissions,
highlight registry, and webauthn code, aligning with the codebase-wide
transition away from brace-initialized smart pointer temporaries.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/Modules/highlight/HighlightRegistry.cpp:
(WebCore::HighlightRegistry::setHighlightVisibility):
(WebCore::HighlightRegistry::addAnnotationHighlightWithRange):
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::Permissions::query):
* Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp:
(fido::readCBOR):

Canonical link: <a href="https://commits.webkit.org/312004@main">https://commits.webkit.org/312004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79d007cd1ad78bbea93d5ff3f7820a017c4c56b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167393 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112648 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff813be7-8696-4109-aff1-4e58727f6133) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122817 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86188 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb85f2bc-5576-4a41-b403-343809db57b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103487 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04e6d054-c39b-41c8-a4a9-260c5f991b55) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24131 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22528 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15164 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169883 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15628 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131004 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26593 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131118 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35506 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142005 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89531 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25811 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18813 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97150 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30656 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30810 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->