### PR TITLE
Programmatic focus() on input should not select all text when there is no cached selection

### DIFF
--- a/LayoutTests/fast/forms/onselect-textfield-expected.txt
+++ b/LayoutTests/fast/forms/onselect-textfield-expected.txt
@@ -2,7 +2,7 @@
 This tests onSelect for text fields.
 
 Calling focus on text field
-After focus: text field selection start: 0 end: 10
+After focus: text field selection start: 0 end: 0
 
 Calling setSelectionRange on text field
 After setSelectionRange(3, 5): text field selection start: 3 end: 5

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/focus-keyboard-js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/focus-keyboard-js-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL focus-keyboard-js assert_equals: #text should not be selected expected 3 but got 0
+PASS focus-keyboard-js
 

--- a/LayoutTests/platform/mac-wk2/fast/forms/input-appearance-focus-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/input-appearance-focus-expected.txt
@@ -31,5 +31,4 @@ layer at (175,46) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13
     RenderText {#text} at (0,0) size 80x13
       text run at (0,0) width 80: "My Text Field 2"
-selection start: position 0 of child 0 {#text} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of child 1 {P} of body
-selection end:   position 15 of child 0 {#text} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of child 1 {P} of body
+caret: position 0 of child 0 {#text} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of child 1 {P} of body

--- a/LayoutTests/platform/mac-wk2/fast/forms/input-appearance-readonly-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/input-appearance-readonly-expected.txt
@@ -12,5 +12,4 @@ layer at (15,30) size 140x13
   RenderBlock {DIV} at (7,4) size 140x13
     RenderText {#text} at (0,0) size 63x13
       text run at (0,0) width 63: "Test Passed"
-selection start: position 0 of child 0 {#text} of child 0 {DIV} of {#document-fragment} of child 2 {INPUT} of body
-selection end:   position 11 of child 0 {#text} of child 0 {DIV} of {#document-fragment} of child 2 {INPUT} of body
+caret: position 0 of child 0 {#text} of child 0 {DIV} of {#document-fragment} of child 2 {INPUT} of body

--- a/LayoutTests/platform/mac-wk2/fast/forms/input-double-click-selection-gap-bug-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/input-double-click-selection-gap-bug-expected.txt
@@ -27,5 +27,4 @@ layer at (37,410) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13
     RenderText {#text} at (0,0) size 38x13
       text run at (0,0) width 38: "foo bar"
-selection start: position 0 of child 0 {#text} of child 0 {DIV} of {#document-fragment} of child 1 {INPUT} of child 1 {TD} of child 0 {TR} of child 1 {TBODY} of child 3 {TABLE} of body
-selection end:   position 7 of child 0 {#text} of child 0 {DIV} of {#document-fragment} of child 1 {INPUT} of child 1 {TD} of child 0 {TR} of child 1 {TBODY} of child 3 {TABLE} of body
+caret: position 0 of child 0 {#text} of child 0 {DIV} of {#document-fragment} of child 1 {INPUT} of child 1 {TD} of child 0 {TR} of child 1 {TBODY} of child 3 {TABLE} of body

--- a/LayoutTests/platform/mac-wk2/fast/forms/input-text-scroll-left-on-blur-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/input-text-scroll-left-on-blur-expected.txt
@@ -54,7 +54,7 @@ layer at (175,12) size 140x13 scrollX 165 scrollWidth 305
       text run at (97,0) width 12: "to"
       text run at (108,0) width 4: " "
       text run at (111,0) width 29: "scroll"
-layer at (333,12) size 142x13 scrollX 164 scrollWidth 307
+layer at (333,12) size 142x13 scrollX 165 scrollWidth 307
   RenderBlock {DIV} at (7,4) size 142x13
     RenderText {#text} at (0,0) size 306x13
       text run at (0,0) width 306: "this text field has a lot of text in it so that it needs to scroll"

--- a/LayoutTests/platform/mac/fast/forms/textfield-outline-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textfield-outline-expected.txt
@@ -8,8 +8,8 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (562,0) size 1x18
       RenderTextControl {INPUT} at (0,18) size 247x27 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
-layer at (10,28) size 243x23
+layer at (10,28) size 243x23 scrollWidth 542
   RenderBlock {DIV} at (2,1) size 243x24
-    RenderText {#text} at (0,-1) size 33x25
-      text run at (0,0) width 33: "abc"
+    RenderText {#text} at (0,-1) size 540x25
+      text run at (0,0) width 540: "abcThis tests that typing doesn't cut holes in the focus outline"
 caret: position 3 of child 0 {#text} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of body

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -471,7 +471,7 @@ void HTMLInputElement::setDefaultSelectionAfterFocus(SelectionRestorationMode re
         start = std::numeric_limits<unsigned>::max();
         direction = SelectionHasForwardDirection;
     }
-    unsigned end = restorationMode == SelectionRestorationMode::PlaceCaretAtStart ? start : std::numeric_limits<unsigned>::max();
+    unsigned end = restorationMode == SelectionRestorationMode::SelectAll ? std::numeric_limits<unsigned>::max() : start;
     setSelectionRange(start, end, direction, revealMode, Element::defaultFocusTextStateChangeIntent());
 }
 


### PR DESCRIPTION
#### 0d3a68e0cf3e0f8228018f21ed5f0509c9f08d71
<pre>
Programmatic focus() on input should not select all text when there is no cached selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=313312">https://bugs.webkit.org/show_bug.cgi?id=313312</a>
<a href="https://rdar.apple.com/175590319">rdar://175590319</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When element.focus() is called from JavaScript on a text input that has
no cached selection, WebKit selects all text (selectionStart=0,
selectionEnd=value.length). Other browsers place the caret without
selecting. HTMLTextAreaElement already does the right thing — its
updateFocusAppearance falls back to setSelectionRange(0, 0) when there
is no cached selection.

The bug is in setDefaultSelectionAfterFocus: it only places the caret
for PlaceCaretAtStart mode, and selects all for everything else. The fix
inverts the condition so that only the explicit SelectAll mode (used by
tab navigation, mouse clicks, and step buttons) selects all text.
RestoreOrSelectAll now behaves as restore-or-place-caret, matching
textarea.

* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/focus-keyboard-js-expected.txt: Progression
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::setDefaultSelectionAfterFocus):

&gt; Rebaselines:
* LayoutTests/fast/forms/onselect-textfield-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/input-appearance-focus-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/input-appearance-readonly-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/input-double-click-selection-gap-bug-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/input-text-scroll-left-on-blur-expected.txt:
* LayoutTests/platform/mac/fast/forms/textfield-outline-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d3a68e0cf3e0f8228018f21ed5f0509c9f08d71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167537 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112792 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32122 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122950 "Found 9 new test failures: editing/deleting/delete-all-text-in-text-field-assertion.html fast/events/before-input-events-prevent-default-in-textfield.html fast/events/before-input-events-prevent-recomposition.html fast/events/input-events-ime-recomposition.html fast/events/selectstart-prevent-selectall.html fast/forms/input-appearance-focus.html fast/forms/input-appearance-readonly.html fast/forms/input-double-click-selection-gap-bug.html fast/forms/textfield-outline.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86281 "5 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103619 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24265 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22667 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15309 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133951 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20354 "Found 2 new test failures: editing/pasteboard/drop-inputtext-acquires-style.html editing/pasteboard/drop-text-without-selection.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170029 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15772 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21979 "Found 14 new test failures: accessibility/spinbutton-crash.html editing/deleting/delete-all-text-in-text-field-assertion.html editing/pasteboard/copy-in-password-field.html editing/pasteboard/input-with-display-none-div.html editing/pasteboard/input-with-visibility-hidden.html editing/pasteboard/paste-plaintext-user-select-none.html fast/events/before-input-events-prevent-default-in-textfield.html fast/events/before-input-events-prevent-recomposition.html fast/events/input-events-ime-recomposition.html fast/events/selectstart-prevent-selectall.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131136 "Found 13 new test failures: editing/deleting/delete-all-text-in-text-field-assertion.html editing/pasteboard/copy-in-password-field.html editing/pasteboard/input-with-display-none-div.html editing/pasteboard/input-with-visibility-hidden.html editing/pasteboard/paste-plaintext-user-select-none.html fast/events/before-input-events-prevent-default-in-textfield.html fast/events/before-input-events-prevent-recomposition.html fast/events/input-events-ime-recomposition.html fast/events/selectstart-prevent-selectall.html fast/forms/input-appearance-focus.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31824 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26732 "Found 10 new test failures: accessibility/spinbutton-crash.html editing/deleting/delete-all-text-in-text-field-assertion.html editing/pasteboard/copy-in-password-field.html editing/pasteboard/input-with-display-none-div.html editing/pasteboard/input-with-visibility-hidden.html editing/pasteboard/paste-plaintext-user-select-none.html fast/events/before-input-events-prevent-default-in-textfield.html fast/events/before-input-events-prevent-recomposition.html fast/events/input-events-ime-recomposition.html fast/events/selectstart-prevent-selectall.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131250 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89713 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25945 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18956 "Found 14 new test failures: accessibility/spinbutton-crash.html editing/deleting/delete-all-text-in-text-field-assertion.html editing/pasteboard/copy-in-password-field.html editing/pasteboard/input-with-display-none-div.html editing/pasteboard/input-with-visibility-hidden.html editing/pasteboard/paste-plaintext-user-select-none.html fast/events/before-input-events-prevent-default-in-textfield.html fast/events/before-input-events-prevent-recomposition.html fast/events/input-events-ime-recomposition.html fast/events/selectstart-prevent-selectall.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31280 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97294 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30800 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31073 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30954 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->