### PR TITLE
[SVG] glyph-orientation-vertical: auto should decode surrogate pairs for UTR#50 lookup

### DIFF
--- a/LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50-surrogate-expected.txt
+++ b/LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50-surrogate-expected.txt
@@ -1,0 +1,18 @@
+😀
+𠀀
+𝄞
+𝐀
+𐀀
+一😀𝐀
+😀𠀀𝐀
+一😀A𝐀
+
+PASS U+1F600 GRINNING FACE is upright (VO=U, surrogate pair)
+PASS U+20000 CJK Ext-B ideograph is upright (VO=U, surrogate pair)
+PASS U+1D11E MUSICAL SYMBOL G CLEF is upright (VO=U, surrogate pair)
+PASS U+1D400 MATHEMATICAL BOLD CAPITAL A is sideways (VO=R, surrogate pair)
+PASS U+10000 LINEAR B SYLLABLE B008 A is sideways (VO=R, surrogate pair)
+PASS Mixed string with BMP and surrogate pair characters
+PASS Consecutive surrogate pairs: offset arithmetic across back-to-back pairs
+PASS Interleaved BMP and surrogate pairs: BMP-surrogate-BMP-surrogate
+

--- a/LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50-surrogate.html
+++ b/LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50-surrogate.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>glyph-orientation-vertical: auto should handle surrogate pairs (UTR#50)</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#GlyphOrientationVerticalProperty">
+<link rel="help" href="https://www.unicode.org/reports/tr50/">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<svg id="container" width="800" height="600" style="writing-mode: tb; glyph-orientation-vertical: auto;"></svg>
+<script>
+const container = document.querySelector('#container');
+
+function createText(content) {
+  const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+  text.setAttribute('x', '50');
+  text.setAttribute('y', '50');
+  text.textContent = content;
+  container.appendChild(text);
+  return text;
+}
+
+// Supplementary characters with VO=U (Upright) — should be 0 degrees
+
+// U+1F600 GRINNING FACE (1F600..1F64F ; U)
+test(() => {
+  const el = createText('😀');
+  assert_equals(el.getRotationOfChar(0), 0, 'U+1F600 GRINNING FACE should be upright');
+}, 'U+1F600 GRINNING FACE is upright (VO=U, surrogate pair)');
+
+// U+20000 CJK UNIFIED IDEOGRAPH-20000 (20000..2A6DF ; U)
+test(() => {
+  const el = createText('𠀀');
+  assert_equals(el.getRotationOfChar(0), 0, 'U+20000 CJK ext-B ideograph should be upright');
+}, 'U+20000 CJK Ext-B ideograph is upright (VO=U, surrogate pair)');
+
+// U+1D11E MUSICAL SYMBOL G CLEF (1D100..1D1FF ; U)
+test(() => {
+  const el = createText('𝄞');
+  assert_equals(el.getRotationOfChar(0), 0, 'U+1D11E MUSICAL SYMBOL G CLEF should be upright');
+}, 'U+1D11E MUSICAL SYMBOL G CLEF is upright (VO=U, surrogate pair)');
+
+// Supplementary characters with VO=R (Rotated) — should be 90 degrees
+
+// U+1D400 MATHEMATICAL BOLD CAPITAL A (1D400..1D7FF ; R)
+test(() => {
+  const el = createText('𝐀');
+  assert_equals(el.getRotationOfChar(0), 90, 'U+1D400 MATH BOLD A should be sideways');
+}, 'U+1D400 MATHEMATICAL BOLD CAPITAL A is sideways (VO=R, surrogate pair)');
+
+// U+10000 LINEAR B SYLLABLE B008 A (10000..1007F ; R)
+test(() => {
+  const el = createText('𐀀');
+  assert_equals(el.getRotationOfChar(0), 90, 'U+10000 LINEAR B SYLLABLE should be sideways');
+}, 'U+10000 LINEAR B SYLLABLE B008 A is sideways (VO=R, surrogate pair)');
+
+// getRotationOfChar() uses UTF-16 code unit indices, not code point indices.
+// Surrogate pairs occupy 2 indices, so offsets must account for that.
+
+// Mixed: BMP(1) + surrogate(2) + surrogate(2) = 5 code units
+// 一 at 0, 😀 at 1, 𝐀 at 3
+test(() => {
+  const el = createText('一😀𝐀');
+  assert_equals(el.getRotationOfChar(0), 0, 'U+4E00 CJK ideograph should be upright');
+  assert_equals(el.getRotationOfChar(1), 0, 'U+1F600 emoji should be upright');
+  assert_equals(el.getRotationOfChar(3), 90, 'U+1D400 math bold A should be sideways');
+}, 'Mixed string with BMP and surrogate pair characters');
+
+// Consecutive surrogate pairs: surrogate(2) + surrogate(2) + surrogate(2) = 6 code units
+// 😀 at 0, 𠀀 at 2, 𝐀 at 4
+test(() => {
+  const el = createText('😀𠀀𝐀');
+  assert_equals(el.getRotationOfChar(0), 0, 'U+1F600 emoji should be upright');
+  assert_equals(el.getRotationOfChar(2), 0, 'U+20000 CJK ext-B should be upright');
+  assert_equals(el.getRotationOfChar(4), 90, 'U+1D400 math bold A should be sideways');
+}, 'Consecutive surrogate pairs: offset arithmetic across back-to-back pairs');
+
+// BMP(1) + surrogate(2) + BMP(1) + surrogate(2) = 6 code units
+// 一 at 0, 😀 at 1, A at 3, 𝐀 at 4
+test(() => {
+  const el = createText('一😀A𝐀');
+  assert_equals(el.getRotationOfChar(0), 0, 'U+4E00 CJK ideograph should be upright');
+  assert_equals(el.getRotationOfChar(1), 0, 'U+1F600 emoji should be upright');
+  assert_equals(el.getRotationOfChar(3), 90, 'Latin A should be sideways');
+  assert_equals(el.getRotationOfChar(4), 90, 'U+1D400 math bold A should be sideways');
+}, 'Interleaved BMP and surrogate pairs: BMP-surrogate-BMP-surrogate');
+</script>

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -522,8 +522,14 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
         float angle = SVGTextLayoutAttributes::isEmptyValue(data.rotate) ? 0 : data.rotate;
 
         // Calculate glyph orientation angle.
-        const char16_t* currentCharacter = characters.subspan(m_visualCharacterOffset).data();
-        float orientationAngle = baselineLayout.calculateGlyphOrientationAngle(m_isVerticalText, style, *currentCharacter);
+        auto remainingCharacters = characters.subspan(m_visualCharacterOffset);
+        char32_t currentCodePoint = remainingCharacters[0];
+        if (U16_IS_LEAD(currentCodePoint) && remainingCharacters.size() > 1) {
+            auto trail = remainingCharacters[1];
+            if (U16_IS_TRAIL(trail))
+                currentCodePoint = U16_GET_SUPPLEMENTARY(currentCodePoint, trail);
+        }
+        float orientationAngle = baselineLayout.calculateGlyphOrientationAngle(m_isVerticalText, style, currentCodePoint);
 
         // Calculate glyph advance & x/y orientation shifts.
         float xOrientationShift = 0;
@@ -537,7 +543,7 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
         updateRelativePositionAdjustmentsIfNeeded(data.dx, data.dy);
 
         // Calculate CSS 'letter-spacing' and 'word-spacing' for next character, if needed.
-        float spacing = spacingLayout.calculateCSSSpacing(currentCharacter ? *currentCharacter : '\0');
+        float spacing = spacingLayout.calculateCSSSpacing(remainingCharacters.empty() ? '\0' : remainingCharacters[0]);
 
         float textPathOffset = 0;
         if (m_inPathLayout) {

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -526,8 +526,14 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
         float angle = SVGTextLayoutAttributes::isEmptyValue(data.rotate) ? 0 : data.rotate;
 
         // Calculate glyph orientation angle.
-        const char16_t* currentCharacter = characters.subspan(m_visualCharacterOffset).data();
-        float orientationAngle = baselineLayout.calculateGlyphOrientationAngle(m_isVerticalText, style, *currentCharacter);
+        auto remainingCharacters = characters.subspan(m_visualCharacterOffset);
+        char32_t currentCodePoint = remainingCharacters[0];
+        if (U16_IS_LEAD(currentCodePoint) && remainingCharacters.size() > 1) {
+            auto trail = remainingCharacters[1];
+            if (U16_IS_TRAIL(trail))
+                currentCodePoint = U16_GET_SUPPLEMENTARY(currentCodePoint, trail);
+        }
+        float orientationAngle = baselineLayout.calculateGlyphOrientationAngle(m_isVerticalText, style, currentCodePoint);
 
         // Calculate glyph advance & x/y orientation shifts.
         float xOrientationShift = 0;
@@ -541,7 +547,7 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
         updateRelativePositionAdjustmentsIfNeeded(data.dx, data.dy);
 
         // Calculate CSS 'letter-spacing' and 'word-spacing' for next character, if needed.
-        float spacing = spacingLayout.calculateCSSSpacing(currentCharacter ? *currentCharacter : '\0');
+        float spacing = spacingLayout.calculateCSSSpacing(currentCodePoint);
 
         float textPathOffset = 0;
         if (m_inPathLayout) {

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -147,7 +147,7 @@ float SVGTextLayoutEngineBaseline::calculateAlignmentBaselineShift(bool isVertic
     return 0;
 }
 
-float SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle(bool isVerticalText, const RenderStyle& style, const char16_t& character) const
+float SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle(bool isVerticalText, const RenderStyle& style, const char32_t& character) const
 {
     if (isVerticalText) {
         return Style::valueRepresentation(style.glyphOrientationVertical(),

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -146,7 +146,7 @@ float SVGTextLayoutEngineBaseline::calculateAlignmentBaselineShift(bool isVertic
     return 0;
 }
 
-float SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle(bool isVerticalText, const RenderStyle& style, const char16_t& character) const
+float SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle(bool isVerticalText, const RenderStyle& style, const char32_t& character) const
 {
     if (isVerticalText) {
         return Style::valueRepresentation(style.glyphOrientationVertical(),

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.h
@@ -39,7 +39,7 @@ public:
 
     float calculateBaselineShift(const RenderStyle&) const;
     float calculateAlignmentBaselineShift(bool isVerticalText, const RenderSVGInlineText& textRenderer) const;
-    float calculateGlyphOrientationAngle(bool isVerticalText, const RenderStyle&, const char16_t& character) const;
+    float calculateGlyphOrientationAngle(bool isVerticalText, const RenderStyle&, const char32_t& character) const;
     float calculateGlyphAdvanceAndOrientation(bool isVerticalText, const SVGTextMetrics&, float angle, float& xOrientationShift, float& yOrientationShift) const;
 
 private:

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.cpp
@@ -35,7 +35,7 @@ SVGTextLayoutEngineSpacing::SVGTextLayoutEngineSpacing(const FontCascade& font)
 {
 }
 
-float SVGTextLayoutEngineSpacing::calculateCSSSpacing(char16_t currentCharacter)
+float SVGTextLayoutEngineSpacing::calculateCSSSpacing(char32_t currentCharacter)
 {
     float spacing = m_font->letterSpacing();
 

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.h
@@ -33,11 +33,11 @@ class SVGTextLayoutEngineSpacing {
 public:
     SVGTextLayoutEngineSpacing(const FontCascade&);
 
-    float NODELETE calculateCSSSpacing(char16_t);
+    float NODELETE calculateCSSSpacing(char32_t);
 
 private:
     const CheckedRef<const FontCascade> m_font;
-    char16_t m_lastCharacter { '\0' };
+    char32_t m_lastCharacter { '\0' };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 70dfce4103b6791ea0adeadf2fb7c87df6056f2d
<pre>
[SVG] glyph-orientation-vertical: auto should decode surrogate pairs for UTR#50 lookup
<a href="https://bugs.webkit.org/show_bug.cgi?id=313299">https://bugs.webkit.org/show_bug.cgi?id=313299</a>
<a href="https://rdar.apple.com/175570881">rdar://175570881</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

calculateGlyphOrientationAngle() took a single char16_t, so for
supplementary characters (U+10000 and above) only the lead surrogate
was passed to ICU&apos;s u_getIntPropertyValue(UCHAR_VERTICAL_ORIENTATION).
This returned the wrong Vertical_Orientation value, causing characters
like U+1F600 GRINNING FACE and U+20000 CJK Ext-B ideographs to be
rotated 90 degrees when they should be upright per UTR#50 [1].

Decode surrogate pairs at the call site in layoutTextOnLineOrPath()
using std::span for bounds-safe access, verify the trail surrogate
with U16_IS_TRAIL before combining, and widen the parameter to
const char32_t&amp; so ICU receives the full code point.

Similar to a fix in Blink: <a href="https://chromium.googlesource.com/chromium/src.git/+/2754c16948f97fcf655d5f23613468fcd63ccb76">https://chromium.googlesource.com/chromium/src.git/+/2754c16948f97fcf655d5f23613468fcd63ccb76</a>

[1] <a href="https://www.unicode.org/reports/tr50/">https://www.unicode.org/reports/tr50/</a>

Test: svg/text/glyph-orientation-vertical-auto-utr50-surrogate.html

* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
(WebCore::SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle const):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.cpp:
(WebCore::SVGTextLayoutEngineSpacing::calculateCSSSpacing):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.h:

&gt; This test is not WPT since other browsers don&apos;t support glyph-orientation-vertical:
* LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50-surrogate-expected.txt: Added.
* LayoutTests/svg/text/glyph-orientation-vertical-auto-utr50-surrogate.html: Added.

Canonical link: <a href="https://commits.webkit.org/314070@main">https://commits.webkit.org/314070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94cc5bdb91819c61b12571b062f8edc51cb8e486

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169334 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/115497 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d9e492b-ced5-46ab-8d6e-2cebb366813e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124389 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/87861 "2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0355bb6-0ccb-44d5-bba3-1bed3874b609) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104988 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d3a3f81-217e-450f-8aeb-67944edfa69d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25683 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24191 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17053 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171812 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/18192 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132648 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132669 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36795 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143652 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/95344 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20466 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99854 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32572 "Built successfully") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32816 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->