### PR TITLE
Import service worker registrations lazily, one top-level origin at a time

### DIFF
--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -83,7 +83,7 @@ static constexpr std::array<ASCIILiteral, 4> swRegistrationUpdatesV2 {
 
 static constexpr int currentSWRegistrationVersion = 2;
 
-static String databaseFilePath(const String& directory)
+String SWRegistrationDatabase::databaseFilePath(const String& directory)
 {
     if (directory.isEmpty())
         return emptyString();
@@ -179,6 +179,10 @@ ASCIILiteral SWRegistrationDatabase::statementString(StatementType type) const
     switch (type) {
     case StatementType::GetAllRecords:
         return "SELECT * FROM Records;"_s;
+    case StatementType::GetRecordsByTopOrigin:
+        return "SELECT * FROM Records WHERE topOrigin = ?;"_s;
+    case StatementType::GetAllTopOrigins:
+        return "SELECT DISTINCT topOrigin, origin FROM Records;"_s;
     case StatementType::CountAllRecords:
         return "SELECT COUNT(*) FROM Records;"_s;
     case StatementType::InsertRecord:
@@ -362,28 +366,64 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
         RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::importRegistrations failed on creating statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
         return std::nullopt;
     }
-    CheckedPtr statement = sqlStatement.get();
 
+    return collectRegistrationsFromStatement(*sqlStatement.get());
+}
+
+std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRegistrations(const SecurityOriginData& topOrigin)
+{
+    if (!prepareDatabase(ShouldCreateIfNotExists::No))
+        return std::nullopt;
+
+    if (!m_database) {
+        deleteAllFiles();
+        return Vector<ServiceWorkerContextData> { };
+    }
+
+    auto sqlStatement = cachedStatement(StatementType::GetRecordsByTopOrigin);
+    if (!sqlStatement) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::importRegistrations(topOrigin) failed on creating statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+        return std::nullopt;
+    }
+
+    CheckedPtr statement = sqlStatement.get();
+    if (statement->bindText(1, topOrigin.databaseIdentifier()) != SQLITE_OK) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::importRegistrations(topOrigin) failed to bind topOrigin");
+        return std::nullopt;
+    }
+
+    auto result = collectRegistrationsFromStatement(*statement);
+    if (result.isEmpty()) {
+        // No registrations for this origin; clean up the database file if it has no records for any origin.
+        if (auto count = recordsCount(); count && !count.value())
+            deleteAllFiles();
+    }
+
+    return result;
+}
+
+Vector<ServiceWorkerContextData> SWRegistrationDatabase::collectRegistrationsFromStatement(SQLiteStatement& statement)
+{
     Vector<ServiceWorkerContextData> registrations;
-    int result = statement->step();
-    for (; result == SQLITE_ROW; result = statement->step()) {
-        auto key = ServiceWorkerRegistrationKey::fromDatabaseKey(statement->columnText(0));
+    int result = statement.step();
+    for (; result == SQLITE_ROW; result = statement.step()) {
+        auto key = ServiceWorkerRegistrationKey::fromDatabaseKey(statement.columnText(0));
         if (!key) {
             RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::importRegistrations failed to decode service worker registration key");
             continue;
         }
-    
-        auto originURL = URL { statement->columnText(1) };
-        auto scopePath = statement->columnText(2);
+
+        auto originURL = URL { statement.columnText(1) };
+        auto scopePath = statement.columnText(2);
         auto scopeURL = URL { originURL, scopePath };
-        auto topOrigin = SecurityOriginData::fromDatabaseIdentifier(statement->columnText(3));
-        auto lastUpdateCheckTime = WallTime::fromRawSeconds(statement->columnDouble(4));
-        auto updateViaCache = convertStringToUpdateViaCache(statement->columnText(5));
-        auto scriptURL = URL { statement->columnText(6) };
-        auto workerType = convertStringToWorkerType(statement->columnText(7));
+        auto topOrigin = SecurityOriginData::fromDatabaseIdentifier(statement.columnText(3));
+        auto lastUpdateCheckTime = WallTime::fromRawSeconds(statement.columnDouble(4));
+        auto updateViaCache = convertStringToUpdateViaCache(statement.columnText(5));
+        auto scriptURL = URL { statement.columnText(6) };
+        auto workerType = convertStringToWorkerType(statement.columnText(7));
 
         std::optional<ContentSecurityPolicyResponseHeaders> contentSecurityPolicy;
-        auto contentSecurityPolicyDataSpan = statement->columnBlobAsSpan(8);
+        auto contentSecurityPolicyDataSpan = statement.columnBlobAsSpan(8);
         if (contentSecurityPolicyDataSpan.size()) {
             WTF::Persistence::Decoder cspDecoder(contentSecurityPolicyDataSpan);
             cspDecoder >> contentSecurityPolicy;
@@ -394,7 +434,7 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
         }
 
         std::optional<CrossOriginEmbedderPolicy> coep;
-        auto coepDataSpan = statement->columnBlobAsSpan(9);
+        auto coepDataSpan = statement.columnBlobAsSpan(9);
         if (coepDataSpan.size()) {
             WTF::Persistence::Decoder coepDecoder(coepDataSpan);
             coepDecoder >> coep;
@@ -404,10 +444,10 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
             }
         }
 
-        auto referrerPolicy = statement->columnText(10);
+        auto referrerPolicy = statement.columnText(10);
 
         MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript> scriptResourceMap;
-        auto scriptResourceMapDataSpan = statement->columnBlobAsSpan(11);
+        auto scriptResourceMapDataSpan = statement.columnBlobAsSpan(11);
         if (scriptResourceMapDataSpan.size()) {
             WTF::Persistence::Decoder scriptResourceMapDecoder(scriptResourceMapDataSpan);
             std::optional<HashMap<URL, ImportedScriptAttributes>> scriptResourceMapWithoutScripts;
@@ -420,7 +460,7 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
                 scriptResourceMap.add(WTF::move(url), ServiceWorkerContextData::ImportedScript { ScriptBuffer(), WTF::move(attrs.responseURL), WTF::move(attrs.mimeType) });
         }
 
-        auto certificateInfoDataSpan = statement->columnBlobAsSpan(12);
+        auto certificateInfoDataSpan = statement.columnBlobAsSpan(12);
         std::optional<CertificateInfo> certificateInfo;
         WTF::Persistence::Decoder certificateInfoDecoder(certificateInfoDataSpan);
         certificateInfoDecoder >> certificateInfo;
@@ -429,7 +469,7 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
             continue;
         }
 
-        auto navigationPreloadStateDataSpan = statement->columnBlobAsSpan(13);
+        auto navigationPreloadStateDataSpan = statement.columnBlobAsSpan(13);
         std::optional<NavigationPreloadState> navigationPreloadState;
 
         WTF::Persistence::Decoder navigationPreloadStateDecoder(navigationPreloadStateDataSpan);
@@ -439,7 +479,7 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
             continue;
         }
 
-        auto routesDataSpan = statement->columnBlobAsSpan(14);
+        auto routesDataSpan = statement.columnBlobAsSpan(14);
         std::optional<Vector<ServiceWorkerRoute>> routes;
 
         if (routesDataSpan.size()) {
@@ -477,6 +517,43 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
         RELEASE_LOG_ERROR(Storage, "SWRegistrationDatabase::importRegistrations failed on executing statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
 
     return registrations;
+}
+
+std::optional<HashSet<ClientOrigin>> SWRegistrationDatabase::importOrigins()
+{
+    if (!prepareDatabase(ShouldCreateIfNotExists::No))
+        return std::nullopt;
+
+    if (!m_database) {
+        deleteAllFiles();
+        return HashSet<ClientOrigin> { };
+    }
+
+    auto sqlStatement = cachedStatement(StatementType::GetAllTopOrigins);
+    if (!sqlStatement) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::importOrigins failed on creating statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+        return std::nullopt;
+    }
+    CheckedPtr statement = sqlStatement.get();
+
+    HashSet<ClientOrigin> origins;
+    int result = statement->step();
+    for (; result == SQLITE_ROW; result = statement->step()) {
+        auto topOrigin = SecurityOriginData::fromDatabaseIdentifier(statement->columnText(0));
+        if (!topOrigin)
+            continue;
+        auto clientOrigin = SecurityOriginData::fromURL(URL { statement->columnText(1) });
+        origins.add(ClientOrigin { WTF::move(*topOrigin), WTF::move(clientOrigin) });
+    }
+
+    if (result != SQLITE_DONE)
+        RELEASE_LOG_ERROR(Storage, "SWRegistrationDatabase::importOrigins failed on executing statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+
+    // Clean up the database file if it exists but contains no registrations.
+    if (origins.isEmpty())
+        deleteAllFiles();
+
+    return origins;
 }
 
 std::optional<Vector<ServiceWorkerScripts>> SWRegistrationDatabase::updateRegistrations(const Vector<ServiceWorkerContextData>& registrationsToUpdate, const Vector<ServiceWorkerRegistrationKey>& registrationsToDelete)

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
@@ -27,15 +27,19 @@
 
 #include <WebCore/ServiceWorkerTypes.h>
 #include <WebCore/ServiceWorkerUpdateViaCache.h>
+#include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
+class SecurityOriginData;
 class ServiceWorkerRegistrationKey;
 class SQLiteDatabase;
 class SQLiteStatement;
 class SQLiteStatementAutoResetScope;
 class SWScriptStorage;
+
+struct ClientOrigin;
 struct ServiceWorkerContextData;
 
 class SWRegistrationDatabase {
@@ -45,8 +49,12 @@ public:
 
     WEBCORE_EXPORT SWRegistrationDatabase(const String& path);
     WEBCORE_EXPORT ~SWRegistrationDatabase();
+
+    WEBCORE_EXPORT static String databaseFilePath(const String& directory);
     
     WEBCORE_EXPORT std::optional<Vector<ServiceWorkerContextData>> importRegistrations();
+    WEBCORE_EXPORT std::optional<Vector<ServiceWorkerContextData>> importRegistrations(const SecurityOriginData& topOrigin);
+    WEBCORE_EXPORT std::optional<HashSet<ClientOrigin>> importOrigins();
     WEBCORE_EXPORT std::optional<Vector<ServiceWorkerScripts>> updateRegistrations(const Vector<ServiceWorkerContextData>&, const Vector<ServiceWorkerRegistrationKey>&);
     WEBCORE_EXPORT std::optional<ServiceWorkerScripts> retrieveWorkerScripts(ServiceWorkerIdentifier, const ServiceWorkerRegistrationKey&, const URL& mainScriptURL, const Vector<URL>& importedScriptURLs);
     WEBCORE_EXPORT void deleteAllFiles();
@@ -56,6 +64,8 @@ private:
     SWScriptStorage& scriptStorage();
     enum class StatementType : uint8_t {
         GetAllRecords,
+        GetRecordsByTopOrigin,
+        GetAllTopOrigins,
         CountAllRecords,
         InsertRecord,
         DeleteRecord,
@@ -68,6 +78,7 @@ private:
     bool ensureValidRecordsTable();
     std::optional<uint64_t> recordsCount();
     std::optional<Vector<ServiceWorkerContextData>> importRegistrationsImpl();
+    Vector<ServiceWorkerContextData> collectRegistrationsFromStatement(SQLiteStatement&);
     std::optional<Vector<ServiceWorkerScripts>> updateRegistrationsImpl(const Vector<ServiceWorkerContextData>&, const Vector<ServiceWorkerRegistrationKey>&);
 
     String m_directory;

--- a/Source/WebCore/workers/service/server/SWRegistrationStore.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationStore.h
@@ -35,8 +35,10 @@
 namespace WebCore {
 
 class SWServerRegistration;
+class SecurityOriginData;
 class ServiceWorkerRegistrationKey;
 
+struct ClientOrigin;
 struct ServiceWorkerContextData;
 struct ServiceWorkerScripts;
 
@@ -47,7 +49,8 @@ public:
     virtual void clearAll(CompletionHandler<void()>&&) = 0;
     virtual void flushChanges(CompletionHandler<void()>&&) = 0;
     virtual void closeFiles(CompletionHandler<void()>&&) = 0;
-    virtual void importRegistrations(CompletionHandler<void(std::optional<Vector<ServiceWorkerContextData>>&&)>&&) = 0;
+    virtual void importRegistrationsForOrigin(const SecurityOriginData&, CompletionHandler<void(std::optional<Vector<ServiceWorkerContextData>>&&)>&&) = 0;
+    virtual void importOriginList(CompletionHandler<void(std::optional<HashSet<ClientOrigin>>&&)>&&) = 0;
     virtual void updateRegistration(const ServiceWorkerContextData&) = 0;
     virtual void removeRegistration(const ServiceWorkerRegistrationKey&) = 0;
     virtual void retrieveWorkerScripts(ServiceWorkerIdentifier, const ServiceWorkerRegistrationKey&, const URL& scriptURL, const Vector<URL>& importedScriptURLs, CompletionHandler<void(std::optional<ServiceWorkerScripts>&&)>&&) = 0;

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -95,13 +95,12 @@ void SWServer::close()
     auto connections = WTF::move(m_connections);
     connections.clear();
 
-    for (auto& callback : std::exchange(m_importCompletedCallbacks, { }))
-        callback();
-
-    for (auto& callback : std::exchange(m_clearCompletionCallbacks, { }))
-        callback();
+    fireAllOriginImportCallbacks();
 
     for (auto& callback : std::exchange(m_getOriginsWithRegistrationsCallbacks, { }))
+        callback({ });
+
+    for (auto& callback : std::exchange(m_getAllOriginsCallbacks, { }))
         callback({ });
 
     Vector<Ref<SWServerWorker>> runningWorkers;
@@ -167,50 +166,104 @@ SWServerRegistration* SWServer::getRegistration(const ServiceWorkerRegistrationK
     return m_scopeToRegistrationMap.get(registrationKey);
 }
 
-void SWServer::registrationStoreImportComplete()
+bool SWServer::isImportCompletedForOrigin(const SecurityOriginData& topOrigin) const
 {
-    ASSERT(!m_importCompleted);
-    m_importCompleted = true;
-    m_originStore->importComplete();
+    if (topOrigin.isNull() || topOrigin.isOpaque())
+        return true;
+    return m_importedTopOrigins.contains(topOrigin);
+}
 
-    auto clearCallbacks = WTF::move(m_clearCompletionCallbacks);
-    for (auto& callback : clearCallbacks)
-        callback();
-
-    performGetOriginsWithRegistrationsCallbacks();
-
-    for (auto& callback : std::exchange(m_importCompletedCallbacks, { }))
+void SWServer::originImportComplete(const SecurityOriginData& topOrigin, MonotonicTime startTime)
+{
+    m_importedTopOrigins.add(topOrigin);
+    m_originsYetToBeImported.removeIf([&topOrigin](auto& origin) {
+        return origin.topOrigin == topOrigin;
+    });
+    auto callbacks = m_pendingOriginImportCallbacks.take(topOrigin);
+#if !RELEASE_LOG_DISABLED
+    auto elapsed = MonotonicTime::now() - startTime;
+    RELEASE_LOG(ServiceWorker, "SWServer::originImportComplete: Completed import for origin %" SENSITIVE_LOG_STRING " in %.0f ms (%zu pending callbacks)", topOrigin.toString().utf8().data(), elapsed.milliseconds(), callbacks.size());
+#else
+    UNUSED_PARAM(startTime);
+#endif
+    for (auto& callback : callbacks)
         callback();
 }
 
-void SWServer::whenImportIsCompleted(CompletionHandler<void()>&& callback)
+void SWServer::fireAllOriginImportCallbacks()
 {
-    ASSERT(!m_importCompleted);
-    m_importCompletedCallbacks.append(WTF::move(callback));
+    auto pendingCallbacks = std::exchange(m_pendingOriginImportCallbacks, { });
+    for (auto& callbacks : pendingCallbacks.values()) {
+        for (auto& callback : callbacks)
+            callback();
+    }
 }
 
-void SWServer::whenImportIsCompletedIfNeeded(CompletionHandler<void()>&& callback)
+void SWServer::importRegistrationsForOrigin(const SecurityOriginData& topOrigin, CompletionHandler<void()>&& callback)
 {
-    if (m_importCompleted) {
+    if (topOrigin.isNull() || topOrigin.isOpaque()) {
         callback();
         return;
     }
-    whenImportIsCompleted(WTF::move(callback));
-}
 
-void SWServer::registrationStoreDatabaseFailedToOpen()
-{
-    LOG(ServiceWorker, "Failed to open SW registration database");
-    ASSERT(!m_importCompleted);
-    if (!m_importCompleted)
-        registrationStoreImportComplete();
+    if (m_importedTopOrigins.contains(topOrigin)) {
+        callback();
+        return;
+    }
+
+    // No registrations on disk for this origin; skip the store query.
+    if (m_originListImportComplete && std::ranges::none_of(m_originsYetToBeImported, [&](auto& origin) { return origin.topOrigin == topOrigin; })) {
+        m_importedTopOrigins.add(topOrigin);
+        callback();
+        return;
+    }
+
+    auto result = m_pendingOriginImportCallbacks.add(topOrigin, Vector<CompletionHandler<void()>>());
+    result.iterator->value.append(WTF::move(callback));
+    if (!result.isNewEntry)
+        return;
+
+    RELEASE_LOG(ServiceWorker, "SWServer::importRegistrationsForOrigin: Starting import for origin %" SENSITIVE_LOG_STRING, topOrigin.toString().utf8().data());
+
+    RefPtr store = m_registrationStore;
+    if (!store) {
+        originImportComplete(topOrigin, MonotonicTime::now());
+        return;
+    }
+
+    auto startTime = MonotonicTime::now();
+    store->importRegistrationsForOrigin(topOrigin, [weakThis = WeakPtr { *this }, topOrigin, startTime, clearAllCounter = m_clearAllCounter](auto&& result) mutable {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis)
+            return;
+
+        RELEASE_LOG(ServiceWorker, "SWServer::importRegistrationsForOrigin: Loaded %zu registrations for origin %" SENSITIVE_LOG_STRING " in %.0f ms", result ? result->size() : 0, topOrigin.toString().utf8().data(), (MonotonicTime::now() - startTime).milliseconds());
+
+        // Discard stale results if clearAll() was called after this import was initiated.
+        if (clearAllCounter != protectedThis->m_clearAllCounter) {
+            protectedThis->originImportComplete(topOrigin, startTime);
+            return;
+        }
+
+        if (!result || result->isEmpty()) {
+            protectedThis->originImportComplete(topOrigin, startTime);
+            return;
+        }
+
+        Ref callbackAggregator = CallbackAggregator::create([weakThis = WTF::move(weakThis), topOrigin, startTime]() mutable {
+            if (RefPtr protectedThis = weakThis)
+                protectedThis->originImportComplete(topOrigin, startTime);
+        });
+
+        for (auto&& data : WTF::move(result.value()))
+            protectedThis->addRegistrationFromStore(WTF::move(data), [callbackAggregator] { });
+    });
 }
 
 void SWServer::addRegistrationFromStore(ServiceWorkerContextData&& data, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(isMainThread());
 
-    // Pages should not have been able to make a new registration to this key while the import was still taking place.
     ASSERT(!m_scopeToRegistrationMap.contains(data.registration.key));
 
     LOG(ServiceWorker, "Adding registration from store for %s", data.registration.key.loggingString().utf8().data());
@@ -320,21 +373,27 @@ void SWServer::removeRegistration(ServiceWorkerRegistrationIdentifier registrati
     protect(backgroundFetchEngine())->remove(*registration);
 }
 
-Vector<ServiceWorkerRegistrationData> SWServer::getRegistrations(const SecurityOriginData& topOrigin, const URL& clientURL)
+void SWServer::getRegistrations(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(Vector<ServiceWorkerRegistrationData>&&)>&& callback)
 {
-    Vector<Ref<SWServerRegistration>> matchingRegistrations;
-    for (auto& item : m_scopeToRegistrationMap) {
-        if (item.key.originIsMatching(topOrigin, clientURL)) {
-            Ref registration = item.value.get();
-            matchingRegistrations.append(WTF::move(registration));
+    importRegistrationsForOrigin(topOrigin, [weakThis = WeakPtr { *this }, topOrigin, clientURL, callback = WTF::move(callback)]() mutable {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis)
+            return callback({ });
+
+        Vector<Ref<SWServerRegistration>> matchingRegistrations;
+        for (auto& item : protectedThis->m_scopeToRegistrationMap) {
+            if (item.key.originIsMatching(topOrigin, clientURL)) {
+                Ref registration = item.value.get();
+                matchingRegistrations.append(WTF::move(registration));
+            }
         }
-    }
-    // The specification mandates that registrations are returned in the insertion order.
-    std::ranges::sort(matchingRegistrations, [](auto& a, auto& b) {
-        return a->creationTime() < b->creationTime();
-    });
-    return matchingRegistrations.map([](auto& registration) {
-        return registration->data();
+        // The specification mandates that registrations are returned in the insertion order.
+        std::ranges::sort(matchingRegistrations, [](auto& a, auto& b) {
+            return a->creationTime() < b->creationTime();
+        });
+        callback(matchingRegistrations.map([](auto& registration) {
+            return registration->data();
+        }));
     });
 }
 
@@ -349,22 +408,21 @@ void SWServer::storeRegistrationsOnDisk(CompletionHandler<void()>&& completionHa
 
 void SWServer::clearAll(CompletionHandler<void()>&& completionHandler)
 {
-    if (!m_importCompleted) {
-        m_clearCompletionCallbacks.append([weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] () mutable {
-            if (RefPtr protectedThis = weakThis.get()) {
-                ASSERT(protectedThis->m_importCompleted);
-                protectedThis->clearAll(WTF::move(completionHandler));
-            } else
-                completionHandler();
-        });
-        return;
-    }
+    RELEASE_LOG(ServiceWorker, "SWServer::clearAll: Clearing all registrations");
 
+    // No need to import all origins first: store->clearAll() below wipes the entire database,
+    // and in-flight store callbacks discard their stale results (see importRegistrationsForOrigin).
     m_jobQueues.clear();
     while (!m_registrations.isEmpty())
         Ref { m_registrations.begin()->value }->clear();
     m_pendingContextDatas.clear();
     m_originStore->clearAll();
+    m_importedTopOrigins.clear();
+    m_originsYetToBeImported.clear();
+    m_originListImportComplete = true;
+    ++m_clearAllCounter;
+
+    fireAllOriginImportCallbacks();
 
     RefPtr store = m_registrationStore;
     if (!store)
@@ -375,61 +433,57 @@ void SWServer::clearAll(CompletionHandler<void()>&& completionHandler)
 
 void SWServer::clear(const SecurityOriginData& securityOrigin, CompletionHandler<void()>&& completionHandler)
 {
-    clearInternal([securityOrigin](auto& key) {
+    clearInternal(securityOrigin, [securityOrigin](auto& key) {
         return key.relatesToOrigin(securityOrigin);
     }, WTF::move(completionHandler));
 }
 
 void SWServer::clear(const ClientOrigin& origin, CompletionHandler<void()>&& completionHandler)
 {
-    clearInternal([origin](auto& key) {
+    clearInternal(origin.topOrigin, [origin](auto& key) {
         return key.topOrigin() == origin.topOrigin && origin.clientOrigin == SecurityOriginData::fromURL(key.scope());
     }, WTF::move(completionHandler));
 }
 
-void SWServer::clearInternal(Function<bool(const ServiceWorkerRegistrationKey&)>&& matches, CompletionHandler<void()>&& completionHandler)
+void SWServer::clearInternal(const SecurityOriginData& topOrigin, Function<bool(const ServiceWorkerRegistrationKey&)>&& matches, CompletionHandler<void()>&& completionHandler)
 {
-    if (!m_importCompleted) {
-        m_clearCompletionCallbacks.append([weakThis = WeakPtr { *this }, matches = WTF::move(matches), completionHandler = WTF::move(completionHandler)] () mutable {
-            if (RefPtr protectedThis = weakThis.get()) {
-                ASSERT(protectedThis->m_importCompleted);
-                protectedThis->clearInternal(WTF::move(matches), WTF::move(completionHandler));
-            } else
-                completionHandler();
-        });
-        return;
-    }
+    // FIXME: We should clear registrations directly in the store by origin instead of importing them into memory first.
+    importRegistrationsForOrigin(topOrigin, [weakThis = WeakPtr { *this }, matches = WTF::move(matches), completionHandler = WTF::move(completionHandler)]() mutable {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis)
+            return completionHandler();
 
-    m_jobQueues.removeIf([&](auto& keyAndValue) {
-        return matches(keyAndValue.key);
+        protectedThis->m_jobQueues.removeIf([&](auto& keyAndValue) {
+            return matches(keyAndValue.key);
+        });
+
+        Vector<Ref<SWServerRegistration>> registrationsToRemove;
+        for (auto& registration : protectedThis->m_registrations.values()) {
+            if (matches(registration->key()))
+                registrationsToRemove.append(registration.get());
+        }
+
+        for (auto& contextDatas : protectedThis->m_pendingContextDatas.values()) {
+            contextDatas.removeAllMatching([&](auto& contextData) {
+                return matches(contextData.registration.key);
+            });
+        }
+
+        if (registrationsToRemove.isEmpty()) {
+            completionHandler();
+            return;
+        }
+
+        // Calling SWServerRegistration::clear() takes care of updating m_registrations, m_originStore and m_registrationStore.
+        for (auto& registration : registrationsToRemove)
+            registration->clear(); // Will destroy the registration.
+
+        RefPtr store = protectedThis->m_registrationStore;
+        if (!store)
+            return completionHandler();
+
+        store->flushChanges(WTF::move(completionHandler));
     });
-
-    Vector<Ref<SWServerRegistration>> registrationsToRemove;
-    for (auto& registration : m_registrations.values()) {
-        if (matches(registration->key()))
-            registrationsToRemove.append(registration.get());
-    }
-
-    for (auto& contextDatas : m_pendingContextDatas.values()) {
-        contextDatas.removeAllMatching([&](auto& contextData) {
-            return matches(contextData.registration.key);
-        });
-    }
-
-    if (registrationsToRemove.isEmpty()) {
-        completionHandler();
-        return;
-    }
-
-    // Calling SWServerRegistration::clear() takes care of updating m_registrations, m_originStore and m_registrationStore.
-    for (auto& registration : registrationsToRemove)
-        registration->clear(); // Will destroy the registration.
-
-    RefPtr store = m_registrationStore;
-    if (!store)
-        return completionHandler();
-
-    store->flushChanges(WTF::move(completionHandler));
 }
 
 void SWServer::Connection::finishFetchingScriptInServer(const ServiceWorkerJobDataIdentifier& jobDataIdentifier, const ServiceWorkerRegistrationKey& registrationKey, WorkerFetchResult&& result)
@@ -444,11 +498,22 @@ void SWServer::Connection::didResolveRegistrationPromise(const ServiceWorkerRegi
         server->didResolveRegistrationPromise(this, key);
 }
 
-RefPtr<SWServerRegistration> SWServer::Connection::doRegistrationMatching(const SecurityOriginData& topOrigin, const URL& clientURL)
+void SWServer::Connection::doRegistrationMatching(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(std::optional<ServiceWorkerRegistrationData>&&)>&& callback)
 {
-    if (RefPtr server = m_server.get())
-        return server->doRegistrationMatching(topOrigin, clientURL);
-    return nullptr;
+    RefPtr server = m_server.get();
+    if (!server)
+        return callback({ });
+
+    server->importRegistrationsForOrigin(topOrigin, [weakThis = WeakPtr { *this }, topOrigin, clientURL, callback = WTF::move(callback)]() mutable {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis)
+            return callback({ });
+        if (RefPtr server = protectedThis->m_server.get()) {
+            if (RefPtr registration = server->doRegistrationMatchingSync(topOrigin, clientURL))
+                return callback(registration->data());
+        }
+        callback({ });
+    });
 }
 
 void SWServer::Connection::addServiceWorkerRegistrationInServer(ServiceWorkerRegistrationIdentifier identifier)
@@ -489,25 +554,33 @@ SWServer::SWServer(SWServerDelegate& delegate, UniqueRef<SWOriginStore>&& origin
 
     if (RefPtr store = delegate.createRegistrationStore(*this)) {
         m_registrationStore = store;
-        store->importRegistrations([weakThis = WeakPtr { *this }](auto&& result) mutable {
-            RefPtr protectedThis = weakThis.get();
+        // Only import the list of origins that have registrations, not the full registration data.
+        // This is lightweight and sufficient for getOriginsWithRegistrations() to work immediately.
+        // Full registrations are imported lazily per origin on first use (see importRegistrationsForOrigin).
+        auto startTime = MonotonicTime::now();
+        store->importOriginList([weakThis = WeakPtr { *this }, startTime](auto&& result) mutable {
+            RefPtr protectedThis = weakThis;
             if (!protectedThis)
                 return;
 
-            if (!result) {
-                protectedThis->registrationStoreDatabaseFailedToOpen();
-                return;
+            // Discard stale results if clearAll() already ran.
+            if (result && !protectedThis->m_originListImportComplete) {
+                for (auto& origin : result.value())
+                    protectedThis->m_originStore->add(origin.topOrigin);
+                protectedThis->m_originsYetToBeImported = WTF::move(*result);
+#if !RELEASE_LOG_DISABLED
+                auto elapsed = MonotonicTime::now() - startTime;
+                RELEASE_LOG(ServiceWorker, "SWServer: Imported origin list with %u top origins in %.0f ms", result->size(), elapsed.milliseconds());
+#else
+                UNUSED_PARAM(startTime);
+#endif
             }
-
-            Ref callbackAggregator = CallbackAggregator::create([weakThis = WTF::move(weakThis)]() mutable {
-                if (RefPtr protectedThis = weakThis.get())
-                    protectedThis->registrationStoreImportComplete();
-            });
-            for (auto&& data : WTF::move(result.value()))
-                protectedThis->addRegistrationFromStore(WTF::move(data), [callbackAggregator] { });
+            protectedThis->m_originListImportComplete = true;
+            protectedThis->m_originStore->importComplete();
+            protectedThis->performGetOriginsWithRegistrationsCallbacks();
         });
     } else
-        registrationStoreImportComplete();
+        m_originStore->importComplete();
 
     UNUSED_PARAM(registrationDatabaseDirectory);
 }
@@ -552,35 +625,42 @@ void SWServer::validateRegistrationDomain(WebCore::RegistrableDomain domain, Ser
 // https://w3c.github.io/ServiceWorker/#schedule-job-algorithm
 void SWServer::scheduleJob(ServiceWorkerJobData&& jobData)
 {
-    ASSERT(m_connections.contains(jobData.connectionIdentifier()) || jobData.connectionIdentifier() == Process::identifier());
-
-    auto registrationKey = jobData.registrationKey();
-    validateRegistrationDomain(WebCore::RegistrableDomain(jobData.topOrigin), jobData.type, m_scopeToRegistrationMap.contains(registrationKey), [weakThis = WeakPtr { *this }, jobData = WTF::move(jobData)] (bool isValid) mutable {
-        RefPtr protectedThis = weakThis.get();
+    auto topOrigin = jobData.topOrigin;
+    importRegistrationsForOrigin(topOrigin, [weakThis = WeakPtr { *this }, jobData = WTF::move(jobData)]() mutable {
+        RefPtr protectedThis = weakThis;
         if (!protectedThis)
             return;
-        if (protectedThis->m_hasServiceWorkerEntitlement || isValid) {
-            CheckedRef jobQueue = *protectedThis->m_jobQueues.ensure(jobData.registrationKey(), [&] {
-                return makeUnique<SWServerJobQueue>(*protectedThis, jobData.registrationKey());
-            }).iterator->value;
 
-            if (!jobQueue->size()) {
-                jobQueue->enqueueJob(WTF::move(jobData));
-                jobQueue->runNextJob();
+        ASSERT(protectedThis->m_connections.contains(jobData.connectionIdentifier()) || jobData.connectionIdentifier() == Process::identifier());
+
+        auto registrationKey = jobData.registrationKey();
+        protectedThis->validateRegistrationDomain(WebCore::RegistrableDomain(jobData.topOrigin), jobData.type, protectedThis->m_scopeToRegistrationMap.contains(registrationKey), [weakThis = WTF::move(weakThis), jobData = WTF::move(jobData)] (bool isValid) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
-            }
-            auto& lastJob = jobQueue->lastJob();
-            if (jobData.isEquivalent(lastJob)) {
-                // FIXME: Per the spec, check if this job is equivalent to the last job on the queue.
-                // If it is, stack it along with that job. For now, we just make sure to not call soft-update too often.
-                if (jobData.type == ServiceWorkerJobType::Update && jobData.connectionIdentifier() == Process::identifier())
+            if (protectedThis->m_hasServiceWorkerEntitlement || isValid) {
+                CheckedRef jobQueue = *protectedThis->m_jobQueues.ensure(jobData.registrationKey(), [&] {
+                    return makeUnique<SWServerJobQueue>(*protectedThis, jobData.registrationKey());
+                }).iterator->value;
+
+                if (!jobQueue->size()) {
+                    jobQueue->enqueueJob(WTF::move(jobData));
+                    jobQueue->runNextJob();
                     return;
-            }
-            jobQueue->enqueueJob(WTF::move(jobData));
-            if (jobQueue->size() == 1)
-                jobQueue->runNextJob();
-        } else
-            protectedThis->rejectJob(jobData, { ExceptionCode::TypeError, "Job rejected for non app-bound domain"_s });
+                }
+                auto& lastJob = jobQueue->lastJob();
+                if (jobData.isEquivalent(lastJob)) {
+                    // FIXME: Per the spec, check if this job is equivalent to the last job on the queue.
+                    // If it is, stack it along with that job. For now, we just make sure to not call soft-update too often.
+                    if (jobData.type == ServiceWorkerJobType::Update && jobData.connectionIdentifier() == Process::identifier())
+                        return;
+                }
+                jobQueue->enqueueJob(WTF::move(jobData));
+                if (jobQueue->size() == 1)
+                    jobQueue->runNextJob();
+            } else
+                protectedThis->rejectJob(jobData, { ExceptionCode::TypeError, "Job rejected for non app-bound domain"_s });
+        });
     });
 }
 
@@ -867,7 +947,7 @@ std::optional<ExceptionData> SWServer::claim(SWServerWorker& worker)
         if (clientURLForRegistrationMatching.protocolIsBlob() && clientData.ownerURL.isValid())
             clientURLForRegistrationMatching = clientData.ownerURL;
 
-        if (doRegistrationMatching(origin.topOrigin, clientURLForRegistrationMatching) != registration.get())
+        if (doRegistrationMatchingSync(origin.topOrigin, clientURLForRegistrationMatching) != registration.get())
             return;
 
         auto result = m_clientToControllingRegistration.add(clientData.identifier, registration->identifier());
@@ -1232,9 +1312,9 @@ void SWServer::removeConnection(SWServerConnectionIdentifier connectionIdentifie
         CheckedRef { *jobQueue }->cancelJobsFromConnection(connectionIdentifier);
 }
 
-RefPtr<SWServerRegistration> SWServer::doRegistrationMatching(const SecurityOriginData& topOrigin, const URL& clientURL)
+RefPtr<SWServerRegistration> SWServer::doRegistrationMatchingSync(const SecurityOriginData& topOrigin, const URL& clientURL)
 {
-    ASSERT(isImportCompleted());
+    ASSERT(isImportCompletedForOrigin(topOrigin));
     RefPtr<SWServerRegistration> selectedRegistration;
     for (auto& pair : m_scopeToRegistrationMap) {
         if (!pair.key.isMatching(topOrigin, clientURL))
@@ -1523,13 +1603,24 @@ void SWServer::resolveRegistrationReadyRequests(SWServerRegistration& registrati
 
 void SWServer::Connection::whenRegistrationReady(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(std::optional<ServiceWorkerRegistrationData>&&)>&& callback)
 {
-    if (RefPtr registration = doRegistrationMatching(topOrigin, clientURL)) {
-        if (registration->activeWorker()) {
-            callback(registration->data());
-            return;
+    RefPtr server = m_server.get();
+    if (!server)
+        return callback({ });
+
+    server->importRegistrationsForOrigin(topOrigin, [weakThis = WeakPtr { *this }, topOrigin, clientURL, callback = WTF::move(callback)]() mutable {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis)
+            return callback({ });
+        if (RefPtr server = protectedThis->m_server.get()) {
+            if (RefPtr registration = server->doRegistrationMatchingSync(topOrigin, clientURL)) {
+                if (registration->activeWorker()) {
+                    callback(registration->data());
+                    return;
+                }
+            }
         }
-    }
-    m_registrationReadyRequests.append({ topOrigin, clientURL, WTF::move(callback) });
+        protectedThis->m_registrationReadyRequests.append({ topOrigin, clientURL, WTF::move(callback) });
+    });
 }
 
 void SWServer::Connection::storeRegistrationsOnDisk(CompletionHandler<void()>&& callback)
@@ -1554,43 +1645,57 @@ void SWServer::Connection::resolveRegistrationReadyRequests(SWServerRegistration
 void SWServer::getOriginsWithRegistrations(CompletionHandler<void(const HashSet<SecurityOriginData>&)>&& callback)
 {
     m_getOriginsWithRegistrationsCallbacks.append(WTF::move(callback));
-
-    if (m_importCompleted)
+    if (m_originListImportComplete)
         performGetOriginsWithRegistrationsCallbacks();
 }
 
 void SWServer::performGetOriginsWithRegistrationsCallbacks()
 {
     ASSERT(isMainThread());
-    ASSERT(m_importCompleted);
+    ASSERT(m_originListImportComplete);
 
-    if (m_getOriginsWithRegistrationsCallbacks.isEmpty())
+    if (m_getOriginsWithRegistrationsCallbacks.isEmpty() && m_getAllOriginsCallbacks.isEmpty())
         return;
 
-    HashSet<SecurityOriginData> originsWithRegistrations;
-    for (auto& key : m_scopeToRegistrationMap.keys()) {
-        originsWithRegistrations.add(key.topOrigin());
-        originsWithRegistrations.add(SecurityOriginData { key.scope().protocol().toString(), key.scope().host().toString(), key.scope().port() });
+    if (!m_getOriginsWithRegistrationsCallbacks.isEmpty()) {
+        HashSet<SecurityOriginData> originsWithRegistrations;
+        for (auto& origin : m_originsYetToBeImported) {
+            originsWithRegistrations.add(origin.topOrigin);
+            originsWithRegistrations.add(origin.clientOrigin);
+        }
+        for (auto& key : m_scopeToRegistrationMap.keys()) {
+            originsWithRegistrations.add(key.topOrigin());
+            originsWithRegistrations.add(SecurityOriginData { key.scope().protocol().toString(), key.scope().host().toString(), key.scope().port() });
+        }
+        for (auto& callback : std::exchange(m_getOriginsWithRegistrationsCallbacks, { }))
+            callback(originsWithRegistrations);
     }
 
-    auto callbacks = WTF::move(m_getOriginsWithRegistrationsCallbacks);
-    for (auto& callback : callbacks)
-        callback(originsWithRegistrations);
+    if (auto callbacks = std::exchange(m_getAllOriginsCallbacks, { }); !callbacks.isEmpty()) {
+        auto clientOrigins = allClientOrigins();
+        for (auto& callback : callbacks)
+            callback(HashSet<ClientOrigin> { clientOrigins });
+    }
+}
+
+HashSet<ClientOrigin> SWServer::allClientOrigins() const
+{
+    HashSet<ClientOrigin> clientOrigins;
+    for (auto& origin : m_originsYetToBeImported)
+        clientOrigins.add(origin);
+    for (auto& key : m_scopeToRegistrationMap.keys())
+        clientOrigins.add(key.clientOrigin());
+    return clientOrigins;
 }
 
 void SWServer::getAllOrigins(CompletionHandler<void(HashSet<ClientOrigin>&&)>&& callback)
 {
-    whenImportIsCompletedIfNeeded([weakThis = WeakPtr { *this }, callback = WTF::move(callback)]() mutable {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis) {
-            callback({ });
-            return;
-        }
-        HashSet<ClientOrigin> clientOrigins;
-        for (auto& key : protectedThis->m_scopeToRegistrationMap.keys())
-            clientOrigins.add(key.clientOrigin());
-        callback(WTF::move(clientOrigins));
-    });
+    if (!m_originListImportComplete) {
+        m_getAllOriginsCallbacks.append(WTF::move(callback));
+        return;
+    }
+
+    callback(allClientOrigins());
 }
 
 void SWServer::addContextConnection(SWServerToContextConnection& connection)
@@ -1705,9 +1810,10 @@ void SWServer::softUpdate(SWServerRegistration& registration)
 
 void SWServer::processPushMessage(std::optional<Vector<uint8_t>>&& data, std::optional<NotificationPayload>&& notificationPayload, URL&& registrationURL, CompletionHandler<void(bool, std::optional<NotificationPayload>&&)>&& callback)
 {
-    whenImportIsCompletedIfNeeded([weakThis = WeakPtr { *this }, data = WTF::move(data), notificationPayload = WTF::move(notificationPayload), registrationURL = WTF::move(registrationURL), callback = WTF::move(callback)]() mutable {
-        LOG(Push, "ServiceWorker import is complete, can handle push message now");
-        RefPtr protectedThis = weakThis.get();
+    auto topOrigin = SecurityOriginData::fromURL(registrationURL);
+    importRegistrationsForOrigin(topOrigin, [weakThis = WeakPtr { *this }, data = WTF::move(data), notificationPayload = WTF::move(notificationPayload), registrationURL = WTF::move(registrationURL), callback = WTF::move(callback)]() mutable {
+        LOG(Push, "ServiceWorker import is complete for origin, can handle push message now");
+        RefPtr protectedThis = weakThis;
         if (!protectedThis) {
             callback(false, WTF::move(notificationPayload));
             return;
@@ -1760,8 +1866,9 @@ void SWServer::processPushMessage(std::optional<Vector<uint8_t>>&& data, std::op
 
 void SWServer::processNotificationEvent(NotificationData&& data, NotificationEventType type, CompletionHandler<void(bool)>&& callback)
 {
-    whenImportIsCompletedIfNeeded([weakThis = WeakPtr { *this }, data = WTF::move(data), type, callback = WTF::move(callback)]() mutable {
-        RefPtr protectedThis = weakThis.get();
+    auto topOrigin = SecurityOriginData::fromURL(data.serviceWorkerRegistrationURL);
+    importRegistrationsForOrigin(topOrigin, [weakThis = WeakPtr { *this }, data = WTF::move(data), type, callback = WTF::move(callback)]() mutable {
+        RefPtr protectedThis = weakThis;
         if (!protectedThis) {
             callback(false);
             return;

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -99,7 +99,7 @@ public:
         Identifier identifier() const { return m_identifier; }
 
         WEBCORE_EXPORT void didResolveRegistrationPromise(const ServiceWorkerRegistrationKey&);
-        WEBCORE_EXPORT RefPtr<SWServerRegistration> doRegistrationMatching(const SecurityOriginData& topOrigin, const URL& clientURL);
+        WEBCORE_EXPORT void doRegistrationMatching(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(std::optional<ServiceWorkerRegistrationData>&&)>&&);
         void resolveRegistrationReadyRequests(SWServerRegistration&);
 
         using ExceptionOrBackgroundFetchInformationCallback = CompletionHandler<void(Expected<std::optional<BackgroundFetchInformation>, ExceptionData>&&)>;
@@ -179,7 +179,8 @@ public:
     WEBCORE_EXPORT SWServerRegistration* getRegistration(const ServiceWorkerRegistrationKey&);
     void addRegistration(Ref<SWServerRegistration>&&);
     void removeRegistration(ServiceWorkerRegistrationIdentifier);
-    WEBCORE_EXPORT Vector<ServiceWorkerRegistrationData> getRegistrations(const SecurityOriginData& topOrigin, const URL& clientURL);
+    WEBCORE_EXPORT void getRegistrations(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(Vector<ServiceWorkerRegistrationData>&&)>&&);
+    WEBCORE_EXPORT RefPtr<SWServerRegistration> doRegistrationMatchingSync(const SecurityOriginData& topOrigin, const URL& clientURL);
     WEBCORE_EXPORT void storeRegistrationsOnDisk(CompletionHandler<void()>&&);
 
     WEBCORE_EXPORT void scheduleJob(ServiceWorkerJobData&&);
@@ -233,8 +234,6 @@ public:
 
     void addRegistrationFromStore(ServiceWorkerContextData&&, CompletionHandler<void()>&&);
     WEBCORE_EXPORT void didSaveWorkerScriptsToDisk(ServiceWorkerIdentifier, ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts);
-    void registrationStoreImportComplete();
-    void registrationStoreDatabaseFailedToOpen();
     void storeRegistrationForWorker(SWServerWorker&);
     void loadWorkerScripts(const SWServerWorker&, CompletionHandler<void(bool)>&&);
 
@@ -252,8 +251,8 @@ public:
     WEBCORE_EXPORT SWServerToContextConnection* contextConnectionForRegistrableDomain(const RegistrableDomain&);
     WEBCORE_EXPORT void createContextConnection(const Site&, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier);
 
-    bool isImportCompleted() const { return m_importCompleted; }
-    WEBCORE_EXPORT void whenImportIsCompleted(CompletionHandler<void()>&&);
+    WEBCORE_EXPORT bool isImportCompletedForOrigin(const SecurityOriginData& topOrigin) const;
+    WEBCORE_EXPORT void importRegistrationsForOrigin(const SecurityOriginData& topOrigin, CompletionHandler<void()>&&);
 
     void softUpdate(SWServerRegistration&);
 
@@ -334,9 +333,8 @@ private:
 
     void terminatePreinstallationWorker(SWServerWorker&);
 
-    void clearInternal(Function<bool(const ServiceWorkerRegistrationKey&)>&& matches, CompletionHandler<void()>&&);
+    void clearInternal(const SecurityOriginData& topOrigin, Function<bool(const ServiceWorkerRegistrationKey&)>&& matches, CompletionHandler<void()>&&);
 
-    WEBCORE_EXPORT RefPtr<SWServerRegistration> doRegistrationMatching(const SecurityOriginData& topOrigin, const URL& clientURL);
     void runServiceWorkerIfNecessary(SWServerWorker&, RunServiceWorkerCallback&&);
     bool runServiceWorker(ServiceWorkerIdentifier);
     bool runServiceWorker(SWServerWorker&);
@@ -347,11 +345,13 @@ private:
     SWServerRegistration* NODELETE registrationFromServiceWorkerIdentifier(ServiceWorkerIdentifier);
 
     void performGetOriginsWithRegistrationsCallbacks();
+    HashSet<ClientOrigin> allClientOrigins() const;
 
     void contextConnectionCreated(SWServerToContextConnection&);
 
     void updateAppInitiatedValueForWorkers(const ClientOrigin&, LastNavigationWasAppInitiated);
-    void whenImportIsCompletedIfNeeded(CompletionHandler<void()>&&);
+    void originImportComplete(const SecurityOriginData& topOrigin, MonotonicTime startTime);
+    void fireAllOriginImportCallbacks();
 
     ResourceRequest createScriptRequest(const URL&, const ServiceWorkerJobData&, SWServerRegistration&);
 
@@ -387,19 +387,26 @@ private:
     HashMap<RegistrableDomain, Vector<ServiceWorkerContextData>> m_pendingContextDatas;
     HashMap<RegistrableDomain, HashMap<ServiceWorkerIdentifier, Vector<RunServiceWorkerCallback>>> m_serviceWorkerRunRequests;
     PAL::SessionID m_sessionID;
-    bool m_importCompleted { false };
     bool m_isProcessTerminationDelayEnabled { true };
-    Vector<CompletionHandler<void()>> m_clearCompletionCallbacks;
     Vector<CompletionHandler<void(const HashSet<SecurityOriginData>&)>> m_getOriginsWithRegistrationsCallbacks;
+    Vector<CompletionHandler<void(HashSet<ClientOrigin>&&)>> m_getAllOriginsCallbacks;
     HashMap<RegistrableDomain, WeakRef<SWServerToContextConnection>> m_contextConnections;
 
     HashSet<RegistrableDomain> m_pendingConnectionDomains;
-    Vector<CompletionHandler<void()>> m_importCompletedCallbacks;
+
+    // Top origins whose registrations have been fully imported from the store into m_scopeToRegistrationMap.
+    HashSet<SecurityOriginData> m_importedTopOrigins;
+    // Origins known to have registrations on disk but not yet imported. Populated by the origin list import at startup,
+    // and drained as origins are lazily imported.
+    HashSet<ClientOrigin> m_originsYetToBeImported;
+    HashMap<SecurityOriginData, Vector<CompletionHandler<void()>>> m_pendingOriginImportCallbacks;
 
     HashSet<RegistrableDomain> m_appBoundDomains;
     bool m_shouldRunServiceWorkersOnMainThreadForTesting { false };
     bool m_hasServiceWorkerEntitlement { false };
     bool m_hasReceivedAppBoundDomains { false };
+    bool m_originListImportComplete { false };
+    uint64_t m_clearAllCounter { 0 };
     unsigned m_uniqueRegistrationCount { 0 };
     std::optional<unsigned> m_overrideServiceWorkerRegistrationCountTestingValue;
     uint64_t m_focusOrder { 0 };

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -594,14 +594,14 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
     CONNECTION_RELEASE_LOG(Loading, "scheduleResourceLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ", existingLoaderToResume=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0, existingLoaderToResume ? existingLoaderToResume->toUInt64() : 0);
 
     if (CheckedPtr session = networkSession()) {
-        if (Ref server = session->ensureSWServer(); !server->isImportCompleted()) {
-            server->whenImportIsCompleted([this, protectedThis = Ref { *this }, loadParameters = WTF::move(loadParameters), existingLoaderToResume]() mutable {
+        Ref server = session->ensureSWServer();
+        auto topOrigin = loadParameters.topOriginForServiceWorkers(loadParameters.request.url());
+        if (!server->isImportCompletedForOrigin(topOrigin)) {
+            CONNECTION_RELEASE_LOG(Loading, "scheduleResourceLoad: Deferring resource load until service worker registrations for origin are imported");
+            server->importRegistrationsForOrigin(topOrigin, [this, protectedThis = Ref { *this }, loadParameters = WTF::move(loadParameters), existingLoaderToResume]() mutable {
                 if (!m_networkProcess->webProcessConnection(webProcessIdentifier()))
                     return;
 
-                ASSERT(networkSession());
-                ASSERT(networkSession()->swServer());
-                ASSERT(networkSession()->swServer()->isImportCompleted());
                 scheduleResourceLoad(WTF::move(loadParameters), existingLoaderToResume);
             });
             return;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -28,6 +28,7 @@
 
 #include "NetworkProcessConnection.h"
 #include "WebProcess.h"
+#include <WebCore/SecurityOriginData.h>
 #include <wtf/RuntimeApplicationChecks.h>
 
 namespace WebKit {
@@ -56,6 +57,15 @@ RefPtr<SecurityOrigin> NetworkResourceLoadParameters::parentOrigin() const
     if (frameAncestorOrigins.isEmpty())
         return nullptr;
     return frameAncestorOrigins.first().ptr();
+}
+
+SecurityOriginData NetworkResourceLoadParameters::topOriginForServiceWorkers(const URL& requestURL) const
+{
+    if (isMainFrameNavigation) {
+        auto url = requestURL.protocolIsBlob() ? URL { requestURL.path().toString() } : requestURL;
+        return SecurityOriginData::fromURLWithoutStrictOpaqueness(url);
+    }
+    return topOrigin->data();
 }
 
 NetworkLoadParameters NetworkResourceLoadParameters::networkLoadParameters() const

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -54,6 +54,7 @@ struct NetworkResourceLoadParameters {
 
     RefPtr<WebCore::SecurityOrigin> NODELETE parentOrigin() const;
     NetworkLoadParameters networkLoadParameters() const;
+    WebCore::SecurityOriginData topOriginForServiceWorkers(const URL& requestURL) const;
 
     WebPageProxyIdentifier webPageProxyID;
     WebCore::PageIdentifier webPageID;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -74,6 +74,7 @@
 #include <WebCore/OriginAccessPatterns.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ReportingScope.h>
+#include <WebCore/SWServer.h>
 #include <WebCore/SameSiteInfo.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityPolicy.h>
@@ -1490,6 +1491,15 @@ void NetworkResourceLoader::continueWillSendRequest(ResourceRequest&& newRequest
     }
 
     if (shouldTryToMatchRegistrationOnRedirection(parameters().options, !!m_serviceWorkerFetchTask)) {
+        auto topOrigin = parameters().topOriginForServiceWorkers(newRequest.url());
+        if (CheckedPtr session = protect(connectionToWebProcess())->networkSession()) {
+            if (RefPtr server = session->swServer(); server && !server->isImportCompletedForOrigin(topOrigin)) {
+                server->importRegistrationsForOrigin(topOrigin, [this, protectedThis = Ref { *this }, newRequest = WTF::move(newRequest), isAllowedToAskUserForCredentials, completionHandler = WTF::move(completionHandler)]() mutable {
+                    continueWillSendRequest(WTF::move(newRequest), isAllowedToAskUserForCredentials, WTF::move(completionHandler));
+                });
+                return;
+            }
+        }
         m_serviceWorkerRegistration = { };
         m_serviceWorkerTimingInfo = { };
         setWorkerStart({ });

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
@@ -74,10 +74,18 @@ void WebSWRegistrationStore::closeFiles(CompletionHandler<void()>&& callback)
         callback();
 }
 
-void WebSWRegistrationStore::importRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&& callback)
+void WebSWRegistrationStore::importRegistrationsForOrigin(const WebCore::SecurityOriginData& topOrigin, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&& callback)
 {
-    if (RefPtr manager = m_manager.get())
-        manager->importServiceWorkerRegistrations(WTF::move(callback));
+    if (RefPtr manager = m_manager)
+        manager->importServiceWorkerRegistrationsForOrigin(topOrigin, WTF::move(callback));
+    else
+        callback(std::nullopt);
+}
+
+void WebSWRegistrationStore::importOriginList(CompletionHandler<void(std::optional<HashSet<WebCore::ClientOrigin>>&&)>&& callback)
+{
+    if (RefPtr manager = m_manager)
+        manager->importServiceWorkerOriginList(WTF::move(callback));
     else
         callback(std::nullopt);
 }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
@@ -55,7 +55,8 @@ private:
     void clearAll(CompletionHandler<void()>&&);
     void flushChanges(CompletionHandler<void()>&&);
     void closeFiles(CompletionHandler<void()>&&);
-    void importRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&&);
+    void importRegistrationsForOrigin(const WebCore::SecurityOriginData&, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&&);
+    void importOriginList(CompletionHandler<void(std::optional<HashSet<WebCore::ClientOrigin>>&&)>&&);
     void updateRegistration(const WebCore::ServiceWorkerContextData&);
     void removeRegistration(const WebCore::ServiceWorkerRegistrationKey&);
     void retrieveWorkerScripts(WebCore::ServiceWorkerIdentifier, const WebCore::ServiceWorkerRegistrationKey&, const URL& scriptURL, const Vector<URL>& importedScriptURLs, CompletionHandler<void(std::optional<WebCore::ServiceWorkerScripts>&&)>&&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -254,8 +254,8 @@ RefPtr<ServiceWorkerFetchTask> WebSWServerConnection::createFetchTask(NetworkRes
 
     std::optional<ServiceWorkerRegistrationIdentifier> serviceWorkerRegistrationIdentifier;
     if (auto resultingClientIdentifier = loader.parameters().options.resultingClientIdentifier) {
-        auto topOrigin = loader.parameters().isMainFrameNavigation ? SecurityOriginData::fromURLWithoutStrictOpaqueness(request.url()) : loader.parameters().topOrigin->data();
-        RefPtr registration = doRegistrationMatching(topOrigin, request.url());
+        auto topOrigin = loader.parameters().topOriginForServiceWorkers(request.url());
+        RefPtr registration = server->doRegistrationMatchingSync(topOrigin, request.url());
         if (!registration)
             return nullptr;
 
@@ -491,11 +491,7 @@ void WebSWServerConnection::matchRegistration(const SecurityOriginData& topOrigi
     if (!checkTopOrigin(topOrigin))
         return;
 
-    if (RefPtr registration = doRegistrationMatching(topOrigin, clientURL)) {
-        callback(registration->data());
-        return;
-    }
-    callback({ });
+    doRegistrationMatching(topOrigin, clientURL, WTF::move(callback));
 }
 
 void WebSWServerConnection::whenRegistrationReady(const WebCore::SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(std::optional<WebCore::ServiceWorkerRegistrationData>&&)>&& callback)
@@ -511,10 +507,13 @@ void WebSWServerConnection::getRegistrations(const SecurityOriginData& topOrigin
     if (!checkTopOrigin(topOrigin))
         return;
 
-    if (RefPtr server = this->server())
-        callback(server->getRegistrations(topOrigin, clientURL));
-    else
-        callback({ });
+    RefPtr server = this->server();
+    if (!server)
+        return callback({ });
+
+    server->getRegistrations(topOrigin, clientURL, [callback = WTF::move(callback)](auto&& registrations) mutable {
+        callback(registrations);
+    });
 }
 
 void WebSWServerConnection::registerServiceWorkerClient(WebCore::ClientOrigin&& clientOrigin, ServiceWorkerClientData&& data, const std::optional<ServiceWorkerRegistrationIdentifier>& controllingServiceWorkerRegistrationIdentifier, String&& userAgent)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -54,6 +54,7 @@
 #include "WebsiteDataType.h"
 #include <WebCore/DOMCacheEngine.h>
 #include <WebCore/IDBRequestData.h>
+#include <WebCore/SWRegistrationDatabase.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/ServiceWorkerContextData.h>
 #include <WebCore/StorageBlockingPolicy.h>
@@ -1098,24 +1099,28 @@ void NetworkStorageManager::getHandle(IPC::Connection& connection, WebCore::File
         completionHandler(makeUnexpected(result.error()));
 }
 
+void NetworkStorageManager::forEachClientOriginDirectoryUnderTopOrigin(const String& encodedTopOrigin, NOESCAPE const Function<void(const String&)>& apply)
+{
+    auto topOriginDirectory = FileSystem::pathByAppendingComponent(m_path, encodedTopOrigin);
+    auto openingOrigins = FileSystem::listDirectory(topOriginDirectory);
+    if (openingOrigins.isEmpty()) {
+        FileSystem::deleteEmptyDirectory(topOriginDirectory);
+        return;
+    }
+
+    for (auto& openingOrigin : openingOrigins) {
+        if (openingOrigin.startsWith('.'))
+            continue;
+
+        auto openingOriginDirectory = FileSystem::pathByAppendingComponent(topOriginDirectory, openingOrigin);
+        apply(openingOriginDirectory);
+    }
+}
+
 void NetworkStorageManager::forEachOriginDirectory(NOESCAPE const Function<void(const String&)>& apply)
 {
-    for (auto& topOrigin : FileSystem::listDirectory(m_path)) {
-        auto topOriginDirectory = FileSystem::pathByAppendingComponent(m_path, topOrigin);
-        auto openingOrigins = FileSystem::listDirectory(topOriginDirectory);
-        if (openingOrigins.isEmpty()) {
-            FileSystem::deleteEmptyDirectory(topOriginDirectory);
-            continue;
-        }
-
-        for (auto& openingOrigin : openingOrigins) {
-            if (openingOrigin.startsWith('.'))
-                continue;
-
-            auto openingOriginDirectory = FileSystem::pathByAppendingComponent(topOriginDirectory, openingOrigin);
-            apply(openingOriginDirectory);
-        }
-    }
+    for (auto& topOrigin : FileSystem::listDirectory(m_path))
+        forEachClientOriginDirectoryUnderTopOrigin(topOrigin, apply);
 }
 
 HashSet<WebCore::ClientOrigin> NetworkStorageManager::getAllOrigins()
@@ -2239,41 +2244,82 @@ void NetworkStorageManager::clearServiceWorkerRegistrations(CompletionHandler<vo
     });
 }
 
-void NetworkStorageManager::importServiceWorkerRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&& completionHandler)
+void NetworkStorageManager::importServiceWorkerRegistrationsForOrigin(const WebCore::SecurityOriginData& topOrigin, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
 
     if (m_closed)
         return completionHandler(std::nullopt);
 
-    RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Starting import", this);
+    RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrationsForOrigin: Starting import", this);
     auto startTime = MonotonicTime::now();
-    workQueue().dispatchWithQOS([this, protectedThis = Ref { *this }, startTime, completionHandler = WTF::move(completionHandler)]() mutable {
+    workQueue().dispatchWithQOS([this, protectedThis = Ref { *this }, topOrigin = crossThreadCopy(topOrigin), startTime, completionHandler = WTF::move(completionHandler)]() mutable {
         assertIsCurrent(workQueue());
 
         std::optional<Vector<WebCore::ServiceWorkerContextData>> result;
         if (m_sharedServiceWorkerStorageManager)
-            result = m_sharedServiceWorkerStorageManager->importRegistrations();
+            result = m_sharedServiceWorkerStorageManager->importRegistrations(topOrigin);
         else {
-            bool hasResult = false;
             Vector<WebCore::ServiceWorkerContextData> registrations;
-            for (auto& origin : getAllOrigins()) {
-                if (auto originRegistrations = originStorageManager(origin)->serviceWorkerStorageManager().importRegistrations()) {
-                    hasResult = true;
+            forEachClientOriginDirectoryUnderTopOrigin(encode(topOrigin.toString(), m_salt), [&](auto& directory) {
+                auto origin = WebCore::StorageUtilities::readOriginFromFile(originFilePath(directory));
+                if (!origin)
+                    return;
+                if (auto originRegistrations = originStorageManager(*origin)->serviceWorkerStorageManager().importRegistrations(topOrigin))
                     registrations.appendVector(WTF::move(*originRegistrations));
-                }
-                removeOriginStorageManagerIfPossible(origin);
-            }
-            if (hasResult)
+                removeOriginStorageManagerIfPossible(*origin);
+            });
+            if (!registrations.isEmpty())
                 result = WTF::move(registrations);
         }
 
         RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), startTime, result = crossThreadCopy(WTF::move(result)), completionHandler = WTF::move(completionHandler)]() mutable {
+#if !RELEASE_LOG_DISABLED
             auto elapsed = MonotonicTime::now() - startTime;
-            if (elapsed > 2_s)
-                RELEASE_LOG_ERROR(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
-            else
-                RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
+            RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrationsForOrigin: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
+#else
+            UNUSED_PARAM(startTime);
+#endif
+            completionHandler(WTF::move(result));
+        });
+    }, WorkQueue::QOS::UserInitiated);
+}
+
+void NetworkStorageManager::importServiceWorkerOriginList(CompletionHandler<void(std::optional<HashSet<WebCore::ClientOrigin>>&&)>&& completionHandler)
+{
+    ASSERT(RunLoop::isMain());
+
+    if (m_closed)
+        return completionHandler(std::nullopt);
+
+    auto startTime = MonotonicTime::now();
+    workQueue().dispatchWithQOS([this, protectedThis = Ref { *this }, startTime, completionHandler = WTF::move(completionHandler)]() mutable {
+        assertIsCurrent(workQueue());
+
+        std::optional<HashSet<WebCore::ClientOrigin>> result;
+        if (m_sharedServiceWorkerStorageManager)
+            result = m_sharedServiceWorkerStorageManager->importOrigins();
+        else {
+            HashSet<WebCore::ClientOrigin> origins;
+            forEachOriginDirectory([&](auto& directory) {
+                auto origin = WebCore::StorageUtilities::readOriginFromFile(originFilePath(directory));
+                if (!origin)
+                    return;
+                auto swStoragePath = originStorageManager(*origin)->resolvedPath(WebsiteDataType::ServiceWorkerRegistrations);
+                if (!swStoragePath.isEmpty() && FileSystem::fileExists(WebCore::SWRegistrationDatabase::databaseFilePath(swStoragePath)))
+                    origins.add(*origin);
+                removeOriginStorageManagerIfPossible(*origin);
+            });
+            result = WTF::move(origins);
+        }
+
+        RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), startTime, result = crossThreadCopy(WTF::move(result)), completionHandler = WTF::move(completionHandler)]() mutable {
+#if !RELEASE_LOG_DISABLED
+            auto elapsed = MonotonicTime::now() - startTime;
+            RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerOriginList: Imported %u origins in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
+#else
+            UNUSED_PARAM(startTime);
+#endif
             completionHandler(WTF::move(result));
         });
     }, WorkQueue::QOS::UserInitiated);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -151,7 +151,8 @@ public:
     void notifyBackgroundFetchChange(const String&, BackgroundFetchChange);
     void closeServiceWorkerRegistrationFiles(CompletionHandler<void()>&&);
     void clearServiceWorkerRegistrations(CompletionHandler<void()>&&);
-    void importServiceWorkerRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&&);
+    void importServiceWorkerRegistrationsForOrigin(const WebCore::SecurityOriginData&, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&&);
+    void importServiceWorkerOriginList(CompletionHandler<void(std::optional<HashSet<WebCore::ClientOrigin>>&&)>&&);
     void updateServiceWorkerRegistrations(Vector<WebCore::ServiceWorkerContextData>&&, Vector<WebCore::ServiceWorkerRegistrationKey>&&, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerScripts>>)>&&);
     void retrieveServiceWorkerScripts(WebCore::ServiceWorkerIdentifier, const WebCore::ServiceWorkerRegistrationKey&, const URL& mainScriptURL, Vector<URL>&& importedScriptURLs, CompletionHandler<void(std::optional<WebCore::ServiceWorkerScripts>&&)>&&);
     const String& path() const LIFETIME_BOUND { return m_pathNormalizedMainThread; }
@@ -173,6 +174,7 @@ private:
     CheckedRef<OriginStorageManager> originStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes);
     bool removeOriginStorageManagerIfPossible(const WebCore::ClientOrigin&);
 
+    void forEachClientOriginDirectoryUnderTopOrigin(const String& encodedTopOrigin, NOESCAPE const Function<void(const String&)>&);
     void forEachOriginDirectory(NOESCAPE const Function<void(const String&)>&);
     HashSet<WebCore::ClientOrigin> getAllOrigins();
     Vector<WebsiteData::Entry> fetchDataFromDisk(OptionSet<WebsiteDataType>, ShouldComputeSize);

--- a/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ServiceWorkerStorageManager.h"
 
+#include <WebCore/ClientOrigin.h>
 #include <WebCore/SWRegistrationDatabase.h>
 #include <WebCore/ServiceWorkerContextData.h>
 #include <WebCore/ServiceWorkerRegistrationKey.h>
@@ -63,6 +64,22 @@ std::optional<Vector<WebCore::ServiceWorkerContextData>> ServiceWorkerStorageMan
 {
     if (auto database = ensureDatabase())
         return database->importRegistrations();
+
+    return std::nullopt;
+}
+
+std::optional<Vector<WebCore::ServiceWorkerContextData>> ServiceWorkerStorageManager::importRegistrations(const WebCore::SecurityOriginData& topOrigin)
+{
+    if (auto database = ensureDatabase())
+        return database->importRegistrations(topOrigin);
+
+    return std::nullopt;
+}
+
+std::optional<HashSet<WebCore::ClientOrigin>> ServiceWorkerStorageManager::importOrigins()
+{
+    if (auto database = ensureDatabase())
+        return database->importOrigins();
 
     return std::nullopt;
 }

--- a/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/SWRegistrationDatabase.h>
+#include <WebCore/SecurityOriginData.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -39,6 +40,8 @@ public:
     void closeFiles();
     void clearAllRegistrations();
     std::optional<Vector<WebCore::ServiceWorkerContextData>> importRegistrations();
+    std::optional<Vector<WebCore::ServiceWorkerContextData>> importRegistrations(const WebCore::SecurityOriginData& topOrigin);
+    std::optional<HashSet<WebCore::ClientOrigin>> importOrigins();
     std::optional<Vector<WebCore::ServiceWorkerScripts>> updateRegistrations(const Vector<WebCore::ServiceWorkerContextData>&, const Vector<WebCore::ServiceWorkerRegistrationKey>&);
     std::optional<WebCore::ServiceWorkerScripts> retrieveWorkerScripts(WebCore::ServiceWorkerIdentifier, const WebCore::ServiceWorkerRegistrationKey&, const URL& mainScriptURL, const Vector<URL>& importedScriptURLs);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -2361,6 +2361,9 @@ void testSuspendServiceWorkerProcessBasedOnClientProcesses(UseSeparateServiceWor
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
@@ -2469,7 +2472,11 @@ TEST(ServiceWorkers, SuspendAndTerminateWorker)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+    [dataStore _setResourceLoadStatisticsEnabled:NO];
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:dataStore.get()];
     if ([[configuration preferences] inactiveSchedulingPolicy] == WKInactiveSchedulingPolicyNone)
         return;
 
@@ -2673,6 +2680,8 @@ TEST(ServiceWorkers, RestoreFromDiskNonDefaultStore)
         RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
         websiteDataStoreConfiguration.get()._serviceWorkerRegistrationDirectory = swDBPath;
         RetainPtr nonDefaultDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        // Disable ITP so it doesn't inadvertently delete our service worker registrations.
+        [nonDefaultDataStore _setResourceLoadStatisticsEnabled:NO];
         configuration.get().websiteDataStore = nonDefaultDataStore.get();
 
         RetainPtr messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration was successful and service worker was activated"]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
@@ -1887,6 +1887,20 @@ TEST(WKWebsiteDataStore, DeleteEmptyServiceWorkerDirectory)
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory.get();
     RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
+    // Navigate to the origin whose empty database is on disk. This triggers the lazy per-origin
+    // import, which opens the database, finds it empty, and deletes the files. The navigation
+    // itself may fail (no internet) but the import is triggered regardless.
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:websiteDataStore.get()];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) { done = true; }];
+    [navigationDelegate setDidFailProvisionalNavigation:^(WKWebView *, WKNavigation *, NSError *) { done = true; }];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+    done = false;
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/"]]];
+    TestWebKitAPI::Util::run(&done);
+
     // Verify record does not exist with empty database.
     __block RetainPtr<NSArray<WKWebsiteDataRecord *>> records;
     RetainPtr dataTypes = [NSSet setWithObjects:WKWebsiteDataTypeServiceWorkerRegistrations, nil];


### PR DESCRIPTION
#### 1bcdb2f2f2ebed2e4ca943b6db153135187c7ef2
<pre>
Import service worker registrations lazily, one top-level origin at a time
<a href="https://bugs.webkit.org/show_bug.cgi?id=313303">https://bugs.webkit.org/show_bug.cgi?id=313303</a>
<a href="https://rdar.apple.com/175432466">rdar://175432466</a>

Reviewed by Youenn Fablet.

Previously, SWServer imported all service worker registrations from all origins on
first navigation. For users with 1000+ registrations across many origins, this took over 12
seconds and blocked all navigations because scheduleResourceLoad() and matchRegistration()
waited for the full import to complete. Additionally, all operations shared the same
serial work queue, so even a per-origin import dispatched alongside the bulk import
would queue behind it. Nowadays, there is a service worker registrations database
per origin that has service workers. This was a lot of databases to open and query
during the first navigation.

This patch replaces the bulk import with a two-phase lazy approach:
  1. On startup, a fast origin list logic populates the SWOriginStore so web processes
     can quickly reject origins without service workers. This relies on checking if
     cache folders for different origin have a service worker database or not. This
     takes ~700ms for &gt; 1200 origins, which is a lot more manageable.
  2. When registration data is actually needed for a specific origin (navigation, fetch,
     matchRegistration, push message, etc.), only that origin&apos;s registrations are imported
     from the database.

Since no bulk import occupies the serial work queue at startup, per-origin imports
dispatch immediately.

* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp:
(WebCore::SWRegistrationDatabase::databaseFilePath):
(WebCore::SWRegistrationDatabase::statementString const):
(WebCore::SWRegistrationDatabase::importRegistrationsImpl):
(WebCore::SWRegistrationDatabase::importRegistrations):
(WebCore::SWRegistrationDatabase::collectRegistrationsFromStatement):
(WebCore::SWRegistrationDatabase::importOrigins):
(WebCore::databaseFilePath): Deleted.
* Source/WebCore/workers/service/server/SWRegistrationDatabase.h:
* Source/WebCore/workers/service/server/SWRegistrationStore.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::close):
(WebCore::SWServer::isImportCompletedForOrigin const):
(WebCore::SWServer::originImportComplete):
(WebCore::SWServer::importRegistrationsForOrigin):
(WebCore::SWServer::addRegistrationFromStore):
(WebCore::SWServer::clearAll):
(WebCore::SWServer::clear):
(WebCore::SWServer::clearInternal):
(WebCore::SWServer::SWServer):
(WebCore::SWServer::doRegistrationMatching):
(WebCore::SWServer::getOriginsWithRegistrations):
(WebCore::SWServer::performGetOriginsWithRegistrationsCallbacks):
(WebCore::SWServer::getAllOrigins):
(WebCore::SWServer::processPushMessage):
(WebCore::SWServer::processNotificationEvent):
(WebCore::SWServer::registrationStoreImportComplete): Deleted.
(WebCore::SWServer::whenImportIsCompleted): Deleted.
(WebCore::SWServer::whenImportIsCompletedIfNeeded): Deleted.
(WebCore::SWServer::registrationStoreDatabaseFailedToOpen): Deleted.
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::isImportCompleted const): Deleted.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp:
(WebKit::WebSWRegistrationStore::importRegistrationsForOrigin):
(WebKit::WebSWRegistrationStore::importOriginList):
(WebKit::WebSWRegistrationStore::importRegistrations): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::resolveUnregistrationJobInClient):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::importServiceWorkerRegistrationsForOrigin):
(WebKit::NetworkStorageManager::importServiceWorkerOriginList):
(WebKit::NetworkStorageManager::importServiceWorkerRegistrations): Deleted.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp:
(WebKit::ServiceWorkerStorageManager::importRegistrations):
(WebKit::ServiceWorkerStorageManager::importOrigins):
* Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h:

Canonical link: <a href="https://commits.webkit.org/312195@main">https://commits.webkit.org/312195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ff22fd41355f876bfdb3a53cd5a76db0059a425

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159143 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113227 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea313f6c-f811-4a6b-b481-7ac8503a27b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123287 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86565 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47c2811b-78da-4557-8632-cf425a34c8ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103953 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4997879e-46d2-4eca-a1a3-1986100d4938) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24618 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23040 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15745 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170467 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16207 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131481 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131593 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35599 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90254 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26290 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19331 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97729 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31235 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31390 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->