### PR TITLE
Adopt LIFETIME_BOUND in the downcast family of functions

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -286,19 +286,19 @@ inline bool isAnyOf(const CheckedPtr<ArgType, ArgPtrTraits>& source)
 }
 
 template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
-inline ExpectedType& downcast(CheckedPtr<ArgType, ArgPtrTraits>& source)
+inline ExpectedType& downcast(CheckedPtr<ArgType, ArgPtrTraits>& source LIFETIME_BOUND)
 {
     return downcast<ExpectedType>(source.get());
 }
 
 template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
-inline ExpectedType& downcast(const CheckedPtr<ArgType, ArgPtrTraits>& source)
+inline ExpectedType& downcast(const CheckedPtr<ArgType, ArgPtrTraits>& source LIFETIME_BOUND)
 {
     return downcast<ExpectedType>(source.get());
 }
 
 template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
-inline const ExpectedType& downcast(CheckedPtr<const ArgType, ArgPtrTraits>& source)
+inline const ExpectedType& downcast(CheckedPtr<const ArgType, ArgPtrTraits>& source LIFETIME_BOUND)
 {
     return downcast<ExpectedType>(source.get());
 }

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -255,19 +255,19 @@ inline bool isAnyOf(const CheckedRef<ArgType, ArgPtrTraits>& source)
 }
 
 template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
-inline ExpectedType& downcast(CheckedRef<ArgType, ArgPtrTraits>& source)
+inline ExpectedType& downcast(CheckedRef<ArgType, ArgPtrTraits>& source LIFETIME_BOUND)
 {
     return downcast<ExpectedType>(source.get());
 }
 
 template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
-inline ExpectedType& downcast(const CheckedRef<ArgType, ArgPtrTraits>& source)
+inline ExpectedType& downcast(const CheckedRef<ArgType, ArgPtrTraits>& source LIFETIME_BOUND)
 {
     return downcast<ExpectedType>(source.get());
 }
 
 template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
-inline const ExpectedType& downcast(CheckedRef<const ArgType, ArgPtrTraits>& source)
+inline const ExpectedType& downcast(CheckedRef<const ArgType, ArgPtrTraits>& source LIFETIME_BOUND)
 {
     return downcast<ExpectedType>(source.get());
 }

--- a/Source/WTF/wtf/TypeCasts.h
+++ b/Source/WTF/wtf/TypeCasts.h
@@ -86,7 +86,7 @@ using match_constness_t =
     typename std::conditional_t<std::is_const_v<Reference>, typename std::add_const_t<T>, typename std::remove_const_t<T>>;
 
 template<typename Target, typename Source>
-inline match_constness_t<Source, Target>& uncheckedDowncast(Source& source)
+inline match_constness_t<Source, Target>& uncheckedDowncast(Source& source LIFETIME_BOUND)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
@@ -95,7 +95,7 @@ inline match_constness_t<Source, Target>& uncheckedDowncast(Source& source)
 }
 
 template<typename Target, typename Source>
-inline match_constness_t<Source, Target>* uncheckedDowncast(Source* source)
+inline match_constness_t<Source, Target>* uncheckedDowncast(Source* source LIFETIME_BOUND)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
@@ -104,7 +104,7 @@ inline match_constness_t<Source, Target>* uncheckedDowncast(Source* source)
 }
 
 template<typename Target, typename Source>
-inline match_constness_t<Source, Target>& downcast(Source& source)
+inline match_constness_t<Source, Target>& downcast(Source& source LIFETIME_BOUND)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
@@ -113,7 +113,7 @@ inline match_constness_t<Source, Target>& downcast(Source& source)
 }
 
 template<typename Target, typename Source>
-inline match_constness_t<Source, Target>* downcast(Source* source)
+inline match_constness_t<Source, Target>* downcast(Source* source LIFETIME_BOUND)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
@@ -122,7 +122,7 @@ inline match_constness_t<Source, Target>* downcast(Source* source)
 }
 
 template<typename Target, typename Source>
-inline match_constness_t<Source, Target>* dynamicDowncast(Source& source)
+inline match_constness_t<Source, Target>* dynamicDowncast(Source& source LIFETIME_BOUND)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
@@ -130,7 +130,7 @@ inline match_constness_t<Source, Target>* dynamicDowncast(Source& source)
 }
 
 template<typename Target, typename Source>
-inline match_constness_t<Source, Target>* dynamicDowncast(Source* source)
+inline match_constness_t<Source, Target>* dynamicDowncast(Source* source LIFETIME_BOUND)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1693,7 +1693,7 @@ T* findUnignoredChild(T& object, F&& matches)
 {
     for (auto child : object.unignoredChildren()) {
         if (matches(child))
-            return downcast<T>(child.ptr());
+            return downcast<T>(child.unsafePtr());
     }
     return nullptr;
 }

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -795,7 +795,7 @@ AccessibilityObject* AXObjectCache::focusedObjectForNode(Node* focusedNode)
 
     if (focus->shouldFocusActiveDescendant()) {
         if (RefPtr descendant = focus->activeDescendant())
-            return dynamicDowncast<AccessibilityObject>(descendant.get());
+            return dynamicDowncast<AccessibilityObject>(descendant.unsafeGet());
     }
 
     if (focus->isIgnored())

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -1662,7 +1662,7 @@ AXIsolatedObject* findObjectWithRuns(AXIsolatedObject& start, AXDirection direct
                 exitObject(*parent);
                 current = parent;
             }
-            return downcast<AXIsolatedObject>(next.get());
+            return downcast<AXIsolatedObject>(next.unsafeGet());
         };
 
         RefPtr current = nextInPreOrder(start);
@@ -1686,7 +1686,7 @@ AXIsolatedObject* findObjectWithRuns(AXIsolatedObject& start, AXDirection direct
             const auto& children = sibling->childrenIncludingIgnored(/* updateChildrenIfNeeded */ true);
             if (children.size())
                 return downcast<AXIsolatedObject>(sibling->deepestLastChildIncludingIgnored(/* updateChildrenIfNeeded */ true));
-            return downcast<AXIsolatedObject>(sibling.get());
+            return downcast<AXIsolatedObject>(sibling.unsafeGet());
         }
         return object.parentObject();
     };

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -244,7 +244,7 @@ AccessibilityObject* AccessibilityNodeObject::ownerParentObject() const
 
     auto owners = this->owners();
     AX_ASSERT(owners.size() <= 1);
-    return owners.size() ? dynamicDowncast<AccessibilityObject>(owners.first().get()) : nullptr;
+    return owners.size() ? dynamicDowncast<AccessibilityObject>(owners.first().unsafeGet()) : nullptr;
 }
 
 AccessibilityObject* AccessibilityNodeObject::parentObject() const
@@ -3128,7 +3128,7 @@ void AccessibilityNodeObject::setColumnIndex(unsigned index)
 AccessibilityNodeObject* AccessibilityNodeObject::parentRow() const
 {
     RefPtr parent = isTableCell() ? parentObjectUnignored() : nullptr;
-    return parent && parent->isExposedTableRow() ? dynamicDowncast<AccessibilityRenderObject>(parent.get()) : nullptr;
+    return parent && parent->isExposedTableRow() ? dynamicDowncast<AccessibilityRenderObject>(parent.unsafeGet()) : nullptr;
 }
 
 #if USE(ATSPI)

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -416,7 +416,7 @@ Element* AccessibilityRenderObject::anchorElement() const
 
         RefPtr object = cache ? cache->getOrCreate(*node) : nullptr;
         if (object && object->isLink())
-            return dynamicDowncast<Element>(*node);
+            return dynamicDowncast<Element>(node.unsafeGet());
     }
 
     return nullptr;
@@ -2310,7 +2310,7 @@ AccessibilityObject* AccessibilityRenderObject::observableObject() const
 {
     // This allows the table to be the one who sends notifications about tables.
     if (RefPtr parentTable = parentTableIfExposedTableRow())
-        return dynamicDowncast<AccessibilityObject>(parentTable.get());
+        return dynamicDowncast<AccessibilityObject>(parentTable.unsafeGet());
 
     // Find the object going up the parent chain that is used in accessibility to monitor certain notifications.
     for (CheckedPtr renderer = this->renderer(); renderer && renderer->node(); renderer = renderer->parent()) {

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -291,7 +291,7 @@ LineLayout* LineLayout::containing(RenderObject& renderer)
                 CheckedPtr containingBlock = renderer.parent();
                 if (is<RenderInline>(containingBlock))
                     containingBlock = containingBlock->containingBlock();
-                return dynamicDowncast<RenderBlockFlow>(containingBlock.get());
+                return dynamicDowncast<RenderBlockFlow>(containingBlock.unsafeGet());
             }
             if (renderer.isFloating()) {
                 // Note that containigBlock() on boxes in top layer (i.e. dialog) may return incorrect result during style change even with not-yet-updated style.

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -99,7 +99,7 @@ PlatformPathImpl& Path::ensurePlatformPathImpl()
     if (RefPtr impl = asImpl()) {
         if (const auto* stream = dynamicDowncast<PathStream>(*impl))
             return downcast<PlatformPathImpl>(setImpl(PlatformPathImpl::create(stream->segments())));
-        return downcast<PlatformPathImpl>(*impl);
+        return downcast<PlatformPathImpl>(*impl.unsafeGet());
     }
     // Generally platform path is never empty. This should only be called during Path::add() on an empty path.
     return downcast<PlatformPathImpl>(setImpl(PlatformPathImpl::create()));

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2314,7 +2314,7 @@ RenderBoxModelObject* RenderElement::offsetParent() const
         current = current->parent();
     }
 
-    return dynamicDowncast<RenderBoxModelObject>(current.get());
+    return dynamicDowncast<RenderBoxModelObject>(current.unsafeGet());
 }
 
 bool RenderElement::hasViewTransitionName() const

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -156,7 +156,7 @@ std::span<const RecentSearch> RenderSearchField::recentSearches()
     if (!m_searchPopup)
         m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*inputElement().inputType()));
 
-    auto& recentSearches = downcast<SearchInputType>(*inputElement().inputType()).recentSearches();
+    auto& recentSearches = downcast<SearchInputType>(*inputElement().inputType().unsafeGet()).recentSearches();
 
     const AtomString& name = autosaveName();
     protect(m_searchPopup)->loadRecentSearches(name, recentSearches);

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -196,8 +196,8 @@ RenderTableCol* RenderTableCol::enclosingColumnGroup() const
 RenderTableCol* RenderTableCol::nextColumn() const
 {
     // If |this| is a column-group, the next column is the colgroup's first child column.
-    if (CheckedPtr firstChild = this->firstChild())
-        return downcast<RenderTableCol>(firstChild.get());
+    if (auto* firstChild = this->firstChild())
+        return downcast<RenderTableCol>(firstChild);
 
     // Otherwise it's the next column along.
     CheckedPtr next = nextSibling();

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -58,10 +58,10 @@ SVGTextPathElement& RenderSVGTextPath::textPathElement() const
     return downcast<SVGTextPathElement>(RenderSVGInline::graphicsElement());
 }
 
-SVGGeometryElement* RenderSVGTextPath::targetElement() const
+RefPtr<SVGGeometryElement> RenderSVGTextPath::targetElement() const
 {
     auto target = SVGURIReference::targetElementFromIRIString(textPathElement().href(), textPathElement().treeScopeForSVGReferences());
-    return dynamicDowncast<SVGGeometryElement>(target.element.get());
+    return dynamicDowncast<SVGGeometryElement>(WTF::move(target.element));
 }
 
 Path RenderSVGTextPath::layoutPath() const

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.h
@@ -37,7 +37,7 @@ public:
     virtual ~RenderSVGTextPath();
 
     SVGTextPathElement& NODELETE textPathElement() const;
-    SVGGeometryElement* targetElement() const;
+    RefPtr<SVGGeometryElement> targetElement() const;
 
     Path layoutPath() const;
     const SVGLengthValue& NODELETE startOffset() const LIFETIME_BOUND;

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -574,10 +574,10 @@ WebCore::LocalFrame* WebFoundTextRangeController::frameForFoundTextRange(const W
     Ref mainFrame = m_webPage.get()->corePage()->mainFrame();
 
     if (range.pathToFrame.isEmpty())
-        return dynamicDowncast<WebCore::LocalFrame>(mainFrame.ptr());
+        return dynamicDowncast<WebCore::LocalFrame>(mainFrame.unsafePtr());
 
     RefPtr foundFrame = protect(mainFrame->page())->findFrameByPath(range.pathToFrame);
-    return dynamicDowncast<WebCore::LocalFrame>(foundFrame.get());
+    return dynamicDowncast<WebCore::LocalFrame>(foundFrame.unsafeGet());
 }
 
 WebCore::Document* WebFoundTextRangeController::documentForFoundTextRange(const WebFoundTextRange& range) const


### PR DESCRIPTION
#### 9b4359d195c9f8f4a9415644ba3e334d316fe6b2
<pre>
Adopt LIFETIME_BOUND in the downcast family of functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=313279">https://bugs.webkit.org/show_bug.cgi?id=313279</a>
<a href="https://rdar.apple.com/175553251">rdar://175553251</a>

Reviewed by David Kilzer.

This was review feedback on a previous patch: We want lifetime information to
survive casting, so that we catch cases where we use the casted value past
its known / safe lifetime.

Adopted unsafeGet() for all the pre-existing cases, so we can start enforcing
this restriction from now on.

* Source/WTF/wtf/CheckedPtr.h:
(WTF::downcast):
* Source/WTF/wtf/CheckedRef.h:
(WTF::downcast):
* Source/WTF/wtf/TypeCasts.h:
(WTF::uncheckedDowncast):
(WTF::downcast):
(WTF::dynamicDowncast):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::Accessibility::findUnignoredChild):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::focusedObjectForNode):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::Accessibility::findObjectWithRuns):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::ownerParentObject const):
(WebCore::AccessibilityNodeObject::parentRow const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::anchorElement const):
(WebCore::AccessibilityRenderObject::observableObject const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::containing):
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::ensurePlatformPathImpl):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::offsetParent const):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::recentSearches):
* Source/WebCore/rendering/RenderTableCol.cpp:
(WebCore::RenderTableCol::nextColumn const):
* Source/WebCore/rendering/svg/RenderSVGTextPath.cpp:
(WebCore::RenderSVGTextPath::targetElement const):
* Source/WebCore/rendering/svg/RenderSVGTextPath.h:
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::frameForFoundTextRange const):

Canonical link: <a href="https://commits.webkit.org/312106@main">https://commits.webkit.org/312106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/025b0733d1496e710cf35dbb6294fa3bccc58b4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158617 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167447 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112702 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122879 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86222 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103548 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24187 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22584 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15219 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150667 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169938 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19451 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15682 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21900 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131064 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131178 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142068 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89598 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24176 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18876 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190899 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31190 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97204 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49080 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30710 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30983 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30864 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->