### PR TITLE
[GStreamer][Rice] Flaky crash in `rice_proto::conncheck::ConnCheckList::add_local_candidate_internal()`

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1498,9 +1498,6 @@ webkit.org/b/311927 accessibility/combobox/gtk/combobox-collapsed-selection-chan
 
 webkit.org/b/311930 fonts/font-cache-memory-pressure-crash.html [ Failure Pass ]
 
-webkit.org/b/312269 imported/w3c/web-platform-tests/webrtc/protocol/vp8-fmtp.html [ Pass Crash ]
-webkit.org/b/312269 imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-constructor.html [ Pass Crash ]
-
 webkit.org/b/312888 inspector/debugger/async-stack-trace-basic.html [ Pass Crash ]
 webkit.org/b/312889 media/video-seek-past-end-paused.html [ Pass Timeout ]
 webkit.org/b/312892 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/window-open-self.html [ Pass Failure ]

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -66,6 +66,12 @@ using WebKitGstRiceStream = struct _WebKitGstRiceStream {
 
 using StreamHashMap = HashMap<unsigned, std::unique_ptr<WebKitGstRiceStream>, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>;
 
+enum class AgentState : uint8_t {
+    Open,
+    Closing,
+    Closed
+};
+
 typedef struct _WebKitGstIceAgentPrivate {
     ~_WebKitGstIceAgentPrivate()
     {
@@ -88,8 +94,9 @@ typedef struct _WebKitGstIceAgentPrivate {
 
     RefPtr<RunLoop> runLoop;
 
-    Atomic<bool> agentIsClosed;
-    GRefPtr<GstPromise> closePromise;
+    Lock stateLock;
+    AgentState state WTF_GUARDED_BY_LOCK(stateLock) { AgentState::Open };
+    GRefPtr<GstPromise> closePromise WTF_GUARDED_BY_LOCK(stateLock);
 
     GstWebRTCICEOnCandidateFunc onCandidate;
     gpointer onCandidateData;
@@ -380,6 +387,7 @@ static GstWebRTCICEStream* webkitGstWebRTCIceAgentAddStream(GstWebRTCICE* ice, g
     auto riceStream = adoptGRef(rice_agent_add_stream(backend->priv->agent.get()));
     auto streamId = static_cast<unsigned>(rice_stream_get_id(riceStream.get()));
     [[maybe_unused]] auto component = adoptGRef(rice_stream_add_component(riceStream.get()));
+    GST_DEBUG_OBJECT(ice, "Component %zu added for stream %u", rice_component_get_id(component.get()), streamId);
 
     auto stream = adoptGRef(GST_WEBRTC_ICE_STREAM(webkitGstWebRTCCreateIceStream(backend, WTF::move(riceStream))));
     backend->priv->streams.add(sessionId, WTF::makeUnique<WebKitGstRiceStream>(streamId, WTF::move(stream)));
@@ -625,14 +633,19 @@ static gboolean webkitGstWebRTCIceAgentGetSelectedPair(GstWebRTCICE* ice, GstWeb
 
 void webkitGstWebRTCIceAgentClosed(WebKitGstIceAgent* agent)
 {
-    agent->priv->agentIsClosed.exchange(true);
-    agent->priv->streams.clear();
+    GST_DEBUG_OBJECT(agent, "Agent successfully closed");
+    auto priv = agent->priv;
 
-    if (!agent->priv->closePromise)
+    Locker locker { priv->stateLock };
+    priv->state = AgentState::Closed;
+
+    priv->streams.clear();
+
+    if (!priv->closePromise)
         return;
 
-    gst_promise_reply(agent->priv->closePromise.get(), nullptr);
-    agent->priv->closePromise.clear();
+    gst_promise_reply(priv->closePromise.get(), nullptr);
+    priv->closePromise.clear();
 }
 
 #if GST_CHECK_VERSION(1, 28, 0)
@@ -640,24 +653,48 @@ static void webkitGstWebRTCIceAgentClose(GstWebRTCICE* ice, GstPromise* promise)
 {
     auto backend = WEBKIT_GST_WEBRTC_ICE_BACKEND(ice);
 
-    auto isClosed = backend->priv->agentIsClosed.load();
-    if (isClosed)
-        return;
+    {
+        Locker locker { backend->priv->stateLock };
 
-    bool shouldWait = promise == nullptr;
-    backend->priv->closePromise = promise;
-    auto now = WTF::MonotonicTime::now().secondsSinceEpoch();
-    rice_agent_close(backend->priv->agent.get(), now.nanoseconds());
+        GST_DEBUG_OBJECT(ice, "Attempting to close connection");
+        if (backend->priv->state >= AgentState::Closing) {
+            GST_DEBUG_OBJECT(ice, "Agent %s, no need to close again", backend->priv->state == AgentState::Closed ? "was closed" : "is closing");
+            return;
+        }
+
+        backend->priv->closePromise = promise;
+        backend->priv->state = AgentState::Closing;
+        auto now = WTF::MonotonicTime::now().secondsSinceEpoch();
+        rice_agent_close(backend->priv->agent.get(), now.nanoseconds());
+    }
+
+    {
+        Locker locker { backend->priv->stateLock };
+
+        bool shouldWait = promise == nullptr;
+        auto isClosed = backend->priv->state == AgentState::Closed;
+        if (!shouldWait || isClosed) {
+            GST_DEBUG_OBJECT(ice, "No need to wait close procedure completion");
+            backend->priv->state = AgentState::Closed;
+            return;
+        }
+    }
+
+    GST_DEBUG_OBJECT(ice, "Waiting close procedure completion");
     webkitGstWebRTCIceAgentWakeup(backend);
 
-    isClosed = backend->priv->agentIsClosed.load();
-    if (!shouldWait || isClosed)
-        return;
-
-    while (!isClosed) {
+    auto timeout = WTF::MonotonicTime::now().secondsSinceEpoch() + 2_s;
+    while (WTF::MonotonicTime::now().secondsSinceEpoch() < timeout) {
+        bool isClosed = false;
+        {
+            Locker locker { backend->priv->stateLock };
+            isClosed = backend->priv->state == AgentState::Closed;
+        }
+        if (isClosed)
+            return;
         g_main_context_iteration(backend->priv->runLoop->mainContext(), FALSE);
-        isClosed = backend->priv->agentIsClosed.load();
     }
+    GST_DEBUG_OBJECT(ice, "Agent failed to properly close connections");
 }
 #endif
 
@@ -667,8 +704,6 @@ static void webkitGstWebRTCIceAgentConstructed(GObject* object)
 
     auto backend = WEBKIT_GST_WEBRTC_ICE_BACKEND(object);
     auto priv = backend->priv;
-
-    priv->agentIsClosed.exchange(false);
 
     static Atomic<uint32_t> counter = 0;
     auto id = counter.load();
@@ -846,10 +881,25 @@ void webkitGstWebRTCIceAgentGatheringDoneForStream(WebKitGstIceAgent* agent, uns
 
 void webkitGstWebRTCIceAgentLocalCandidateGatheredForStream(WebKitGstIceAgent* agent, unsigned streamId, RiceAgentGatheredCandidate& candidate)
 {
+    auto priv = agent->priv;
+    {
+        Locker locker { priv->stateLock };
+
+        if (priv->state >= AgentState::Closing) {
+            GST_DEBUG_OBJECT(agent, "Agent %s, no need to notify gathered candidate anymore", priv->state == AgentState::Closed ? "was closed" : "is closing");
+            return;
+        }
+    }
+
     findStreamAndApply(agent->priv->streams, streamId, [&](const auto* stream) {
+        Locker locker { priv->stateLock };
+        if (priv->state >= AgentState::Closing) {
+            GST_DEBUG_OBJECT(agent, "Agent %s, no need to notify gathered candidate anymore", priv->state == AgentState::Closed ? "was closed" : "is closing");
+            return;
+        }
         auto sdp = GMallocString::unsafeAdoptFromUTF8(rice_candidate_to_sdp_string(&candidate.gathered.candidate));
 
-        if (agent->priv->forceRelay && candidate.gathered.candidate.candidate_type != RICE_CANDIDATE_TYPE_RELAYED) {
+        if (priv->forceRelay && candidate.gathered.candidate.candidate_type != RICE_CANDIDATE_TYPE_RELAYED) {
             GST_DEBUG_OBJECT(agent, "Ignoring non-relay ICE candidate %s", sdp.utf8());
             webkitGstWebRTCIceStreamAddLocalGatheredCandidate(stream, candidate.gathered);
             return;
@@ -858,7 +908,7 @@ void webkitGstWebRTCIceAgentLocalCandidateGatheredForStream(WebKitGstIceAgent* a
         GST_DEBUG_OBJECT(agent, "Notifying candidate %s", sdp.utf8());
         ASSERT(startsWith(sdp.span(), "a="_s));
         String strippedSdp(sdp.span().subspan(2));
-        agent->priv->onCandidate(GST_WEBRTC_ICE(agent), streamId, strippedSdp.utf8().data(), agent->priv->onCandidateData);
+        priv->onCandidate(GST_WEBRTC_ICE(agent), streamId, strippedSdp.utf8().data(), priv->onCandidateData);
         webkitGstWebRTCIceStreamAddLocalGatheredCandidate(stream, candidate.gathered);
     });
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
@@ -103,6 +103,7 @@ void webkitGstWebRTCIceStreamGatheringDone(const WebKitGstIceStream* ice)
 void webkitGstWebRTCIceStreamAddLocalGatheredCandidate(const WebKitGstIceStream* ice, const RiceGatheredCandidate& candidate)
 {
     auto stream = WEBKIT_GST_WEBRTC_ICE_STREAM(ice);
+    GST_DEBUG_OBJECT(ice, "Local candidate gathered for stream %u on component %zu", stream->priv->streamId, candidate.candidate.component_id);
     rice_stream_add_local_gathered_candidate(stream->priv->riceStream.get(), &candidate);
 }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -179,13 +179,15 @@ RTCRtpSendParameters GStreamerRtpSenderBackend::getParameters() const
         m_currentParameters = source->parameters();
     }, [&](const Ref<RealtimeOutgoingVideoSourceGStreamer>& source) {
         m_currentParameters = source->parameters();
-    }, [](const std::nullptr_t&) {
+    }, [&](const std::nullptr_t&) {
+        GST_DEBUG_OBJECT(m_rtcSender.get(), "No outgoing source yet, unable to retrieve parameters");
     });
 
     GST_DEBUG_OBJECT(m_rtcSender.get(), "Current parameters: %" GST_PTR_FORMAT, m_currentParameters.get());
-    if (!m_currentParameters)
+    if (!m_currentParameters) {
+        GST_DEBUG_OBJECT(m_rtcSender.get(), "Using init data: %" GST_PTR_FORMAT, m_initData.get());
         return toRTCRtpSendParameters(m_initData.get());
-
+    }
     return toRTCRtpSendParameters(m_currentParameters.get());
 }
 


### PR DESCRIPTION
#### 6ff991b88b5ffb1194feb9e0b0db65dbc9756798
<pre>
[GStreamer][Rice] Flaky crash in `rice_proto::conncheck::ConnCheckList::add_local_candidate_internal()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=312269">https://bugs.webkit.org/show_bug.cgi?id=312269</a>

Reviewed by Xabier Rodriguez-Calvar.

There was a race condition where the agent would start closing, wake-up it main loop and that would
trigger a local candidate notification after rice_agent_close() was called. We now distinguish the
&quot;closing&quot; case from the &quot;closed&quot; case using an enum that can be checked before processing local
candidate notifications.

* LayoutTests/platform/gtk/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
(_WebKitGstIceAgentPrivate::WTF_GUARDED_BY_LOCK):
(webkitGstWebRTCIceAgentAddStream):
(webkitGstWebRTCIceAgentClosed):
(webkitGstWebRTCIceAgentClose):
(webkitGstWebRTCIceAgentConstructed):
(webkitGstWebRTCIceAgentLocalCandidateGatheredForStream):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp:
(webkitGstWebRTCIceStreamAddLocalGatheredCandidate):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
(WebCore::GStreamerRtpSenderBackend::getParameters const):

Canonical link: <a href="https://commits.webkit.org/312189@main">https://commits.webkit.org/312189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/777a00f3ce7f0f721bbf7a81ae5f870e7d9d3c45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112997 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123125 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86452 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24451 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22852 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15514 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134137 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170235 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15977 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131315 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131427 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35595 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142332 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90014 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26129 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19141 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31485 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97499 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31005 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->