### PR TITLE
[JSC] Inline tight loop of String#localeCompare in FTL

### DIFF
--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -117,6 +117,7 @@ namespace JSC::B3 {
     macro(JSGlobalObject_regExpGlobalData_cachedResult_result_end, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, end), Mutability::Mutable) \
     macro(JSGlobalObject_regExpGlobalData_cachedResult_reified, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfReified(), Mutability::Mutable) \
     macro(JSGlobalObject_regExpGlobalData_cachedResult_oneCharacterMatch, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfOneCharacterMatch(), Mutability::Mutable) \
+    macro(JSGlobalObject_canDoASCIIUCADUCETLocaleCompare, JSGlobalObject::offsetOfCanDoASCIIUCADUCETLocaleCompare(), Mutability::Mutable) \
     macro(JSGlobalProxy_target, JSGlobalProxy::targetOffset(), Mutability::Mutable) \
     macro(JSObject_butterfly, JSObject::butterflyOffset(), Mutability::Mutable) \
     macro(JSPropertyNameEnumerator_cachedInlineCapacity, JSPropertyNameEnumerator::cachedInlineCapacityOffset(), Mutability::Mutable) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -51,6 +51,7 @@
 #include "Interpreter.h"
 #include "InterpreterInlines.h"
 #include "IntlCollator.h"
+#include "IntlObjectInlines.h"
 #include "JITCode.h"
 #include "JITWorklist.h"
 #include "JSArrayBufferConstructor.h"
@@ -3348,6 +3349,12 @@ JSC_DEFINE_JIT_OPERATION(operationStringLocaleCompare, UCPUStrictInt32, (JSGloba
 
     auto that = argument->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, 0);
+
+    if (globalObject->canDoASCIIUCADUCETLocaleCompare() && string->is8Bit() && that->is8Bit()) {
+        auto result = compareASCIIWithUCADUCET(string->span8(), that->span8());
+        if (result)
+            OPERATION_RETURN(scope, toUCPUStrictInt32(*result));
+    }
 
     auto* collator = globalObject->defaultCollator();
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -65,6 +65,7 @@
 #include "FTLThunks.h"
 #include "FTLWeightedTarget.h"
 #include "HasOwnPropertyCache.h"
+#include "IntlObject.h"
 #include "JITAddGenerator.h"
 #include "JITBitAndGenerator.h"
 #include "JITBitOrGenerator.h"
@@ -11636,8 +11637,179 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileStringLocaleCompare()
     {
+        // JSString* left = ...
+        // JSString* right = ...
+        //
+        // if (left == right)
+        //     return 0;
+        //
+        // if (left->isRope())
+        //     goto slow_path
+        // if (right->isRope())
+        //     goto slow_path
+        //
+        // StringImpl* leftImpl = left->tryGetValueImpl();
+        // StringImpl* rightImpl = right->tryGetValueImpl();
+        //
+        // if (leftImpl == rightImpl)
+        //     return 0;
+        //
+        // if (!globalObject->canDoASCIIUCADUCETLocaleCompare)
+        //     goto slow_path
+        //
+        // if (!((leftImpl->flags() & rightImpl->flags()) & StringImpl::flagIs8Bit()))
+        //     goto slow_path
+        //
+        // size_t leftLength = leftImpl->length();
+        // size_t rightLength = rightImpl->length();
+        // const uint8_t* leftData = leftImpl->characters8();
+        // const uint8_t* rightData = rightImpl->characters8();
+        // size_t commonLength = std::min(leftLength, rightLength);
+        // size_t index = 0;
+        //
+        // while (index < commonLength) {
+        //     uint8_t leftByte = leftData[index];
+        //     uint8_t rightByte = rightData[index];
+        //     if (leftByte == rightByte) {
+        //         if (leftByte >= 128)
+        //             goto slow_path;
+        //     } else {
+        //         uint8_t leftWeight = ducetLevel1Weights[leftByte];
+        //         uint8_t rightWeight = ducetLevel1Weights[rightByte];
+        //         if ((!leftWeight) | (!rightWeight))
+        //             goto slow_path;
+        //         if (leftWeight != rightWeight)
+        //             return leftWeight > rightWeight ? 1 : -1;
+        //     }
+        //     index++;
+        // }
+        //
+        // if (leftLength == rightLength)
+        //     goto slow_path;
+        //
+        // const uint8_t* longerData = leftLength > rightLength ? leftData : rightData;
+        // size_t shorterLength = std::min(leftLength, rightLength);
+        // if (!ducetLevel1Weights[longerData[shorterLength]])
+        //     goto slow_path;
+        // return leftLength > rightLength ? 1 : -1;
+
         auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-        setInt32(vmCall(Int32, operationStringLocaleCompare, weakPointer(globalObject), lowString(m_node->child1()), lowString(m_node->child2())));
+        LValue leftJSString = lowString(m_node->child1());
+        LValue rightJSString = lowString(m_node->child2());
+
+        LBasicBlock checkLeftRope = m_out.newBlock();
+        LBasicBlock checkRightRope = m_out.newBlock();
+        LBasicBlock bothResolved = m_out.newBlock();
+        LBasicBlock checkDUCET = m_out.newBlock();
+        LBasicBlock is8Bit = m_out.newBlock();
+        LBasicBlock loopSetup = m_out.newBlock();
+        LBasicBlock loop = m_out.newBlock();
+        LBasicBlock checkASCII = m_out.newBlock();
+        LBasicBlock checkWeights = m_out.newBlock();
+        LBasicBlock compareWeights = m_out.newBlock();
+        LBasicBlock advance = m_out.newBlock();
+        LBasicBlock loopDone = m_out.newBlock();
+        LBasicBlock lengthsDiffer = m_out.newBlock();
+        LBasicBlock slowCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        // Pointer-equal JSStrings -> return 0
+        ValueFromBlock sameStringResult = m_out.anchor(m_out.int32Zero);
+        m_out.branch(m_out.equal(leftJSString, rightJSString), unsure(continuation), unsure(checkLeftRope));
+
+        // Check left is not rope
+        LBasicBlock lastNext = m_out.appendTo(checkLeftRope, checkRightRope);
+        m_out.branch(isRopeString(leftJSString, m_node->child1()), rarely(slowCase), usually(checkRightRope));
+
+        // Check right is not rope
+        m_out.appendTo(checkRightRope, bothResolved);
+        m_out.branch(isRopeString(rightJSString, m_node->child2()), rarely(slowCase), usually(bothResolved));
+
+        // Load StringImpl pointers; pointer-equal -> return 0
+        m_out.appendTo(bothResolved, checkDUCET);
+        LValue leftImpl = m_out.loadPtr(leftJSString, m_heaps.JSString_value);
+        LValue rightImpl = m_out.loadPtr(rightJSString, m_heaps.JSString_value);
+        ValueFromBlock sameImplResult = m_out.anchor(m_out.int32Zero);
+        m_out.branch(m_out.equal(leftImpl, rightImpl), unsure(continuation), unsure(checkDUCET));
+
+        // Check JSGlobalObject.m_canDoASCIIUCADUCETLocaleCompare
+        m_out.appendTo(checkDUCET, is8Bit);
+        m_out.branch(
+            m_out.isZero32(m_out.load8ZeroExt32(weakPointer(globalObject), m_heaps.JSGlobalObject_canDoASCIIUCADUCETLocaleCompare)),
+            rarely(slowCase), usually(is8Bit));
+
+        // Check both are 8-bit
+        m_out.appendTo(is8Bit, loopSetup);
+        LValue leftFlag = m_out.load32(leftImpl, m_heaps.StringImpl_hashAndFlags);
+        LValue rightFlag = m_out.load32(rightImpl, m_heaps.StringImpl_hashAndFlags);
+        m_out.branch(
+            m_out.testIsZero32(m_out.bitAnd(leftFlag, rightFlag), m_out.constInt32(StringImpl::flagIs8Bit())),
+            unsure(slowCase), unsure(loopSetup));
+
+        // Load lengths and data pointers
+        m_out.appendTo(loopSetup, loop);
+        LValue leftLength = m_out.zeroExtPtr(m_out.load32(leftImpl, m_heaps.StringImpl_length));
+        LValue rightLength = m_out.zeroExtPtr(m_out.load32(rightImpl, m_heaps.StringImpl_length));
+        LValue leftData = m_out.loadPtr(leftImpl, m_heaps.StringImpl_data);
+        LValue rightData = m_out.loadPtr(rightImpl, m_heaps.StringImpl_data);
+        LValue commonLength = m_out.select(m_out.below(leftLength, rightLength), leftLength, rightLength);
+        LValue tableBase = m_out.constIntPtr(ducetLevel1Weights);
+        ValueFromBlock indexAtStart = m_out.anchor(m_out.intPtrZero);
+        m_out.branch(m_out.isNull(commonLength), unsure(loopDone), unsure(loop));
+
+        // Main loop: load bytes and branch on equality
+        m_out.appendTo(loop, checkASCII);
+        LValue index = m_out.phi(pointerType(), indexAtStart);
+        LValue leftByte = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, leftData, index));
+        LValue rightByte = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, rightData, index));
+        m_out.branch(m_out.notEqual(leftByte, rightByte), unsure(checkWeights), unsure(checkASCII));
+
+        // Equal bytes: skip weight lookup if ASCII, else bail
+        m_out.appendTo(checkASCII, checkWeights);
+        m_out.branch(m_out.aboveOrEqual(leftByte, m_out.constInt32(128)), rarely(slowCase), usually(advance));
+
+        // Bytes differ: look up DUCET level-1 weights
+        m_out.appendTo(checkWeights, compareWeights);
+        LValue leftWeight = m_out.load8ZeroExt32(TypedPointer(m_heaps.absolute.atAnyAddress(), m_out.add(tableBase, m_out.zeroExtPtr(leftByte))));
+        LValue rightWeight = m_out.load8ZeroExt32(TypedPointer(m_heaps.absolute.atAnyAddress(), m_out.add(tableBase, m_out.zeroExtPtr(rightByte))));
+        m_out.branch(m_out.bitOr(m_out.isZero32(leftWeight), m_out.isZero32(rightWeight)), rarely(slowCase), usually(compareWeights));
+
+        // Compare weights: differ -> return result, equal -> advance (case diff like A/a)
+        m_out.appendTo(compareWeights, advance);
+        LValue differResult = m_out.select(m_out.above(leftWeight, rightWeight), m_out.int32One, m_out.constInt32(-1));
+        ValueFromBlock differResultPhi = m_out.anchor(differResult);
+        m_out.branch(m_out.notEqual(leftWeight, rightWeight), unsure(continuation), unsure(advance));
+
+        // Advance index (reached from checkASCII or compareWeights)
+        m_out.appendTo(advance, loopDone);
+        LValue nextIndex = m_out.add(index, m_out.intPtrOne);
+        ValueFromBlock indexForNext = m_out.anchor(nextIndex);
+        m_out.addIncomingToPhi(index, indexForNext);
+        m_out.branch(m_out.below(nextIndex, commonLength), unsure(loop), unsure(loopDone));
+
+        // Loop done: all common characters matched at level 1
+        m_out.appendTo(loopDone, lengthsDiffer);
+        m_out.branch(m_out.equal(leftLength, rightLength), unsure(slowCase), unsure(lengthsDiffer));
+
+        // Different lengths: check the next char in the longer string has valid DUCET weight
+        m_out.appendTo(lengthsDiffer, slowCase);
+        LValue isLeftLonger = m_out.above(leftLength, rightLength);
+        LValue longerData = m_out.select(isLeftLonger, leftData, rightData);
+        LValue shorterLength = m_out.select(isLeftLonger, rightLength, leftLength);
+        LValue nextChar = m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, longerData, shorterLength));
+        LValue nextCharWeight = m_out.load8ZeroExt32(TypedPointer(m_heaps.absolute.atAnyAddress(), m_out.add(tableBase, m_out.zeroExtPtr(nextChar))));
+        LValue lengthResult = m_out.select(isLeftLonger, m_out.int32One, m_out.constInt32(-1));
+        ValueFromBlock lengthResultPhi = m_out.anchor(lengthResult);
+        m_out.branch(m_out.isZero32(nextCharWeight), rarely(slowCase), usually(continuation));
+
+        // Slow case: fall back to C++ operation
+        m_out.appendTo(slowCase, continuation);
+        ValueFromBlock slowResult = m_out.anchor(vmCall(Int32, operationStringLocaleCompare, weakPointer(globalObject), leftJSString, rightJSString));
+        m_out.jump(continuation);
+
+        // Merge results
+        m_out.appendTo(continuation, lastNext);
+        setInt32(m_out.phi(Int32, sameStringResult, sameImplResult, differResultPhi, lengthResultPhi, slowResult));
     }
 
     void compileStringIndexOf()

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1688,6 +1688,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
             collator->initializeCollator(globalObject, jsUndefined(), jsUndefined());
             RETURN_IF_EXCEPTION(scope, void());
             init.set(collator);
+            globalObject->m_canDoASCIIUCADUCETLocaleCompare = collator->canDoASCIIUCADUCETComparison();
         });
 
     m_defaultDateTimeFormat.initLater(

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -635,6 +635,7 @@ public:
     bool m_evalEnabled { true };
     bool m_webAssemblyEnabled { true };
     bool m_needsSiteSpecificQuirks { false };
+    bool m_canDoASCIIUCADUCETLocaleCompare { false };
     unsigned m_globalLexicalBindingEpoch { 1 };
     String m_evalDisabledErrorMessage;
     String m_webAssemblyDisabledErrorMessage;
@@ -756,6 +757,7 @@ public:
     JSIteratorConstructor* iteratorConstructor() const LIFETIME_BOUND { return m_iteratorConstructor.get(); }
 
     IntlCollator* defaultCollator() const LIFETIME_BOUND { return m_defaultCollator.get(this); }
+    bool canDoASCIIUCADUCETLocaleCompare() const { return m_canDoASCIIUCADUCETLocaleCompare; }
     IntlDateTimeFormat* defaultDateTimeFormat() const LIFETIME_BOUND { return m_defaultDateTimeFormat.get(this); }
     IntlDateTimeFormat* defaultDateFormat() const LIFETIME_BOUND { return m_defaultDateFormat.get(this); }
     IntlDateTimeFormat* defaultTimeFormat() const LIFETIME_BOUND { return m_defaultTimeFormat.get(this); }
@@ -1022,6 +1024,7 @@ public:
     static constexpr ptrdiff_t offsetOfVM() { return OBJECT_OFFSETOF(JSGlobalObject, m_vm); }
     static constexpr ptrdiff_t offsetOfGlobalLexicalEnvironment() { return OBJECT_OFFSETOF(JSGlobalObject, m_globalLexicalEnvironment); }
     static constexpr ptrdiff_t offsetOfGlobalLexicalBindingEpoch() { return OBJECT_OFFSETOF(JSGlobalObject, m_globalLexicalBindingEpoch); }
+    static constexpr ptrdiff_t offsetOfCanDoASCIIUCADUCETLocaleCompare() { return OBJECT_OFFSETOF(JSGlobalObject, m_canDoASCIIUCADUCETLocaleCompare); }
     static constexpr ptrdiff_t offsetOfVarInjectionWatchpoint() { return OBJECT_OFFSETOF(JSGlobalObject, m_varInjectionWatchpointSet); }
     static constexpr ptrdiff_t offsetOfVarReadOnlyWatchpoint() { return OBJECT_OFFSETOF(JSGlobalObject, m_varReadOnlyWatchpointSet); }
     static constexpr ptrdiff_t offsetOfFunctionProtoHasInstanceSymbolFunction() { return OBJECT_OFFSETOF(JSGlobalObject, m_functionProtoHasInstanceSymbolFunction); }


### PR DESCRIPTION
#### aa6c00c696e60d57f228c0921b316171eed272c1
<pre>
[JSC] Inline tight loop of String#localeCompare in FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=313291">https://bugs.webkit.org/show_bug.cgi?id=313291</a>
<a href="https://rdar.apple.com/175559239">rdar://175559239</a>

Reviewed by Yijia Huang.

This patch implements a fast path of String#localeCompare in FTL.
Right now, we do this intentionally in FTL as it indicates that this
is hot enough to do this optimization.

* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileStringLocaleCompare):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::canDoASCIIUCADUCETLocaleCompare const):
(JSC::JSGlobalObject::offsetOfCanDoASCIIUCADUCETLocaleCompare):

Canonical link: <a href="https://commits.webkit.org/312145@main">https://commits.webkit.org/312145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afd72721a5234fd947f0c66acf20696e58c91b5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167854 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/841a2a04-ab95-45f1-a279-d3f432bc7ffc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123217 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21b1be16-8760-42c5-a277-080f44a1aaa9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161982 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/25496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103884 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bbe7f95-9def-41d2-aecd-2d26a0000a37) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15627 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151075 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134237 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170347 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19858 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16089 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131408 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32142 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131520 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90136 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24205 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26225 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19249 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191307 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31597 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97611 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49173 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31117 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31390 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31272 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->