### PR TITLE
[JSC] Use __builtin_cpu_supports for x86_64 CPU feature detection

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.cpp
@@ -500,6 +500,7 @@ void MacroAssemblerX86_64::collectCPUFeatures()
 {
     static std::once_flag onceKey;
     std::call_once(onceKey, [] {
+#if OS(DARWIN)
         {
             CPUID cpuid = getCPUID(0x1);
             s_sse3CheckState = (cpuid[2] & (1 << 0)) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
@@ -507,13 +508,8 @@ void MacroAssemblerX86_64::collectCPUFeatures()
             s_sse4_1CheckState = (cpuid[2] & (1 << 19)) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
             s_sse4_2CheckState = (cpuid[2] & (1 << 20)) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
             s_popcntCheckState = (cpuid[2] & (1 << 23)) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
-#if OS(DARWIN)
             s_avxCheckState = CPUIDCheckState::Set;
-#else
-            s_avxCheckState = (cpuid[2] & (1 << 28)) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
-#endif
         }
-#if OS(DARWIN)
         {
             uint32_t val = 0;
             size_t valSize = sizeof(val);
@@ -524,11 +520,15 @@ void MacroAssemblerX86_64::collectCPUFeatures()
             s_avx2CheckState = (rc >= 0 && val) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
         }
 #else
-        {
-            CPUID cpuid = getCPUID(0x7);
-            s_bmi1CheckState = (cpuid[2] & (1 << 3)) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
-            s_avx2CheckState = (cpuid[2] & (1 << 5)) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
-        }
+        __builtin_cpu_init();
+        s_sse3CheckState = __builtin_cpu_supports("sse3") ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
+        s_supplementalSSE3CheckState = __builtin_cpu_supports("ssse3") ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
+        s_sse4_1CheckState = __builtin_cpu_supports("sse4.1") ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
+        s_sse4_2CheckState = __builtin_cpu_supports("sse4.2") ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
+        s_popcntCheckState = __builtin_cpu_supports("popcnt") ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
+        s_avxCheckState = __builtin_cpu_supports("avx") ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
+        s_avx2CheckState = __builtin_cpu_supports("avx2") ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
+        s_bmi1CheckState = __builtin_cpu_supports("bmi") ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
 #endif
         {
             CPUID cpuid = getCPUID(0x80000001);


### PR DESCRIPTION
#### ba6f71ea8f40c744caf66a260d2b5bb0252770ce
<pre>
[JSC] Use __builtin_cpu_supports for x86_64 CPU feature detection
<a href="https://bugs.webkit.org/show_bug.cgi?id=313293">https://bugs.webkit.org/show_bug.cgi?id=313293</a>

Reviewed by NOBODY (OOPS!).

collectCPUFeatures() on Linux/Windows decided AVX is available based
solely on CPUID.1:ECX[28]. That bit only says the CPU implements AVX;
it says nothing about whether the OS has enabled XSAVE and set XCR0 to
preserve YMM state. Under several hypervisors (Xen, Hyper-V, some KVM
configurations, AVX-passthrough-less Windows VMs) the AVX feature bit
is exposed to the guest while OSXSAVE/XCR0 is not, so every VEX-encoded
instruction the JIT emits raises #UD and the process dies with SIGILL.

Separately, the leaf-7 probe was reading ECX for BMI1 and AVX2; per
[1, Vol. 2A, CPUID, EAX=07H] those bits live in EBX (ECX[3]/ECX[5] are
PKU/WAITPKG).

On non-Darwin, replace the hand-rolled CPUID probes for SSE3/SSSE3/
SSE4.1/SSE4.2/POPCNT/AVX/AVX2/BMI1 with __builtin_cpu_supports. Both
compiler-rt [2] and libgcc [3] implement the full detection sequence
from [1, Vol. 1, §14.3] (CPUID.1:ECX.AVX &amp;&amp; CPUID.1:ECX.OSXSAVE &amp;&amp;
XGETBV(0)[2:1] == 11b) before reporting &quot;avx&quot;/&quot;avx2&quot;, and read
BMI1/AVX2 from leaf 7 EBX, so this fixes both issues without
open-coding CPUID. LZCNT keeps using CPUID(0x80000001) since older
clang rejects &quot;lzcnt&quot; as a __builtin_cpu_supports argument.

OS(DARWIN) keeps the existing CPUID/sysctlbyname code path unchanged:
JavaScriptCore links with -no_inits, and __builtin_cpu_supports pulls
in compiler-rt&apos;s __cpu_indicator_init constructor. Also, Rosetta
reports AVX as unsupported via CPUID even though it actually works, so
we want to keep force-enabling it there.

[1] Intel 64 and IA-32 Architectures Software Developer&apos;s Manual.
    <a href="https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html">https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html</a>
[2] <a href="https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/cpu_model/x86.c">https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/cpu_model/x86.c</a>
[3] <a href="https://github.com/gcc-mirror/gcc/blob/master/gcc/common/config/i386/cpuinfo.h">https://github.com/gcc-mirror/gcc/blob/master/gcc/common/config/i386/cpuinfo.h</a>

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.cpp:
(JSC::MacroAssemblerX86_64::collectCPUFeatures):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba6f71ea8f40c744caf66a260d2b5bb0252770ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112849 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122997 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86327 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142628 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24320 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22717 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15366 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150814 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170086 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19598 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22034 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131183 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131297 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142201 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89793 "Hash ba6f71ea for PR 63574 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19010 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191046 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31337 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97351 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49115 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31130 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->