### PR TITLE
[JSC] Compare 8-bit strings a word at a time in DFG/FTL string equality

### DIFF
--- a/JSTests/microbenchmarks/string-equality-256-8bit.js
+++ b/JSTests/microbenchmarks/string-equality-256-8bit.js
@@ -1,0 +1,25 @@
+function makeString(len, ch) {
+    let s = "";
+    for (let i = 0; i < len; ++i)
+        s += ch;
+    return s;
+}
+
+let a = makeString(255, "a") + "x";
+let b = makeString(255, "a") + "x";
+let c = makeString(255, "a") + "y";
+
+function eq(x, y) {
+    return x === y;
+}
+noInline(eq);
+
+let n = 0;
+for (let i = 0; i < 1e6; ++i) {
+    if (eq(a, b))
+        n++;
+    if (eq(a, c))
+        n++;
+}
+if (n !== 1e6)
+    throw "Bad result: " + n;

--- a/JSTests/microbenchmarks/string-equality-long-8bit.js
+++ b/JSTests/microbenchmarks/string-equality-long-8bit.js
@@ -1,0 +1,26 @@
+function makeString(len, ch) {
+    let s = "";
+    for (let i = 0; i < len; ++i)
+        s += ch;
+    return s;
+}
+
+// Two distinct JSString cells with identical 8-bit content (avoid pointer-equal fast path).
+let a = makeString(64, "a") + "x";
+let b = makeString(64, "a") + "x";
+let c = makeString(64, "a") + "y";
+
+function eq(x, y) {
+    return x === y;
+}
+noInline(eq);
+
+let n = 0;
+for (let i = 0; i < 1e6; ++i) {
+    if (eq(a, b))
+        n++;
+    if (eq(a, c))
+        n++;
+}
+if (n !== 1e6)
+    throw "Bad result: " + n;

--- a/JSTests/microbenchmarks/string-equality-short-8bit.js
+++ b/JSTests/microbenchmarks/string-equality-short-8bit.js
@@ -1,0 +1,26 @@
+function makeString(len, ch) {
+    let s = "";
+    for (let i = 0; i < len; ++i)
+        s += ch;
+    return s;
+}
+
+// length 7: worst case for the byte-at-a-time loop (just below the word threshold).
+let a = makeString(6, "a") + "x";
+let b = makeString(6, "a") + "x";
+let c = makeString(6, "a") + "y";
+
+function eq(x, y) {
+    return x === y;
+}
+noInline(eq);
+
+let n = 0;
+for (let i = 0; i < 1e6; ++i) {
+    if (eq(a, b))
+        n++;
+    if (eq(a, c))
+        n++;
+}
+if (n !== 1e6)
+    throw "Bad result: " + n;

--- a/JSTests/stress/string-equality-word-compare.js
+++ b/JSTests/stress/string-equality-word-compare.js
@@ -1,0 +1,29 @@
+function eq(a, b) { return a === b; }
+noInline(eq);
+
+function make(s) {
+    // Force a fresh, resolved, non-atom JSString with its own StringImpl.
+    return (s + "!").slice(0, s.length);
+}
+
+let cases = [];
+for (let len = 0; len <= 40; ++len) {
+    let base = "";
+    for (let i = 0; i < len; ++i)
+        base += String.fromCharCode(97 + (i % 26));
+    cases.push([make(base), make(base), true]);
+    if (len > 0) {
+        for (let pos of [0, (len >> 1), len - 1]) {
+            let arr = base.split("");
+            arr[pos] = String.fromCharCode(arr[pos].charCodeAt(0) + 1);
+            cases.push([make(base), make(arr.join("")), false]);
+        }
+    }
+}
+
+for (let i = 0; i < 1e4; ++i) {
+    for (let [a, b, expected] of cases) {
+        if (eq(a, b) !== expected)
+            throw new Error("FAIL len=" + a.length + " a=" + a + " b=" + b + " expected=" + expected);
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -7737,19 +7737,36 @@ void SpeculativeJIT::compileStringEquality(
     
     loadPtr(Address(leftTempGPR, StringImpl::dataOffset()), leftTempGPR);
     loadPtr(Address(rightTempGPR, StringImpl::dataOffset()), rightTempGPR);
-    
-    Label loop = label();
-    
-    sub32(TrustedImm32(1), lengthGPR);
 
-    // This isn't going to generate the best code on x86. But that's OK, it's still better
-    // than not inlining.
+    constexpr unsigned wordSize = sizeof(void*);
+
+    Jump longString = branch32(AboveOrEqual, lengthGPR, TrustedImm32(wordSize));
+
+    // length in [1, wordSize): byte-at-a-time loop.
+    Label byteLoop = label();
+    sub32(TrustedImm32(1), lengthGPR);
     load8(BaseIndex(leftTempGPR, lengthGPR, TimesOne), leftTemp2GPR);
     load8(BaseIndex(rightTempGPR, lengthGPR, TimesOne), rightTemp2GPR);
     falseCase.append(branch32(NotEqual, leftTemp2GPR, rightTemp2GPR));
-    
-    branchTest32(NonZero, lengthGPR).linkTo(loop, this);
-    
+    branchTest32(NonZero, lengthGPR).linkTo(byteLoop, this);
+    trueCase.append(jump());
+
+    // length >= wordSize: compare a pointer-sized word at a time, walking backwards.
+    longString.link(this);
+    Label wordLoop = label();
+    sub32(TrustedImm32(wordSize), lengthGPR);
+    loadPtr(BaseIndex(leftTempGPR, lengthGPR, TimesOne), leftTemp2GPR);
+    loadPtr(BaseIndex(rightTempGPR, lengthGPR, TimesOne), rightTemp2GPR);
+    falseCase.append(branchPtr(NotEqual, leftTemp2GPR, rightTemp2GPR));
+    branch32(AboveOrEqual, lengthGPR, TrustedImm32(wordSize)).linkTo(wordLoop, this);
+
+    // 0 <= lengthGPR < wordSize bytes remain at the head. Since the original length was
+    // >= wordSize, a single overlapping word load at offset 0 safely covers the remainder.
+    trueCase.append(branchTest32(Zero, lengthGPR));
+    loadPtr(Address(leftTempGPR), leftTemp2GPR);
+    loadPtr(Address(rightTempGPR), rightTemp2GPR);
+    falseCase.append(branchPtr(NotEqual, leftTemp2GPR, rightTemp2GPR));
+
     trueCase.link(this);
     moveTrueTo(leftTempGPR);
     

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -21094,8 +21094,13 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock rightReadyCase = m_out.newBlock();
         LBasicBlock left8BitCase = m_out.newBlock();
         LBasicBlock right8BitCase = m_out.newBlock();
-        LBasicBlock loop = m_out.newBlock();
+        LBasicBlock byteLoop = m_out.newBlock();
         LBasicBlock bytesEqual = m_out.newBlock();
+        LBasicBlock wordLoopPreheader = m_out.newBlock();
+        LBasicBlock wordLoop = m_out.newBlock();
+        LBasicBlock wordsEqual = m_out.newBlock();
+        LBasicBlock wordTail = m_out.newBlock();
+        LBasicBlock wordTailCompare = m_out.newBlock();
         LBasicBlock trueCase = m_out.newBlock();
         LBasicBlock falseCase = m_out.newBlock();
         LBasicBlock slowCase = m_out.newBlock();
@@ -21131,32 +21136,57 @@ IGNORE_CLANG_WARNINGS_END
                 m_out.constInt32(StringImpl::flagIs8Bit())),
             unsure(slowCase), unsure(right8BitCase));
 
-        m_out.appendTo(right8BitCase, loop);
+        m_out.appendTo(right8BitCase, byteLoop);
 
         LValue leftData = m_out.loadPtr(left, m_heaps.StringImpl_data);
         LValue rightData = m_out.loadPtr(right, m_heaps.StringImpl_data);
 
-        ValueFromBlock indexAtStart = m_out.anchor(length);
+        constexpr unsigned wordSize = 8;
+        ValueFromBlock byteIndexAtStart = m_out.anchor(length);
+        // Lay out the byte loop as the fall-through so that short strings only pay for a
+        // not-taken branch; long strings easily amortize the taken-branch cost over the word loop.
+        m_out.branch(m_out.below(length, m_out.constInt32(wordSize)), usually(byteLoop), rarely(wordLoopPreheader));
 
-        m_out.jump(loop);
-
-        m_out.appendTo(loop, bytesEqual);
-
-        LValue indexAtLoopTop = m_out.phi(Int32, indexAtStart);
-        LValue indexInLoop = m_out.sub(indexAtLoopTop, m_out.int32One);
-
+        // length in [1, wordSize): byte-at-a-time loop.
+        m_out.appendTo(byteLoop, bytesEqual);
+        LValue byteIndexAtLoopTop = m_out.phi(Int32, byteIndexAtStart);
+        LValue byteIndexInLoop = m_out.sub(byteIndexAtLoopTop, m_out.int32One);
         LValue leftByte = m_out.load8ZeroExt32(
-            m_out.baseIndex(m_heaps.characters8, leftData, m_out.zeroExtPtr(indexInLoop)));
+            m_out.baseIndex(m_heaps.characters8, leftData, m_out.zeroExtPtr(byteIndexInLoop)));
         LValue rightByte = m_out.load8ZeroExt32(
-            m_out.baseIndex(m_heaps.characters8, rightData, m_out.zeroExtPtr(indexInLoop)));
-
+            m_out.baseIndex(m_heaps.characters8, rightData, m_out.zeroExtPtr(byteIndexInLoop)));
         m_out.branch(m_out.notEqual(leftByte, rightByte), unsure(falseCase), unsure(bytesEqual));
 
-        m_out.appendTo(bytesEqual, trueCase);
+        m_out.appendTo(bytesEqual, wordLoopPreheader);
+        m_out.addIncomingToPhi(byteIndexAtLoopTop, m_out.anchor(byteIndexInLoop));
+        m_out.branch(m_out.notZero32(byteIndexInLoop), unsure(byteLoop), unsure(trueCase));
 
-        ValueFromBlock indexForNextIteration = m_out.anchor(indexInLoop);
-        m_out.addIncomingToPhi(indexAtLoopTop, indexForNextIteration);
-        m_out.branch(m_out.notZero32(indexInLoop), unsure(loop), unsure(trueCase));
+        // length >= wordSize: compare a word at a time, walking backwards.
+        m_out.appendTo(wordLoopPreheader, wordLoop);
+        ValueFromBlock wordIndexAtStart = m_out.anchor(length);
+        m_out.jump(wordLoop);
+
+        m_out.appendTo(wordLoop, wordsEqual);
+        LValue wordIndexAtLoopTop = m_out.phi(Int32, wordIndexAtStart);
+        LValue wordIndexInLoop = m_out.sub(wordIndexAtLoopTop, m_out.constInt32(wordSize));
+        LValue wordOffset = m_out.zeroExtPtr(wordIndexInLoop);
+        LValue leftWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), m_out.add(leftData, wordOffset)));
+        LValue rightWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), m_out.add(rightData, wordOffset)));
+        m_out.branch(m_out.notEqual(leftWord, rightWord), unsure(falseCase), unsure(wordsEqual));
+
+        m_out.appendTo(wordsEqual, wordTail);
+        m_out.addIncomingToPhi(wordIndexAtLoopTop, m_out.anchor(wordIndexInLoop));
+        m_out.branch(m_out.aboveOrEqual(wordIndexInLoop, m_out.constInt32(wordSize)), unsure(wordLoop), unsure(wordTail));
+
+        // 0 <= wordIndexInLoop < wordSize bytes remain at the head. Since the original length was
+        // >= wordSize, a single overlapping word load at offset 0 safely covers the remainder.
+        m_out.appendTo(wordTail, wordTailCompare);
+        m_out.branch(m_out.isZero32(wordIndexInLoop), unsure(trueCase), unsure(wordTailCompare));
+
+        m_out.appendTo(wordTailCompare, trueCase);
+        LValue leftTailWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), leftData));
+        LValue rightTailWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), rightData));
+        m_out.branch(m_out.notEqual(leftTailWord, rightTailWord), unsure(falseCase), unsure(trueCase));
 
         m_out.appendTo(trueCase, falseCase);
 


### PR DESCRIPTION
#### 2fc620c5697bc627241531f657fe52d5728b34d1
<pre>
[JSC] Compare 8-bit strings a word at a time in DFG/FTL string equality
<a href="https://bugs.webkit.org/show_bug.cgi?id=313306">https://bugs.webkit.org/show_bug.cgi?id=313306</a>

Reviewed by Yusuke Suzuki.

The inlined string equality fast path in DFG SpeculativeJIT and FTL
stringsEqual() compared 8-bit characters one byte at a time. Compare a
pointer-sized word per iteration instead, walking backwards. The 1..7
byte head remainder is handled with a single overlapping word load at
offset 0, which is safe because we only enter the word loop when the
length is at least one word, so we never read past the buffer.

Strings shorter than a word keep the existing byte loop, laid out as
the fall-through so they only pay for one not-taken branch. In FTL the
word loop gets its own preheader and is hinted rarely() so the byte
phi&apos;s Upsilon does not leak an extra mov onto the short-string path.

                                     baseline                  patched

    string-equality-short-8bit     6.6425+-0.2105     ?      6.7322+-0.2411       ? might be 1.0135x slower
    string-equality-256-8bit      80.5512+-2.1960     ^     13.7656+-0.2686       ^ definitely 5.8516x faster
    string-equality-long-8bit     21.1002+-0.4639     ^      7.3678+-0.2527       ^ definitely 2.8638x faster
    &lt;geometric&gt;                   22.4252+-0.2778     ^      8.8020+-0.1449       ^ definitely 2.5477x faster

Tests: JSTests/microbenchmarks/string-equality-256-8bit.js
       JSTests/microbenchmarks/string-equality-long-8bit.js
       JSTests/microbenchmarks/string-equality-short-8bit.js
       JSTests/stress/string-equality-word-compare.js

* JSTests/microbenchmarks/string-equality-256-8bit.js: Added.
(makeString):
(eq):
* JSTests/microbenchmarks/string-equality-long-8bit.js: Added.
(makeString):
(eq):
* JSTests/microbenchmarks/string-equality-short-8bit.js: Added.
(makeString):
(eq):
* JSTests/stress/string-equality-word-compare.js: Added.
(eq):
(make):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/312326@main">https://commits.webkit.org/312326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2375f86825e793a99c7d8bce8b4126bfbce72527

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112774 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122932 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86263 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142557 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103601 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24253 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22648 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15291 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/150739 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170011 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/19523 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15754 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21962 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131121 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131235 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35710 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142130 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89684 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25928 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18938 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/190971 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31262 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97276 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49103 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30782 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->