### PR TITLE
[macOS] imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html is a flaky text failure.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html
@@ -69,9 +69,11 @@ function testPreservesPitch(preservesPitch, playbackRate, expectedPitch, descrip
         }
 
         // Wait until we have played some audio. Otherwise, the detector
-        // might return a pitch of 0Hz.
+        // might return a pitch of 0Hz. Scale the threshold by the playback
+        // rate so that there is always enough wall-clock time for the
+        // analyser to accumulate data.
         audio.play();
-        await waitUntil(0.5);
+        await waitUntil(0.5 * Math.max(playbackRate, 1));
 
         var pitch = detector.detect();
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2402,8 +2402,6 @@ webkit.org/b/306444 [ Release ] imported/w3c/web-platform-tests/editing/other/ty
 
 webkit.org/b/307850 media/modern-media-controls/tracks-support/audio-single-track.html [ Pass Timeout ]
 
-webkit.org/b/313259 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html [ Pass Failure ]
-
 webkit.org/b/312499 imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/form.html [ Pass Failure ]
 
 webkit.org/b/307886 [ Release arm64 ] js/dom/promise-stack-overflow.html [ Pass Failure ]


### PR DESCRIPTION
#### 3d18dd4a26d962f724f9baa620ddd5435260b765
<pre>
[macOS] imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html is a flaky text failure.
<a href="https://rdar.apple.com/175529361">rdar://175529361</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313259">https://bugs.webkit.org/show_bug.cgi?id=313259</a>

Reviewed by NOBODY (OOPS!).

The test flakily fails the assertion which tests pitch is not adjusted at 2x playbackRate.
The test waits until the media reaches a hardcoded 0.5s before checking the pitch.
It appears that at 2x speed, currentTime hits 0.5 in only 0.25s of real time which (under
high system loads) is sometimes not enough for the WebKit to sample the pitch resulting in
the pitch detector returning 0Hz (empty data).

The fix is to adjust the waiting mechansism to account for playback rate with waitUntil(0.5 * Math.max(playbackRate, 1)):
    - Math.max(playbackRate, 1) — only scale up for fast rates (&gt;1.0). Slow rates already
      getmore wall-clock time than needed, so leave them unchanged.
    - 0.5 * playbackRate — at rate 2.0 this gives waitUntil(1.0), and 1.0 / 2.0 = 0.5s
      wall-clock. Exactly the intended minimum.

Files Changed(1):
    preserves-pitch.html:76 - Change waitUntil(0.5) to waitUntil(0.5 * Math.max(playbackRate, 1))

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/preserves-pitch.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d18dd4a26d962f724f9baa620ddd5435260b765

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112669 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122841 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86199 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103510 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22548 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15185 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169905 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21861 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131024 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131138 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89552 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25832 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18837 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31157 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30677 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->