### PR TITLE
[Site Isolation] http/tests/security/frameNavigation/not-opener.html has intentional log diff

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -435,3 +435,4 @@ http/tests/security/block-top-level-navigation-to-different-scheme-by-third-part
 http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propagated-user-gesture.html [ Failure ]
 http/tests/security/block-top-level-navigations-by-third-party-iframes.html [ Failure ]
 http/tests/security/block-top-level-navigations-by-third-party-sandboxed-iframe.html [ Failure ]
+http/tests/security/frameNavigation/not-opener.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -525,6 +525,7 @@ http/tests/security/block-top-level-navigation-to-different-scheme-by-third-part
 http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propagated-user-gesture.html [ Failure ]
 http/tests/security/block-top-level-navigations-by-third-party-iframes.html [ Failure ]
 http/tests/security/block-top-level-navigations-by-third-party-sandboxed-iframe.html [ Failure ]
+http/tests/security/frameNavigation/not-opener.html [ Failure ]
 
 # This test has different output with site isolation enabled. A copy with site isolation enabled is
 # stored and run separately at http/tests/site-isolation/inspector/unit-tests/target-manager.html.


### PR DESCRIPTION
#### 82c23c393f9b9c5226015513aa053b4f8cd61f7e
<pre>
[Site Isolation] http/tests/security/frameNavigation/not-opener.html has intentional log diff
<a href="https://bugs.webkit.org/show_bug.cgi?id=313262">https://bugs.webkit.org/show_bug.cgi?id=313262</a>
<a href="https://rdar.apple.com/175533445">rdar://175533445</a>

Reviewed by Sihui Liu.

With site isolation enabled,
http/tests/security/frameNavigation/not-opener.html
has an intentional test difference between the output
when run with site isolation disabled. See the following diff:

@@ -1,3 +1,3 @@
-CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL &apos;<a href="http://127.0.0.1">http://127.0.0.1</a>:8000/security/frameNavigation/resources/ready.html&apos; from frame with URL &apos;<a href="http://localhost">http://localhost</a>:8000/security/frameNavigation/resources/not-opener-helper.html&apos;. The frame attempting navigation is neither same-origin with the target, nor is it the target&apos;s parent or opener.
+CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL &apos;<a href="http://127.0.0.1">http://127.0.0.1</a>:8000/&apos; from frame with URL &apos;<a href="http://localhost">http://localhost</a>:8000/security/frameNavigation/resources/not-opener-helper.html&apos;. The frame attempting navigation is neither same-origin with the target, nor is it the target&apos;s parent or opener.

This was an intentional difference caused by <a href="https://commits.webkit.org/310093@main">https://commits.webkit.org/310093@main</a>
since we don&apos;t want to allow a web process to access the full URL of a remote frame.

Also see <a href="https://commits.webkit.org/310523@main">https://commits.webkit.org/310523@main</a>

This patch moves http/tests/security/frameNavigation/not-opener.html
to the section of site isolation TestExpectations which cover these
expected differences.

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/312005@main">https://commits.webkit.org/312005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcde0906dad2f3bac9c97f8b53ca12af010bec6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112668 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122836 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86197 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103505 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24151 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22547 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15184 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169904 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131021 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131135 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35508 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31645 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89551 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25833 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18836 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31156 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30676 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30949 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30830 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->