### PR TITLE
Clean up stale web extension origin data after migration

### DIFF
--- a/Source/WebKit/Shared/WebsiteData/WebsiteDataFetchOption.h
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteDataFetchOption.h
@@ -30,6 +30,7 @@ namespace WebKit {
 enum class WebsiteDataFetchOption : uint8_t {
     ComputeSizes = 1 << 0,
     DoNotCreateProcesses = 1 << 1,
+    IncludeAllOrigins = 1 << 2,
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebsiteData/WebsiteDataFetchOption.serialization.in
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteDataFetchOption.serialization.in
@@ -23,4 +23,5 @@
 [OptionSet] enum class WebKit::WebsiteDataFetchOption : uint8_t {
     ComputeSizes,
     DoNotCreateProcesses,
+    IncludeAllOrigins,
 };

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -61,6 +61,8 @@
 #import "WKWebViewConfigurationInternal.h"
 #import "WKWebViewInternal.h"
 #import "WKWebpagePreferencesPrivate.h"
+#import "WKWebsiteDataRecordInternal.h"
+#import "WKWebsiteDataStoreInternal.h"
 #import "WKWebsiteDataStorePrivate.h"
 #import "WKWindowFeaturesPrivate.h"
 #import "WebExtensionAction.h"
@@ -68,6 +70,7 @@
 #import "WebExtensionContextProxyMessages.h"
 #import "WebExtensionDataType.h"
 #import "WebExtensionDynamicScripts.h"
+#import "WebExtensionMatchPattern.h"
 #import "WebExtensionMenuItemContextParameters.h"
 #import "WebExtensionPermission.h"
 #import "WebExtensionTab.h"
@@ -78,6 +81,9 @@
 #import "WebPreferences.h"
 #import "WebScriptMessageHandler.h"
 #import "WebUserContentControllerProxy.h"
+#import "WebsiteDataFetchOption.h"
+#import "WebsiteDataRecord.h"
+#import "WebsiteDataStore.h"
 #import "_WKWebExtensionDeclarativeNetRequestRule.h"
 #import "_WKWebExtensionDeclarativeNetRequestTranslator.h"
 #import <UniformTypeIdentifiers/UTType.h>
@@ -300,6 +306,8 @@ Expected<bool, RefPtr<API::Error>> WebExtensionContext::load(WebExtensionControl
         if (!isLoaded())
             return;
 
+        removeStaleExtensionWebsiteData();
+
         m_safeToInjectContent = true;
 
         loadBackgroundWebViewDuringLoad();
@@ -492,13 +500,90 @@ void WebExtensionContext::writeStateToStorage() const
 
 void WebExtensionContext::moveLocalStorageIfNeeded(const URL& previousBaseURL, CompletionHandler<void()>&& completionHandler)
 {
-    if (previousBaseURL == baseURL()) {
+    if (!previousBaseURL.isValid() || previousBaseURL == baseURL()) {
         completionHandler();
         return;
     }
 
     static NSSet<NSString *> *dataTypes = [NSSet setWithObjects:WKWebsiteDataTypeIndexedDBDatabases, WKWebsiteDataTypeLocalStorage, nil];
-    [webViewConfiguration().websiteDataStore _renameOrigin:previousBaseURL.createNSURL().get() to:baseURL().createNSURL().get() forDataOfTypes:dataTypes completionHandler:makeBlockPtr(WTF::move(completionHandler)).get()];
+    [webViewConfiguration().websiteDataStore _renameOrigin:previousBaseURL.createNSURL().get() to:baseURL().createNSURL().get() forDataOfTypes:dataTypes completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, previousBaseURL, completionHandler = WTF::move(completionHandler)]() mutable {
+        removeWebsiteDataForOrigin(previousBaseURL, WTF::move(completionHandler));
+    }).get()];
+}
+
+static OptionSet<WebsiteDataType> allWebsiteDataTypes()
+{
+    return toWebsiteDataTypes([WKWebsiteDataStore _allWebsiteDataTypesIncludingPrivate]);
+}
+
+void WebExtensionContext::removeWebsiteDataForOrigin(const URL& originURL, CompletionHandler<void()>&& completionHandler)
+{
+    if (!originURL.isValid())
+        return completionHandler();
+
+    RetainPtr<WKWebsiteDataStore> dataStore = webViewConfiguration().websiteDataStore;
+    RefPtr websiteDataStore = dataStore ? dataStore->_websiteDataStore.get() : nullptr;
+    if (!websiteDataStore)
+        return completionHandler();
+
+    auto origin = WebCore::SecurityOriginData::fromURLWithoutStrictOpaqueness(originURL);
+    auto dataTypes = allWebsiteDataTypes();
+
+    WebsiteDataRecord record;
+    for (auto type : dataTypes)
+        record.add(type, origin);
+
+    websiteDataStore->removeData(dataTypes, { record }, WTF::move(completionHandler));
+}
+
+void WebExtensionContext::removeStaleExtensionWebsiteData()
+{
+    if (!storageIsPersistent())
+        return;
+
+    RefPtr controller = extensionController();
+    if (!controller || !controller->markDidRemoveStaleExtensionWebsiteData())
+        return;
+
+    auto sentinelPath = FileSystem::pathByAppendingComponent(controller->configuration().storageDirectory(), "StaleExtensionOriginsCleared"_s);
+    if (FileSystem::fileExists(sentinelPath))
+        return;
+
+    RetainPtr<WKWebsiteDataStore> dataStore = webViewConfiguration().websiteDataStore;
+    RefPtr websiteDataStore = dataStore ? dataStore->_websiteDataStore.get() : nullptr;
+    if (!websiteDataStore)
+        return;
+
+    auto dataTypes = allWebsiteDataTypes();
+    websiteDataStore->fetchData(dataTypes, { WebsiteDataFetchOption::IncludeAllOrigins }, [protectedThis = Ref { *this }, dataTypes, websiteDataStore, sentinelPath](Vector<WebsiteDataRecord> records) {
+        RefPtr controller = protectedThis->extensionController();
+        if (!controller)
+            return;
+
+        auto activeExtensionURLs = controller->activeExtensionURLs();
+
+        Vector<WebsiteDataRecord> staleRecords;
+        for (auto& record : records) {
+            WebsiteDataRecord staleRecord;
+            for (auto& origin : record.origins) {
+                if (WebExtensionMatchPattern::isWebExtensionURL(origin.toURL()) && !activeExtensionURLs.contains(origin.toURL().protocolHostAndPort().convertToASCIILowercase()))
+                    staleRecord.origins.add(origin);
+            }
+            if (!staleRecord.origins.isEmpty()) {
+                staleRecord.types = record.types;
+                staleRecords.append(WTF::move(staleRecord));
+            }
+        }
+
+        if (staleRecords.isEmpty()) {
+            FileSystem::overwriteEntireFile(sentinelPath, { });
+            return;
+        }
+
+        websiteDataStore->removeData(dataTypes, staleRecords, [sentinelPath] {
+            FileSystem::overwriteEntireFile(sentinelPath, { });
+        });
+    });
 }
 
 void WebExtensionContext::invalidateStorage()

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -586,6 +586,26 @@ String WebExtensionController::storageDirectory(const String& uniqueIdentifier) 
     return FileSystem::pathByAppendingComponent(m_configuration->storageDirectory(), uniqueIdentifier);
 }
 
+HashSet<String> WebExtensionController::activeExtensionURLs() const
+{
+    HashSet<String> origins;
+
+    for (auto& context : m_extensionContexts)
+        origins.add(context->baseURL().protocolHostAndPort().convertToASCIILowercase());
+
+    if (m_configuration->storageIsPersistent()) {
+        for (auto& uniqueIdentifier : FileSystem::listDirectory(m_configuration->storageDirectory())) {
+            if (uniqueIdentifier == "StaleExtensionOriginsCleared"_s)
+                continue;
+            URL lastSeenBaseURL;
+            if (WebExtensionContext::readLastBaseURLFromState(stateFilePath(uniqueIdentifier), lastSeenBaseURL))
+                origins.add(lastSeenBaseURL.protocolHostAndPort().convertToASCIILowercase());
+        }
+    }
+
+    return origins;
+}
+
 RefPtr<WebExtensionStorageSQLiteStore> WebExtensionController::sqliteStore(const String& storageDirectory, WebExtensionDataType type, RefPtr<WebExtensionContext> extensionContext)
 {
     if (type == WebExtensionDataType::Session) {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -681,6 +681,8 @@ private:
 
     void determineInstallReasonDuringLoad();
     void moveLocalStorageIfNeeded(const URL& previousBaseURL, CompletionHandler<void()>&&);
+    void removeWebsiteDataForOrigin(const URL&, CompletionHandler<void()>&&);
+    void removeStaleExtensionWebsiteData();
 
     void permissionsDidChange(PermissionNotification, const PermissionsSet&);
     void permissionsDidChange(PermissionNotification, const MatchPatternSet&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -110,6 +110,15 @@ WebExtensionController::WebProcessProxySet WebExtensionController::allProcesses(
     return result;
 }
 
+bool WebExtensionController::markDidRemoveStaleExtensionWebsiteData()
+{
+    if (m_didRemoveStaleExtensionWebsiteData)
+        return false;
+
+    m_didRemoveStaleExtensionWebsiteData = true;
+    return true;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -194,6 +194,9 @@ public:
     bool isShowingActionPopup() { return m_showingActionPopup; };
     void setShowingActionPopup(bool isOpen) { m_showingActionPopup = isOpen; };
 
+    bool markDidRemoveStaleExtensionWebsiteData();
+    HashSet<String> activeExtensionURLs() const;
+
 #ifdef __OBJC__
     WKWebExtensionController *wrapper() const { return (WKWebExtensionController *)API::ObjectImpl<API::Object::Type::WebExtensionController>::wrapper(); }
     WKWebExtensionControllerDelegatePrivate *delegate() const { return (WKWebExtensionControllerDelegatePrivate *)protect(wrapper()).get().delegate; }
@@ -282,6 +285,7 @@ private:
     UserContentControllerProxySet m_allNonPrivateUserContentControllers;
     UserContentControllerProxySet m_allPrivateUserContentControllers;
     WebExtensionURLSchemeHandlerMap m_registeredSchemeHandlers;
+    bool m_didRemoveStaleExtensionWebsiteData { false };
 
     bool m_freshlyCreated : 1 { true };
 #ifdef NDEBUG

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -643,7 +643,7 @@ void WebsiteDataStore::fetchDataAndApply(OptionSet<WebsiteDataType> dataTypes, O
             for (auto& entry : websiteData.entries) {
                 auto displayName = WebsiteDataRecord::displayNameForOrigin(entry.origin);
                 if (!displayName) {
-                    if (!allowsWebsiteDataRecordsForAllOrigins)
+                    if (!allowsWebsiteDataRecordsForAllOrigins && !m_fetchOptions.contains(WebsiteDataFetchOption::IncludeAllOrigins))
                         continue;
 
                     String hostString = entry.origin.host().isEmpty() ? emptyString() : makeString(' ', entry.origin.host());

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
@@ -661,8 +661,8 @@ TEST(IPCTestingAPI, SerializedTypeInfo)
     NSDictionary *expectedDictionary = @{
         @"isOptionSet" : @1,
         @"size" : @1,
-        @"validValues" : @[@1, @2],
-        @"valueMap" : @[@{@"value": @1, @"name": @"ComputeSizes"}, @{@"value": @2, @"name": @"DoNotCreateProcesses"}]
+        @"validValues" : @[@1, @2, @4],
+        @"valueMap" : @[@{@"value": @1, @"name": @"ComputeSizes"}, @{@"value": @2, @"name": @"DoNotCreateProcesses"}, @{@"value": @4, @"name": @"IncludeAllOrigins"}]
     };
     NSDictionary *enumInfo = [webView objectByEvaluatingJavaScript:@"IPC.serializedEnumInfo"];
     EXPECT_TRUE([enumInfo[@"WebKit::WebsiteDataFetchOption"] isEqualToDictionary:expectedDictionary]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
@@ -1869,10 +1869,10 @@ TEST(WKWebExtensionAPIScripting, MigrateScriptDataToNewFormat)
     // Give the extension a unique identifier so it opts into saving data in the temporary configuration.
     manager.get().context.uniqueIdentifier = @"org.webkit.test.extension (76C788B8)";
 
-    [manager load];
-
     auto *storageDirectory = manager.get().controller.configuration._storageDirectoryPath;
     storageDirectory = [storageDirectory stringByAppendingPathComponent:manager.get().context.uniqueIdentifier];
+
+    [NSFileManager.defaultManager createDirectoryAtPath:storageDirectory withIntermediateDirectories:YES attributes:nil error:nil];
 
     static auto *files = @[
         [NSBundle.test_resourcesBundle URLForResource:@"RegisteredContentScripts" withExtension:@"db"],
@@ -1885,7 +1885,7 @@ TEST(WKWebExtensionAPIScripting, MigrateScriptDataToNewFormat)
         [NSFileManager.defaultManager copyItemAtURL:file toURL:[NSURL fileURLWithPath:combinedPath] error:nil];
     }
 
-    [manager run];
+    [manager loadAndRun];
 }
 
 TEST(WKWebExtensionAPIScripting, ContentScriptsAndStyleSheetsWithManyMatchPatterns)


### PR DESCRIPTION
#### 1c19ff8379e1fa2a96799943e6d0e6b503f66ffa
<pre>
Clean up stale web extension origin data after migration
<a href="https://bugs.webkit.org/show_bug.cgi?id=313295">https://bugs.webkit.org/show_bug.cgi?id=313295</a>
<a href="https://rdar.apple.com/175484888">rdar://175484888</a>

Reviewed by Timothy Hatcher.

Each time a web extension loads, it gets a new unique base URL (e.g. webkit-extension://&lt;new-uuid&gt;/).
moveLocalStorageIfNeeded renames localStorage and IndexedDB from the old origin to the new one, but leaves behind all
other data (service worker registrations, DOM cache, etc.) for the old origin. Over time these stale origins accumulate
and slow down storage initialization, as NetworkStorageManager::getAllOrigins must traverse every origin directory.

This patch makes two changes:
1. After renaming localStorage/IndexedDB, delete all remaining website data for the previous origin so no stale data
accumulates going forward.
2. On the first extension load per controller lifetime, fetch all origins from the data store, identify any web
extension origins that don&apos;t belong to a currently loaded extension, and remove them. This cleans up stale origins that
accumulated before the going-forward fix.

To support this, add a new WebsiteDataFetchOption::IncludeAllOrigins that bypasses the displayNameForOrigin filter in
WebsiteDataStore::fetchDataAndApply, which otherwise silently drops origins with custom URL schemes like
safari-web-extension://.

Also, update moveLocalStorageIfNeeded return early when there is no previous base URL -- this helps avoid round-trip IPC
to network process when migration will not happen and it is needed to avoid crash in removeWebsiteDataForOrigin. With
this change, update TestWebKitAPI.WKWebExtensionAPIScripting.MigrateScriptDataToNewFormat test to copy the old-format
database files before loading the extension, since moveLocalStorageIfNeeded now completes synchronously when there is no
previous base URL, changing the timing of loading scripts.

* Source/WebKit/Shared/WebsiteData/WebsiteDataFetchOption.h:
* Source/WebKit/Shared/WebsiteData/WebsiteDataFetchOption.serialization.in:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::moveLocalStorageIfNeeded):
(WebKit::allWebsiteDataTypes):
(WebKit::WebExtensionContext::removeWebsiteDataForOrigin):
(WebKit::WebExtensionContext::removeStaleExtensionWebsiteData):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::activeExtensionURLs const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::markDidRemoveStaleExtensionWebsiteData):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::fetchDataAndApply):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm:
(SerializedTypeInfo)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, MigrateScriptDataToNewFormat)):

Canonical link: <a href="https://commits.webkit.org/312231@main">https://commits.webkit.org/312231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7134608104c81cbd5aa1895cf713eae9f3e3c7df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168085 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123386 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104053 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24706 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23134 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15857 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170579 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16571 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131581 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131725 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35627 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142614 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90395 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26385 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19423 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31827 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98224 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31347 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31502 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->