### PR TITLE
[GTK] Minibrowser: On opening search bar, search for selected text if any

### DIFF
--- a/Tools/MiniBrowser/gtk/BrowserSearchBox.c
+++ b/Tools/MiniBrowser/gtk/BrowserSearchBox.c
@@ -139,6 +139,54 @@ static void searchEntryChangedCallback(GtkEntry *entry, BrowserSearchBox *search
     doSearch(searchBox);
 }
 
+static void get_selected_text_cb(GObject *object, GAsyncResult *result, gpointer userData)
+{
+    JSCValue *value;
+    GError *error = NULL;
+
+    value = webkit_web_view_evaluate_javascript_finish(WEBKIT_WEB_VIEW(object), result, &error);
+    if (!value) {
+        g_warning("Error running javascript: %s", error->message);
+        g_error_free(error);
+        return;
+    }
+
+    if (!jsc_value_is_string(value)) {
+        g_warning("Error running javascript: unexpected return value");
+        g_object_unref(value);
+        return;
+    }
+
+    gchar *selectedText = jsc_value_to_string(value);
+    JSCException *exception = jsc_context_get_exception(jsc_value_get_context(value));
+    if (exception) {
+        g_warning("Error running javascript: %s", jsc_exception_get_message(exception));
+        g_free(selectedText);
+        g_object_unref(value);
+        return;
+    }
+
+    // Set selected text into search box.
+    BrowserSearchBox *searchBox = BROWSER_SEARCH_BOX(userData);
+    #if GTK_CHECK_VERSION(3, 98, 5)
+        gtk_editable_set_text(GTK_EDITABLE(searchBox->entry), selectedText);
+    #else
+        gtk_entry_set_text(GTK_ENTRY(searchBox->entry), selectedText);
+    #endif
+    g_free(selectedText);
+
+    g_object_unref(value);
+}
+
+static void searchEntryMapCallback(BrowserSearchBox *searchBox)
+{
+    gchar *script;
+
+    script = g_strdup_printf("window.getSelection().toString();");
+    webkit_web_view_evaluate_javascript(searchBox->webView, script, -1, NULL, NULL, NULL, get_selected_text_cb, searchBox);
+    g_free(script);
+}
+
 static void searchEntryActivatedCallback(BrowserSearchBox *searchBox)
 {
     searchNext(searchBox);
@@ -258,6 +306,7 @@ static void browser_search_box_init(BrowserSearchBox *searchBox)
     g_signal_connect_swapped(searchBox->entry, "icon-release", G_CALLBACK(searchEntryClearIconReleasedCallback), searchBox);
     g_signal_connect_after(searchBox->entry, "changed", G_CALLBACK(searchEntryChangedCallback), searchBox);
     g_signal_connect_swapped(searchBox->entry, "activate", G_CALLBACK(searchEntryActivatedCallback), searchBox);
+    g_signal_connect_swapped(searchBox->entry, "map", G_CALLBACK(searchEntryMapCallback), searchBox);
 }
 
 static void browserSearchBoxFinalize(GObject *gObject)


### PR DESCRIPTION
#### 96be579a9642cc4d6518e3be15f054d3c7d7b6e9
<pre>
[GTK] Minibrowser: On opening search bar, search for selected text if any
<a href="https://bugs.webkit.org/show_bug.cgi?id=128459">https://bugs.webkit.org/show_bug.cgi?id=128459</a>

Reviewed by NOBODY (OOPS!).

It&apos;s a common feature in all browsers that when opening the search box
it inmediately starts searching the selected text, if any.

* Tools/MiniBrowser/gtk/BrowserSearchBox.c:
(get_selected_text_cb):
(searchEntryMapCallback):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96be579a9642cc4d6518e3be15f054d3c7d7b6e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112778 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122937 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86267 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103606 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24250 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22653 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15295 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170015 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131124 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131238 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142136 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89688 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25929 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18944 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31266 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30786 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30940 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->