### PR TITLE
[Site Isolation] http/tests/navigation/redirect-preserves-fragment.html fails

### DIFF
--- a/LayoutTests/http/tests/navigation/redirect-preserves-fragment-expected.txt
+++ b/LayoutTests/http/tests/navigation/redirect-preserves-fragment-expected.txt
@@ -2,6 +2,7 @@ http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#foo - 
 http://127.0.0.1:8000/navigation/redirect-preserves-fragment.html - didFinishLoading
 http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#foo - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/navigation/resources/success.html#foo, main document URL http://127.0.0.1:8000/navigation/redirect-preserves-fragment.html, http method GET> redirectResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#foo, http status code 302>
 http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#foo - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/success.html#foo, http status code 200>
+http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#foo - didFinishLoading
 Test passes if WebKit preserves the request fragment identifier after the redirection.
 
 

--- a/LayoutTests/http/tests/navigation/redirect-preserves-fragment.html
+++ b/LayoutTests/http/tests/navigation/redirect-preserves-fragment.html
@@ -3,6 +3,7 @@
 <head>
 <script>
 if (window.testRunner) {
+    internals.clearMemoryCache();
     testRunner.dumpAsText();
     testRunner.dumpResourceLoadCallbacks();
     testRunner.waitUntilDone();
@@ -10,7 +11,7 @@ if (window.testRunner) {
 
 onload = function() {
     if (window.testRunner)
-        testRunner.notifyDone();
+        setTimeout(() => testRunner.notifyDone(), 0);
 }
 </script>
 </head>

--- a/LayoutTests/platform/wk2/http/tests/navigation/redirect-preserves-fragment-expected.txt
+++ b/LayoutTests/platform/wk2/http/tests/navigation/redirect-preserves-fragment-expected.txt
@@ -2,6 +2,7 @@ http://127.0.0.1:8000/navigation/redirect-preserves-fragment.html - didFinishLoa
 http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#foo - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#foo, main document URL http://127.0.0.1:8000/navigation/redirect-preserves-fragment.html, http method GET> redirectResponse (null)
 http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#foo - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/navigation/resources/success.html#foo, main document URL http://127.0.0.1:8000/navigation/redirect-preserves-fragment.html, http method GET> redirectResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#foo, http status code 302>
 http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#foo - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/success.html#foo, http status code 200>
+http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#foo - didFinishLoading
 Test passes if WebKit preserves the request fragment identifier after the redirection.
 
 


### PR DESCRIPTION
#### 57b25bb7569fb729c8f8315b24ccf5336fd82ff7
<pre>
[Site Isolation] http/tests/navigation/redirect-preserves-fragment.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313283">https://bugs.webkit.org/show_bug.cgi?id=313283</a>

Reviewed by Megan Gardner.

The failure was caused by the race between testRunner.notifyDone finishing the test vs. subframe
finish loading getting logged. Fixed the test by always delaying testRunner.notifyDone with a 0s timer.

* LayoutTests/http/tests/navigation/redirect-preserves-fragment-expected.txt:
* LayoutTests/http/tests/navigation/redirect-preserves-fragment.html:
* LayoutTests/platform/wk2/http/tests/navigation/redirect-preserves-fragment-expected.txt:

Canonical link: <a href="https://commits.webkit.org/312012@main">https://commits.webkit.org/312012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfbb2cf3aa27b1c59a3795639f9191288955c790

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167463 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112718 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122882 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86231 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103551 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24195 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15235 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169954 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21907 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131070 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131184 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89608 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24122 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25874 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18883 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31206 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30726 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30999 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30880 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->