### PR TITLE
[GTK][WPE] Skia Compositor: Make *ForChildren transforms transient

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -339,16 +339,15 @@ std::optional<SkiaCompositingLayer::AnimationsState> SkiaCompositingLayer::syncA
     return state;
 }
 
-bool SkiaCompositingLayer::computeTransformsAndAnimations(RefPtr<SkiaCompositingLayer> parent, MonotonicTime time)
+bool SkiaCompositingLayer::computeTransformsAndAnimations(const TransformationMatrix& parentTransform, const TransformationMatrix& futureParentTransform, MonotonicTime time)
 {
     m_animationsState = syncAnimations(time);
     bool hasRunningAnimations = m_animationsState ? m_animationsState->isRunning : false;
 
-    if (!m_size.isEmpty() || !m_masksToBounds) {
-        TransformationMatrix parentTransform;
-        if (parent)
-            parentTransform = parent == m_parent ? parent->m_transforms.combinedForChildren : parent->m_transforms.combined;
+    TransformationMatrix combinedForChildren;
+    TransformationMatrix futureCombinedForChildren;
 
+    if (!m_size.isEmpty() || !m_masksToBounds) {
 #if ENABLE(DAMAGE_TRACKING)
         TransformationMatrix previousTransform = m_transforms.combined;
 #endif
@@ -360,36 +359,32 @@ bool SkiaCompositingLayer::computeTransformsAndAnimations(RefPtr<SkiaCompositing
             .translate3d(origin.x() + (m_position.x() - m_boundsOrigin.x()), origin.y() + (m_position.y() - m_boundsOrigin.y()), m_anchorPoint.z())
             .multiply(localTransform());
 
-        m_transforms.combinedForChildren = m_transforms.combined;
+        combinedForChildren = m_transforms.combined;
         m_transforms.combined.translate3d(-origin.x(), -origin.y(), -m_anchorPoint.z());
 
         if (isReplica())
             m_transforms.combined.translate(-m_position.x(), -m_position.y());
 
         if (!m_preserves3D)
-            m_transforms.combinedForChildren.flatten();
-        m_transforms.combinedForChildren.multiply(m_childrenTransform);
-        m_transforms.combinedForChildren.translate3d(-origin.x(), -origin.y(), -m_anchorPoint.z());
-
-        TransformationMatrix futureParentTransform;
-        if (parent)
-            futureParentTransform = parent == m_parent ? parent->m_transforms.futureCombinedForChildren : parent->m_transforms.futureCombined;
+            combinedForChildren.flatten();
+        combinedForChildren.multiply(m_childrenTransform);
+        combinedForChildren.translate3d(-origin.x(), -origin.y(), -m_anchorPoint.z());
 
         m_transforms.futureCombined = futureParentTransform;
         m_transforms.futureCombined
             .translate3d(origin.x() + (m_position.x() - m_boundsOrigin.x()), origin.y() + (m_position.y() - m_boundsOrigin.y()), m_anchorPoint.z())
             .multiply(futureLocalTransform());
 
-        m_transforms.futureCombinedForChildren = m_transforms.futureCombined;
+        futureCombinedForChildren = m_transforms.futureCombined;
         m_transforms.futureCombined.translate3d(-origin.x(), -origin.y(), -m_anchorPoint.z());
 
         if (isReplica())
             m_transforms.futureCombined.translate(-m_position.x(), -m_position.y());
 
         if (!m_preserves3D)
-            m_transforms.futureCombinedForChildren.flatten();
-        m_transforms.futureCombinedForChildren.multiply(m_childrenTransform);
-        m_transforms.futureCombinedForChildren.translate3d(-origin.x(), -origin.y(), -m_anchorPoint.z());
+            futureCombinedForChildren.flatten();
+        futureCombinedForChildren.multiply(m_childrenTransform);
+        futureCombinedForChildren.translate3d(-origin.x(), -origin.y(), -m_anchorPoint.z());
 
 #if ENABLE(DAMAGE_TRACKING)
         if (frameDamagePropagationEnabled() && previousTransform != m_transforms.combined) {
@@ -404,13 +399,15 @@ bool SkiaCompositingLayer::computeTransformsAndAnimations(RefPtr<SkiaCompositing
             m_animatedBackingStoreClient->requestBackingStoreUpdateIfNeeded(m_transforms.futureCombined);
     }
 
-    if (m_mask)
-        hasRunningAnimations |= m_mask->computeTransformsAndAnimations(m_replicatedLayer ? m_replicatedLayer.get() : this, time);
+    if (m_mask) {
+        auto& maskParent = m_replicatedLayer ? *m_replicatedLayer : *this;
+        hasRunningAnimations |= m_mask->computeTransformsAndAnimations(maskParent.m_transforms.combined, maskParent.m_transforms.futureCombined, time);
+    }
     if (m_replica)
-        hasRunningAnimations |= m_replica->computeTransformsAndAnimations(m_replica->m_replicatedLayer, time);
+        hasRunningAnimations |= m_replica->computeTransformsAndAnimations(m_replica->m_replicatedLayer->m_transforms.combined, m_replica->m_replicatedLayer->m_transforms.futureCombined, time);
 
     for (auto& child : m_children)
-        hasRunningAnimations |= child->computeTransformsAndAnimations(this, time);
+        hasRunningAnimations |= child->computeTransformsAndAnimations(combinedForChildren, futureCombinedForChildren, time);
 
     // If the layer is invisible because of opacity and there's no opacity animation, the content won't
     // be visible ever, so triggering repaints doesn't make sense.
@@ -422,7 +419,7 @@ bool SkiaCompositingLayer::computeTransformsAndAnimations(RefPtr<SkiaCompositing
 
 bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& damage)
 {
-    bool hasRunningAnimations = computeTransformsAndAnimations(nullptr, MonotonicTime::now());
+    bool hasRunningAnimations = computeTransformsAndAnimations({ }, { }, MonotonicTime::now());
     PaintContext context(damage);
     recursivePaint(canvas, context);
 

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -118,7 +118,7 @@ private:
     bool hasVisualContent() const;
     Ref<SkiaCompositingLayer> backdropRoot();
 
-    bool computeTransformsAndAnimations(RefPtr<SkiaCompositingLayer>, MonotonicTime);
+    bool computeTransformsAndAnimations(const TransformationMatrix& parentTransform, const TransformationMatrix& futureParentTransform, MonotonicTime);
 
     struct PaintContext {
         explicit PaintContext(std::optional<Damage>& damage)
@@ -238,9 +238,7 @@ private:
     std::optional<AnimationsState> m_animationsState;
     struct {
         TransformationMatrix combined;
-        TransformationMatrix combinedForChildren;
         TransformationMatrix futureCombined;
-        TransformationMatrix futureCombinedForChildren;
     } m_transforms;
 #if ENABLE(DAMAGE_TRACKING)
     std::shared_ptr<Damage> m_sharedFrameDamage;


### PR DESCRIPTION
#### 9c49484130231194fe829f08a2b625151927e804
<pre>
[GTK][WPE] Skia Compositor: Make *ForChildren transforms transient
<a href="https://bugs.webkit.org/show_bug.cgi?id=313307">https://bugs.webkit.org/show_bug.cgi?id=313307</a>

Reviewed by Carlos Garcia Campos.

The combinedForChildren and futureCombinedForChildren matrices on
SkiaCompositingLayer::m_transforms are only consumed by the parent&apos;s
recursive call into each child within computeTransformsAndAnimations.
no paint-time site reads them. Storing them in m_transforms causes
confusion because both are actually transient.

Drop both fields from m_transforms and pass them as parameters to the
recursive call instead.  Also drop the parent parameter and hoist
parent == m_parent decision into each caller.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::computeTransformsAndAnimations):
(WebCore::SkiaCompositingLayer::paint):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:

Canonical link: <a href="https://commits.webkit.org/312066@main">https://commits.webkit.org/312066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b021f0f3b513327374c82a41536c0a74fc36d59d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112902 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123045 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86375 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103714 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24371 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22769 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170139 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15882 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131232 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131346 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142251 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89869 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24159 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26049 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19060 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31390 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97404 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30910 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31183 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->