### PR TITLE
[CMake] Add generate-cmake-vscode-project-macos for the cmake-mac build

### DIFF
--- a/Tools/Scripts/generate-cmake-vscode-project-macos
+++ b/Tools/Scripts/generate-cmake-vscode-project-macos
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+generate-cmake-vscode-project-macos
+
+Emits a VS Code multi-root workspace that wraps a CMake/Ninja build directory:
+  - One ninja build task wired as the default (Cmd-Shift-B), with $gcc/$swift
+    problem matchers so errors land in the Problems panel.
+  - For each .app bundle, a launch config that builds, launches under lldb,
+    and loads Tools/lldb/webkit_auto_attach.py -- a libproc poller that fires
+    CodeLLDB's DAP startDebugging reverse-request for every WebKit XPC service
+    spawned from this build dir, so WebContent / Networking / GPU (and every
+    per-tab respawn) appear as nested child sessions automatically. One F5.
+  - Per-executable launch configs for the single-process tools (jsc, TestWTF,
+    TestWebKitAPI, ...).
+  - clangd pointed at the build's compile_commands.json so go-to-definition,
+    hover, and find-references work across both checked-in and DerivedSources
+    code without indexing the whole workspace up front.
+
+The .code-workspace file is self-contained -- folders, settings, tasks, launch
+configs and extension recommendations are all embedded, so `open <file>` or
+`code <file>` lands in a ready-to-debug session with nothing written into the
+checkout's .vscode/.
+
+Helper logic (executable discovery, prefix-map inversion, sanitizer options,
+lldbinit) is imported from generate-cmake-xcode-project so the two front-ends
+stay in lock-step as the build evolves.
+
+Usage:
+    Tools/Scripts/generate-cmake-vscode-project-macos [build-dir]
+
+Output:
+    <build-dir>/WebKit.code-workspace
+    <build-dir>/lldbinit
+"""
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_sibling(name):
+    here = Path(__file__).resolve().parent
+    spec = importlib.util.spec_from_loader(
+        name, importlib.machinery.SourceFileLoader(name, str(here / name)))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+xc = _load_sibling("generate-cmake-xcode-project")
+
+
+def default_build_dir(source_dir: Path) -> Path:
+    for cfg in ("ASan", "Debug", "RelWithDebInfo", "TSan", "Release"):
+        candidate = source_dir / "WebKitBuild" / "cmake-mac" / cfg
+        if (candidate / "CMakeCache.txt").exists():
+            return candidate
+    return source_dir / "WebKitBuild" / "cmake-mac" / "ASan"
+
+
+def launch_env(build_dir: Path, is_bundle: bool):
+    """Sanitizer tuning only. The cmake-mac build bakes an absolute LC_RPATH to
+    the build dir into every executable and XPC service, so DYLD_FRAMEWORK_PATH
+    (and the __XPC_ forwarding dance run-minibrowser does for the xcodebuild
+    layout) is unnecessary -- @rpath/WebKit.framework already resolves to the
+    just-built copy."""
+    env = {}
+    asan = xc.asan_options(build_dir)
+    if asan:
+        env["ASAN_OPTIONS"] = asan
+        if is_bundle:
+            env["__XPC_ASAN_OPTIONS"] = asan
+    tsan = getattr(xc, "tsan_options", lambda _: "")(build_dir)
+    if tsan:
+        env["TSAN_OPTIONS"] = tsan
+        if is_bundle:
+            env["__XPC_TSAN_OPTIONS"] = tsan
+    return env
+
+
+def make_tasks(build_dir: Path, ninja_path: str):
+    return {
+        "version": "2.0.0",
+        "tasks": [{
+            "label": "ninja",
+            "type": "shell",
+            "command": ninja_path,
+            "args": ["-C", str(build_dir)],
+            "options": {"cwd": str(build_dir)},
+            "group": {"kind": "build", "isDefault": True},
+            "presentation": {"reveal": "always", "clear": True, "panel": "dedicated"},
+            "problemMatcher": ["$gcc", "$swiftc"],
+        }],
+    }
+
+
+def make_launch(build_dir: Path, source_dir: Path):
+    lldbinit = str(build_dir / "lldbinit")
+    auto_attach = str(source_dir / "Tools" / "lldb" / "webkit_auto_attach.py")
+    # CodeLLDB applies sourceMap before lldbinit's target.source-map; provide
+    # both so breakpoints set from the editor (sourceMap) and `source list` in
+    # the debug console (lldbinit) agree.
+    source_map = {token: real for token, real in xc.read_prefix_maps(build_dir)}
+    init_commands = [f"command source {lldbinit}"]
+
+    configs = []
+    for name, path, is_bundle in xc.discover_executables(build_dir):
+        program = str(path / "Contents" / "MacOS" / name) if is_bundle else str(path)
+        cfg = {
+            "name": name,
+            "type": "lldb",
+            "request": "launch",
+            "program": program,
+            "args": [],
+            "cwd": str(source_dir),
+            "env": launch_env(build_dir, is_bundle),
+            "initCommands": init_commands,
+            "sourceMap": source_map,
+            "preLaunchTask": "ninja",
+        }
+        if is_bundle:
+            cfg["postRunCommands"] = [f"command script import {auto_attach}"]
+            cfg["presentation"] = {"group": "1-app", "order": 0}
+        else:
+            cfg["presentation"] = {"group": "2-tool"}
+        configs.append(cfg)
+
+    return {"version": "0.2.0", "configurations": configs}
+
+
+def make_settings(build_dir: Path):
+    return {
+        # clangd reads .clangd from the first workspace folder (the repo root);
+        # --compile-commands-dir makes it look up flags in the ninja build's
+        # database instead of guessing, so headers resolve via the same -I set
+        # the compiler used.
+        "clangd.arguments": [
+            f"--compile-commands-dir={build_dir}",
+            "--header-insertion=never",
+            "--background-index",
+        ],
+        # Microsoft C/C++ IntelliSense and clangd fight over the same hover /
+        # go-to-definition providers; turn IntelliSense off but leave the
+        # extension installed for its debugger contributions.
+        "C_Cpp.intelliSenseEngine": "disabled",
+        # Do NOT set lldb.library to Xcode's LLDB.framework: CodeLLDB dlopens it
+        # and dlsyms a fixed SB API surface, and Apple's lldb periodically drops
+        # overloads upstream still has (e.g. SBFrame::GetValueForVariablePath).
+        # The bundled liblldb is ABI-matched and reads our dSYMs fine.
+        "lldb.launch.expressions": "native",
+        "files.exclude": {
+            "**/CMakeFiles": True,
+            "**/*.o": True,
+        },
+        "search.exclude": {
+            "**/LayoutTests": True,
+            "**/WebKitBuild": True,
+        },
+        "search.followSymlinks": False,
+    }
+
+
+def make_workspace(build_dir: Path, source_dir: Path, ninja_path: str):
+    folders = [{"name": "WebKit", "path": str(source_dir)}]
+    for d in sorted(build_dir.glob("*/DerivedSources")):
+        if any(d.iterdir()):
+            folders.append({"name": f"DerivedSources/{d.parent.name}", "path": str(d)})
+
+    return {
+        "folders": folders,
+        "settings": make_settings(build_dir),
+        "tasks": make_tasks(build_dir, ninja_path),
+        "launch": make_launch(build_dir, source_dir),
+        "extensions": {
+            "recommendations": [
+                "llvm-vs-code-extensions.vscode-clangd",
+                "vadimcn.vscode-lldb",
+            ],
+        },
+    }
+
+
+def main():
+    script_dir = Path(__file__).resolve().parent
+    source_dir = script_dir.parent.parent
+
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("build_dir", nargs="?",
+                    help="CMake binary dir (default: first configured "
+                         "WebKitBuild/cmake-mac/{Debug,RelWithDebInfo,Release,ASan})")
+    args = ap.parse_args()
+
+    if args.build_dir:
+        build_dir = Path(args.build_dir)
+        if not build_dir.is_absolute():
+            build_dir = (source_dir / build_dir).resolve()
+    else:
+        build_dir = default_build_dir(source_dir)
+
+    if not (build_dir / "CMakeCache.txt").exists():
+        sys.exit(f"error: {build_dir}/CMakeCache.txt not found -- run "
+                 f"'cmake --preset mac-asan' first")
+
+    ninja_path = xc.find_ninja()
+
+    (build_dir / "lldbinit").write_text(xc.generate_lldbinit(source_dir, build_dir))
+
+    ws = make_workspace(build_dir, source_dir, ninja_path)
+    ws_path = build_dir / "WebKit.code-workspace"
+    ws_path.write_text(json.dumps(ws, indent=4) + "\n")
+
+    n_launch = len(ws["launch"]["configurations"])
+    print(f"Generated {ws_path}")
+    print(f"  {n_launch} launch config(s)")
+    print(f"  lldbinit: {build_dir}/lldbinit")
+    print()
+    print(f"  code {ws_path}")
+    print(f"  Cmd-Shift-B  -> ninja -C {build_dir}")
+    print(f"  F5           -> ninja, launch MiniBrowser, auto-attach every XPC child")
+    print()
+    print("  # one-time: install the extensions the workspace recommends")
+    print("  code --install-extension vadimcn.vscode-lldb                  # debugger")
+    print("  code --install-extension llvm-vs-code-extensions.vscode-clangd # go-to-definition")
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/lldb/webkit_auto_attach.py
+++ b/Tools/lldb/webkit_auto_attach.py
@@ -1,0 +1,201 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+webkit_auto_attach -- CodeLLDB auto-attach to WebKit XPC children.
+
+Loaded via `postRunCommands` on a CodeLLDB launch of MiniBrowser (or any
+WebKit2 client built into a CMake build dir). Spawns a daemon thread that
+polls libproc for processes whose executable lives under this build's
+WebKit.framework/XPCServices/, and for each new arrival fires CodeLLDB's
+DAP `startDebugging` reverse-request so the child appears as a nested debug
+session in VS Code's Call Stack.
+
+Polling proc_pidpath at 50 ms gets the attach in before anything past
+XPCServiceMain has run in practice, which is good enough for breakpoints in
+WebCore/JSC; it cannot guarantee catching the very first instructions of
+service entry the way a suspended-spawn debugger hook would.
+
+Filtering by *executable path under the build dir* (rather than process name
+or parent PID) means we never attach to system Safari's services or another
+checkout's MiniBrowser -- only binaries produced by this exact ninja build.
+"""
+
+import ctypes
+import os
+import threading
+import time
+
+import lldb
+
+POLL_INTERVAL_S = 0.05
+PROC_ALL_PIDS = 1
+PROC_PIDPATHINFO_MAXSIZE = 4096
+
+_libproc = ctypes.CDLL("/usr/lib/libproc.dylib")
+_libproc.proc_listpids.restype = ctypes.c_int
+_libproc.proc_listpids.argtypes = [ctypes.c_uint32, ctypes.c_uint32, ctypes.c_void_p, ctypes.c_int]
+_libproc.proc_pidpath.restype = ctypes.c_int
+_libproc.proc_pidpath.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint32]
+
+
+def _list_pids():
+    n = _libproc.proc_listpids(PROC_ALL_PIDS, 0, None, 0)
+    if n <= 0:
+        return []
+    buf = (ctypes.c_int * (n // ctypes.sizeof(ctypes.c_int)))()
+    n = _libproc.proc_listpids(PROC_ALL_PIDS, 0, buf, ctypes.sizeof(buf))
+    return buf[: n // ctypes.sizeof(ctypes.c_int)]
+
+
+def _pid_path(pid, _buf=ctypes.create_string_buffer(PROC_PIDPATHINFO_MAXSIZE)):
+    n = _libproc.proc_pidpath(pid, _buf, PROC_PIDPATHINFO_MAXSIZE)
+    return _buf.raw[:n].decode("utf-8", "replace") if n > 0 else ""
+
+
+def _read_cmake_cache(build_dir, key):
+    try:
+        with open(os.path.join(build_dir, "CMakeCache.txt")) as f:
+            for line in f:
+                if line.startswith(key + ":"):
+                    return line.split("=", 1)[1].rstrip()
+    except OSError:
+        pass
+    return ""
+
+
+def _display_name(exe_path, pid, counts):
+    # com.apple.WebKit.WebContent.Development -> WebContent
+    name = os.path.basename(exe_path)
+    name = name.removeprefix("com.apple.WebKit.").removesuffix(".Development")
+    n = counts[name] = counts.get(name, 0) + 1
+    return f"{name} ({pid})" if n == 1 else f"{name} #{n} ({pid})"
+
+
+class _Watcher:
+    def __init__(self, debugger):
+        try:
+            from codelldb import interface as codelldb_interface
+        except ImportError:
+            print("webkit_auto_attach: codelldb module not available; "
+                  "auto-attach only works under the CodeLLDB adapter.")
+            return
+
+        self._fire = codelldb_interface.fire_event
+        self._debugger_id = debugger.GetID()
+
+        target = debugger.GetSelectedTarget()
+        process = target.GetProcess()
+        self._ui_pid = process.GetProcessID()
+        if self._ui_pid in (0, lldb.LLDB_INVALID_PROCESS_ID):
+            self._log("no running process; load via postRunCommands, not initCommands.")
+            return
+
+        exe = target.GetExecutable()
+        exe_path = os.path.join(exe.GetDirectory() or "", exe.GetFilename() or "")
+        # Walk up from the executable until we hit the CMake build dir; covers
+        # both bare tools (<build>/WebKitTestRunner) and bundles
+        # (<build>/MiniBrowser.app/Contents/MacOS/MiniBrowser).
+        probe = os.path.dirname(exe_path)
+        for _ in range(4):
+            if os.path.exists(os.path.join(probe, "CMakeCache.txt")):
+                self._build_dir = probe
+                break
+            probe = os.path.dirname(probe)
+        else:
+            self._log(f"could not locate CMakeCache.txt above {exe_path}; disabled.")
+            return
+
+        self._xpc_prefix = os.path.join(
+            self._build_dir, "WebKit.framework", "Versions", "A", "XPCServices") + os.sep
+        source_dir = _read_cmake_cache(self._build_dir, "CMAKE_HOME_DIRECTORY")
+        self._child_init = [f"command source {os.path.join(self._build_dir, 'lldbinit')}"]
+        self._child_source_map = {".": source_dir, "build": self._build_dir} if source_dir else {}
+
+        self._seen = set()
+        self._counts = {}
+
+        self._log(f"watching for XPC children of pid {self._ui_pid} under {self._xpc_prefix}")
+        t = threading.Thread(target=self._run, name="webkit-auto-attach", daemon=True)
+        t.start()
+
+    def _log(self, msg):
+        try:
+            self._fire(self._debugger_id,
+                       dict(type="DebuggerMessage", category="console",
+                            output=f"[auto-attach] {msg}\n"))
+        except Exception:
+            print(f"[auto-attach] {msg}")
+
+    def _ui_alive(self):
+        try:
+            os.kill(self._ui_pid, 0)
+            return True
+        except OSError:
+            return False
+
+    def _run(self):
+        while self._ui_alive():
+            try:
+                self._scan()
+            except Exception as e:  # noqa: BLE001 -- a watcher must not die.
+                self._log(f"scan error: {e!r}")
+            time.sleep(POLL_INTERVAL_S)
+        self._log("UI process exited; stopping.")
+
+    def _scan(self):
+        live = set()
+        for pid in _list_pids():
+            if pid == 0 or pid == self._ui_pid:
+                continue
+            path = _pid_path(pid)
+            if not path.startswith(self._xpc_prefix):
+                continue
+            live.add(pid)
+            if pid in self._seen:
+                continue
+            self._seen.add(pid)
+            self._attach(pid, path)
+        # Forget dead ones so a same-PID-reuse (rare) or our own bookkeeping
+        # doesn't grow unbounded over a long session.
+        self._seen &= live
+
+    def _attach(self, pid, path):
+        name = _display_name(path, pid, self._counts)
+        self._log(f"attaching: {name}")
+        self._fire(self._debugger_id, dict(
+            type="StartDebugging",
+            request="attach",
+            configuration=dict(
+                name=name,
+                pid=pid,
+                stopOnEntry=False,
+                initCommands=self._child_init,
+                sourceMap=self._child_source_map,
+                presentation=dict(group="auto-attach"),
+            ),
+        ))
+
+
+def __lldb_init_module(debugger, internal_dict):
+    internal_dict["__webkit_auto_attach"] = _Watcher(debugger)


### PR DESCRIPTION
#### a44ee729d333771aa6990ee138314868be363d82
<pre>
[CMake] Add generate-cmake-vscode-project-macos for the cmake-mac build
<a href="https://bugs.webkit.org/show_bug.cgi?id=313310">https://bugs.webkit.org/show_bug.cgi?id=313310</a>

Reviewed by David Kilzer.

Sibling of generate-cmake-xcode-project: wraps a configured CMake/Ninja
build directory in a self-contained VS Code multi-root workspace so that
`code WebKitBuild/cmake-mac/ASan/WebKit.code-workspace` lands in a
ready-to-debug session with nothing written into the checkout&apos;s .vscode/.

The generated workspace embeds:

  - A default ninja build task (Cmd-Shift-B) with $gcc/$swiftc problem
    matchers so compile errors land in the Problems panel.

  - One CodeLLDB launch config per discovered .app bundle and Mach-O
    executable, each with preLaunchTask=ninja, sanitizer environment
    (ASAN_OPTIONS / TSAN_OPTIONS plus __XPC_ forwarding), a sourceMap that
    inverts the build&apos;s -fdebug-prefix-map so editor breakpoints resolve,
    and the shared lldbinit. F5 on MiniBrowser builds, launches, and
    debugs.

  - clangd settings: --compile-commands-dir pointed at the build
    directory&apos;s compile_commands.json, with the Microsoft C/C++
    IntelliSense engine disabled so the two don&apos;t fight over hover /
    go-to-definition. DerivedSources/&lt;framework&gt; directories are added as
    workspace folders so generated message receivers and bindings are
    navigable alongside checked-in code.

  - Extension recommendations for vadimcn.vscode-lldb and
    llvm-vs-code-extensions.vscode-clangd; the script also prints the
    `code --install-extension` lines for one-shot setup.

Executable discovery, prefix-map inversion, sanitizer-option derivation
and lldbinit generation are imported from generate-cmake-xcode-project so
the two front ends stay in lock-step as the build evolves.

webkit_auto_attach.py provides the multi-process debugging piece. Loaded
via postRunCommands on the UI-process launch, it derives the build
directory by walking up from the target executable to CMakeCache.txt,
then runs a daemon thread that polls proc_listpids/proc_pidpath (via
ctypes, ~50 ms interval) for processes whose executable lives under
&lt;build-dir&gt;/WebKit.framework/Versions/A/XPCServices/. For each new PID it
fires CodeLLDB&apos;s DAP startDebugging reverse-request, so every WebContent,
Networking and GPU process -- including per-tab WebContent instances and
respawns after a crash -- appears as a nested child session in the Call
Stack panel without any manual attach step. Filtering by executable path
under the build directory (rather than process name) scopes attachment to
this exact build; other WebKit-based applications on the machine are left
alone. The poller stops when the UI process exits and degrades to a no-op
when the script is imported under a plain lldb without CodeLLDB.

The attach is a poll, not a suspended-spawn, so the very first
instructions of XPC service entry are not guaranteed to be caught; for
breakpoints anywhere past process bootstrap the experience matches
debugging the same processes from the Xcode wrapper.

Usage:
    cmake --preset mac-asan
    ninja -C WebKitBuild/cmake-mac/ASan
    Tools/Scripts/generate-cmake-vscode-project-macos WebKitBuild/cmake-mac/ASan
    code --install-extension vadimcn.vscode-lldb
    code --install-extension llvm-vs-code-extensions.vscode-clangd
    open WebKitBuild/cmake-mac/ASan/WebKit.code-workspace
    # Select MiniBrowser, F5

* Tools/Scripts/generate-cmake-vscode-project-macos: Added.
* Tools/lldb/webkit_auto_attach.py: Added.

Canonical link: <a href="https://commits.webkit.org/312150@main">https://commits.webkit.org/312150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c97eda24caf62e80116c4fed4da0b0c27558405f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113041 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02a54e88-a79c-4bbc-a162-352ddec26005) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123161 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86484 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53854c20-1484-45ee-808d-811578b9b3ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103829 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6db36020-c59b-4b5b-98fb-75a7f5d10a99) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24493 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22890 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15558 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170279 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131349 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26957 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131461 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142376 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90068 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24208 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19185 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31529 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31049 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31322 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31204 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->