### PR TITLE
Absolutely positioned child clipped in composited element with single-axis overflow-x: clip

### DIFF
--- a/LayoutTests/compositing/overflow/absolute-child-in-single-axis-overflow-clip-expected.html
+++ b/LayoutTests/compositing/overflow/absolute-child-in-single-axis-overflow-clip-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+        .absolute {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 200px;
+            height: 200px;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <p>There should be a 200x200 green square below.</p>
+    <div style="position: relative">
+        <div class="absolute"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/overflow/absolute-child-in-single-axis-overflow-clip.html
+++ b/LayoutTests/compositing/overflow/absolute-child-in-single-axis-overflow-clip.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+        .container {
+            will-change: transform;
+            overflow-x: clip;
+            overflow-y: visible;
+        }
+        .absolute {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 200px;
+            height: 200px;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <p>There should be a 200x200 green square below.</p>
+    <div class="container">
+        <div class="absolute"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5356,6 +5356,17 @@ LayoutRect RenderLayer::clipRectRelativeToAncestor(const RenderLayer* ancestor, 
         options.add(ClipRectsOption::Temporary);
     ClipRectsContext clipRectsContext(ancestor, PaintingClipRects, options);
     auto backgroundRect = calculateBackgroundRect(clipRectsContext, offsetFromAncestor);
+
+    if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer())) {
+        auto& style = box->style();
+        bool hasSingleAxisOverflowClip = (style.overflowX() == Overflow::Clip && style.overflowY() == Overflow::Visible)
+            || (style.overflowY() == Overflow::Clip && style.overflowX() == Overflow::Visible);
+        if (hasSingleAxisOverflowClip) {
+            auto foregroundRect = calculateForegroundRect(clipRectsContext, offsetFromAncestor);
+            return intersection(unionRect(backgroundRect.rect(), foregroundRect.rect()), constrainingRect);
+        }
+    }
+
     return intersection(backgroundRect.rect(), constrainingRect);
 }
 


### PR DESCRIPTION
#### 01ebf280e3ec99accf3297cf7a60d31aab2838b6
<pre>
Absolutely positioned child clipped in composited element with single-axis overflow-x: clip
<a href="https://bugs.webkit.org/show_bug.cgi?id=271457">https://bugs.webkit.org/show_bug.cgi?id=271457</a>
<a href="https://rdar.apple.com/125239811">rdar://125239811</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When an element has overflow-x: clip with overflow-y: visible and triggers
compositing (e.g. via will-change: transform), absolutely positioned children
extending beyond the border box in Y are incorrectly clipped.

clipRectRelativeToAncestor() only considered calculateBackgroundRect(), which
intersects with rendererBorderBoxRect() on both axes. This fed into
calculateLayerBounds() via the UseLocalClipRectIfPossible optimization, sizing
the compositing layer to just the border box height. The foregroundRect
(via rendererOverflowClipRect()) correctly extends in Y via expandToInfiniteY()
but was never consulted.

The fix unions backgroundRect with foregroundRect when single-axis overflow-clip
is detected, so the compositing layer bounds account for children in the
unclipped direction.

Test: compositing/overflow/absolute-child-in-single-axis-overflow-clip.html

* LayoutTests/compositing/overflow/absolute-child-in-single-axis-overflow-clip-expected.html: Added.
* LayoutTests/compositing/overflow/absolute-child-in-single-axis-overflow-clip.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01ebf280e3ec99accf3297cf7a60d31aab2838b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112772 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2939a52-577d-4444-a529-8009272375e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122931 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86261 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8936d902-36e5-49b7-a12d-8048e59c303c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103600 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28559677-20db-4328-95e4-47514de23321) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24246 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22647 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15289 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133932 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170009 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15752 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131118 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131232 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89681 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18954 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97274 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30780 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31053 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30934 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->