### PR TITLE
WIP Cannot resolve percentages when computing preferred widths

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/keyword-sizes-on-replaced-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/keyword-sizes-on-replaced-element-expected.txt
@@ -74,13 +74,13 @@ height expected 60 but got 110
 PASS .test 71
 FAIL .test 72 assert_equals:
 <canvas width="100" height="100" class="test max-height" style="max-width: 50px; max-height: fit-content" data-expected-width="60" data-expected-height="60"></canvas>
-height expected 60 but got 110
+height expected 60 but got 70
 FAIL .test 73 assert_equals:
 <canvas width="100" height="100" class="test height" style="min-width: 150px; height: fit-content" data-expected-width="160" data-expected-height="160"></canvas>
 height expected 160 but got 110
 FAIL .test 74 assert_equals:
 <canvas width="100" height="100" class="test min-height" style="min-width: 150px; min-height: fit-content" data-expected-width="160" data-expected-height="160"></canvas>
-height expected 160 but got 110
+width expected 160 but got 170
 PASS .test 75
 PASS .test 76
 PASS .test 77
@@ -91,13 +91,13 @@ height expected 60 but got 110
 PASS .test 80
 FAIL .test 81 assert_equals:
 <canvas width="100" height="100" class="test max-height" style="max-width: 50px; max-height: min-content" data-expected-width="60" data-expected-height="60"></canvas>
-height expected 60 but got 110
+height expected 60 but got 70
 FAIL .test 82 assert_equals:
 <canvas width="100" height="100" class="test height" style="min-width: 150px; height: min-content" data-expected-width="160" data-expected-height="160"></canvas>
 height expected 160 but got 110
 FAIL .test 83 assert_equals:
 <canvas width="100" height="100" class="test min-height" style="min-width: 150px; min-height: min-content" data-expected-width="160" data-expected-height="160"></canvas>
-height expected 160 but got 110
+width expected 160 but got 170
 PASS .test 84
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<link rel="match" href="replaced-max-width-with-height-fit-content-ref.html">
+</head>
+<body>
+<img style="max-width: 100px; height: fit-content;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<link rel="match" href="replaced-max-width-with-height-max-content-ref.html">
+</head>
+<body>
+<img style="max-width: 100px; height: max-content;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<img style="width: 100px; height: 100px;" src="support/replaced-min-max-2.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-replaced-height">
+<link rel="match" href="replaced-max-width-with-height-min-content-ref.html">
+</head>
+<body>
+<img style="max-width: 100px; height: min-content;" src="support/replaced-min-max-2.png">
+</body>
+</html>
+	

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -108,6 +108,7 @@
 #include <math.h>
 #include <wtf/Assertions.h>
 #include <wtf/RuntimeApplicationChecks.h>
+#include <wtf/Scope.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -5244,6 +5245,13 @@ std::pair<LayoutUnit, LayoutUnit> RenderBox::computeMinMaxLogicalHeightFromAspec
 {
     LayoutUnit transferredMinSize = LayoutUnit();
     LayoutUnit transferredMaxSize = LayoutUnit::max();
+
+#if ASSERT_ENABLED
+    auto checkMinMaxSizes = makeScopeExit([&transferredMinSize, &transferredMaxSize] {
+        ASSERT(transferredMaxSize >= transferredMinSize);
+    });
+#endif
+
     std::optional<double> aspectRatio = resolveAspectRatio();
     if (!aspectRatio)
         return { transferredMinSize, transferredMaxSize };

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -46,7 +46,6 @@ struct PaintInfo;
 
 enum class AvailableLogicalHeightType : bool { ExcludeMarginBorderPadding, IncludeMarginBorderPadding };
 
-enum class ShouldComputePreferred : bool { ComputeActual, ComputePreferred };
 
 enum class StretchingMode { Normal, Explicit };
 

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -297,11 +297,11 @@ LayoutUnit RenderImage::computeReplacedLogicalWidth(ComputePreferredLogicalWidth
     return RenderReplaced::computeReplacedLogicalWidth(computePreferredLogicalWidth);
 }
 
-LayoutUnit RenderImage::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth) const
+LayoutUnit RenderImage::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth, ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
     if (shouldCollapseToEmpty())
         return { };
-    return RenderReplaced::computeReplacedLogicalHeight(estimatedUsedWidth);
+    return RenderReplaced::computeReplacedLogicalHeight(estimatedUsedWidth, computePreferredLogicalWidth);
 }
 
 void RenderImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -290,11 +290,11 @@ bool RenderImage::shouldCollapseToEmpty() const
     return document().inNoQuirksMode() || (style().logicalWidth().isAuto() && style().logicalHeight().isAuto());
 }
 
-LayoutUnit RenderImage::computeReplacedLogicalWidth(ShouldComputePreferred shouldComputePreferred) const
+LayoutUnit RenderImage::computeReplacedLogicalWidth(ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
     if (shouldCollapseToEmpty())
         return { };
-    return RenderReplaced::computeReplacedLogicalWidth(shouldComputePreferred);
+    return RenderReplaced::computeReplacedLogicalWidth(computePreferredLogicalWidth);
 }
 
 LayoutUnit RenderImage::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth) const

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -137,7 +137,7 @@ private:
 
     bool hasShadowContent() const { return m_hasShadowControls || m_hasImageOverlay; }
 
-    LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred = ShouldComputePreferred::ComputeActual) const override;
+    LayoutUnit computeReplacedLogicalWidth(ComputePreferredLogicalWidth = ComputePreferredLogicalWidth::No) const override;
     LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const override;
 
     bool shouldCollapseToEmpty() const;

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -138,7 +138,7 @@ private:
     bool hasShadowContent() const { return m_hasShadowControls || m_hasImageOverlay; }
 
     LayoutUnit computeReplacedLogicalWidth(ComputePreferredLogicalWidth = ComputePreferredLogicalWidth::No) const override;
-    LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const override;
+    LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt, ComputePreferredLogicalWidth = ComputePreferredLogicalWidth::No) const override;
 
     bool shouldCollapseToEmpty() const;
 

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -707,13 +707,13 @@ static inline bool NODELETE hasIntrinsicSize(RenderBox*contentRenderer, bool has
     return false;
 }
 
-LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred shouldComputePreferred) const
+LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
     auto& style = this->style();
     if (style.logicalWidth().isSpecified())
-        return computeReplacedLogicalWidthRespectingMinMaxWidth(computeReplacedLogicalWidthUsing(style.logicalWidth()), shouldComputePreferred);
+        return computeReplacedLogicalWidthRespectingMinMaxWidth(computeReplacedLogicalWidthUsing(style.logicalWidth()), computePreferredLogicalWidth);
     if (style.logicalWidth().isIntrinsicOrStretch())
-        return computeReplacedLogicalWidthRespectingMinMaxWidth(computeReplacedLogicalWidthUsing(style.logicalWidth()), shouldComputePreferred);
+        return computeReplacedLogicalWidthRespectingMinMaxWidth(computeReplacedLogicalWidthUsing(style.logicalWidth()), computePreferredLogicalWidth);
 
     RenderBox* contentRenderer = embeddedContentBox();
 
@@ -731,11 +731,11 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
         // grid item has an intrinsic size. It is possible (indeed, common) for an SVG graphic to have an intrinsic aspect ratio but not to have an intrinsic
         // width or height. There are also elements with intrinsic sizes but without intrinsic ratio (like an iframe).
         if (auto overridingLogicalHeight = (!intrinsicRatio.isEmpty() && (isFlexItem() || isGridItem()) && hasIntrinsicSize(contentRenderer, hasIntrinsicWidth, hasIntrinsicHeight) ? this->overridingBorderBoxLogicalHeight() : std::nullopt))
-            return computeReplacedLogicalWidthRespectingMinMaxWidth(contentBoxLogicalHeight(*overridingLogicalHeight) * intrinsicRatio.aspectRatioDouble(), shouldComputePreferred);
+            return computeReplacedLogicalWidthRespectingMinMaxWidth(contentBoxLogicalHeight(*overridingLogicalHeight) * intrinsicRatio.aspectRatioDouble(), computePreferredLogicalWidth);
 
         // If 'height' and 'width' both have computed values of 'auto' and the element also has an intrinsic width, then that intrinsic width is the used value of 'width'.
         if (computedHeightIsAuto && hasIntrinsicWidth)
-            return computeReplacedLogicalWidthRespectingMinMaxWidth(constrainedSize.width(), shouldComputePreferred);
+            return computeReplacedLogicalWidthRespectingMinMaxWidth(constrainedSize.width(), computePreferredLogicalWidth);
 
         if (!intrinsicRatio.isEmpty()) {
             // If 'height' and 'width' both have computed values of 'auto' and the element has no intrinsic width, but does have an intrinsic height and intrinsic ratio;
@@ -746,16 +746,16 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
                     if (hasIntrinsicWidth)
                         return LayoutUnit(constrainedSize.width());
 
-                    if (shouldComputePreferred == ShouldComputePreferred::ComputePreferred)
-                        return computeReplacedLogicalWidthRespectingMinMaxWidth(0_lu, ShouldComputePreferred::ComputePreferred);
+                    if (computePreferredLogicalWidth == ComputePreferredLogicalWidth::Yes)
+                        return computeReplacedLogicalWidthRespectingMinMaxWidth(0_lu, ComputePreferredLogicalWidth::Yes);
 
                     auto constrainedLogicalWidth = computeConstrainedLogicalWidth();
-                    return computeReplacedLogicalWidthRespectingMinMaxWidth(constrainedLogicalWidth, ShouldComputePreferred::ComputeActual);
+                    return computeReplacedLogicalWidthRespectingMinMaxWidth(constrainedLogicalWidth, ComputePreferredLogicalWidth::No);
                 }();
 
                 LayoutUnit logicalHeight = computeReplacedLogicalHeight(std::optional<LayoutUnit>(estimatedUsedWidth));
                 auto boxSizing = style.aspectRatio().hasRatio() ? style.boxSizingForAspectRatio() : BoxSizing::ContentBox;
-                return computeReplacedLogicalWidthRespectingMinMaxWidth(resolveWidthForRatio(borderAndPaddingLogicalHeight(), borderAndPaddingLogicalWidth(), logicalHeight, intrinsicRatio.aspectRatioDouble(), boxSizing), shouldComputePreferred);
+                return computeReplacedLogicalWidthRespectingMinMaxWidth(resolveWidthForRatio(borderAndPaddingLogicalHeight(), borderAndPaddingLogicalWidth(), logicalHeight, intrinsicRatio.aspectRatioDouble(), boxSizing), computePreferredLogicalWidth);
             }
 
             // If 'height' and 'width' both have computed values of 'auto' and the
@@ -767,11 +767,11 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
             // non-replaced elements in normal flow.
             if (computedHeightIsAuto && !hasIntrinsicWidth && !hasIntrinsicHeight) {
                 bool isFlexItemComputingBaseSize = isFlexItem() && downcast<RenderFlexibleBox>(parent())->isComputingFlexBaseSizes();
-                if (shouldComputePreferred == ShouldComputePreferred::ComputePreferred && !isFlexItemComputingBaseSize) {
+                if (computePreferredLogicalWidth == ComputePreferredLogicalWidth::Yes && !isFlexItemComputingBaseSize) {
                     // When there's a min/max-height and an intrinsic ratio, the preferred width
                     // should reflect the transferred size constraints from the opposite axis.
                     auto [transferredMin, transferredMax] = computeMinMaxLogicalWidthFromAspectRatio();
-                    return computeReplacedLogicalWidthRespectingMinMaxWidth(std::clamp(0_lu, transferredMin, transferredMax), ShouldComputePreferred::ComputePreferred);
+                    return computeReplacedLogicalWidthRespectingMinMaxWidth(std::clamp(0_lu, transferredMin, transferredMax), ComputePreferredLogicalWidth::Yes);
                 }
 
                 auto constrainedLogicalWidth = computeConstrainedLogicalWidth();
@@ -789,13 +789,13 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
                     return std::max(minLogicalWidth, constrainedLogicalWidth);
                 }
 
-                return computeReplacedLogicalWidthRespectingMinMaxWidth(constrainedLogicalWidth, ShouldComputePreferred::ComputeActual);
+                return computeReplacedLogicalWidthRespectingMinMaxWidth(constrainedLogicalWidth, ComputePreferredLogicalWidth::No);
             }
         }
 
         // Otherwise, if 'width' has a computed value of 'auto', and the element has an intrinsic width, then that intrinsic width is the used value of 'width'.
         if (hasIntrinsicWidth)
-            return computeReplacedLogicalWidthRespectingMinMaxWidth(constrainedSize.width(), shouldComputePreferred);
+            return computeReplacedLogicalWidthRespectingMinMaxWidth(constrainedSize.width(), computePreferredLogicalWidth);
 
         // Otherwise, if 'width' has a computed value of 'auto', but none of the conditions above are met, then the used value of 'width' becomes 300px. If 300px is too
         // wide to fit the device, UAs should use the width of the largest rectangle that has a 2:1 ratio and fits the device instead.
@@ -804,7 +804,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
         // has no intrinsic size, which is wrong per CSS 2.1, but matches our behavior since a long time.
     }
 
-    return computeReplacedLogicalWidthRespectingMinMaxWidth(intrinsicLogicalWidth(), shouldComputePreferred);
+    return computeReplacedLogicalWidthRespectingMinMaxWidth(intrinsicLogicalWidth(), computePreferredLogicalWidth);
 }
 
 LayoutUnit RenderReplaced::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth) const
@@ -878,7 +878,7 @@ void RenderReplaced::computePreferredLogicalWidths()
     if (style().logicalWidth().isPercentOrCalculated())
         computeAspectRatioAdjustedIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
     else
-        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = computeReplacedLogicalWidth(ShouldComputePreferred::ComputePreferred);
+        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = computeReplacedLogicalWidth(ComputePreferredLogicalWidth::Yes);
 
     bool ignoreMinMaxSizes = shouldIgnoreLogicalMinMaxWidthSizes();
     const RenderStyle& styleToUse = style();
@@ -1117,15 +1117,15 @@ void RenderReplaced::computeReplacedOutOfFlowPositionedLogicalHeight(LogicalExte
     blockConstraints.adjustLogicalTopWithLogicalHeightIfNeeded(computedValues);
 }
 
-LayoutUnit RenderReplaced::computeReplacedLogicalWidthRespectingMinMaxWidth(LayoutUnit logicalWidth, ShouldComputePreferred shouldComputePreferred) const
+LayoutUnit RenderReplaced::computeReplacedLogicalWidthRespectingMinMaxWidth(LayoutUnit logicalWidth, ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
     if (shouldIgnoreLogicalMinMaxWidthSizes())
         return logicalWidth;
 
     auto& logicalMinWidth = style().logicalMinWidth();
     auto& logicalMaxWidth = style().logicalMaxWidth();
-    bool useLogicalWidthForMinWidth = (shouldComputePreferred == ShouldComputePreferred::ComputePreferred && logicalMinWidth.isPercentOrCalculated());
-    bool useLogicalWidthForMaxWidth = (shouldComputePreferred == ShouldComputePreferred::ComputePreferred && logicalMaxWidth.isPercentOrCalculated()) || logicalMaxWidth.isNone();
+    bool useLogicalWidthForMinWidth = (computePreferredLogicalWidth == ComputePreferredLogicalWidth::Yes && logicalMinWidth.isPercentOrCalculated());
+    bool useLogicalWidthForMaxWidth = (computePreferredLogicalWidth == ComputePreferredLogicalWidth::Yes && logicalMaxWidth.isPercentOrCalculated()) || logicalMaxWidth.isNone();
     auto minLogicalWidth =  useLogicalWidthForMinWidth ? logicalWidth : computeReplacedLogicalWidthUsing(logicalMinWidth);
     auto maxLogicalWidth =  useLogicalWidthForMaxWidth ? logicalWidth : computeReplacedLogicalWidthUsing(logicalMaxWidth);
     return std::max(minLogicalWidth, std::min(logicalWidth, maxLogicalWidth));

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -753,7 +753,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ComputePreferredLogicalWi
                     return computeReplacedLogicalWidthRespectingMinMaxWidth(constrainedLogicalWidth, ComputePreferredLogicalWidth::No);
                 }();
 
-                LayoutUnit logicalHeight = computeReplacedLogicalHeight(std::optional<LayoutUnit>(estimatedUsedWidth));
+                LayoutUnit logicalHeight = computeReplacedLogicalHeight(std::optional<LayoutUnit>(estimatedUsedWidth), computePreferredLogicalWidth);
                 auto boxSizing = style.aspectRatio().hasRatio() ? style.boxSizingForAspectRatio() : BoxSizing::ContentBox;
                 return computeReplacedLogicalWidthRespectingMinMaxWidth(resolveWidthForRatio(borderAndPaddingLogicalHeight(), borderAndPaddingLogicalWidth(), logicalHeight, intrinsicRatio.aspectRatioDouble(), boxSizing), computePreferredLogicalWidth);
             }
@@ -807,11 +807,11 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ComputePreferredLogicalWi
     return computeReplacedLogicalWidthRespectingMinMaxWidth(intrinsicLogicalWidth(), computePreferredLogicalWidth);
 }
 
-LayoutUnit RenderReplaced::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth) const
+LayoutUnit RenderReplaced::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth, ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
     // 10.5 Content height: the 'height' property: http://www.w3.org/TR/CSS21/visudet.html#propdef-height
     if (hasReplacedLogicalHeight())
-        return computeReplacedLogicalHeightRespectingMinMaxHeight(computeReplacedLogicalHeightUsing(style().logicalHeight()));
+        return computeReplacedLogicalHeightRespectingMinMaxHeight(computeReplacedLogicalHeightUsing(style().logicalHeight(), computePreferredLogicalWidth));
 
     RenderBox* contentRenderer = embeddedContentBox();
 
@@ -1276,7 +1276,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeightRespectingMinMaxHeight(La
 }
 
 template<typename SizeType>
-LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsingGeneric(const SizeType& logicalHeight) const
+LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsingGeneric(const SizeType& logicalHeight, ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
 #if ASSERT_ENABLED
     // This function should get called with Style::MinimumSize/Style::MaximumSize only if replaced[Min|Max]LogicalHeightComputesAsNone
@@ -1374,6 +1374,8 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsingGeneric(const SizeTy
             return percentageOrCalculated(calculatedLogicalHeight);
         },
         [&](const CSS::Keyword::FitContent&) -> LayoutUnit {
+            if (computePreferredLogicalWidth == ComputePreferredLogicalWidth::Yes)
+                return content();
             auto [transferredMinLogicalHeight, transferredMaxLogicalHeight] = computeMinMaxLogicalHeightFromAspectRatio();
             return std::clamp(content(), transferredMinLogicalHeight, transferredMaxLogicalHeight);
         },
@@ -1384,10 +1386,14 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsingGeneric(const SizeTy
             return intrinsicLogicalHeight();
         },
         [&](const CSS::Keyword::MinContent&) -> LayoutUnit {
+            if (computePreferredLogicalWidth == ComputePreferredLogicalWidth::Yes)
+                return content();
             auto [transferredMinLogicalHeight, transferredMaxLogicalHeight] = computeMinMaxLogicalHeightFromAspectRatio();
             return std::clamp(content(), transferredMinLogicalHeight, transferredMaxLogicalHeight);
         },
         [&](const CSS::Keyword::MaxContent&) -> LayoutUnit {
+            if (computePreferredLogicalWidth == ComputePreferredLogicalWidth::Yes)
+                return content();
             auto [transferredMinLogicalHeight, transferredMaxLogicalHeight] = computeMinMaxLogicalHeightFromAspectRatio();
             return std::clamp(content(), transferredMinLogicalHeight, transferredMaxLogicalHeight);
         },
@@ -1409,9 +1415,9 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsingGeneric(const SizeTy
     );
 }
 
-LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsing(const Style::PreferredSize& logicalHeight) const
+LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsing(const Style::PreferredSize& logicalHeight, ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
-    return computeReplacedLogicalHeightUsingGeneric(logicalHeight);
+    return computeReplacedLogicalHeightUsingGeneric(logicalHeight, computePreferredLogicalWidth);
 }
 
 LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsing(const Style::MinimumSize& logicalHeight) const

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -1374,7 +1374,8 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsingGeneric(const SizeTy
             return percentageOrCalculated(calculatedLogicalHeight);
         },
         [&](const CSS::Keyword::FitContent&) -> LayoutUnit {
-            return content();
+            auto [transferredMinLogicalHeight, transferredMaxLogicalHeight] = computeMinMaxLogicalHeightFromAspectRatio();
+            return std::clamp(content(), transferredMinLogicalHeight, transferredMaxLogicalHeight);
         },
         [&](const CSS::Keyword::Stretch&) -> LayoutUnit {
             // stretch with indefinite containing block falls back to intrinsic height for replaced elements.
@@ -1383,10 +1384,12 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsingGeneric(const SizeTy
             return intrinsicLogicalHeight();
         },
         [&](const CSS::Keyword::MinContent&) -> LayoutUnit {
-            return content();
+            auto [transferredMinLogicalHeight, transferredMaxLogicalHeight] = computeMinMaxLogicalHeightFromAspectRatio();
+            return std::clamp(content(), transferredMinLogicalHeight, transferredMaxLogicalHeight);
         },
         [&](const CSS::Keyword::MaxContent&) -> LayoutUnit {
-            return content();
+            auto [transferredMinLogicalHeight, transferredMaxLogicalHeight] = computeMinMaxLogicalHeightFromAspectRatio();
+            return std::clamp(content(), transferredMinLogicalHeight, transferredMaxLogicalHeight);
         },
         [&](const CSS::Keyword::Intrinsic&) -> LayoutUnit {
             return intrinsicLogicalHeight();

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -25,6 +25,8 @@
 
 namespace WebCore {
 
+enum class ComputePreferredLogicalWidth : bool { No, Yes };
+
 class RenderReplaced : public RenderBox {
     WTF_MAKE_TZONE_ALLOCATED(RenderReplaced);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderReplaced);
@@ -55,7 +57,7 @@ public:
     LayoutUnit computeReplacedLogicalHeightUsing(const Style::MinimumSize& logicalHeight) const;
     LayoutUnit computeReplacedLogicalHeightUsing(const Style::MaximumSize& logicalHeight) const;
 
-    virtual LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred  = ShouldComputePreferred::ComputeActual) const;
+    virtual LayoutUnit computeReplacedLogicalWidth(ComputePreferredLogicalWidth  = ComputePreferredLogicalWidth::No) const;
     virtual LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const;
 
     bool replacedMinLogicalHeightComputesAsNone() const;
@@ -92,8 +94,8 @@ protected:
 
     virtual void layoutShadowContent(const LayoutSize&);
 
-    LayoutUnit computeReplacedLogicalWidthRespectingMinMaxWidth(LayoutUnit logicalWidth, ShouldComputePreferred = ShouldComputePreferred::ComputeActual) const;
-    template<typename T> LayoutUnit computeReplacedLogicalWidthRespectingMinMaxWidth(T logicalWidth, ShouldComputePreferred shouldComputePreferred = ShouldComputePreferred::ComputeActual) const { return computeReplacedLogicalWidthRespectingMinMaxWidth(LayoutUnit(logicalWidth), shouldComputePreferred); }
+    LayoutUnit computeReplacedLogicalWidthRespectingMinMaxWidth(LayoutUnit logicalWidth, ComputePreferredLogicalWidth = ComputePreferredLogicalWidth::No) const;
+    template<typename T> LayoutUnit computeReplacedLogicalWidthRespectingMinMaxWidth(T logicalWidth, ComputePreferredLogicalWidth computePreferredLogicalWidth = ComputePreferredLogicalWidth::No) const { return computeReplacedLogicalWidthRespectingMinMaxWidth(LayoutUnit(logicalWidth), computePreferredLogicalWidth); }
 
 private:
     LayoutUnit computeConstrainedLogicalWidth() const;

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -53,12 +53,12 @@ public:
 
     virtual bool paintsContent() const { return true; }
 
-    LayoutUnit computeReplacedLogicalHeightUsing(const Style::PreferredSize& logicalHeight) const;
+    LayoutUnit computeReplacedLogicalHeightUsing(const Style::PreferredSize& logicalHeight, ComputePreferredLogicalWidth = ComputePreferredLogicalWidth::No) const;
     LayoutUnit computeReplacedLogicalHeightUsing(const Style::MinimumSize& logicalHeight) const;
     LayoutUnit computeReplacedLogicalHeightUsing(const Style::MaximumSize& logicalHeight) const;
 
     virtual LayoutUnit computeReplacedLogicalWidth(ComputePreferredLogicalWidth  = ComputePreferredLogicalWidth::No) const;
-    virtual LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const;
+    virtual LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt, ComputePreferredLogicalWidth = ComputePreferredLogicalWidth::No) const;
 
     bool replacedMinLogicalHeightComputesAsNone() const;
     bool replacedMaxLogicalHeightComputesAsNone() const;
@@ -101,7 +101,7 @@ private:
     LayoutUnit computeConstrainedLogicalWidth() const;
 
     template<typename SizeType> LayoutUnit computeReplacedLogicalWidthUsing(const SizeType& logicalWidth) const;
-    template<typename SizeType> LayoutUnit computeReplacedLogicalHeightUsingGeneric(const SizeType& logicalHeight) const;
+    template<typename SizeType> LayoutUnit computeReplacedLogicalHeightUsingGeneric(const SizeType& logicalHeight, ComputePreferredLogicalWidth = ComputePreferredLogicalWidth::No) const;
     LayoutUnit computeReplacedLogicalHeightRespectingMinMaxHeight(LayoutUnit logicalHeight) const;
     template<typename T> LayoutUnit computeReplacedLogicalHeightRespectingMinMaxHeight(T logicalHeight) const { return computeReplacedLogicalHeightRespectingMinMaxHeight(LayoutUnit(logicalHeight)); }
     bool replacedMinMaxLogicalHeightComputesAsNone(const auto& logicalHeight, const auto& initialLogicalHeight) const;

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -349,9 +349,9 @@ bool RenderVideo::updatePlayer()
     return intrinsicSizeChanged;
 }
 
-LayoutUnit RenderVideo::computeReplacedLogicalWidth(ShouldComputePreferred shouldComputePreferred) const
+LayoutUnit RenderVideo::computeReplacedLogicalWidth(ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
-    return computeReplacedLogicalWidthRespectingMinMaxWidth(RenderReplaced::computeReplacedLogicalWidth(shouldComputePreferred), shouldComputePreferred);
+    return computeReplacedLogicalWidthRespectingMinMaxWidth(RenderReplaced::computeReplacedLogicalWidth(computePreferredLogicalWidth), computePreferredLogicalWidth);
 }
 
 LayoutUnit RenderVideo::minimumReplacedHeight() const 

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -82,7 +82,7 @@ private:
 
     void visibleInViewportStateChanged() final;
 
-    LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred  = ShouldComputePreferred::ComputeActual) const final;
+    LayoutUnit computeReplacedLogicalWidth(ComputePreferredLogicalWidth  = ComputePreferredLogicalWidth::No) const final;
     LayoutUnit minimumReplacedHeight() const final;
 
     bool updatePlayer();

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -149,7 +149,7 @@ bool RenderSVGRoot::isEmbeddedThroughFrameContainingSVGDocument() const
     return frame().document()->isSVGDocument();
 }
 
-LayoutUnit RenderSVGRoot::computeReplacedLogicalWidth(ShouldComputePreferred shouldComputePreferred) const
+LayoutUnit RenderSVGRoot::computeReplacedLogicalWidth(ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
     // When we're embedded through SVGImage (border-image/background-image/<html:img>/...) we're forced to resize to a specific size.
     if (!m_containerSize.isEmpty())
@@ -159,7 +159,7 @@ LayoutUnit RenderSVGRoot::computeReplacedLogicalWidth(ShouldComputePreferred sho
         return containingBlock()->contentBoxLogicalWidth();
 
     // Standalone SVG / SVG embedded via SVGImage (background-image/border-image/etc) / Inline SVG.
-    auto result = RenderReplaced::computeReplacedLogicalWidth(shouldComputePreferred);
+    auto result = RenderReplaced::computeReplacedLogicalWidth(computePreferredLogicalWidth);
     if (svgSVGElement().hasIntrinsicWidth())
         return result;
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -170,7 +170,7 @@ LayoutUnit RenderSVGRoot::computeReplacedLogicalWidth(ComputePreferredLogicalWid
     return result;
 }
 
-LayoutUnit RenderSVGRoot::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth) const
+LayoutUnit RenderSVGRoot::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth, ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
     // When we're embedded through SVGImage (border-image/background-image/<html:img>/...) we're forced to resize to a specific size.
     if (!m_containerSize.isEmpty())
@@ -180,7 +180,7 @@ LayoutUnit RenderSVGRoot::computeReplacedLogicalHeight(std::optional<LayoutUnit>
         return containingBlock()->availableLogicalHeight(AvailableLogicalHeightType::IncludeMarginBorderPadding);
 
     // Standalone SVG / SVG embedded via SVGImage (background-image/border-image/etc) / Inline SVG.
-    auto result = RenderReplaced::computeReplacedLogicalHeight(estimatedUsedWidth);
+    auto result = RenderReplaced::computeReplacedLogicalHeight(estimatedUsedWidth, computePreferredLogicalWidth);
     if (svgSVGElement().hasIntrinsicHeight())
         return result;
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -90,7 +90,7 @@ private:
     std::optional<FloatRect> NODELETE computeFloatVisibleRectInContainer(const FloatRect&, const RenderLayerModelObject*, VisibleRectContext) const final;
 
     LayoutUnit computeReplacedLogicalWidth(ComputePreferredLogicalWidth  = ComputePreferredLogicalWidth::No) const final;
-    LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const final;
+    LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt, ComputePreferredLogicalWidth = ComputePreferredLogicalWidth::No) const final;
     void layout() final;
     void layoutChildren();
     void paint(PaintInfo&, const LayoutPoint&) final;

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -89,7 +89,7 @@ private:
     // To prevent certain legacy code paths to hit assertions in debug builds, when switching off LBSE (during the teardown of the LBSE tree).
     std::optional<FloatRect> NODELETE computeFloatVisibleRectInContainer(const FloatRect&, const RenderLayerModelObject*, VisibleRectContext) const final;
 
-    LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred  = ShouldComputePreferred::ComputeActual) const final;
+    LayoutUnit computeReplacedLogicalWidth(ComputePreferredLogicalWidth  = ComputePreferredLogicalWidth::No) const final;
     LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const final;
     void layout() final;
     void layoutChildren();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -139,7 +139,7 @@ bool LegacyRenderSVGRoot::isEmbeddedThroughFrameContainingSVGDocument() const
     return frame().document()->isSVGDocument();
 }
 
-LayoutUnit LegacyRenderSVGRoot::computeReplacedLogicalWidth(ShouldComputePreferred shouldComputePreferred) const
+LayoutUnit LegacyRenderSVGRoot::computeReplacedLogicalWidth(ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
     // When we're embedded through SVGImage (border-image/background-image/<html:img>/...) we're forced to resize to a specific size.
     if (!m_containerSize.isEmpty())
@@ -149,7 +149,7 @@ LayoutUnit LegacyRenderSVGRoot::computeReplacedLogicalWidth(ShouldComputePreferr
         return containingBlock()->contentBoxLogicalWidth();
 
     // SVG embedded via SVGImage (background-image/border-image/etc) / Inline SVG.
-    return RenderReplaced::computeReplacedLogicalWidth(shouldComputePreferred);
+    return RenderReplaced::computeReplacedLogicalWidth(computePreferredLogicalWidth);
 }
 
 LayoutUnit LegacyRenderSVGRoot::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth) const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -152,7 +152,7 @@ LayoutUnit LegacyRenderSVGRoot::computeReplacedLogicalWidth(ComputePreferredLogi
     return RenderReplaced::computeReplacedLogicalWidth(computePreferredLogicalWidth);
 }
 
-LayoutUnit LegacyRenderSVGRoot::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth) const
+LayoutUnit LegacyRenderSVGRoot::computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth, ComputePreferredLogicalWidth computePreferredLogicalWidth) const
 {
     // When we're embedded through SVGImage (border-image/background-image/<html:img>/...) we're forced to resize to a specific size.
     if (!m_containerSize.isEmpty())
@@ -162,7 +162,7 @@ LayoutUnit LegacyRenderSVGRoot::computeReplacedLogicalHeight(std::optional<Layou
         return containingBlock()->availableLogicalHeight(AvailableLogicalHeightType::IncludeMarginBorderPadding);
 
     // SVG embedded via SVGImage (background-image/border-image/etc) / Inline SVG.
-    return RenderReplaced::computeReplacedLogicalHeight(estimatedUsedWidth);
+    return RenderReplaced::computeReplacedLogicalHeight(estimatedUsedWidth, computePreferredLogicalWidth);
 }
 
 void LegacyRenderSVGRoot::layout()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -80,7 +80,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderSVGRoot"_s; }
 
     LayoutUnit computeReplacedLogicalWidth(ComputePreferredLogicalWidth  = ComputePreferredLogicalWidth::No) const override;
-    LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const override;
+    LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt, ComputePreferredLogicalWidth = ComputePreferredLogicalWidth::No) const override;
     void layout() override;
     void paintReplaced(PaintInfo&, const LayoutPoint&) override;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -79,7 +79,7 @@ private:
     // Intentially left 'RenderSVGRoot' instead of 'LegacyRenderSVGRoot', to avoid breaking layout tests.
     ASCIILiteral renderName() const override { return "RenderSVGRoot"_s; }
 
-    LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred  = ShouldComputePreferred::ComputeActual) const override;
+    LayoutUnit computeReplacedLogicalWidth(ComputePreferredLogicalWidth  = ComputePreferredLogicalWidth::No) const override;
     LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const override;
     void layout() override;
     void paintReplaced(PaintInfo&, const LayoutPoint&) override;


### PR DESCRIPTION
#### 92d1fd62b108d4955cc7f4aadfbfe015de2ce6cf
<pre>
WIP Cannot resolve percentages when computing preferred widths
</pre>
----------------------------------------------------------------------
#### 7229f26b03703023832bbedac27152e5a10c5434
<pre>
Rename ShouldComputePreferred to ComputePreferredLogicalWidth and move to RenderReplaced

Rename the enum from ShouldComputePreferred { ComputeActual, ComputePreferred }
to ComputePreferredLogicalWidth : bool { No, Yes } and move it from RenderBox.h
to RenderReplaced.h where it is actually used. Update all variable names
from shouldComputePreferred to computePreferredLogicalWidth to match.

Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 06f84ce2f2adfef3b9c252c6b8456cab0a65b808
<pre>
glance.cx: Home page shows stretched image next to &quot;Employee Workspaces&quot; section.
<a href="https://bugs.webkit.org/show_bug.cgi?id=309086">https://bugs.webkit.org/show_bug.cgi?id=309086</a>
<a href="https://rdar.apple.com/168264069">rdar://168264069</a>

Reviewed by Alan Baradlay.

The aforementioned image on the glance.cx homepage has styling with
width: 100%, max-width: 100%, and height: fit-content. We compute the width
of the image to be the same size as other engines, but the height of the
image is much taller compared to the others. In fact, the height of the
image comes from the natural size of it.

We currently see to return the intrinsic size of the image when computing
the fit-content size in RenderReplaced::computeReplacedLogicalHeightUsingGeneric,
which gets from eventually calling into computeIntrinsicLogicalContentHeightUsingGeneric.
This seems to be fine according to the way the intrinsic height is supposed
to be computed according to CSS-Box-Sizing-3, which defers to some language
from CSS2:
<a href="https://www.w3.org/TR/2021/WD-css-sizing-3-20211217/#intrinsic-sizes">https://www.w3.org/TR/2021/WD-css-sizing-3-20211217/#intrinsic-sizes</a>

However, there is an additional note that we do not seem to be taking
into account.
Note: When the box has a preferred aspect ratio, size constraints in the
opposite dimension will transfer through and can affect the auto size in
the considered one.

Essentially, we are not taking into consideration the transferred min/max
size constraints using those properties and the aspect ratio. The spec seems
to imply that we should be doing this since it has some language that says
it’s sized as &quot;if it was a float given an auto size in that axis,&quot; and includes
that note below the text.

So here we just apply those transferred size constraints by using the
computeMinMaxLogicalHeightFromAspectRatio helper that computes them and
clamping the intrinsic size between them. I also went ahead and did this
for the min-content and max-content cases since it was trivial to create
those test cases and it seems like that is what other engines are doing
as well. However, I did not do it for the WebkitFillAvailable since other
engines end up actually using the intrinsic size in that case.

Tests: imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content-ref.html
       imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-fit-content.html
       imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content-ref.html
       imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-max-content.html
       imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content-ref.html
       imported/w3c/web-platform-tests/css/css-sizing/replaced-max-width-with-height-min-content.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/keyword-sizes-on-replaced-element-expected.txt:
Rebasing this test since we were previously failing it and are still failing
it, but the sizes of the boxes do seem to be much closer to what is expected.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeMinMaxLogicalHeightFromAspectRatio const):
We already make sure that the transferred max size is at least as large
as the min at the end of this function, but I think it would be nice
to have this be a bit more resilient to changes by having a ScopeExit
check for this in debug builds.

Canonical link: <a href="https://commits.webkit.org/308995@main">https://commits.webkit.org/308995@main</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92d1fd62b108d4955cc7f4aadfbfe015de2ce6cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167433 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112688 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0eb11996-b2a4-4928-b0e8-af4b096342dc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122858 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86213 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103527 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3a4b728-3d88-45c2-a939-6740dcf0a511) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24168 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22569 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15205 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169924 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15668 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131043 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131157 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31665 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142052 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89571 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18860 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31176 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97190 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30696 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30969 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30850 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->