### PR TITLE
[JSC] Add `emitBytecodeInConditionContext` for comma expression

### DIFF
--- a/JSTests/stress/comma-in-condition-context.js
+++ b/JSTests/stress/comma-in-condition-context.js
@@ -1,0 +1,336 @@
+//@ requireOptions("--validateGraph=true")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${expected}, got ${actual}`);
+}
+
+function shouldThrow(fn, errorType, msg) {
+    let threw = false;
+    try {
+        fn();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof errorType))
+            throw new Error(`FAIL: ${msg}: expected ${errorType.name}, got ${e.constructor.name}`);
+    }
+    if (!threw)
+        throw new Error(`FAIL: ${msg}: expected throw, got no throw`);
+}
+
+// =========================================================================
+// Basic patterns
+// =========================================================================
+
+function testIf(a, b) {
+    if ((a, b))
+        return "T";
+    return "F";
+}
+noInline(testIf);
+
+function testNot(a, b) {
+    if (!(a, b))
+        return "T";
+    return "F";
+}
+noInline(testNot);
+
+function testAnd(a, b, c) {
+    if ((a, b && c))
+        return "T";
+    return "F";
+}
+noInline(testAnd);
+
+function testOr(a, b, c) {
+    if ((a, b || c))
+        return "T";
+    return "F";
+}
+noInline(testOr);
+
+function testNested(a, b, c, d) {
+    if ((a, b && (c || d)))
+        return "T";
+    return "F";
+}
+noInline(testNested);
+
+function testTernary(a, b, c, d) {
+    return (a, b ? c : d);
+}
+noInline(testTernary);
+
+function testTernaryCond(a, b) {
+    return (a, b) ? "T" : "F";
+}
+noInline(testTernaryCond);
+
+function testMulti(a, b, c, d) {
+    if ((a, b, c, d))
+        return "T";
+    return "F";
+}
+noInline(testMulti);
+
+function testWhile(state) {
+    let c = 0;
+    while ((state.tick++, state.n-- > 0))
+        c++;
+    return c;
+}
+noInline(testWhile);
+
+function testFor(arr) {
+    let log = [];
+    for (let i = 0; (log.push("c"), i < arr.length); i++)
+        log.push(arr[i]);
+    return log.join(",");
+}
+noInline(testFor);
+
+function testDoWhile(state) {
+    let c = 0;
+    do {
+        c++;
+    } while ((state.tick++, --state.n > 0));
+    return c;
+}
+noInline(testDoWhile);
+
+function testRel(a, b, c) {
+    if ((a, b < c))
+        return "T";
+    return "F";
+}
+noInline(testRel);
+
+function testEq(a, b, c) {
+    if ((a, b === c))
+        return "T";
+    return "F";
+}
+noInline(testEq);
+
+function testNestedComma(a, b, c) {
+    if (((a, b), c))
+        return "T";
+    return "F";
+}
+noInline(testNestedComma);
+
+function testOuterAnd(a, b, c) {
+    if ((a, b) && c)
+        return "T";
+    return "F";
+}
+noInline(testOuterAnd);
+
+function testOuterOr(a, b, c) {
+    if ((a, b) || c)
+        return "T";
+    return "F";
+}
+noInline(testOuterOr);
+
+function testNullish(a, b, c) {
+    if ((a, b) ?? c)
+        return "T";
+    return "F";
+}
+noInline(testNullish);
+
+// =========================================================================
+// Run basic patterns
+// =========================================================================
+
+for (let i = 0; i < 1e4; i++) {
+    shouldBe(testIf(0, 1), "T", "testIf(0,1): last truthy");
+    shouldBe(testIf(1, 0), "F", "testIf(1,0): last falsy");
+    shouldBe(testIf(0, 0), "F", "testIf(0,0)");
+    shouldBe(testIf(undefined, "x"), "T", "testIf(undef,'x')");
+    shouldBe(testIf(NaN, ""), "F", "testIf(NaN,'')");
+
+    shouldBe(testNot(0, 1), "F", "testNot(0,1)");
+    shouldBe(testNot(1, 0), "T", "testNot(1,0)");
+
+    shouldBe(testAnd(99, 1, 1), "T", "testAnd(99,1,1)");
+    shouldBe(testAnd(99, 0, 1), "F", "testAnd: short-circuit on b");
+    shouldBe(testAnd(99, 1, 0), "F", "testAnd: c falsy");
+    shouldBe(testAnd(99, 0, 0), "F", "testAnd: both falsy");
+
+    shouldBe(testOr(99, 0, 1), "T", "testOr: c truthy");
+    shouldBe(testOr(99, 1, 0), "T", "testOr: b truthy short-circuit");
+    shouldBe(testOr(99, 0, 0), "F", "testOr: both falsy");
+
+    shouldBe(testNested(99, 1, 0, 1), "T", "nested: b && (c||d): d truthy");
+    shouldBe(testNested(99, 1, 1, 0), "T", "nested: c truthy");
+    shouldBe(testNested(99, 0, 1, 1), "F", "nested: b falsy");
+    shouldBe(testNested(99, 1, 0, 0), "F", "nested: c||d both falsy");
+
+    shouldBe(testTernary(99, true, "yes", "no"), "yes", "testTernary truthy");
+    shouldBe(testTernary(99, false, "yes", "no"), "no", "testTernary falsy");
+    shouldBe(testTernary(99, 0, "yes", "no"), "no", "testTernary 0");
+
+    shouldBe(testTernaryCond(99, 1), "T", "testTernaryCond truthy");
+    shouldBe(testTernaryCond(99, 0), "F", "testTernaryCond falsy");
+
+    shouldBe(testMulti(1, 2, 3, 4), "T", "testMulti(1,2,3,4)");
+    shouldBe(testMulti(1, 2, 3, 0), "F", "testMulti last 0");
+    shouldBe(testMulti(0, 0, 0, 1), "T", "testMulti only last truthy");
+
+    shouldBe(testWhile({ tick: 0, n: 5 }), 5, "testWhile counts down");
+    shouldBe(testFor([1, 2, 3]), "c,1,c,2,c,3,c", "testFor with side-effect cond");
+    shouldBe(testDoWhile({ tick: 0, n: 3 }), 3, "testDoWhile");
+
+    shouldBe(testRel(99, 1, 2), "T", "testRel 1<2");
+    shouldBe(testRel(99, 2, 1), "F", "testRel 2<1");
+    shouldBe(testEq(99, 1, 1), "T", "testEq 1===1");
+    shouldBe(testEq(99, 1, 2), "F", "testEq 1!==2");
+
+    shouldBe(testNestedComma(0, 0, 1), "T", "((a,b),c): c truthy");
+    shouldBe(testNestedComma(1, 1, 0), "F", "((a,b),c): c falsy");
+
+    shouldBe(testOuterAnd(0, 1, 1), "T", "outerAnd both truthy");
+    shouldBe(testOuterAnd(0, 0, 1), "F", "outerAnd left falsy");
+    shouldBe(testOuterAnd(0, 1, 0), "F", "outerAnd right falsy");
+
+    shouldBe(testOuterOr(0, 0, 1), "T", "outerOr right truthy");
+    shouldBe(testOuterOr(0, 1, 0), "T", "outerOr left truthy");
+    shouldBe(testOuterOr(0, 0, 0), "F", "outerOr both falsy");
+
+    shouldBe(testNullish(99, null, 1), "T", "nullish: (a,null) ?? 1");
+    shouldBe(testNullish(99, undefined, 0), "F", "nullish: (a,undef) ?? 0");
+    shouldBe(testNullish(99, 0, 1), "F", "nullish: (a,0) non-nullish & falsy");
+    shouldBe(testNullish(99, 5, 0), "T", "nullish: (a,5) non-nullish & truthy");
+}
+
+// =========================================================================
+// Side effect ordering
+// =========================================================================
+
+let log = [];
+function s(v, tag) {
+    log.push(tag);
+    return v;
+}
+
+function testOrder(a, b) {
+    if ((s(a, "a"), s(b, "b")))
+        return "T";
+    return "F";
+}
+noInline(testOrder);
+
+function testOrderMany(a, b, c) {
+    if ((s(a, "a"), s(b, "b"), s(c, "c")))
+        return "T";
+    return "F";
+}
+noInline(testOrderMany);
+
+function testOrderInAnd(a, b, c) {
+    if ((s(a, "a"), s(b, "b") && s(c, "c")))
+        return "T";
+    return "F";
+}
+noInline(testOrderInAnd);
+
+for (let i = 0; i < 1e3; i++) {
+    log = [];
+    shouldBe(testOrder(0, 1), "T", "order");
+    shouldBe(log.join(","), "a,b", "order: both side-effects in order");
+
+    log = [];
+    shouldBe(testOrderMany(0, 1, 2), "T", "orderMany");
+    shouldBe(log.join(","), "a,b,c", "orderMany: all in order");
+
+    log = [];
+    shouldBe(testOrderMany(1, 2, 0), "F", "orderMany falsy last");
+    shouldBe(log.join(","), "a,b,c", "orderMany: still all evaluated");
+
+    log = [];
+    shouldBe(testOrderInAnd(0, 1, 1), "T", "orderInAnd truthy");
+    shouldBe(log.join(","), "a,b,c", "orderInAnd: a then b then c");
+
+    log = [];
+    shouldBe(testOrderInAnd(0, 0, 1), "F", "orderInAnd: b falsy short-circuit");
+    shouldBe(log.join(","), "a,b", "orderInAnd: c skipped on short-circuit");
+}
+
+// =========================================================================
+// Throws
+// =========================================================================
+
+function testThrowFirst() {
+    if ((() => { throw new Error("first"); })(), 1)
+        return "T";
+    return "F";
+}
+function testThrowLast() {
+    if (1, (() => { throw new Error("last"); })())
+        return "T";
+    return "F";
+}
+noInline(testThrowFirst);
+noInline(testThrowLast);
+
+for (let i = 0; i < 1e3; i++) {
+    shouldThrow(() => testThrowFirst(), Error, "throw in first");
+    shouldThrow(() => testThrowLast(), Error, "throw in last");
+}
+
+// =========================================================================
+// Generator / async
+// =========================================================================
+
+function* gen(a, b) {
+    if ((a, b))
+        yield "T";
+    else
+        yield "F";
+}
+
+async function asyncFn(a, b) {
+    if ((a, b))
+        return "T";
+    return "F";
+}
+
+(async () => {
+    for (let i = 0; i < 100; i++) {
+        const it = gen(0, 1);
+        shouldBe(it.next().value, "T", "generator truthy");
+        const it2 = gen(1, 0);
+        shouldBe(it2.next().value, "F", "generator falsy");
+
+        shouldBe(await asyncFn(0, 1), "T", "async truthy");
+        shouldBe(await asyncFn(1, 0), "F", "async falsy");
+    }
+})();
+
+// =========================================================================
+// Switch
+// =========================================================================
+
+function testSwitch(a, b) {
+    switch (true) {
+        case (a, b > 5):
+            return "big";
+        case (a, b > 0):
+            return "small";
+        default:
+            return "none";
+    }
+}
+noInline(testSwitch);
+
+for (let i = 0; i < 1e3; i++) {
+    shouldBe(testSwitch(99, 10), "big");
+    shouldBe(testSwitch(99, 3), "small");
+    shouldBe(testSwitch(99, -1), "none");
+    shouldBe(testSwitch(99, 0), "none");
+}
+
+print("PASS");

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4419,6 +4419,17 @@ RegisterID* CommaNode::emitBytecode(BytecodeGenerator& generator, RegisterID* ds
     return generator.emitNodeInTailPosition(dst, node->m_expr);
 }
 
+void CommaNode::emitBytecodeInConditionContext(BytecodeGenerator& generator, Label& trueTarget, Label& falseTarget, FallThroughMode fallThroughMode)
+{
+    if (needsDebugHook()) [[unlikely]]
+        generator.emitDebugHook(this);
+
+    CommaNode* node = this;
+    for (; node->next(); node = node->next())
+        generator.emitNodeInIgnoreResultPosition(node->m_expr);
+    generator.emitNodeInConditionContext(node->m_expr, trueTarget, falseTarget, fallThroughMode);
+}
+
 // ------------------------------ SourceElements -------------------------------
 
 inline void SourceElements::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -1645,6 +1645,7 @@ namespace JSC {
     private:
         bool isCommaNode() const final { return true; }
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
+        void emitBytecodeInConditionContext(BytecodeGenerator&, Label& trueTarget, Label& falseTarget, FallThroughMode) final;
 
         ExpressionNode* m_expr;
         CommaNode* m_next { nullptr };


### PR DESCRIPTION
#### f3359ae0f15f798cca7490218a3f5e88b70a6917
<pre>
[JSC] Add `emitBytecodeInConditionContext` for comma expression
<a href="https://bugs.webkit.org/show_bug.cgi?id=313292">https://bugs.webkit.org/show_bug.cgi?id=313292</a>

Reviewed by Yusuke Suzuki.

`if ((a, b))` emitted the trailing operand as a value into a temporary
register, then tested it with `jfalse`. When the trailing operand is a
node that has its own condition-context lowering (e.g. `&amp;&amp;`, `||`), the
default path defeats that optimization because the value is forced to
materialize before the test.

Implement CommaNode::emitBytecodeInConditionContext to evaluate the
leading operands in ignore-result position (preserving side effects)
and route the final operand directly through the condition context.
The optimization composes with existing condition-context handling in
LogicalOpNode, LogicalNotNode, and ConditionalNode, so patterns like
`if ((tick(), b &amp;&amp; c))`, `while ((step(), cond1 || cond2))`, and
`(log(), a) ? x : y` all benefit automatically.

For trailing operands that already fuse via peephole (e.g. `&lt;`, `===`,
`!`) or that are simple register references, bytecode is unchanged.

Before:
    if ((a, b &amp;&amp; c))
    [ 0] enter
    [ 1] mov                loc5, arg2
    [ 4] jfalse             loc5, -&gt;10
    [ 7] mov                loc5, arg3
    [10] jfalse             loc5, -&gt;15
    [13] ret                &quot;T&quot;
    [15] ret                &quot;F&quot;

After:
    [ 0] enter
    [ 1] jfalse             arg2, -&gt;9
    [ 4] jfalse             arg3, -&gt;9
    [ 7] ret                &quot;T&quot;
    [ 9] ret                &quot;F&quot;

Test: JSTests/stress/comma-in-condition-context.js

* JSTests/stress/comma-in-condition-context.js: Added.
(shouldBe):
(testNot):
(testAnd):
(testOr):
(testNested):
(testTernary):
(testTernaryCond):
(testMulti):
(testWhile):
(testFor):
(testDoWhile):
(testRel):
(testEq):
(testNestedComma):
(testOuterAnd):
(testOuterOr):
(testNullish):
(testOrder):
(testOrderMany):
(testOrderInAnd):
(testThrowFirst):
(testThrowLast):
(gen):
(async asyncFn):
(async for):
(testSwitch):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::CommaNode::emitBytecodeInConditionContext):
* Source/JavaScriptCore/parser/Nodes.h:

Canonical link: <a href="https://commits.webkit.org/312371@main">https://commits.webkit.org/312371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ae5bda9033062daf048213be95a66c8fbc0390a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112734 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122898 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86239 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142520 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24214 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22612 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15251 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150699 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169970 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19483 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15714 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131083 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131197 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35742 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142093 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89626 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25893 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18901 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190931 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31222 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97236 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49092 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30742 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->