### PR TITLE
[Site Isolation] http/tests/navigation/redirect-to-fragment.html and redirect-to-fragment2.html fail

### DIFF
--- a/LayoutTests/http/tests/navigation/redirect-to-fragment-expected.txt
+++ b/LayoutTests/http/tests/navigation/redirect-to-fragment-expected.txt
@@ -2,6 +2,7 @@ http://127.0.0.1:8000/navigation/resources/redirect-to-fragment.py#foo - willSen
 http://127.0.0.1:8000/navigation/redirect-to-fragment.html - didFinishLoading
 http://127.0.0.1:8000/navigation/resources/redirect-to-fragment.py#foo - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/navigation/resources/success.html#bar, main document URL http://127.0.0.1:8000/navigation/redirect-to-fragment.html, http method GET> redirectResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/redirect-to-fragment.py#foo, http status code 302>
 http://127.0.0.1:8000/navigation/resources/redirect-to-fragment.py#foo - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/success.html#bar, http status code 200>
+http://127.0.0.1:8000/navigation/resources/redirect-to-fragment.py#foo - didFinishLoading
 Test passes if WebKit ignores the request fragment identifier after the redirect to a url with a fragment identifier.
 
 

--- a/LayoutTests/http/tests/navigation/redirect-to-fragment.html
+++ b/LayoutTests/http/tests/navigation/redirect-to-fragment.html
@@ -3,6 +3,7 @@
 <head>
 <script>
 if (window.testRunner) {
+    internals.clearMemoryCache();
     testRunner.dumpAsText();
     testRunner.dumpResourceLoadCallbacks();
     testRunner.waitUntilDone();
@@ -10,7 +11,7 @@ if (window.testRunner) {
 
 onload = function() {
     if (window.testRunner)
-        testRunner.notifyDone();
+        setTimeout(() => testRunner.notifyDone(), 0);
 }
 </script>
 </head>

--- a/LayoutTests/http/tests/navigation/redirect-to-fragment2-expected.txt
+++ b/LayoutTests/http/tests/navigation/redirect-to-fragment2-expected.txt
@@ -3,6 +3,7 @@ http://127.0.0.1:8000/navigation/redirect-to-fragment2.html - didFinishLoading
 http://127.0.0.1:8000/navigation/resources/redirect-to-fragment2.py - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#bar, main document URL http://127.0.0.1:8000/navigation/redirect-to-fragment2.html, http method GET> redirectResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/redirect-to-fragment2.py, http status code 302>
 http://127.0.0.1:8000/navigation/resources/redirect-to-fragment2.py - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/navigation/resources/success.html#bar, main document URL http://127.0.0.1:8000/navigation/redirect-to-fragment2.html, http method GET> redirectResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#bar, http status code 302>
 http://127.0.0.1:8000/navigation/resources/redirect-to-fragment2.py - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/success.html#bar, http status code 200>
+http://127.0.0.1:8000/navigation/resources/redirect-to-fragment2.py - didFinishLoading
 Test passes if WebKit keeps fragment identifier from first redirected URL.
 
 

--- a/LayoutTests/http/tests/navigation/redirect-to-fragment2.html
+++ b/LayoutTests/http/tests/navigation/redirect-to-fragment2.html
@@ -3,6 +3,7 @@
 <head>
 <script>
 if (window.testRunner) {
+    internals.clearMemoryCache();
     testRunner.dumpAsText();
     testRunner.dumpResourceLoadCallbacks();
     testRunner.waitUntilDone();
@@ -10,7 +11,7 @@ if (window.testRunner) {
 
 onload = function() {
     if (window.testRunner)
-        testRunner.notifyDone();
+        setTimeout(() => testRunner.notifyDone(), 0);
 }
 </script>
 </head>

--- a/LayoutTests/platform/glib/http/tests/navigation/redirect-to-fragment2-expected.txt
+++ b/LayoutTests/platform/glib/http/tests/navigation/redirect-to-fragment2-expected.txt
@@ -3,6 +3,7 @@ http://127.0.0.1:8000/navigation/resources/redirect-to-fragment2.py - willSendRe
 http://127.0.0.1:8000/navigation/resources/redirect-to-fragment2.py - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#bar, main document URL http://127.0.0.1:8000/navigation/redirect-to-fragment2.html, http method GET> redirectResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/redirect-to-fragment2.py, http status code 302>
 http://127.0.0.1:8000/navigation/resources/redirect-to-fragment2.py - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/navigation/resources/success.html#bar, main document URL http://127.0.0.1:8000/navigation/redirect-to-fragment2.html, http method GET> redirectResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/redirect-preserves-fragment.py#bar, http status code 302>
 http://127.0.0.1:8000/navigation/resources/redirect-to-fragment2.py - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/success.html#bar, http status code 200>
+http://127.0.0.1:8000/navigation/resources/redirect-to-fragment2.py - didFinishLoading
 Test passes if WebKit keeps fragment identifier from first redirected URL.
 
 

--- a/LayoutTests/platform/wk2/http/tests/navigation/redirect-to-fragment-expected.txt
+++ b/LayoutTests/platform/wk2/http/tests/navigation/redirect-to-fragment-expected.txt
@@ -2,6 +2,7 @@ http://127.0.0.1:8000/navigation/redirect-to-fragment.html - didFinishLoading
 http://127.0.0.1:8000/navigation/resources/redirect-to-fragment.py#foo - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/navigation/resources/redirect-to-fragment.py#foo, main document URL http://127.0.0.1:8000/navigation/redirect-to-fragment.html, http method GET> redirectResponse (null)
 http://127.0.0.1:8000/navigation/resources/redirect-to-fragment.py#foo - willSendRequest <NSURLRequest URL http://127.0.0.1:8000/navigation/resources/success.html#bar, main document URL http://127.0.0.1:8000/navigation/redirect-to-fragment.html, http method GET> redirectResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/redirect-to-fragment.py#foo, http status code 302>
 http://127.0.0.1:8000/navigation/resources/redirect-to-fragment.py#foo - didReceiveResponse <NSURLResponse http://127.0.0.1:8000/navigation/resources/success.html#bar, http status code 200>
+http://127.0.0.1:8000/navigation/resources/redirect-to-fragment.py#foo - didFinishLoading
 Test passes if WebKit ignores the request fragment identifier after the redirect to a url with a fragment identifier.
 
 


### PR DESCRIPTION
#### b7e777fc0816d69ddf1c68be05654d0e4b27f315
<pre>
[Site Isolation] http/tests/navigation/redirect-to-fragment.html and redirect-to-fragment2.html fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=313289">https://bugs.webkit.org/show_bug.cgi?id=313289</a>

Reviewed by Abrar Rahman Protyasha.

The failure was caused by the race between testRunner.notifyDone finishing the test vs. subframe
finish loading getting logged. Fixed the test by always delaying testRunner.notifyDone with a 0s timer.

* LayoutTests/http/tests/navigation/redirect-to-fragment-expected.txt:
* LayoutTests/http/tests/navigation/redirect-to-fragment.html:
* LayoutTests/http/tests/navigation/redirect-to-fragment2-expected.txt:
* LayoutTests/http/tests/navigation/redirect-to-fragment2.html:
* LayoutTests/platform/glib/http/tests/navigation/redirect-to-fragment2-expected.txt:
* LayoutTests/platform/wk2/http/tests/navigation/redirect-to-fragment-expected.txt:

Canonical link: <a href="https://commits.webkit.org/312027@main">https://commits.webkit.org/312027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ab1c6ebbf89588fa6d69dc883c9cbbd8d987060

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112822 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122975 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86304 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103644 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24292 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22697 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15339 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170059 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131161 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131275 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142174 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89755 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24130 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18983 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31310 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30830 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31103 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30984 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->