### PR TITLE
Add preliminary cursor shape support for WPEQtView

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
@@ -29,6 +29,7 @@
 #include "WPEQtView.h"
 
 #include <epoxy/egl.h>
+#include <wtf/SortedArrayMap.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
@@ -37,6 +38,9 @@
 #include <QOpenGLFunctions>
 #include <QQuickWindow>
 #include <QSGTexture>
+#include <QCursor>
+
+#include <string_view>
 
 /**
  * WPEViewQtQuick:
@@ -75,6 +79,60 @@ static gboolean wpeViewQtQuickRenderBuffer(WPEView* view, WPEBuffer* buffer, con
     return TRUE;
 }
 
+static QCursor webCursorNameToQCursor(const char* name)
+{
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/cursor
+    // https://doc.qt.io/qt-6/qcursor.html
+    // Unsupported in Qt:
+    // context-menu, cell, all-scroll, zoom-in, zoom-out
+    // Limited:
+    // vertical-text (fallback to text),
+    // no-drop (fallback to forbidden),
+    // all single-direction resizes (fallback to double-direction resizes)
+    using namespace std::literals;
+    static constexpr SortedArrayMap shapeMap { std::to_array<std::pair<std::string_view, Qt::CursorShape>>({
+        { "alias"sv, Qt::DragLinkCursor },
+        { "col-resize"sv, Qt::SplitHCursor },
+        { "copy"sv, Qt::DragCopyCursor },
+        { "crosshair"sv, Qt::CrossCursor },
+        { "default"sv, Qt::ArrowCursor },
+        { "e-resize"sv, Qt::SizeHorCursor },
+        { "ew-resize"sv, Qt::SizeHorCursor },
+        { "grab"sv, Qt::OpenHandCursor },
+        { "grabbing"sv, Qt::ClosedHandCursor },
+        { "help"sv, Qt::WhatsThisCursor },
+        { "move"sv, Qt::DragMoveCursor },
+        { "n-resize"sv, Qt::SizeVerCursor },
+        { "ne-resize"sv, Qt::SizeBDiagCursor },
+        { "nesw-resize"sv, Qt::SizeBDiagCursor },
+        { "no-drop"sv, Qt::ForbiddenCursor },
+        { "none"sv, Qt::BlankCursor },
+        { "not-allowed"sv, Qt::ForbiddenCursor },
+        { "ns-resize"sv, Qt::SizeVerCursor },
+        { "nw-resize"sv, Qt::SizeFDiagCursor },
+        { "nwse-resize"sv, Qt::SizeFDiagCursor },
+        { "pointer"sv, Qt::PointingHandCursor },
+        { "progress"sv, Qt::BusyCursor },
+        { "row-resize"sv, Qt::SplitVCursor },
+        { "s-resize"sv, Qt::SizeVerCursor },
+        { "se-resize"sv, Qt::SizeFDiagCursor },
+        { "sw-resize"sv, Qt::SizeBDiagCursor },
+        { "text"sv, Qt::IBeamCursor },
+        { "vertical-text"sv, Qt::IBeamCursor },
+        { "w-resize"sv, Qt::SizeHorCursor },
+        { "wait"sv, Qt::WaitCursor },
+    }) };
+    auto shape = shapeMap.get(std::string_view(name), Qt::ArrowCursor);
+    return QCursor(shape);
+}
+
+static void wpeViewQtQuickSetCursorFromName(WPEView* view, const char* name)
+{
+    auto* priv = WPE_VIEW_QTQUICK(view)->priv;
+    QCursor cursor = webCursorNameToQCursor(name);
+    priv->wpeQtView->setCursor(cursor);
+}
+
 static void wpe_view_qtquick_class_init(WPEViewQtQuickClass* viewQtQuickClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(viewQtQuickClass);
@@ -82,6 +140,7 @@ static void wpe_view_qtquick_class_init(WPEViewQtQuickClass* viewQtQuickClass)
 
     WPEViewClass* viewClass = WPE_VIEW_CLASS(viewQtQuickClass);
     viewClass->render_buffer = wpeViewQtQuickRenderBuffer;
+    viewClass->set_cursor_from_name = wpeViewQtQuickSetCursorFromName;
 }
 
 WPEView* wpe_view_qtquick_new(WPEDisplayQtQuick* display)


### PR DESCRIPTION
#### 5a8b1e3dcd90a244d15db5bacdd54ba4bfd46bd7
<pre>
Add preliminary cursor shape support for WPEQtView

<a href="https://bugs.webkit.org/show_bug.cgi?id=313305">https://bugs.webkit.org/show_bug.cgi?id=313305</a>

Reviewed by Claudio Saavedra.

Add support for the stock pointer shapes that Qt supports.

Go to
<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/cursor">https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/cursor</a>
and verify you can see various cursor shapes applied.

* Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp:
(webCursorNameToQCursor): Use a SortedArrayMap to find out the cursor shape.
(wpeViewQtQuickSetCursorFromName): Use QQuickItem::setCursor to set
cursor shape.
(wpe_view_qtquick_class_init): Implement set_cursor_from_name virtual method.

Canonical link: <a href="https://commits.webkit.org/312139@main">https://commits.webkit.org/312139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d330cf2aecce5953873ee6b752d51cc280ce74f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113040 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123186 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86483 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103830 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24498 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22894 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15557 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134184 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170278 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16020 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131350 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131462 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142372 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90067 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24202 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26171 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19181 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31528 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97542 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31048 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->