### PR TITLE
Fixed the CMake Swift build with recent toolchains

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -85,6 +85,10 @@
                 "PORT": {
                     "type": "STRING",
                     "value": "Mac"
+                },
+                "ENABLE_EXPERIMENTAL_FEATURES": {
+                    "type": "BOOL",
+                    "value": "OFF"
                 }
             },
             "environment": {
@@ -107,13 +111,7 @@
         {
             "name": "mac-dev-release",
             "displayName": "macOS Development (Release, ccache, compile_commands)",
-            "inherits": ["mac-release", "dev"],
-            "cacheVariables": {
-                "ENABLE_EXPERIMENTAL_FEATURES": {
-                    "type": "BOOL",
-                    "value": "OFF"
-                }
-            }
+            "inherits": ["mac-release", "dev"]
         },
         {
             "name": "mac-dev-debug",

--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -51,11 +51,13 @@ set(webrtc_SOURCES
     Source/third_party/abseil-cpp/absl/container/internal/test_instance_tracker.cc
     Source/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
     Source/third_party/abseil-cpp/absl/debugging/internal/address_is_readable.cc
+    Source/third_party/abseil-cpp/absl/debugging/internal/decode_rust_punycode.cc
     Source/third_party/abseil-cpp/absl/debugging/internal/demangle.cc
     Source/third_party/abseil-cpp/absl/debugging/internal/demangle_rust.cc
     Source/third_party/abseil-cpp/absl/debugging/internal/elf_mem_image.cc
     Source/third_party/abseil-cpp/absl/debugging/internal/examine_stack.cc
     Source/third_party/abseil-cpp/absl/debugging/internal/stack_consumption.cc
+    Source/third_party/abseil-cpp/absl/debugging/internal/utf8_for_code_point.cc
     Source/third_party/abseil-cpp/absl/debugging/internal/vdso_support.cc
     Source/third_party/abseil-cpp/absl/debugging/leak_check.cc
     Source/third_party/abseil-cpp/absl/debugging/stacktrace.cc

--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -843,6 +843,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/graphics/cocoa/AV1UtilitiesCocoa.h
     platform/graphics/cocoa/CMUtilities.h
+    platform/graphics/cocoa/CVPixelBufferUtilities.h
     platform/graphics/cocoa/ColorCocoa.h
     platform/graphics/cocoa/DynamicContentScalingDisplayList.h
     platform/graphics/cocoa/FontCacheCoreText.h
@@ -859,6 +860,8 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/cocoa/MediaPlayerPrivateWebM.h
     platform/graphics/cocoa/NullPlaybackSessionInterface.h
     platform/graphics/cocoa/NullVideoPresentationInterface.h
+    platform/graphics/cocoa/ShareableCVPixelBuffer.h
+    platform/graphics/cocoa/ShareableCVPixelFormat.h
     platform/graphics/cocoa/SourceBufferParser.h
     platform/graphics/cocoa/SourceBufferParserWebM.h
     platform/graphics/cocoa/SystemFontDatabaseCoreText.h

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -212,6 +212,22 @@ if (_sdk_version)
     endif ()
 endif ()
 
+# CMake's Swift link rule passes -sdk but not -target, so swiftc falls back to
+# its built-in default deployment target while clang honors
+# CMAKE_OSX_DEPLOYMENT_TARGET. That mismatch produces an ld warning per object.
+# Pass -target explicitly so the Swift driver and clang agree.
+if (CMAKE_OSX_DEPLOYMENT_TARGET)
+    list(LENGTH CMAKE_OSX_ARCHITECTURES _arch_count)
+    if (_arch_count EQUAL 1)
+        set(_swift_arch "${CMAKE_OSX_ARCHITECTURES}")
+    elseif (_arch_count EQUAL 0)
+        set(_swift_arch "${CMAKE_SYSTEM_PROCESSOR}")
+    endif ()
+    if (_swift_arch)
+        string(APPEND CMAKE_Swift_FLAGS " -target ${_swift_arch}-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGET}")
+    endif ()
+endif ()
+
 # -----------------------------------------------------------------------------
 # SDK additions overlay (AvailabilityProhibitedInternal.h)
 # -----------------------------------------------------------------------------

--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -395,15 +395,20 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
             VERBATIM
         )
         # compile_commands.json
-        add_custom_target(UpdateCompileCommandsSymlink
-            ALL
+        set(_compile_commands_symlink_stamp ${CMAKE_BINARY_DIR}/DeveloperTools/compile_commands_symlink.stamp)
+        add_custom_command(
+            OUTPUT ${_compile_commands_symlink_stamp}
             DEPENDS ${CMAKE_BINARY_DIR}/DeveloperTools/compile_commands.json
                     ${CMAKE_SOURCE_DIR}/update-compile-commands-symlink.conf
             COMMAND ${Python_EXECUTABLE}
                     ${TOOLS_DIR}/clangd/update-compile-commands-symlink
                     ${CMAKE_SOURCE_DIR}/compile_commands.json
                     ${CMAKE_SOURCE_DIR}/update-compile-commands-symlink.conf
+            COMMAND ${CMAKE_COMMAND} -E touch ${_compile_commands_symlink_stamp}
             VERBATIM
+        )
+        add_custom_target(UpdateCompileCommandsSymlink ALL
+            DEPENDS ${_compile_commands_symlink_stamp}
         )
         # .clangd
         add_custom_command(

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -193,7 +193,8 @@ macro(_WEBKIT_TARGET_SETUP _target _logical_name)
 
     if (DEVELOPER_MODE_CXX_FLAGS)
         target_compile_options(${_target} PRIVATE $<$<NOT:$<COMPILE_LANGUAGE:Swift>>:${DEVELOPER_MODE_CXX_FLAGS}>)
-        target_compile_options(${_target} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:-warnings-as-errors>)
+        target_compile_options(${_target} PRIVATE
+            "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Werror ExistentialAny -Werror StrictMemorySafety -Werror ForeignReferenceType>")
     endif ()
 
     target_compile_definitions(${_target} PRIVATE "BUILDING_${_logical_name}")
@@ -611,6 +612,10 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         string(JSON _swift_target_paths GET ${_swift_target_info} "paths")
         string(JSON _swift_runtime_resource_path GET ${_swift_target_paths} "runtimeResourcePath")
         target_include_directories(${_target} SYSTEM AFTER PRIVATE "${_swift_runtime_resource_path}")
+        # Swift C++-interop objects auto-link swiftCxx/swiftCxxStdlib; consumers
+        # linked by clang++ need this search path to satisfy those directives.
+        string(JSON _swift_runtime_library_path GET ${_swift_target_paths} "runtimeLibraryPaths" 0)
+        target_link_directories(${_target} INTERFACE "${_swift_runtime_library_path}")
 
         # Assemble arguments which need to be passed to swiftc.
         # Add WebKit's various feature flags as -D directives to the Swift compiler.
@@ -690,7 +695,7 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
             DEPENDS ${_swift_sources}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             COMMAND
-                ${ORIGINAL_Swift_COMPILER} -typecheck
+                ${CMAKE_Swift_COMPILER} --original-swift-compiler=${ORIGINAL_Swift_COMPILER} -typecheck
                 ${_swift_options}
                 ${${_target}_SWIFT_EXTRA_OPTIONS}
                 ${_swift_sdk_flag}

--- a/Tools/Scripts/swift/swiftc-wrapper.sh
+++ b/Tools/Scripts/swift/swiftc-wrapper.sh
@@ -3,6 +3,21 @@
 # This script filters out the arguments that swiftc cannot accommodate.
 
 set -e
+set -o pipefail
+
+# Swift's C++ interop changes which imported members are @unsafe between
+# toolchain versions, so an `unsafe` that is required on one toolchain emits
+# "no unsafe operations occur within 'unsafe' expression" on another. The
+# diagnostic has no group, so it can't be suppressed with -Wwarning; filter it
+# (and its multi-line source snippet) from stderr instead.
+filter_benign_warnings() {
+    awk '
+        /: warning: no unsafe operations occur within .unsafe. expression/ { skip = 1; next }
+        skip && /^[[:space:]]*[0-9]*[[:space:]]*\|/ { next }
+        skip && /^[[:space:]]*$/ { skip = 0; next }
+        { skip = 0; print }
+    '
+}
 
 REAL_SWIFTC=swiftc
 args=()
@@ -49,4 +64,4 @@ for arg in "$@"; do
     esac
 done
 
-exec "$REAL_SWIFTC" "${args[@]}"
+{ "$REAL_SWIFTC" "${args[@]}" 2>&1 1>&3 | filter_benign_warnings >&2; } 3>&1

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/DOMWindowExtensionBasic_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/DOMWindowExtensionBasic_Bundle.cpp
@@ -115,7 +115,7 @@ void DOMWindowExtensionBasic::frameLoadFinished(WKBundleFrameRef frame)
         m_finishedOneMainFrameLoad = true;
 
     char body[16384];
-    sprintf(body, "%s finished loading", mainFrame ? "Main frame" : "Subframe");
+    snprintf(body, sizeof(body), "%s finished loading", mainFrame ? "Main frame" : "Subframe");
     
     // Only consider load finished for the main frame
     const char* name = mainFrame ? "DidFinishLoadForMainFrame" : "DidFinishLoadForFrame";
@@ -130,7 +130,7 @@ void DOMWindowExtensionBasic::frameLoadFinished(WKBundleFrameRef frame)
 void DOMWindowExtensionBasic::sendExtensionStateMessage()
 {
     char body[16384];
-    sprintf(body, "Extension states:\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s",
+    snprintf(body, sizeof(body), "Extension states:\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s",
         m_extensionRecords[0].name, stateNames[m_extensionRecords[0].state],
         m_extensionRecords[1].name, stateNames[m_extensionRecords[1].state],
         m_extensionRecords[2].name, stateNames[m_extensionRecords[2].state],

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/DOMWindowExtensionNoCache_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/DOMWindowExtensionNoCache_Bundle.cpp
@@ -118,7 +118,7 @@ void DOMWindowExtensionNoCache::frameLoadFinished(WKBundleFrameRef frame)
         m_numberMainFrameLoads++;
 
     char body[16384];
-    sprintf(body, "%s finished loading", mainFrame ? "Main frame" : "Subframe");
+    snprintf(body, sizeof(body), "%s finished loading", mainFrame ? "Main frame" : "Subframe");
 
     // Only consider load finished for the main frame
     const char* name = mainFrame ? "DidFinishLoadForMainFrame" : "DidFinishLoadForFrame";
@@ -133,7 +133,7 @@ void DOMWindowExtensionNoCache::frameLoadFinished(WKBundleFrameRef frame)
 void DOMWindowExtensionNoCache::sendExtensionStateMessage()
 {
     char body[16384];
-    sprintf(body, "Extension states:\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s",
+    snprintf(body, sizeof(body), "Extension states:\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s\n%s - %s",
             m_extensionRecords[0].name, states[m_extensionRecords[0].state],
             m_extensionRecords[1].name, states[m_extensionRecords[1].state],
             m_extensionRecords[2].name, states[m_extensionRecords[2].state],

--- a/Tools/clangd/update-compile-commands-symlink
+++ b/Tools/clangd/update-compile-commands-symlink
@@ -55,17 +55,9 @@ class Config:
 
 
 def update_symlink_with_path(symlink_path: Path, target_str: str):
-    try:
-        current_target = os.readlink(symlink_path)
-        symlink_exists = True
-    except FileNotFoundError:
-        current_target = None
-        symlink_exists = False
-
-    if symlink_exists and current_target != target_str:
+    if os.path.lexists(symlink_path):
         os.remove(symlink_path)
-    if not symlink_exists or current_target != target_str:
-        os.symlink(target_str, symlink_path)
+    os.symlink(target_str, symlink_path)
 
 
 def update_symlink_from_candidates(symlink_path: Path, config_path: Path):

--- a/Tools/clangd/update-compile-commands-symlink.conf.example
+++ b/Tools/clangd/update-compile-commands-symlink.conf.example
@@ -6,6 +6,10 @@
 candidates =
     WebKitBuild/Debug/DeveloperTools/compile_commands.json
     WebKitBuild/Release/DeveloperTools/compile_commands.json
+    WebKitBuild/cmake-mac/Debug/DeveloperTools/compile_commands.json
+    WebKitBuild/cmake-mac/Release/DeveloperTools/compile_commands.json
+    WebKitBuild/cmake-mac/RelWithDebInfo/DeveloperTools/compile_commands.json
+    WebKitBuild/cmake-mac/ASan/DeveloperTools/compile_commands.json
     WebKitBuild/GTK/Debug/DeveloperTools/compile_commands.json
     WebKitBuild/GTK/Release/DeveloperTools/compile_commands.json
     WebKitBuild/WPE/Debug/DeveloperTools/compile_commands.json


### PR DESCRIPTION
#### ba55759b9349346c46573cb9c97aba5cc1aed80c
<pre>
Fixed the CMake Swift build with recent toolchains
<a href="https://bugs.webkit.org/show_bug.cgi?id=313294">https://bugs.webkit.org/show_bug.cgi?id=313294</a>
<a href="https://rdar.apple.com/175562562">rdar://175562562</a>

Reviewed by David Kilzer and Charlie Wolfe.

* CMakePresets.json: Turn off experimental features on all configs because they
don&apos;t build cleanly.

* Source/ThirdParty/libwebrtc/CMakeLists.txt: Add missing files to address
a linker issue.

* Source/WebCore/Headers.cmake: Fix the header listing regression from d801bd01eb61.

* Source/WebCore/PlatformMac.cmake: Fix the header include regression from 95a3f2348f1e.

* Source/cmake/OptionsMac.cmake: Support invoking the Swift compiler with a
toolchain version that doesn&apos;t match your OS version.

* Source/cmake/WebKitCommon.cmake: Don&apos;t run the symlink step every build; only
run when out of date.

* Source/cmake/WebKitMacros.cmake: Don&apos;t enable -Werror for all errors at once
because then the &quot;no unsafe operations occur within unsafe expression&quot; fails
the build.

Instead, enable the specific errors we enable in Xcode.

* Tools/Scripts/swift/swiftc-wrapper.sh: Silence the &quot;no unsafe operations...&quot;
warning text to clean up build output.

* Tools/TestWebKitAPI/Tests/WebKit/WKPage/DOMWindowExtensionBasic_Bundle.cpp:
(TestWebKitAPI::DOMWindowExtensionBasic::frameLoadFinished):
(TestWebKitAPI::DOMWindowExtensionBasic::sendExtensionStateMessage):
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/DOMWindowExtensionNoCache_Bundle.cpp:
(TestWebKitAPI::DOMWindowExtensionNoCache::frameLoadFinished):
(TestWebKitAPI::DOMWindowExtensionNoCache::sendExtensionStateMessage): Took the
opportunity to clean up this snprintf shmutz in the build output too.

* Tools/clangd/update-compile-commands-symlink:
(update_symlink_with_path): Handle both the CMake and Xcode case by removing the old
symlink or file unconditionally.

* Tools/clangd/update-compile-commands-symlink.conf.example: Updated to match our
recommended presets.

Canonical link: <a href="https://commits.webkit.org/312109@main">https://commits.webkit.org/312109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddb3f83b5b541d03afb9e01a9ac35ab81f2240fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158869 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112953 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8bac674-6a14-446b-a074-9ed9979b3e42) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123081 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86411 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de8cf762-06a4-4164-a190-2572f7a0bd3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103750 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eda361af-a0f5-4b9f-bfc2-79f9f9ae8a63) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24414 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22809 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15470 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150919 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170190 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19702 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15933 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131270 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131384 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142291 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89937 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24178 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26091 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19100 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/191150 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31441 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97455 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49139 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30961 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31234 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31115 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->