### PR TITLE
CSS scroll anchoring doesn't work after scrollable range shrinkage

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-001-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Scroll anchoring properly works after scrollable range shrinkage assert_equals: expected 608 but got 626
+PASS Scroll anchoring properly works after scrollable range shrinkage
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Scroll anchoring properly works after scrollable range shrinkage assert_equals: expected 608 but got 1226
+PASS Scroll anchoring properly works after scrollable range shrinkage
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Scroll anchoring properly works after scrollable range shrinkage assert_equals: expected 3008 but got 3626
+PASS Scroll anchoring properly works after scrollable range shrinkage
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-004-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Scroll anchoring properly works after scrollable range shrinkage assert_equals: expected 608 but got 1226
+PASS Scroll anchoring properly works after scrollable range shrinkage
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchoring-with-bounds-clamping-div-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchoring-with-bounds-clamping-div-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Anchoring combined with scroll bounds clamping in a <div>. assert_equals: expected 100 but got 515
+PASS Anchoring combined with scroll bounds clamping in a <div>.
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -118,6 +118,12 @@ void ScrollAnchoringController::scrollPositionDidChange()
     if (m_isUpdatingScrollPositionForAnchoring)
         return;
 
+    // When we're between updateBeforeLayout() and adjustScrollPositionForAnchoring(),
+    // the scroll position may change due to clamping when the scrollable range shrinks.
+    // Preserve the anchor so the pending adjustment can still run.
+    if (m_isQueuedForScrollPositionUpdate)
+        return;
+
     LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::scrollPositionChanged() to " << m_owningScrollableArea->scrollPosition() << " - clearing scroll anchor");
 
     if (m_owningScrollableArea->currentScrollType() == ScrollType::User)

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -248,7 +248,7 @@ bool ScrollAnimator::handleTouchEvent(const PlatformTouchEvent&)
 
 static void notifyScrollAnchoringControllerOfScroll(ScrollableArea& scrollableArea)
 {
-    scrollableArea.clearScrollAnchor();
+    scrollableArea.notifyScrollAnchoringControllerOfScrollPositionChange();
 }
 
 void ScrollAnimator::setCurrentPosition(const FloatPoint& position, NotifyScrollableArea notify)

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -299,6 +299,12 @@ void ScrollableArea::clearScrollAnchor(IncludeAncestors includeAncestors)
         controller->clearAnchor(includeAncestors == IncludeAncestors::Yes);
 }
 
+void ScrollableArea::notifyScrollAnchoringControllerOfScrollPositionChange()
+{
+    if (CheckedPtr controller = scrollAnchoringController())
+        controller->scrollPositionDidChange();
+}
+
 void ScrollableArea::adjustScrollAnchoringPosition()
 {
     if (CheckedPtr controller = scrollAnchoringController())

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -456,6 +456,7 @@ public:
         Yes
     };
     void clearScrollAnchor(IncludeAncestors = IncludeAncestors::No);
+    void notifyScrollAnchoringControllerOfScrollPositionChange();
     void adjustScrollAnchoringPosition();
     virtual ScrollAnchoringController* scrollAnchoringController() const { return nullptr; }
 


### PR DESCRIPTION
#### 4ba410727bd6d3e5fc7880c2a676f863c74e3d3b
<pre>
CSS scroll anchoring doesn&apos;t work after scrollable range shrinkage
<a href="https://bugs.webkit.org/show_bug.cgi?id=313269">https://bugs.webkit.org/show_bug.cgi?id=313269</a>
<a href="https://rdar.apple.com/175545530">rdar://175545530</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When the scrollable overflow area shrinks during layout, adjustViewSize()
calls setContentsSize() which triggers updateScrollbars() to clamp the
scroll position to the new maximum. This clamping notifies the scroll
anchoring controller through two paths -- scrollPositionDidChange() and
notifyScrollAnchoringControllerOfScroll() -- both of which destroy
the saved anchor before adjustScrollAnchoringPositionForScrollableAreas()
runs in performPostLayoutTasks().

Guard scrollPositionDidChange() to preserve the anchor when
m_isQueuedForScrollPositionUpdate is true (between updateBeforeLayout()
and adjustScrollPositionForAnchoring()). Route the second notification
path in ScrollAnimator through scrollPositionDidChange() instead of
clearScrollAnchor() so both paths share the same guard.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchoring-with-bounds-clamping-div-expected.txt:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::scrollPositionDidChange):
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::notifyScrollAnchoringControllerOfScroll):
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::notifyScrollAnchoringControllerOfScrollPositionChange):
* Source/WebCore/platform/ScrollableArea.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ba410727bd6d3e5fc7880c2a676f863c74e3d3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112687 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c5aacca-04eb-40e7-bcb7-a34a1b582579) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32017 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122856 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/changing-scroll-snap-align.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/remove-current-target.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86211 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55ceb32e-3843-4e4a-8ca8-b584255364e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103525 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4eba4120-51e7-4b05-86b8-199273c3adee) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24169 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/changing-scroll-snap-align.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/remove-current-target.html imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-window-stop-in-onnavigate.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22568 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15204 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169923 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15667 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21880 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-intrinsic-size-001.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/changing-scroll-snap-align.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/remove-current-target.html imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131044 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/changing-scroll-snap-align.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/remove-current-target.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31718 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26632 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-intrinsic-size-001.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/changing-scroll-snap-align.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/remove-current-target.html imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131158 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142048 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89570 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25848 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18856 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-intrinsic-size-001.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/changing-scroll-snap-align.html imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/remove-current-target.html imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31175 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97189 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30695 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30968 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30849 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->