### PR TITLE
Fix wheel event handling in WPEQtView

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
@@ -285,9 +285,22 @@ void wpe_view_dispatch_wheel_event(WPEViewQtQuick *view, QWheelEvent *event)
 {
     auto position = event->position().toPoint();
     auto numPixels = event->pixelDelta();
-
+    double scrollX = 0;
+    double scrollY = 0;
+    auto hasPreciseDeltas = !numPixels.isNull();
+    if (hasPreciseDeltas) {
+        scrollX = numPixels.x();
+        scrollY = numPixels.y();
+    } else {
+        // Qt gives 120 for the wheel scroll of one tick
+        // In WebEventFactoryWPE.cpp, it accepts number of ticks
+        // for wheel events and convert it to pixels.
+        auto angleDelta = event->angleDelta().toPointF() / 120;
+        scrollX = angleDelta.x();
+        scrollY = angleDelta.y();
+    }
     auto* wpeEvent = wpe_event_scroll_new(WPE_VIEW(view), WPE_INPUT_SOURCE_MOUSE, event->timestamp(),
-        modifiersFromEvent(event), numPixels.x(), numPixels.y(), FALSE, FALSE, position.x(), position.y());
+        modifiersFromEvent(event), scrollX, scrollY, hasPreciseDeltas, FALSE, position.x(), position.y());
     wpe_view_event(WPE_VIEW(view), wpeEvent);
     wpe_event_unref(wpeEvent);
 }


### PR DESCRIPTION
#### a3c1d3be6028c7262bb797faa842fefe5b1aa4fa
<pre>
Fix wheel event handling in WPEQtView

<a href="https://bugs.webkit.org/show_bug.cgi?id=313311">https://bugs.webkit.org/show_bug.cgi?id=313311</a>

Reviewed by Adrian Perez de Castro.

On some platforms QWheelEvent will not have pixelDelta. Qt recommends
fallback to angleDelta when it is not available.

See <a href="https://doc.qt.io/qt-6/qwheelevent.html#pixelDelta-prop">https://doc.qt.io/qt-6/qwheelevent.html#pixelDelta-prop</a>

Also, WPEEvent for scroll expects number of ticks if and only if
has_precise_deltas is false. This means that we should set
has_precise_deltas to true if we have pixelDelta.

Go to
<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event">https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event</a>
and check the wheel event is working.

* Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp:
(wpe_view_dispatch_wheel_event): Fix wheel event handling when
pixelDelta is not available.

Canonical link: <a href="https://commits.webkit.org/312019@main">https://commits.webkit.org/312019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/488e068239cfbbf78ba9ac62f56e0a5142b000db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112788 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122946 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86277 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103615 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24261 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22662 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15305 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133947 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170025 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15768 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131132 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131246 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142145 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89702 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24126 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25941 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18953 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97290 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30796 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->