### PR TITLE
[Swift in WebKit] Re-apply formatting/linting to Source/

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -561,88 +561,87 @@ private func nodeDataTypeString(_ data: _Proto_ShaderNodeGraph.Node.NodeData) ->
 
 extension MTLPixelFormat {
     var bytesPerPixel: Int? {
-    switch self {
+        switch self {
+        // MARK: - 8-bit (1 byte)
+        case .a8Unorm,
+            .r8Unorm,
+            .r8Unorm_srgb,
+            .r8Snorm,
+            .r8Uint,
+            .r8Sint,
+            .stencil8:
+            return 1
 
-    // MARK: - 8-bit (1 byte)
-    case .a8Unorm,
-         .r8Unorm,
-         .r8Unorm_srgb,
-         .r8Snorm,
-         .r8Uint,
-         .r8Sint,
-         .stencil8:
-        return 1
+        // MARK: - 16-bit (2 bytes)
+        case .r16Unorm,
+            .r16Snorm,
+            .r16Uint,
+            .r16Sint,
+            .r16Float,
+            .rg8Unorm,
+            .rg8Unorm_srgb,
+            .rg8Snorm,
+            .rg8Uint,
+            .rg8Sint,
+            .b5g6r5Unorm,
+            .a1bgr5Unorm,
+            .abgr4Unorm,
+            .bgr5A1Unorm,
+            .depth16Unorm:
+            return 2
 
-    // MARK: - 16-bit (2 bytes)
-    case .r16Unorm,
-         .r16Snorm,
-         .r16Uint,
-         .r16Sint,
-         .r16Float,
-         .rg8Unorm,
-         .rg8Unorm_srgb,
-         .rg8Snorm,
-         .rg8Uint,
-         .rg8Sint,
-         .b5g6r5Unorm,
-         .a1bgr5Unorm,
-         .abgr4Unorm,
-         .bgr5A1Unorm,
-         .depth16Unorm:
-        return 2
+        // MARK: - 32-bit (4 bytes)
+        case .r32Uint,
+            .r32Sint,
+            .r32Float,
+            .rg16Unorm,
+            .rg16Snorm,
+            .rg16Uint,
+            .rg16Sint,
+            .rg16Float,
+            .rgba8Unorm,
+            .rgba8Unorm_srgb,
+            .rgba8Snorm,
+            .rgba8Uint,
+            .rgba8Sint,
+            .bgra8Unorm,
+            .bgra8Unorm_srgb,
+            .rgb10a2Unorm,
+            .rgb10a2Uint,
+            .rg11b10Float,
+            .rgb9e5Float,
+            .bgr10a2Unorm,
+            .bgr10_xr,
+            .bgr10_xr_srgb,
+            .depth32Float,
+            .x24_stencil8:
+            return 4
 
-    // MARK: - 32-bit (4 bytes)
-    case .r32Uint,
-         .r32Sint,
-         .r32Float,
-         .rg16Unorm,
-         .rg16Snorm,
-         .rg16Uint,
-         .rg16Sint,
-         .rg16Float,
-         .rgba8Unorm,
-         .rgba8Unorm_srgb,
-         .rgba8Snorm,
-         .rgba8Uint,
-         .rgba8Sint,
-         .bgra8Unorm,
-         .bgra8Unorm_srgb,
-         .rgb10a2Unorm,
-         .rgb10a2Uint,
-         .rg11b10Float,
-         .rgb9e5Float,
-         .bgr10a2Unorm,
-         .bgr10_xr,
-         .bgr10_xr_srgb,
-         .depth32Float,
-         .x24_stencil8:
-        return 4
+        // MARK: - 64-bit (8 bytes)
+        case .rgba16Unorm,
+            .rgba16Snorm,
+            .rgba16Uint,
+            .rgba16Sint,
+            .rgba16Float,
+            .rg32Uint,
+            .rg32Sint,
+            .rg32Float,
+            .bgra10_xr,
+            .bgra10_xr_srgb,
+            .depth32Float_stencil8,
+            .x32_stencil8:
+            return 8
 
-    // MARK: - 64-bit (8 bytes)
-    case .rgba16Unorm,
-         .rgba16Snorm,
-         .rgba16Uint,
-         .rgba16Sint,
-         .rgba16Float,
-         .rg32Uint,
-         .rg32Sint,
-         .rg32Float,
-         .bgra10_xr,
-         .bgra10_xr_srgb,
-         .depth32Float_stencil8,
-         .x32_stencil8:
-        return 8
+        // MARK: - 128-bit (16 bytes)
+        case .rgba32Uint,
+            .rgba32Sint,
+            .rgba32Float:
+            return 16
 
-    // MARK: - 128-bit (16 bytes)
-    case .rgba32Uint,
-         .rgba32Sint,
-         .rgba32Float:
-        return 16
-
-    // MARK: - Compressed / Unknown
-    default:
-        return nil // Block-compressed (BCn, ASTC, EAC, PVRTC, etc.) or invalid
-    }
+        // MARK: - Compressed / Unknown
+        default:
+            return nil // Block-compressed (BCn, ASTC, EAC, PVRTC, etc.) or invalid
+        }
     }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -313,7 +313,7 @@ private func makeParameters(
     guard let argumentTableDescriptor = function.argumentTableDescriptor else { return nil }
     let parameterMapping = function.parameterMapping
 
-    var optTextures: [_Proto_LowLevelTextureResource_v1?] = argumentTableDescriptor.textures.map({ _ in nil })
+    var optTextures: [_Proto_LowLevelTextureResource_v1?] = .init(repeating: nil, count: argumentTableDescriptor.textures.count)
     for parameter in parameterMapping?.textures ?? [] {
         if let textureHashAndResource = textureHashesAndResources.values.first(where: { $0.0 == parameter.name }) {
             optTextures[parameter.textureIndex] = textureHashAndResource.1
@@ -323,9 +323,13 @@ private func makeParameters(
             optTextures[parameter.textureIndex] = fallbackTexture
         }
     }
-    let textures = optTextures.map({ $0! })
+    let textures = optTextures.map {
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+        // swift-format-ignore: NeverForceUnwrap
+        $0!
+    }
 
-    let buffers: [_Proto_LowLevelBufferSpan_v1] = try argumentTableDescriptor.buffers.map { bufferRequirements in
+    let buffers = try argumentTableDescriptor.buffers.map { bufferRequirements in
         let capacity = (bufferRequirements.size + 16 - 1) / 16 * 16
         let buffer = try renderContext.makeBufferResource(descriptor: .init(capacity: capacity))
         buffer.replace { span in
@@ -554,17 +558,13 @@ extension WKBridgeReceiver {
     }
 
     func commandBuffer() -> (any MTLCommandBuffer)? {
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-        // swift-format-ignore: NeverForceUnwrap
-        commandQueue.makeCommandBuffer()!
+        commandQueue.makeCommandBuffer()
     }
 
     @objc(renderWithTexture:commandBuffer:)
     func render(with texture: any MTLTexture, commandBuffer: any MTLCommandBuffer) {
         for (identifier, meshes) in meshToMeshInstances {
             let originalTransforms = meshTransforms[identifier]
-            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-            // swift-format-ignore: NeverForceUnwrap
 
             for (index, meshInstance) in meshes.enumerated() {
                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
@@ -576,13 +576,18 @@ extension WKBridgeReceiver {
 
         // animate
         if !meshResourceToDeformationContext.isEmpty {
+            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+            // swift-format-ignore: NeverForceUnwrap
             let commandBuffer = self.commandQueue.makeCommandBuffer()!
 
             for (identifier, deformationContext) in meshResourceToDeformationContext where deformationContext.dirty {
                 let result = deformationContext.deformation.execute(
                     deformation: deformationContext.description,
                     commandBuffer: commandBuffer
-                ) { (commandBuffer: any MTLCommandBuffer) in }
+                ) { _ in }
+
+                // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+                // swift-format-ignore: NeverForceUnwrap
                 meshResourceToDeformationContext[identifier]!.dirty = false
 
                 if case .failure(let error) = result {
@@ -1436,9 +1441,9 @@ private func toWebMaterialGraph(_ material: _Proto_ShaderNodeGraph?) -> WKBridge
 
     // Serialize primvarMappings as parallel arrays (sorted for determinism).
     // _Proto_TextureCoordinate.name is internal so we map to the canonical UV name string.
-    let sortedPrimvarKeys = material.primvarMappings.keys.sorted()
-    let primvarPrimvarNames = sortedPrimvarKeys
-    let primvarTexcoordNames = sortedPrimvarKeys.map { texcoordName(for: material.primvarMappings[$0]!) }
+    let sortedPrimvarMappings = material.primvarMappings.sorted { $0.key < $1.key }
+    let primvarPrimvarNames = sortedPrimvarMappings.map(\.key)
+    let primvarTexcoordNames = sortedPrimvarMappings.map { texcoordName(for: $0.value) }
 
     return WKBridgeMaterialGraph(
         graphName: material.sgGraph.name,


### PR DESCRIPTION
#### 1a11a6b9769fb90cde67809f931db2a3a349c840
<pre>
[Swift in WebKit] Re-apply formatting/linting to Source/
<a href="https://bugs.webkit.org/show_bug.cgi?id=313296">https://bugs.webkit.org/show_bug.cgi?id=313296</a>
<a href="https://rdar.apple.com/175567308">rdar://175567308</a>

Reviewed by NOBODY (OOPS!).

Apply formatting, and address linting errors by fixing a few force unwraps.

* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
(MTLPixelFormat.bytesPerPixel):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(optTextures):
(commandBuffer() -&gt; (any MTLCommandBuffer:)):
(render(with:commandBuffer:)):
(SGDataTypeRawValue.toWebMaterialGraph(_:)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a11a6b9769fb90cde67809f931db2a3a349c840

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112748 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd44fcb7-54bb-4968-a9e2-b52b02c280da) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122908 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86246 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/688acca5-045a-43e9-9317-b9e71ae64c3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142533 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103577 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bda8c264-ac9a-4bc9-8d5e-0e19ddfe8c7d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24223 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22624 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15265 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133909 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169985 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15728 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131095 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131209 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89640 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25902 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18914 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31236 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97250 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30756 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31029 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30910 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->