### PR TITLE
[GLIB] compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html is a flaky failure

### DIFF
--- a/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport-expected.html
+++ b/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport-expected.html
@@ -11,13 +11,13 @@
   if (window.testRunner)
     window.testRunner.waitUntilDone();
   async function runTest() {
-    requestAnimationFrame(async function() {
+    await new Promise(requestAnimationFrame(async function() {
       if (window.testRunner) {
-        await testRunner.setPageScaleFactor(0.5, 0, 0);
+        await window.testRunner.setPageScaleFactor(0.5, 0, 0);
         await window.testRunner.displayAndTrackRepaints();
-        await window.testRunner.displayAndTrackRepaints();
-        window.testRunner.notifyDone();
       }
+    }).then(() => {
+        window.testRunner.notifyDone();
     });
   }
 </script>

--- a/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html
+++ b/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html
@@ -31,13 +31,13 @@
   if (window.testRunner)
     window.testRunner.waitUntilDone();
   async function runTest() {
-    requestAnimationFrame(async function() {
+    await new Promise(requestAnimationFrame(async function() {
       if (window.testRunner) {
         await window.testRunner.setPageScaleFactor(0.5, 0, 0);
         await window.testRunner.displayAndTrackRepaints();
-        await window.testRunner.displayAndTrackRepaints();
-        window.testRunner.notifyDone();
       }
+    }).then(() => {
+        window.testRunner.notifyDone();
     });
   }
 </script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4677,8 +4677,6 @@ webkit.org/b/191885 fast/inline/simple-inline-with-out-of-flow-descendant.html [
 webkit.org/b/191885 fast/inline/simple-inline-with-out-of-flow-descendant2.html [ Failure ]
 webkit.org/b/191885 fast/inline/simple-intruding-floats3.html [ Failure ]
 
-webkit.org/b/195259 compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html [ ImageOnlyFailure Pass ]
-
 # Requires mix-blend-mode
 webkit.org/b/276086 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-cue-rendering.html
 webkit.org/b/276086 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/white-space-pre-line.html

--- a/LayoutTests/platform/gtk-wayland/TestExpectations
+++ b/LayoutTests/platform/gtk-wayland/TestExpectations
@@ -80,7 +80,6 @@ webkit.org/b/169917 webgl/1.0.x/conformance/textures/texture-mips.html [ Pass ]
 webkit.org/b/169917 webgl/1.0.x/conformance/textures/texture-npot.html [ Pass ]
 webkit.org/b/169917 webgl/1.0.x/conformance/textures/texture-size-limit.html [ Pass ]
 webkit.org/b/169918 compositing/backing/solid-color-with-paints-into-ancestor.html [ ImageOnlyFailure ]
-webkit.org/b/195259 compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html [ ImageOnlyFailure Pass ]
 
 # testRunner.setWindowIsKey() depends on gtk_window_present(),which
 # does not work currently in Wayland. See GNOME bug #766284.


### PR DESCRIPTION
#### 66c18fd1cf0c099c7054c2049926ea1fd3be40d0
<pre>
[GLIB] compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=195259">https://bugs.webkit.org/show_bug.cgi?id=195259</a>

Reviewed by NOBODY (OOPS!).

Wrap test function into a promise that waits until
&apos;displayAndTrackRepaoints&apos; is done. Then, call &apos;notifyDone&apos;.

This also allows to remove one extra &apos;displayAndTrackRepaints&apos; call.

* LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport-expected.html:
* LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk-wayland/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66c18fd1cf0c099c7054c2049926ea1fd3be40d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112783 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122941 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86271 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103610 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24256 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22657 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15300 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170020 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131128 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131242 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142140 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89693 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18948 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31271 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30791 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31064 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30945 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->