### PR TITLE
[Swift in WebKit] Apply formatting/linting to Tools/TestWebKitAPI

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestPDFDocument.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestPDFDocument.swift
@@ -100,7 +100,9 @@ extension TestPDFPage {
     @objc(colorAtPoint:)
     func color(at point: CGPoint) -> CocoaColor {
         let boundsRect = bounds
-        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)
+        guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) else {
+            preconditionFailure("Unable to create sRGB color space")
+        }
 
         // FIXME: document safety invariants here.
         #if HAVE_CGCONTEXT_INIT_WITH_BITMAP_INFO_AND_NULLABLE_COLORSPACE
@@ -120,7 +122,7 @@ extension TestPDFPage {
             height: Int(boundsRect.size.height),
             bitsPerComponent: 8,
             bytesPerRow: 0,
-            space: colorSpace!,
+            space: colorSpace,
             bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue).union(.byteOrder32Big).rawValue
         )
         #endif
@@ -180,7 +182,10 @@ extension TestPDFDocument {
 
     @objc(initFromData:)
     init(from data: Data) {
-        let document = PDFDocument(data: data)!
+        guard let document = PDFDocument(data: data) else {
+            preconditionFailure("failed to create PDFDocument from data")
+        }
+
         self.document = document
         self.pages = .init(repeating: nil, count: document.pageCount)
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift
@@ -182,18 +182,19 @@ struct URLSchemeHandlerTests {
     @Test
     func basicSchemeHandling() async throws {
         let html = """
-        <html>
-        <img src='testing:image'>
-        </html>
-        """.data(using: .utf8)!
+            <html>
+            <img src='testing:image'>
+            </html>
+            """
+            .data(using: .utf8)
 
-        let handler = TestURLSchemeHandler(data: html, mimeType: "text/html")
+        let handler = try TestURLSchemeHandler(data: #require(html), mimeType: "text/html")
         var configuration = WebPage.Configuration()
-        configuration.urlSchemeHandlers[URLScheme("testing")!] = handler
+        try configuration.urlSchemeHandlers[#require(URLScheme("testing"))] = handler
 
         let page = WebPage(configuration: configuration)
 
-        let url = URL(string: "testing:main")!
+        let url = try #require(URL(string: "testing:main"))
         let request = URLRequest(url: url)
 
         async let replyStream = Array(handler.replyStream.prefix(2))

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -33,7 +33,7 @@ private import TestWebKitAPILibrary
 // MARK: Supporting test types
 
 @MainActor
-fileprivate class TestNavigationDecider: WebPage.NavigationDeciding {
+private class TestNavigationDecider: WebPage.NavigationDeciding {
     init() {
         (self.navigationActionStream, self.navigationActionContinuation) = AsyncStream.makeStream(of: WebPage.NavigationAction.self)
         (self.navigationResponseStream, self.navigationResponseContinuation) = AsyncStream.makeStream(of: WebPage.NavigationResponse.self)
@@ -47,7 +47,10 @@ fileprivate class TestNavigationDecider: WebPage.NavigationDeciding {
 
     var preferencesMutation: (inout WebPage.NavigationPreferences) -> Void = { _ in }
 
-    func decidePolicy(for action: WebPage.NavigationAction, preferences: inout WebPage.NavigationPreferences) async -> WKNavigationActionPolicy {
+    func decidePolicy(
+        for action: WebPage.NavigationAction,
+        preferences: inout WebPage.NavigationPreferences
+    ) async -> WKNavigationActionPolicy {
         preferencesMutation(&preferences)
 
         navigationActionContinuation.yield(action)
@@ -69,13 +72,13 @@ struct WebPageTests {
         let page = WebPage()
 
         let html = """
-        <html>
-        <head>
-            <title>Title</title>
-        </head>
-        <body></body>
-        </html>
-        """
+            <html>
+            <head>
+                <title>Title</title>
+            </head>
+            <body></body>
+            </html>
+            """
 
         #expect(page.url == nil)
         #expect(page.title == "")


### PR DESCRIPTION
#### 90e427ecea275cf4071955f3d65cb9295f126098
<pre>
[Swift in WebKit] Apply formatting/linting to Tools/TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=313297">https://bugs.webkit.org/show_bug.cgi?id=313297</a>
<a href="https://rdar.apple.com/175567693">rdar://175567693</a>

Reviewed by Abrar Rahman Protyasha.

* Tools/TestWebKitAPI/Helpers/cocoa/TestPDFDocument.swift:
(TestPDFPage.color(at:)):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/URLSchemeHandlerTests.swift:
(URLSchemeHandlerTests.basicSchemeHandling):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:
(WebPageTests.observableProperties):
(TestNavigationDecider.decidePolicy(for:preferences:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/312011@main">https://commits.webkit.org/312011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/919b115afb5f3ad83e53f7aa531ca8487ec96085

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167495 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/112750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3eb4301-d3f8-4f76-b89b-dde9e1dc09c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122910 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/112750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be98c1a1-eafe-4eea-9bbc-4e1e34fc6f26) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103579 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5c4f9d4-8e3b-4c4b-8334-d211731a5266) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15267 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169987 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131097 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31782 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131211 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35513 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89642 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25907 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18915 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31238 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30758 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31031 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30912 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->