### PR TITLE
[AppKit Gestures] Support gesture recognizer-initiated drag sessions

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -56,6 +56,9 @@ OBJC_CLASS NSPanGestureRecognizer;
 
 - (instancetype)initWithPage:(std::reference_wrapper<WebKit::WebPageProxy>)page viewImpl:(std::reference_wrapper<WebKit::WebViewImpl>)viewImpl;
 - (void)enableGesturesIfNeeded;
+- (NSGestureRecognizer *)activeDragGestureRecognizer;
+- (void)setGestureDraggingSession:(NSDraggingSession *)session;
+- (void)clearGestureDragState;
 
 #if ENABLE(TWO_PHASE_CLICKS)
 

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -177,6 +177,10 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
 
     bool _mouseTrackingHasSentMouseDown;
     WebCore::FloatPoint _mouseTrackingStartLocationInWindow;
+
+    RetainPtr<NSPressGestureRecognizer> _dragPressGestureRecognizer;
+    RetainPtr<NSDraggingSession> _gestureDraggingSession;
+    bool _dragGestureHasSentMouseDown;
 }
 
 #if __has_include(<WebKitAdditions/WKAppKitGestureControllerAdditionsImpl.mm>)
@@ -207,6 +211,7 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     [self setUpSingleClickGestureRecognizer];
     [self setUpDoubleClickGestureRecognizer];
     [self setUpSecondaryClickGestureRecognizer];
+    [self setUpDragPressGestureRecognizer];
 }
 
 - (void)setUpPanGestureRecognizer
@@ -268,6 +273,7 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     [webView addGestureRecognizer:_singleClickGestureRecognizer.get()];
     [webView addGestureRecognizer:_doubleClickGestureRecognizer.get()];
     [webView addGestureRecognizer:_secondaryClickGestureRecognizer.get()];
+    [webView addGestureRecognizer:_dragPressGestureRecognizer.get()];
 }
 
 - (void)enableGesturesIfNeeded
@@ -277,6 +283,7 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     [self enableGestureIfNeeded:_singleClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_doubleClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_secondaryClickGestureRecognizer.get()];
+    [self enableGestureIfNeeded:_dragPressGestureRecognizer.get()];
 }
 
 - (void)enableGestureIfNeeded:(NSGestureRecognizer *)gesture
@@ -431,6 +438,9 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 - (void)mouseTrackingGestureRecognized:(NSGestureRecognizer *)gesture
 {
+    if (_dragGestureHasSentMouseDown)
+        return;
+
     CheckedPtr viewImpl = _viewImpl.get();
     if (!viewImpl)
         return;
@@ -511,6 +521,82 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         _mouseTrackingHasSentMouseDown = false;
         break;
 
+    default:
+        break;
+    }
+}
+
+#pragma mark - Drag Press Gesture
+
+- (void)setUpDragPressGestureRecognizer
+{
+    _dragPressGestureRecognizer = adoptNS([[NSPressGestureRecognizer alloc] initWithTarget:self action:@selector(dragPressGestureRecognized:)]);
+    [self configureForDragPress:_dragPressGestureRecognizer.get()];
+    [_dragPressGestureRecognizer setDelegate:self];
+    [_dragPressGestureRecognizer setName:@"WKDragPressGesture"];
+}
+
+- (void)dragPressGestureRecognized:(NSGestureRecognizer *)gesture
+{
+    CheckedPtr viewImpl = _viewImpl.get();
+    if (!viewImpl)
+        return;
+
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@", gesture);
+
+    if (_dragPressGestureRecognizer != gesture)
+        return;
+
+    if (viewImpl->ignoresAllEvents()) {
+        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "Ignored gesture");
+        return;
+    }
+
+    NSPoint locationInWindow = [gesture locationInView:nil];
+    auto windowNumber = viewImpl->windowNumber();
+    auto timestamp = GetCurrentEventTime();
+
+    switch (gesture.state) {
+    case NSGestureRecognizerStateBegan: {
+        [self _handleClickCancelled];
+        _dragGestureHasSentMouseDown = false;
+
+        RetainPtr mouseDown = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:locationInWindow modifierFlags:0 timestamp:timestamp windowNumber:windowNumber context:nil eventNumber:0 clickCount:1 pressure:1.0];
+        viewImpl->mouseDown(mouseDown.get(), WebKit::WebEventInputSource::Automation, WebCore::PlatformMouseEvent::CanInitiateDrag::Yes);
+        _dragGestureHasSentMouseDown = true;
+        break;
+    }
+    case NSGestureRecognizerStateChanged: {
+        if (!_dragGestureHasSentMouseDown)
+            break;
+        if (_gestureDraggingSession)
+            [_gestureDraggingSession updateDragWithGesture:gesture];
+        else {
+            RetainPtr mouseDragged = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDragged location:locationInWindow modifierFlags:0 timestamp:timestamp windowNumber:windowNumber context:nil eventNumber:0 clickCount:1 pressure:1.0];
+            viewImpl->mouseDragged(mouseDragged.get(), WebKit::WebEventInputSource::Automation, WebCore::PlatformMouseEvent::CanInitiateDrag::Yes);
+        }
+        break;
+    }
+    case NSGestureRecognizerStateEnded:
+    case NSGestureRecognizerStateCancelled:
+    case NSGestureRecognizerStateFailed: {
+        if (!_dragGestureHasSentMouseDown)
+            break;
+        if (_gestureDraggingSession)
+            [_gestureDraggingSession updateDragWithGesture:gesture];
+
+        RetainPtr mouseUp = [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp location:locationInWindow modifierFlags:0 timestamp:timestamp windowNumber:windowNumber context:nil eventNumber:0 clickCount:1 pressure:0.0];
+        viewImpl->mouseUp(mouseUp.get(), WebKit::WebEventInputSource::Automation, WebCore::PlatformMouseEvent::CanInitiateDrag::Yes);
+
+        // We do not clear gesture drag state here since startDrag() may still be in flight via IPC.
+        // State is cleared in draggingSessionEnded: (normal completion) or in startDrag() when
+        // beginDraggingSessionWithItems:gesture: returns nil (gesture ended before session started).
+        break;
+    }
     default:
         break;
     }
@@ -810,6 +896,26 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "Interrupted momentum scrolling");
 }
 
+#pragma mark - Drag Gesture State
+
+- (NSGestureRecognizer *)activeDragGestureRecognizer
+{
+    if (_dragGestureHasSentMouseDown)
+        return _dragPressGestureRecognizer.get();
+    return nil;
+}
+
+- (void)setGestureDraggingSession:(NSDraggingSession *)session
+{
+    _gestureDraggingSession = session;
+}
+
+- (void)clearGestureDragState
+{
+    _gestureDraggingSession = nil;
+    _dragGestureHasSentMouseDown = false;
+}
+
 #pragma mark - NSGestureRecognizerDelegate
 
 static BOOL isBuiltInScrollViewPanGestureRecognizer(NSGestureRecognizer *recognizer)
@@ -834,6 +940,12 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
         return YES;
 
     if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), _panGestureRecognizer.get()))
+        return YES;
+
+    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _dragPressGestureRecognizer.get(), _singleClickGestureRecognizer.get()))
+        return YES;
+
+    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _dragPressGestureRecognizer.get(), _mouseTrackingGestureRecognizer.get()))
         return YES;
 
     if (gestureRecognizer == _singleClickGestureRecognizer

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4671,6 +4671,9 @@ NSDragOperation WebViewImpl::dragSourceOperationMask(NSDraggingSession *, NSDrag
 void WebViewImpl::draggingSessionEnded(NSDraggingSession *, NSPoint endPoint, NSDragOperation operation)
 {
     sendDragEndToPage(NSPointToCGPoint(endPoint), operation);
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    [appKitGestureController() clearGestureDragState];
+#endif
 }
 
 #endif // ENABLE(DRAG_SUPPORT)
@@ -4718,7 +4721,13 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
 
             RetainPtr pasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameDrag];
 
-            if (!lastMouseDownEvent) {
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+            RetainPtr gestureController = protectedThis->appKitGestureController();
+            bool missingDragInitiator = !lastMouseDownEvent && ![gestureController activeDragGestureRecognizer];
+#else
+            bool missingDragInitiator = !lastMouseDownEvent;
+#endif
+            if (missingDragInitiator) {
                 page->dragCancelled();
                 return;
             }
@@ -4771,7 +4780,20 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
                 draggingItem = adoptNS([[NSDraggingItem alloc] initWithPasteboardWriter:pasteboardItem.get()]);
                 [draggingItem setDraggingFrame:NSMakeRect(clientDragLocation.x(), clientDragLocation.y(), size.width(), size.height()) contents:dragNSImage.get()];
             }
-            [view beginDraggingSessionWithItems:@[draggingItem.get()] event:lastMouseDownEvent.get() source:(id<NSDraggingSource>)view.get()];
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+            if (RetainPtr gesture = [gestureController activeDragGestureRecognizer]) {
+                RetainPtr session = [view beginDraggingSessionWithItems:@[ draggingItem ] gesture:gesture source:static_cast<id<NSDraggingSource>>(view.get())];
+                [gestureController setGestureDraggingSession:session.get()];
+                if (!session) {
+                    page->dragCancelled();
+                    [gestureController clearGestureDragState];
+                    return;
+                }
+            } else
+#endif
+            {
+                [view beginDraggingSessionWithItems:@[ draggingItem ] event:lastMouseDownEvent source:static_cast<id<NSDraggingSource>>(view.get())];
+            }
 
             if (promisedAttachmentInfo) {
                 for (size_t index = 0; index < promisedAttachmentInfo.additionalTypesAndData.size(); ++index) {


### PR DESCRIPTION
#### 6c0e1dc821389bd22729429636a8c46963f76474
<pre>
[AppKit Gestures] Support gesture recognizer-initiated drag sessions
<a href="https://bugs.webkit.org/show_bug.cgi?id=313285">https://bugs.webkit.org/show_bug.cgi?id=313285</a>
<a href="https://rdar.apple.com/166409432">rdar://166409432</a>

Reviewed by Wenson Hsieh.

This commit brings up support to drive drag-and-drop interactions with
gesture recognizers, using WebCore&apos;s existing mouse event pipeline.

When a press gesture fires, we synthesize mouseDown/mouseDragged/mouseUp
events that end up routing through EventHandler::handleDrag. Once event
handling decides to start a drag, WebViewImpl::startDrag() uses the
beginDraggingSessionWithItems: API and pumps a dragging session through
updateDragWithGesture:.

The drag press gesture recognizes simultaneously with the click and
mouse tracking gestures so that synthetic clicks can fire before the
press threshold is reached. When the press gesture does fire, it cancels
any pending click via _handleClickCancelled and suppresses the mouse
tracking handler to prevent competing synthetic events. In the future,
we can consider collapsing the drag-and-drop gesture recognizer with the
mouse tracking gesture recognizer, given how similar their work is, but
disambiguation will require more work in WebCore event handling to make
that happen.

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController setUpGestureRecognizers]):
(-[WKAppKitGestureController addGesturesToWebView]):
(-[WKAppKitGestureController enableGesturesIfNeeded]):
(-[WKAppKitGestureController mouseTrackingGestureRecognized:]):
(-[WKAppKitGestureController setUpDragPressGestureRecognizer]):
(-[WKAppKitGestureController dragPressGestureRecognized:]):
(-[WKAppKitGestureController activeDragGestureRecognizer]):
(-[WKAppKitGestureController setGestureDraggingSession:]):
(-[WKAppKitGestureController clearGestureDragState]):
(-[WKAppKitGestureController gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::draggingSessionEnded):
(WebKit::WebViewImpl::startDrag):

Canonical link: <a href="https://commits.webkit.org/312023@main">https://commits.webkit.org/312023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78fcd43d05ee21d03928570532795606ec3b17e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112759 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122919 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86252 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103588 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24233 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22635 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15276 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133919 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169996 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15739 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131106 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131220 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/35520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142115 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89660 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24128 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18923 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31247 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97261 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30767 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31040 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30921 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->