### PR TITLE
`height: 100%` has wrong calculation for img as grid cell nested inside flexbox

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-001-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#grid-item-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<style>
+.flex {
+    display: flex;
+    flex-direction: column;
+    height: 200px;
+    width: 100px;
+}
+.grid {
+    height: 100%;
+    display: grid;
+    grid-template-rows: 1fr 1fr;
+}
+img {
+    height: 100%;
+}
+</style>
+<div class="flex">
+    <div class="grid">
+        <img src="grid-items/support/100x100-green.png">
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-002-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-002.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#grid-item-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<style>
+.flex {
+    display: flex;
+    flex-direction: column;
+    height: 400px;
+    width: 100px;
+}
+.grid {
+    height: 100%;
+    display: grid;
+    grid-template-rows: 1fr 3fr;
+}
+img {
+    height: 100%;
+}
+</style>
+<div class="flex">
+    <div class="grid">
+        <img src="grid-items/support/100x100-green.png">
+    </div>
+</div>

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -1326,10 +1326,10 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeightUsingGeneric(const SizeTy
         if (isOutOfFlowPositioned()) {
             PositionedLayoutConstraints constraints(*this, LogicalBoxAxis::Block);
             availableHeight = constraints.containingSize();
-        } else if (stretchedHeight)
-            availableHeight = stretchedHeight.value();
-        else if (auto gridAreaLogicalHeight = isGridItem() ? this->gridAreaContentLogicalHeight() : std::nullopt; gridAreaLogicalHeight && *gridAreaLogicalHeight)
+        } else if (auto gridAreaLogicalHeight = isGridItem() ? this->gridAreaContentLogicalHeight() : std::nullopt; gridAreaLogicalHeight && *gridAreaLogicalHeight)
             availableHeight = gridAreaLogicalHeight->value();
+        else if (stretchedHeight)
+            availableHeight = stretchedHeight.value();
         else {
             availableHeight = hasPerpendicularContainingBlock ? containingBlockLogicalWidthForContent() : containingBlockLogicalHeightForContent(AvailableLogicalHeightType::IncludeMarginBorderPadding);
             // It is necessary to use the border-box to match WinIE's broken


### PR DESCRIPTION
#### bd1628731f5e8164788c7bcbcb72a67fb10fb98e
<pre>
`height: 100%` has wrong calculation for img as grid cell nested inside flexbox
<a href="https://rdar.apple.com/169431440">rdar://169431440</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306258">https://bugs.webkit.org/show_bug.cgi?id=306258</a>

Reviewed by Alan Baradlay.

When a replaced element is a grid item then its containing block becomes
the grid area which is computed during grid layout. The code we are
changing in this patch already has this existing logic, but we do not
currently use it to resolve the percentage because we end up checking
the containing block of the grid item (i.e. the grid) to see if has some
sort of stretched height in the formatting context it participates in.

To fix this issue we just swap the order of these checks becuase the
element being a grid item has a stronger precedence than any logic than
the formatting context the grid is in. Said another way, since grid
layout is responsible for computing and setting the containing block for
the item we should try to respect it.

Test: imported/w3c/web-platform-tests/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-001.html
      imported/w3c/web-platform-tests/css/css-grid/replaced-element-percentage-height-in-grid-nested-in-flex-002.html

Canonical link: <a href="https://commits.webkit.org/312281@main">https://commits.webkit.org/312281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c1e5ef9c39813d9c73afc9b26a93656019a4bf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168212 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113758 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123482 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/86672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104147 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24794 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23239 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15983 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170704 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131687 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131800 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35656 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32441 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142725 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90566 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19534 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31952 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98404 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31472 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31627 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->