### PR TITLE
Reland memory64 bulk memory operations in OMG tier

### DIFF
--- a/JSTests/wasm/stress/memory64-bulk-memory.js
+++ b/JSTests/wasm/stress/memory64-bulk-memory.js
@@ -62,3 +62,71 @@ function test() {
 
 for (let i = 0; i < wasmTestLoopCount; i++)
     test();
+
+function testOverflow() {
+  // memory.fill: dstAddress + count overflows uint64
+  assert.throws(() => testFill(0xffffffffffffffffn, 0, 1n),
+      WebAssembly.RuntimeError,
+      "Out of bounds memory access");
+
+  assert.throws(() => testFill(1n, 0, 0xffffffffffffffffn),
+      WebAssembly.RuntimeError,
+      "Out of bounds memory access");
+
+  // memory.copy: dstAddress + count overflows uint64
+  assert.throws(() => testCopy(0xffffffffffffffffn, 0n, 1n),
+      WebAssembly.RuntimeError,
+      "Out of bounds memory access");
+
+  // memory.copy: srcAddress + count overflows uint64
+  assert.throws(() => testCopy(0n, 0xffffffffffffffffn, 1n),
+      WebAssembly.RuntimeError,
+      "Out of bounds memory access");
+
+  assert.throws(() => testCopy(0n, 1n, 0xffffffffffffffffn),
+      WebAssembly.RuntimeError,
+      "Out of bounds memory access");
+}
+
+for (let i = 0; i < wasmTestLoopCount; i++)
+    testOverflow();
+
+let i32Wat = `
+(module
+    (memory (export "mem") 1)
+    (data (i32.const 0) "world!")
+    (func $i32Copy (export "i32Copy") (param $dst i32) (param $src i32) (param $sz i32)
+      (memory.copy
+        (local.get $dst)
+        (local.get $src)
+        (local.get $sz))
+    )
+)
+`;
+
+const worldBytes = "world!";
+const i32Instance = await instantiate(i32Wat, {}, {});
+const { i32Copy, mem: i32Mem } = i32Instance.exports;
+const i32MemView = new DataView(i32Mem.buffer);
+
+function testI32Copy() {
+  i32Copy(16, 0, worldBytes.length);
+  for (let i = 0; i < worldBytes.length; i++)
+    assert.eq(i32MemView.getInt8(16 + i), worldBytes.charCodeAt(i));
+}
+
+for (let i = 0; i < wasmTestLoopCount; i++)
+    testI32Copy();
+
+function testI32CopyOOB() {
+  assert.throws(() => i32Copy(0, 0xfffffff0 | 0, 32),
+      WebAssembly.RuntimeError,
+      "Out of bounds memory access");
+
+  assert.throws(() => i32Copy(0, -1, 1),
+      WebAssembly.RuntimeError,
+      "Out of bounds memory access");
+}
+
+for (let i = 0; i < wasmTestLoopCount; i++)
+    testI32CopyOOB();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -1144,6 +1144,18 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     ASSERT(count.type() == m_info.memory(memoryIndex).addressType());
     ASSERT(targetValue.type() == TypeKind::I32);
 
+    if (!m_info.memory(memoryIndex).isMemory64()) {
+        if (!dstAddress.isConst()) {
+            Location dstLoc = loadIfNecessary(dstAddress);
+            m_jit.zeroExtend32ToWord(dstLoc.asGPR(), dstLoc.asGPR());
+        }
+
+        if (!count.isConst()) {
+            Location countLoc = loadIfNecessary(count);
+            m_jit.zeroExtend32ToWord(countLoc.asGPR(), countLoc.asGPR());
+        }
+    }
+
     Vector<Value, 8> arguments = {
         instanceValue(),
         dstAddress, targetValue, count, Value::fromI32(memoryIndex)
@@ -1170,6 +1182,27 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     else
         ASSERT(count.type() == TypeKind::I32);
 
+    if (!m_info.memory(dstMemoryIndex).isMemory64()) {
+        if (!dstAddress.isConst()) {
+            Location dstLoc = loadIfNecessary(dstAddress);
+            m_jit.zeroExtend32ToWord(dstLoc.asGPR(), dstLoc.asGPR());
+        }
+    }
+
+    if (!m_info.memory(srcMemoryIndex).isMemory64()) {
+        if (!srcAddress.isConst()) {
+            Location srcLoc = loadIfNecessary(srcAddress);
+            m_jit.zeroExtend32ToWord(srcLoc.asGPR(), srcLoc.asGPR());
+        }
+    }
+
+    if (!m_info.memory(srcMemoryIndex).isMemory64() || !m_info.memory(dstMemoryIndex).isMemory64()) {
+        if (!count.isConst()) {
+            Location countLoc = loadIfNecessary(count);
+            m_jit.zeroExtend32ToWord(countLoc.asGPR(), countLoc.asGPR());
+        }
+    }
+
     Vector<Value, 8> arguments = {
         instanceValue(),
         dstAddress, srcAddress, count, Value::fromI32(dstMemoryIndex), Value::fromI32(srcMemoryIndex)
@@ -1192,6 +1225,13 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     ASSERT(dstAddress.type() == m_info.memory(memoryIndex).addressType());
     ASSERT(srcAddress.type() == TypeKind::I32);
     ASSERT(length.type() == TypeKind::I32);
+
+    if (!m_info.memory(memoryIndex).isMemory64()) {
+        if (!dstAddress.isConst()) {
+            Location dstLoc = loadIfNecessary(dstAddress);
+            m_jit.zeroExtend32ToWord(dstLoc.asGPR(), dstLoc.asGPR());
+        }
+    }
 
     Vector<Value, 8> arguments = {
         instanceValue(),

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -614,7 +614,8 @@ WASM_IPINT_EXTERN_CPP_DECL(memory_init, int32_t dataIndex, IPIntStackEntry* sp, 
 {
     int32_t n = sp[0].i32;
     int32_t s = sp[1].i32;
-    int64_t d = sp[2].i64;
+    const auto& info = instance->module().moduleInformation();
+    uint64_t d = info.memory(memoryIndex).isMemory64() ? sp[2].i64 : static_cast<uint32_t>(sp[2].i32);
 
     if (!Wasm::memoryInit(instance, dataIndex, d, s, n, memoryIndex))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsMemoryAccess);
@@ -631,9 +632,11 @@ WASM_IPINT_EXTERN_CPP_DECL(memory_copy, IPIntStackEntry* sp)
 {
     uint8_t srcMemoryIndex = static_cast<uint8_t>(sp[0].i64);
     uint8_t dstMemoryIndex = static_cast<uint8_t>(sp[1].i64);
-    int64_t count = sp[2].i64;
-    int64_t src = sp[3].i64;
-    int64_t dst = sp[4].i64;
+    const auto& info = instance->module().moduleInformation();
+    bool bothMemory64 = info.memory(srcMemoryIndex).isMemory64() && info.memory(dstMemoryIndex).isMemory64();
+    uint64_t count = bothMemory64 ? sp[2].i64 : static_cast<uint32_t>(sp[2].i32);
+    uint64_t src = info.memory(srcMemoryIndex).isMemory64() ? sp[3].i64 : static_cast<uint32_t>(sp[3].i32);
+    uint64_t dst = info.memory(dstMemoryIndex).isMemory64() ? sp[4].i64 : static_cast<uint32_t>(sp[4].i32);
     if (!Wasm::memoryCopy(instance, dst, src, count, dstMemoryIndex, srcMemoryIndex))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsMemoryAccess);
     IPINT_END();
@@ -642,9 +645,10 @@ WASM_IPINT_EXTERN_CPP_DECL(memory_copy, IPIntStackEntry* sp)
 WASM_IPINT_EXTERN_CPP_DECL(memory_fill, IPIntStackEntry* sp)
 {
     uint8_t memoryIndex = static_cast<uint8_t>(sp[0].i64);
-    int64_t count = sp[1].i64;
+    const auto& info = instance->module().moduleInformation();
+    uint64_t count = info.memory(memoryIndex).isMemory64() ? sp[1].i64 : static_cast<uint32_t>(sp[1].i32);
     int32_t targetValue = sp[2].i32;
-    int64_t dst = sp[3].i64;
+    uint64_t dst = info.memory(memoryIndex).isMemory64() ? sp[3].i64 : static_cast<uint32_t>(sp[3].i32);
     if (!Wasm::memoryFill(instance, dst, targetValue, count, memoryIndex))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsMemoryAccess);
     IPINT_END();

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -391,9 +391,13 @@ Expected<PageCount, GrowFailReason> Memory::grow(VM& vm, PageCount delta)
     return oldPageCount;
 }
 
-bool Memory::fill(uint32_t offset, uint8_t targetValue, uint32_t count)
+bool Memory::fill(uint64_t offset, uint8_t targetValue, uint64_t count)
 {
-    if (sumOverflows<uint32_t>(offset, count))
+    bool offsetAndCountOverflows = addressType().is64Bit()
+        ? sumOverflows<uint64_t>(offset, count)
+        : sumOverflows<uint32_t>(offset, count);
+
+    if (offsetAndCountOverflows)
         return false;
 
     if (offset + count > m_handle->size())
@@ -403,13 +407,19 @@ bool Memory::fill(uint32_t offset, uint8_t targetValue, uint32_t count)
     return true;
 }
 
-bool Memory::copy(uint32_t dstAddress, uint32_t srcAddress, uint32_t count)
+bool Memory::copy(uint64_t dstAddress, uint64_t srcAddress, uint64_t count)
 {
-    if (sumOverflows<uint32_t>(dstAddress, count) || sumOverflows<uint32_t>(srcAddress, count))
+    bool dstAndCountOverflows = addressType().is64Bit()
+        ? sumOverflows<uint64_t>(dstAddress, count)
+        : sumOverflows<uint32_t>(dstAddress, count);
+    bool srcAndCountOverflows = addressType().is64Bit()
+        ? sumOverflows<uint64_t>(srcAddress, count)
+        : sumOverflows<uint32_t>(srcAddress, count);
+    if (dstAndCountOverflows || srcAndCountOverflows)
         return false;
 
-    const uint32_t lastDstAddress = dstAddress + count;
-    const uint32_t lastSrcAddress = srcAddress + count;
+    const uint64_t lastDstAddress = dstAddress + count;
+    const uint64_t lastSrcAddress = srcAddress + count;
 
     if (lastDstAddress > size() || lastSrcAddress > size())
         return false;

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -89,8 +89,8 @@ public:
     MemoryMode mode() const { return m_handle->mode(); }
 
     Expected<PageCount, GrowFailReason> grow(VM&, PageCount);
-    bool fill(uint32_t, uint8_t, uint32_t);
-    bool copy(uint32_t, uint32_t, uint32_t);
+    bool fill(uint64_t, uint8_t, uint64_t);
+    bool copy(uint64_t, uint64_t, uint64_t);
     bool init(uint64_t, const uint8_t*, uint32_t);
 
     void registerInstance(JSWebAssemblyInstance&);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2081,15 +2081,21 @@ auto OMGIRGenerator::addCurrentMemory(ExpressionType& result, uint8_t memoryInde
 
 auto OMGIRGenerator::addMemoryFill(ExpressionType dstAddress, ExpressionType target, ExpressionType count, uint8_t memoryIndex) -> PartialResult
 {
+    auto* dstAddressValue = m_info.memory(memoryIndex).isMemory64()
+        ? get(dstAddress)
+        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
+    auto* targetValue = get(target);
+    auto* countValue = m_info.memory(memoryIndex).isMemory64()
+        ? get(count)
+        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(count));
+
     if (!memoryIndex) {
         auto* memorySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfCachedMemory0Size()));
         m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_cachedMemory0Size, memorySize);
 
-        auto* dstAddressValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
-        auto* targetValue = get(target);
-        auto* countValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(count));
-
-        Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, Above, origin(), m_currentBlock->appendNew<Value>(m_proc, Add, origin(), dstAddressValue, countValue), memorySize);
+        auto* sum = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), dstAddressValue, countValue);
+        auto* sumOverflowed = m_currentBlock->appendNew<Value>(m_proc, Below, origin(), sum, dstAddressValue);
+        Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, BitOr, origin(), sumOverflowed, m_currentBlock->appendNew<Value>(m_proc, Above, origin(), sum, memorySize));
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), outOfBounds);
         check->setGenerator([=, this, origin = this->origin()](CCallHelpers& jit, const B3::StackmapGenerationParams&) {
             this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
@@ -2102,7 +2108,7 @@ auto OMGIRGenerator::addMemoryFill(ExpressionType dstAddress, ExpressionType tar
             countValue);
     } else {
         Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmMemoryFill,
-            instanceValue(), get(dstAddress), get(target), get(count), constant(Int32, memoryIndex));
+            instanceValue(), dstAddressValue, targetValue, countValue, constant(Int32, memoryIndex));
 
         {
             CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
@@ -2119,10 +2125,16 @@ auto OMGIRGenerator::addMemoryFill(ExpressionType dstAddress, ExpressionType tar
 
 auto OMGIRGenerator::addMemoryInit(unsigned dataSegmentIndex, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length, uint8_t memoryIndex) -> PartialResult
 {
+    auto dstAddressValue = m_info.memory(memoryIndex).isMemory64()
+        ? get(dstAddress)
+        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
+
+    auto srcAddressValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(srcAddress));
+
     Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmMemoryInit,
         instanceValue(),
         constant(Int32, dataSegmentIndex),
-        get(dstAddress), get(srcAddress), get(length), constant(Int32, memoryIndex));
+        dstAddressValue, srcAddressValue, get(length), constant(Int32, memoryIndex));
 
     {
         CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
@@ -2138,22 +2150,33 @@ auto OMGIRGenerator::addMemoryInit(unsigned dataSegmentIndex, ExpressionType dst
 
 auto OMGIRGenerator::addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex) -> PartialResult
 {
+    auto* dstAddressValue = m_info.memory(dstMemoryIndex).isMemory64()
+        ? get(dstAddress)
+        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
+    auto* srcAddressValue = m_info.memory(srcMemoryIndex).isMemory64()
+        ? get(srcAddress)
+        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(srcAddress));
+    auto* countValue = m_info.memory(srcMemoryIndex).isMemory64() && m_info.memory(dstMemoryIndex).isMemory64()
+        ? get(count)
+        : m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(count));
+
     if (!dstMemoryIndex && !srcMemoryIndex) {
         auto* memorySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfCachedMemory0Size()));
         m_heaps.decorateMemory(&m_heaps.JSWebAssemblyInstance_cachedMemory0Size, memorySize);
-
-        auto* dstAddressValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(dstAddress));
-        auto* srcAddressValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(srcAddress));
-        auto* countValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), get(count));
-
         {
-            CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), m_currentBlock->appendNew<Value>(m_proc, Above, origin(), m_currentBlock->appendNew<Value>(m_proc, Add, origin(), dstAddressValue, countValue), memorySize));
+            auto* dstSum = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), dstAddressValue, countValue);
+            auto* dstSumOverflowed = m_currentBlock->appendNew<Value>(m_proc, Below, origin(), dstSum, dstAddressValue);
+            Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, BitOr, origin(), dstSumOverflowed, m_currentBlock->appendNew<Value>(m_proc, Above, origin(), dstSum, memorySize));
+            CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), outOfBounds);
             check->setGenerator([=, this, origin = this->origin()](CCallHelpers& jit, const B3::StackmapGenerationParams&) {
                 this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
             });
         }
         {
-            CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), m_currentBlock->appendNew<Value>(m_proc, Above, origin(), m_currentBlock->appendNew<Value>(m_proc, Add, origin(), srcAddressValue, countValue), memorySize));
+            auto* srcSum = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), srcAddressValue, countValue);
+            auto* srcSumOverflowed = m_currentBlock->appendNew<Value>(m_proc, Below, origin(), srcSum, srcAddressValue);
+            Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, BitOr, origin(), srcSumOverflowed, m_currentBlock->appendNew<Value>(m_proc, Above, origin(), srcSum, memorySize));
+            CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), outOfBounds);
             check->setGenerator([=, this, origin = this->origin()](CCallHelpers& jit, const B3::StackmapGenerationParams&) {
                 this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
             });
@@ -2167,7 +2190,7 @@ auto OMGIRGenerator::addMemoryCopy(ExpressionType dstAddress, ExpressionType src
     } else {
         Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmMemoryCopy,
             instanceValue(),
-            get(dstAddress), get(srcAddress), get(count), constant(Int32, dstMemoryIndex), constant(Int32, srcMemoryIndex));
+            dstAddressValue, srcAddressValue, countValue, constant(Int32, dstMemoryIndex), constant(Int32, srcMemoryIndex));
 
         {
             CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1542,12 +1542,12 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemorySizeInPages, int64_t, (JSWe
     return instance->memory(memoryIndex)->memory().size() >> 16;
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryFill, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint32_t dstAddress, uint32_t targetValue, uint32_t count, uint8_t memoryIndex))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryFill, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t dstAddress, uint32_t targetValue, uint64_t count, uint8_t memoryIndex))
 {
     return toUCPUStrictInt32(memoryFill(instance, dstAddress, targetValue, count, memoryIndex));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryCopy, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint32_t dstAddress, uint32_t srcAddress, uint32_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryCopy, UCPUStrictInt32, (JSWebAssemblyInstance* instance, uint64_t dstAddress, uint64_t srcAddress, uint64_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex))
 {
     return toUCPUStrictInt32(memoryCopy(instance, dstAddress, srcAddress, count, dstMemoryIndex, srcMemoryIndex));
 }
@@ -1629,7 +1629,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicNotify, UCPUStrictInt32, 
     return toUCPUStrictInt32(memoryAtomicNotify(instance, base, offset, countValue, memoryIndex));
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned dataSegmentIndex, uint32_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned dataSegmentIndex, uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex))
 {
     return toUCPUStrictInt32(memoryInit(instance, dataSegmentIndex, dstAddress, srcAddress, length, memoryIndex));
 }

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -92,8 +92,8 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationPopcount32, UCPUStrictInt32, (int32_
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationPopcount64, uint64_t, (int64_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGrowMemory, int64_t, (JSWebAssemblyInstance*, int64_t, uint8_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemorySizeInPages, int64_t, (JSWebAssemblyInstance* instance, uint8_t memoryIndex));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryFill, UCPUStrictInt32, (JSWebAssemblyInstance*, uint32_t dstAddress, uint32_t targetValue, uint32_t count, uint8_t memoryIndex));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryCopy, UCPUStrictInt32, (JSWebAssemblyInstance*, uint32_t dstAddress, uint32_t srcAddress, uint32_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryFill, UCPUStrictInt32, (JSWebAssemblyInstance*, uint64_t dstAddress, uint32_t targetValue, uint64_t count, uint8_t memoryIndex));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryCopy, UCPUStrictInt32, (JSWebAssemblyInstance*, uint64_t dstAddress, uint64_t srcAddress, uint64_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableElement, EncodedJSValue, (JSWebAssemblyInstance*, unsigned, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationSetWasmTableElement, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned, uint32_t, EncodedJSValue encValue));
@@ -108,7 +108,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationGetWasmTableSize, UCPUStrictInt32, (
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait32, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int32_t value, int64_t timeout, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicWait64, UCPUStrictInt32, (JSWebAssemblyInstance* instance, unsigned base, unsigned offset, int64_t value, int64_t timeout, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicNotify, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned, unsigned, int32_t, uint8_t memoryIndex));
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned dataSegmentIndex, uint32_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned dataSegmentIndex, uint64_t dstAddress, uint32_t srcAddress, uint32_t length, uint8_t memoryIndex));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmDataDrop, void, (JSWebAssemblyInstance*, unsigned dataSegmentIndex));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmStructNewEmpty, EncodedJSValue, (JSWebAssemblyInstance*, uint32_t));

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -686,12 +686,15 @@ inline bool memoryInit(JSWebAssemblyInstance* instance, unsigned dataSegmentInde
     return instance->memoryInit(dstAddress, srcAddress, length, dataSegmentIndex, memoryIndex);
 }
 
-inline bool memoryFill(JSWebAssemblyInstance* instance, uint32_t dstAddress, uint32_t targetValue, uint32_t count, uint8_t memoryIndex)
+inline bool memoryFill(JSWebAssemblyInstance* instance, uint64_t dstAddress, uint32_t targetValue, uint64_t count, uint8_t memoryIndex)
 {
     auto* base = std::bit_cast<uint8_t*>(instance->memory(memoryIndex)->basePointer());
     uint64_t size = instance->memory(memoryIndex)->memory().size();
 
-    uint64_t lastDstAddress = static_cast<uint64_t>(dstAddress) + count;
+    if (instance->memory(memoryIndex)->memory().addressType().is64Bit() && sumOverflows<uint64_t>(dstAddress, count))
+        return false;
+
+    uint64_t lastDstAddress = dstAddress + count;
     if (lastDstAddress > size)
         return false;
 
@@ -699,15 +702,21 @@ inline bool memoryFill(JSWebAssemblyInstance* instance, uint32_t dstAddress, uin
     return true;
 }
 
-inline bool memoryCopy(JSWebAssemblyInstance* instance, uint32_t dstAddress, uint32_t srcAddress, uint32_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex)
+inline bool memoryCopy(JSWebAssemblyInstance* instance, uint64_t dstAddress, uint64_t srcAddress, uint64_t count, uint8_t dstMemoryIndex, uint8_t srcMemoryIndex)
 {
     auto* dstBase = std::bit_cast<uint8_t*>(instance->memory(dstMemoryIndex)->basePointer());
     uint64_t dstSize = instance->memory(dstMemoryIndex)->memory().size();
     auto* srcBase = std::bit_cast<uint8_t*>(instance->memory(srcMemoryIndex)->basePointer());
     uint64_t srcSize = instance->memory(srcMemoryIndex)->memory().size();
 
-    uint64_t lastDstAddress = static_cast<uint64_t>(dstAddress) + count;
-    uint64_t lastSrcAddress = static_cast<uint64_t>(srcAddress) + count;
+    if (instance->memory(dstMemoryIndex)->memory().addressType().is64Bit() && sumOverflows<uint64_t>(dstAddress, count))
+        return false;
+
+    if (instance->memory(srcMemoryIndex)->memory().addressType().is64Bit() && sumOverflows<uint64_t>(srcAddress, count))
+        return false;
+
+    uint64_t lastDstAddress = dstAddress + count;
+    uint64_t lastSrcAddress = srcAddress + count;
 
     if (lastDstAddress > dstSize || lastSrcAddress > srcSize)
         return false;


### PR DESCRIPTION
#### c3893af655596c2fd06b0450cb01f10d5ee1bced
<pre>
Reland memory64 bulk memory operations in OMG tier
<a href="https://bugs.webkit.org/show_bug.cgi?id=313267">https://bugs.webkit.org/show_bug.cgi?id=313267</a>
<a href="https://rdar.apple.com/175539058">rdar://175539058</a>

Reviewed by Keith Miller.

The original patch: <a href="https://commits.webkit.org/311796@main">https://commits.webkit.org/311796@main</a> caused some
failures in JetStream. The original patch widened some arguments from
uint32_t to uint64_t that were called from jitted and interpreted code.

Any 32 bit value passed to these functions will be treated as a 64 bit
value, meaning there will be garbage in the upper 32 bits. To address
this issue, I zero extended the 32 bit arguments to a 64 bit in the
memory32 case.

The JetStream benchmark is passing now.

* JSTests/wasm/stress/memory64-bulk-memory.js:
(testOverflow):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryInit):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::fill):
(JSC::Wasm::Memory::copy):
* Source/JavaScriptCore/wasm/WasmMemory.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addMemoryFill):
(JSC::Wasm::OMGIRGenerator::addMemoryInit):
(JSC::Wasm::OMGIRGenerator::addMemoryCopy):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::memoryFill):
(JSC::Wasm::memoryCopy):

Canonical link: <a href="https://commits.webkit.org/312534@main">https://commits.webkit.org/312534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8842024da9137d3fba7fe26a3446fb10d1fd52f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114558 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21b4d60f-eaf1-4749-8b8e-1851b2647467) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124169 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87095 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/964c8633-8913-44a3-bfea-02ef63fb5639) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143872 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104768 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9cc5a1e-9991-4bb1-ade0-0aab274977df) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25464 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23958 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToBackground (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16798 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152233 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171555 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21014 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17545 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132420 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132446 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35827 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143430 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91575 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27064 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20244 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192540 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32817 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99214 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49518 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32315 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32561 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32465 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->